### PR TITLE
Use k8s-internal DNS in make launch-kube, and upgrade k8s itself

### DIFF
--- a/etc/kube/start-kube-docker.sh
+++ b/etc/kube/start-kube-docker.sh
@@ -13,12 +13,14 @@ docker run \
     --net=host \
     --pid=host \
     --privileged=true \
-    gcr.io/google_containers/hyperkube:v1.4.0 \
+    gcr.io/google_containers/hyperkube:v1.4.6 \
     /hyperkube kubelet \
         --containerized \
         --hostname-override="127.0.0.1" \
         --address="0.0.0.0" \
         --api-servers=http://localhost:8080 \
+        --cluster_dns=10.0.0.10 \
+        --cluster_domain=cluster.local \
         --config=/etc/kubernetes/manifests \
         --allow-privileged=true
 until kubectl version 2>/dev/null >/dev/null; do sleep 5; done


### PR DESCRIPTION
Modify start-kube-docker.sh so that dockerized kubernetes uses internal DNS (which IIUC inherits from the node[1]) rather than the system's DNS directly.

Also, upgrade the version of k8s used from 1.4.0 to 1.4.6

[1] http://kubernetes.io/docs/admin/dns/, in particular "When running a pod, kubelet will prepend the cluster DNS server and search paths to the node’s own DNS settings. If the node is able to resolve DNS names specific to the larger environment, pods should be able to, also. See “Known issues” below for a caveat."