### PR TITLE
Fix hashtree.Merge(); add hashtree tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_script:
 - docker version
 script:
 - make lint
-- make docker-build clean-launch-dev launch-dev pfs-test pps-test
+- make docker-build clean-launch-dev launch-dev test-pfs test-pps test-hashtree
 notifications:
   slack: pachyderm:qmSCZSX1Q2yWxc6DjNZZFLGd

--- a/Makefile
+++ b/Makefile
@@ -213,11 +213,14 @@ pretest:
 
 test: pretest test-client clean-launch-test-rethinkdb launch-test-rethinkdb test-fuse test-local docker-build docker-build-netcat clean-launch-dev launch-dev integration-tests example-tests
 
-pfs-test:
+test-pfs:
 	go test ./src/server/pfs/server
 
-pps-test:
+test-pps:
 	go test ./src/server/pachyderm_test.go
+
+test-hashtree:
+	go test ./src/server/pkg/hashtree
 
 bench:
 	go test ./src/server -run=XXX -bench=.

--- a/src/server/pkg/hashtree/hashtree.go
+++ b/src/server/pkg/hashtree/hashtree.go
@@ -20,7 +20,7 @@ const (
 
 func (n *NodeProto) nodetype() nodetype {
 	switch {
-	case n == nil:
+	case n == nil || (n.DirNode == nil && n.FileNode == nil):
 		return none
 	case n.DirNode != nil:
 		return directory
@@ -121,10 +121,10 @@ func NewHashTree() OpenHashTree {
 	}
 }
 
-// canonicalize updates the hash and size of the node N at 'path'. If N is a
-// directory canonicalize will also update the hash of all of N's children
-// recursively. Thus, h.canonicalize("/") will update all hash and subtree_size
-// fields in h, making the whole tree consistent.
+// canonicalize updates the hash of the node N at 'path'. If N is a directory
+// canonicalize will also update the hash of all of N's children recursively.
+// Thus, h.canonicalize("/") will update the Hash field of all nodes in h,
+// making the whole tree consistent.
 func (h *hashtree) canonicalize(path string) error {
 	path = clean(path)
 	if !h.changed[path] {
@@ -135,41 +135,38 @@ func (h *hashtree) canonicalize(path string) error {
 		return errorf(Internal, "no node at \"%s\"; cannot canonicalize", path)
 	}
 
-	// Compute hash and size of 'n'
+	// Compute hash of 'n'
 	hash := sha256.New()
-	size := int64(0)
 	switch n.nodetype() {
 	case directory:
 		// Compute n.Hash by concatenating name + hash of all children of n.DirNode
-		// Note that PutFile keeps n.DirNode.Children sorted, so the order is stable
+		// Note that PutFile keeps n.DirNode.Children sorted, so the order is
+		// stable.
 		for _, child := range n.DirNode.Children {
 			childpath := join(path, child)
 			if err := h.canonicalize(childpath); err != nil {
 				return err
 			}
-			n, ok := h.fs[childpath]
+			childnode, ok := h.fs[childpath]
 			if !ok {
 				return errorf(Internal, "could not find node for \"%s\" while "+
 					"updating hash of \"%s\"", join(path, child), path)
 			}
 			// append child.Name and child.Hash to b
-			hash.Write([]byte(fmt.Sprintf("%s:%s:", n.Name, n.Hash)))
-			size += n.SubtreeSize
+			hash.Write([]byte(fmt.Sprintf("%s:%s:", childnode.Name, childnode.Hash)))
 		}
 	case file:
-		// Compute n.Hash by concatenating all BlockRef hashes in n.FileNode
+		// Compute n.Hash by concatenating all BlockRef hashes in n.FileNode.
 		for _, object := range n.FileNode.Objects {
 			hash.Write([]byte(object.Hash))
 		}
-		size += n.SubtreeSize
 	default:
 		return errorf(Internal,
 			"malformed node at \"%s\" is neither a file nor a directory", path)
 	}
 
-	// Update hash and size of 'n'
+	// Update hash of 'n'
 	n.Hash = hash.Sum(nil)
-	n.SubtreeSize = size
 	delete(h.changed, path)
 	return nil
 }
@@ -196,7 +193,7 @@ func nop(*NodeProto, string, string) error {
 // 2. update(node at "/path"    or nil, "/path",    "to")
 // 3. update(node at "/"        or nil, "",         "path")
 //
-// This is useful for propagating changes to size and hash upwards.
+// This is useful for propagating changes to size upwards.
 func (h *hashtree) visit(path string, update updateFn) error {
 	for path != "" {
 		parent, child := split(path)
@@ -259,8 +256,8 @@ func (h *HashTreeProto) Open() OpenHashTree {
 	return h3
 }
 
-// Finish makes a deep copy of the OpenHashTree, updates all of the hashes and
-// node size metadata in the copy, and returns the copy
+// Finish makes a deep copy of the OpenHashTree, updates all of the hashes in
+// the copy, and returns the copy
 func (h *hashtree) Finish() (HashTree, error) {
 	if err := h.canonicalize(""); err != nil {
 		return nil, err
@@ -299,16 +296,14 @@ func (h *hashtree) PutFile(path string, objects []*pfs.Object, size int64) error
 	// Append new object
 	node.FileNode.Objects = append(node.FileNode.Objects, objects...)
 	h.changed[path] = true
-
 	node.SubtreeSize += size
 
-	// Add 'path' to parent & update hashes back to root
+	// Add 'path' to parent (if it's new) & mark nodes as 'changed' back to root
 	if err := h.visit(path, func(node *NodeProto, parent, child string) error {
 		if node == nil {
 			node = &NodeProto{
-				Name:        base(parent),
-				SubtreeSize: 0,
-				DirNode:     &DirectoryNodeProto{},
+				Name:    base(parent),
+				DirNode: &DirectoryNodeProto{},
 			}
 			h.fs[parent] = node
 		}
@@ -374,6 +369,7 @@ func (h *hashtree) DeleteFile(path string) error {
 		return errorf(PathNotFound, "no file at \"%s\"", path)
 	}
 	h.removeFromMap(path) // Deletes children recursively
+	size := node.SubtreeSize
 
 	// Remove 'path' from its parent directory
 	parent, child := split(path)
@@ -388,13 +384,14 @@ func (h *hashtree) DeleteFile(path string) error {
 	if !removeStr(&node.DirNode.Children, child) {
 		return errorf(Internal, "parent of \"%s\" does not contain it", path)
 	}
-	// Update hashes back to root
+	// Mark nodes as 'changed' back to root
 	if err := h.visit(path, func(node *NodeProto, parent, child string) error {
 		if node == nil {
 			return errorf(Internal,
 				"encountered orphaned file \"%s\" while deleting \"%s\"", path,
 				join(parent, child))
 		}
+		node.SubtreeSize -= size
 		h.changed[parent] = true
 		return nil
 	}); err != nil {
@@ -423,6 +420,7 @@ func (h *hashtree) GetOpen(path string) (*OpenNode, error) {
 	}
 	return &OpenNode{
 		Name:     np.Name,
+		Size:     np.SubtreeSize,
 		FileNode: np.FileNode,
 		DirNode:  np.DirNode,
 	}, nil
@@ -455,15 +453,15 @@ func (h *HashTreeProto) List(path string) ([]*NodeProto, error) {
 }
 
 // Glob returns a list of files and directories that match 'pattern'.
-// The nodes returned have their `Name`s set to their full paths.
+// The nodes returned have their 'Name' field set to their full paths.
 func (h *HashTreeProto) Glob(pattern string) ([]*NodeProto, error) {
 	// "*" should be an allowed pattern, but our paths always start with "/", so
 	// modify the pattern to fit our path structure.
 	pattern = clean(pattern)
 
 	var res []*NodeProto
-	for p, node := range h.Fs {
-		matched, err := pathlib.Match(pattern, p)
+	for path, node := range h.Fs {
+		matched, err := pathlib.Match(pattern, path)
 		if err != nil {
 			if err == pathlib.ErrBadPattern {
 				return nil, errorf(MalformedGlob, "glob \"%s\" is malformed", pattern)
@@ -473,7 +471,7 @@ func (h *HashTreeProto) Glob(pattern string) ([]*NodeProto, error) {
 		if matched {
 			nodeCopy := new(NodeProto)
 			*nodeCopy = *node
-			nodeCopy.Name = p
+			nodeCopy.Name = path
 			res = append(res, nodeCopy)
 		}
 	}
@@ -490,27 +488,24 @@ func (h *HashTreeProto) Size() int64 {
 }
 
 // mergeNode merges the node at 'path' from the trees in 'srcs' into 'h'.
-func (h *hashtree) mergeNode(path string, srcs []HashTree) error {
+func (h *hashtree) mergeNode(path string, srcs []HashTree) (int64, error) {
 	path = clean(path)
 	// Get the node at path in 'h' and determine its type (i.e. file, dir)
-	d, err := h.GetOpen(path)
-	var destNode *NodeProto
-	if d != nil {
+	destNode, ok := h.fs[path]
+	if !ok {
 		destNode = &NodeProto{
-			Name:        d.Name,
-			Hash:        nil,
+			Name:        base(path),
 			SubtreeSize: 0,
-			FileNode:    d.FileNode,
-			DirNode:     d.DirNode,
+			Hash:        nil,
+			FileNode:    nil,
+			DirNode:     nil,
 		}
-	}
-	if err != nil && Code(err) != PathNotFound {
-		return err
-	}
-	if destNode.nodetype() == unrecognized {
-		return errorf(Internal, "malformed node at \"%s\" in destination "+
+		h.fs[path] = destNode
+	} else if destNode.nodetype() == unrecognized {
+		return 0, errorf(Internal, "malformed node at \"%s\" in destination "+
 			"hashtree is neither a file nor a directory", path)
 	}
+	sizeDelta := int64(0) // We return this to propagate file additions upwards
 
 	// Get node at 'path' in all 'srcs'. All such nodes must have the same type as
 	// each other and the same type as 'destNode'
@@ -521,8 +516,7 @@ func (h *hashtree) mergeNode(path string, srcs []HashTree) error {
 	//   'srcs' (but it's convenient to build it here, before we've checked them
 	//   all)
 	// - We need to group trees by common children, so that children present in
-	//   multiple 'srcNodes' are only merged once, and we only recompute the hash
-	//   for that child once
+	//   multiple 'srcNodes' are only merged once
 	// - if every srcNode has a unique file /foo/shard-xxxxx (00000 to 99999)
 	//   then we'd call mergeNode("/foo") 100k times, once for each tree in
 	//   'srcs', while running mergeNode("/").
@@ -533,45 +527,43 @@ func (h *hashtree) mergeNode(path string, srcs []HashTree) error {
 	childrenToTrees := make(map[string][]HashTree)
 	// Amount of data being added to node at 'path' in 'h'
 	for _, src := range srcs {
+		// Get the node at 'path' from 'src', and initialize 'h' at 'path' if needed
 		n, err := src.Get(path)
+		if Code(err) == PathNotFound {
+			continue
+		}
 		if err != nil && Code(err) != PathNotFound {
-			return err
+			return 0, err
 		}
 		if pathtype == none {
+			// 'h' is uninitialized at this path
+			if n.nodetype() == directory {
+				destNode.DirNode = &DirectoryNodeProto{}
+			} else if n.nodetype() == file {
+				destNode.FileNode = &FileNodeProto{}
+			} else {
+				return 0, errorf(Internal, "could not merge unrecognized node type at "+
+					"\"%s\", which is neither a file nore a directory", path)
+			}
 			pathtype = n.nodetype()
 		} else if pathtype != n.nodetype() {
-			return errorf(PathConflict, "could not merge path \"%s\" which is "+
-				"not consistently a file/directory in the hashtrees being merged")
+			return sizeDelta, errorf(PathConflict, "could not merge path \"%s\" "+
+				"which is a file in some hashtrees and a directory in others", path)
 		}
 		switch n.nodetype() {
 		case directory:
-			// Create destination directory if none exists
-			if destNode == nil {
-				destNode = &NodeProto{
-					Name:    base(path),
-					DirNode: &DirectoryNodeProto{},
-				}
-				h.fs[path] = destNode
-			}
 			// Instead of merging here, we build a reverse-index and merge below
 			for _, c := range n.DirNode.Children {
 				childrenToTrees[c] = append(childrenToTrees[c], src)
 			}
 		case file:
-			// Create destination file if none exists
-			if destNode == nil {
-				destNode = &NodeProto{
-					Name:     base(path),
-					FileNode: &FileNodeProto{},
-				}
-				h.fs[path] = destNode
-			}
-			// Append new blocks
+			// Append new objects, and update size of target node (since that can't be
+			// done in canonicalize)
 			destNode.FileNode.Objects = append(destNode.FileNode.Objects,
 				n.FileNode.Objects...)
-			destNode.SubtreeSize += n.SubtreeSize
+			sizeDelta += n.SubtreeSize
 		default:
-			return errorf(Internal, "malformed node at \"%s\" in source "+
+			return sizeDelta, errorf(Internal, "malformed node at \"%s\" in source "+
 				"hashtree is neither a file nor a directory", path)
 		}
 	}
@@ -580,15 +572,18 @@ func (h *hashtree) mergeNode(path string, srcs []HashTree) error {
 	if pathtype == directory {
 		// Merge all children (collected in childrenToTrees)
 		for c, cSrcs := range childrenToTrees {
-			err := h.mergeNode(join(path, c), cSrcs)
+			childSizeDelta, err := h.mergeNode(join(path, c), cSrcs)
 			if err != nil {
-				return err
+				return sizeDelta, err
 			}
+			sizeDelta += childSizeDelta
 			insertStr(&destNode.DirNode.Children, c)
 		}
 	}
+	// Update the size of destNode, and mark it changed
+	destNode.SubtreeSize += sizeDelta
 	h.changed[path] = true
-	return nil
+	return sizeDelta, nil
 }
 
 // Merge merges the HashTrees in 'trees' into 'h'. The result is nil if no
@@ -614,7 +609,7 @@ func (h *hashtree) Merge(trees ...HashTree) error {
 	if err != nil {
 		return errorf(Internal, "could not snapshot hashtree before merge: %s", err)
 	}
-	if err = hmod.mergeNode("/", nonEmptyTrees); err != nil {
+	if _, err = hmod.mergeNode("/", nonEmptyTrees); err != nil {
 		return err
 	}
 	*h = *hmod

--- a/src/server/pkg/hashtree/hashtree.go
+++ b/src/server/pkg/hashtree/hashtree.go
@@ -569,6 +569,7 @@ func (h *hashtree) mergeNode(path string, srcs []HashTree) error {
 			// Append new blocks
 			destNode.FileNode.Objects = append(destNode.FileNode.Objects,
 				n.FileNode.Objects...)
+			destNode.SubtreeSize += n.SubtreeSize
 		default:
 			return errorf(Internal, "malformed node at \"%s\" in source "+
 				"hashtree is neither a file nor a directory", path)

--- a/src/server/pkg/hashtree/hashtree_bench_test.go
+++ b/src/server/pkg/hashtree/hashtree_bench_test.go
@@ -27,21 +27,32 @@ import (
 // Benchmarked times at rev. 6b8e9df38e42f624d2da0aaa785753e9e1d68c0d
 //  cnt |  time (s)
 // -----+-------------
-// 1k   | 0.007 s/op
-// 10k  | 0.088 s/op
-// 100k | 1.006 s/op
-func BenchmarkPutFile(b *testing.B) {
+// 1k   | 0.006 s/op
+// 10k  | 0.068 s/op
+// 100k | 0.813 s/op
+func benchmarkPutFileN(b *testing.B, cnt int) {
 	// Add 'cnt' files
-	cnt := int(1e3)
 	r := rand.New(rand.NewSource(0))
 	for n := 0; n < b.N; n++ {
 		h := NewHashTree()
 		for i := 0; i < cnt; i++ {
 			h.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-				obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
+				obj(fmt.Sprintf(`hash:"%x"`, r.Uint32())), 1)
 		}
 		h.Finish()
 	}
+}
+
+func BenchmarkPutFile1k(b *testing.B) {
+	benchmarkPutFileN(b, 1e3)
+}
+
+func BenchmarkPutFile10k(b *testing.B) {
+	benchmarkPutFileN(b, 1e4)
+}
+
+func BenchmarkPutFile100k(b *testing.B) {
+	benchmarkPutFileN(b, 1e5)
 }
 
 // BenchmarkMerge measures how long it takes to merge 'cnt' trees, each of which
@@ -53,19 +64,18 @@ func BenchmarkPutFile(b *testing.B) {
 // Benchmarked times at rev. 6b8e9df38e42f624d2da0aaa785753e9e1d68c0d
 //  cnt |  time (s)
 // -----+-------------
-// 1k   | 0.009 s/op
-// 10k  | 0.139 s/op
-// 100k | 3.668 s/op
-func BenchmarkMerge(b *testing.B) {
+// 1k   | 0.006 s/op
+// 10k  | 0.082 s/op
+// 100k | 2.750 s/op
+func benchmarkMergeN(b *testing.B, cnt int) {
 	// Merge 'cnt' trees, each with 1 file (simulating a job)
-	cnt := int(1e5)
 	trees := make([]HashTree, cnt)
 	r := rand.New(rand.NewSource(0))
 	var err error
 	for i := 0; i < cnt; i++ {
 		t := NewHashTree()
 		t.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-			obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
+			obj(fmt.Sprintf(`hash:"%x"`, r.Uint32())), 1)
 		trees[i], err = t.Finish()
 		if err != nil {
 			b.Fatal("could not run benchmark: " + err.Error())
@@ -80,6 +90,18 @@ func BenchmarkMerge(b *testing.B) {
 	}
 }
 
+func BenchmarkMerge1k(b *testing.B) {
+	benchmarkMergeN(b, 1e3)
+}
+
+func BenchmarkMerge10k(b *testing.B) {
+	benchmarkMergeN(b, 1e4)
+}
+
+func BenchmarkMerge100k(b *testing.B) {
+	benchmarkMergeN(b, 1e5)
+}
+
 // BenchmarkClone is idential to BenchmarkDelete, except that it doesn't
 // actually call DeleteFile. The idea is to provide a baseline for how long it
 // takes to clone a HashTree with 'cnt' elements, so that that number can be
@@ -89,23 +111,34 @@ func BenchmarkMerge(b *testing.B) {
 // Benchmarked times at rev. 6b8e9df38e42f624d2da0aaa785753e9e1d68c0d
 //  cnt |  time (s)
 // -----+-------------
-// 1k   | 0.003 s/op
-// 10k  | 0.037 s/op
-// 100k | 0.430 s/op
-func BenchmarkClone(b *testing.B) {
+// 1k   | 0.002 s/op
+// 10k  | 0.028 s/op
+// 100k | 0.346 s/op
+func benchmarkCloneN(b *testing.B, cnt int) {
 	// Create a tree with 'cnt' files
-	cnt := int(1e4)
 	r := rand.New(rand.NewSource(0))
 	h := NewHashTree().(*hashtree)
 	for i := 0; i < cnt; i++ {
 		h.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-			obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
+			obj(fmt.Sprintf(`hash:"%x"`, r.Uint32())), 1)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.clone()
 	}
+}
+
+func BenchmarkClone1k(b *testing.B) {
+	benchmarkCloneN(b, 1e3)
+}
+
+func BenchmarkClone10k(b *testing.B) {
+	benchmarkCloneN(b, 1e4)
+}
+
+func BenchmarkClone100k(b *testing.B) {
+	benchmarkCloneN(b, 1e5)
 }
 
 // BenchmarkDelete measures how long it takes to delete a directory with 'cnt'
@@ -116,17 +149,16 @@ func BenchmarkClone(b *testing.B) {
 // Benchmarked times at rev. 6b8e9df38e42f624d2da0aaa785753e9e1d68c0d
 //  cnt |  time (s)
 // -----+-------------
-// 1k   | 0.004 s/op
-// 10k  | 0.040 s/op
-// 100k | 0.485 s/op
-func BenchmarkDelete(b *testing.B) {
+// 1k   | 0.002 s/op
+// 10k  | 0.030 s/op
+// 100k | 0.395 s/op
+func benchmarkDeleteN(b *testing.B, cnt int) {
 	// Create a tree with 'cnt' files
-	cnt := int(1e5)
 	r := rand.New(rand.NewSource(0))
 	h := NewHashTree().(*hashtree)
 	for i := 0; i < cnt; i++ {
 		h.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-			obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
+			obj(fmt.Sprintf(`hash:"%x"`, r.Uint32())), 1)
 	}
 
 	b.ResetTimer()
@@ -137,4 +169,16 @@ func BenchmarkDelete(b *testing.B) {
 		}
 		h2.DeleteFile("/foo")
 	}
+}
+
+func BenchmarkDelete1k(b *testing.B) {
+	benchmarkDeleteN(b, 1e3)
+}
+
+func BenchmarkDelete10k(b *testing.B) {
+	benchmarkDeleteN(b, 1e4)
+}
+
+func BenchmarkDelete100k(b *testing.B) {
+	benchmarkDeleteN(b, 1e5)
 }

--- a/src/server/pkg/hashtree/hashtree_bench_test.go
+++ b/src/server/pkg/hashtree/hashtree_bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkPutFile(b *testing.B) {
 		h := NewHashTree()
 		for i := 0; i < cnt; i++ {
 			h.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-				br(fmt.Sprintf(`block{hash:"%x"}`, r.Uint32())))
+				obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
 		}
 		h.Finish()
 	}
@@ -65,7 +65,7 @@ func BenchmarkMerge(b *testing.B) {
 	for i := 0; i < cnt; i++ {
 		t := NewHashTree()
 		t.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-			br(fmt.Sprintf(`block{hash:"%x"}`, r.Uint32())))
+			obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
 		trees[i], err = t.Finish()
 		if err != nil {
 			b.Fatal("could not run benchmark: " + err.Error())
@@ -99,7 +99,7 @@ func BenchmarkClone(b *testing.B) {
 	h := NewHashTree().(*hashtree)
 	for i := 0; i < cnt; i++ {
 		h.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-			br(fmt.Sprintf(`block{hash:"%x"}`, r.Uint32())))
+			obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
 	}
 
 	b.ResetTimer()
@@ -126,7 +126,7 @@ func BenchmarkDelete(b *testing.B) {
 	h := NewHashTree().(*hashtree)
 	for i := 0; i < cnt; i++ {
 		h.PutFile(fmt.Sprintf("/foo/shard-%05d", i),
-			br(fmt.Sprintf(`block{hash:"%x"}`, r.Uint32())))
+			obj(fmt.Sprintf(`object{hash:"%x"}`, r.Uint32())), 1)
 	}
 
 	b.ResetTimer()

--- a/src/server/pkg/hashtree/hashtree_test.go
+++ b/src/server/pkg/hashtree/hashtree_test.go
@@ -12,18 +12,12 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 )
 
-// br parses a string as a BlockRef
-func br(s ...string) []*pfs.BlockRef {
-	result := make([]*pfs.BlockRef, len(s))
+// obj parses a string as an Object
+func obj(s ...string) []*pfs.Object {
+	result := make([]*pfs.Object, len(s))
 	for i, ss := range s {
-		result[i] = &pfs.BlockRef{}
+		result[i] = &pfs.Object{}
 		proto.UnmarshalText(ss, result[i])
-		if result[i].Range == nil {
-			result[i].Range = &pfs.ByteRange{
-				Lower: 0,
-				Upper: 1, // Makes sure test files have non-zero size
-			}
-		}
 	}
 	return result
 }
@@ -113,16 +107,16 @@ func requireOperationInvariant(t *testing.T, h OpenHashTree, op func()) {
 func TestPutFileBasic(t *testing.T) {
 	// Put a file
 	h := NewHashTree().(*hashtree)
-	h.PutFile("/foo", br(`block{hash:"20c27"}`))
+	h.PutFile("/foo", obj(`object{hash:"20c27"}`), 1)
 	require.Equal(t, int64(1), h.fs["/foo"].SubtreeSize)
 	require.Equal(t, int64(1), h.fs[""].SubtreeSize)
 
 	// Put a file under a directory and make sure changes are propagated upwards
-	h.PutFile("/dir/bar", br(`block{hash:"ebc57"}`))
+	h.PutFile("/dir/bar", obj(`object{hash:"ebc57"}`), 1)
 	require.Equal(t, int64(1), h.fs["/dir/bar"].SubtreeSize)
 	require.Equal(t, int64(1), h.fs["/dir"].SubtreeSize)
 	require.Equal(t, int64(2), h.fs[""].SubtreeSize)
-	h.PutFile("/dir/buzz", br(`block{hash:"8e02c"}`))
+	h.PutFile("/dir/buzz", obj(`object{hash:"8e02c"}`), 1)
 	require.Equal(t, int64(1), h.fs["/dir/buzz"].SubtreeSize)
 	require.Equal(t, int64(2), h.fs["/dir"].SubtreeSize)
 	require.Equal(t, int64(3), h.fs[""].SubtreeSize)
@@ -145,7 +139,7 @@ func TestPutFileBasic(t *testing.T) {
 	require.Equal(t, int64(1), h1.Fs["/foo"].SubtreeSize)
 
 	// Make sure subsequent PutFile calls append
-	h.PutFile("/foo", br(`block{hash:"413e7"}`))
+	h.PutFile("/foo", obj(`object{hash:"413e7"}`), 1)
 	h2 := finish(t, h)
 	require.NotEqual(t, h1.Fs["/foo"].Hash, h2.Fs["/foo"].Hash)
 	require.Equal(t, int64(2), h2.Fs["/foo"].SubtreeSize)
@@ -185,7 +179,7 @@ func TestPutDirBasic(t *testing.T) {
 	require.Equal(t, emptySha[:], h3.Fs["/dir"].Hash)
 
 	// Make sure that deleting a dir also deletes files under the dir
-	h.PutFile("/dir/foo/bar", br(`block{hash:"20c27"}`))
+	h.PutFile("/dir/foo/bar", obj(`object{hash:"20c27"}`), 1)
 	h.DeleteFile("/dir/foo")
 	require.Equal(t, []string{}, h.fs["/dir"].DirNode.Children)
 	require.Equal(t, len(h.fs), 2)
@@ -201,12 +195,12 @@ func TestPutDirBasic(t *testing.T) {
 
 func TestPutError(t *testing.T) {
 	h := NewHashTree()
-	err := h.PutFile("/foo", br(`block{hash:"20c27"}`))
+	err := h.PutFile("/foo", obj(`object{hash:"20c27"}`), 1)
 	require.NoError(t, err)
 
 	// PutFile fails if the parent is a file, and h is unchanged
 	requireOperationInvariant(t, h, func() {
-		err := h.PutFile("/foo/bar", br(`block{hash:"8e02c"}`))
+		err := h.PutFile("/foo/bar", obj(`object{hash:"8e02c"}`), 1)
 		require.YesError(t, err)
 		require.Equal(t, PathConflict, Code(err))
 		node, err := h.GetOpen("/foo/bar")
@@ -229,8 +223,8 @@ func TestPutError(t *testing.T) {
 	// Merge fails if src and dest disagree about whether a node is a file or
 	// directory, and h is unchanged
 	srcOpen := NewHashTree()
-	srcOpen.PutFile("/buzz", br(`block{hash:"9d432"}`))
-	srcOpen.PutFile("/foo/bar", br(`block{hash:"ebc57"}`))
+	srcOpen.PutFile("/buzz", obj(`object{hash:"9d432"}`), 1)
+	srcOpen.PutFile("/foo/bar", obj(`object{hash:"ebc57"}`), 1)
 	src, err := srcOpen.Finish()
 	require.NoError(t, err)
 	requireOperationInvariant(t, h, func() {
@@ -242,10 +236,10 @@ func TestPutError(t *testing.T) {
 	// PutFile fails if a directory already exists (put /foo when /foo/bar exists)
 	err = h.DeleteFile("/foo")
 	require.NoError(t, err)
-	err = h.PutFile("/foo/bar", br(`block{hash:"ebc57"}`))
+	err = h.PutFile("/foo/bar", obj(`object{hash:"ebc57"}`), 1)
 	require.NoError(t, err)
 	requireOperationInvariant(t, h, func() {
-		err := h.PutFile("/foo", br(`block{hash:"8e02c"}`))
+		err := h.PutFile("/foo", obj(`object{hash:"8e02c"}`), 1)
 		require.YesError(t, err)
 		require.Equal(t, PathConflict, Code(err))
 	})
@@ -268,7 +262,7 @@ func TestDeleteDirError(t *testing.T) {
 func TestAddDeleteReverts(t *testing.T) {
 	h := NewHashTree()
 	addDeleteFile := func() {
-		h.PutFile("/dir/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+		h.PutFile("/dir/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 		h.DeleteFile("/dir/__NEW_FILE__")
 	}
 	addDeleteDir := func() {
@@ -276,7 +270,7 @@ func TestAddDeleteReverts(t *testing.T) {
 		h.DeleteFile("/dir/__NEW_DIR__")
 	}
 	addDeleteSubFile := func() {
-		h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+		h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 		h.DeleteFile("/dir/__NEW_DIR__")
 	}
 
@@ -286,8 +280,8 @@ func TestAddDeleteReverts(t *testing.T) {
 	requireOperationInvariant(t, h, addDeleteSubFile)
 	// Add some files to make sure the test still passes when D already has files
 	// in it.
-	h.PutFile("/dir/foo", br(`block{hash:"ebc57"}`))
-	h.PutFile("/dir/bar", br(`block{hash:"20c27"}`))
+	h.PutFile("/dir/foo", obj(`object{hash:"ebc57"}`), 1)
+	h.PutFile("/dir/bar", obj(`object{hash:"20c27"}`), 1)
 	requireOperationInvariant(t, h, addDeleteFile)
 	requireOperationInvariant(t, h, addDeleteDir)
 	requireOperationInvariant(t, h, addDeleteSubFile)
@@ -299,7 +293,7 @@ func TestDeleteAddReverts(t *testing.T) {
 	h := NewHashTree()
 	deleteAddFile := func() {
 		h.DeleteFile("/dir/__NEW_FILE__")
-		h.PutFile("/dir/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+		h.PutFile("/dir/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 	}
 	deleteAddDir := func() {
 		h.DeleteFile("/dir/__NEW_DIR__")
@@ -307,26 +301,26 @@ func TestDeleteAddReverts(t *testing.T) {
 	}
 	deleteAddSubFile := func() {
 		h.DeleteFile("/dir/__NEW_DIR__")
-		h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+		h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 	}
 
-	h.PutFile("/dir/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+	h.PutFile("/dir/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 	requireOperationInvariant(t, h, deleteAddFile)
 	h.PutDir("/dir/__NEW_DIR__")
 	requireOperationInvariant(t, h, deleteAddDir)
-	h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+	h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 	requireOperationInvariant(t, h, deleteAddSubFile)
 
 	// Make sure test still passes when trees are nonempty
 	h = NewHashTree()
-	h.PutFile("/dir/foo", br(`block{hash:"ebc57"}`))
-	h.PutFile("/dir/bar", br(`block{hash:"20c27"}`))
+	h.PutFile("/dir/foo", obj(`object{hash:"ebc57"}`), 1)
+	h.PutFile("/dir/bar", obj(`object{hash:"20c27"}`), 1)
 
-	h.PutFile("/dir/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+	h.PutFile("/dir/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 	requireOperationInvariant(t, h, deleteAddFile)
 	h.PutDir("/dir/__NEW_DIR__")
 	requireOperationInvariant(t, h, deleteAddDir)
-	h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", br(`block{hash:"8e02c"}`))
+	h.PutFile("/dir/__NEW_DIR__/__NEW_FILE__", obj(`object{hash:"8e02c"}`), 1)
 	requireOperationInvariant(t, h, deleteAddSubFile)
 }
 
@@ -337,8 +331,8 @@ func TestPutFileCommutative(t *testing.T) {
 	h2 := NewHashTree()
 	// Puts files into h in the order [A, B] and into h2 in the order [B, A]
 	comparePutFiles := func() {
-		h.PutFile("/dir/__NEW_FILE_A__", br(`block{hash:"ebc57"}`))
-		h.PutFile("/dir/__NEW_FILE_B__", br(`block{hash:"20c27"}`))
+		h.PutFile("/dir/__NEW_FILE_A__", obj(`object{hash:"ebc57"}`), 1)
+		h.PutFile("/dir/__NEW_FILE_B__", obj(`object{hash:"20c27"}`), 1)
 
 		// Get state of both /dir and /, to make sure changes are preserved upwards
 		// through the file hierarchy
@@ -347,8 +341,8 @@ func TestPutFileCommutative(t *testing.T) {
 		rootNodePtr, err := h.GetOpen("/")
 		require.NoError(t, err)
 
-		h2.PutFile("/dir/__NEW_FILE_B__", br(`block{hash:"20c27"}`))
-		h2.PutFile("/dir/__NEW_FILE_A__", br(`block{hash:"ebc57"}`))
+		h2.PutFile("/dir/__NEW_FILE_B__", obj(`object{hash:"20c27"}`), 1)
+		h2.PutFile("/dir/__NEW_FILE_A__", obj(`object{hash:"ebc57"}`), 1)
 
 		dirNodePtr2, err := h2.GetOpen("/dir")
 		require.NoError(t, err)
@@ -362,10 +356,10 @@ func TestPutFileCommutative(t *testing.T) {
 	comparePutFiles()
 	// (2) Add some files & check that test still passes when trees are nonempty
 	h, h2 = NewHashTree(), NewHashTree()
-	h.PutFile("/dir/foo", br(`block{hash:"8e02c"}`))
-	h2.PutFile("/dir/foo", br(`block{hash:"8e02c"}`))
-	h.PutFile("/dir/bar", br(`block{hash:"9d432"}`))
-	h2.PutFile("/dir/bar", br(`block{hash:"9d432"}`))
+	h.PutFile("/dir/foo", obj(`object{hash:"8e02c"}`), 1)
+	h2.PutFile("/dir/foo", obj(`object{hash:"8e02c"}`), 1)
+	h.PutFile("/dir/bar", obj(`object{hash:"9d432"}`), 1)
+	h2.PutFile("/dir/bar", obj(`object{hash:"9d432"}`), 1)
 	comparePutFiles()
 }
 
@@ -375,7 +369,7 @@ func TestPutFileCommutative(t *testing.T) {
 func TestRenameChangesHash(t *testing.T) {
 	// Write a file, and then get the hash of every node from the file to the root
 	h := NewHashTree()
-	h.PutFile("/dir/foo", br(`block{hash:"ebc57"}`))
+	h.PutFile("/dir/foo", obj(`object{hash:"ebc57"}`), 1)
 
 	h1 := finish(t, h)
 	dirPre, err := h1.Get("/dir")
@@ -385,7 +379,7 @@ func TestRenameChangesHash(t *testing.T) {
 
 	// rename /dir/foo to /dir/bar, and make sure that changes the hash
 	h.DeleteFile("/dir/foo")
-	h.PutFile("/dir/bar", br(`block{hash:"ebc57"}`))
+	h.PutFile("/dir/bar", obj(`object{hash:"ebc57"}`), 1)
 
 	h2 := finish(t, h)
 	dirPost, err := h2.Get("/dir")
@@ -400,7 +394,7 @@ func TestRenameChangesHash(t *testing.T) {
 
 	// rename /dir to /dir2, and make sure that changes the hash
 	h.DeleteFile("/dir")
-	h.PutFile("/dir2/foo", br(`block{hash:"ebc57"}`))
+	h.PutFile("/dir2/foo", obj(`object{hash:"ebc57"}`), 1)
 
 	h3 := finish(t, h)
 	dirPost, err = h3.Get("/dir2")
@@ -419,7 +413,7 @@ func TestRenameChangesHash(t *testing.T) {
 // if the contents are identical.
 func TestRewriteChangesHash(t *testing.T) {
 	h := NewHashTree()
-	h.PutFile("/dir/foo", br(`block{hash:"ebc57"}`))
+	h.PutFile("/dir/foo", obj(`object{hash:"ebc57"}`), 1)
 
 	h1 := finish(t, h)
 	dirPre, err := h1.Get("/dir")
@@ -429,7 +423,7 @@ func TestRewriteChangesHash(t *testing.T) {
 
 	// Change
 	h.DeleteFile("/dir/foo")
-	h.PutFile("/dir/foo", br(`block{hash:"8e02c"}`))
+	h.PutFile("/dir/foo", obj(`object{hash:"8e02c"}`), 1)
 
 	h2 := finish(t, h)
 	dirPost, err := h2.Get("/dir")
@@ -445,9 +439,9 @@ func TestRewriteChangesHash(t *testing.T) {
 
 func TestGlobFile(t *testing.T) {
 	hTmp := NewHashTree()
-	hTmp.PutFile("/foo", br(`block{hash:"20c27"}`))
-	hTmp.PutFile("/dir/bar", br(`block{hash:"ebc57"}`))
-	hTmp.PutFile("/dir/buzz", br(`block{hash:"8e02c"}`))
+	hTmp.PutFile("/foo", obj(`object{hash:"20c27"}`), 1)
+	hTmp.PutFile("/dir/bar", obj(`object{hash:"ebc57"}`), 1)
+	hTmp.PutFile("/dir/buzz", obj(`object{hash:"8e02c"}`), 1)
 	h, err := hTmp.Finish()
 	require.NoError(t, err)
 
@@ -484,25 +478,25 @@ func TestGlobFile(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	lTmp, rTmp := NewHashTree(), NewHashTree()
-	lTmp.PutFile("/foo-left", br(`block{hash:"20c27"}`))
-	lTmp.PutFile("/dir-left/bar-left", br(`block{hash:"ebc57"}`))
-	lTmp.PutFile("/dir-shared/buzz-left", br(`block{hash:"8e02c"}`))
-	lTmp.PutFile("/dir-shared/file-shared", br(`block{hash:"9d432"}`))
-	rTmp.PutFile("/foo-right", br(`block{hash:"20c27"}`))
-	rTmp.PutFile("/dir-right/bar-right", br(`block{hash:"ebc57"}`))
-	rTmp.PutFile("/dir-shared/buzz-right", br(`block{hash:"8e02c"}`))
-	rTmp.PutFile("/dir-shared/file-shared", br(`block{hash:"9d432"}`))
+	lTmp.PutFile("/foo-left", obj(`object{hash:"20c27"}`), 1)
+	lTmp.PutFile("/dir-left/bar-left", obj(`object{hash:"ebc57"}`), 1)
+	lTmp.PutFile("/dir-shared/buzz-left", obj(`object{hash:"8e02c"}`), 1)
+	lTmp.PutFile("/dir-shared/file-shared", obj(`object{hash:"9d432"}`), 1)
+	rTmp.PutFile("/foo-right", obj(`object{hash:"20c27"}`), 1)
+	rTmp.PutFile("/dir-right/bar-right", obj(`object{hash:"ebc57"}`), 1)
+	rTmp.PutFile("/dir-shared/buzz-right", obj(`object{hash:"8e02c"}`), 1)
+	rTmp.PutFile("/dir-shared/file-shared", obj(`object{hash:"9d432"}`), 1)
 	l, r := finish(t, lTmp), finish(t, rTmp)
 
 	expectedTmp := NewHashTree()
-	expectedTmp.PutFile("/foo-left", br(`block{hash:"20c27"}`))
-	expectedTmp.PutFile("/dir-left/bar-left", br(`block{hash:"ebc57"}`))
-	expectedTmp.PutFile("/dir-shared/buzz-left", br(`block{hash:"8e02c"}`))
-	expectedTmp.PutFile("/dir-shared/file-shared", br(`block{hash:"9d432"}`))
-	expectedTmp.PutFile("/foo-right", br(`block{hash:"20c27"}`))
-	expectedTmp.PutFile("/dir-right/bar-right", br(`block{hash:"ebc57"}`))
-	expectedTmp.PutFile("/dir-shared/buzz-right", br(`block{hash:"8e02c"}`))
-	expectedTmp.PutFile("/dir-shared/file-shared", br(`block{hash:"9d432"}`))
+	expectedTmp.PutFile("/foo-left", obj(`object{hash:"20c27"}`), 1)
+	expectedTmp.PutFile("/dir-left/bar-left", obj(`object{hash:"ebc57"}`), 1)
+	expectedTmp.PutFile("/dir-shared/buzz-left", obj(`object{hash:"8e02c"}`), 1)
+	expectedTmp.PutFile("/dir-shared/file-shared", obj(`object{hash:"9d432"}`), 1)
+	expectedTmp.PutFile("/foo-right", obj(`object{hash:"20c27"}`), 1)
+	expectedTmp.PutFile("/dir-right/bar-right", obj(`object{hash:"ebc57"}`), 1)
+	expectedTmp.PutFile("/dir-shared/buzz-right", obj(`object{hash:"8e02c"}`), 1)
+	expectedTmp.PutFile("/dir-shared/file-shared", obj(`object{hash:"9d432"}`), 1)
 	expected, err := expectedTmp.Finish()
 	require.NoError(t, err)
 
@@ -522,8 +516,8 @@ func TestMerge(t *testing.T) {
 // Test that Merge() works with empty hash trees
 func TestMergeEmpty(t *testing.T) {
 	expectedTmp := NewHashTree()
-	expectedTmp.PutFile("/foo", br(`block{hash:"20c27"}`))
-	expectedTmp.PutFile("/dir/bar", br(`block{hash:"ebc57"}`))
+	expectedTmp.PutFile("/foo", obj(`object{hash:"20c27"}`), 1)
+	expectedTmp.PutFile("/dir/bar", obj(`object{hash:"ebc57"}`), 1)
 	expected, err := expectedTmp.Finish()
 	require.NoError(t, err)
 
@@ -548,11 +542,11 @@ func TestErrorCode(t *testing.T) {
 	_, err := hdone.Get("/path")
 	require.Equal(t, PathNotFound, Code(err))
 
-	h.PutFile("/foo", br(`block{hash:"20c27"}`))
-	err = h.PutFile("/foo/bar", br(`block{hash:"9d432"}`))
+	h.PutFile("/foo", obj(`object{hash:"20c27"}`), 1)
+	err = h.PutFile("/foo/bar", obj(`object{hash:"9d432"}`), 1)
 	require.Equal(t, PathConflict, Code(err))
-	h.PutFile("/bar/foo", br(`block{hash:"9d432"}`))
-	err = h.PutFile("/bar", br(`block{hash:"20c27"}`))
+	h.PutFile("/bar/foo", obj(`object{hash:"9d432"}`), 1)
+	err = h.PutFile("/bar", obj(`object{hash:"20c27"}`), 1)
 	require.Equal(t, PathConflict, Code(err))
 
 	_, err = finish(t, h).Glob("/*\\")
@@ -561,8 +555,8 @@ func TestErrorCode(t *testing.T) {
 
 func TestSerialize(t *testing.T) {
 	hTmp := NewHashTree()
-	require.NoError(t, hTmp.PutFile("/foo", br(`block{hash:"20c27"}`)))
-	require.NoError(t, hTmp.PutFile("/bar/buzz", br(`block{hash:"9d432"}`)))
+	require.NoError(t, hTmp.PutFile("/foo", obj(`object{hash:"20c27"}`), 1))
+	require.NoError(t, hTmp.PutFile("/bar/buzz", obj(`object{hash:"9d432"}`), 1))
 	h := finish(t, hTmp)
 
 	// Serialize and Deserialize 'h'
@@ -573,7 +567,7 @@ func TestSerialize(t *testing.T) {
 	requireSame(t, h, h2)
 
 	// Modify 'h', and Serialize and Deserialize it again
-	require.NoError(t, hTmp.PutFile("/bar/buzz2", br(`block{hash:"8e02c"}`)))
+	require.NoError(t, hTmp.PutFile("/bar/buzz2", obj(`object{hash:"8e02c"}`), 1))
 	h = finish(t, hTmp)
 	bts, err = Serialize(h)
 	require.NoError(t, err)

--- a/src/server/pkg/hashtree/interface.go
+++ b/src/server/pkg/hashtree/interface.go
@@ -67,10 +67,11 @@ type HashTree interface {
 	Size() int64
 }
 
-// OpenNode is similar to NodeProto, except that it doesn't include the Hash or
-// Size fields (which are not generally meaningful in an OpenHashTree)
+// OpenNode is similar to NodeProto, except that it doesn't include the Hash
+// field (which is not generally meaningful in an OpenHashTree)
 type OpenNode struct {
 	Name string
+	Size int64
 
 	FileNode *FileNodeProto
 	DirNode  *DirectoryNodeProto

--- a/src/server/pkg/hashtree/path.go
+++ b/src/server/pkg/hashtree/path.go
@@ -1,6 +1,6 @@
 // This is a library that provides some path-cleaning and path manipulation
 // functions for hashtree.go. The functions it defines are very similar to the
-// function in go's "path" library.
+// functions in go's "path" library.
 
 // In both, a canonicalized path has a leading slash and no trailing slash in
 // general. The difference is:


### PR DESCRIPTION
A bug was introduced in #1404 that made it such that `hashtree.Merge` returns a tree that has sizes of zero for all nodes.  This PR fixes the bug, and also adds the hashtree tests to CI.