### PR TITLE
Fix a bug where non-incremental pipelines don't trigger

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1719,11 +1719,6 @@ func (a *apiServer) runPipeline(ctx context.Context, pipelineInfo *ppsclient.Pip
 					if err != nil {
 						return err
 					}
-					if parentJob == nil {
-						// This happens if the parent job was not run due to reasons
-						// such as the parent's input commits got cancelled.
-						continue
-					}
 				}
 				_, err = a.CreateJob(
 					ctx,


### PR DESCRIPTION
This bug was introduced as part of the fix for #1084 in #1094.

Interestingly, I can't figure out why I added these lines, since they don't really make sense in retrospect, and they don't seem to directly address #1084 either.