### PR TITLE
Make lease and heartbeat periods configurable

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
@@ -20,12 +19,15 @@ const (
 	// see its own name.  The pod name is made available through the Kubernetes
 	// downward API.
 	PPSPodNameEnv = "PPS_POD_NAME"
-	// PPSLeasePeriod is the amount of time for a lease on a chunk to expire.
+	// PPSLeasePeriodEnv is the amount of time for a lease on a chunk
+	// to expire.
 	// That is, a pod needs to send ContinueJob to PPS at lease once every this
 	// amount of time in order to keep owning a chunk.  In reality, pods send
 	// ContinueJob more often than that because they need to account for network
 	// latency.
-	PPSLeasePeriod = 30 * time.Second
+	PPSLeasePeriodSecsEnv     = "PPS_LEASE_PERIOD_SECS"
+	PPSHeartbeatSecsEnv       = "PPS_HEARTBEAT_SECS"
+	PPSMaxHeartbeatRetriesEnv = "PPS_MAX_HEARTBEAT_RETRIES"
 )
 
 var (

--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -19,14 +19,18 @@ const (
 	// see its own name.  The pod name is made available through the Kubernetes
 	// downward API.
 	PPSPodNameEnv = "PPS_POD_NAME"
-	// PPSLeasePeriodEnv is the amount of time for a lease on a chunk
+	// PPSLeasePeriodSecsEnv is the amount of time for a lease on a chunk
 	// to expire.
 	// That is, a pod needs to send ContinueJob to PPS at lease once every this
 	// amount of time in order to keep owning a chunk.  In reality, pods send
 	// ContinueJob more often than that because they need to account for network
 	// latency.
-	PPSLeasePeriodSecsEnv     = "PPS_LEASE_PERIOD_SECS"
-	PPSHeartbeatSecsEnv       = "PPS_HEARTBEAT_SECS"
+	PPSLeasePeriodSecsEnv = "PPS_LEASE_PERIOD_SECS"
+	// PPSHeartbeatSecsEnv controls how many seconds before a pod sends
+	// a heartbeat again.
+	PPSHeartbeatSecsEnv = "PPS_HEARTBEAT_SECS"
+	// PPSMaxHeartbeatRetriesEnv controls how many times a pod can fail
+	// to send heartbeats before it decides to shut itself down.
 	PPSMaxHeartbeatRetriesEnv = "PPS_MAX_HEARTBEAT_RETRIES"
 )
 

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -50,22 +50,25 @@ func init() {
 }
 
 type appEnv struct {
-	Port               uint16 `env:"PORT,default=650"`
-	NumShards          uint64 `env:"NUM_SHARDS,default=32"`
-	StorageRoot        string `env:"PACH_ROOT,default=/pach"`
-	StorageBackend     string `env:"STORAGE_BACKEND,default="`
-	DatabaseAddress    string `env:"RETHINK_PORT_28015_TCP_ADDR,required"`
-	PPSDatabaseName    string `env:"DATABASE_NAME,default=pachyderm_pps"`
-	PFSDatabaseName    string `env:"DATABASE_NAME,default=pachyderm_pfs"`
-	KubeAddress        string `env:"KUBERNETES_PORT_443_TCP_ADDR,required"`
-	EtcdAddress        string `env:"ETCD_PORT_2379_TCP_ADDR,required"`
-	Namespace          string `env:"NAMESPACE,default=default"`
-	Metrics            bool   `env:"METRICS,default=true"`
-	Init               bool   `env:"INIT,default=false"`
-	BlockCacheBytes    int64  `env:"BLOCK_CACHE_BYTES,default=5368709120"` //default = 5 gigabyte
-	JobShimImage       string `env:"JOB_SHIM_IMAGE,default="`
-	JobImagePullPolicy string `env:"JOB_IMAGE_PULL_POLICY,default="`
-	LogLevel           string `env:"LOG_LEVEL,default=info"`
+	Port                uint16 `env:"PORT,default=650"`
+	NumShards           uint64 `env:"NUM_SHARDS,default=32"`
+	StorageRoot         string `env:"PACH_ROOT,default=/pach"`
+	StorageBackend      string `env:"STORAGE_BACKEND,default="`
+	DatabaseAddress     string `env:"RETHINK_PORT_28015_TCP_ADDR,required"`
+	PPSDatabaseName     string `env:"DATABASE_NAME,default=pachyderm_pps"`
+	PFSDatabaseName     string `env:"DATABASE_NAME,default=pachyderm_pfs"`
+	KubeAddress         string `env:"KUBERNETES_PORT_443_TCP_ADDR,required"`
+	EtcdAddress         string `env:"ETCD_PORT_2379_TCP_ADDR,required"`
+	Namespace           string `env:"NAMESPACE,default=default"`
+	Metrics             bool   `env:"METRICS,default=true"`
+	Init                bool   `env:"INIT,default=false"`
+	BlockCacheBytes     int64  `env:"BLOCK_CACHE_BYTES,default=5368709120"` //default = 5 gigabyte
+	JobShimImage        string `env:"JOB_SHIM_IMAGE,default="`
+	JobImagePullPolicy  string `env:"JOB_IMAGE_PULL_POLICY,default="`
+	LogLevel            string `env:"LOG_LEVEL,default=info"`
+	LeasePeriodSecs     string `env:"PPS_LEASE_PERIOD_SECS,default=30"`
+	HeartbeatSecs       string `env:"PPS_HEARTBEAT_SECS,default=10"`
+	MaxHeartbeatRetries string `env:"PPS_MAX_HEARTBEAT_RETRIES,default=3"`
 }
 
 func main() {
@@ -194,6 +197,9 @@ func do(appEnvObj interface{}) error {
 		appEnv.JobShimImage,
 		appEnv.JobImagePullPolicy,
 		reporter,
+		appEnv.LeasePeriodSecs,
+		appEnv.HeartbeatSecs,
+		appEnv.MaxHeartbeatRetries,
 	)
 	go func() {
 		if err := sharder.Register(nil, address, []shard.Server{ppsAPIServer, cacheServer}); err != nil {

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/server/pfs/server"
 	"github.com/pachyderm/pachyderm/src/server/pkg/deploy"
 	"github.com/ugorji/go/codec"
@@ -235,6 +236,18 @@ func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, v
 								{
 									Name:  "LOG_LEVEL",
 									Value: logLevel,
+								},
+								{
+									Name:  client.PPSLeasePeriodSecsEnv,
+									Value: "30",
+								},
+								{
+									Name:  client.PPSHeartbeatSecsEnv,
+									Value: "10",
+								},
+								{
+									Name:  client.PPSMaxHeartbeatRetriesEnv,
+									Value: "3",
 								},
 							},
 							Ports: []api.ContainerPort{

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -29,6 +29,9 @@ func NewAPIServer(
 	jobShimImage string,
 	jobImagePullPolicy string,
 	reporter *metrics.Reporter,
+	leasePeriodSecs string,
+	heartbeatSecs string,
+	maxHeartbeatRetries string,
 ) APIServer {
 	return &apiServer{
 		Logger:                  protorpclog.NewLogger("pps.API"),
@@ -51,5 +54,8 @@ func NewAPIServer(
 		jobShimImage:            jobShimImage,
 		jobImagePullPolicy:      jobImagePullPolicy,
 		reporter:                reporter,
+		leasePeriodSecs:         leasePeriodSecs,
+		heartbeatSecs:           heartbeatSecs,
+		maxHeartbeatRetries:     maxHeartbeatRetries,
 	}
 }


### PR DESCRIPTION
This PR adds three knobs:

1. Lease period: how long a pod can be unresponsive before the server considers the pod dead.
2. Heartbeat period: how long before a pod sends a heartbeat again.
3. Heartbeat maximum retries: how many times a pod can fail to send a heartbeat before it kills itself.

The code kinda sucks, but I don't wanna spend too much time on it since 1.4 is landing soon.