### PR TITLE
Change runEmpty to mean that the specified parallelism is always resp…

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -499,6 +499,12 @@ func (a *apiServer) CreateJob(ctx context.Context, request *ppsclient.CreateJobR
 // 3. Repeat step 2, until the product of the moduli hits the given parallelism,
 // or until all inputs have been removed from consideration.
 func (a *apiServer) shardModuli(ctx context.Context, inputs []*ppsclient.JobInput, parallelism uint64, repoToFromCommit map[string]*pfsclient.Commit) ([]uint64, error) {
+	// The fast path for when there's only one input and its runEmpty
+	// flag is set; we just use the specified parallelism
+	if len(inputs) == 1 && inputs[0].RunEmpty {
+		return []uint64{parallelism}, nil
+	}
+
 	pfsClient, err := a.getPfsClient()
 	if err != nil {
 		return nil, err

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -520,13 +520,8 @@ func (a *apiServer) shardModuli(ctx context.Context, inputs []*ppsclient.JobInpu
 			return nil, err
 		}
 
-		if commitInfo.SizeBytes == 0 {
-			if input.RunEmpty {
-				// An empty input shouldn't be partitioned
-				limitHit[i] = true
-			} else {
-				return nil, newErrEmptyInput(input.Commit.ID)
-			}
+		if commitInfo.SizeBytes == 0 && !input.RunEmpty {
+			return nil, newErrEmptyInput(input.Commit.ID)
 		}
 
 		inputSizes = append(inputSizes, commitInfo.SizeBytes)
@@ -583,6 +578,9 @@ func product(numbers []uint64) uint64 {
 //
 // TODO: it's very inefficient as of now, since it involves many calls to ListFile
 func (a *apiServer) noEmptyShards(ctx context.Context, input *ppsclient.JobInput, modulus uint64, repoToFromCommit map[string]*pfsclient.Commit) (bool, error) {
+	if input.RunEmpty {
+		return true, nil
+	}
 	pfsClient, err := a.getPfsClient()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
…ected, even if a pod might have empty input; it used to mean that the pipeline is triggered even if the input commit is empty.