### PR TITLE
Improve fault tolerance for worker-related failures

### DIFF
--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -182,7 +182,7 @@ func do(appEnvObj interface{}) error {
 
 	// Actually write "key" into etcd
 	ctx, _ = context.WithTimeout(context.Background(), 10*time.Second) // new ctx
-	if _, err := etcdClient.Put(ctx, key, "", etcd.WithLease(resp.ID)); err != nil {
+	if _, err := etcdClient.Put(ctx, key, appEnv.PodName, etcd.WithLease(resp.ID)); err != nil {
 		return err
 	}
 

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1170,7 +1170,7 @@ func (a *apiServer) pipelineManager(ctx context.Context, pipelineInfo *pps.Pipel
 			}
 		}
 
-		// Create a k8s replication controller that runs the workers
+		// Create a k8s deployment that runs the workers
 		if err := a.createWorkersForPipeline(pipelineInfo); err != nil {
 			if !isAlreadyExistsErr(err) {
 				return err

--- a/src/server/pps/server/worker_pool.go
+++ b/src/server/pps/server/worker_pool.go
@@ -218,6 +218,7 @@ func (w *workerPool) runWorker(ctx context.Context, addr string) {
 			case w.failCh <- dt:
 			case <-ctx.Done():
 			}
+			protolion.Errorf("deleting worker %s for job %s", addr, w.jobID)
 			// If this worker keeps failing to process the datum (note that
 			// failing to process a datum is different than if the user code
 			// ran and returned a non-zero exit code), we eventually give up
@@ -354,7 +355,6 @@ func workerClients(ctx context.Context, id string, etcdClient *etcd.Client, etcd
 	if err != nil {
 		return nil, err
 	}
-	protolion.Printf("resp: %+v\n", resp)
 
 	var result []workerpkg.WorkerClient
 	for _, kv := range resp.Kvs {


### PR DESCRIPTION
With this PR, Pachyderm will do the following if a worker is experiencing failures (i.e. that the worker returns an error to `Process`):

1. Retry the `Process` call a couple times.
2. If all the calls fail, delete the worker pod so a new one gets created by k8s.