### PR TITLE
Ui deploy part2

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -141,7 +141,6 @@ This resets the cluster to its initial state.`,
 pod=$(kubectl %v get pod -l app=pachd | awk '{if (NR!=1) { print $1; exit 0 }}')
 kubectl %v port-forward "$pod" %d:650
 `, kubeCtlFlags, kubeCtlFlags, port))
-				fmt.Println("Port forwarded, CTRL-C to exit.")
 				return cmdutil.RunIO(cmdutil.IO{
 					Stdin:  stdin,
 					Stderr: os.Stderr,
@@ -153,7 +152,6 @@ kubectl %v port-forward "$pod" %d:650
 pod=$(kubectl %v get pod -l app=dash | awk '{if (NR!=1) { print $1; exit 0 }}')
 kubectl %v port-forward "$pod" %d:8080
 `, kubeCtlFlags, kubeCtlFlags, uiPort))
-				fmt.Printf("Dash UI Port forwarded, navigate to localhost:%v", uiPort)
 				return cmdutil.RunIO(cmdutil.IO{
 					Stdin:  stdin,
 					Stderr: os.Stderr,
@@ -165,13 +163,13 @@ kubectl %v port-forward "$pod" %d:8080
 pod=$(kubectl %v get pod -l app=dash | awk '{if (NR!=1) { print $1; exit 0 }}')
 kubectl %v port-forward "$pod" %d:8081
 `, kubeCtlFlags, kubeCtlFlags, uiWebsocketPort))
-				fmt.Println("Websocket Port forwarded")
 				return cmdutil.RunIO(cmdutil.IO{
 					Stdin:  stdin,
 					Stderr: os.Stderr,
 				}, "sh")
 			})
 
+			fmt.Printf("Pachd port forwarded\nDash websocket port forwarded\nDash UI port forwarded, navigate to localhost:%v\nCTRL-C to exit", uiPort)
 			return eg.Wait()
 		}),
 	}

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -73,6 +73,7 @@ type AssetOpts struct {
 	// its cache of PFS blocks.
 	BlockCacheSize string
 	noDash         bool
+	DashImage      string
 }
 
 // ServiceAccount returns a kubernetes service account for use with Pachyderm.
@@ -697,7 +698,7 @@ func EtcdStatefulSet(opts *AssetOpts, backend backend, diskSpace int) interface{
 }
 
 // DashDeployment creates a Deployment for the pachyderm dashboard.
-func DashDeployment() *extensions.Deployment {
+func DashDeployment(dashImage string) *extensions.Deployment {
 	return &extensions.Deployment{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Deployment",
@@ -936,7 +937,7 @@ func WriteAssets(w io.Writer, opts *AssetOpts, objectStoreBackend backend,
 	if !opts.noDash {
 		DashService().CodecEncodeSelf(encoder)
 		fmt.Fprintf(w, "\n")
-		DashDeployment().CodecEncodeSelf(encoder)
+		DashDeployment(opts.DashImage).CodecEncodeSelf(encoder)
 		fmt.Fprintf(w, "\n")
 	}
 	return nil

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -5,12 +5,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pachyderm/pachyderm/src/client/version"
@@ -213,7 +210,7 @@ func DeployCmd(noMetrics *bool) *cobra.Command {
 	deploy.PersistentFlags().StringVar(&logLevel, "log-level", "info", "The level of log messages to print options are, from least to most verbose: \"error\", \"info\", \"debug\".")
 	deploy.PersistentFlags().StringVar(&blockCacheSize, "block-cache-size", "5G", "Size of in-memory cache to use for blocks. "+
 		"Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc).")
-	deploy.PersistentFlags().StringVar(&dashImage, "dash-image", getDefaultDashImage(), "Image URL for pachyderm dashboard")
+	deploy.PersistentFlags().StringVar(&dashImage, "dash-image", defaultDashImage, "Image URL for pachyderm dashboard")
 	deploy.AddCommand(deployLocal)
 	deploy.AddCommand(deployAmazon)
 	deploy.AddCommand(deployGoogle)
@@ -291,19 +288,4 @@ unrecoverable. If your persistent volume was manually provisioned (i.e. if
 you used the "--static-etcd-volume" flag), the underlying volume will not be
 removed.`)
 	return []*cobra.Command{deploy, undeploy}
-}
-
-func getDefaultDashImage() string {
-	// Try to get the latest according to our pachctl version, or fall back to the encoded default
-	url := fmt.Sprintf("https://pachyderm.io/versions/dash/%v.%v/latest", version.MajorVersion, version.MinorVersion)
-	resp, err := http.Get(url)
-	if err != nil {
-		return defaultDashImage
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return defaultDashImage
-	}
-	return fmt.Sprintf("pachyderm/dash:%v", strings.TrimSpace(string(body)))
 }


### PR DESCRIPTION
This PR does three things:

1) Adds the `--dash-image` flag to `pachctl deploy` so that you can manually specify a dash image (helpful for debugging purposes)
2) Comes with a default dash image to provide for the image URL
    - Tries to lookup, e.g. `https://pachyderm.io/versions/dash/1.4/latest` to get the latest version compatible w the given version of pachctl
    - We opted for this bcz we anticipate a bunch of releases of the dashboard, so this will be convenient for us and users
3) Updates `pachctl port-forward` to also forward ports for the UI frontend + websocket proxy

Things this PR does not do:

- provide any docs on the UI
- handle the multi-cluster port forwarding case (described in #1684)
- update the release script to update the default version of the UI defined in goland when we cut a point release, I'll update #1514 to include this modification if this PR lands

