### PR TITLE
Pipe readiness check errors to stderr

### DIFF
--- a/etc/kube/check_pachd_ready.sh
+++ b/etc/kube/check_pachd_ready.sh
@@ -4,7 +4,7 @@
 results=`kubectl get pods \
   -l app=pachd \
   -o jsonpath='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}' \
-  | tr ';' "\n"`
+  2>/dev/null | tr ';' "\n"`
 
 if [ -z "$results" ]; then
   echo "Empty result"


### PR DESCRIPTION
Fixes #457 

This fixes the (false) errors we see when this script runs to check if the launch succeeds.

Ran it a few times locally and didn't see those errors anymore ....... so I think we're good.