### PR TITLE
Fix a bug where pachd servers can cut off contact with workers and not re-establish contact

### DIFF
--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -174,7 +174,11 @@ func do(appEnvObj interface{}) error {
 	if err != nil {
 		return err
 	}
-	etcdClient.KeepAlive(context.Background(), resp.ID) // keepalive forever
+
+	// keepalive forever
+	if _, err := etcdClient.KeepAlive(context.Background(), resp.ID); err != nil {
+		return err
+	}
 
 	// Actually write "key" into etcd
 	ctx, _ = context.WithTimeout(context.Background(), 30*time.Second) // new ctx

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1340,7 +1340,6 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 		tree := hashtree.NewHashTree()
 		files := df.Next()
 		for {
-			fmt.Println("sending datum")
 			var resp hashtree.HashTree
 			var failed bool
 			if files != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1006,7 +1006,7 @@ func (a *apiServer) pipelineManager(ctx context.Context, pipelineInfo *pps.Pipel
 		}
 
 		// Start worker pool
-		a.workerPool(ctx, PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version))
+		a.workerPool(PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version))
 
 		var provenance []*pfs.Repo
 		for _, input := range pipelineInfo.Inputs {
@@ -1240,9 +1240,9 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 		// Start worker pool
 		var wp WorkerPool
 		if jobInfo.Pipeline != nil {
-			wp = a.workerPool(ctx, PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion))
+			wp = a.workerPool(PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion))
 		} else {
-			wp = a.workerPool(ctx, JobRcName(jobInfo.Job.ID))
+			wp = a.workerPool(JobRcName(jobInfo.Job.ID))
 		}
 
 		// We have a goroutine that receives the datums that fail to

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1265,7 +1265,7 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 						protolion.Infof("retrying datum %v", dts[0].files)
 						dts = dts[1:]
 					case dt := <-wp.FailCh():
-						dt.retries += 1
+						dt.retries++
 						if dt.retries >= MaximumRetriesPerDatum {
 							close(jobFailedCh)
 							return
@@ -1278,7 +1278,7 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 				} else {
 					select {
 					case dt := <-wp.FailCh():
-						dt.retries += 1
+						dt.retries++
 						if dt.retries >= MaximumRetriesPerDatum {
 							close(jobFailedCh)
 							return

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1338,9 +1338,9 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 		}()
 
 		tree := hashtree.NewHashTree()
-		respCh := make(chan hashtree.HashTree)
 		files := df.Next()
 		for {
+			fmt.Println("sending datum")
 			var resp hashtree.HashTree
 			var failed bool
 			if files != nil {
@@ -1350,7 +1350,7 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 				}:
 					files = df.Next()
 					inflightData++
-				case resp = <-respCh:
+				case resp = <-wp.SuccessCh():
 					inflightData--
 				case <-jobFailedCh:
 					failed = true

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1335,6 +1335,7 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 			if datum != nil {
 				select {
 				case wp.DataCh() <- &datumAndResp{
+					ctx:    ctx,
 					datum:  datum,
 					respCh: respCh,
 					errCh:  errCh,

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -75,7 +75,6 @@ func NewAPIServer(
 		shardCtxs:             make(map[uint64]*ctxAndCancel),
 		pipelineCancels:       make(map[string]context.CancelFunc),
 		jobCancels:            make(map[string]context.CancelFunc),
-		workerPools:           make(map[string]WorkerPool),
 		namespace:             namespace,
 		workerImage:           workerImage,
 		workerImagePullPolicy: workerImagePullPolicy,

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -58,13 +58,12 @@ func (w *worker) run(dataCh chan *datumAndResp) {
 		}
 	}
 	for {
-		var dr *datumAndResp
-		select {
-		case dr = <-dataCh:
-		case <-dr.ctx.Done():
-			continue
+		dr, ok := <-dataCh
+		if !ok {
+			protolion.Errorf("worker %s exiting", w.addr)
+			return
 		}
-		resp, err := w.workerClient.Process(w.ctx, &workerpkg.ProcessRequest{
+		resp, err := w.workerClient.Process(dr.ctx, &workerpkg.ProcessRequest{
 			JobID: dr.jobID,
 			Data:  dr.datum,
 		})

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -131,7 +131,7 @@ func (w *workerPool) delWorker(addr string) error {
 
 func (w *workerPool) runWorker(ctx context.Context, addr string) {
 	defer func() {
-		protolion.Infof("goro for worker %s is exiting", addr)
+		protolion.Infof("goro for worker %s for job %s is exiting", addr, w.jobID)
 	}()
 
 	var workerClient workerpkg.WorkerClient
@@ -168,7 +168,7 @@ func (w *workerPool) runWorker(ctx context.Context, addr string) {
 		func() (retErr error) {
 			defer func() {
 				if retErr != nil {
-					protolion.Errorf("%v", retErr)
+					protolion.Errorf("datum error in job %s: %v", w.jobID, retErr)
 					select {
 					case w.failCh <- dt:
 					case <-ctx.Done():

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -95,6 +95,12 @@ func (w *workerPool) discoverWorkers() {
 		}
 		panic("unreachable")
 	}, b, func(err error, d time.Duration) error {
+		select {
+		case <-w.ctx.Done():
+			// Exit the retry loop if context got cancelled
+			return err
+		default:
+		}
 		protolion.Errorf("error discovering workers for %v: %v; retrying in %v", w.workerDir, err, d)
 		return nil
 	})
@@ -138,6 +144,12 @@ func (w *workerPool) runWorker(ctx context.Context, addr string) {
 		workerClient = workerpkg.NewWorkerClient(conn)
 		return nil
 	}, b, func(err error, d time.Duration) error {
+		select {
+		case <-w.ctx.Done():
+			// Exit the retry loop if context got cancelled
+			return err
+		default:
+		}
 		protolion.Infof("error establishing connection with worker %s; retrying in %v", addr, d)
 		return nil
 	})


### PR DESCRIPTION
Fix #1660 

The issue is that, currently the lifetime of a worker pool is tied to the lifetime of the process that created it.  So when you have a multi-node cluster, you might end up in a situation where a job created a worker pool, then another job starts using the worker pool, then the first job exits, bringing the worker pool down with it.  Thus the second job is stuck because it doesn't have workers to use anymore.