### PR TITLE
Add lint command to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
 - docker version
 script:
 - make test
+- make lint
 after_success:
 - make tag-release
 notifications:


### PR DESCRIPTION
Removed from #474 in order to let that pass. This change will not pass CI until #474 is merged and linting errors are fixed, at which point it should be merged and kept there to keep the code nice and clean.