### PR TITLE
Make it so that deleting a nonexistent file does not result in any errors

### DIFF
--- a/src/server/pfs/drive/driver.go
+++ b/src/server/pfs/drive/driver.go
@@ -474,7 +474,11 @@ func (d *driver) FinishCommit(ctx context.Context, commit *pfs.Commit) error {
 
 		if string(kv.Value) == tombstone {
 			if err := tree.DeleteFile(filePath); err != nil {
-				return err
+				// Deleting a non-existent file in an open commit should
+				// be a no-op
+				if !(hashtree.Code(err) == hashtree.PathNotFound) {
+					return err
+				}
 			}
 		} else {
 			var objectHash string

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -1260,6 +1260,12 @@ func TestDeleteFile(t *testing.T) {
 
 	_, err = client.InspectFile(repo, commit3.ID, "bar")
 	require.YesError(t, err)
+
+	// Delete a nonexistent file; it should be no-op
+	commit4, err := client.StartCommit(repo, "master")
+	require.NoError(t, err)
+	require.NoError(t, client.DeleteFile(repo, commit4.ID, "nonexistent"))
+	require.NoError(t, client.FinishCommit(repo, commit4.ID))
 }
 
 func TestDeleteDir(t *testing.T) {


### PR DESCRIPTION
Currently, deleting a nonexistent file results in a failure in `FinishCommit`.