### PR TITLE
Update docs to change `pachctl deploy` to `pachctl deploy local`

### DIFF
--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -30,7 +30,7 @@ To check that installation was successful, you can try running `pachctl help`, w
 Now that you have Minikube running, it's incredibly easy to deploy Pachyderm.
 
 ```sh
-pachctl deploy
+pachctl deploy local
 ```
 This generates a Pachyderm manifest and deploys Pachyderm on Kubernetes. It may take a few minutes for the pachd nodes to be running because it's pulling containers from DockerHub. You can see the cluster status by using `kubectl get all`:
 


### PR DESCRIPTION
Running the command `pachctl deploy` on pachyderm's latest version displays the help page for the command:
```Oren$ pachctl deploy
Deploy a Pachyderm cluster.

Usage:
  pachctl deploy [command]

Available Commands:
  local       Deploy a single-node Pachyderm cluster with local metadata storage.
  amazon      Deploy a Pachyderm cluster running on AWS.
  google      Deploy a Pachyderm cluster running on GCP.
  microsoft   Deploy a Pachyderm cluster running on Microsoft Azure.

Flags:
      --dry-run                       Don't actually deploy pachyderm to Kubernetes, instead just print the manifest.
  -h, --help                          help for deploy
      --log-level string              The level of log messages to print options are, from least to most verbose: "error", "info", "debug". (default "info")
      --rethinkdb-cache-size string   Size of in-memory cache to use for Pachyderm's RethinkDB instance, e.g. "2G". Default is "768M". Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc) (default "768M")
  -s, --shards int                    The static number of shards for pfs. (default 32)

Global Flags:
      --no-metrics   Don't report user metrics for this command
  -v, --verbose      Output verbose logs

Use "pachctl deploy [command] --help" for more information about a command.
```