### PR TITLE
Fix pipeline spec manifests

### DIFF
--- a/doc/examples/fruit_stand/pipeline.json
+++ b/doc/examples/fruit_stand/pipeline.json
@@ -10,7 +10,10 @@
         "done"
     ]
   },
-  "parallelism": "1",
+  "parallelism_spec" {
+    "strategy": "CONSTANT",
+    "constant": 1
+  },
   "inputs": [
     {
       "repo": {
@@ -32,7 +35,10 @@
         "done"
     ]
   },
-  "parallelism": "1",
+  "parallelism_spec" {
+    "strategy": "CONSTANT",
+    "constant": 1
+  },
   "inputs": [
     {
       "repo": {

--- a/doc/examples/opencv/edges.json
+++ b/doc/examples/opencv/edges.json
@@ -6,7 +6,10 @@
     "cmd": [ "python3", "/edges.py" ],
     "image": "opencv"
   },
-  "parallelism": "1",
+  "parallelism_spec": {
+    "strategy": "CONSTANT",
+    "constant": "1"
+  },
   "inputs": [
     {
       "repo": {

--- a/doc/examples/opencv_dominant_color/opencv-pipeline.json
+++ b/doc/examples/opencv_dominant_color/opencv-pipeline.json
@@ -11,7 +11,10 @@
       "./dominant_color -images_file /pfs/images/images -aws_bucket_name [your aws s3 bucket of images] >> /pfs/out/opencv"
     ]
   },
-  "parallelism": "1",
+  "parallelism_spec" {
+    "strategy": "CONSTANT",
+    "constant": 1
+  },
   "inputs": [
     {
       "repo": {

--- a/doc/examples/scraper/scraper.json
+++ b/doc/examples/scraper/scraper.json
@@ -18,7 +18,10 @@
     ],
     "acceptReturnCode": [4,5,6,7,8]
   },
-  "parallelism": "1",
+  "parallelism_spec" {
+    "strategy": "CONSTANT",
+    "constant": 1
+  },
   "inputs": [
     {
       "repo": {

--- a/doc/examples/word_count/pipeline.json
+++ b/doc/examples/word_count/pipeline.json
@@ -17,7 +17,10 @@
     ],
     "acceptReturnCode": [4,5,6,7,8]
   },
-  "parallelism": 1
+  "parallelism_spec" {
+    "strategy": "CONSTANT",
+    "constant": 1
+  },
 }
 {
   "pipeline": {


### PR DESCRIPTION
Replace "parallelism" with "parallelism_spec" in all of our example pipeline manifests