### PR TITLE
Make sure that the hash includes repo name; also use a uuid for diff …

### DIFF
--- a/src/server/pfs/db/driver.go
+++ b/src/server/pfs/db/driver.go
@@ -1106,7 +1106,7 @@ func (d *driver) PutFile(file *pfs.File, delimiter pfs.Delimiter, reader io.Read
 	// the ancestor directories
 	for _, prefix := range getPrefixes(file.Path) {
 		diffs = append(diffs, &persist.Diff{
-			ID:       getDiffID(commit.ID, prefix),
+			ID:       getDiffID(commit.Repo, commit.ID, prefix),
 			Repo:     commit.Repo,
 			Delete:   false,
 			Path:     prefix,
@@ -1118,7 +1118,7 @@ func (d *driver) PutFile(file *pfs.File, delimiter pfs.Delimiter, reader io.Read
 
 	// the file itself
 	diffs = append(diffs, &persist.Diff{
-		ID:        getDiffID(commit.ID, file.Path),
+		ID:        getDiffID(commit.Repo, commit.ID, file.Path),
 		Repo:      commit.Repo,
 		Delete:    false,
 		Path:      file.Path,
@@ -1178,8 +1178,8 @@ func getPrefixes(path string) []string {
 	return res
 }
 
-func getDiffID(commitID string, path string) string {
-	s := fmt.Sprintf("%s:%s", commitID, path)
+func getDiffID(repo string, commitID string, path string) string {
+	s := fmt.Sprintf("%s:%s:%s", commitID, path)
 	hash := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(hash[:])
 }
@@ -1199,7 +1199,7 @@ func (d *driver) MakeDirectory(file *pfs.File) (retErr error) {
 	}
 
 	diff := &persist.Diff{
-		ID:       getDiffID(commit.ID, file.Path),
+		ID:       getDiffID(commit.Repo, commit.ID, file.Path),
 		Repo:     commit.Repo,
 		Delete:   false,
 		Path:     file.Path,
@@ -1535,9 +1535,12 @@ func (d *driver) SquashCommit(fromCommits []*pfs.Commit, toCommit *pfs.Commit) e
 
 	_, err = d.getTerm(diffTable).Insert(diffs.Merge(func(diff gorethink.Term) map[string]interface{} {
 		return map[string]interface{}{
-			// diff IDs are of the form:
-			// commitID:path
-			"ID":    gorethink.Expr(toCommit.ID).Add(":", diff.Field("Path")),
+			// the ID doesn't matter anymore, because the only reason why it had
+			// to be a hash of (repo+commit+path) in PutFile is that we want
+			// multiple clients writting the same file to be modifying the same
+			// Diff.  But in Squash and Replay, the Diffs are not supposed to
+			// be mutated anymore.
+			"ID":    gorethink.UUID(),
 			"Clock": newClock,
 		}
 	})).RunWrite(d.dbClient)
@@ -1608,7 +1611,7 @@ func (d *driver) ReplayCommit(fromCommits []*pfs.Commit, toBranch string) ([]*pf
 		// TODO: conflict detection
 		_, err = d.getTerm(diffTable).Insert(d.getTerm(diffTable).GetAllByIndex(DiffClockIndex.Name, diffClockIndexKey(repo, oldClock.Branch, oldClock.Clock)).Merge(func(diff gorethink.Term) map[string]interface{} {
 			return map[string]interface{}{
-				"ID":    gorethink.Expr(newCommit.ID).Add(":", diff.Field("Path")),
+				"ID":    gorethink.UUID(),
 				"Clock": newClock,
 			}
 		})).RunWrite(d.dbClient)
@@ -1970,7 +1973,7 @@ func (d *driver) DeleteFile(file *pfs.File) error {
 	var diffs []*persist.Diff
 	for _, path := range paths {
 		diffs = append(diffs, &persist.Diff{
-			ID:        getDiffID(commitID, path),
+			ID:        getDiffID(repo, commitID, path),
 			Repo:      repo,
 			Path:      path,
 			BlockRefs: nil,


### PR DESCRIPTION
…ID when we squash or replay