### PR TITLE
Add a benchmark

### DIFF
--- a/src/server/pachyderm_bench_test.go
+++ b/src/server/pachyderm_bench_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	nFiles = 100
-	MB     = 1024 * 1024
+	MB = 1024 * 1024
 )
 
 type CountWriter struct {
@@ -34,6 +33,7 @@ func BenchmarkPachyderm(b *testing.B) {
 	c, err := client.NewInCluster()
 	require.NoError(b, err)
 	require.NoError(b, c.CreateRepo(repo))
+	nFiles := 1000
 
 	commit, err := c.StartCommit(repo, "master")
 	require.NoError(b, err)
@@ -48,7 +48,7 @@ func BenchmarkPachyderm(b *testing.B) {
 					return err
 				})
 			}
-			b.SetBytes(nFiles * MB)
+			b.SetBytes(int64(nFiles * MB))
 			require.NoError(b, eg.Wait())
 		}
 	}) {
@@ -82,7 +82,7 @@ func BenchmarkPachyderm(b *testing.B) {
 				nil,
 				&ppsclient.ParallelismSpec{
 					Strategy: ppsclient.ParallelismSpec_CONSTANT,
-					Constant: 1,
+					Constant: 4,
 				},
 				[]*ppsclient.PipelineInput{{Repo: client.NewRepo(repo)}},
 				false,
@@ -97,6 +97,80 @@ func BenchmarkPachyderm(b *testing.B) {
 			require.NoError(b, err)
 			b.SetBytes(int64(repoInfo.SizeBytes))
 		}
+	}) {
+		return
+	}
+}
+
+func BenchmarkBigPFSWorkload(b *testing.B) {
+	repo := uniqueString("BenchmarkBigPFSWorkload")
+	c, err := client.NewInCluster()
+	require.NoError(b, err)
+	require.NoError(b, c.CreateRepo(repo))
+
+	// We use a Zipf generator to generate file size, because it's been
+	// found that most files in a big-data workload tend to be small.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	zipf := rand.NewZipf(r, 1.1, 1, 20)
+
+	commit1, err := c.StartCommit(repo, "master")
+	require.NoError(b, err)
+	numTopLevelFiles := 1000
+	if !b.Run(fmt.Sprintf("Put%dTopLevelFiles", numTopLevelFiles), func(b *testing.B) {
+		var eg errgroup.Group
+		var totalMB uint64
+		for k := 0; k < numTopLevelFiles; k++ {
+			k := k
+			fileSizeMB := zipf.Uint64() + 1
+			totalMB += fileSizeMB
+			eg.Go(func() error {
+				rand := rand.New(rand.NewSource(int64(time.Now().UnixNano())))
+				_, err := c.PutFile(repo, commit1.ID, fmt.Sprintf("file%d", k), workload.NewReader(rand, int(fileSizeMB*MB)))
+				return err
+			})
+		}
+		b.SetBytes(int64(totalMB * MB))
+		require.NoError(b, eg.Wait())
+	}) {
+		return
+	}
+	require.NoError(b, c.FinishCommit(repo, commit1.ID))
+
+	commit2, err := c.StartCommit(repo, commit1.ID)
+	require.NoError(b, err)
+	numDirs := 10
+	numDeepFiles := 1000
+	if !b.Run(fmt.Sprintf("Put%dDeepFiles", numDeepFiles), func(b *testing.B) {
+		var eg errgroup.Group
+		var totalMB uint64
+		for k := 0; k < numDeepFiles; k++ {
+			k := k
+			fileSizeMB := zipf.Uint64() + 1
+			totalMB += fileSizeMB
+			eg.Go(func() error {
+				rand := rand.New(rand.NewSource(int64(time.Now().UnixNano())))
+				_, err := c.PutFile(repo, commit2.ID, fmt.Sprintf("dir%d/file%d", k%numDirs, k), workload.NewReader(rand, int(fileSizeMB*MB)))
+				return err
+			})
+		}
+		b.SetBytes(int64(totalMB * MB))
+		require.NoError(b, eg.Wait())
+	}) {
+		return
+	}
+	require.NoError(b, c.FinishCommit(repo, commit2.ID))
+
+	if !b.Run(fmt.Sprintf("Get%dTopLevelFiles", numTopLevelFiles), func(b *testing.B) {
+		var eg errgroup.Group
+		w := &CountWriter{}
+		defer func() { b.SetBytes(w.count) }()
+		for k := 0; k < numTopLevelFiles; k++ {
+			k := k
+			eg.Go(func() error {
+				return c.GetFile(repo, commit1.ID, fmt.Sprintf("file%d", k), 0, 0, "", false, nil, w)
+			})
+		}
+		require.NoError(b, eg.Wait())
 	}) {
 		return
 	}


### PR DESCRIPTION
This benchmark is more sophisticated than the old one because:

1. It generates files using a zipf distribution, so that most files tend to be small files with a few big ones.  Not gonna cite sources here but according to a few papers I've read that's how most big-data workloads are.
2. The workload includes nested files (i.e. non-top-level), which we know incur additional overhead.