### PR TITLE
Manifest Upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,6 @@ launch-kube: check-kubectl
 clean-launch-kube:
 	docker kill $$(docker ps -q)
 
-kube-cluster-assets: install
-	pach-deploy -s 32 >etc/kube/pachyderm.json
-
 launch: check-kubectl install
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST)

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ tag-release:
 release-pachd:
 	./etc/build/release_pachd
 
+release-manifest: install
+	@if [ -z $$VERSION ]; then \
+		echo "Missing version. Please run via: 'make VERSION=v1.2.3-4567 release-manifest'"; \
+		exit 1; \
+	else \
+		pach-deploy --version ${VERSION} > etc/kube/pachyderm-versioned.json; \
+	fi
+
+
 docker-build-compile:
 	# Running locally, not on travis
 	if [ -z $$TRAVIS_BUILD_NUMBER ]; then \

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ release-manifest: install
 	else \
 		pach-deploy -s 32 --version ${VERSION} > etc/kube/pachyderm-versioned.json; \
 	fi
-
+	pach-deploy -s 32 > etc/kube/pachyderm.json
 
 docker-build-compile:
 	# Running locally, not on travis

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ launch: check-kubectl install
 	until timeout 1s ./etc/kube/check_pachd_ready.sh; do sleep 1; done
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
-launch-dev: install
+launch-dev: check-kubectl install
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl $(KUBECTLFLAGS) create -f $(DEV_MANIFEST)
 	# wait for the pachyderm to come up

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -24,27 +24,20 @@ make doc
     make release-pachd
 ```
 
-3) Use the image by tag in the manifest
+3) Update the manifest
 
-To update the version, look in `etc/kube/pachyderm.json` and update any lines where you see `pachd` listed as the image. An example of a line that should be changed to reflect the latest version:
+Run the following command (w the version you're releasing):
 
 ```shell
-            "image": "pachyderm/pachd:v1.0.0-530",
+make VERSION=v1.2.3-4567 release-manifest
 ```
+
+This updates the local manifest files.
 
 To test / verify:
 
 ```shell
-    git pull --tags
-    cp etc/kube/pachyderm.json .
-    tag=`git tag -l --points-at HEAD`
-    docker_tag=`echo $tag | sed -e 's/[\(]/-/g' | sed -e 's/[\)]//g'`
-    sed "s/pachyderm\/pachd/pachyderm\/pachd:$docker_tag/" pachyderm.json > tagged_pachyderm.json
-    docker ps # check DM is connected
-    kubectl get all # check k8s is up
-    make clean-launch
-    kubectl create -f tagged_pachyderm.json
-    until timeout 5s pachctl list-repo 2>/dev/null >/dev/null; do sleep 5; done
+    make launch
 ```
 
 Then do:
@@ -65,7 +58,7 @@ Once you've verified the image works, you'll need to update the image referenced
 To do that:
 
 1. Clone the corpsite repository (www)
-2. Update the `manifest.json` file by replacing it w a copy of the manifest from `etc/kube/pachyderm.json`
+2. Update the `manifest.json` file by replacing it w a copy of the manifest from `etc/kube/pachyderm-versioned.json`
 3. Commit your change on a branch
 4. Run the make command to deploy
 5. Repeat the verification steps above (from #3) using the manifest from the live url: `https://pachyderm.io/manifest.json`

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -1,16 +1,5 @@
 # Release procedure
 
-
-## Pachctl
-
-1) Update the CLI docs in this repo by doing:
-
-```shell
-make doc
-```
-
-2) [Follow the release instructions for pachctl](https://github.com/pachyderm/homebrew-tap/blob/master/README.md)
-
 ## Pachd
 
 - [find the tag/release on github you want to release](https://github.com/pachyderm/pachyderm/releases)
@@ -21,7 +10,7 @@ make doc
 
 ```shell
     git fetch --tags
-    make release-pachd
+   make release-pachd
 ```
 
 3) Update the manifest
@@ -64,7 +53,14 @@ To do that:
 5. Repeat the verification steps above (from #3) using the manifest from the live url: `https://pachyderm.io/manifest.json`
 6. Once its verified to be working, merge your branch onto master
 
+## Pachctl
 
+1) Update the CLI docs in this repo by doing:
 
+```shell
+make doc
+```
+
+2) [Follow the release instructions for pachctl](https://github.com/pachyderm/homebrew-tap/blob/master/README.md)
 
 

--- a/etc/kube/pachyderm-versioned.json
+++ b/etc/kube/pachyderm-versioned.json
@@ -3,8 +3,8 @@
     "name": "pachyderm",
     "creationTimestamp": null,
     "labels": {
-      "app": "",
-      "suite": "pachyderm"
+      "suite": "pachyderm",
+      "app": ""
     }
   },
   "kind": "ServiceAccount",
@@ -114,8 +114,8 @@
     "name": "rethink",
     "creationTimestamp": null,
     "labels": {
-      "app": "rethink",
-      "suite": "pachyderm"
+      "suite": "pachyderm",
+      "app": "rethink"
     }
   },
   "spec": {
@@ -155,8 +155,8 @@
     "name": "rethink",
     "creationTimestamp": null,
     "labels": {
-      "app": "rethink",
-      "suite": "pachyderm"
+      "suite": "pachyderm",
+      "app": "rethink"
     }
   },
   "spec": {
@@ -228,8 +228,8 @@
     "name": "pachd-init",
     "creationTimestamp": null,
     "labels": {
-      "suite": "pachyderm",
-      "app": "pachd-init"
+      "app": "pachd-init",
+      "suite": "pachyderm"
     }
   },
   "spec": {
@@ -252,7 +252,7 @@
         "containers": [
           {
             "name": "pachd-init",
-            "image": "pachyderm/pachd",
+            "image": "pachyderm/pachd:v1.0.0-849",
             "env": [
               {
                 "name": "PACH_ROOT",
@@ -339,7 +339,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd",
+            "image": "pachyderm/pachd:v1.0.0-849",
             "ports": [
               {
                 "name": "api-grpc-port",

--- a/etc/kube/pachyderm.json
+++ b/etc/kube/pachyderm.json
@@ -3,8 +3,8 @@
     "name": "pachyderm",
     "creationTimestamp": null,
     "labels": {
-      "suite": "pachyderm",
-      "app": ""
+      "app": "",
+      "suite": "pachyderm"
     }
   },
   "kind": "ServiceAccount",
@@ -29,8 +29,8 @@
         "name": "etcd",
         "creationTimestamp": null,
         "labels": {
-          "suite": "pachyderm",
-          "app": "etcd"
+          "app": "etcd",
+          "suite": "pachyderm"
         }
       },
       "spec": {
@@ -228,8 +228,8 @@
     "name": "pachd-init",
     "creationTimestamp": null,
     "labels": {
-      "suite": "pachyderm",
-      "app": "pachd-init"
+      "app": "pachd-init",
+      "suite": "pachyderm"
     }
   },
   "spec": {
@@ -252,7 +252,7 @@
         "containers": [
           {
             "name": "pachd-init",
-            "image": "pachyderm/pachd:v1.0.0-1397",
+            "image": "pachyderm/pachd",
             "env": [
               {
                 "name": "PACH_ROOT",
@@ -339,7 +339,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:v1.0.0-1397",
+            "image": "pachyderm/pachd",
             "ports": [
               {
                 "name": "api-grpc-port",

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -583,7 +583,10 @@ func WriteAssets(w io.Writer, shards uint64, backend backend, volumeName string,
 	fmt.Fprintf(w, "\n")
 }
 
-func WriteLocalAssets(w io.Writer, shards uint64, hostPath string) {
+func WriteLocalAssets(w io.Writer, shards uint64, hostPath string, version string) {
+	if version != "" {
+		pachdImage = fmt.Sprintf("%v:%v", pachdImage, version)
+	}
 	WriteAssets(w, shards, localBackend, "", 0, hostPath)
 }
 

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -13,13 +13,14 @@ import (
 func DeployCmd() *cobra.Command {
 	var shards int
 	var hostPath string
+	var version string
 	cmd := &cobra.Command{
 		Use:   os.Args[0] + " [amazon bucket id secret token region [volume-name volume-size-in-GB] | google bucket [volume-name volume-size-in-GB]]",
 		Short: "Print a kubernetes manifest for a Pachyderm cluster.",
 		Long:  "Print a kubernetes manifest for a Pachyderm cluster.",
 		Run: pkgcobra.RunBoundedArgs(pkgcobra.Bounds{Min: 0, Max: 8}, func(args []string) error {
 			if len(args) == 0 {
-				assets.WriteLocalAssets(os.Stdout, uint64(shards), hostPath)
+				assets.WriteLocalAssets(os.Stdout, uint64(shards), hostPath, version)
 			} else {
 				var volumeName string
 				var volumeSize int
@@ -50,5 +51,6 @@ func DeployCmd() *cobra.Command {
 	}
 	cmd.Flags().IntVarP(&shards, "shards", "s", 32, "The static number of shards for pfs.")
 	cmd.Flags().StringVarP(&hostPath, "host-path", "p", "", "the path on the host machine where data will be stored; this is only relevant if you are running pachyderm locally; by default, a directory under /tmp is used")
+	cmd.Flags().StringVarP(&version, "version", "v", "", "The version of pachd images to use. E.g. v1.0.0-849")
 	return cmd
 }


### PR DESCRIPTION
Fixes #507 

- `make launch` now uses the local versioned manifest copy
- for development, we'll use `make launch-dev` and `make clean-launch-dev` as needed
