### PR TITLE
Add make launch-logging task

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "etc/plugin/logging"]
+	path = etc/plugin/logging
+	url = git://github.com/pachyderm/elk-kubernetes.git

--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,16 @@ launch-monitoring:
 	@echo "All services up. Now port forwarding grafana to localhost:3000"
 	kubectl --namespace=kube-system port-forward `kubectl --namespace=kube-system get pods -l k8s-app=grafana -o json | jq '.items[0].metadata.name' -r` 3000:3000 &
 
+clean-launch-logging: check-kubectl check-kubectl-connection
+	git submodule update --init
+	cd etc/plugin/logging && ./undeploy.sh
+
+launch-logging: check-kubectl check-kubectl-connection
+	@# Creates Fluentd / Elasticsearch / Kibana services for logging under --namespace=monitoring
+	git submodule update --init
+	cd etc/plugin/logging && ./deploy.sh
+	kubectl --namespace=monitoring port-forward kibana-logging-v2-690172596-pztws 35601:5601
+
 grep-data:
 	go run examples/grep/generate.go >examples/grep/set1.txt
 	go run examples/grep/generate.go >examples/grep/set2.txt

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ launch-logging: check-kubectl check-kubectl-connection
 	@# Creates Fluentd / Elasticsearch / Kibana services for logging under --namespace=monitoring
 	git submodule update --init
 	cd etc/plugin/logging && ./deploy.sh
-	kubectl --namespace=monitoring port-forward kibana-logging-v2-690172596-pztws 35601:5601
+	kubectl --namespace=monitoring port-forward `kubectl --namespace=monitoring get pods -l k8s-app=kibana-logging -o json | jq '.items[0].metadata.name' -r` 35601:5601 &
 
 grep-data:
 	go run examples/grep/generate.go >examples/grep/set1.txt


### PR DESCRIPTION

This allows us to deploy logging search / filtering via kibana via a make task. I tested this on my aws cluster (see screenshot below).

The log parsing isn't perfect, but it works and seems to aggregate. This should help us when debugging customer deployments.
