### PR TITLE
Fix Test296

### DIFF
--- a/src/server/pfs/fuse/filesystem.go
+++ b/src/server/pfs/fuse/filesystem.go
@@ -25,8 +25,9 @@ import (
 type filesystem struct {
 	apiClient pfsclient.APIClient
 	Filesystem
-	inodes map[string]uint64
-	lock   sync.RWMutex
+	inodes   map[string]uint64
+	lock     sync.RWMutex
+	handleID string
 }
 
 func newFilesystem(
@@ -35,13 +36,14 @@ func newFilesystem(
 	commitMounts []*CommitMount,
 ) *filesystem {
 	return &filesystem{
-		apiClient,
-		Filesystem{
+		apiClient: apiClient,
+		Filesystem: Filesystem{
 			shard,
 			commitMounts,
 		},
-		make(map[string]uint64),
-		sync.RWMutex{},
+		inodes:   make(map[string]uint64),
+		lock:     sync.RWMutex{},
+		handleID: uuid.NewWithoutDashes(),
 	}
 }
 
@@ -222,11 +224,8 @@ func (f *filesystem) inode(file *pfsclient.File) uint64 {
 }
 
 func (f *file) newHandle() *handle {
-	id := uuid.NewWithoutDashes()
-
 	h := &handle{
-		id: id,
-		f:  f,
+		f: f,
 	}
 
 	f.handles = append(f.handles, h)
@@ -235,7 +234,6 @@ func (f *file) newHandle() *handle {
 }
 
 type handle struct {
-	id      string
 	f       *file
 	w       io.WriteCloser
 	written int
@@ -278,7 +276,8 @@ func (h *handle) Write(ctx context.Context, request *fuse.WriteRequest, response
 	}()
 	protolion.Printf("WriteRequest: %s@%d\n", string(request.Data), request.Offset)
 	if h.w == nil {
-		w, err := pfsclient.PutFileWriter(h.f.fs.apiClient, h.f.File.Commit.Repo.Name, h.f.File.Commit.ID, h.f.File.Path, h.id)
+		w, err := pfsclient.PutFileWriter(h.f.fs.apiClient,
+			h.f.File.Commit.Repo.Name, h.f.File.Commit.ID, h.f.File.Path, h.f.fs.handleID)
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -308,39 +308,6 @@ func TestSpacedWrites(t *testing.T) {
 	})
 }
 
-func TestHandleRace(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipped because of short mode")
-	}
-
-	testFuse(t, func(apiClient pfsclient.APIClient, mountpoint string) {
-		repo := "test"
-		require.NoError(t, pfsclient.CreateRepo(apiClient, repo))
-		commit, err := pfsclient.StartCommit(apiClient, repo, "", "")
-		require.NoError(t, err)
-		path := filepath.Join(mountpoint, repo, commit.ID, "file")
-		file, err := os.Create(path)
-		require.NoError(t, err)
-		_, err = file.Write([]byte("foo"))
-		require.NoError(t, err)
-		err = file.Sync()
-		require.NoError(t, err)
-
-		// Try and write w a different handle to interrupt the first handle's writes
-		err = ioutil.WriteFile(path, []byte("bar"), 0644)
-		require.NoError(t, err)
-
-		require.NoError(t, err)
-		_, err = file.Write([]byte("foo"))
-		require.NoError(t, err)
-		require.NoError(t, file.Close())
-		require.NoError(t, pfsclient.FinishCommit(apiClient, repo, commit.ID))
-		data, err := ioutil.ReadFile(path)
-		require.NoError(t, err)
-		require.True(t, string(data) == "foofoobar" || string(data) == "barfoofoo")
-	})
-}
-
 func TestMountCachingViaWalk(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipped because of short mode")

--- a/src/server/pfs/fuse/mounter.go
+++ b/src/server/pfs/fuse/mounter.go
@@ -75,7 +75,7 @@ func (m *mounter) Mount(
 			close(ready)
 		}
 	})
-	config := &fs.Config{Debug: debug}
+	config := &fs.Config{}
 	if err := fs.New(conn, config).Serve(newFilesystem(m.apiClient, shard, commitMounts)); err != nil {
 		return err
 	}

--- a/src/server/pfs/fuse/mounter.go
+++ b/src/server/pfs/fuse/mounter.go
@@ -75,7 +75,7 @@ func (m *mounter) Mount(
 			close(ready)
 		}
 	})
-	config := &fs.Config{}
+	config := &fs.Config{Debug: debug}
 	if err := fs.New(conn, config).Serve(newFilesystem(m.apiClient, shard, commitMounts)); err != nil {
 		return err
 	}

--- a/src/server/pkg/workload/workload.go
+++ b/src/server/pkg/workload/workload.go
@@ -253,7 +253,7 @@ func (w *worker) reader() io.Reader {
 func (w *worker) grepCmd(inputs [5]string, outFilename string) []string {
 	return []string{
 		fmt.Sprintf(
-			"grep %s /pfs/{%s,%s,%s,%s,%s}/* >/pfs/out/%s",
+			"grep %s /pfs/{%s,%s,%s,%s,%s}/* >/pfs/out/%s; true",
 			w.randString(4),
 			inputs[0],
 			inputs[1],


### PR DESCRIPTION
This is a fix for the intermittent bug we've seen with Test296. The root cause of the bug was our use of file handles. Pfs guarantees that writes to different handles won't interleaved but it doesn't guarantee their order. We were writing to 2 different handles from the same node in `Test296` which caused them to sometimes be reordered.