### PR TITLE
Port forward rethinkdb interface on port 30080 for easy debugging

### DIFF
--- a/etc/kube/pachyderm.json
+++ b/etc/kube/pachyderm.json
@@ -127,13 +127,14 @@
     }
   },
   "spec": {
+    "type": "NodePort",
     "ports": [
       {
         "name": "admin-port",
         "protocol": "",
         "port": 8080,
         "targetPort": 0,
-        "nodePort": 0
+        "nodePort": 30080
       },
       {
         "name": "driver-port",


### PR DESCRIPTION
Now rethinkdb interface can be accessed on `<docker-machine>:30080`.