### PR TITLE
Fix 406 - Inject PACH_COMMIT_ID into job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@ COMPILE_RUN_ARGS = -v /var/run/docker.sock:/var/run/docker.sock --privileged=tru
 CLUSTER_NAME = pachyderm
 MANIFEST = etc/kube/pachyderm.json
 
+
+ifndef TRAVIS_BUILD_NUMBER
+	# Travis succeeds/fails much faster. If it is a timeout error, no use waiting a long time on travis
+	TIMEOUT = 100s
+else
+	# Locally ... it can take almost this much time to complete
+	TIMEOUT = 500s
+endif
+
 all: build
 
 version:
@@ -125,7 +134,7 @@ clean-pps-storage:
 	kubectl $(KUBECTLFLAGS) delete pv rethink-volume
 
 integration-tests:
-	CGOENABLED=0 go test ./src/server -timeout 500s
+	CGOENABLED=0 go test ./src/server -timeout $(TIMEOUT)
 
 proto: docker-build-proto
 	find src -regex ".*\.proto" \

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -46,7 +46,7 @@ func testJob(t *testing.T, shards int) {
 
 	t.Parallel()
 	c := getPachClient(t)
-	dataRepo := uniqueString("TestJob.data")
+	dataRepo := uniqueString("TestJob_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 	commit, err := c.StartCommit(dataRepo, "", "")
 	require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestDuplicatedJob(t *testing.T) {
 
 	c := getPachClient(t)
 
-	dataRepo := uniqueString("TestDuplicatedJob.data")
+	dataRepo := uniqueString("TestDuplicatedJob_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 
 	commit, err := c.StartCommit(dataRepo, "", "")
@@ -186,7 +186,7 @@ func TestDuplicatedJob(t *testing.T) {
 
 	require.NoError(t, c.FinishCommit(dataRepo, commit.ID))
 
-	pipelineName := uniqueString("TestDuplicatedJob.pipeline")
+	pipelineName := uniqueString("TestDuplicatedJob_pipeline")
 	require.NoError(t, c.CreateRepo(pipelineName))
 
 	cmd := []string{"cp", path.Join("/pfs", dataRepo, "file"), "/pfs/out/file"}
@@ -263,7 +263,7 @@ func TestGrep(t *testing.T) {
 	}
 
 	t.Parallel()
-	dataRepo := uniqueString("TestGrep.data")
+	dataRepo := uniqueString("TestGrep_data")
 	c := getPachClient(t)
 	require.NoError(t, c.CreateRepo(dataRepo))
 	commit, err := c.StartCommit(dataRepo, "", "")
@@ -342,7 +342,7 @@ func TestPipeline(t *testing.T) {
 	t.Parallel()
 	c := getPachClient(t)
 	// create repos
-	dataRepo := uniqueString("TestPipeline.data")
+	dataRepo := uniqueString("TestPipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 	// create pipeline
 	pipelineName := uniqueString("pipeline")
@@ -440,7 +440,7 @@ func TestPipelineWithTooMuchParallelism(t *testing.T) {
 	t.Parallel()
 	c := getPachClient(t)
 	// create repos
-	dataRepo := uniqueString("TestPipelineWithTooMuchParallelism.data")
+	dataRepo := uniqueString("TestPipelineWithTooMuchParallelism_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 	// create pipeline
 	pipelineName := uniqueString("pipeline")

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -93,6 +93,10 @@ func testJob(t *testing.T, shards int) {
 
 func TestPachCommitIdEnvVarInJob(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
 	shards := 0
 	c := getPachClient(t)
 	repos := []string{

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -81,6 +81,16 @@ func TestInvalidRepo(t *testing.T) {
 	t.Parallel()
 	client, _ := getClientAndServer(t)
 	require.YesError(t, client.CreateRepo("/repo"))
+
+	require.NoError(t, client.CreateRepo("lenny"))
+	require.NoError(t, client.CreateRepo("lenny123"))
+	require.NoError(t, client.CreateRepo("lenny_123"))
+
+	require.YesError(t, client.CreateRepo("lenny-123"))
+	require.YesError(t, client.CreateRepo("lenny.123"))
+	require.YesError(t, client.CreateRepo("lenny:"))
+	require.YesError(t, client.CreateRepo("lenny,"))
+	require.YesError(t, client.CreateRepo("lenny#"))
 }
 
 func TestSimple(t *testing.T) {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -935,6 +935,10 @@ func newJobInfo(persistJobInfo *persist.JobInfo) (*ppsclient.JobInfo, error) {
 	}, nil
 }
 
+func RepoNameToEnvString(repoName string) string {
+	return strings.ToUpper(repoName)
+}
+
 func job(jobInfo *persist.JobInfo) *extensions.Job {
 	app := jobInfo.JobID
 	parallelism := int(jobInfo.Parallelism)
@@ -942,6 +946,25 @@ func job(jobInfo *persist.JobInfo) *extensions.Job {
 	if jobInfo.Transform.Image != "" {
 		image = jobInfo.Transform.Image
 	}
+
+	var jobEnv []api.EnvVar
+	jobEnv = append(
+		jobEnv,
+		api.EnvVar{
+			Name:  "PACH_OUTPUT_COMMIT_ID",
+			Value: jobInfo.OutputCommit.ID,
+		},
+	)
+	for _, input := range jobInfo.Inputs {
+		jobEnv = append(
+			jobEnv,
+			api.EnvVar{
+				Name:  fmt.Sprintf("PACH_%v_COMMIT_ID", RepoNameToEnvString(input.Commit.Repo.Name)),
+				Value: input.Commit.ID,
+			},
+		)
+	}
+
 	return &extensions.Job{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Job",
@@ -972,12 +995,7 @@ func job(jobInfo *persist.JobInfo) *extensions.Job {
 								Privileged: &trueVal, // god is this dumb
 							},
 							ImagePullPolicy: "IfNotPresent",
-							Env: []api.EnvVar{
-								api.EnvVar{
-									Name:  "PACH_COMMIT_ID",
-									Value: jobInfo.OutputCommit.ID,
-								},
-							},
+							Env:             jobEnv,
 						},
 					},
 					RestartPolicy: "OnFailure",

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -972,6 +972,12 @@ func job(jobInfo *persist.JobInfo) *extensions.Job {
 								Privileged: &trueVal, // god is this dumb
 							},
 							ImagePullPolicy: "IfNotPresent",
+							Env: []api.EnvVar{
+								api.EnvVar{
+									Name:  "PACH_COMMIT_ID",
+									Value: jobInfo.OutputCommit.ID,
+								},
+							},
 						},
 					},
 					RestartPolicy: "OnFailure",

--- a/src/server/pps/util.go
+++ b/src/server/pps/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 func JobRepo(job *ppsclient.Job) *pfs.Repo {
-	return &pfs.Repo{Name: fmt.Sprintf("job-%s", job.ID)}
+	return &pfs.Repo{Name: fmt.Sprintf("job_%s", job.ID)}
 }
 
 func PipelineRepo(pipeline *ppsclient.Pipeline) *pfs.Repo {


### PR DESCRIPTION
Simple implementation. Added it to the k8s manifest on job creation, and added a test.