### PR TITLE
Scale for many files

### DIFF
--- a/src/server/pfs/db/driver.go
+++ b/src/server/pfs/db/driver.go
@@ -1653,7 +1653,7 @@ func (d *driver) SquashCommit(fromCommits []*pfs.Commit, toCommit *pfs.Commit) e
 			"ID":    gorethink.UUID(),
 			"Clock": newPersistCommit.FullClock,
 		}
-	})).RunWrite(d.dbClient)
+	})).RunWrite(d.dbClient, gorethink.RunOpts{ArrayLimit: 10000000})
 	if err != nil {
 		return err
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -525,13 +525,8 @@ func (a *apiServer) shardModuli(ctx context.Context, inputs []*ppsclient.JobInpu
 			return nil, err
 		}
 
-		if commitInfo.SizeBytes == 0 {
-			if input.RunEmpty {
-				// An empty input shouldn't be partitioned
-				limitHit[i] = true
-			} else {
-				return nil, newErrEmptyInput(input.Commit.ID)
-			}
+		if commitInfo.SizeBytes == 0 && !input.RunEmpty {
+			return nil, newErrEmptyInput(input.Commit.ID)
 		}
 
 		inputSizes = append(inputSizes, commitInfo.SizeBytes)
@@ -553,7 +548,7 @@ func (a *apiServer) shardModuli(ctx context.Context, inputs []*ppsclient.JobInpu
 			}
 		}
 
-		b := true
+		b := false
 
 		if !inputs[modulusIndex].RunEmpty {
 			b, err = a.noEmptyShards(ctx, inputs[modulusIndex], shardModuli[modulusIndex]*2, repoToFromCommit)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -548,7 +548,7 @@ func (a *apiServer) shardModuli(ctx context.Context, inputs []*ppsclient.JobInpu
 			}
 		}
 
-		b := false
+		b := true
 
 		if !inputs[modulusIndex].RunEmpty {
 			b, err = a.noEmptyShards(ctx, inputs[modulusIndex], shardModuli[modulusIndex]*2, repoToFromCommit)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -553,9 +553,13 @@ func (a *apiServer) shardModuli(ctx context.Context, inputs []*ppsclient.JobInpu
 			}
 		}
 
-		b, err := a.noEmptyShards(ctx, inputs[modulusIndex], shardModuli[modulusIndex]*2, repoToFromCommit)
-		if err != nil {
-			return nil, err
+		b := true
+
+		if !inputs[modulusIndex].RunEmpty {
+			b, err = a.noEmptyShards(ctx, inputs[modulusIndex], shardModuli[modulusIndex]*2, repoToFromCommit)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if b {


### PR DESCRIPTION
Up's rethinks size limit for the squash commit query.

Doesn't check the 'emptiness' of the partitions if the `runEmpty` flag is set (this took an exorbitantly long time w many files).

These changes allow us to run jobs w the number of files on the order of 100,000