### PR TITLE
Don't run TestParallelismSpec in short mode

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3488,6 +3488,9 @@ func TestChainedPipelinesNoDelay(t *testing.T) {
 }
 
 func TestParallelismSpec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	// Test Constant strategy
 	parellelism, err := pps_server.GetExpectedNumWorkers(getKubeClient(t), &ppsclient.ParallelismSpec{
 		Strategy: ppsclient.ParallelismSpec_CONSTANT,


### PR DESCRIPTION
Since it needs the k8s client to run