### PR TITLE
Minimizes the pachd container image.

### DIFF
--- a/Dockerfile.pachd
+++ b/Dockerfile.pachd
@@ -1,11 +1,6 @@
-FROM ubuntu:14.04
+FROM scratch
 MAINTAINER jdoliner@pachyderm.io
 
-RUN \
-  apt-get update -yq && \
-  apt-get install -yq --no-install-recommends \
-    ca-certificates && \
-  apt-get clean && \
-  rm -rf /var/lib/apt
 ADD ./pachd /
+ADD ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/pachd"]

--- a/etc/compile/compile.sh
+++ b/etc/compile/compile.sh
@@ -10,7 +10,7 @@ LD_FLAGS="${2}"
 PROFILE="${3}"
 
 mkdir -p _tmp
-go build \
+CGO_ENABLED=0 GOOS=linux go build \
   -a \
   -installsuffix netgo \
   -tags netgo \
@@ -24,6 +24,7 @@ echo "LD_FLAGS=$LD_FLAGS"
 if [ -z ${PROFILE} ]
 then
     cp Dockerfile.${BINARY} _tmp/Dockerfile
+    cp /etc/ssl/certs/ca-certificates.crt _tmp/ca-certificates.crt
     docker build -t pachyderm_${BINARY} _tmp
     docker tag pachyderm_${BINARY}:latest pachyderm/${BINARY}:latest
     docker tag pachyderm_${BINARY}:latest pachyderm/${BINARY}:local


### PR DESCRIPTION
Pachd image is now 60MB total and it's probably not getting much smaller since that's nothing more than the go binary and some certificates.