### PR TITLE
Fix CreateJob bug.

### DIFF
--- a/src/server/pkg/sync/sync.go
+++ b/src/server/pkg/sync/sync.go
@@ -47,9 +47,12 @@ func pullDir(ctx context.Context, client pfs.APIClient, root string, commit *pfs
 	}
 
 	var g errgroup.Group
+	sem := make(chan struct{}, 100)
 	for _, fileInfo := range fileInfos.FileInfo {
 		fileInfo := fileInfo
+		sem <- struct{}{}
 		g.Go(func() (retErr error) {
+			defer func() { <-sem }()
 			switch fileInfo.FileType {
 			case pfs.FileType_FILE_TYPE_REGULAR:
 				path := filepath.Join(root, fileInfo.File.Path)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -341,7 +341,22 @@ func (a *apiServer) CreateJob(ctx context.Context, request *ppsclient.CreateJobR
 		}
 		outputCommit, err = pfsAPIClient.StartCommit(ctx, startCommitRequest)
 		if err != nil {
-			return nil, err
+			if strings.Contains(err.Error(), "already exists") {
+				if _, err := pfsAPIClient.DeleteCommit(
+					ctx,
+					&pfsclient.DeleteCommitRequest{
+						Commit: client.NewCommit(parent.Repo.Name, strings.Split(parent.ID, "/")[0]),
+					},
+				); err != nil {
+					return nil, err
+				}
+				outputCommit, err = pfsAPIClient.StartCommit(ctx, startCommitRequest)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
The bug here is that it's possible for us to wind up with a job in state `FAILURE` that still has an open commit which will permanently block the next job. Instead we make it so that the last thing we do in `CreateJob` is insert the job into the database so that if that succeeds we can be sure that the rest of the `CreateJob` has succeeded as well.