### PR TITLE
fix some issues causing errors with go {lint, vet}

### DIFF
--- a/src/cmd/pachd/main.go
+++ b/src/cmd/pachd/main.go
@@ -37,7 +37,7 @@ type appEnv struct {
 	DatabaseName    string `env:"DATABASE_NAME,default=pachyderm"`
 	KubeAddress     string `env:"KUBERNETES_PORT_443_TCP_ADDR,required"`
 	EtcdAddress     string `env:"ETCD_PORT_2379_TCP_ADDR,required"`
-	Namespace       string `env:NAMESPACE,default=default"`
+	Namespace       string `env:"NAMESPACE,default=default"`
 }
 
 func main() {

--- a/src/pkg/deploy/assets/assets.go
+++ b/src/pkg/deploy/assets/assets.go
@@ -36,7 +36,7 @@ func ServiceAccount() *api.ServiceAccount {
 	}
 }
 
-//TODO secrets is only necessary because dockerized kube chokes on them
+//PachdRc TODO secrets is only necessary because dockerized kube chokes on them
 func PachdRc(shards uint64, secrets bool) *api.ReplicationController {
 	volumes := []api.Volume{
 		{


### PR DESCRIPTION
"golint" fix for the following issue:
```
./src/pkg/deploy/assets/assets.go:39:1: comment on exported function PachdRc should be of the form "PachdRc ..."
```

"go vet" fix for the following issue:
```
src/cmd/pachd/main.go:40: struct field tag `env:NAMESPACE,default=default"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
src/cmd/pachd/main.go:40: struct field tag `env:NAMESPACE,default=default"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
```