### PR TITLE
Make sure ~/go/bin is in the path

### DIFF
--- a/etc/initdev/init.sh
+++ b/etc/initdev/init.sh
@@ -25,6 +25,7 @@ curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.
 echo 'export PATH=${PATH}:/usr/local/go/bin' >> '/etc/profile'
 su - ${1} -c "echo mkdir -p /home/${1}/go >> /home/${1}/.profile"
 su - ${1} -c "echo export GOPATH=/home/${1}/go >> /home/${1}/.profile"
+su - ${1} -c "echo export PATH=/home/${1}/go/bin:"'${PATH}'" >> /home/${1}/.profile"
 su - ${1} -c "echo export GO15VENDOREXPERIMENT=1 >> /home/${1}/.profile"
 
 # installs docker


### PR DESCRIPTION
This change is necessary to make the vagrant instructions in the
README.md work correctly.  Without this change, lots of 'make test'
errors due to the fact that golint is installed into ~/go/bin for the
vagrant user.