### PR TITLE
Fix a bug where pachd crashes under certain circumstances

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1312,7 +1312,9 @@ func (a *apiServer) pipelineManager(ctx context.Context, pipelineInfo *pps.Pipel
 			if err != nil {
 				return err
 			}
-			scaleDownTimer.Stop()
+			if scaleDownTimer != nil {
+				scaleDownTimer.Stop()
+			}
 			runningJobSet[job.ID] = true
 			go a.watchJobCompletion(ctx, job, jobCompletionCh)
 			protolion.Infof("pipeline %s created job %v with the following input commits: %v", pipelineName, job.ID, jobInputs)


### PR DESCRIPTION
Specifically, pachd might crash if one of the following occurs:

1. A pipeline restarts while there are some jobs running, *and then* it gets new input commits.
2. A pipeline starts out with some input commits, and then Go schedules goros in a certain way such that the erroneous code path is triggered (namely, that `scaleDownTimer` is used before it's initialized).

I tested 1.4.4 on GF's workload and one pachd node crashed once.  However, the workload was able to complete successfully.  Let's keep an eye on the impact of this issue.