### PR TITLE
Fix big files

### DIFF
--- a/src/server/cmd/job-shim/main.go
+++ b/src/server/cmd/job-shim/main.go
@@ -159,6 +159,15 @@ func do(appEnvObj interface{}) error {
 				return err
 			}
 
+			// Setup the hostPath mount to use a unique directory for this pod
+			podDataDir := filepath.Join("/pach-job-data", appEnv.PodName)
+			if err := os.Mkdir(podDataDir, 0777); err != nil {
+				return err
+			}
+			if err := os.Symlink(podDataDir, "/pfs"); err != nil {
+				return err
+			}
+
 			if err := downloadInput(c, response.CommitMounts); err != nil {
 				return err
 			}

--- a/src/server/pfs/server/local_block_api_server.go
+++ b/src/server/pfs/server/local_block_api_server.go
@@ -183,6 +183,9 @@ func readBlock(delimiter pfsclient.Delimiter, reader *bufio.Reader, decoder *jso
 		if bytesWritten > blockSize && delimiter != pfsclient.Delimiter_NONE {
 			break
 		}
+		if bytesWritten > maxBlockSize {
+			break
+		}
 	}
 
 	return &pfsclient.BlockRef{

--- a/src/server/pfs/server/local_block_api_server.go
+++ b/src/server/pfs/server/local_block_api_server.go
@@ -184,7 +184,7 @@ func readBlock(delimiter pfsclient.Delimiter, reader *bufio.Reader, decoder *jso
 		if bytesWritten > client.BlockSize && delimiter != pfsclient.Delimiter_NONE {
 			break
 		}
-		if bytesWritten > clien.MaxBlockSize {
+		if bytesWritten > client.MaxBlockSize {
 			break
 		}
 	}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	blockSize = 8 * 1024 * 1024 // 8 Megabytes
+	blockSize    = 8 * 1024 * 1024   // 8 Megabytes
+	maxBlockSize = 100 * 1024 * 1024 // 100 MB max for blocks of any type (LINE, JSON, NONE)
 	// MaxMsgSize is used to define the GRPC frame size, which we need to be greater than a block
 	MaxMsgSize = 3 * blockSize
 )

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dancannon/gorethink"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/uuid"
 	"github.com/pachyderm/pachyderm/src/client/version"
 	persist "github.com/pachyderm/pachyderm/src/server/pfs/db"
+	pfs_persist "github.com/pachyderm/pachyderm/src/server/pfs/db/persist"
 	pfssync "github.com/pachyderm/pachyderm/src/server/pkg/sync"
 )
 
@@ -508,6 +510,50 @@ func TestPutFileOverMaxMsgSize(t *testing.T) {
 	var buffer bytes.Buffer
 	require.NoError(t, client.GetFile(repo, commit1.ID, "foo", 0, 0, "", false, nil, &buffer))
 	require.Equal(t, string(expectedOutputA), buffer.String())
+}
+
+func TestPutFileOverMaxBlockSize(t *testing.T) {
+	t.Parallel()
+	dbName := "pachyderm_test_" + uuid.NewWithoutDashes()[0:12]
+	client := getClientWithDB(t, dbName)
+
+	repo := "test"
+	require.NoError(t, client.CreateRepo(repo))
+	rawMessage := "Some\nreal\ncustom\ncontent."
+	customPath := "/some/custom/path/" + uuid.NewWithoutDashes()[0:12]
+
+	// Write a big blob that would normally not fit in a block
+	var expectedOutputA []byte
+	for !(len(expectedOutputA) > pclient.MaxBlockSize) {
+		expectedOutputA = append(expectedOutputA, []byte(rawMessage)...)
+	}
+	r := bytes.NewReader(expectedOutputA)
+
+	commit1, err := client.StartCommit(repo, "master")
+	require.NoError(t, err)
+	_, err = client.PutFileWithDelimiter(repo, commit1.ID, customPath, pfs.Delimiter_NONE, r)
+	require.NoError(t, err)
+	err = client.FinishCommit(repo, "master")
+	require.NoError(t, err)
+
+	var buffer bytes.Buffer
+	require.NoError(t, client.GetFile(repo, commit1.ID, customPath, 0, 0, "", false, nil, &buffer))
+	require.Equal(t, string(expectedOutputA), buffer.String())
+
+	dbClient, err := gorethink.Connect(gorethink.ConnectOpts{
+		Address: RethinkAddress,
+		Timeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	cursor, err := gorethink.DB(dbName).Table("Diffs").Filter(
+		map[string]interface{}{
+			"Path": customPath,
+		}).Run(dbClient)
+	defer cursor.Close()
+	var diff *pfs_persist.Diff
+	require.NoError(t, cursor.One(&diff))
+	require.Equal(t, 2, len(diff.BlockRefs))
 }
 
 func TestPutFile(t *testing.T) {
@@ -3535,6 +3581,10 @@ func runServers(t *testing.T, port int32, apiServer pfs.APIServer,
 
 func getClient(t *testing.T) pclient.APIClient {
 	dbName := "pachyderm_test_" + uuid.NewWithoutDashes()[0:12]
+	return getClientWithDB(t, dbName)
+}
+
+func getClientWithDB(t *testing.T, dbName string) pclient.APIClient {
 	testDBs = append(testDBs, dbName)
 
 	if err := persist.InitDB(RethinkAddress, dbName); err != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2224,6 +2224,19 @@ func getJobOptions(kubeClient *kube.Client, jobInfo *persist.JobInfo, jobShimIma
 		Name:      "pach-bin",
 		MountPath: "/pach-bin",
 	})
+	dataPath := "pach-job-data"
+	volumes = append(volumes, api.Volume{
+		Name: dataPath,
+		VolumeSource: api.VolumeSource{
+			HostPath: &api.HostPathVolumeSource{
+				Path: fmt.Sprintf("/%v", dataPath),
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, api.VolumeMount{
+		Name:      dataPath,
+		MountPath: fmt.Sprintf("/%v", dataPath),
+	})
 	var imagePullSecrets []api.LocalObjectReference
 	for _, secret := range jobInfo.Transform.ImagePullSecrets {
 		imagePullSecrets = append(imagePullSecrets, api.LocalObjectReference{Name: secret})


### PR DESCRIPTION
Fixes a bug so we don't read all of a binary file into memory.

Also utilizes a hostpath mount for /pfs so we don't hit container disk limits.