### PR TITLE
Change our Makefile and .travis.yml to give Travis 60 minutes to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_script:
 - docker version
 script:
 - make lint
-- travis_wait 30 make test
+- travis_wait 60 make test
 notifications:
   slack: pachyderm:qmSCZSX1Q2yWxc6DjNZZFLGd

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CLUSTER_SIZE?=4
 
 ifdef TRAVIS_BUILD_NUMBER
 	# Upper bound for travis test timeout
-	TIMEOUT = 1000s
+	TIMEOUT = 3600s
 else
 ifndef TIMEOUT
 	# You should be able to specify your own timeout, but by default we'll use the same bound as travis


### PR DESCRIPTION
This will hopefully get CI passing consistently again. If we want to shrink the amount of time it takes our tests to run, I think one easy target might be some of the example tests. Word count, for example, takes nearly 10 minutes.