### PR TITLE
Add readiness check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ kube-cluster-assets: install
 	pach-deploy -s 32 >etc/kube/pachyderm.json
 
 launch: install
-	$(eval STARTTIME := $(shell date +%s)	)
+	$(eval STARTTIME := $(shell date +%s))
 	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST)
 	# wait for the pachyderm to come up
 	until timeout 1s ./etc/kube/check_pachd_ready.sh; do sleep 1; done

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,7 @@ kube-cluster-assets: install
 launch: install
 	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST)
 	# wait for the pachyderm to come up
-	# if we can call the list repo, that means that the cluster is ready to serve
-	until timeout 5s $(GOPATH)/bin/pachctl list-repo 2>/dev/null >/dev/null; do sleep 5; done
+	until timeout 5s ./etc/kube/check_pachd_ready.sh; do sleep 5; done
 
 launch-dev: launch-kube launch
 

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ launch: install
 	$(eval STARTTIME := $(shell date +%s)	)
 	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST)
 	# wait for the pachyderm to come up
-	until timeout 5s ./etc/kube/check_pachd_ready.sh; do sleep 5; done
+	until timeout 1s ./etc/kube/check_pachd_ready.sh; do sleep 1; done
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
 launch-dev: launch-kube launch

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,11 @@ kube-cluster-assets: install
 	pach-deploy -s 32 >etc/kube/pachyderm.json
 
 launch: install
+	$(eval STARTTIME := $(shell date +%s)	)
 	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST)
 	# wait for the pachyderm to come up
 	until timeout 5s ./etc/kube/check_pachd_ready.sh; do sleep 5; done
+	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
 launch-dev: launch-kube launch
 

--- a/etc/kube/check_pachd_ready.sh
+++ b/etc/kube/check_pachd_ready.sh
@@ -21,12 +21,9 @@ if [ "$allPods" -eq 0 ]; then
     exit 1
 fi
 
-echo $results | tr ' ' "\n"
-echo "-------"
-
 if [ "$readyPods" -ne "$allPods" ]; then
     exit 1
 fi
 
-echo "Success"
+echo "All pods are ready."
 exit 0

--- a/etc/kube/check_pachd_ready.sh
+++ b/etc/kube/check_pachd_ready.sh
@@ -12,21 +12,19 @@ if [ -z "$results" ]; then
   exit 1
 fi
 
-echo $results | tr ' ' "\n"
 
 readyPods=`echo $results | tr ' ' "\n" | grep "Ready=True" | wc -l`
 allPods=`echo $results | tr ' ' "\n" | grep "Ready=" | wc -l`
-
-echo "$readyPods, $allPods"
 
 if [ "$allPods" -eq 0 ]; then
     echo "No pods found yet"
     exit 1
 fi
 
-#if [ "$readyPods" -ne "$allPods" ]; then
+echo $results | tr ' ' "\n"
+echo "-------"
+
 if [ "$readyPods" -ne "$allPods" ]; then
-    echo "$readyPods != $allPods"
     exit 1
 fi
 

--- a/etc/kube/check_pachd_ready.sh
+++ b/etc/kube/check_pachd_ready.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+results=`kubectl get pods \
+  -l app=pachd \
+  -o jsonpath='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'`
+
+if [ -z $results ]; then \
+  echo "Empty result"; \
+  echo $results; \
+  exit 1; \
+fi
+
+echo $results \
+  | tr ';' "\n" \
+  | grep "Ready=" \
+  | while read line; do \
+    echo $line | grep True; \
+    ready=$?; \
+    echo "line: $line"; \
+    echo "ready? ($ready)"; \
+    if [[ $ready -ne "0" ]]; then \
+        echo "Not ready, exiting"; \
+        exit 1; \
+    fi; \
+  done
+
+
+echo "Success"
+exit 0

--- a/etc/kube/pachyderm.json
+++ b/etc/kube/pachyderm.json
@@ -16,8 +16,8 @@
     "name": "etcd",
     "creationTimestamp": null,
     "labels": {
-      "app": "etcd",
-      "suite": "pachyderm"
+      "suite": "pachyderm",
+      "app": "etcd"
     }
   },
   "spec": {
@@ -84,8 +84,8 @@
     "name": "etcd",
     "creationTimestamp": null,
     "labels": {
-      "suite": "pachyderm",
-      "app": "etcd"
+      "app": "etcd",
+      "suite": "pachyderm"
     }
   },
   "spec": {
@@ -245,8 +245,8 @@
   "spec": {
     "selector": {
       "matchLabels": {
-        "app": "pachd-init",
-        "suite": "pachyderm"
+        "suite": "pachyderm",
+        "app": "pachd-init"
       }
     },
     "template": {
@@ -382,14 +382,14 @@
               }
             ],
             "readinessProbe": {
+              "initialDelaySeconds": 15,
+              "timeoutSeconds": 1,
               "exec": {
                 "command": [
                   "./pachd",
                   "--readiness-check"
                 ]
-              },
-              "initialDelaySeconds": 15,
-              "timeoutSeconds": 1
+              }
             },
             "imagePullPolicy": "IfNotPresent",
             "securityContext": {

--- a/etc/kube/pachyderm.json
+++ b/etc/kube/pachyderm.json
@@ -382,9 +382,11 @@
               }
             ],
             "readinessProbe": {
-              "httpGet": {
-                "path": "/pfs.API/ListRepo",
-                "port": 650
+              "exec": {
+                "command": [
+                  "./pachd",
+                  "--readiness-check"
+                ]
               },
               "initialDelaySeconds": 15,
               "timeoutSeconds": 1

--- a/etc/kube/pachyderm.json
+++ b/etc/kube/pachyderm.json
@@ -381,6 +381,14 @@
                 "mountPath": "/pach"
               }
             ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/pfs.API/ListRepo",
+                "port": 650
+              },
+              "initialDelaySeconds": 15,
+              "timeoutSeconds": 1
+            },
             "imagePullPolicy": "IfNotPresent",
             "securityContext": {
               "privileged": true

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	"os"
 
 	"github.com/pachyderm/pachyderm/src/client"
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
@@ -22,12 +22,12 @@ import (
 	persist_server "github.com/pachyderm/pachyderm/src/server/pps/persist/server"
 	pps_server "github.com/pachyderm/pachyderm/src/server/pps/server"
 
+	flag "github.com/spf13/pflag"
 	"go.pedge.io/env"
 	"go.pedge.io/lion/proto"
 	"go.pedge.io/proto/server"
 	"google.golang.org/grpc"
 	kube "k8s.io/kubernetes/pkg/client/unversioned"
-	"os"
 )
 
 var readinessCheck bool

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc"
 	kube "k8s.io/kubernetes/pkg/client/unversioned"
 	"os"
-	"time"
 )
 
 var readinessCheck bool

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -68,7 +68,6 @@ func do(appEnvObj interface{}) error {
 		}
 		return nil
 	}
-	fmt.Printf("Readiness check? %v\n", readinessCheck)
 	if readinessCheck {
 		//c, err := client.NewInCluster()
 		c, err := client.NewFromAddress("127.0.0.1:650")
@@ -86,8 +85,7 @@ func do(appEnvObj interface{}) error {
 
 		return nil
 	}
-	// Delay startup just to test readiness
-	time.Sleep(30 * time.Second)
+
 	clusterID, err := getClusterID(etcdClient)
 	if err != nil {
 		return err

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -65,6 +65,18 @@ func PachdRc(shards uint64, backend backend) *api.ReplicationController {
 			MountPath: "/pach",
 		},
 	}
+	readinessProbe := &api.Probe{
+		Handler: api.Handler{
+			Exec: &api.ExecAction{
+				Command: []string{
+					"./pachd",
+					"--readiness-check",
+				},
+			},
+		},
+		InitialDelaySeconds: 15,
+		TimeoutSeconds:      1,
+	}
 	var backendEnvVar string
 	switch backend {
 	case localBackend:
@@ -150,6 +162,7 @@ func PachdRc(shards uint64, backend backend) *api.ReplicationController {
 							SecurityContext: &api.SecurityContext{
 								Privileged: &trueVal, // god is this dumb
 							},
+							ReadinessProbe:  readinessProbe,
 							ImagePullPolicy: "IfNotPresent",
 						},
 					},


### PR DESCRIPTION
Fixes #407 

During development / debugging we definitely saw some pods reporting being ready before others. `Ready` is defined as being able to respond to a `ListRepo` request. That guarantees the pod knows its own version and that it can connect to rethink to gather metadata.

There seem to be a few other bugs causing CI to fail, but this at least seems to make the integration tests either pass or fail quickly.