### PR TITLE
Improve btrfs version check

### DIFF
--- a/src/btrfs/btrfs.go
+++ b/src/btrfs/btrfs.go
@@ -661,7 +661,9 @@ func checkVersion() {
 		return
 	}
 	split := strings.Split(splittedVersion[1], ".")
-	if len(split) >= 2 {
+	if len(split) < 2 {
+		checkVersionErr = fmt.Errorf("unknown version string: %s", versionString)
+		return
 	}
 	major, err := strconv.ParseInt(split[0], 10, 64)
 	if err != nil {

--- a/src/btrfs/btrfs.go
+++ b/src/btrfs/btrfs.go
@@ -655,11 +655,13 @@ func checkVersion() {
 		return
 	}
 	versionString := strings.TrimSpace(string(data))
-	version := strings.Replace(versionString, "Btrfs v", "", -1)
-	split := strings.Split(version, ".")
-	if len(split) != 2 {
+	splittedVersion := strings.Split(versionString, " v")
+	if len(splittedVersion) != 2 {
 		checkVersionErr = fmt.Errorf("unknown version string: %s", versionString)
 		return
+	}
+	split := strings.Split(splittedVersion[1], ".")
+	if len(split) >= 2 {
 	}
 	major, err := strconv.ParseInt(split[0], 10, 64)
 	if err != nil {
@@ -667,17 +669,18 @@ func checkVersion() {
 		return
 	}
 	if major < majorVersion {
-		checkVersionErr = fmt.Errorf("need at least btrfs version %d.%d, got %s", majorVersion, minorVersion, version)
+		checkVersionErr = fmt.Errorf("need at least btrfs version %d.%d, got %s", majorVersion, minorVersion, splittedVersion[1])
 		return
-	}
-	minor, err := strconv.ParseInt(split[1], 10, 64)
-	if err != nil {
-		checkVersionErr = err
-		return
-	}
-	if minor < minorVersion {
-		checkVersionErr = fmt.Errorf("need at least btrfs version %d.%d, got %s", minorVersion, minorVersion, version)
-		return
+	} else if major == majorVersion {
+		minor, err := strconv.ParseInt(split[1], 10, 64)
+		if err != nil {
+			checkVersionErr = err
+			return
+		}
+		if minor < minorVersion {
+			checkVersionErr = fmt.Errorf("need at least btrfs version %d.%d, got %s", majorVersion, minorVersion, splittedVersion[1])
+			return
+		}
 	}
 }
 

--- a/src/btrfs/btrfs.go
+++ b/src/btrfs/btrfs.go
@@ -661,7 +661,8 @@ func checkVersion() {
 		return
 	}
 	split := strings.Split(splittedVersion[1], ".")
-	if len(split) < 2 {
+	versionNumbers := len(split)
+	if versionNumbers != 2 && versionNumbers != 3 {
 		checkVersionErr = fmt.Errorf("unknown version string: %s", versionString)
 		return
 	}


### PR DESCRIPTION
We'll probably drop the btrfs code anytime soon but in the meantime, some small improvements:
- Allow to have a newer major version than the one specified
- Fix an error message typo where the needed minor version was shown twice
- Split the error message in a more accurate way (my version was reporting `btrfs-tools v4.1.2` instead of `Btrfs v4.1.2` like we were waiting for)