### PR TITLE
Decouple MaxMsgSize from BlockSize

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -45,10 +45,8 @@ type APIClient struct {
 }
 
 var (
-	//BlockSize is used internally by PFS blockserver
-	BlockSize = 8 * 1024 * 1024 // 8 Megabytes
-	// MaxMsgSize is used to define the GRPC frame size, which we need to be greater than a block
-	MaxMsgSize = 3 * BlockSize
+	// MaxMsgSize is used to define the GRPC frame size
+	MaxMsgSize = 10 * 1024 * 1024
 )
 
 // NewMetricsClientFromAddress Creates a client that will report a user's Metrics

--- a/src/server/pfs/server/local_block_api_server.go
+++ b/src/server/pfs/server/local_block_api_server.go
@@ -71,7 +71,7 @@ func (s *localBlockAPIServer) PutBlock(putBlockServer pfsclient.BlockAPI_PutBloc
 			return err
 		}
 		result.BlockRef = append(result.BlockRef, blockRef)
-		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(client.BlockSize) {
+		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(blockSize) {
 			break
 		}
 	}

--- a/src/server/pfs/server/local_block_api_server.go
+++ b/src/server/pfs/server/local_block_api_server.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/pachyderm/pachyderm/src/client"
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 

--- a/src/server/pfs/server/local_block_api_server.go
+++ b/src/server/pfs/server/local_block_api_server.go
@@ -181,7 +181,7 @@ func readBlock(delimiter pfsclient.Delimiter, reader *bufio.Reader, decoder *jso
 		buffer.Write(value)
 		hash.Write(value)
 		bytesWritten += len(value)
-		if bytesWritten > client.BlockSize && delimiter != pfsclient.Delimiter_NONE {
+		if bytesWritten > blockSize && delimiter != pfsclient.Delimiter_NONE {
 			break
 		}
 	}

--- a/src/server/pfs/server/obj_block_api_server.go
+++ b/src/server/pfs/server/obj_block_api_server.go
@@ -171,7 +171,7 @@ func (s *objBlockAPIServer) PutBlock(putBlockServer pfsclient.BlockAPI_PutBlockS
 			}
 			return nil
 		})
-		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(client.BlockSize) {
+		if (blockRef.Range.Upper - blockRef.Range.Lower) < uint64(blockSize) {
 			break
 		}
 	}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -15,6 +15,10 @@ const (
 	MicrosoftBackendEnvVar = "MICROSOFT"
 )
 
+var (
+	blockSize = 8 * 1024 * 1024 // 8 Megabytes
+)
+
 // APIServer represents and api server.
 type APIServer interface {
 	pfsclient.APIServer


### PR DESCRIPTION
Now that our client PutFileWriter.Write() method buffers any data into multiple
grpc send's, these are no longer functionally related at all

Fixes #1335 