### PR TITLE
Print commit duration

### DIFF
--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -47,7 +47,7 @@ Provenance: {{range .Provenance}} {{.Name}} {{end}} {{end}}
 
 // PrintCommitInfoHeader prints a commit info header.
 func PrintCommitInfoHeader(w io.Writer) {
-	fmt.Fprint(w, "BRANCH\tREPO/ID\tPARENT\tSTARTED\tFINISHED\tSIZE\t\n")
+	fmt.Fprint(w, "BRANCH\tREPO/ID\tPARENT\tSTARTED\tDURATION\tSIZE\t\n")
 }
 
 // PrintCommitInfo pretty-prints commit info.
@@ -64,11 +64,11 @@ func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo) {
 		"%s\t",
 		pretty.Ago(commitInfo.Started),
 	)
-	finished := "\t"
+	duration := "-\t"
 	if commitInfo.Finished != nil {
-		finished = fmt.Sprintf("%s\t", pretty.Ago(commitInfo.Finished))
+		duration = fmt.Sprintf("%s\t", pretty.Duration(commitInfo.Started, commitInfo.Finished))
 	}
-	fmt.Fprintf(w, finished)
+	fmt.Fprintf(w, duration)
 	fmt.Fprintf(w, "%s\t\n", units.BytesSize(float64(commitInfo.SizeBytes)))
 }
 


### PR DESCRIPTION
Fixes #1012 

The output of `inspect-commit` now looks like:

```
pachyderm:0$pachctl create-repo foo
pachyderm:0$$GOPATH/bin/pachctl start-commit foo master
master/0
pachyderm:0$$GOPATH/bin/pachctl finish-commit foo master
pachyderm:0$$GOPATH/bin/pachctl list-commit foo
BRANCH              REPO/ID             PARENT              STARTED             DURATION            SIZE                
master              foo/master/0        <none>              10 seconds ago      6 seconds           0 B 
```