### PR TITLE
Fix dev metrics

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd_test.go
+++ b/src/server/cmd/pachctl/cmd/cmd_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	deploycmds "github.com/pachyderm/pachyderm/src/server/pkg/deploy/cmds"
+)
+
+func TestMetrics(t *testing.T) {
+
+	// Run deploy normally, should see METRICS=true
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	os.Args = []string{"deploy", "--dry-run"}
+	err := deploycmds.DeployCmd().Execute()
+	require.NoError(t, err)
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// restore stdout
+	w.Close()
+	os.Stdout = old
+	out := <-outC
+
+	decoder := json.NewDecoder(strings.NewReader(out))
+	for {
+		var jsonObj json.RawMessage
+		err = decoder.Decode(&jsonObj)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		var manifests []interface{}
+		for _, obj := range manifests {
+			manifest, ok := obj.(map[string]interface{})
+			require.Equal(t, true, ok)
+			metadata, ok := manifest["metadata"].(map[string]interface{})
+			require.Equal(t, true, ok)
+			name, ok := metadata["name"].(string)
+			require.Equal(t, true, ok)
+
+			if name == "pachd" {
+				spec, ok := manifest["spec"].(map[string]interface{})
+				require.Equal(t, true, ok)
+				template, ok := spec["template"].(map[string]interface{})
+				require.Equal(t, true, ok)
+				innerSpec, ok := template["spec"].(map[string]interface{})
+				require.Equal(t, true, ok)
+				containers, ok := innerSpec["containers"].([]interface{})
+				require.Equal(t, true, ok)
+				container, ok := containers[0].(map[string]interface{})
+				require.Equal(t, true, ok)
+				env, ok := container["env"].([]interface{})
+				require.Equal(t, true, ok)
+				metricsSetToTrue := map[string]string{
+					"name":  "METRICS",
+					"value": "true",
+				}
+				fmt.Printf("env: %v\n", env)
+				require.OneOfEquals(t, metricsSetToTrue, env)
+			}
+		}
+	}
+
+	// Run deploy w dev flag, should see METRICS=false
+}

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -63,7 +63,7 @@ func PachdRc(shards uint64, backend backend, hostPath string, version string) *a
 	// we turn metrics on only if we have a static version this prevents dev
 	// clusters from reporting metrics
 	metrics := "true"
-	if version == "" {
+	if version == "local" {
 		metrics = "false"
 	}
 	volumes := []api.Volume{

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/pachyderm/pachyderm/src/server/pfs/server"
+	"github.com/pachyderm/pachyderm/src/server/pkg/deploy"
 	"github.com/ugorji/go/codec"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -63,7 +64,7 @@ func PachdRc(shards uint64, backend backend, hostPath string, version string) *a
 	// we turn metrics on only if we have a static version this prevents dev
 	// clusters from reporting metrics
 	metrics := "true"
-	if version == "local" {
+	if version == deploy.DevVersionTag {
 		metrics = "false"
 	}
 	volumes := []api.Volume{

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/pachyderm/pachyderm/src/client/version"
+	"github.com/pachyderm/pachyderm/src/server/pkg/deploy"
 	"github.com/pachyderm/pachyderm/src/server/pkg/deploy/assets"
 	"github.com/spf13/cobra"
 	"go.pedge.io/pkg/cobra"
@@ -27,7 +28,7 @@ func DeployCmd() *cobra.Command {
 		Run: pkgcobra.RunBoundedArgs(pkgcobra.Bounds{Min: 0, Max: 8}, func(args []string) error {
 			version := version.PrettyPrintVersion(version.Version)
 			if dev {
-				version = "local"
+				version = deploy.DevVersionTag
 			}
 			var out io.Writer
 			var manifest bytes.Buffer

--- a/src/server/pkg/deploy/deploy.go
+++ b/src/server/pkg/deploy/deploy.go
@@ -1,3 +1,4 @@
 package deploy // import "github.com/pachyderm/pachyderm/src/server/pkg/deploy"
 
+// DevVersionTag is used to specify and detect that we're using a non-released version of a pachd image
 const DevVersionTag = "local"

--- a/src/server/pkg/deploy/deploy.go
+++ b/src/server/pkg/deploy/deploy.go
@@ -1,1 +1,3 @@
 package deploy // import "github.com/pachyderm/pachyderm/src/server/pkg/deploy"
+
+const DevVersionTag = "local"


### PR DESCRIPTION
This PR fixes metrics -- we have them enabled in dev mode which means our clusters and CI are probably reporting metrics to mixpanel. This was happening (probably) since we updated the way we handle images (using the "local" tag in lieu of the "latest" tag).

And we add a test to make sure that we don't have this regression again. This is the first pachctl CLI test so I put the test under `src/server/cmd/pachctl/cmd` since thats probably the start of where we'll put the [CLI test suite](https://github.com/pachyderm/pachyderm/issues/710), but an argument could be made to put it under `src/server/pkg/deploy/cmds` since thats the only command we're testing. I'm ok either way.