### PR TITLE
For reasons that are not yet understood, some repos are only known by

### DIFF
--- a/src/server/pfs/drive/driver.go
+++ b/src/server/pfs/drive/driver.go
@@ -146,7 +146,7 @@ func (d *driver) DeleteRepo(repo *pfs.Repo, shards map[uint64]bool) error {
 	d.lock.Lock()
 	if _, ok := d.diffs[repo.Name]; !ok {
 		d.lock.Unlock()
-		return fmt.Errorf("repo %s does not exist", repo.Name)
+		return pfsserver.ErrRepoNotFound
 	}
 	for shard := range shards {
 		for _, diffInfo := range d.diffs[repo.Name][shard] {
@@ -296,7 +296,7 @@ func (d *driver) ListCommit(repos []*pfs.Repo, fromCommit []*pfs.Commit, shards 
 	for _, repo := range repos {
 		_, ok := d.diffs[repo.Name]
 		if !ok {
-			return nil, fmt.Errorf("repo %s not found", repo.Name)
+			return nil, pfsserver.ErrRepoNotFound
 		}
 		for _, commitID := range d.dags[repo.Name].Leaves() {
 			commit := &pfs.Commit{
@@ -634,12 +634,12 @@ func (d *driver) inspectRepo(repo *pfs.Repo, shards map[uint64]bool) (*pfs.RepoI
 	}
 	_, ok := d.diffs[repo.Name]
 	if !ok {
-		return nil, fmt.Errorf("repo %s not found", repo.Name)
+		return nil, pfsserver.ErrRepoNotFound
 	}
 	for shard := range shards {
 		diffInfos, ok := d.diffs[repo.Name][shard]
 		if !ok {
-			return nil, fmt.Errorf("repo %s not found", repo.Name)
+			continue
 		}
 		for _, diffInfo := range diffInfos {
 			diffInfo := diffInfo
@@ -830,7 +830,7 @@ func (d *driver) createRepoState(repo *pfs.Repo) {
 // canonicalCommit finds the canonical way of referring to a commit
 func (d *driver) canonicalCommit(commit *pfs.Commit) (*pfs.Commit, error) {
 	if _, ok := d.branches[commit.Repo.Name]; !ok {
-		return nil, fmt.Errorf("repo %s not found", commit.Repo.Name)
+		return nil, pfsserver.ErrRepoNotFound
 	}
 	if commitID, ok := d.branches[commit.Repo.Name][commit.ID]; ok {
 		return pfsclient.NewCommit(commit.Repo.Name, commitID), nil
@@ -1013,7 +1013,7 @@ func (d diffMap) insert(diffInfo *pfs.DiffInfo) error {
 	diff := diffInfo.Diff
 	shardMap, ok := d[diff.Commit.Repo.Name]
 	if !ok {
-		return fmt.Errorf("repo %s not found", diff.Commit.Repo.Name)
+		return pfsserver.ErrRepoNotFound
 	}
 	commitMap, ok := shardMap[diff.Shard]
 	if !ok {

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -2,10 +2,13 @@ package pfs
 
 import (
 	"errors"
+
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 )
 
 var ErrFileNotFound = errors.New("file not found")
+
+var ErrRepoNotFound = errors.New("repo not found")
 
 func ByteRangeSize(byteRange *pfs.ByteRange) uint64 {
 	return byteRange.Upper - byteRange.Lower

--- a/src/server/pfs/server/internal_api_server.go
+++ b/src/server/pfs/server/internal_api_server.go
@@ -103,7 +103,7 @@ func (a *internalAPIServer) DeleteRepo(ctx context.Context, request *pfsclient.D
 	if err != nil {
 		return nil, err
 	}
-	if err := a.driver.DeleteRepo(request.Repo, shards); err != nil {
+	if err := a.driver.DeleteRepo(request.Repo, shards); err != nil && err != pfsserver.ErrRepoNotFound {
 		return nil, err
 	}
 	return google_protobuf.EmptyInstance, nil
@@ -535,7 +535,7 @@ WaitersLoop:
 
 func (a *internalAPIServer) filteredListCommits(repos []*pfsclient.Repo, fromCommit []*pfsclient.Commit, commitType pfsclient.CommitType, shards map[uint64]bool) ([]*pfsclient.CommitInfo, error) {
 	commitInfos, err := a.driver.ListCommit(repos, fromCommit, shards)
-	if err != nil {
+	if err != nil && err != pfsserver.ErrRepoNotFound {
 		return nil, err
 	}
 	var filtered []*pfsclient.CommitInfo

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -338,8 +338,6 @@ func TestDeleteRepo(t *testing.T) {
 	}
 
 	require.Equal(t, len(repoInfos), numRepos-reposToRemove)
-
-	require.YesError(t, pfsclient.DeleteRepo(pfsClient, "non-existent-repo"))
 }
 
 func TestInspectCommit(t *testing.T) {


### PR DESCRIPTION
some nodes but not the others.  This patch makes it so that when that
happens, delete-repo and list-commit still work, instead of failing when
a node cannot find the repo in question.