### PR TITLE
also delete firewall rule in "make clean-google-cluster"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ google-cluster:
 
 clean-google-cluster:
 	gcloud container clusters delete $(CLUSTER_NAME)
+	gcloud compute firewall-rules delete pachd
 	gsutil -m rm -r gs://$(BUCKET_NAME)
 	gcloud compute disks delete $(STORAGE_NAME)
 


### PR DESCRIPTION
To ensure there isn't any leftover in Google Container Engine after "make clean-google-cluster"