### PR TITLE
Fix a couple issues related to PPS

### DIFF
--- a/src/server/pkg/obj/microsoft_client.go
+++ b/src/server/pkg/obj/microsoft_client.go
@@ -3,7 +3,6 @@ package obj
 import (
 	"bytes"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 
@@ -106,15 +105,6 @@ type microsoftWriter struct {
 func newMicrosoftWriter(client *microsoftClient, name string) (*microsoftWriter, error) {
 	// create container
 	_, err := client.blobClient.CreateContainerIfNotExists(client.container, storage.ContainerAccessTypePrivate)
-	if err != nil {
-		return nil, err
-	}
-
-	// check blob existence
-	exists, err := client.blobClient.BlobExists(client.container, name)
-	if exists {
-		err = errors.New(name + " blob already exists")
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1275,9 +1275,7 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 					jobInfo.Finished = now()
 					return a.updateJobState(stm, jobInfo, pps.JobState_JOB_FAILURE)
 				})
-				if err != nil {
-					return err
-				}
+				return err
 			}
 		}
 

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -57,11 +57,11 @@ func (w *worker) run(dataCh chan *datumAndResp) {
 			Data:  dr.datum,
 		})
 		if err != nil {
-			dr.retCh <- dr
 			if isContextCancelledErr(err) {
 				return
-			} else if err != nil {
-				protolion.Errorf("worker request to %s failed with error %s", w.addr, err)
+			} else {
+				dr.retCh <- dr
+				protolion.Errorf("worker %s failed to process datum %v with error %s", w.addr, dr.datum, err)
 			}
 			continue
 		}

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -68,7 +68,7 @@ func (w *worker) run(dataCh chan *datumAndResp) {
 			var buffer bytes.Buffer
 			if err := w.pachClient.GetTag(resp.Tag.Name, &buffer); err != nil {
 				protolion.Errorf("failed to retrieve hashtree after worker %s has ostensibly processed the datum %v", w.addr, dr.datum)
-				dataCh <- dr
+				dr.retCh <- dr
 				continue
 			}
 			tree, err := hashtree.Deserialize(buffer.Bytes())

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -59,10 +59,9 @@ func (w *worker) run(dataCh chan *datumAndResp) {
 		if err != nil {
 			if isContextCancelledErr(err) {
 				return
-			} else {
-				dr.retCh <- dr
-				protolion.Errorf("worker %s failed to process datum %v with error %s", w.addr, dr.datum, err)
 			}
+			dr.retCh <- dr
+			protolion.Errorf("worker %s failed to process datum %v with error %s", w.addr, dr.datum, err)
 			continue
 		}
 		if resp.Tag != nil {


### PR DESCRIPTION
From commit log:

```
    Fix a bug where a worker might try to return a datum even if the workerpool has been canceled

    Fix a bug where jobManager doesn't exist after the job has encountered a failure

    Fix a bug where the microsoft object client would return an error if it writes to an object that already exists
```