### PR TITLE
AWS deployment script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ amazon-cluster-manifest:
 	@pach-deploy amazon $(BUCKET_NAME) $(AWS_ID) $(AWS_KEY) $(AWS_TOKEN) $(AWS_REGION) $(STORAGE_NAME) $(STORAGE_SIZE)
 
 amazon-cluster:
-	aws s3api create-bucket --bucket $(BUCKET_NAME) --region $(AWS_REGION)
+	aws s3api create-bucket --bucket $(BUCKET_NAME) --create-bucket-configuration LocationConstraint=$(AWS_REGION)
 	aws ec2 create-volume --size $(STORAGE_SIZE) --region $(AWS_REGION) --availability-zone $(AWS_AVAILABILITY_ZONE) --volume-type gp2
 
 clean-amazon-cluster:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-#ma
-### VARIABLES
+#### VARIABLES
 # RUNARGS: arguments for run
 # DOCKER_OPTS: docker-compose options for run, test, launch-*
 # TESTPKGS: packages for test, default ./src/...
@@ -117,10 +116,7 @@ docker-build-pachd: docker-clean-pachd docker-build-compile
 docker-wait-pachd:
 	docker wait pachd_compile
 
-docker-build-fruitstand:
-	docker build -t fruit_stand examples/fruit_stand
-
-docker-build: docker-build-job-shim docker-build-pachd docker-wait-job-shim docker-wait-pachd docker-build-fruitstand 
+docker-build: docker-build-job-shim docker-build-pachd docker-wait-job-shim docker-wait-pachd
 
 docker-build-proto:
 	docker build -t pachyderm_proto etc/proto
@@ -263,7 +259,6 @@ amazon-cluster-manifest:
 	@pach-deploy amazon $(BUCKET_NAME) $(AWS_ID) $(AWS_KEY) $(AWS_TOKEN) $(AWS_REGION) $(STORAGE_NAME) $(STORAGE_SIZE)
 
 amazon-cluster:
-	#aws s3api create-bucket --bucket $(BUCKET_NAME) --region $(AWS_REGION)
 	aws s3api create-bucket --bucket $(BUCKET_NAME) --create-bucket-configuration LocationConstraint=$(AWS_REGION)
 	aws ec2 create-volume --size $(STORAGE_SIZE) --region $(AWS_REGION) --availability-zone $(AWS_AVAILABILITY_ZONE) --volume-type gp2
 
@@ -337,7 +332,6 @@ goxc-build:
 	docker-build-pachd \
 	docker-build \
 	docker-build-proto \
-	docker-build-fruitstand \
 	docker-push-job-shim \
 	docker-push-pachd \
 	docker-push \

--- a/Makefile
+++ b/Makefile
@@ -145,14 +145,14 @@ clean-launch-kube:
 
 launch: check-kubectl
 	$(eval STARTTIME := $(shell date +%s))
-	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST) --validate=false
+	kubectl $(KUBECTLFLAGS) create -f $(MANIFEST)
 	# wait for the pachyderm to come up
 	until timeout 1s ./etc/kube/check_pachd_ready.sh; do sleep 1; done
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
 launch-dev: check-kubectl install
 	$(eval STARTTIME := $(shell date +%s))
-	kubectl $(KUBECTLFLAGS) create -f $(DEV_MANIFEST) --validate=false
+	kubectl $(KUBECTLFLAGS) create -f $(DEV_MANIFEST)
 	# wait for the pachyderm to come up
 	until timeout 1s ./etc/kube/check_pachd_ready.sh; do sleep 1; done
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/doc/deploying_setup.md
+++ b/doc/deploying_setup.md
@@ -143,7 +143,7 @@ Deploying Kubernetes on AWS is still a relatively lengthy and manual process com
 First of all, set these environment variables:
 
 ```shell
-$ export KUBECTLFLAGS="-s [the IP address of the node where Kubernetes runs]"
+$ export KUBECTLFLAGS="-s [the Public IP address of the node where Kubernetes-master runs]"
 $ export BUCKET_NAME=[the name of the bucket where your data will be stored; this name needs to be unique across the entire AWS region]
 $ export STORAGE_SIZE=[the size of the EBS volume that you are going to create, in GBs]
 $ export AWS_REGION=[the AWS region where you want the bucket and EBS volume to reside]
@@ -184,7 +184,13 @@ $ AWS_ID=[access key ID] AWS_KEY=[secret access key] AWS_TOKEN=[session token] m
 $ make MANIFEST=manifest launch
 ```
 
-It may take a while to complete for the first time, as a lot of Docker images need to be pulled.
+It may take a while to complete for the first time, as a lot of Docker images need to be pulled. User can tear down the pachyderm bu running:
+
+```shell
+$ make amazon-clean$
+```
+
+It may take about 30 seconds to delete the pachyderm components.
 
 # OpenShift
 


### PR DESCRIPTION
A request is pulled to revise the `Makefile` in order to be compatible with AWS client.

First Part:
The original script would lead to a fatal error `IllegalLocationConstraintException`
```
amazon-cluster:
        #aws s3api create-bucket --bucket $(BUCKET_NAME) --region $(AWS_REGION)
        aws ec2 create-volume --size $(STORAGE_SIZE) --region $(AWS_REGION) --availability-zone $(AWS_AVAILABILITY_ZONE) --volume-type gp2
```

I suggest to revise the script to
```
amazon-cluster:
        aws s3api create-bucket --bucket $(BUCKET_NAME) --create-bucket-configuration LocationConstraint=$(AWS_REGION)
        aws ec2 create-volume --size $(STORAGE_SIZE) --region $(AWS_REGION) --availability-zone $(AWS_AVAILABILITY_ZONE) --volume-type gp2
```

The new script has been checked and it works for following process.
Similar issues are also reported to aws_cli team. The reference here (https://github.com/aws/aws-cli/issues/589)
The option used in the original script is not allowed in aws client reference. http://kubernetes.io/docs/user-guide/kubectl/kubectl_create/

fix #706 

Second Part:
The Makefile is not effective enough in the section clean-amazon-cluster. Several components remained undeleted after make clean-launch and make clean-amazon-cluster. I suggest to add a amazon-clean-launch section to clearly delete the pachyderm component. Also the readme.md is revised to display the change.

fix #708 

Note:  Some version mismatching occurred in my commits, it has been corrected in the final one. Thanks. 