### PR TITLE
fix PFS lint error during 'make test'

### DIFF
--- a/src/pfs/pfs.go
+++ b/src/pfs/pfs.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-var ErrFileNotFound error = errors.New("file not found")
+var ErrFileNotFound = errors.New("file not found")
 
 func ByteRangeSize(byteRange *ByteRange) uint64 {
 	return byteRange.Upper - byteRange.Lower


### PR DESCRIPTION
Fixes this lint error from 'make test':
```
vagrant@vagrant-ubuntu-vivid-64:~/go/src/github.com/pachyderm/pachyderm$
make test
go get -v github.com/kisielk/errcheck
go get -v github.com/golang/lint/golint
for file in $(find "./src" -name '*.go' | grep -v '\.pb\.go' | grep -v
'\.pb\.gw\.go'); do \
	golint $file | grep -v unexported; \
	if [ -n "$(golint $file | grep -v unexported)" ]; then \
	exit 1; \
	fi; \
	done;
./src/pfs/pfs.go:7:21: should omit type error from declaration of var
ErrFileNotFound; it will be inferred from the right-hand side
Makefile:140: recipe for target 'pretest' failed
make: *** [pretest] Error 1
vagrant@vagrant-ubuntu-vivid-64:~/go/src/github.com/pachyderm/pachyderm$
```