### PR TITLE
Don't even spawn a job if the parent has not completed

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -191,7 +191,13 @@ func (a *apiServer) CreateJob(ctx context.Context, request *ppsclient.CreateJobR
 
 	var parentJobInfo *persist.JobInfo
 	if request.ParentJob != nil {
-		inspectJobRequest := &ppsclient.InspectJobRequest{Job: request.ParentJob}
+		// We Block on our parent's state because the job may access its
+		// parent's output while it's running so we want the job and its output
+		// commit to have finished.
+		inspectJobRequest := &ppsclient.InspectJobRequest{
+			Job:        request.ParentJob,
+			BlockState: true,
+		}
 		parentJobInfo, err = persistClient.InspectJob(ctx, inspectJobRequest)
 		if err != nil {
 			return nil, err
@@ -740,12 +746,8 @@ func (a *apiServer) StartPod(ctx context.Context, request *ppsserver.StartPodReq
 
 	var parentJobInfo *persist.JobInfo
 	if jobInfo.ParentJob != nil {
-		// We Block on our parent's state because the job may access its
-		// parent's output while it's running so we want the job and its output
-		// commit to have finished.
 		inspectJobRequest := &ppsclient.InspectJobRequest{
-			Job:        jobInfo.ParentJob,
-			BlockState: true,
+			Job: jobInfo.ParentJob,
 		}
 		parentJobInfo, err = persistClient.InspectJob(ctx, inspectJobRequest)
 		if err != nil {


### PR DESCRIPTION
Right now even though a job always waits for its parent to complete before it runs, the job is nevertheless spawned and scheduled; it just blocks until its parent completes.  This wastes cluster resources.  This PR makes it so that a job is not even spawned if its parent has not completed.