### PR TITLE
Forgot the pfs Commit.SizeBytes - new migration for that

### DIFF
--- a/migration/1.3.7-1.3.8/Makefile
+++ b/migration/1.3.7-1.3.8/Makefile
@@ -1,0 +1,2 @@
+run:
+	kubectl $(KUBECTLFLAGS) run migrate --image="pachyderm/pachd:1.3.8" --restart=Never -- ./pachd --migrate=1.3.7-1.3.8

--- a/migration/1.3.7-1.3.8/README.md
+++ b/migration/1.3.7-1.3.8/README.md
@@ -1,0 +1,23 @@
+## Backup
+
+Please backup your metadata storage system before running this script.  See the [migration guide](http://pachyderm.readthedocs.io/en/latest/production/migration.html) for details.
+
+## How to run this script
+
+Make sure that your `kubectl` has been configured correctly to talk to the Kubernetes cluster where your Pachyderm runs.  Then simply:
+
+```
+make run
+```
+
+You should see a pod named `migrate` being created:
+
+```
+kubectl get all
+```
+
+Once the pod finishes running, the migration is complete.  You can make sure that nothing went wrong by looking at the logs of the pod:
+
+```
+kubectl logs migrate
+```


### PR DESCRIPTION
Here's my manual test to show it worked:

```
17-02-17[14:09:49]:~:0$pachctl version
COMPONENT           VERSION             
pachctl             1.3.7               
pachd               1.3.6-76538082a2729fbf026d8f573163f085ae410614   
17-02-17[14:09:53]:~:0$pachctl list-repo
NAME                CREATED             SIZE                
data                About an hour ago   1.696 KiB           
filter              About an hour ago   800 B               
sum                 About an hour ago   48 B                
17-02-17[14:09:56]:~:0$pachctl list-commit data
BRANCH              REPO/ID             PARENT              STARTED             DURATION             SIZE                
master              data/master/0       <none>              About an hour ago   Less than a second   0 B                 
master              data/master/1       master/0            About an hour ago   Less than a second   0 B                 
17-02-17[14:23:15]:pachyderm:0$kubectl run migrateg --image="pachyderm/pachd:latest" --restart=Never -- ./pachd --migrate=1.3.7-1.3.8
pod "migrateg" created
17-02-17[14:23:44]:pachyderm:0$kubectl logs po/migrateg
time="2017-02-17T22:23:45Z" level=info msg="Renaming Commit 'Size' to 'SizeBytes'" 
time="2017-02-17T22:23:46Z" level=info msg="Migration succeeded" 
17-02-17[14:09:59]:~:0$pachctl list-commit data
BRANCH              REPO/ID             PARENT              STARTED             DURATION             SIZE                
master              data/master/0       <none>              About an hour ago   Less than a second   874 B               
master              data/master/1       master/0            About an hour ago   Less than a second   863 B               
17-02-17[14:23:54]:~:0$
```