### PR TITLE
Don't use streamSemaphore if it's nil.

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -152,12 +152,9 @@ func (c APIClient) DeleteAll() error {
 }
 
 // SetMaxConcurrentStreams Sets the maximum number of concurrent streams the
-// client can have.  This method cannot be safely used be concurrent
-// goroutines.
+// client can have. It is not safe to call this operations while operations are
+// outstanding.
 func (c APIClient) SetMaxConcurrentStreams(n int) {
-	for i := 0; i < cap(c.streamSemaphore); i++ {
-		c.streamSemaphore <- struct{}{}
-	}
 	c.streamSemaphore = make(chan struct{}, n)
 }
 

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -151,6 +151,16 @@ func (c APIClient) DeleteAll() error {
 	return nil
 }
 
+// SetMaxConcurrentStreams Sets the maximum number of concurrent streams the
+// client can have.  This method cannot be safely used be concurrent
+// goroutines.
+func (c APIClient) SetMaxConcurrentStreams(n int) {
+	for i := 0; i < cap(c.streamSemaphore); i++ {
+		c.streamSemaphore <- struct{}{}
+	}
+	c.streamSemaphore = make(chan struct{}, n)
+}
+
 func (c *APIClient) connect() error {
 	clientConn, err := grpc.Dial(c.addr, grpc.WithInsecure())
 	if err != nil {

--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -447,8 +447,10 @@ func (c APIClient) PutFileWriter(repoName string, commitID string, path string, 
 
 // PutFile writes a file to PFS from a reader.
 func (c APIClient) PutFile(repoName string, commitID string, path string, reader io.Reader) (_ int, retErr error) {
-	c.streamSemaphore <- struct{}{}
-	defer func() { <-c.streamSemaphore }()
+	if c.streamSemaphore != nil {
+		c.streamSemaphore <- struct{}{}
+		defer func() { <-c.streamSemaphore }()
+	}
 	return c.PutFileWithDelimiter(repoName, commitID, path, pfs.Delimiter_LINE, reader)
 }
 
@@ -502,8 +504,10 @@ func (c APIClient) PutFileURL(repoName string, commitID string, path string, url
 // blocks in the file. shard may be left nil in which case the entire file will be returned
 func (c APIClient) GetFile(repoName string, commitID string, path string, offset int64,
 	size int64, fromCommitID string, fullFile bool, shard *pfs.Shard, writer io.Writer) error {
-	c.streamSemaphore <- struct{}{}
-	defer func() { <-c.streamSemaphore }()
+	if c.streamSemaphore != nil {
+		c.streamSemaphore <- struct{}{}
+		defer func() { <-c.streamSemaphore }()
+	}
 	return c.getFile(repoName, commitID, path, offset, size, fromCommitID, fullFile, shard, writer)
 }
 

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1962,6 +1962,7 @@ func (a *apiServer) jobManager(ctx context.Context, job *ppsclient.Job) error {
 			return err
 		}
 		pClient := client.APIClient{PfsAPIClient: pfsAPIClient}
+		pClient.SetMaxConcurrentStreams(200)
 		objClient, err := obj.NewClientFromURLAndSecret(context.Background(), jobInfo.Output.URL)
 		if err != nil {
 			return err


### PR DESCRIPTION
We often construct `client`s in ways the bypass the stream semaphore.