### PR TITLE
Fix a bug for put-file where the commit can be finished before -i takes its full effect

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -610,11 +610,6 @@ files into your Pachyderm cluster.
 				sources = filePaths
 			}
 			var eg errgroup.Group
-			defer func() {
-				if err := eg.Wait(); retErr == nil && err != nil {
-					retErr = err
-				}
-			}()
 			for _, source := range sources {
 				if len(args) == 2 {
 					// The user has not specific a path so we use source as path.
@@ -636,7 +631,7 @@ files into your Pachyderm cluster.
 					})
 				}
 			}
-			return nil
+			return eg.Wait()
 		}),
 	}
 	putFile.Flags().StringSliceVarP(&filePaths, "file", "f", []string{"-"}, "The file to be put, it can be a local file or a URL.")

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -611,6 +611,7 @@ files into your Pachyderm cluster.
 			}
 			var eg errgroup.Group
 			for _, source := range sources {
+				source := source
 				if len(args) == 2 {
 					// The user has not specific a path so we use source as path.
 					if source == "-" {


### PR DESCRIPTION
Basically, the defer function that waits for -i to take full effect runs after the defer function that closes the commit.  So the commit can be closed before all goroutines are finished.