### PR TITLE
Use goxc to cross-compile and release pachctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ src/cmd/pfs/pfs
 src/cmd/pfsd/pfsd
 src/cmd/pps/pps
 src/cmd/ppsd/ppsd
+/.goxc.local.json
+build/

--- a/.goxc.json
+++ b/.goxc.json
@@ -1,0 +1,15 @@
+{
+	"ArtifactsDest": "build",
+	"Tasks": [
+		"default",
+		"publish-github"
+	],
+	"BuildConstraints": "linux,amd64 darwin,amd64",
+	"TaskSettings": {
+		"publish-github": {
+			"owner": "pachyderm",
+			"repository": "pachyderm"
+		}
+	},
+	"ConfigVersion": "0.9"
+}

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,19 @@ lint:
 		fi \
 	done
 
+goxc-generate-local:
+	@if [ -z $$GITHUB_OAUTH_TOKEN ]; then \
+		echo "Missing token. Please run via: 'make GITHUB_OAUTH_TOKEN=12345 goxc-generate-local'"; \
+		exit 1; \
+	fi
+	goxc -wlc default publish-github -apikey=$(GITHUB_OAUTH_TOKEN)
+
+goxc-release:
+	@if [ -z $$VERSION ]; then \
+		echo "Missing version. Please run via: 'make VERSION=v1.2.3-4567 goxc-release'"; \
+		exit 1; \
+	fi
+	goxc -pv=$(VERSION) -wd=./src/server/cmd/pachctl
 
 .PHONY:
 	all \
@@ -326,4 +339,7 @@ lint:
 	amazon-cluster \
 	clean-amazon-cluster \
 	install-go-bindata \
-	assets
+	assets \
+	lint \
+	goxc-generate-local \
+	goxc-release

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,9 @@ goxc-release:
 	fi
 	goxc -pv=$(VERSION) -wd=./src/server/cmd/pachctl
 
+goxc-build:
+	goxc -tasks=xc -wd=./src/server/cmd/pachctl
+
 .PHONY:
 	all \
 	version \
@@ -342,4 +345,5 @@ goxc-release:
 	assets \
 	lint \
 	goxc-generate-local \
-	goxc-release
+	goxc-release \
+	goxc-build


### PR DESCRIPTION
Current usage:
- `$ make goxc-build`: Cross-compile pachctl into `build/snapshot` and don't release anything.
- `$ make VERSION=v1.2.3-4567 goxc-release`: Cross-compile pachctl into `build/$VERSION` and upload the release to Github.

Uploading releases to Github requires an [access token](https://github.com/settings/tokens) which should be stored in `.goxc.local.json` by running `$ make GITHUB_OAUTH_TOKEN=12345 goxc-generate-local`. Once releases are moved to CI, this token should either be stored in repository settings or `.travis.yml` (encrypted in the latter case).