### PR TITLE
Buffer our PutFile writes

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -44,6 +44,13 @@ type APIClient struct {
 	metricsPrefix     string
 }
 
+var (
+	//BlockSize is used internally by PFS blockserver
+	BlockSize = 8 * 1024 * 1024 // 8 Megabytes
+	// MaxMsgSize is used to define the GRPC frame size, which we need to be greater than a block
+	MaxMsgSize = 3 * BlockSize
+)
+
 // NewMetricsClientFromAddress Creates a client that will report a user's Metrics
 func NewMetricsClientFromAddress(addr string, metrics bool, prefix string) (*APIClient, error) {
 	c, err := NewFromAddress(addr)

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -203,7 +203,7 @@ func do(appEnvObj interface{}) error {
 		},
 		grpcutil.ServeOptions{
 			Version:    version.Version,
-			MaxMsgSize: pfs_server.MaxMsgSize,
+			MaxMsgSize: client.MaxMsgSize,
 		},
 		grpcutil.ServeEnv{
 			GRPCPort: appEnv.Port,

--- a/src/server/pfs/server/local_block_api_server.go
+++ b/src/server/pfs/server/local_block_api_server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"github.com/pachyderm/pachyderm/src/client"
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 
@@ -70,7 +71,7 @@ func (s *localBlockAPIServer) PutBlock(putBlockServer pfsclient.BlockAPI_PutBloc
 			return err
 		}
 		result.BlockRef = append(result.BlockRef, blockRef)
-		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(blockSize) {
+		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(client.BlockSize) {
 			break
 		}
 	}
@@ -180,7 +181,7 @@ func readBlock(delimiter pfsclient.Delimiter, reader *bufio.Reader, decoder *jso
 		buffer.Write(value)
 		hash.Write(value)
 		bytesWritten += len(value)
-		if bytesWritten > blockSize && delimiter != pfsclient.Delimiter_NONE {
+		if bytesWritten > client.BlockSize && delimiter != pfsclient.Delimiter_NONE {
 			break
 		}
 	}

--- a/src/server/pfs/server/obj_block_api_server.go
+++ b/src/server/pfs/server/obj_block_api_server.go
@@ -171,7 +171,7 @@ func (s *objBlockAPIServer) PutBlock(putBlockServer pfsclient.BlockAPI_PutBlockS
 			}
 			return nil
 		})
-		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(blockSize) {
+		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(client.BlockSize) {
 			break
 		}
 	}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -7,12 +7,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 )
 
-var (
-	blockSize = 8 * 1024 * 1024 // 8 Megabytes
-	// MaxMsgSize is used to define the GRPC frame size, which we need to be greater than a block
-	MaxMsgSize = 3 * blockSize
-)
-
 // Valid object storage backends
 const (
 	MinioBackendEnvVar     = "MINIO"


### PR DESCRIPTION
So that we don't exceed the grpc MaxMsgSize

Additionally, I had to move the `blockSize` and `MaxMsgSize` variables into the client, because the client now needs to know to buffer its writes. This is less than ideal, but because of vendoring issues (client can never import server code) those values have to be in the client.