### PR TITLE
Fix duplicate file insertiions

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -473,10 +473,11 @@ Files can be read from finished commits with get-file.`,
 			if info.IsDir() {
 				return nil
 			}
-			if len(args) == 3 {
+			if len(args) < 3 {
+				eg.Go(func() error { return cpFile(client, args[0], args[1], path, path) })
+			} else {
 				eg.Go(func() error { return cpFile(client, args[0], args[1], filepath.Join(args[2], path), path) })
 			}
-			eg.Go(func() error { return cpFile(client, args[0], args[1], path, path) })
 			return nil
 		})
 		return eg.Wait()


### PR DESCRIPTION
When providing a path inside pfs to place a directory (using -r with the
3-argument version of put-file), the directory tree is inserted twice. Add an
else clause to eliminate the double insertion.