### PR TITLE
Fixes an array index error.

### DIFF
--- a/src/server/pfs/drive/driver.go
+++ b/src/server/pfs/drive/driver.go
@@ -955,9 +955,10 @@ func (r *fileReader) blockRef() *pfsclient.BlockRef {
 
 func (r *fileReader) Read(data []byte) (int, error) {
 	if r.reader == nil {
-		for r.offset != 0 && r.offset > int64(pfsserver.ByteRangeSize(r.blockRef().Range)) {
-			r.index++
+		// skip blocks as long as our offset is past the end of the current block
+		for r.offset != 0 && r.index < len(r.blockRefs) && r.offset > int64(pfsserver.ByteRangeSize(r.blockRef().Range)) {
 			r.offset -= int64(pfsserver.ByteRangeSize(r.blockRef().Range))
+			r.index++
 		}
 		if r.index == len(r.blockRefs) {
 			return 0, io.EOF

--- a/src/server/pfs/drive/driver.go
+++ b/src/server/pfs/drive/driver.go
@@ -949,19 +949,22 @@ func newFileReader(blockClient pfsclient.BlockAPIClient, blockRefs []*pfs.BlockR
 	}
 }
 
+func (r *fileReader) blockRef() *pfsclient.BlockRef {
+	return r.blockRefs[r.index]
+}
+
 func (r *fileReader) Read(data []byte) (int, error) {
 	if r.reader == nil {
+		for r.offset != 0 && r.offset > int64(pfsserver.ByteRangeSize(r.blockRef().Range)) {
+			r.index++
+			r.offset -= int64(pfsserver.ByteRangeSize(r.blockRef().Range))
+		}
 		if r.index == len(r.blockRefs) {
 			return 0, io.EOF
 		}
-		blockRef := r.blockRefs[r.index]
-		for r.offset != 0 && r.offset > int64(pfsserver.ByteRangeSize(blockRef.Range)) {
-			r.index++
-			r.offset -= int64(pfsserver.ByteRangeSize(blockRef.Range))
-		}
 		var err error
 		r.reader, err = pfsclient.GetBlock(r.blockClient,
-			r.blockRefs[r.index].Block.Hash, uint64(r.offset), uint64(r.size))
+			r.blockRef().Block.Hash, uint64(r.offset), uint64(r.size))
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
This is a fix for a bug that I ran into while prepping the kube talk.
It still needs a test which shouldn't be too hard, reading with an offset larger than a block should trigger it.