### PR TITLE
Properly propagate rethink error in ClaimChunk

### DIFF
--- a/src/server/pps/persist/server/rethink_api_server.go
+++ b/src/server/pps/persist/server/rethink_api_server.go
@@ -657,6 +657,9 @@ func (a *rethinkAPIServer) ClaimChunk(ctx context.Context, request *persist.Clai
 			break
 		}
 	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
 	return chunk, nil
 }
 


### PR DESCRIPTION
This solves an issue where a rethinkdb connectivity issue could cause pachd to crash with a stacktrace similar to the following:

```
panic: runtime error: index out of range



goroutine 26518 [running]:

panic(0x1677e00, 0xc42000a0a0)

    /usr/local/go/src/runtime/panic.go:500 +0x1a1

github.com/pachyderm/pachyderm/src/server/pps/server.(*apiServer).StartPod(0xc420155900, 0x7fe2bac2cd90, 0xc420c390b0, 0xc421008d20, 0x0, 0x0, 0x0)

    /go/src/github.com/pachyderm/pachyderm/src/server/pps/server/api_server.go:949 +0xe28

github.com/pachyderm/pachyderm/src/server/pps._InternalPodAPI_StartPod_Handler.func1(0x7fe2bac2cd90, 0xc420c390b0, 0x16f2d40, 0xc421008d20, 0x1, 0x18, 0x16c57e0, 0x16f2d40)

    /go/src/github.com/pachyderm/pachyderm/src/server/pps/pps.pb.go:217 +0xa2

github.com/pachyderm/pachyderm/src/server/vendor/go.pedge.io/proto/rpclog.newLoggingUnaryServerInterceptor.func1(0x7fe2bac2cd90, 0xc420c390b0, 0x16f2d40, 0xc421008d20, 0xc421008d80, 0xc421008da0, 0x4c, 0x0, 0x0, 0xc4202deb20)

    /go/src/github.com/pachyderm/pachyderm/src/server/vendor/go.pedge.io/proto/rpclog/protorpclog.go:99 +0xb5

github.com/pachyderm/pachyderm/src/server/pps._InternalPodAPI_StartPod_Handler(0x1816360, 0xc420155900, 0x7fe2bac2cd90, 0xc420c390b0, 0xc4214cd940, 0x1931b98, 0x0, 0x411419, 0xc42029c9b8, 0xc400000000)

    /go/src/github.com/pachyderm/pachyderm/src/server/pps/pps.pb.go:219 +0x166

github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc4202294d0, 0x22b6dc0, 0xc4213e0bd0, 0xc420b161c0, 0xc420371240, 0x2302420, 0xc420c39080, 0x0, 0x0)

    /go/src/github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc/server.go:530 +0xa2d

github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc.(*Server).handleStream(0xc4202294d0, 0x22b6dc0, 0xc4213e0bd0, 0xc420b161c0, 0xc420c39080)

    /go/src/github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc/server.go:687 +0x6ad

github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc420c34140, 0xc4202294d0, 0x22b6dc0, 0xc4213e0bd0, 0xc420b161c0)

    /go/src/github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc/server.go:352 +0xab

created by github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc.(*Server).serveStreams.func1

    /go/src/github.com/pachyderm/pachyderm/src/server/vendor/google.golang.org/grpc/server.go:353 +0xa3
```