### PR TITLE
Refactor pkg/deploy/assets/assets.go and pkg/deploy/cmds/cmds.go

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -57,6 +57,28 @@ const (
 	s3CustomArgs = 6
 )
 
+// AssetOpts are options that are applicable to all the asset types.
+type AssetOpts struct {
+	PachdShards   uint64
+	RethinkShards uint64
+	Version       string
+	LogLevel      string
+	Metrics       bool
+
+	// DeployRethinkAsStatefulSet deploys RethinkDB as a  single-node rethink
+	// managed by a RC, rather than a multi-node, highly-available Stateful Set.
+	// This will be necessary until GKE supports Stateful Set
+	DeployRethinkAsStatefulSet bool
+
+	// RethinkCacheSize is the amount of memory each RethinkDB node allocates
+	// towards its cache.
+	RethinkCacheSize string
+
+	// BlockCacheSize is the amount of memory each PachD node allocates towards
+	// its cache of PFS blocks.
+	BlockCacheSize string
+}
+
 // ServiceAccount returns a kubernetes service account for use with Pachyderm.
 func ServiceAccount() *api.ServiceAccount {
 	return &api.ServiceAccount{
@@ -72,15 +94,15 @@ func ServiceAccount() *api.ServiceAccount {
 }
 
 // PachdRc returns a pachd replication controller.
-func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, version string, metrics bool, blockCacheSize string) *api.ReplicationController {
+func PachdRc(opts *AssetOpts, objectStoreBackend backend, hostPath string) *api.ReplicationController {
 	image := pachdImage
-	if version != "" {
-		image += ":" + version
+	if opts.Version != "" {
+		image += ":" + opts.Version
 	}
 	// we turn metrics off if we dont have a static version
 	// this prevents dev clusters from reporting metrics
-	if version == deploy.DevVersionTag {
-		metrics = false
+	if opts.Version == deploy.DevVersionTag {
+		opts.Metrics = false
 	}
 	volumes := []api.Volume{
 		{
@@ -106,7 +128,7 @@ func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, v
 		TimeoutSeconds:      1,
 	}
 	var backendEnvVar string
-	switch backend {
+	switch objectStoreBackend {
 	case localBackend:
 		volumes[0].HostPath = &api.HostPathVolumeSource{
 			Path: filepath.Join(hostPath, "pachd"),
@@ -203,7 +225,7 @@ func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, v
 								},
 								{
 									Name:  "NUM_SHARDS",
-									Value: strconv.FormatUint(shards, 10),
+									Value: strconv.FormatUint(opts.PachdShards, 10),
 								},
 								{
 									Name:  "STORAGE_BACKEND",
@@ -220,7 +242,7 @@ func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, v
 								},
 								{
 									Name:  "JOB_SHIM_IMAGE",
-									Value: fmt.Sprintf("pachyderm/job-shim:%s", version),
+									Value: fmt.Sprintf("pachyderm/job-shim:%s", opts.Version),
 								},
 								{
 									Name:  "JOB_IMAGE_PULL_POLICY",
@@ -228,15 +250,15 @@ func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, v
 								},
 								{
 									Name:  "PACHD_VERSION",
-									Value: version,
+									Value: opts.Version,
 								},
 								{
 									Name:  "METRICS",
-									Value: strconv.FormatBool(metrics),
+									Value: strconv.FormatBool(opts.Metrics),
 								},
 								{
 									Name:  "LOG_LEVEL",
-									Value: logLevel,
+									Value: opts.LogLevel,
 								},
 								{
 									Name:  client.PPSLeasePeriodSecsEnv,
@@ -252,7 +274,7 @@ func PachdRc(shards uint64, backend backend, hostPath string, logLevel string, v
 								},
 								{
 									Name:  "BLOCK_CACHE_BYTES",
-									Value: blockCacheSize,
+									Value: opts.BlockCacheSize,
 								},
 							},
 							Ports: []api.ContainerPort{
@@ -412,11 +434,11 @@ func EtcdService() *api.Service {
 }
 
 // RethinkRc returns a rethinkdb replication controller.
-func RethinkRc(volume string, rethinkdbCacheSize string) *api.ReplicationController {
+func RethinkRc(opts *AssetOpts, volume string) *api.ReplicationController {
 	replicas := int32(1)
-	rethinkCacheQuantity := resource.MustParse(rethinkdbCacheSize)
-	containerFootprint := rethinkCacheQuantity.Copy()
-	containerFootprint.Add(resource.MustParse("256M"))
+	rethinkCacheQuantity := resource.MustParse(opts.RethinkCacheSize)
+	mem := rethinkCacheQuantity.Copy()
+	mem.Add(rethinkNonCacheMemFootprint)
 	spec := &api.ReplicationController{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "ReplicationController",
@@ -471,7 +493,7 @@ func RethinkRc(volume string, rethinkdbCacheSize string) *api.ReplicationControl
 							ImagePullPolicy: "IfNotPresent",
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{
-									api.ResourceMemory: *containerFootprint,
+									api.ResourceMemory: *mem,
 								},
 							},
 						},
@@ -494,13 +516,13 @@ func RethinkRc(volume string, rethinkdbCacheSize string) *api.ReplicationControl
 }
 
 // RethinkStatefulSet returns a rethinkdb stateful set
-func RethinkStatefulSet(shards int, diskSpace int, cacheSize string) interface{} {
-	rethinkCacheQuantity := resource.MustParse(cacheSize)
-	containerFootprint := rethinkCacheQuantity.Copy()
-	containerFootprint.Add(rethinkNonCacheMemFootprint)
-	// As of Oct 24 2016, the Kubernetes client does not include structs for Stateful Set, so we generate the kubernetes
-	// manifest using raw json.
+func RethinkStatefulSet(opts *AssetOpts, diskSpace int) interface{} {
+	rethinkCacheQuantity := resource.MustParse(opts.RethinkCacheSize)
+	mem := rethinkCacheQuantity.Copy()
+	mem.Add(rethinkNonCacheMemFootprint)
 
+	// As of Oct 24 2016, the Kubernetes client does not include structs for
+	// Stateful Set, so we generate the kubernetes manifest using raw json.
 	// Stateful Set config:
 	return map[string]interface{}{
 		"apiVersion": "apps/v1beta1",
@@ -513,7 +535,7 @@ func RethinkStatefulSet(shards int, diskSpace int, cacheSize string) interface{}
 		"spec": map[string]interface{}{
 			// Effectively configures a RC
 			"serviceName": rethinkHeadlessName,
-			"replicas":    shards,
+			"replicas":    int(opts.RethinkShards),
 			"selector": map[string]interface{}{
 				"matchLabels": labels(rethinkControllerName),
 			},
@@ -561,7 +583,7 @@ func RethinkStatefulSet(shards int, diskSpace int, cacheSize string) interface{}
 							"imagePullPolicy": "IfNotPresent",
 							"resources": map[string]interface{}{
 								"requests": map[string]interface{}{
-									"memory": containerFootprint.String(),
+									"memory": mem.String(),
 								},
 							},
 						},
@@ -796,8 +818,8 @@ func MicrosoftSecret(container string, id string, secret string) *api.Secret {
 
 // WriteRethinkVolumes creates 'shards' persistent volumes, either backed by IAAS persistent volumes (EBS volumes for amazon, GCP volumes for Google, etc)
 // or local volumes (if 'backend' == 'local'). All volumes are created with size 'size'.
-func WriteRethinkVolumes(w io.Writer, backend backend, shards int, hostPath string, names []string, size int) error {
-	if backend != localBackend && len(names) < shards {
+func WriteRethinkVolumes(w io.Writer, computeBackend backend, shards int, hostPath string, names []string, size int) error {
+	if computeBackend != localBackend && len(names) < shards {
 		return fmt.Errorf("could not create non-local rethink cluster with %d shards, as there are only %d external volumes", shards, len(names))
 	}
 	encoder := codec.NewEncoder(w, jsonEncoderHandle)
@@ -820,7 +842,7 @@ func WriteRethinkVolumes(w io.Writer, backend backend, shards int, hostPath stri
 			},
 		}
 
-		switch backend {
+		switch computeBackend {
 		case amazonBackend:
 			spec.Spec.PersistentVolumeSource = api.PersistentVolumeSource{
 				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
@@ -855,7 +877,7 @@ func WriteRethinkVolumes(w io.Writer, backend backend, shards int, hostPath stri
 				},
 			}
 		default:
-			return fmt.Errorf("cannot generate volume spec for unknown backend \"%v\"", backend)
+			return fmt.Errorf("cannot generate volume spec for unknown backend \"%v\"", computeBackend)
 		}
 		spec.CodecEncodeSelf(encoder)
 		fmt.Fprintf(w, "\n")
@@ -890,30 +912,15 @@ func RethinkVolumeClaim(size int) *api.PersistentVolumeClaim {
 	}
 }
 
-// AssetOpts are options that are applicable to all the asset types.
-type AssetOpts struct {
-	PachdShards        uint64
-	RethinkShards      uint64
-	RethinkdbCacheSize string
-	BlockCacheSize     string
-	Version            string
-	LogLevel           string
-	Metrics            bool
-
-	// Deploy single-node rethink managed by a RC, rather than a multi-node,
-	// highly-available Stateful Set. This will be necessary until GKE supports Stateful Set
-	DeployRethinkAsStatefulSet bool
-}
-
 // WriteAssets writes the assets to w.
-func WriteAssets(w io.Writer, opts *AssetOpts, objectStore backend, persistentDisk backend,
+func WriteAssets(w io.Writer, opts *AssetOpts, objectStoreBackend backend, computeBackend backend,
 	volumeNames []string, volumeSize int, hostPath string) error {
 	encoder := codec.NewEncoder(w, jsonEncoderHandle)
 
 	ServiceAccount().CodecEncodeSelf(encoder)
 	fmt.Fprintf(w, "\n")
 
-	if err := WriteRethinkVolumes(w, persistentDisk, int(opts.RethinkShards), hostPath, volumeNames, volumeSize); err != nil {
+	if err := WriteRethinkVolumes(w, computeBackend, int(opts.RethinkShards), hostPath, volumeNames, volumeSize); err != nil {
 		return err
 	}
 
@@ -925,19 +932,23 @@ func WriteAssets(w io.Writer, opts *AssetOpts, objectStore backend, persistentDi
 	RethinkNodeportService(opts).CodecEncodeSelf(encoder)
 	fmt.Fprintf(w, "\n")
 	if opts.DeployRethinkAsStatefulSet {
-		encoder.Encode(RethinkStatefulSet(int(opts.RethinkShards), volumeSize, opts.RethinkdbCacheSize))
+		encoder.Encode(RethinkStatefulSet(opts, volumeSize))
 		fmt.Fprintf(w, "\n")
 		RethinkHeadlessService().CodecEncodeSelf(encoder)
 	} else {
-		if objectStore != localBackend && len(volumeNames) != 1 {
-			return fmt.Errorf("RethinkDB can only be managed by a ReplicationController as a single instance, but recieved %d volumes", len(volumeNames))
-		}
 		RethinkVolumeClaim(volumeSize).CodecEncodeSelf(encoder)
-		volumeName := ""
-		if objectStore != localBackend {
-			volumeName = volumeNames[0]
+		if computeBackend == localBackend {
+			// with localBackend, we store rethink data on a hostPath volume, and
+			// therefore don't pass any storage volumes.
+			RethinkRc(opts, "").CodecEncodeSelf(encoder)
+		} else {
+			if len(volumeNames) != 1 {
+				return fmt.Errorf("RethinkDB can only be managed by a "+
+					"ReplicationController as a single instance, but recieved %d volumes",
+					len(volumeNames))
+			}
+			RethinkRc(opts, volumeNames[0]).CodecEncodeSelf(encoder)
 		}
-		RethinkRc(volumeName, opts.RethinkdbCacheSize).CodecEncodeSelf(encoder)
 	}
 	fmt.Fprintf(w, "\n")
 
@@ -946,7 +957,7 @@ func WriteAssets(w io.Writer, opts *AssetOpts, objectStore backend, persistentDi
 
 	PachdService().CodecEncodeSelf(encoder)
 	fmt.Fprintf(w, "\n")
-	PachdRc(opts.PachdShards, objectStore, hostPath, opts.LogLevel, opts.Version, opts.Metrics, opts.BlockCacheSize).CodecEncodeSelf(encoder)
+	PachdRc(opts, objectStoreBackend, hostPath).CodecEncodeSelf(encoder)
 	fmt.Fprintf(w, "\n")
 	return nil
 }


### PR DESCRIPTION
This will resolve many of the merge conflicts in https://github.com/pachyderm/pachyderm/pull/1377.

This should have no user-visible effect (except for a minor bug fix). The change mostly involves:
- Renaming variables and rearranging code
- Replacing many of the arguments to functions in assets.go with a reference to AssetOpts, from which the function extracts information
- Rewriting some of the help for `pachctl deploy custom` (hopefully making it clearer and more explicit). Also, fixing a minor bug in WriteAssets, in which the wrong backend is used to create the "rethink volume claim" portion of the k8s manifest.

This was tested by running the following commands using both the version of pachctl in `master` and the version of pachctl in this branch, and comparing the outputs (no meaningful discrepancies were found):
```
  ./pachctl deploy local --dry-run >local_no_shards.json
  ./pachctl deploy local --deploy-rethink-as-stateful-set --rethink-shards=3 --dry-run >local_3_shards.json
  ./pachctl deploy amazon S3_bucket id secret token region EBS_volume_name 100 --dry-run >amazon_no_shards.json
  ./pachctl deploy amazon S3_bucket id secret token region EBS_volume_1,EBS_volume_2,EBS_volume_3 100 --deploy-rethink-as-stateful-set --rethink-shards=3 --dry-run >amazon_3_shards.json
  ./pachctl deploy google GCS_bucket GCE_persistent_disk 100 --dry-run >google_no_shards.json
  ./pachctl deploy google GCS_bucket GCE_disk_1,GCE_disk_2,GCE_disk_3 100 --deploy-rethink-as-stateful-set --rethink-shards=3 --dry-run >google_3_shards.json
  ./pachctl deploy microsoft container storage_account_name "$(echo "storage_account_key" | base64 )" http://volume_URI 100 --dry-run >microsoft_no_shards.json
  ./pachctl deploy microsoft container storage_account_name "$(echo "storage_account_key" | base64 )" http://volume_1,http://volume_2,http://volume_3 100 --deploy-rethink-as-stateful-set --rethink-shards=3 --dry-run >microsoft_3_shards.json
 ./pachctl deploy custom --compute-backend google --object-store-backend s3 EBS_volume_name 100 bucket id secret endpoint --dry-run >custom.json
```