### PR TITLE
Update integration tests to be compatible w new k8s

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -25,6 +25,7 @@ import (
 	ppsserver "github.com/pachyderm/pachyderm/src/server/pps"
 	pps_server "github.com/pachyderm/pachyderm/src/server/pps/server"
 	"k8s.io/kubernetes/pkg/api"
+	kube_client "k8s.io/kubernetes/pkg/client/restclient"
 	kube "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
@@ -1735,7 +1736,7 @@ func scalePachd(t *testing.T, k *kube.Client) {
 	require.NoError(t, err)
 	originalReplicas := pachdRc.Spec.Replicas
 	for {
-		pachdRc.Spec.Replicas = rand.Intn(originalReplicas*2) + 1
+		pachdRc.Spec.Replicas = int32(rand.Intn(int(originalReplicas)*2) + 1)
 		if pachdRc.Spec.Replicas != originalReplicas {
 			break
 		}
@@ -1817,7 +1818,7 @@ func getPachClient(t *testing.T) *client.APIClient {
 }
 
 func getKubeClient(t *testing.T) *kube.Client {
-	config := &kube.Config{
+	config := &kube_client.Config{
 		Host:     "0.0.0.0:8080",
 		Insecure: false,
 	}


### PR DESCRIPTION
There were a few new lines on master when the ci-fix-468 branch got merged that were incompatible w the new k8s. This is fixed now.