### PR TITLE
Add missing error checks in tests

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -518,6 +518,8 @@ func TestPipelineWithEmptyInputs(t *testing.T) {
 			Name: pipelineName,
 		},
 	})
+	require.NoError(t, err)
+
 	inspectJobRequest := &ppsclient.InspectJobRequest{
 		Job:        job,
 		BlockState: true,
@@ -551,6 +553,7 @@ func TestPipelineWithEmptyInputs(t *testing.T) {
 			Name: pipelineName,
 		},
 	})
+	require.NoError(t, err)
 	require.True(t, job.ID != job2.ID)
 }
 
@@ -581,6 +584,7 @@ func TestPipelineThatWritesToOneFile(t *testing.T) {
 			Name: pipelineName,
 		},
 	})
+	require.NoError(t, err)
 
 	listCommitRequest := &pfsclient.ListCommitRequest{
 		Repo:       []*pfsclient.Repo{outRepo},
@@ -628,6 +632,7 @@ func TestPipelineThatOverwritesFile(t *testing.T) {
 			Name: pipelineName,
 		},
 	})
+	require.NoError(t, err)
 
 	listCommitRequest := &pfsclient.ListCommitRequest{
 		Repo:       []*pfsclient.Repo{outRepo},
@@ -654,6 +659,7 @@ func TestPipelineThatOverwritesFile(t *testing.T) {
 		},
 		ParentJob: job,
 	})
+	require.NoError(t, err)
 
 	listCommitRequest = &pfsclient.ListCommitRequest{
 		Repo:       []*pfsclient.Repo{outRepo},
@@ -700,6 +706,7 @@ func TestPipelineThatAppendsToFile(t *testing.T) {
 			Name: pipelineName,
 		},
 	})
+	require.NoError(t, err)
 
 	listCommitRequest := &pfsclient.ListCommitRequest{
 		Repo:       []*pfsclient.Repo{outRepo},
@@ -726,6 +733,7 @@ func TestPipelineThatAppendsToFile(t *testing.T) {
 		},
 		ParentJob: job,
 	})
+	require.NoError(t, err)
 
 	listCommitRequest = &pfsclient.ListCommitRequest{
 		Repo:       []*pfsclient.Repo{outRepo},


### PR DESCRIPTION
This at least partially explains some of the test timeouts that we are seeing.  Basically the following sequence of events has been occurring:

1. Creating a Kubernetes job results in a timeout error for some undetermined reason (maybe cuz Kubernetes is overwhelmed by integration tests)?

2. We were ignoring the error returned from `CreateJob`, so we used the returned job ID in subsequent API calls without knowing that it's `nil`.

3. Because job ID is nil, pachd crashed, resulting in tests hanging.

However, this PR does not solve the fundamental problem which is that Kubernetes sometimes times out when we try to create a job.