### PR TITLE
Fix compile errors from API change

### DIFF
--- a/src/server/pfs/fuse/filesystem_seek_mac_test.go
+++ b/src/server/pfs/fuse/filesystem_seek_mac_test.go
@@ -1,6 +1,6 @@
 // +build darwin
 
-package fuse_test
+package fuse
 
 import (
 	"fmt"
@@ -27,7 +27,7 @@ func TestSeekRead(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "", "")
+		commit, err := c.StartCommit(repo, "")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file")
 		file, err := os.Create(path)
@@ -84,7 +84,7 @@ func TestSeekWriteGap(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "", "")
+		commit, err := c.StartCommit(repo, "")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file")
 		file, err := os.Create(path)
@@ -132,7 +132,7 @@ func TestSeekWriteBackwards(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "", "")
+		commit, err := c.StartCommit(repo, "")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file")
 		file, err := os.Create(path)

--- a/src/server/pfs/fuse/filesystem_seek_mac_test.go
+++ b/src/server/pfs/fuse/filesystem_seek_mac_test.go
@@ -27,7 +27,7 @@ func TestSeekRead(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "")
+		commit, err := c.StartCommit(repo, "master")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file")
 		file, err := os.Create(path)
@@ -84,7 +84,7 @@ func TestSeekWriteGap(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "")
+		commit, err := c.StartCommit(repo, "master")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file")
 		file, err := os.Create(path)
@@ -132,7 +132,7 @@ func TestSeekWriteBackwards(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "")
+		commit, err := c.StartCommit(repo, "master")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file")
 		file, err := os.Create(path)

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -325,7 +325,7 @@ func TestBigCopy(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "", "")
+		commit, err := c.StartCommit(repo, "")
 		require.NoError(t, err)
 		path := filepath.Join(mountpoint, repo, commit.ID, "file1")
 		rawMessage := "Some\ncontent\nblah\nblah\nyup\nnope\nuh-huh.\n"

--- a/src/server/pfs/fuse/filesystem_test.go
+++ b/src/server/pfs/fuse/filesystem_test.go
@@ -325,9 +325,9 @@ func TestBigCopy(t *testing.T) {
 	testFuse(t, func(c client.APIClient, mountpoint string) {
 		repo := "test"
 		require.NoError(t, c.CreateRepo(repo))
-		commit, err := c.StartCommit(repo, "")
+		commit, err := c.StartCommit(repo, "master")
 		require.NoError(t, err)
-		path := filepath.Join(mountpoint, repo, commit.ID, "file1")
+		path := filepath.Join(mountpoint, repo, commitIDToPath(commit.ID), "file1")
 		rawMessage := "Some\ncontent\nblah\nblah\nyup\nnope\nuh-huh.\n"
 		// Write a big blob that would normally not fit in a block
 		var expectedOutput []byte


### PR DESCRIPTION
The mac file system ones are easy to miss ... since they only run on os x.

The other one in `filesystem.go` was from a recent PR of mine that got merged (w a net new test)