### PR TITLE
Upgrade putfile logs

### DIFF
--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -319,7 +319,16 @@ func (a *apiServer) PutFile(putFileServer pfs.API_PutFileServer) (retErr error) 
 }
 
 func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest, url *url.URL) (retErr error) {
-	put := func(filePath string, objPath string) error {
+	put := func(filePath string, objPath string) (thisRetErr error) {
+		a.Logger.Info("pfs.API", "putFileObj", request, nil, nil, 0)
+		defer func(start time.Time) {
+			if thisRetErr != nil {
+				a.Logger.Error("pfs.API", "putFileObj", request, response, thisRetErr, time.Since(start))
+			} else {
+				a.Logger.Info("pfs.API", "putFileObj", request, response, thisRetErr, time.Since(start))
+			}
+		}(time.Now())
+
 		r, err := objClient.Reader(objPath, 0, 0)
 		if err != nil {
 			return err

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -354,9 +354,9 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 	put := func(filePath string, objPath string) (thisRetErr error) {
 		request.Url = objPath
 		request.File.Path = filePath
-		rpclog.Log("pfs.API", "putFileObj", request, nil, nil, 0)
+		protorpclog.Log("pfs.API", "putFileObj", request, nil, nil, 0)
 		defer func(start time.Time) {
-			rpclog.Log("pfs.API", "putFileObj", request, nil, retErr, time.Since(start))
+			protorpclog.Log("pfs.API", "putFileObj", request, nil, retErr, time.Since(start))
 		}(time.Now())
 
 		r, err := objClient.Reader(objPath, 0, 0)

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -340,7 +340,7 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 		Method:   "putFileObjHelper",
 		Request:  requestString,
 		Duration: duration.String(),
-		Err:      err,
+		Error:    err,
 		FilePath: filePath,
 		ObjPath:  objPath,
 	}
@@ -379,20 +379,12 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 		var eg errgroup.Group
 		path := strings.TrimPrefix(url.Path, "/")
 		sem := make(chan struct{}, client.DefaultMaxConcurrentStreams)
-		fmt.Printf("Going to walk folder: %v\n", path)
 		objClient.Walk(path, func(name string) error {
-			fmt.Printf("I spy %v\n", name)
 			eg.Go(func() error {
-				fmt.Printf("acquiring sem\n")
 				sem <- struct{}{}
-				fmt.Printf("acquired sem\n")
 				defer func() {
-					fmt.Printf("releasing sem\n")
 					<-sem
-					fmt.Printf("released sem\n")
-
 				}()
-				fmt.Printf("putting file %v\n", filepath.Join(request.File.Path, strings.TrimPrefix(name, path)))
 				return put(filepath.Join(request.File.Path, strings.TrimPrefix(name, path)), name)
 			})
 			return nil

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -353,12 +353,10 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest, url *url.URL) (retErr error) {
 	put := func(filePath string, objPath string) (thisRetErr error) {
 		request.Url = objPath
-		request.File = &pfs.File{Path: filePath}
-		func() {
-			a.Log(request, nil, nil, 0)
-		}()
+		request.File.Path = filePath
+		rpclog.Log("pfs.API", "putFileObj", request, nil, nil, 0)
 		defer func(start time.Time) {
-			a.Log(request, nil, retErr, time.Since(start))
+			rpclog.Log("pfs.API", "putFileObj", request, nil, retErr, time.Since(start))
 		}(time.Now())
 
 		r, err := objClient.Reader(objPath, 0, 0)

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 
-	"go.pedge.io/lion"
 	"go.pedge.io/proto/rpclog"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -317,37 +316,6 @@ func (a *apiServer) PutFile(putFileServer pfs.API_PutFileServer) (retErr error) 
 		}
 	}
 	return nil
-}
-
-type putFileHelperLog struct {
-	Service  string `json:"service,omitempty"`
-	Method   string `json:"method,omitempty"`
-	Request  string `json:"request,omitempty"`
-	Duration string `json:"duration,omitempty"`
-	Error    error  `json:"error,omitempty"`
-	FilePath string `json:"filepath,omitempty"`
-	ObjPath  string `json:"objpath,omitempty"`
-}
-
-func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Duration, filePath string, objPath string) {
-	requestString := ""
-	if request != nil {
-		requestString = request.String()
-	}
-	l := &putFileHelperLog{
-		Service:  "pfs.API",
-		Method:   "putFileObjHelper",
-		Request:  requestString,
-		Duration: duration.String(),
-		Error:    err,
-		FilePath: filePath,
-		ObjPath:  objPath,
-	}
-	if l.Error != nil {
-		lion.Errorln(l)
-	} else {
-		lion.Infoln(l)
-	}
 }
 
 func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest, url *url.URL) (retErr error) {

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -344,16 +343,10 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 		FilePath: filePath,
 		ObjPath:  objPath,
 	}
-	logJSON, err := json.Marshal(l)
-	if err != nil {
-		lion.Errorln("malformed putFileObj log")
-		return
-	}
-	rawLog := string(logJSON)
 	if l.Error != nil {
-		lion.Errorln(rawLog)
+		lion.Errorln(l)
 	} else {
-		lion.Infoln(rawLog)
+		lion.Infoln(l)
 	}
 }
 

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -319,14 +319,11 @@ func (a *apiServer) PutFile(putFileServer pfs.API_PutFileServer) (retErr error) 
 }
 
 func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest, url *url.URL) (retErr error) {
+	protorpclog.Log("pfs.API", "putFileObj", request, nil, nil, 0)
 	put := func(filePath string, objPath string) (thisRetErr error) {
-		a.Logger.Info("pfs.API", "putFileObj", request, nil, nil, 0)
+		protorpclog.Log("pfs.API", "putFileObjHelper", request, nil, nil, 0)
 		defer func(start time.Time) {
-			if thisRetErr != nil {
-				a.Logger.Error("pfs.API", "putFileObj", request, response, thisRetErr, time.Since(start))
-			} else {
-				a.Logger.Info("pfs.API", "putFileObj", request, response, thisRetErr, time.Since(start))
-			}
+			protorpclog.Log("pfs.API", "putFileObjHelper", request, nil, thisRetErr, time.Since(start))
 		}(time.Now())
 
 		r, err := objClient.Reader(objPath, 0, 0)
@@ -344,6 +341,7 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 		var eg errgroup.Group
 		path := strings.TrimPrefix(url.Path, "/")
 		sem := make(chan struct{}, client.DefaultMaxConcurrentStreams)
+		fmt.Printf("Going to walk folder: %v\n", path)
 		objClient.Walk(path, func(name string) error {
 			eg.Go(func() error {
 				sem <- struct{}{}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -343,11 +343,18 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 		sem := make(chan struct{}, client.DefaultMaxConcurrentStreams)
 		fmt.Printf("Going to walk folder: %v\n", path)
 		objClient.Walk(path, func(name string) error {
+			fmt.Printf("I spy %v\n", name)
 			eg.Go(func() error {
+				fmt.Printf("acquiring sem\n")
 				sem <- struct{}{}
+				fmt.Printf("acquired sem\n")
 				defer func() {
+					fmt.Printf("releasing sem\n")
 					<-sem
+					fmt.Printf("released sem\n")
+
 				}()
+				fmt.Printf("putting file %v\n", filepath.Join(request.File.Path, strings.TrimPrefix(name, path)))
 				return put(filepath.Join(request.File.Path, strings.TrimPrefix(name, path)), name)
 			})
 			return nil

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -329,11 +330,10 @@ type putFileHelperLog struct {
 }
 
 func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Duration, filePath string, objPath string) {
-	requestString = ""
+	requestString := ""
 	if request != nil {
 		requestString = request.String()
 	}
-	errorString = ""
 	l := &putFileHelperLog{
 		Service:  "pfs.API",
 		Request:  requestString,
@@ -342,12 +342,13 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 		FilePath: filePath,
 		ObjPath:  objPath,
 	}
-	rawLog, err := json.Marshal(l)
+	logJSON, err := json.Marshal(l)
 	if err != nil {
 		lion.Errorln("Malformed putFileObj log")
 		return
 	}
-	if l.err != nil {
+	rawLog := string(logJSON)
+	if l.Error != nil {
 		lion.Errorln(rawLog)
 	} else {
 		lion.Infoln(rawLog)

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -358,7 +358,6 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 			Url:       objPath,
 			File: &pfs.File{
 				Path: filePath,
-				Repo: request.File.Repo,
 			},
 			Recursive: request.Recursive,
 		}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -352,8 +352,14 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 
 func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest, url *url.URL) (retErr error) {
 	put := func(filePath string, objPath string) (thisRetErr error) {
-		request.Url = objPath
-		request.File.Path = filePath
+		logRequest := &pfs.PutFileRequest{
+			FileType:  request.FileType,
+			Delimiter: request.Delimiter,
+			Url:       objPath,
+			File:      request.File,
+			Recursive: request.Recursive,
+		}
+		logRequest.File.Path = filePath
 		protorpclog.Log("pfs.API", "putFileObj", request, nil, nil, 0)
 		defer func(start time.Time) {
 			protorpclog.Log("pfs.API", "putFileObj", request, nil, retErr, time.Since(start))

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -321,13 +321,13 @@ func (a *apiServer) PutFile(putFileServer pfs.API_PutFileServer) (retErr error) 
 }
 
 type putFileHelperLog struct {
-	service  string
-	method   string
-	request  string
-	duration string
-	err      error
-	filePath string
-	objPath  string
+	Service  string `json:"service,omitempty"`
+	Method   string `json:"method,omitempty"`
+	Request  string `json:"request,omitempty"`
+	Duration string `json:"duration,omitempty"`
+	Error    error  `json:"error,omitempty"`
+	FilePath string `json:"filepath,omitempty"`
+	ObjPath  string `json:"objpath,omitempty"`
 }
 
 func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Duration, filePath string, objPath string) {
@@ -336,13 +336,13 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 		requestString = request.String()
 	}
 	l := &putFileHelperLog{
-		service:  "pfs.API",
-		method:   "putFileObjHelper",
-		request:  requestString,
-		duration: duration.String(),
-		err:      err,
-		filePath: filePath,
-		objPath:  objPath,
+		Service:  "pfs.API",
+		Method:   "putFileObjHelper",
+		Request:  requestString,
+		Duration: duration.String(),
+		Err:      err,
+		FilePath: filePath,
+		ObjPath:  objPath,
 	}
 	logJSON, err := json.Marshal(l)
 	if err != nil {
@@ -350,7 +350,7 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 		return
 	}
 	rawLog := string(logJSON)
-	if l.err != nil {
+	if l.Error != nil {
 		lion.Errorln(rawLog)
 	} else {
 		lion.Infoln(rawLog)

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -321,12 +321,13 @@ func (a *apiServer) PutFile(putFileServer pfs.API_PutFileServer) (retErr error) 
 }
 
 type putFileHelperLog struct {
-	Service  string
-	Request  string
-	Duration string
-	Error    error
-	FilePath string
-	ObjPath  string
+	service  string
+	method   string
+	request  string
+	duration string
+	err      error
+	filePath string
+	objPath  string
 }
 
 func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Duration, filePath string, objPath string) {
@@ -335,20 +336,21 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 		requestString = request.String()
 	}
 	l := &putFileHelperLog{
-		Service:  "pfs.API",
-		Request:  requestString,
-		Duration: duration.String(),
-		Error:    err,
-		FilePath: filePath,
-		ObjPath:  objPath,
+		service:  "pfs.API",
+		method:   "putFileObjHelper",
+		request:  requestString,
+		duration: duration.String(),
+		err:      err,
+		filePath: filePath,
+		objPath:  objPath,
 	}
 	logJSON, err := json.Marshal(l)
 	if err != nil {
-		lion.Errorln("Malformed putFileObj log")
+		lion.Errorln("malformed putFileObj log")
 		return
 	}
 	rawLog := string(logJSON)
-	if l.Error != nil {
+	if l.err != nil {
 		lion.Errorln(rawLog)
 	} else {
 		lion.Infoln(rawLog)

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -352,9 +352,13 @@ func putFileLogHelper(request *pfs.PutFileRequest, err error, duration time.Dura
 
 func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest, url *url.URL) (retErr error) {
 	put := func(filePath string, objPath string) (thisRetErr error) {
-		putFileLogHelper(request, nil, 0, filePath, objPath)
+		request.Url = objPath
+		request.File = &pfs.File{Path: filePath}
+		func() {
+			a.Log(request, nil, nil, 0)
+		}()
 		defer func(start time.Time) {
-			putFileLogHelper(request, thisRetErr, time.Since(start), filePath, objPath)
+			a.Log(request, nil, retErr, time.Since(start))
 		}(time.Now())
 
 		r, err := objClient.Reader(objPath, 0, 0)

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -356,10 +356,12 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 			FileType:  request.FileType,
 			Delimiter: request.Delimiter,
 			Url:       objPath,
-			File:      request.File,
+			File: &pfs.File{
+				Path: filePath,
+				Repo: request.File.Repo,
+			},
 			Recursive: request.Recursive,
 		}
-		logRequest.File.Path = filePath
 		protorpclog.Log("pfs.API", "putFileObj", logRequest, nil, nil, 0)
 		defer func(start time.Time) {
 			protorpclog.Log("pfs.API", "putFileObj", logRequest, nil, retErr, time.Since(start))

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -360,9 +360,9 @@ func (a *apiServer) putFileObj(objClient obj.Client, request *pfs.PutFileRequest
 			Recursive: request.Recursive,
 		}
 		logRequest.File.Path = filePath
-		protorpclog.Log("pfs.API", "putFileObj", request, nil, nil, 0)
+		protorpclog.Log("pfs.API", "putFileObj", logRequest, nil, nil, 0)
 		defer func(start time.Time) {
-			protorpclog.Log("pfs.API", "putFileObj", request, nil, retErr, time.Since(start))
+			protorpclog.Log("pfs.API", "putFileObj", logRequest, nil, retErr, time.Since(start))
 		}(time.Now())
 
 		r, err := objClient.Reader(objPath, 0, 0)

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -56,6 +56,7 @@ func (c *amazonClient) Walk(name string, fn func(name string) error) error {
 	); err != nil {
 		return err
 	}
+	fmt.Printf("finished checking bucket\n")
 	return fnErr
 }
 

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -37,12 +37,14 @@ func (c *amazonClient) Writer(name string) (io.WriteCloser, error) {
 
 func (c *amazonClient) Walk(name string, fn func(name string) error) error {
 	var fnErr error
+	fmt.Printf("checking bucket %v and prefix %v\n", c.bucket, name)
 	if err := c.s3.ListObjectsPages(
 		&s3.ListObjectsInput{
 			Bucket: aws.String(c.bucket),
 			Prefix: aws.String(name),
 		},
 		func(listObjectsOutput *s3.ListObjectsOutput, lastPage bool) bool {
+			fmt.Printf("got %v results in s3 ListObjectsOutput: %v\n", len(listObjectsOutput.Contents), listObjectsOutput)
 			for _, object := range listObjectsOutput.Contents {
 				if err := fn(*object.Key); err != nil {
 					fnErr = err

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -37,14 +37,12 @@ func (c *amazonClient) Writer(name string) (io.WriteCloser, error) {
 
 func (c *amazonClient) Walk(name string, fn func(name string) error) error {
 	var fnErr error
-	fmt.Printf("checking bucket %v and prefix %v\n", c.bucket, name)
 	if err := c.s3.ListObjectsPages(
 		&s3.ListObjectsInput{
 			Bucket: aws.String(c.bucket),
 			Prefix: aws.String(name),
 		},
 		func(listObjectsOutput *s3.ListObjectsOutput, lastPage bool) bool {
-			fmt.Printf("got %v results in s3 ListObjectsOutput: %v\n", len(listObjectsOutput.Contents), listObjectsOutput)
 			for _, object := range listObjectsOutput.Contents {
 				if err := fn(*object.Key); err != nil {
 					fnErr = err
@@ -56,7 +54,6 @@ func (c *amazonClient) Walk(name string, fn func(name string) error) error {
 	); err != nil {
 		return err
 	}
-	fmt.Printf("finished checking bucket\n")
 	return fnErr
 }
 


### PR DESCRIPTION
Fixes #1359 

For every object that we're putting from an obj store into pachyderm, it should not get its own log line. This will give us a breadcrumb trail of progress for large data set uploads.

Here's an example (expanded) log line thats generated from a recursive putfile now:

```
2017-02-25T01:26:40Z INFO  
{
    "duration": "208.555745ms",
    "filepath": "test/20006.txt",
    "method": "putFileObjHelper",
    "objpath": "test/20006.txt",
    "request": "file:<commit:<repo:<name:\"debug\" > id:\"i\" > path:\"test\" > file_type:FILE_TYPE_REGULAR url:\"s3://tests3recursiveputs/test\" recursive:true ",
    "service": "pfs.API"
}
```