### PR TITLE
Fix pipeline -f url syntax.

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -72,7 +72,11 @@ func newPipelineManifestReader(path string) (result *pipelineManifestReader, ret
 				retErr = sanitizeErr(err)
 			}
 		}()
-		pipelineReader = resp.Body
+		rawBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		pipelineReader = io.TeeReader(strings.NewReader(string(rawBytes)), &result.buf)
 	} else {
 		rawBytes, err := ioutil.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
Fixes #947 

@msteffen whenever you have a chance. I think you might have introduced this bug, the issue is just that it's deferring a close on `resp.Body` but then also returning that Reader from the function which means that outside the function it's already closed.