### PR TITLE
Push the latest tag as well as the versioned one

### DIFF
--- a/etc/build/release_job_shim
+++ b/etc/build/release_job_shim
@@ -12,5 +12,6 @@ make docker-build-job-shim
 make docker-wait-job-shim
 docker tag pachyderm/job-shim:latest pachyderm/job-shim:$VERSION
 docker push pachyderm/job-shim:$VERSION
+docker push pachyderm/job-shim:latest
 
 echo "--- Successfully released job-shim"

--- a/etc/build/release_pachd
+++ b/etc/build/release_pachd
@@ -12,5 +12,6 @@ make docker-build-pachd
 make docker-wait-pachd
 docker tag pachyderm/pachd:latest pachyderm/pachd:$VERSION
 docker push pachyderm/pachd:$VERSION
+docker push pachyderm/pachd:latest
 
 echo "--- Successfully released pachd"


### PR DESCRIPTION
This was a regression @derekchiang caught. We should push the latest tag as well.