### PR TITLE
Use custom theme even on RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,14 +128,9 @@ todo_include_todos = True
 # a list of builtin themes.
 #
 #html_theme = 'alabaster'
-import os
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-if on_rtd:
-    html_theme = 'default'
-else:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_theme_options = {
    'collapse_navigation': True,


### PR DESCRIPTION
Now that we've tested it locally we want it on `production' RTD

I've tested this by using a custom version on RTD, and you can [see the link here](http://pachyderm.readthedocs.io/en/debug_rtd/getting_started/getting_started.html)