### PR TITLE
Fix metrics flag

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -44,8 +44,6 @@ Environment variables:
   ADDRESS=<host>:<port>, the pachd server to connect to (e.g. 127.0.0.1:30650).
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("!!! prerun verbose: %v\n", verbose)
-			fmt.Printf("!!! prerun nometrics: %v\n", noMetrics)
 			if !verbose {
 				// Silence any grpc logs
 				grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
@@ -56,10 +54,6 @@ Environment variables:
 	}
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Output verbose logs")
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
-
-	fmt.Printf("!!! root noMetrics: %v\n", noMetrics)
-	fmt.Printf("!!! root verbose: %v\n", verbose)
-	fmt.Printf("!!! querying a metrics value: %v\n", rootCmd.PersistentFlags().Lookup("no-metrics").Value)
 
 	pfsCmds := pfscmds.Cmds(address, !noMetrics)
 	for _, cmd := range pfsCmds {
@@ -72,7 +66,6 @@ Environment variables:
 	for _, cmd := range ppsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	fmt.Printf("In pachctl cmd, metrics: %v\n", !noMetrics)
 	rootCmd.AddCommand(deploycmds.DeployCmd())
 
 	version := &cobra.Command{

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -55,7 +55,7 @@ Environment variables:
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Output verbose logs")
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
 
-	pfsCmds := pfscmds.Cmds(address, !noMetrics)
+	pfsCmds := pfscmds.Cmds(address, rootCmd)
 	for _, cmd := range pfsCmds {
 		rootCmd.AddCommand(cmd)
 	}

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -44,6 +44,8 @@ Environment variables:
   ADDRESS=<host>:<port>, the pachd server to connect to (e.g. 127.0.0.1:30650).
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("!!! prerun verbose: %v\n", verbose)
+			fmt.Printf("!!! prerun nometrics: %v\n", noMetrics)
 			if !verbose {
 				// Silence any grpc logs
 				grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
@@ -54,6 +56,10 @@ Environment variables:
 	}
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Output verbose logs")
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
+
+	fmt.Printf("!!! root noMetrics: %v\n", noMetrics)
+	fmt.Printf("!!! root verbose: %v\n", verbose)
+	fmt.Printf("!!! querying a metrics value: %v\n", rootCmd.PersistentFlags().Lookup("no-metrics").Value)
 
 	pfsCmds := pfscmds.Cmds(address, !noMetrics)
 	for _, cmd := range pfsCmds {
@@ -66,7 +72,8 @@ Environment variables:
 	for _, cmd := range ppsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	rootCmd.AddCommand(deploycmds.DeployCmd(!noMetrics))
+	fmt.Printf("In pachctl cmd, metrics: %v\n", !noMetrics)
+	rootCmd.AddCommand(deploycmds.DeployCmd())
 
 	version := &cobra.Command{
 		Use:   "version",

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -55,16 +55,10 @@ Environment variables:
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Output verbose logs")
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
 
-	pfsCmds := pfscmds.Cmds(address, rootCmd)
-	for _, cmd := range pfsCmds {
-		rootCmd.AddCommand(cmd)
-	}
-	ppsCmds, err := ppscmds.Cmds(address, rootCmd)
+	pfscmds.AddCmds(address, rootCmd)
+	err := ppscmds.AddCmds(address, rootCmd)
 	if err != nil {
 		return nil, sanitizeErr(err)
-	}
-	for _, cmd := range ppsCmds {
-		rootCmd.AddCommand(cmd)
 	}
 	rootCmd.AddCommand(deploycmds.DeployCmd())
 

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -59,7 +59,7 @@ Environment variables:
 	for _, cmd := range pfsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	ppsCmds, err := ppscmds.Cmds(address, !noMetrics)
+	ppsCmds, err := ppscmds.Cmds(address, rootCmd)
 	if err != nil {
 		return nil, sanitizeErr(err)
 	}

--- a/src/server/cmd/pachctl/cmd/cmd_test.go
+++ b/src/server/cmd/pachctl/cmd/cmd_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/config"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
-	deploycmds "github.com/pachyderm/pachyderm/src/server/pkg/deploy/cmds"
 	api "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -51,14 +50,16 @@ func testDeploy(t *testing.T, devFlag bool, noMetrics bool, expectedEnvValue boo
 	os.Stdout = w
 
 	os.Args = []string{
+		"pachctl",
 		"deploy",
 		"local",
 		"--dry-run",
 		fmt.Sprintf("-d=%v", devFlag),
+		fmt.Sprintf("--no-metrics=%v", noMetrics),
 	}
-	// the noMetrics flag is defined globally, so is undefined on just this command
-	// but we can pass it in directly to the command:
-	err = deploycmds.DeployCmd(!noMetrics).Execute()
+	rootCommand, err := PachctlCmd("127.0.0.1:30650")
+	require.NoError(t, err)
+	err = rootCommand.Execute()
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
 	// restore stdout

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -36,7 +36,7 @@ func noMetricsFlag(c *cobra.Command) bool {
 }
 
 // Cmds returns a slice containing pfs commands.
-func Cmds(address string, rootCmd *cobra.Command) []*cobra.Command {
+func AddCmds(address string, rootCmd *cobra.Command) {
 	var fileNumber int
 	var fileModulus int
 	var blockNumber int
@@ -801,32 +801,34 @@ mount | grep pfs:// | cut -f 3 -d " "
 		}),
 	}
 
-	var result []*cobra.Command
-	result = append(result, repo)
-	result = append(result, createRepo)
-	result = append(result, inspectRepo)
-	result = append(result, listRepo)
-	result = append(result, deleteRepo)
-	result = append(result, commit)
-	result = append(result, startCommit)
-	result = append(result, forkCommit)
-	result = append(result, finishCommit)
-	result = append(result, inspectCommit)
-	result = append(result, listCommit)
-	result = append(result, squashCommit)
-	result = append(result, replayCommit)
-	result = append(result, flushCommit)
-	result = append(result, listBranch)
-	result = append(result, file)
-	result = append(result, putFile)
-	result = append(result, getFile)
-	result = append(result, inspectFile)
-	result = append(result, listFile)
-	result = append(result, deleteFile)
-	result = append(result, mount)
-	result = append(result, unmount)
-	result = append(result, archiveAll)
-	return result
+	var commands []*cobra.Command
+	commands = append(commands, repo)
+	commands = append(commands, createRepo)
+	commands = append(commands, inspectRepo)
+	commands = append(commands, listRepo)
+	commands = append(commands, deleteRepo)
+	commands = append(commands, commit)
+	commands = append(commands, startCommit)
+	commands = append(commands, forkCommit)
+	commands = append(commands, finishCommit)
+	commands = append(commands, inspectCommit)
+	commands = append(commands, listCommit)
+	commands = append(commands, squashCommit)
+	commands = append(commands, replayCommit)
+	commands = append(commands, flushCommit)
+	commands = append(commands, listBranch)
+	commands = append(commands, file)
+	commands = append(commands, putFile)
+	commands = append(commands, getFile)
+	commands = append(commands, inspectFile)
+	commands = append(commands, listFile)
+	commands = append(commands, deleteFile)
+	commands = append(commands, mount)
+	commands = append(commands, unmount)
+	commands = append(commands, archiveAll)
+	for _, cmd := range commands {
+		rootCmd.AddCommand(cmd)
+	}
 }
 
 func parseCommitMounts(args []string) []*fuse.CommitMount {

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -35,7 +35,7 @@ func noMetricsFlag(c *cobra.Command) bool {
 	return noMetrics
 }
 
-// Cmds returns a slice containing pfs commands.
+// AddCmds adds all the PFS commands to the provided root command
 func AddCmds(address string, rootCmd *cobra.Command) {
 	var fileNumber int
 	var fileModulus int

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -28,8 +29,14 @@ import (
 	"go.pedge.io/pkg/exec"
 )
 
+func noMetricsFlag(c *cobra.Command) bool {
+	// we can ignore the error since cobra already validates that the flag is a valid boolean
+	noMetrics, _ := strconv.ParseBool(c.Flags().Lookup("no-metrics").Value.String())
+	return noMetrics
+}
+
 // Cmds returns a slice containing pfs commands.
-func Cmds(address string, metrics bool) []*cobra.Command {
+func Cmds(address string, rootCmd *cobra.Command) []*cobra.Command {
 	var fileNumber int
 	var fileModulus int
 	var blockNumber int
@@ -66,7 +73,7 @@ Repos are created with create-repo.`,
 		Short: "Create a new repo.",
 		Long:  "Create a new repo.",
 		Run: cmd.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -79,7 +86,7 @@ Repos are created with create-repo.`,
 		Short: "Return info about a repo.",
 		Long:  "Return info about a repo.",
 		Run: cmd.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -100,7 +107,7 @@ Repos are created with create-repo.`,
 		Short: "Return all repos.",
 		Long:  "Reutrn all repos.",
 		Run: cmd.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -124,7 +131,7 @@ Repos are created with create-repo.`,
 		Short: "Delete a repo.",
 		Long:  "Delete a repo.",
 		Run: cmd.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -167,7 +174,7 @@ Examples:
 	$ pachctl start-commit foo master/3
 `,
 		Run: cmd.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -191,7 +198,7 @@ Examples:
 	$ pachctl fork-commit test foo/2 bar
 `,
 		Run: cmd.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -210,7 +217,7 @@ Examples:
 		Short: "Finish a started commit.",
 		Long:  "Finish a started commit. Commit-id must be a writeable commit.",
 		Run: cmd.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -227,7 +234,7 @@ Examples:
 		Short: "Return info about a commit.",
 		Long:  "Return info about a commit.",
 		Run: cmd.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -287,7 +294,7 @@ Examples:
 				status = pfsclient.CommitStatus_ALL
 			}
 
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -329,7 +336,7 @@ Examples:
 				return nil
 			}
 
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -354,7 +361,7 @@ Examples:
 				return nil
 			}
 
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -392,7 +399,7 @@ Examples:
 				return err
 			}
 
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -422,7 +429,7 @@ Examples:
 		Short: "Return all branches on a repo.",
 		Long:  "Return all branches on a repo.",
 		Run: cmd.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -532,7 +539,7 @@ files into your Pachyderm cluster.
 	pachctl put-file repo commit -i http://host/path
 `,
 		Run: cmd.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -613,7 +620,7 @@ files into your Pachyderm cluster.
 		Short: "Return the contents of a file.",
 		Long:  "Return the contents of a file.",
 		Run: cmd.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -628,7 +635,7 @@ files into your Pachyderm cluster.
 		Short: "Return info about a file.",
 		Long:  "Return info about a file.",
 		Run: cmd.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -656,7 +663,7 @@ files into your Pachyderm cluster.
 				return fmt.Errorf("you may only provide either --fast or --recurse, but not both")
 			}
 
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -691,7 +698,7 @@ files into your Pachyderm cluster.
 		Short: "Delete a file.",
 		Long:  "Delete a file.",
 		Run: cmd.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -706,7 +713,7 @@ files into your Pachyderm cluster.
 		Short: "Mount pfs locally. This command blocks.",
 		Long:  "Mount pfs locally. This command blocks.",
 		Run: cmd.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "fuse")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -786,7 +793,7 @@ mount | grep pfs:// | cut -f 3 -d " "
 		Short: "Archives all commits in all repos.",
 		Long:  "Archives all commits in all repos.",
 		Run: cmd.RunFixedArgs(0, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -46,7 +46,6 @@ func DeployCmd() *cobra.Command {
 		Short: "Deploy a single-node Pachyderm cluster with local metadata storage.",
 		Long:  "Deploy a single-node Pachyderm cluster with local metadata storage.",
 		Run: pkgcobra.RunBoundedArgs(pkgcobra.Bounds{Min: 0, Max: 0}, func(args []string) (retErr error) {
-			fmt.Printf("!!! got metrics: %v\n", opts.Metrics)
 			if opts.Metrics && !dev {
 				metricsFn := _metrics.ReportAndFlushUserAction("Deploy")
 				defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
@@ -55,8 +54,6 @@ func DeployCmd() *cobra.Command {
 			if dev {
 				opts.Version = deploy.DevVersionTag
 			}
-			fmt.Printf("!!! metrics? %v\n", opts.Metrics)
-			fmt.Printf("!!! writing manifest w options: %v\n", opts)
 			assets.WriteLocalAssets(manifest, opts, hostPath)
 			return maybeKcCreate(dryRun, manifest)
 		}),

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -108,7 +108,7 @@ func (r *pipelineManifestReader) nextCreatePipelineRequest() (*ppsclient.CreateP
 	return &result, nil
 }
 
-// AddCmds returns a slice containing pps commands.
+// AddCmds adds all the PPS commands to the provided root command
 func AddCmds(address string, rootCmd *cobra.Command) error {
 	marshaller := &jsonpb.Marshaler{Indent: "  "}
 

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -709,6 +709,11 @@ func pushImage(registry string, username string, password string, image string) 
 
 func noMetricsFlag(c *cobra.Command) bool {
 	// we can ignore the error since cobra already validates that the flag is a valid boolean
-	noMetrics, _ := strconv.ParseBool(c.Flags().Lookup("no-metrics").Value.String())
+	flag := c.Flags().Lookup("no-metrics")
+	if flag == nil {
+		// This only happens in tests because of how the harness initializes commands
+		return false
+	}
+	noMetrics, _ := strconv.ParseBool(flag.Value.String())
 	return noMetrics
 }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/user"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -108,7 +109,7 @@ func (r *pipelineManifestReader) nextCreatePipelineRequest() (*ppsclient.CreateP
 }
 
 // Cmds returns a slice containing pps commands.
-func Cmds(address string, metrics bool) ([]*cobra.Command, error) {
+func Cmds(address string, rootCmd *cobra.Command) ([]*cobra.Command, error) {
 	marshaller := &jsonpb.Marshaler{Indent: "  "}
 
 	job := &cobra.Command{
@@ -152,7 +153,7 @@ The increase the throughput of a job increase the Shard paremeter.
 		Short: "Create a new job. Returns the id of the created job.",
 		Long:  fmt.Sprintf("Create a new job from a spec, the spec looks like this\n%s", exampleCreateJobRequest),
 		Run: pkgcmd.RunFixedArgs(0, func(args []string) (retErr error) {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -223,7 +224,7 @@ The increase the throughput of a job increase the Shard paremeter.
 		Short: "Return info about a job.",
 		Long:  "Return info about a job.",
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -261,7 +262,7 @@ Examples:
 
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				pkgcmd.ErrorAndExit("error from InspectJob: %v", sanitizeErr(err))
 			}
@@ -298,7 +299,7 @@ Examples:
 		Short: "Return logs from a job.",
 		Long:  "Return logs from a job.",
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -332,7 +333,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			if err != nil {
 				return err
 			}
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return sanitizeErr(err)
 			}
@@ -376,7 +377,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			if err != nil {
 				return err
 			}
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return sanitizeErr(err)
 			}
@@ -418,7 +419,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about a pipeline.",
 		Long:  "Return info about a pipeline.",
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -438,7 +439,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about all pipelines.",
 		Long:  "Return info about all pipelines.",
 		Run: pkgcmd.RunFixedArgs(0, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -460,7 +461,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Delete a pipeline.",
 		Long:  "Delete a pipeline.",
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -476,7 +477,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Restart a stopped pipeline.",
 		Long:  "Restart a stopped pipeline.",
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -492,7 +493,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Stop a running pipeline.",
 		Long:  "Stop a running pipeline.",
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -509,7 +510,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Run a pipeline once.",
 		Long:  fmt.Sprintf("Run a pipeline once, optionally overriding some pipeline options by providing a spec.  The spec looks like this:\n%s", exampleRunPipelineSpec),
 		Run: pkgcmd.RunFixedArgs(1, func(args []string) (retErr error) {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pach.NewMetricsClientFromAddress(address, !noMetricsFlag(rootCmd), "user")
 			if err != nil {
 				return err
 			}
@@ -700,4 +701,10 @@ func pushImage(registry string, username string, password string, image string) 
 		return "", err
 	}
 	return fmt.Sprintf("%s:%s", pushRepo, pushTag), nil
+}
+
+func noMetricsFlag(c *cobra.Command) bool {
+	// we can ignore the error since cobra already validates that the flag is a valid boolean
+	noMetrics, _ := strconv.ParseBool(c.Flags().Lookup("no-metrics").Value.String())
+	return noMetrics
 }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -108,7 +108,7 @@ func (r *pipelineManifestReader) nextCreatePipelineRequest() (*ppsclient.CreateP
 	return &result, nil
 }
 
-// Cmds returns a slice containing pps commands.
+// AddCmds returns a slice containing pps commands.
 func AddCmds(address string, rootCmd *cobra.Command) error {
 	marshaller := &jsonpb.Marshaler{Indent: "  "}
 

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -109,7 +109,7 @@ func (r *pipelineManifestReader) nextCreatePipelineRequest() (*ppsclient.CreateP
 }
 
 // Cmds returns a slice containing pps commands.
-func Cmds(address string, rootCmd *cobra.Command) ([]*cobra.Command, error) {
+func AddCmds(address string, rootCmd *cobra.Command) error {
 	marshaller := &jsonpb.Marshaler{Indent: "  "}
 
 	job := &cobra.Command{
@@ -133,12 +133,12 @@ The increase the throughput of a job increase the Shard paremeter.
 
 	exampleCreateJobRequest, err := marshaller.MarshalToString(example.CreateJobRequest)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	exampleRunPipelineSpec, err := marshaller.MarshalToString(example.RunPipelineSpec)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	pipelineSpec := string(pachyderm.MustAsset("doc/deployment/pipeline_spec.md"))
@@ -564,22 +564,26 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 	}
 	runPipeline.Flags().StringVarP(&specPath, "file", "f", "", "The file containing the run-pipeline spec, - reads from stdin.")
 
-	var result []*cobra.Command
-	result = append(result, job)
-	result = append(result, createJob)
-	result = append(result, inspectJob)
-	result = append(result, getLogs)
-	result = append(result, listJob)
-	result = append(result, pipeline)
-	result = append(result, createPipeline)
-	result = append(result, updatePipeline)
-	result = append(result, inspectPipeline)
-	result = append(result, listPipeline)
-	result = append(result, deletePipeline)
-	result = append(result, startPipeline)
-	result = append(result, stopPipeline)
-	result = append(result, runPipeline)
-	return result, nil
+	var commands []*cobra.Command
+	commands = append(commands, job)
+	commands = append(commands, createJob)
+	commands = append(commands, inspectJob)
+	commands = append(commands, getLogs)
+	commands = append(commands, listJob)
+	commands = append(commands, pipeline)
+	commands = append(commands, createPipeline)
+	commands = append(commands, updatePipeline)
+	commands = append(commands, inspectPipeline)
+	commands = append(commands, listPipeline)
+	commands = append(commands, deletePipeline)
+	commands = append(commands, startPipeline)
+	commands = append(commands, stopPipeline)
+	commands = append(commands, runPipeline)
+
+	for _, cmd := range commands {
+		rootCmd.AddCommand(cmd)
+	}
+	return nil
 }
 
 func describeSyntaxError(originalErr error, parsedBuffer bytes.Buffer) error {

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -34,10 +34,7 @@ const badJSON2 = `
 
 func rootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{}
-	cmds, _ := Cmds("0.0.0.0:30650", false)
-	for _, cmd := range cmds {
-		rootCmd.AddCommand(cmd)
-	}
+	AddCmds("0.0.0.0:30650", rootCmd)
 	return rootCmd
 }
 


### PR DESCRIPTION
Fixes #1109

Still need to add a pachctl test so we don't have a regression.

We were using the uninitialized values for the metrics flag, which were sane defaults. But to actually get the value of the flag when the `Run()` functions are called, we need to query the command to get the value.

In the cobra examples, any subcommands are defined in the same file and the flags are defined as global variables. Since that's not how our code is structured, we query the command at runtime instead.

Also since we needed the root command I went ahead and removed the return values from `pfscmds.Cmds()` and `ppscmds.Cmds()` and instead just add the commands to the root.