### PR TITLE
Test invalid aws creds

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -138,6 +138,9 @@ func DeployCmd(noMetrics *bool) *cobra.Command {
 				return fmt.Errorf("volume size needs to be an integer; instead got %v", args[6])
 			}
 			manifest := &bytes.Buffer{}
+			if strings.Contains(args[2], "/") {
+				return fmt.Errorf("invalid Amazon secret access key; key cannot contain a slash '/'")
+			}
 			if err = assets.WriteAmazonAssets(manifest, opts, args[0], args[1], args[2], args[3], args[4], volumeNames, volumeSize); err != nil {
 				return err
 			}


### PR DESCRIPTION
This makes deployment fail immediately if the provided AWS secret access token contains a '/'

If this error is not caught early, when doing a putfile you'll see an error like:

```
17-02-20[17:23:20]:aws-deploy:0$pachctl put-file aaa master -f $PSRC/Makefile 
AuthorizationHeaderMalformed: The authorization header is malformed; the Credential is mal-formed; expecting "<YOUR-AKID>/YYYYMMDD/REGION/SERVICE/aws4_request".
	status code: 400, request id: D403914CA91AEFB2
```

In particular you'll see a bad auth header that looks like:

```
Authorization:[AWS4-HMAC-SHA256 Credential=abbadabbaa/zabbadoo/20170222/us-west-2/s3/aws4_request, SignedHeaders=content-encoding;content-length;host;x-amz-date;x-amz-security-token, ... 

```

Instead of a good one that looks like:

```
Authorization:[AWS4-HMAC-SHA256 Credential=abbadabbazabbadoo/us-west-2/s3/aws4_request, SignedHeaders=content-encoding;content-length;host;x-amz-date;x-amz-security-token, ...
```

This isn't our bug. Either the AWS toolchain isn't quite in sync (they generate a key that is invalid w the go client) or perhaps it was a user copy paste error. Either way, we should detect this as early as possible and err.