### PR TITLE
Update Dockerfile to use go 1.7 instead of go 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   curl -sSL https://github.com/docker/compose/releases/download/1.5.0rc2/docker-compose-Linux-x86_64 > /bin/docker-compose && \
   chmod +x /bin/docker-compose
 RUN \
-  curl -sSL https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz | tar -C /usr/local -xz && \
+  curl -sSL https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz | tar -C /usr/local -xz && \
   mkdir -p /go/bin
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go


### PR DESCRIPTION
This seems to just work. Unfortunately, docker-compose is used by `etc/compile/compile.sh`, which is used by `make docker-build-pachd` and `make docker-build-job-shim` so I had to leave that in for now