### PR TITLE
Install golint in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ assets: install-go-bindata
 	go-bindata -o assets.go -pkg pachyderm doc/
 
 lint:
-	@for file in $$(find "./src" -name '*.go' | grep -v '/vendor/' |grep -v '\.pb\.go'); do \
+	@go get -u github.com/golang/lint/golint
+	@for file in $$(find "./src" -name '*.go' | grep -v '/vendor/' | grep -v '\.pb\.go'); do \
 		golint $$file; \
 		if [ -n "$$(golint $$file)" ]; then \
 			echo "golint errors!" && echo && exit 1; \

--- a/src/server/pfs/drive/driver.go
+++ b/src/server/pfs/drive/driver.go
@@ -23,6 +23,7 @@ func newPermissionError(repo string, commitID string) error {
 	return fmt.Errorf("commit %s/%s has already been finished", repo, commitID)
 }
 
+// IsPermissionError returns true if a given error is a permission error.
 func IsPermissionError(err error) bool {
 	return strings.Contains(err.Error(), "has already been finished")
 }


### PR DESCRIPTION
Currently failing because
```
./src/server/pfs/drive/driver.go:26:1: exported function IsPermissionError should have comment or be unexported
golint errors!

make: *** [lint] Error 1
```
but it installs golint and fixes #635 