### PR TITLE
Accidentally added an illegal flag to proto build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ docker-build-fruitstand:
 docker-build: docker-build-job-shim docker-build-pachd docker-build-fruitstand docker-wait-job-shim docker-wait-pachd
 
 docker-build-proto:
-	docker build -d -t pachyderm_proto etc/proto
+	docker build -t pachyderm_proto etc/proto
 
 docker-push-job-shim: docker-build-job-shim
 	docker push pachyderm/job-shim


### PR DESCRIPTION
`-d` doesn't work in build. I inadvertently added it in the smarter compile pr.