### PR TITLE
Changed commitID to be consistent

### DIFF
--- a/doc/getting_started/beginner_tutorial.rst
+++ b/doc/getting_started/beginner_tutorial.rst
@@ -164,7 +164,7 @@ the new data we've added. We'll see a corresponding commit to the output
 
 .. code-block:: shell
 
- $ pachctl get-file sum 4092f4675650476ab0a3fde5b7780316/0 apple
+ $ pachctl get-file sum e4060e15948c4b7b89947a02eace5dca/1 apple
  324
 
 One thing that's interesting to note is that our pipeline is completely incremental. Since ``grep`` is a ``map`` operation, Pachyderm will only ``grep`` the new data from set2.txt instead of re-filtering all the data. If you look back at the "sum" pipeline, you'll notice the ``method`` and that our code uses ``/pfs/prev`` to compute the sum incrementally based upon our previous commit. You can learn more about incrementally in our advanced :doc:`../advanced/incrementality` docs.
@@ -212,7 +212,7 @@ other local filesystem such as using ``ls`` or pointing your browser at it.
 
  # And commits
  $ ls ~/pfs/sum
- 4092f4675650476ab0a3fde5b7780316/1	4092f4675650476ab0a3fde5b7780316/0
+ e4060e15948c4b7b89947a02eace5dca/1	e4060e15948c4b7b89947a02eace5dca/0
 
 .. note::
 


### PR DESCRIPTION
In the 'Beginner Tutorial' it changes commitID's for some reason. There may be something different on the the creator's end when this was written but when I completed it my commitID didn't change when putting in more data. The only thing that changed was the number after the '/' (ex: /0 to /1 which reflects the next commit increment). In the doc, the original commit id was 'e4060e15948c4b7b89947a02eace5dca' and then it changed to '4092f4675650476ab0a3fde5b7780316'. Mine did not change so again this could just be something on my end :)