### PR TITLE
Migration 1.3.0

### DIFF
--- a/migration/1.2.4-1.3.0/Makefile
+++ b/migration/1.2.4-1.3.0/Makefile
@@ -1,0 +1,2 @@
+run:
+	kubectl $(KUBECTLFLAGS) run migrate --image="pachyderm/pachd:1.3.0" --restart=Never -- ./pachd --migrate=1.2.4-1.3.0'

--- a/migration/1.2.4-1.3.0/Makefile
+++ b/migration/1.2.4-1.3.0/Makefile
@@ -1,2 +1,2 @@
 run:
-	kubectl $(KUBECTLFLAGS) run migrate --image="pachyderm/pachd:1.3.0" --restart=Never -- ./pachd --migrate=1.2.4-1.3.0'
+	kubectl $(KUBECTLFLAGS) run migrate --image="pachyderm/pachd:1.3.0" --restart=Never -- ./pachd --migrate=1.2.4-1.3.0

--- a/migration/1.2.4-1.3.0/README.md
+++ b/migration/1.2.4-1.3.0/README.md
@@ -1,0 +1,23 @@
+## Backup
+
+Please backup your metadata storage system before running this script.  See the [migration guide](http://pachyderm.readthedocs.io/en/latest/production/migration.html) for details.
+
+## How to run this script
+
+Make sure that your `kubectl` has been configured correctly to talk to the Kubernetes cluster where your Pachyderm runs.  Then simply:
+
+```
+make run
+```
+
+You should see a pod named `migrate` being created:
+
+```
+kubectl get all
+```
+
+Once the pod finishes running, the migration is complete.  You can make sure that nothing went wrong by looking at the logs of the pod:
+
+```
+kubectl logs migrate
+```

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -52,7 +52,7 @@ func init() {
 type appEnv struct {
 	Port               uint16 `env:"PORT,default=650"`
 	NumShards          uint64 `env:"NUM_SHARDS,default=32"`
-	StorageRoot        string `env:"PACH_ROOT,required"`
+	StorageRoot        string `env:"PACH_ROOT,default=/pach`
 	StorageBackend     string `env:"STORAGE_BACKEND,default="`
 	DatabaseAddress    string `env:"RETHINK_PORT_28015_TCP_ADDR,required"`
 	PPSDatabaseName    string `env:"DATABASE_NAME,default=pachyderm_pps"`

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -60,6 +60,7 @@ type appEnv struct {
 	Namespace          string `env:"NAMESPACE,default=default"`
 	Metrics            bool   `env:"METRICS,default=true"`
 	Init               bool   `env:"INIT,default=false"`
+	Migrate            string `env:"MIGRATE,default="`
 	BlockCacheBytes    int64  `env:"BLOCK_CACHE_BYTES,default=1073741824"` //default = 1 gigabyte
 	JobShimImage       string `env:"JOB_SHIM_IMAGE,default="`
 	JobImagePullPolicy string `env:"JOB_IMAGE_PULL_POLICY,default="`
@@ -118,6 +119,9 @@ func do(appEnvObj interface{}) error {
 		os.Exit(0)
 
 		return nil
+	}
+	if appEnv.Migrate != "" {
+		return persist_server.Migrate(rethinkAddress, appEnv.PPSDatabaseName, appEnv.Migrate)
 	}
 
 	clusterID, err := getClusterID(etcdClient)

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -41,9 +41,11 @@ import (
 )
 
 var readinessCheck bool
+var migrate string
 
 func init() {
 	flag.BoolVar(&readinessCheck, "readiness-check", false, "Set to true when checking if local pod is ready")
+	flag.StringVar(&migrate, "migrate", "", "Use the format FROM_VERSION-TO_VERSION; e.g. 1.2.4-1.3.0")
 	flag.Parse()
 }
 
@@ -60,7 +62,6 @@ type appEnv struct {
 	Namespace          string `env:"NAMESPACE,default=default"`
 	Metrics            bool   `env:"METRICS,default=true"`
 	Init               bool   `env:"INIT,default=false"`
-	Migrate            string `env:"MIGRATE,default="`
 	BlockCacheBytes    int64  `env:"BLOCK_CACHE_BYTES,default=1073741824"` //default = 1 gigabyte
 	JobShimImage       string `env:"JOB_SHIM_IMAGE,default="`
 	JobImagePullPolicy string `env:"JOB_IMAGE_PULL_POLICY,default="`
@@ -120,8 +121,8 @@ func do(appEnvObj interface{}) error {
 
 		return nil
 	}
-	if appEnv.Migrate != "" {
-		return persist_server.Migrate(rethinkAddress, appEnv.PPSDatabaseName, appEnv.Migrate)
+	if migrate != "" {
+		return persist_server.Migrate(rethinkAddress, appEnv.PPSDatabaseName, migrate)
 	}
 
 	clusterID, err := getClusterID(etcdClient)

--- a/src/server/pps/persist/server/migration.go
+++ b/src/server/pps/persist/server/migration.go
@@ -18,6 +18,7 @@ var (
 	}
 )
 
+// Migrate updates the database schema only in the forward direction
 func Migrate(address, databaseName, migrationKey string) error {
 	migrate, ok := migrationMap[migrationKey]
 	if !ok {

--- a/src/server/pps/persist/server/migration.go
+++ b/src/server/pps/persist/server/migration.go
@@ -60,7 +60,7 @@ func oneTwoFourToOneThreeZero(address, databaseName string) error {
 	}
 
 	lion.Infof("Adding GC flag to all jobs")
-	if _, err := gorethink.DB(databaseName).Table(pipelineInfosTable).Update(map[string]interface{}{
+	if _, err := gorethink.DB(databaseName).Table(jobInfosTable).Update(map[string]interface{}{
 		"Gc": false,
 	}).Run(session); err != nil {
 		return err

--- a/src/server/pps/persist/server/migration.go
+++ b/src/server/pps/persist/server/migration.go
@@ -18,7 +18,7 @@ var (
 	}
 )
 
-func Migrarte(address, databaseName, migrationKey string) error {
+func Migrate(address, databaseName, migrationKey string) error {
 	migrate, ok := migrationMap[migrationKey]
 	if !ok {
 		return fmt.Errorf("migration %s is not supported", migrationKey)


### PR DESCRIPTION
This PR adds a migration script for `1.2.4 -> 1.3.0` and moves the migration logic into `pachd` itself.  It partially addresses #1055, but to completely clos #1055 we still need to be able to automatically detect the current version of pachd.