### PR TITLE
Fix a bug where error is not returned when primary key is not found

### DIFF
--- a/src/server/pps/persist/server/rethink_api_server.go
+++ b/src/server/pps/persist/server/rethink_api_server.go
@@ -502,7 +502,7 @@ func (a *rethinkAPIServer) getMessageByPrimaryKey(table Table, key interface{}, 
 	if cursor.IsNil() {
 		return fmt.Errorf("%v %v not found", table, key)
 	}
-	if cursor.Next(message) {
+	if !cursor.Next(message) {
 		return cursor.Err()
 	}
 	return nil


### PR DESCRIPTION
`Next()` returns false when there's an error.  So it's when `Next()` is false that you want to return `cursor.Err()`.