### PR TITLE
Fuse delimiter support

### DIFF
--- a/src/server/pfs/fuse/filesystem.go
+++ b/src/server/pfs/fuse/filesystem.go
@@ -292,7 +292,7 @@ func (f *file) delimiter() pfsclient.Delimiter {
 	if strings.HasSuffix(f.File.Path, ".json") {
 		return pfsclient.Delimiter_JSON
 	}
-	if strings.HasSuffix(f.File.Path, ".blob") {
+	if strings.HasSuffix(f.File.Path, ".bin") {
 		return pfsclient.Delimiter_NONE
 	}
 	return pfsclient.Delimiter_LINE

--- a/src/server/pfs/fuse/filesystem.go
+++ b/src/server/pfs/fuse/filesystem.go
@@ -288,12 +288,22 @@ func (f *file) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 	return nil
 }
 
+func (f *file) delimiter() pfsclient.Delimiter {
+	if strings.HasSuffix(f.File.Path, ".json") {
+		return pfsclient.Delimiter_JSON
+	}
+	if strings.HasSuffix(f.File.Path, ".blob") {
+		return pfsclient.Delimiter_NONE
+	}
+	return pfsclient.Delimiter_LINE
+}
+
 func (f *file) touch() error {
 	w, err := f.fs.apiClient.PutFileWriter(
 		f.File.Commit.Repo.Name,
 		f.File.Commit.ID,
 		f.File.Path,
-		pfsclient.Delimiter_LINE,
+		f.delimiter(),
 		f.fs.handleID,
 	)
 	if err != nil {
@@ -380,7 +390,7 @@ func (h *handle) Write(ctx context.Context, request *fuse.WriteRequest, response
 	}()
 	if h.w == nil {
 		w, err := h.f.fs.apiClient.PutFileWriter(
-			h.f.File.Commit.Repo.Name, h.f.File.Commit.ID, h.f.File.Path, pfsclient.Delimiter_LINE, h.f.fs.handleID)
+			h.f.File.Commit.Repo.Name, h.f.File.Commit.ID, h.f.File.Path, h.f.delimiter(), h.f.fs.handleID)
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -542,6 +542,71 @@ func TestDelimitJSON(t *testing.T) {
 	})
 }
 
+func TestNoDelimiter(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("Skipped because of short mode")
+	}
+	testFuse(t, func(c client.APIClient, mountpoint string) {
+
+		repo := "test"
+		name := "foo.blob"
+		require.NoError(t, c.CreateRepo(repo))
+		commit1, err := c.StartCommit(repo, "", "")
+		require.NoError(t, err)
+
+		rawMessage := "Some\ncontent\nthat\nshouldnt\nbe\nline\ndelimited.\n"
+		filePath := filepath.Join(mountpoint, repo, commit1.ID, name)
+
+		// Write a big blob that would normally not fit in a block
+		var expectedOutputA []byte
+		for !(len(expectedOutputA) > 9*1024*1024) {
+			expectedOutputA = append(expectedOutputA, []byte(rawMessage)...)
+		}
+		require.NoError(t, ioutil.WriteFile(filePath, expectedOutputA, 0644))
+
+		// Write another big block
+		var expectedOutputB []byte
+		for !(len(expectedOutputB) > 10*1024*1024) {
+			expectedOutputB = append(expectedOutputB, []byte(rawMessage)...)
+		}
+		require.NoError(t, ioutil.WriteFile("/tmp/b", expectedOutputB, 0644))
+		stdin := strings.NewReader(fmt.Sprintf("cat /tmp/b >>%s", filePath))
+		require.NoError(t, pkgexec.RunStdin(stdin, "sh"))
+
+		// Finish the commit so I can read the data
+		require.NoError(t, c.FinishCommit(repo, commit1.ID))
+
+		// Make sure all the content is there
+		var buffer bytes.Buffer
+		require.NoError(t, c.GetFile(repo, commit1.ID, name, 0, 0, "", nil, &buffer))
+		require.Equal(t, len(expectedOutputA)+len(expectedOutputB), buffer.Len())
+		require.Equal(t, string(append(expectedOutputA, expectedOutputB...)), buffer.String())
+
+		// Now verify that each block only contains objects of the size we've written
+		bigModulus := 10 // Make it big to make it less likely that I return both blocks together
+		blockLengths := []interface{}{len(expectedOutputA), len(expectedOutputB)}
+		for b := 0; b < bigModulus; b++ {
+			blockFilter := &pfsclient.Shard{
+				BlockNumber:  uint64(b),
+				BlockModulus: uint64(bigModulus),
+			}
+
+			buffer.Reset()
+			require.NoError(t, c.GetFile(repo, commit1.ID, name, 0, 0, "", blockFilter, &buffer))
+
+			// If any single block returns content of size equal to the total, we
+			// got a block collision and we're not testing anything
+			require.NotEqual(t, len(expectedOutputA)+len(expectedOutputB), buffer.Len())
+			if buffer.Len() == 0 {
+				continue
+			}
+			require.EqualOneOf(t, blockLengths, buffer.Len())
+		}
+	})
+
+}
+
 func testFuse(
 	t *testing.T,
 	test func(client client.APIClient, mountpoint string),

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -550,7 +550,7 @@ func TestNoDelimiter(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 
 		repo := "test"
-		name := "foo.blob"
+		name := "foo.bin"
 		require.NoError(t, c.CreateRepo(repo))
 		commit1, err := c.StartCommit(repo, "", "")
 		require.NoError(t, err)


### PR DESCRIPTION
Fixes #506 

- FUSE now looks at the file suffix to denote the delimiter it uses in the `PutFile` request
- json / none / line delimiters supported via `.json` / `.blob` / and `.txt` (or no suffix) respectively

We were concerned that the buffered writes from fuse -> PFS would cause trouble in particular for the `Delimiter_NONE` case.

I added a breaking test case explicitly for this, and it passes once FUSE detects suffix. Specifically, the reason that the buffered writes to PFS don't count as separate `PutFile()` requests, is a combination of two things:

1)  that we re-use the writer to the `PutFile()` request (see [here](https://github.com/pachyderm/pachyderm/blob/master/src/server/pfs/fuse/filesystem.go#L373)). This means that all write requests that fuse sees get aggregated together into the same `PutFile()` request

and

2) Fuse seems to call `Flush()` ([here](https://github.com/pachyderm/pachyderm/blob/master/src/server/pfs/fuse/filesystem.go#L409)) at the Right Times (in our case ... between when I write the file the first time and when I append to it) which means the putfile writer gets reset at the correct times



