### PR TITLE
Setup user config prior to pps cmd test suite

### DIFF
--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/fsouza/go-dockerclient"
+	"github.com/pachyderm/pachyderm/src/client/pkg/config"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,11 @@ func testJSONSyntaxErrorsReported(inputFile string, inputFileValue string, input
 }
 
 func testBadJSON(t *testing.T, testName string, inputFile string, inputFileValue string, inputCommand []string, expectedOutput string) {
+
+	// Setup user config prior to test
+	// So that stdout only contains JSON no warnings
+	_, err := config.Read()
+	require.NoError(t, err)
 
 	if os.Getenv("BE_CRASHER") == "1" {
 		testJSONSyntaxErrorsReported(inputFile, inputFileValue, inputCommand)


### PR DESCRIPTION
With the CI upgrade (more cores), it seems that this test suite gets run
earlier than it used to, and the user config in travis isn't setup yet.

This fixes the issue.