### PR TITLE
Dynamically set shards to the number of kube nodes

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -66,6 +66,7 @@ func testJob(t *testing.T, shards int) {
 	jobInfo, err := pachClient.InspectJob(context.Background(), inspectJobRequest)
 	require.NoError(t, err)
 	require.Equal(t, ppsclient.JobState_JOB_STATE_SUCCESS.String(), jobInfo.State.String())
+	require.True(t, jobInfo.Shards > 0)
 	commitInfo, err := pfsclient.InspectCommit(pachClient, jobInfo.OutputCommit.Repo.Name, jobInfo.OutputCommit.ID)
 	require.NoError(t, err)
 	require.Equal(t, pfsclient.CommitType_COMMIT_TYPE_READ, commitInfo.CommitType)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -27,7 +27,14 @@ const (
 )
 
 func TestJob(t *testing.T) {
+	testJob(t, 1)
+}
 
+func TestJobNoShard(t *testing.T) {
+	testJob(t, 0)
+}
+
+func testJob(t *testing.T, shards int) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -46,7 +53,7 @@ func TestJob(t *testing.T) {
 		"",
 		[]string{"cp", path.Join("/pfs", dataRepo, "file"), "/pfs/out/file"},
 		nil,
-		1,
+		uint64(shards),
 		[]*ppsclient.JobInput{{Commit: commit}},
 		"",
 	)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	kube "k8s.io/kubernetes/pkg/client/unversioned"
+	kubeAPI "k8s.io/kubernetes/pkg/api"
 )
 
 var (
@@ -76,7 +77,16 @@ func (a *apiServer) CreateJob(ctx context.Context, request *ppsclient.CreateJobR
 		}
 	}()
 	if request.Shards == 0 {
-		return nil, fmt.Errorf("pachyderm.ppsclient.jobserver: request.Shards cannot be 0")
+		nodeList, err := a.kubeClient.Nodes().List(kubeAPI.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("pachyderm.ppsclient.jobserver: shards set to zero and unable to retrieve node list from k8s")
+		}
+
+		if len(nodeList.Items) == 0 {
+			return nil, fmt.Errorf("pachyderm.ppsclient.jobserver: no k8s nodes found")
+		}
+
+		request.Shards = uint64(len(nodeList.Items))
 	}
 	repoSet := make(map[string]bool)
 	for _, input := range request.Inputs {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	kube "k8s.io/kubernetes/pkg/client/unversioned"
-	kubeAPI "k8s.io/kubernetes/pkg/api"
+	kube_api "k8s.io/kubernetes/pkg/api"
 )
 
 var (
@@ -77,7 +77,7 @@ func (a *apiServer) CreateJob(ctx context.Context, request *ppsclient.CreateJobR
 		}
 	}()
 	if request.Shards == 0 {
-		nodeList, err := a.kubeClient.Nodes().List(kubeAPI.ListOptions{})
+		nodeList, err := a.kubeClient.Nodes().List(kube_api.ListOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("pachyderm.ppsclient.jobserver: shards set to zero and unable to retrieve node list from k8s")
 		}


### PR DESCRIPTION
...when it's not specified by the user