### PR TITLE
Don't log errors when files aren't found.

### DIFF
--- a/src/server/pfs/fuse/filesystem.go
+++ b/src/server/pfs/fuse/filesystem.go
@@ -96,7 +96,7 @@ func (d *directory) Attr(ctx context.Context, a *fuse.Attr) (retErr error) {
 
 func (d *directory) Lookup(ctx context.Context, name string) (result fs.Node, retErr error) {
 	defer func() {
-		if retErr == nil {
+		if retErr == nil || retErr == fuse.ENOENT {
 			protolion.Debug(&DirectoryLookup{&d.Node, name, getNode(result), errorToString(retErr)})
 		} else {
 			protolion.Error(&DirectoryLookup{&d.Node, name, getNode(result), errorToString(retErr)})


### PR DESCRIPTION
This error message has been confusing people. With this patch it's considered an Info log rather than an Error log.