### PR TITLE
Branch in fuse

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -540,7 +540,7 @@ Put the data from a URL as repo/commit/url_path:
 		}),
 	}
 	addShardFlags(mount)
-	finishCommit.Flags().BoolVarP(&debug, "debug", "d", false, "turn on debug messages")
+	mount.Flags().BoolVarP(&debug, "debug", "d", false, "turn on debug messages")
 
 	var result []*cobra.Command
 	result = append(result, repo)

--- a/src/server/pfs/fuse/filesystem.go
+++ b/src/server/pfs/fuse/filesystem.go
@@ -647,9 +647,16 @@ func (d *directory) readCommits(ctx context.Context) ([]fuse.Dirent, error) {
 	if err != nil {
 		return nil, err
 	}
+	branchCommitInfos, err := d.fs.apiClient.ListBranch(d.File.Commit.Repo.Name)
+	if err != nil {
+		return nil, err
+	}
 	var result []fuse.Dirent
 	for _, commitInfo := range commitInfos {
 		result = append(result, fuse.Dirent{Name: commitInfo.Commit.ID, Type: fuse.DT_Dir})
+	}
+	for _, commitInfo := range branchCommitInfos {
+		result = append(result, fuse.Dirent{Name: commitInfo.Branch, Type: fuse.DT_Dir})
 	}
 	return result, nil
 }

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -702,6 +702,25 @@ func TestReadCancelledCommit(t *testing.T) {
 	})
 }
 
+func TestListBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipped because of short mode")
+	}
+
+	testFuse(t, func(c client.APIClient, mountpoint string) {
+		repo := "TestListBranch"
+		require.NoError(t, c.CreateRepo(repo))
+		commit, err := c.StartCommit(repo, "", "master")
+		_, err = c.PutFile(repo, commit.ID, "file", strings.NewReader("foo\n"))
+		require.NoError(t, c.FinishCommit(repo, commit.ID))
+		dirs, err := ioutil.ReadDir(filepath.Join(mountpoint, repo))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(dirs))
+		require.OneOfEquals(t, commit.ID, []interface{}{dirs[0].Name(), dirs[1].Name()})
+		require.OneOfEquals(t, "master", []interface{}{dirs[0].Name(), dirs[1].Name()})
+	})
+}
+
 func testFuse(
 	t *testing.T,
 	test func(client client.APIClient, mountpoint string),

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -16,6 +16,7 @@ import (
 	pfsserver "github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 
+	"go.pedge.io/lion"
 	"go.pedge.io/pb/go/google/protobuf"
 	"go.pedge.io/proto/rpclog"
 	"go.pedge.io/proto/stream"
@@ -294,7 +295,10 @@ func (a *apiServer) InspectCommit(ctx context.Context, request *pfs.InspectCommi
 
 	commitInfos = pfsserver.ReduceCommitInfos(commitInfos)
 
-	if len(commitInfos) != 1 || commitInfos[0].Commit.ID != request.Commit.ID {
+	if len(commitInfos) != 1 ||
+		(commitInfos[0].Commit.ID != request.Commit.ID &&
+			commitInfos[0].Branch != request.Commit.ID) {
+		lion.Printf("commitInfos: %+v", commitInfos)
 		return nil, fmt.Errorf("incorrect commit returned (this is likely a bug)")
 	}
 

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -16,7 +16,6 @@ import (
 	pfsserver "github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 
-	"go.pedge.io/lion"
 	"go.pedge.io/pb/go/google/protobuf"
 	"go.pedge.io/proto/rpclog"
 	"go.pedge.io/proto/stream"
@@ -298,7 +297,6 @@ func (a *apiServer) InspectCommit(ctx context.Context, request *pfs.InspectCommi
 	if len(commitInfos) != 1 ||
 		(commitInfos[0].Commit.ID != request.Commit.ID &&
 			commitInfos[0].Branch != request.Commit.ID) {
-		lion.Printf("commitInfos: %+v", commitInfos)
 		return nil, fmt.Errorf("incorrect commit returned (this is likely a bug)")
 	}
 


### PR DESCRIPTION
Makes it so that when you mount locally you'll see `/pfs/repo/branch` as well as `/pfs/repo/commitID` this only works in local mounts, it doesn't work in jobs.