### PR TITLE
Move clone() from hashtree_test.go into hashtree.go

### DIFF
--- a/src/server/pkg/hashtree/hashtree_bench_test.go
+++ b/src/server/pkg/hashtree/hashtree_bench_test.go
@@ -96,12 +96,12 @@ func BenchmarkClone(b *testing.B) {
 		srcTs[i].PutFile(fmt.Sprintf("/foo/shard-%05d", i),
 			br(fmt.Sprintf(`block{hash:"%x"}`, r.Uint32())))
 	}
-	h := NewHashTree()
+	h := NewHashTree().(*hashtree)
 	h.Merge(srcTs)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		clone(h)
+		h.clone()
 	}
 }
 
@@ -130,7 +130,7 @@ func BenchmarkDelete(b *testing.B) {
 	h.Merge(srcTs)
 	srcBytes, err := h.Serialize()
 	if err != nil {
-		b.Fatal("could not marshal hashtree in BenchmarkDelete")
+		b.Fatal("could not serialize hashtree in BenchmarkDelete")
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
Use the new clone() in the implementation of HashTree.Merge, and update hashtree_test.go