### PR TITLE
Updated CreatePipeline to take a *pps.Transform

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -228,9 +228,7 @@ func (c APIClient) GetLogs(
 // update indicates that you want to update an existing pipeline
 func (c APIClient) CreatePipeline(
 	name string,
-	image string,
-	cmd []string,
-	stdin []string,
+	transform *pps.Transform,
 	parallelismSpec *pps.ParallelismSpec,
 	inputs []*pps.PipelineInput,
 	update bool,
@@ -239,11 +237,7 @@ func (c APIClient) CreatePipeline(
 		c.ctx(),
 		&pps.CreatePipelineRequest{
 			Pipeline: NewPipeline(name),
-			Transform: &pps.Transform{
-				Image: image,
-				Cmd:   cmd,
-				Stdin: stdin,
-			},
+			Transform: transform,
 			ParallelismSpec: parallelismSpec,
 			Inputs:          inputs,
 			Update:          update,

--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/src/client/pfs"
-	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
+	"github.com/pachyderm/pachyderm/src/client/pps"
 )
 
 // NewJob creates a pps.Job.
@@ -228,7 +228,15 @@ func (c APIClient) GetLogs(
 // update indicates that you want to update an existing pipeline
 func (c APIClient) CreatePipeline(
 	name string,
-	transform *pps.Transform,
+	image string,
+	cmd []string,
+	env map[string]string,
+	secrets []*pps.Secret,
+	imagePullSecrets []string,
+	stdin []string,
+	acceptReturnCode []int64,
+	debug bool,
+	overwrite bool,
 	parallelismSpec *pps.ParallelismSpec,
 	inputs []*pps.PipelineInput,
 	update bool,
@@ -237,7 +245,17 @@ func (c APIClient) CreatePipeline(
 		c.ctx(),
 		&pps.CreatePipelineRequest{
 			Pipeline: NewPipeline(name),
-			Transform: transform,
+			Transform: &pps.Transform{
+				Image:            image,
+				Cmd:              cmd,
+				Env:              env,
+				Secrets:          secrets,
+				ImagePullSecrets: imagePullSecrets,
+				Stdin:            stdin,
+				AcceptReturnCode: acceptReturnCode,
+				Debug:            debug,
+				Overwrite:        overwrite,
+			},
 			ParallelismSpec: parallelismSpec,
 			Inputs:          inputs,
 			Update:          update,

--- a/src/client/pps_test.go
+++ b/src/client/pps_test.go
@@ -20,18 +20,16 @@ func Example_pps() {
 	// Create a map pipeline
 	if err := c.CreatePipeline(
 		"map", // the name of the pipeline
-		&pps.Transform{
-			"pachyderm/test_image", // your docker image
-			[]string{"map"},        // the command run in your docker image
-			nil,                    // no env vars
-			nil,                    // no secrets
-			nil,                    // no imagePullSecrets
-			nil,                    // no stdin
-			nil,                    // no acceptReturnCode
-			false,                  // no debug
-			false,                  // overwrite false
-		},
-		nil,                    // let pachyderm decide the parallelism
+		"pachyderm/test_image", // your docker image
+		[]string{"map"},        // the command run in your docker image
+		nil,                    // no env vars
+		nil,                    // no secrets
+		nil,                    // no imagePullSecrets
+		nil,                    // no stdin
+		nil,                    // no acceptReturnCode
+		false,                  // no debug
+		false,                  // overwrite false
+		nil, // let pachyderm decide the parallelism
 		[]*pps.PipelineInput{
 			// map over "repo"
 			client.NewPipelineInput("repo", client.MapMethod),
@@ -43,17 +41,15 @@ func Example_pps() {
 
 	if err := c.CreatePipeline(
 		"reduce",               // the name of the pipeline
-		&pps.Transform{
-			"pachyderm/test_image", // your docker image
-			[]string{"reduce"},     // the command run in your docker image
-			nil,                    // no env vars
-			nil,                    // no secrets
-			nil,                    // no imagePullSecrets
-			nil,                    // no stdin
-			nil,                    // no acceptReturnCode
-			false,                  // no debug
-			false,                  // overwrite false
-		},
+		"pachyderm/test_image", // your docker image
+		[]string{"reduce"},     // the command run in your docker image
+		nil,                    // no env vars
+		nil,                    // no secrets
+		nil,                    // no imagePullSecrets
+		nil,                    // no stdin
+		nil,                    // no acceptReturnCode
+		false,                  // no debug
+		false,                  // overwrite false
 		nil,                    // let pachyderm decide the parallelism
 		[]*pps.PipelineInput{
 			// reduce over "map"

--- a/src/client/pps_test.go
+++ b/src/client/pps_test.go
@@ -20,9 +20,17 @@ func Example_pps() {
 	// Create a map pipeline
 	if err := c.CreatePipeline(
 		"map", // the name of the pipeline
-		"pachyderm/test_image", // your docker image
-		[]string{"map"},        // the command run in your docker image
-		nil,                    // no stdin
+		&pps.Transform{
+			"pachyderm/test_image", // your docker image
+			[]string{"map"},        // the command run in your docker image
+			nil,                    // no env vars
+			nil,                    // no secrets
+			nil,                    // no imagePullSecrets
+			nil,                    // no stdin
+			nil,                    // no acceptReturnCode
+			false,                  // no debug
+			false,                  // overwrite false
+		},
 		nil,                    // let pachyderm decide the parallelism
 		[]*pps.PipelineInput{
 			// map over "repo"
@@ -35,9 +43,17 @@ func Example_pps() {
 
 	if err := c.CreatePipeline(
 		"reduce",               // the name of the pipeline
-		"pachyderm/test_image", // your docker image
-		[]string{"reduce"},     // the command run in your docker image
-		nil,                    // no stdin
+		&pps.Transform{
+			"pachyderm/test_image", // your docker image
+			[]string{"reduce"},     // the command run in your docker image
+			nil,                    // no env vars
+			nil,                    // no secrets
+			nil,                    // no imagePullSecrets
+			nil,                    // no stdin
+			nil,                    // no acceptReturnCode
+			false,                  // no debug
+			false,                  // overwrite false
+		},
 		nil,                    // let pachyderm decide the parallelism
 		[]*pps.PipelineInput{
 			// reduce over "map"


### PR DESCRIPTION
When creating pipelines, `image`, `cmd` and `stdin` wasn't enough and I wondered why `CreatePipeline` didn't allow specifying things like environment variables, image secrets, etc.