### PR TITLE
Get rid of translation of protobuf enums from JSON

### DIFF
--- a/doc/examples/fruit_stand/pipeline.json
+++ b/doc/examples/fruit_stand/pipeline.json
@@ -45,7 +45,7 @@
         "name": "filter"
       },
       "method": {
-        "partition": "file",
+        "partition": "FILE",
         "incremental": "DIFF"
       }
     }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -539,25 +539,6 @@ func replaceMethodAliases(decoder *json.Decoder) (string, error) {
 			} else {
 				return "", fmt.Errorf("unrecognized input alias: %s", methodAlias)
 			}
-		} else {
-			if !(input.ExistsP("method.partition") && input.ExistsP("method.incremental")) {
-				return "", fmt.Errorf("an input method needs to be either a string alias or a json object; please read the pipeline specification for details")
-			}
-			partition, ok := input.S("method", "partition").Data().(string)
-			if ok {
-				switch partition {
-				case "block":
-					input.SetP(ppsclient.Partition_BLOCK, "method.partition")
-				case "file":
-					input.SetP(ppsclient.Partition_FILE, "method.partition")
-				case "repo":
-					input.SetP(ppsclient.Partition_REPO, "method.partition")
-				default:
-					return "", fmt.Errorf("partition needs to be 'block', 'file', or 'repo'; got %s instead", partition)
-				}
-			} else {
-				return "", fmt.Errorf("partition needs to be a string")
-			}
 		}
 	}
 


### PR DESCRIPTION
Protobuf parser will parse enums if they're all-caps