### PR TITLE
remove log file for shard binary

### DIFF
--- a/src/cmd/shard/main.go
+++ b/src/cmd/shard/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	stdlog "log"
 	"os"
-	"path"
 
 	"github.com/pachyderm/pachyderm/src/log"
 	"github.com/pachyderm/pachyderm/src/shard"
@@ -18,18 +16,6 @@ func main() {
 }
 
 func do() error {
-	if err := os.MkdirAll("/var/lib/pfs/log", 0777); err != nil {
-		return err
-	}
-	logF, err := os.Create(path.Join("/var/lib/pfs/log", "log-"+os.Args[1]))
-	if err != nil {
-		return err
-	}
-	defer logF.Close()
-
-	// TODO(pedge)
-	log.SetLogger(stdlog.New(logF, "", stdlog.Lshortfile))
-
 	s, err := shard.ShardFromArgs()
 	if err != nil {
 		return err

--- a/src/shard/shard.go
+++ b/src/shard/shard.go
@@ -406,10 +406,6 @@ func (s *Shard) pullHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Shard) logHandler(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "/var/lib/pfs/log/log-"+s.shardStr)
-}
-
 // ShardMux creates a multiplexer for a Shard writing to the passed in FS.
 func (s *Shard) ShardMux() *http.ServeMux {
 	mux := http.NewServeMux()
@@ -421,7 +417,6 @@ func (s *Shard) ShardMux() *http.ServeMux {
 	mux.HandleFunc("/pipeline/", s.pipelineHandler)
 	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "pong\n") })
 	mux.HandleFunc("/pull", s.pullHandler)
-	mux.HandleFunc("/log", s.logHandler)
 
 	return mux
 }


### PR DESCRIPTION
There has to be a better way to do this - we can get the container logs, and this is a hard coded path that is relying on /var/lib/pfs being mounted