### PR TITLE
Don't drop job-shim image tag

### DIFF
--- a/doc/examples/word_count/inputPipeline.json
+++ b/doc/examples/word_count/inputPipeline.json
@@ -3,7 +3,6 @@
     "name": "wordcount_input"
   },
   "transform": {
-    "image": "pachyderm/job-shim",
     "cmd": [ "wget",
         "-e", "robots=off",
         "--recursive",

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1685,7 +1685,9 @@ func job(kubeClient *kube.Client, jobInfo *persist.JobInfo, jobShimImage string,
 	}
 	parallelism := int32(parallelism64)
 	image := jobShimImage
-	if jobInfo.Transform.Image != "" {
+	// If the job image refers to pachyderm/job-shim explicitly, we want to use the version of
+	// job-shim that pachd gets from the JOB_SHIM_IMAGE environment variable
+	if jobInfo.Transform.Image != "" && jobInfo.Transform.Image != "pachyderm/job-shim" {
 		image = jobInfo.Transform.Image
 	}
 	if jobImagePullPolicy == "" {


### PR DESCRIPTION
Don't drop the version tag if the pipeline "image" field explicitly refers to pachyderm/job-shim