### PR TITLE
Fix aufs problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,11 @@ docker-build-job-shim: docker-build-compile
 docker-build-pachd: docker-build-compile
 	docker run $(COMPILE_RUN_ARGS) pachyderm_compile sh etc/compile/compile.sh pachd
 
+docker-build-hyperkube:
+	docker build -t privileged_hyperkube etc/kube
+
 docker-build: docker-build-test docker-build-job-shim docker-build-pachd
+
 
 docker-push-test: docker-build-test
 	docker push pachyderm/test
@@ -83,7 +87,7 @@ docker-push-pachd: docker-build-pachd
 
 docker-push: docker-push-job-shim docker-push-pachd
 
-launch-kube:
+launch-kube: docker-build-hyperkube
 	etc/kube/start-kube-docker.sh
 
 clean-launch-kube:

--- a/SETUP.md
+++ b/SETUP.md
@@ -11,7 +11,7 @@ we'll help you find an install path and then document it here.
 ## Dependencies
 
 - [Go](#go) >= 1.6
-- [Docker](#docker) >= 1.9 (must deploy with [`--storage-driver=devicemapper`](http://muehe.org/posts/switching-docker-from-aufs-to-devicemapper/), supported as described [here](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/))
+- [Docker](#docker) >= 1.10
 - [Kubernetes](#kubernetes) and [Kubectl](#kubectl) >= 1.1.7
 - [FUSE](#fuse) 2.8.2 (https://osxfuse.github.io/)
 
@@ -22,13 +22,6 @@ Find Go 1.6 [here](https://golang.org/doc/install).
 
 Docker has great docs for installing on any platform, check them out
 [here](https://docs.docker.com/engine/installation/).
-
-There is one Pachyderm specific wrinkle, we're not compatible with aufs, we've
-found device mapper to be the best backend for Pachyderm. Using device mapper
-is should be as simple as passing `--storage-driver=devicemapper` to your
-docker invocation. Or adding that same line to `DOCKER_OPTS`. This [blog
-post](http://muehe.org/posts/switching-docker-from-aufs-to-devicemapper/)
-discusses more.
 
 ## Kubernetes
 

--- a/etc/kube/Dockerfile
+++ b/etc/kube/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/hyperkube:v1.1.7
+ADD master.json /etc/kubernetes/manifests/master.json

--- a/examples/grep/GUIDE.md
+++ b/examples/grep/GUIDE.md
@@ -9,7 +9,7 @@ to a virtually limitless stream of data. Let's dive in.
 
 Before we can launch a cluster you'll need the following things:
 
-- Docker >= 1.9 (must deploy with [`--storage-driver=devicemapper`](http://muehe.org/posts/switching-docker-from-aufs-to-devicemapper/), supported as described [here](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/))
+- Docker >= 1.10
 - Go >= 1.5
 - Kubernetes and Kubectl >= 1.1.2
 - FUSE 2.8.2 (https://osxfuse.github.io/)


### PR DESCRIPTION
Rather than trying to add the modified manifest with `docker cp` we create a new container `privileged_hyperkube` with the modified manifest inside. Then we can use it normally and aufs doesn't bug us.

@sjezewski this should hopefully make ci a bit easier