### PR TITLE
Increase lease period

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -26,7 +26,7 @@ const (
 	// amount of time in order to keep owning a chunk.  In reality, pods send
 	// ContinueJob more often than that because they need to account for network
 	// latency.
-	PPSLeasePeriod = 20 * time.Second
+	PPSLeasePeriod = 30 * time.Second
 )
 
 var (


### PR DESCRIPTION
We've been seeing some pipelines failing due to chunks being consistently revoked, which means pods lost contact with PPS for an extended period of time.

By increasing the lease period, we make sure that a pod needs to miss at least two heartbeats before its chunk is revoked.  Ideally we'd figure out why pods lost contact with PPS in the first place but that's for another PR.