### PR TITLE
1.4.1 fix for the minio client

### DIFF
--- a/src/server/pkg/obj/minio_client.go
+++ b/src/server/pkg/obj/minio_client.go
@@ -63,6 +63,9 @@ func (l *limitReadCloser) Close() (err error) {
 }
 
 func (c *minioClient) Reader(name string, offset uint64, size uint64) (io.ReadCloser, error) {
+	if _, err := c.StatObject(c.bucket, name); err != nil {
+		return nil, err
+	}
 	obj, err := c.GetObject(c.bucket, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes https://github.com/pachyderm/pachyderm/issues/1595

```
➔ 
➔ kubectl get all
NAME             READY     STATUS    RESTARTS   AGE
po/etcd-h28xm    1/1       Running   0          2m
po/pachd-bgm3r   1/1       Running   2          2m

NAME       DESIRED   CURRENT   READY     AGE
rc/etcd    1         1         1         2m
rc/pachd   1         1         1         2m

NAME             CLUSTER-IP     EXTERNAL-IP   PORT(S)                       AGE
svc/etcd         10.3.251.182   <nodes>       2379:30051/TCP                2m
svc/kubernetes   10.3.240.1     <none>        443/TCP                       2h
svc/pachd        10.3.253.57    <nodes>       650:30650/TCP,651:30651/TCP   2m
➔ 
➔ ~/go/bin/pachctl create-repo testminio
➔ ~/go/bin/pachctl put-file testminio master blah -c -f README.md 
➔ ~/go/bin/pachctl list-repo
NAME                CREATED             SIZE                
testminio           25 seconds ago      5.018 KiB           
➔ ~/go/bin/pachctl list-file testminio master
NAME                TYPE                SIZE                
blah                file                5.018 KiB           
➔ 
➔ 
```