### PR TITLE
change deploy doc titles

### DIFF
--- a/doc/deployment/amazon_web_services.md
+++ b/doc/deployment/amazon_web_services.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - Amazon Web Services
+# Amazon Web Services
 
 ### Prerequisites
 

--- a/doc/deployment/azure.md
+++ b/doc/deployment/azure.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - Azure
+# Azure
 
 ## Prerequisites
 

--- a/doc/deployment/custom_object_stores.md
+++ b/doc/deployment/custom_object_stores.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - Custom Object Stores
+# Custom Object Stores
 
 In other sections of this guide was have demonstrated how to deploy Pachyderm in a single cloud using that cloud's object store offering.  However, Pachyderm can be backed by any object store, and you are not restricted to the object store service provided by the cloud in which you are deploying.
 

--- a/doc/deployment/deploy_intro.md
+++ b/doc/deployment/deploy_intro.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - Intro
+# Intro
 
 Pachyderm runs on [Kubernetes](http://kubernetes.io/) and is backed by an object store of your choice.  As such, Pachyderm can run on any platform that supports Kubernetes and an object store. These docs cover the following commonly used deployments:
 

--- a/doc/deployment/google_cloud_platform.md
+++ b/doc/deployment/google_cloud_platform.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - Google Cloud Platform
+# Google Cloud Platform
 
 Google Cloud Platform has excellent support for Kubernetes through the [Google Container Engine](https://cloud.google.com/container-engine/).
 

--- a/doc/deployment/migrations.md
+++ b/doc/deployment/migrations.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - Migrations
+# Migrations
 
 Occationally, Pachyderm introduces changes that are backward-incompatible: repos/commits/files created on an old version of Pachyderm may be unusable on a new version of Pachyderm. When that happens, we try our best to write a migration script that "upgrades" your data so it’s usable by the new version of Pachyderm.
 

--- a/doc/deployment/on_premises.md
+++ b/doc/deployment/on_premises.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - On Premises
+# On Premises
 
 Pachyderm is built on [Kubernetes](https://kubernetes.io/) and can be backed by an object store of your choice. As such, Pachyderm can run on any on premise platforms/frameworks that support Kubernetes, a persistent disk/volume, and an object store.
 

--- a/doc/deployment/openshift.md
+++ b/doc/deployment/openshift.md
@@ -1,4 +1,4 @@
-# Deploying Pachyderm - OpenShift
+# OpenShift
 
 [OpenShift](https://www.openshift.com/) is a popular enterprise Kubernetes distribution.  Pachyderm can run on OpenShift with two additional steps:
 


### PR DESCRIPTION
Right now the deploy docs all have a "Deploying Pachyderm - " prefix in their titles.  This removes that prefix as it is already in the section title.