### PR TITLE
Hash file path to generate diff IDs

### DIFF
--- a/src/server/pfs/db/driver.go
+++ b/src/server/pfs/db/driver.go
@@ -1061,8 +1061,20 @@ func (d *driver) checkFileType(repo string, commit string, path string, typ pers
 	return nil
 }
 
+// checkPath checks if a file path is legal
+func checkPath(path string) error {
+	if strings.Contains(path, "\x00") {
+		return fmt.Errorf("filename cannot contain null character: %s", path)
+	}
+	return nil
+}
+
 func (d *driver) PutFile(file *pfs.File, delimiter pfs.Delimiter, reader io.Reader) (retErr error) {
 	fixPath(file)
+	if err := checkPath(file.Path); err != nil {
+		return err
+	}
+
 	// TODO: eventually optimize this with a cache so that we don't have to
 	// go to the database to figure out if the commit exists
 	commit, err := d.getRawCommit(file.Commit)

--- a/src/server/pfs/db/driver.go
+++ b/src/server/pfs/db/driver.go
@@ -1,6 +1,8 @@
 package persist
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -1165,12 +1167,9 @@ func getPrefixes(path string) []string {
 }
 
 func getDiffID(commitID string, path string) string {
-	return fmt.Sprintf("%s:%s", commitID, path)
-}
-
-// the equivalent of above except that commitID is a rethink term
-func getDiffIDFromTerm(commitID gorethink.Term, path string) gorethink.Term {
-	return commitID.Add(":" + path)
+	s := fmt.Sprintf("%s:%s", commitID, path)
+	hash := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(hash[:])
 }
 
 func (d *driver) MakeDirectory(file *pfs.File) (retErr error) {

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -1723,22 +1723,6 @@ func TestPutFileWithNoDelimiter(t *testing.T) {
 
 }
 
-func TestPutFileNullCharacter(t *testing.T) {
-	t.Parallel()
-	client := getClient(t)
-
-	repo := "test"
-	require.NoError(t, client.CreateRepo(repo))
-
-	commit, err := client.StartCommit(repo, "master")
-	require.NoError(t, err)
-
-	_, err = client.PutFile(repo, commit.ID, "foo\x00bar", strings.NewReader("foobar\n"))
-	// null characters error because when you `ls` files with null characters
-	// they truncate things after the null character leading to strange results
-	require.YesError(t, err)
-}
-
 func TestArchiveCommit(t *testing.T) {
 	t.Parallel()
 	client := getClient(t)

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -1720,7 +1720,22 @@ func TestPutFileWithNoDelimiter(t *testing.T) {
 		}
 		require.EqualOneOf(t, blockLengths, buffer.Len())
 	}
+}
 
+func TestPutFileNullCharacter(t *testing.T) {
+	t.Parallel()
+	client := getClient(t)
+
+	repo := "test"
+	require.NoError(t, client.CreateRepo(repo))
+
+	commit, err := client.StartCommit(repo, "master")
+	require.NoError(t, err)
+
+	_, err = client.PutFile(repo, commit.ID, "foo\x00bar", strings.NewReader("foobar\n"))
+	// null characters error because when you `ls` files with null characters
+	// they truncate things after the null character leading to strange results
+	require.YesError(t, err)
 }
 
 func TestArchiveCommit(t *testing.T) {

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -534,6 +534,25 @@ func TestPutFile(t *testing.T) {
 	require.YesError(t, client.GetFile(repo, commit4.ID, "dir2", 0, 0, "", false, nil, &buffer))
 }
 
+func TestPutFileLongName(t *testing.T) {
+	t.Parallel()
+	client := getClient(t)
+
+	repo := "test"
+	require.NoError(t, client.CreateRepo(repo))
+
+	fileName := `oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)oaidhzoshd()&)(@*^$@(#)oandoancoasid1)(&@$)(@U)`
+
+	commit, err := client.StartCommit(repo, "master")
+	require.NoError(t, err)
+	_, err = client.PutFile(repo, commit.ID, fileName, strings.NewReader("foo\n"))
+	require.NoError(t, client.FinishCommit(repo, commit.ID))
+
+	var buffer bytes.Buffer
+	require.NoError(t, client.GetFile(repo, commit.ID, fileName, 0, 0, "", false, nil, &buffer))
+	require.Equal(t, "foo\n", buffer.String())
+}
+
 func TestListFileTwoCommits(t *testing.T) {
 	t.Parallel()
 	client := getClient(t)


### PR DESCRIPTION
Fix #820 

Also fixed the issue where filenames couldn't contain special characters.