### PR TITLE
Fix Jupyter example Makefile and docs errors

### DIFF
--- a/doc/examples/jupyter_notebook/Makefile
+++ b/doc/examples/jupyter_notebook/Makefile
@@ -1,12 +1,11 @@
 build:
 	docker build -t pachyderm_jupyter .
 
-prep: build
+prep:
 	pachctl version
-	./citibike_data/load.sh
-	./weather_data/load.sh
+	cd citibike_data && ./load.sh
+	cd weather_data && ./load.sh
 	pachctl create-pipeline -f ./sales_data/pipeline.json
-	pachctl create-job -f jupyter.json
 
 launch-jupyter:
 	pachctl create-job -f jupyter.json

--- a/doc/examples/jupyter_notebook/jupyter.json
+++ b/doc/examples/jupyter_notebook/jupyter.json
@@ -4,7 +4,7 @@
     "external_port": 30888
   },
   "transform": {
-    "image": "pachyderm_jupyter",
+    "image": "dwhitena/pachyderm_jupyter",
     "cmd": [ "sh" ],
     "stdin": [
 		"/opt/conda/bin/jupyter notebook"

--- a/doc/examples/jupyter_notebook/jupyter.json
+++ b/doc/examples/jupyter_notebook/jupyter.json
@@ -4,7 +4,7 @@
     "external_port": 30888
   },
   "transform": {
-    "image": "dwhitena/pachyderm_jupyter",
+    "image": "pachyderm/pachyderm_jupyter",
     "cmd": [ "sh" ],
     "stdin": [
 		"/opt/conda/bin/jupyter notebook"

--- a/doc/examples/jupyter_notebook/readme.md
+++ b/doc/examples/jupyter_notebook/readme.md
@@ -25,7 +25,7 @@ make prep
 2) Determine the output commit we are going to access with Jupyter:
 
 ```
-pachctl flush-commit -f trips/master/30
+pachctl flush-commit trips/master/30
 ```
 
 and replace the `<output-commitid>` in `jupyter.json` with the sales repo commitid shown. 


### PR DESCRIPTION
The Makefile in the jupyter example was causing issues.  It was trying to attach Jupyter to data that wasn't there.  This caused a bunch of weird errors with port-forwarding and other things.  

This PR fixes the Makefile and a couple of other typos in the docs.