### PR TITLE
Makes init job idempotent again.

### DIFF
--- a/src/server/pfs/db/driver.go
+++ b/src/server/pfs/db/driver.go
@@ -118,6 +118,9 @@ func initDB(session *gorethink.Session, dbName string) error {
 	_, err := gorethink.DBCreate(dbName).RunWrite(session)
 	if err != nil && !isDBCreated(err) {
 		return err
+	} else if err != nil && isDBCreated(err) {
+		// This function has already run so we abort.
+		return nil
 	}
 
 	// Create tables

--- a/src/server/pps/persist/server/rethink_api_server.go
+++ b/src/server/pps/persist/server/rethink_api_server.go
@@ -76,6 +76,9 @@ func InitDBs(address string, databaseName string) error {
 	}
 	if _, err := gorethink.DBCreate(databaseName).RunWrite(session); err != nil && !isDBCreated(err) {
 		return err
+	} else if err != nil && isDBCreated(err) {
+		// This function has already run so we abort.
+		return nil
 	}
 	for _, table := range tables {
 		tableCreateOpts, ok := tableToTableCreateOpts[table]


### PR DESCRIPTION
This prevents the annoying scenario where the second time you deploy you're left with an init job in CrashLoop.