### PR TITLE
Fix a flaky test

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1332,7 +1332,7 @@ func TestPachdRestartResumesRunningJobs(t *testing.T) {
 
 	jobInfo, err := c.InspectJob(jobInfos[0].Job.ID, true)
 	require.NoError(t, err)
-	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfo)
+	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfo.State)
 }
 
 //func TestScrubbedErrors(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1330,14 +1330,9 @@ func TestPachdRestartResumesRunningJobs(t *testing.T) {
 	// need a new client because the old one will have a defunct connection
 	c = getUsablePachClient(t)
 
-	commitIter, err := c.FlushCommit([]*pfs.Commit{commit}, nil)
+	jobInfo, err := c.InspectJob(jobInfos[0].Job.ID, true)
 	require.NoError(t, err)
-	collectCommitInfos(t, commitIter)
-
-	jobInfos, err = c.ListJob(pipelineName, nil)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(jobInfos))
-	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfos[0].State)
+	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfo)
 }
 
 //func TestScrubbedErrors(t *testing.T) {


### PR DESCRIPTION
My hypothesis is that it was flaky because it uses `FlushCommit` and then immediately asserts that the job's succeeded.  However, there's a small window between when the output commit is finished and when the job's state is actually updated to `success`.