### PR TITLE
Fix 429

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -66,9 +67,10 @@ The increase the throughput of a job increase the Shard paremeter.
 			if err != nil {
 				pkgcmd.ErrorAndExit("Error connecting to pps: %v", err)
 			}
+			var buf bytes.Buffer
 			var jobReader io.Reader
 			if jobPath == "-" {
-				jobReader = os.Stdin
+				jobReader = io.TeeReader(os.Stdin, &buf)
 				fmt.Print("Reading from stdin.\n")
 			} else {
 				jobFile, err := os.Open(jobPath)
@@ -80,13 +82,13 @@ The increase the throughput of a job increase the Shard paremeter.
 						pkgcmd.ErrorAndExit("Error closing%s: %v", jobPath, err)
 					}
 				}()
-				jobReader = jobFile
+				jobReader = io.TeeReader(jobFile, &buf)
 			}
 			var request ppsclient.CreateJobRequest
 			decoder := json.NewDecoder(jobReader)
 			s, err := replaceMethodAliases(decoder)
 			if err != nil {
-				err = describeSyntaxError(err, jobReader)
+				err = describeSyntaxError(err, buf)
 				pkgcmd.ErrorAndExit("Error parsing job spec: %v", err)
 			}
 			if err := jsonpb.UnmarshalString(s, &request); err != nil {
@@ -222,18 +224,18 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			if err != nil {
 				pkgcmd.ErrorAndExit("Error connecting to pps: %s", err.Error())
 			}
+			var buf bytes.Buffer
 			var pipelineReader io.Reader
-			var bytes []byte
 			if pipelinePath == "-" {
-				pipelineReader = os.Stdin
+				pipelineReader = io.TeeReader(os.Stdin, &buf)
 				fmt.Print("Reading from stdin.\n")
 			} else {
-				bytes, err = ioutil.ReadFile(pipelinePath)
+				rawBytes, err := ioutil.ReadFile(pipelinePath)
 				if err != nil {
 					pkgcmd.ErrorAndExit("Error reading file %s", pipelinePath)
 				}
 
-				pipelineReader = strings.NewReader(string(bytes))
+				pipelineReader = io.TeeReader(strings.NewReader(string(rawBytes)), &buf)
 			}
 			var request ppsclient.CreatePipelineRequest
 			decoder := json.NewDecoder(pipelineReader)
@@ -243,7 +245,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 					if err == io.EOF {
 						break
 					}
-					err = describeSyntaxError(err, strings.NewReader(string(bytes)))
+					err = describeSyntaxError(err, buf)
 					pkgcmd.ErrorAndExit("Error parsing pipeline spec: %v", err)
 				}
 				if err := jsonpb.UnmarshalString(s, &request); err != nil {
@@ -337,9 +339,10 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 				Force: true,
 			}
 
+			var buf bytes.Buffer
 			var specReader io.Reader
 			if specPath == "-" {
-				specReader = os.Stdin
+				specReader = io.TeeReader(os.Stdin, &buf)
 				fmt.Print("Reading from stdin.\n")
 			} else if specPath != "" {
 				specFile, err := os.Open(specPath)
@@ -353,11 +356,11 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 					}
 				}()
 
-				specReader = specFile
+				specReader = io.TeeReader(specFile, &buf)
 				decoder := json.NewDecoder(specReader)
 				s, err := replaceMethodAliases(decoder)
 				if err != nil {
-					err = describeSyntaxError(err, specReader)
+					err = describeSyntaxError(err, buf)
 					pkgcmd.ErrorAndExit("Error parsing pipeline spec: %v", err)
 				}
 
@@ -394,7 +397,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 	return result, nil
 }
 
-func describeSyntaxError(originalErr error, reader io.Reader) error {
+func describeSyntaxError(originalErr error, parsedBuffer bytes.Buffer) error {
 
 	sErr, ok := originalErr.(*json.SyntaxError)
 	if !ok {
@@ -402,11 +405,8 @@ func describeSyntaxError(originalErr error, reader io.Reader) error {
 	}
 
 	buffer := make([]byte, sErr.Offset)
-	file, ok := reader.(*os.File)
-	if ok {
-		file.Seek(0, 0)
-	}
-	reader.Read(buffer)
+	parsedBuffer.Read(buffer)
+
 	lineOffset := strings.LastIndex(string(buffer[:len(buffer)-1]), "\n")
 	if lineOffset == -1 {
 		lineOffset = 0

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -1,0 +1,86 @@
+package cmds
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/spf13/cobra"
+)
+
+const badJSON1 = `
+{
+"356weryt
+
+}
+`
+
+const badJSON2 = `
+{
+    "a": 1,
+    "b": [23,4,4,64,56,36,7456,7],
+    "c": {a,f,g,h,j,j},
+    "d": 3452.36456,
+}
+`
+
+func testJSONSyntaxErrorsReported() {
+	address := "0.0.0.0:30650"
+
+	rootCmd := &cobra.Command{
+		Use: os.Args[0],
+		Long: `Access the Pachyderm API.
+
+Envronment variables:
+  ADDRESS=0.0.0.0:30650, the server to connect to.
+`,
+	}
+
+	cmds, _ := Cmds(address)
+	for _, cmd := range cmds {
+		rootCmd.AddCommand(cmd)
+	}
+
+	// Call create job
+
+	ioutil.WriteFile("bad1.json", []byte(badJSON1), 0644)
+	defer func() {
+		os.Remove("bad1.json")
+	}()
+	os.Args = []string{"pachctl", "create-job", "-f", "bad1.json"}
+
+	rootCmd.Execute()
+}
+
+func TestJSONSyntaxErrorsReported(t *testing.T) {
+	if os.Getenv("BE_CRASHER") == "1" {
+		testJSONSyntaxErrorsReported()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestJSONSyntaxErrorsReported")
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+	out, err := cmd.CombinedOutput()
+
+	require.YesError(t, err)
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+
+		descriptiveOutput := `Error parsing job spec: Syntax Error on line 3:
+
+"356weryt
+
+         ^
+invalid character '\n' in string literal
+`
+
+		require.Equal(t, descriptiveOutput, string(out))
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+
+	fmt.Printf("err? %v\n", err)
+	fmt.Printf("asdf")
+
+}

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -44,12 +45,7 @@ Envronment variables:
 		rootCmd.AddCommand(cmd)
 	}
 
-	// Call create job
-
 	ioutil.WriteFile(inputFile, []byte(inputFileValue), 0644)
-	defer func() {
-		os.Remove(inputFile)
-	}()
 	os.Args = inputCommand
 	rootCmd.Execute()
 }
@@ -60,9 +56,16 @@ func testBadJSON(t *testing.T, testName string, inputFile string, inputFileValue
 		testJSONSyntaxErrorsReported(inputFile, inputFileValue, inputCommand)
 		return
 	}
+
 	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%v", testName))
 	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
 	out, err := cmd.CombinedOutput()
+
+	// Do our cleanup here, since we have an exit 1 in the actual run:
+	wd, _ := os.Getwd()
+	fileName := filepath.Join(wd, inputFile)
+	e := os.Remove(fileName)
+	fmt.Printf("err removing file %v\n", e)
 
 	require.YesError(t, err)
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
@@ -116,4 +119,57 @@ invalid character 'a' looking for beginning of object key string
 `
 	cmd := []string{"pachctl", "run-pipeline", "-f", "bad2.json", "somePipelineName"}
 	testBadJSON(t, "TestJSONSyntaxErrorsReportedRunPipeline", "bad2.json", badJSON2, cmd, descriptiveOutput)
+}
+
+func TestJSONSyntaxErrorsReportedCreatePipelineFromStdin(t *testing.T) {
+	descriptiveOutput := `Reading from stdin.
+Error parsing pipeline spec: Syntax Error on line 5:
+
+    "c": {a
+          ^
+invalid character 'a' looking for beginning of object key string
+`
+	rawCmd := []string{"pachctl", "create-pipeline"}
+	testName := "TestJSONSyntaxErrorsReportedCreatePipelineFromStdin"
+
+	if os.Getenv("BE_CRASHER") == "1" {
+		address := "0.0.0.0:30650"
+		rootCmd := &cobra.Command{
+			Use: os.Args[0],
+			Long: `Access the Pachyderm API.
+
+Envronment variables:
+  ADDRESS=0.0.0.0:30650, the server to connect to.
+`,
+		}
+
+		cmds, _ := Cmds(address)
+		for _, cmd := range cmds {
+			rootCmd.AddCommand(cmd)
+		}
+
+		os.Args = rawCmd
+		ioutil.WriteFile("bad2.json", []byte(badJSON2), 0644)
+		os.Stdin, _ = os.Open("bad2.json")
+		rootCmd.Execute()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%v", testName))
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+	out, err := cmd.CombinedOutput()
+
+	// Put our cleanup here, since we have an exit 1 in the actual run:
+
+	wd, _ := os.Getwd()
+	e := os.Remove(filepath.Join(wd, "bad2.json"))
+	fmt.Printf("error removing file ... %v\n", e)
+
+	require.YesError(t, err)
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		require.Equal(t, descriptiveOutput, string(out))
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+
 }

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -64,8 +64,7 @@ func testBadJSON(t *testing.T, testName string, inputFile string, inputFileValue
 	// Do our cleanup here, since we have an exit 1 in the actual run:
 	wd, _ := os.Getwd()
 	fileName := filepath.Join(wd, inputFile)
-	e := os.Remove(fileName)
-	fmt.Printf("err removing file %v\n", e)
+	os.Remove(fileName)
 
 	require.YesError(t, err)
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
@@ -162,8 +161,7 @@ Envronment variables:
 	// Put our cleanup here, since we have an exit 1 in the actual run:
 
 	wd, _ := os.Getwd()
-	e := os.Remove(filepath.Join(wd, "bad2.json"))
-	fmt.Printf("error removing file ... %v\n", e)
+	os.Remove(filepath.Join(wd, "bad2.json"))
 
 	require.YesError(t, err)
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -83,7 +83,6 @@ invalid character '\n' in string literal
 `
 	cmd := []string{"pachctl", "create-job", "-f", "bad1.json"}
 	testBadJSON(t, "TestJSONSyntaxErrorsReportedCreateJob", "bad1.json", badJSON1, cmd, descriptiveOutput)
-	fmt.Printf("err?")
 }
 
 func TestJSONSyntaxErrorsReportedCreateJob2(t *testing.T) {
@@ -95,5 +94,26 @@ invalid character 'a' looking for beginning of object key string
 `
 	cmd := []string{"pachctl", "create-job", "-f", "bad2.json"}
 	testBadJSON(t, "TestJSONSyntaxErrorsReportedCreateJob2", "bad2.json", badJSON2, cmd, descriptiveOutput)
-	fmt.Printf("err?")
+}
+
+func TestJSONSyntaxErrorsReportedCreatePipeline(t *testing.T) {
+	descriptiveOutput := `Error parsing pipeline spec: Syntax Error on line 5:
+
+    "c": {a
+          ^
+invalid character 'a' looking for beginning of object key string
+`
+	cmd := []string{"pachctl", "create-pipeline", "-f", "bad2.json"}
+	testBadJSON(t, "TestJSONSyntaxErrorsReportedCreatePipeline", "bad2.json", badJSON2, cmd, descriptiveOutput)
+}
+
+func TestJSONSyntaxErrorsReportedRunPipeline(t *testing.T) {
+	descriptiveOutput := `Error parsing pipeline spec: Syntax Error on line 5:
+
+    "c": {a
+          ^
+invalid character 'a' looking for beginning of object key string
+`
+	cmd := []string{"pachctl", "run-pipeline", "-f", "bad2.json", "somePipelineName"}
+	testBadJSON(t, "TestJSONSyntaxErrorsReportedRunPipeline", "bad2.json", badJSON2, cmd, descriptiveOutput)
 }


### PR DESCRIPTION
- Reports a more descriptive error when JSON input is invalid
    - Specifically, reports the line # and location of the error
    - Only detects syntax errors (doesn't detect Type errors for instance when trying to provide the wrong info in a json object)
- Does this in all 3 places we consume a json file (create-job / create-pipeline / run-pipeline)
- Reports whether it comes from stdin or a 'real' file

Here's some example output:


```shell
$ pachctl create-job -f bad.json
Error parsing job spec: Syntax Error on line 4:

    "c": {a
          ^
invalid character 'a' looking for beginning of object key string
```
