### PR TITLE
Point doc/README.md at read the docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,21 +1,3 @@
-# Pachyderm Documentation #
+# Docs
 
-[Deploying Pachyderm](https://github.com/pachyderm/pachyderm/blob/master/doc/deploying_setup.md)
-
-[Quickstart Guide](../examples/fruit_stand/README.md)
-
-[Pachctl CLI](pachctl)
-
-[Golang Client](https://godoc.org/github.com/pachyderm/pachyderm/src/client)
-
-[Frequently Asked Questions](FAQ.md)
-
-[Use Cases](https://pachyderm.io/use_cases.html)
-
-[Pachyderm Design Goals](https://pachyderm.io/dsbor.html)
-
-[Pipeline Specification](pipeline_spec.md)
-
-[Miscellaneous](miscellaneous.md)
-
-
+[Refer here for our Developer Docs](http://pachyderm.readthedocs.io)


### PR DESCRIPTION
Read the docs is the canonical place to _view_ the docs.

This was confusing to users, because as is the readme used github links to point at the github versions of the markdown files. But some links won't work on GH, only on read the docs.