### PR TITLE
Wordcount

### DIFF
--- a/examples/word_count/Dockerfile
+++ b/examples/word_count/Dockerfile
@@ -1,4 +1,4 @@
-FROM derekchiang/job-shim:latest
+FROM pachyderm/job-shim:latest
 
 # Install Go
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/examples/word_count/Dockerfile
+++ b/examples/word_count/Dockerfile
@@ -1,0 +1,29 @@
+FROM derekchiang/job-shim:latest
+
+# Install Go
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+        curl \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.6.2
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+ADD map.go /
+RUN go build -o /map /map.go 
+ENTRYPOINT ["/map"]

--- a/examples/word_count/README.md
+++ b/examples/word_count/README.md
@@ -1,0 +1,144 @@
+# Quick Start Guide: Word Count
+
+In this guide, we will write a classic [word count](https://portal.futuresystems.org/manual/hadoop-wordcount) application on Pachyderm.  This is a somewhat advanced guide; to learn the basic usage of Pachyderm, start with [fruit_stand](../fruit_stand) or [scraper](../scraper).
+
+## Setup
+
+This guide assumes that you already have a Pachyderm cluster running and have configured `pachctl` to talk to the cluster.  [Detailed setup instructions can be found here](../../SETUP.md).
+
+## Pipelines
+
+In this example, we will have three connected pipelines.  We say that two pipelines are "connected" if one pipeline's output is the input of the other. 
+
+## wordcount_input
+
+Let's create the first pipeline:
+
+```
+$ pachctl create-pipeline << EOF
+{
+  "pipeline": {
+    "name": "wordcount_input"
+  },
+  "transform": {
+    "image": "pachyderm/job-shim:latest",
+    "cmd": [ "wget",
+        "-e", "robots=off",
+        "--recursive",
+        "--level", "1",
+        "--adjust-extension",
+        "--no-check-certificate",
+        "--no-directories",
+        "--directory-prefix",
+        "/pfs/out",
+        "https://en.wikipedia.org/wiki/Main_Page"
+    ],
+    "acceptReturnCode": [4,5,6,7,8]
+  },
+  "parallelism": 1
+}
+EOF
+```
+
+This first pipeline, `wordcount_input`, uses `wget` to download web pages from Wikipedia which will be used as the input for the next pipeline.  We set `parallelism` to 1 because `wget` can't be parallelized.
+
+Note how this pipeline itself has no inputs.  A pipeline that doesn't have inputs can only be triggered manually:
+
+```
+$ pachctl run-pipeline wordcount_input
+```
+
+Now you should be able to see a job running:
+
+```
+$ pachctl list-job
+```
+
+## wordcount_map
+
+This pipeline counts the number of occurrences of each word it encounters.  While this task can very well be accomplished in Bash, we will demonstrate how to use custom code in Pachyderm by using a [Go program](map.go).
+
+First of all, we build a [Docker image](Dockerfile) that contains our Go program:
+
+```
+$ docker build -t wordcount-map .
+```
+
+Then, we simply refer to the image in our pipeline:
+
+```
+$ pachctl create-pipeline << EOF
+{
+  "pipeline": {
+    "name": "wordcount_map"
+  },
+  "transform": {
+    "image": "wordcount-map:latest",
+    "cmd": ["/map", "/pfs/wordcount_input", "/pfs/out"]
+  },
+  "inputs": [
+    {
+      "repo": {
+        "name": "wordcount_input"
+      }
+    }
+  ]
+}
+EOF
+```
+
+As soon as you create this pipeline, it will start processing data from `wordcount_input`.  Note that we did not specify a `parallelism` for this pipeline.  In this case, Pachyderm will automatically scale your pipeline based on the number of nodes in the cluster.  
+
+To parallelize the pipeline, Pachyderm spins up N concurrently running containers where each container gets `1/N` of the data.  For each word a container encounters, it writes a file whose filename is the word, and whose content is the number of occurrences.  If multiple containers write the same file, the content is merged.  As an example, the file `morning` might look like this:
+
+```
+$ pachctl list-job -p wordcount_map  # use this command to find out the output commit ID
+ID                                 OUTPUT                                           STARTED             DURATION            STATE               
+6600c71be4e8604f716ce1965895dc27   wordcount_map/5b0e5c8f345b4f8c9690c77333564687   46 hours ago        -                   success
+$ pachctl get-file wordcount_map 5b0e5c8f345b4f8c9690c77333564687 morning  # your commit ID will be different
+217
+355
+142
+```
+
+This shows that there were three containers that wrote to the file `morning`.
+
+## wordcount_reduce
+
+The final pipeline goes through every file and adds up the numbers in each file.  For this pipeline we can use a simple bash script:
+
+```
+{
+  "pipeline": {
+    "name": "wordcount_reduce"
+  },
+  "transform": {
+    "image": "pachyderm/job-shim:latest",
+    "cmd": ["sh"],
+    "stdin": [
+        "find /pfs/wordcount_map -name '*' | while read count; do cat $count | awk '{ sum+=$1} END {print sum}' >/tmp/count; mv /tmp/count /pfs/out/`basename $count`; done"
+    ]
+  },
+  "inputs": [
+    {
+      "repo": {
+        "name": "wordcount_map"
+      },
+	  "method": "reduce"
+    }
+  ]
+}
+```
+
+The final output might look like this:
+
+```
+$ pachctl get-file wordcount_reduce [commit ID] morning
+714
+```
+
+To get a complete list of the words counted:
+
+```
+$ pachctl list-file wordcount_reduce [commit ID]
+```

--- a/examples/word_count/map.go
+++ b/examples/word_count/map.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var (
+	reg       *regexp.Regexp
+	inputDir  string
+	outputDir string
+)
+
+func sanitize(word string) []string {
+	sanitized := reg.ReplaceAllString(word, " ")
+	return strings.Split(strings.ToLower(sanitized), " ")
+}
+
+func shuffle(slice []os.FileInfo) {
+	for i := range slice {
+		j := rand.Intn(i + 1)
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}
+
+type Pair struct {
+	word  string
+	count int
+}
+
+func worker(jobs <-chan Pair, wg *sync.WaitGroup) {
+	for {
+		pair, ok := <-jobs
+		if !ok {
+			wg.Done()
+			return
+		}
+		if err := ioutil.WriteFile(filepath.Join(outputDir, pair.word), []byte(strconv.Itoa(pair.count)+"\n"), 0644); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+	if len(args) != 2 {
+		log.Fatalf("expect two arguemnts; got %v", len(args))
+	}
+
+	var err error
+	reg, err = regexp.Compile(`[^A-Za-z]+`)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	inputDir = args[0]
+	outputDir = args[1]
+
+	files, err := ioutil.ReadDir(inputDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// we want to process files in a random order in order to
+	// avoid flash-crowd behavior
+	shuffle(files)
+
+	wordMap := make(map[string]int)
+
+	for _, file := range files {
+		log.Printf("scanning file %v", file.Name())
+		f, err := os.Open(filepath.Join(inputDir, file.Name()))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		scanner := bufio.NewScanner(f)
+		scanner.Split(bufio.ScanWords)
+		count := 0
+		for scanner.Scan() {
+			count += 1
+			for _, word := range sanitize(scanner.Text()) {
+				if word != "" {
+					wordMap[word] = wordMap[word] + 1
+				}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			log.Fatal(err)
+		}
+
+		log.Printf("found %d words in %s", count, file.Name())
+
+		if err := f.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	jobs := make(chan Pair)
+
+	// spawn 100 workers
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go worker(jobs, &wg)
+	}
+
+	for word, count := range wordMap {
+		jobs <- Pair{
+			word:  word,
+			count: count,
+		}
+	}
+	close(jobs)
+
+	wg.Wait()
+}

--- a/examples/word_count/pipeline.json
+++ b/examples/word_count/pipeline.json
@@ -1,0 +1,59 @@
+{
+  "pipeline": {
+    "name": "wordcount_input"
+  },
+  "transform": {
+    "image": "derekchiang/job-shim:latest",
+    "cmd": [ "wget",
+        "-e", "robots=off",
+        "--recursive",
+        "--level", "2",
+        "--adjust-extension",
+        "--no-check-certificate",
+        "--no-directories",
+        "--directory-prefix",
+        "/pfs/out",
+        "https://en.wikipedia.org/wiki/Main_Page"
+    ],
+    "acceptReturnCode": [4,5,6,7,8]
+  },
+  "parallelism": 1
+}
+{
+  "pipeline": {
+    "name": "wordcount_map"
+  },
+  "transform": {
+    "image": "derekchiang/wordcount-map:latest",
+    "cmd": ["/map", "/pfs/wordcount_input", "/pfs/out"]
+  },
+  "inputs": [
+    {
+      "repo": {
+        "name": "wordcount_input"
+      }
+    }
+  ],
+  "parallelism": 3
+}
+{
+  "pipeline": {
+    "name": "wordcount_reduce"
+  },
+  "transform": {
+    "image": "derekchiang/job-shim:latest",
+    "cmd": ["sh"],
+    "stdin": [
+        "find /pfs/wordcount_map/* | while read count; do cat $count | awk '{ sum+=$1} END {print sum}' >/tmp/count; mv /tmp/count /pfs/out/`basename $count`; done"
+    ]
+  },
+  "inputs": [
+    {
+      "repo": {
+        "name": "wordcount_map"
+      },
+	  "method": "reduce"
+    }
+  ],
+  "parallelism": 9
+}

--- a/examples/word_count/pipeline.json
+++ b/examples/word_count/pipeline.json
@@ -3,11 +3,11 @@
     "name": "wordcount_input"
   },
   "transform": {
-    "image": "derekchiang/job-shim:latest",
+    "image": "pachyderm/job-shim:latest",
     "cmd": [ "wget",
         "-e", "robots=off",
         "--recursive",
-        "--level", "2",
+        "--level", "1",
         "--adjust-extension",
         "--no-check-certificate",
         "--no-directories",
@@ -24,7 +24,7 @@
     "name": "wordcount_map"
   },
   "transform": {
-    "image": "derekchiang/wordcount-map:latest",
+    "image": "wordcount-map:latest",
     "cmd": ["/map", "/pfs/wordcount_input", "/pfs/out"]
   },
   "inputs": [
@@ -33,18 +33,17 @@
         "name": "wordcount_input"
       }
     }
-  ],
-  "parallelism": 3
+  ]
 }
 {
   "pipeline": {
     "name": "wordcount_reduce"
   },
   "transform": {
-    "image": "derekchiang/job-shim:latest",
+    "image": "pachyderm/job-shim:latest",
     "cmd": ["sh"],
     "stdin": [
-        "find /pfs/wordcount_map/* | while read count; do cat $count | awk '{ sum+=$1} END {print sum}' >/tmp/count; mv /tmp/count /pfs/out/`basename $count`; done"
+        "find /pfs/wordcount_map -name '*' | while read count; do cat $count | awk '{ sum+=$1} END {print sum}' >/tmp/count; mv /tmp/count /pfs/out/`basename $count`; done"
     ]
   },
   "inputs": [
@@ -54,6 +53,5 @@
       },
 	  "method": "reduce"
     }
-  ],
-  "parallelism": 9
+  ]
 }

--- a/src/server/pfs/drive/driver.go
+++ b/src/server/pfs/drive/driver.go
@@ -658,8 +658,6 @@ func (d *driver) ListFile(file *pfs.File, filterShard *pfs.Shard, from *pfs.Comm
 
 func (d *driver) DeleteFile(file *pfs.File, shard uint64, unsafe bool, handle string) error {
 	d.lock.RLock()
-	// We don't want to be able to delete files that are only added in the current
-	// commit, which is why we set unsafe to false.
 	fileInfo, _, err := d.inspectFile(file, nil, shard, nil, false, unsafe, handle)
 	if err != nil {
 		d.lock.RUnlock()

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -634,6 +634,25 @@ func TestNoDelimiter(t *testing.T) {
 	})
 }
 
+func TestWriteManyFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipped because of short mode")
+	}
+
+	testFuse(t, func(c client.APIClient, mountpoint string) {
+		repo := "TestWriteManyFiles"
+		require.NoError(t, c.CreateRepo(repo))
+		commit, err := c.StartCommit(repo, "", "")
+		require.NoError(t, err)
+
+		for i := 0; i < 10000; i++ {
+			fileName := fmt.Sprintf("file-%d", i)
+			filePath := filepath.Join(mountpoint, repo, commit.ID, fileName)
+			require.NoError(t, ioutil.WriteFile(filePath, []byte(fileName), 0644))
+		}
+	})
+}
+
 func testFuse(
 	t *testing.T,
 	test func(client client.APIClient, mountpoint string),

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -602,16 +602,16 @@ func WriteLocalAssets(w io.Writer, shards uint64, hostPath string, version strin
 }
 
 func WriteAmazonAssets(w io.Writer, shards uint64, bucket string, id string, secret string, token string, region string, volumeName string, volumeSize int) {
-	WriteAssets(w, shards, amazonBackend, volumeName, volumeSize, "")
 	encoder := codec.NewEncoder(w, &codec.JsonHandle{Indent: 2})
 	AmazonSecret(bucket, id, secret, token, region).CodecEncodeSelf(encoder)
+	WriteAssets(w, shards, amazonBackend, volumeName, volumeSize, "")
 	fmt.Fprintf(w, "\n")
 }
 
 func WriteGoogleAssets(w io.Writer, shards uint64, bucket string, volumeName string, volumeSize int) {
-	WriteAssets(w, shards, googleBackend, volumeName, volumeSize, "")
 	encoder := codec.NewEncoder(w, &codec.JsonHandle{Indent: 2})
 	GoogleSecret(bucket).CodecEncodeSelf(encoder)
+	WriteAssets(w, shards, googleBackend, volumeName, volumeSize, "")
 	fmt.Fprintf(w, "\n")
 }
 

--- a/src/server/pkg/obj/google_client.go
+++ b/src/server/pkg/obj/google_client.go
@@ -2,6 +2,9 @@ package obj
 
 import (
 	"io"
+	"reflect"
+
+	"go.pedge.io/lion/proto"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
@@ -72,7 +75,10 @@ func (c *googleClient) Delete(name string) error {
 	return c.bucket.Object(name).Delete(c.ctx)
 }
 
-func (c *googleClient) IsRetryable(err error) bool {
+func (c *googleClient) IsRetryable(err error) (ret bool) {
+	defer func() {
+		protolion.Infof("retryable: %v; type of err: %s; err: %v", ret, reflect.TypeOf(err).String(), err)
+	}()
 	googleErr, ok := err.(*googleapi.Error)
 	if !ok {
 		return false

--- a/src/server/vendor/bazil.org/fuse/fuse.go
+++ b/src/server/vendor/bazil.org/fuse/fuse.go
@@ -235,7 +235,7 @@ func initMount(c *Conn, conf *mountConfig) error {
 	s := &InitResponse{
 		Library:      proto,
 		MaxReadahead: conf.maxReadahead,
-		MaxWrite:     128 * 1024,
+		MaxWrite:     maxWrite,
 		Flags:        InitBigWrites | conf.initFlags,
 	}
 	r.Respond(s)
@@ -402,9 +402,6 @@ func (h *Header) RespondError(err error) {
 	hOut.Error = -int32(errno)
 	h.respond(buf)
 }
-
-// Maximum file write size we are prepared to receive from the kernel.
-const maxWrite = 16 * 1024 * 1024
 
 // All requests read from the kernel, without data, are shorter than
 // this.

--- a/src/server/vendor/bazil.org/fuse/fuse_darwin.go
+++ b/src/server/vendor/bazil.org/fuse/fuse_darwin.go
@@ -1,0 +1,9 @@
+package fuse
+
+// Maximum file write size we are prepared to receive from the kernel.
+//
+// This value has to be >=16MB or OSXFUSE (3.4.0 observed) will
+// forcibly close the /dev/fuse file descriptor on a Setxattr with a
+// 16MB value. See TestSetxattr16MB and
+// https://github.com/bazil/fuse/issues/42
+const maxWrite = 16 * 1024 * 1024

--- a/src/server/vendor/bazil.org/fuse/fuse_freebsd.go
+++ b/src/server/vendor/bazil.org/fuse/fuse_freebsd.go
@@ -1,0 +1,6 @@
+package fuse
+
+// Maximum file write size we are prepared to receive from the kernel.
+//
+// This number is just a guess.
+const maxWrite = 128 * 1024

--- a/src/server/vendor/bazil.org/fuse/fuse_linux.go
+++ b/src/server/vendor/bazil.org/fuse/fuse_linux.go
@@ -1,0 +1,7 @@
+package fuse
+
+// Maximum file write size we are prepared to receive from the kernel.
+//
+// Linux 4.2.0 has been observed to cap this value at 128kB
+// (FUSE_MAX_PAGES_PER_REQ=32, 4kB pages).
+const maxWrite = 128 * 1024

--- a/src/server/vendor/vendor.json
+++ b/src/server/vendor/vendor.json
@@ -17,26 +17,26 @@
 		{
 			"checksumSHA1": "xCAVewAtJpNeqReS0fRzarfwfjA=",
 			"path": "bazil.org/fuse",
-			"revision": "0dfaa72ce1313ab5a43f1cb501fd87e2f367283f",
-			"revisionTime": "2015-11-25T17:25:30Z"
+			"revision": "9e8e65293a037ce998ba0df102710c49313aa513",
+			"revisionTime": "2016-06-23T20:17:38-07:00"
 		},
 		{
 			"checksumSHA1": "389JFJTJADMtZkTIfdSnsmHVOUs=",
 			"path": "bazil.org/fuse/fs",
-			"revision": "0dfaa72ce1313ab5a43f1cb501fd87e2f367283f",
-			"revisionTime": "2015-11-25T17:25:30Z"
+			"revision": "9e8e65293a037ce998ba0df102710c49313aa513",
+			"revisionTime": "2016-06-23T20:17:38-07:00"
 		},
 		{
 			"checksumSHA1": "wy8DrEJ4Al2iZk5hKQEbIqaghGM=",
 			"path": "bazil.org/fuse/fs/fstestutil",
-			"revision": "0dfaa72ce1313ab5a43f1cb501fd87e2f367283f",
-			"revisionTime": "2015-11-25T17:25:30Z"
+			"revision": "9e8e65293a037ce998ba0df102710c49313aa513",
+			"revisionTime": "2016-06-23T20:17:38-07:00"
 		},
 		{
 			"checksumSHA1": "NPgkh9UWMsaTtsAAs3kPrclHT9Y=",
 			"path": "bazil.org/fuse/fuseutil",
-			"revision": "0dfaa72ce1313ab5a43f1cb501fd87e2f367283f",
-			"revisionTime": "2015-11-25T17:25:30Z"
+			"revision": "9e8e65293a037ce998ba0df102710c49313aa513",
+			"revisionTime": "2016-06-23T20:17:38-07:00"
 		},
 		{
 			"path": "context",


### PR DESCRIPTION
This patch includes a few things:

1. TV's patch to lower the buffer size for the FUSE library.  Along with #591, this fixes #581 
2. Add another example for "word count", a classic big data application where you compute the number of occurrences for each word in a collection of documents.
3. Make the retry mechanism more robust.  Specifically, GCS sometimes return a 500+ error code on the creation of `NewRangeReader` which wasn't handled by the retry mechanism.