### PR TITLE
Fix list-pipeline if output repo is missing

### DIFF
--- a/src/pps/pretty/pretty.go
+++ b/src/pps/pretty/pretty.go
@@ -35,5 +35,9 @@ func PrintPipelineInfo(w io.Writer, pipelineInfo *pps.PipelineInfo) {
 			fmt.Fprintf(w, ", ")
 		}
 	}
-	fmt.Fprintf(w, "%s\t\n", pipelineInfo.OutputRepo.Name)
+	if pipelineInfo.OutputRepo != nil {
+		fmt.Fprintf(w, "%s\t\n", pipelineInfo.OutputRepo.Name)
+	} else {
+		fmt.Fprintf(w, "\t\n")
+	}
 }


### PR DESCRIPTION
Fixes panic when output repo is nil.

```
$ pachctl list-pipeline
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x15f5d5]

goroutine 1 [running]:
github.com/pachyderm/pachyderm/src/pps/pretty.PrintPipelineInfo(0x2043028, 0xc82010e800, 0xc82017b400)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/src/pps/pretty/pretty.go:38 +0x435
github.com/pachyderm/pachyderm/src/pps/cmds.Cmds.func6(0x10f5cd0, 0x0, 0x0, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/src/pps/cmds/cmds.go:226 +0x3ea
github.com/pachyderm/pachyderm/vendor/go.pedge.io/pkg/cobra.RunBoundedArgs.func1(0xc820249000, 0x10f5cd0, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/vendor/go.pedge.io/pkg/cobra/pkgcobra.go:25 +0xb0
github.com/pachyderm/pachyderm/vendor/github.com/spf13/cobra.(*Command).execute(0xc820249000, 0x10f5cd0, 0x0, 0x0, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/vendor/github.com/spf13/cobra/command.go:572 +0x869
github.com/pachyderm/pachyderm/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc820126400, 0xc820249000, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/vendor/github.com/spf13/cobra/command.go:662 +0x54e
github.com/pachyderm/pachyderm/vendor/github.com/spf13/cobra.(*Command).Execute(0xc820126400, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/vendor/github.com/spf13/cobra/command.go:618 +0x2d
main.do(0x7aa3a0, 0xc82015c5a0, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/src/cmd/pachctl/main.go:118 +0x7a7
github.com/pachyderm/pachyderm/vendor/go.pedge.io/env.Main(0xd42750, 0x7aa3a0, 0xc82015c5a0, 0x0, 0x0, 0x0)
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/vendor/go.pedge.io/env/env.go:46 +0x1ff
main.main()
	/Users/toni/code/gopath/src/github.com/pachyderm/pachyderm/src/cmd/pachctl/main.go:37 +0x74
```