### PR TITLE
No archived commits in fuse

### DIFF
--- a/src/server/cmd/job-shim/main.go
+++ b/src/server/cmd/job-shim/main.go
@@ -90,6 +90,7 @@ func do(appEnvObj interface{}) error {
 					response.CommitMounts,
 					ready,
 					response.Transform.Debug,
+					false,
 				); err != nil {
 					errCh <- err
 				}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -577,6 +577,7 @@ Files and URLs should be newline delimited.
 	}
 
 	var debug bool
+	var allCommits bool
 	mount := &cobra.Command{
 		Use:   "mount path/to/mount/point",
 		Short: "Mount pfs locally. This command blocks.",
@@ -593,7 +594,7 @@ Files and URLs should be newline delimited.
 				<-ready
 				fmt.Println("Filesystem mounted, CTRL-C to exit.")
 			}()
-			err = mounter.Mount(mountPoint, shard(), nil, ready, debug)
+			err = mounter.Mount(mountPoint, shard(), nil, ready, debug, allCommits)
 			if err != nil {
 				return err
 			}
@@ -601,7 +602,8 @@ Files and URLs should be newline delimited.
 		}),
 	}
 	addShardFlags(mount)
-	mount.Flags().BoolVarP(&debug, "debug", "d", false, "turn on debug messages")
+	mount.Flags().BoolVarP(&debug, "debug", "d", false, "Turn on debug messages.")
+	mount.Flags().BoolVarP(&allCommits, "all-commits", "a", false, "Show archived and cancelled commits.")
 
 	archiveAll := &cobra.Command{
 		Use:   "archive-all",

--- a/src/server/pfs/fuse/filesystem_seek_mac_test.go
+++ b/src/server/pfs/fuse/filesystem_seek_mac_test.go
@@ -73,7 +73,7 @@ func TestSeekRead(t *testing.T) {
 
 		fmt.Printf("==== Read word len %v : %v\n", n2, string(word2))
 
-	})
+	}, false)
 }
 
 func TestSeekWriteGap(t *testing.T) {
@@ -121,7 +121,7 @@ func TestSeekWriteGap(t *testing.T) {
 		require.Equal(t, 3, n1)
 
 		require.NoError(t, c.FinishCommit(repo, commit.ID))
-	})
+	}, false)
 }
 
 func TestSeekWriteBackwards(t *testing.T) {
@@ -171,5 +171,5 @@ func TestSeekWriteBackwards(t *testing.T) {
 		fmt.Printf("==== %v - write word len %v\n", time.Now(), n1)
 
 		require.NoError(t, c.FinishCommit(repo, commit.ID))
-	})
+	}, false)
 }

--- a/src/server/pfs/fuse/filesystem_seek_test.go
+++ b/src/server/pfs/fuse/filesystem_seek_test.go
@@ -65,7 +65,7 @@ func TestSeekRead(t *testing.T) {
 
 		fmt.Printf("==== Read word len %v : %v\n", n2, string(word2)) */
 
-	})
+	}, false)
 }
 
 func TestSeekWriteGap(t *testing.T) {
@@ -108,7 +108,7 @@ func TestSeekWriteGap(t *testing.T) {
 		require.Equal(t, 3, n1)
 
 		require.NoError(t, c.FinishCommit(repo, commit.ID)) */
-	})
+	}, false)
 }
 
 func TestSeekWriteBackwards(t *testing.T) {
@@ -153,5 +153,5 @@ func TestSeekWriteBackwards(t *testing.T) {
 		fmt.Printf("==== %v - write word len %v\n", time.Now(), n1)
 
 		require.NoError(t, c.FinishCommit(repo, commit.ID)) */
-	})
+	}, false)
 }

--- a/src/server/pfs/fuse/fuse.go
+++ b/src/server/pfs/fuse/fuse.go
@@ -14,6 +14,7 @@ type Mounter interface {
 		commitMounts []*CommitMount, // nil means mount all commits
 		ready chan bool,
 		debug bool,
+		allCommits bool,
 	) error
 
 	Mount(
@@ -22,6 +23,7 @@ type Mounter interface {
 		commitMounts []*CommitMount, // nil means mount all commits
 		ready chan bool,
 		debug bool,
+		allCommits bool,
 	) error
 	// Unmount unmounts a mounted filesystem (duh).
 	// There's nothing special about this unmount, it's just doing a syscall under the hood.

--- a/src/server/pfs/fuse/mounter.go
+++ b/src/server/pfs/fuse/mounter.go
@@ -34,11 +34,12 @@ func (m *mounter) MountAndCreate(
 	commitMounts []*CommitMount,
 	ready chan bool,
 	debug bool,
+	allCommits bool,
 ) error {
 	if err := os.MkdirAll(mountPoint, 0777); err != nil {
 		return err
 	}
-	return m.Mount(mountPoint, shard, commitMounts, ready, debug)
+	return m.Mount(mountPoint, shard, commitMounts, ready, debug, allCommits)
 }
 
 func (m *mounter) Mount(
@@ -47,6 +48,7 @@ func (m *mounter) Mount(
 	commitMounts []*CommitMount,
 	ready chan bool,
 	debug bool,
+	allCommits bool,
 ) (retErr error) {
 	var once sync.Once
 	defer once.Do(func() {
@@ -89,7 +91,7 @@ func (m *mounter) Mount(
 	if debug {
 		config.Debug = func(msg interface{}) { lion.Printf("%+v", msg) }
 	}
-	if err := fs.New(conn, config).Serve(newFilesystem(m.apiClient, shard, commitMounts)); err != nil {
+	if err := fs.New(conn, config).Serve(newFilesystem(m.apiClient, shard, commitMounts, allCommits)); err != nil {
 		return err
 	}
 	<-conn.Ready


### PR DESCRIPTION
Changes the default with fuse mounts to not show archived and cancelled commits.
You can get the old behavior back with a flag. `-a`