### PR TITLE
Downgrade rethinkdb to 2.3.2

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -21,7 +21,7 @@ var (
 	volumeSuite            = "pachyderm-pps-storage"
 	pachdImage             = "pachyderm/pachd"
 	etcdImage              = "gcr.io/google_containers/etcd:2.0.12"
-	rethinkImage           = "rethinkdb:2.3.3"
+	rethinkImage           = "rethinkdb:2.3.2"
 	serviceAccountName     = "pachyderm"
 	etcdName               = "etcd"
 	pachdName              = "pachd"


### PR DESCRIPTION
Because starting from 2.3.3 rethinkdb seems to have a memory leak issue:

https://github.com/rethinkdb/rethinkdb/issues/5865