### PR TITLE
Don't error if worker dir already exists

### DIFF
--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -136,7 +136,7 @@ func do(appEnvObj interface{}) error {
 
 	// Setup the hostPath mount to use a unique directory for this worker
 	workerDir := filepath.Join(client.PPSHostPath, appEnv.PodName)
-	if err := os.Mkdir(workerDir, 0777); err != nil {
+	if err := os.MkdirAll(workerDir, 0777); err != nil {
 		return err
 	}
 	if err := os.Symlink(workerDir, client.PPSInputPrefix); err != nil {


### PR DESCRIPTION
Fix #1606 