### PR TITLE
Remove worker's ReplicaSet when its Deployment has been removed

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1804,8 +1804,30 @@ func (a *apiServer) deleteWorkersForPipeline(pipelineInfo *pps.PipelineInfo) err
 	deleteOptions := &api.DeleteOptions{
 		OrphanDependents: &falseVal,
 	}
-	rcName := PipelineDeploymentName(pipelineInfo.Pipeline.Name, pipelineInfo.Version)
-	return a.kubeClient.Extensions().Deployments(a.namespace).Delete(rcName, deleteOptions)
+	deploymentName := PipelineDeploymentName(pipelineInfo.Pipeline.Name, pipelineInfo.Version)
+	if err := a.kubeClient.Extensions().Deployments(a.namespace).Delete(deploymentName, deleteOptions); err != nil {
+		return err
+	}
+	// In k8s 1.6+, a replica set can be automatically removed when the
+	// deployment that created it is removed.  However, for lower versions
+	// of k8s, you have to do the following manually.
+	rsInterface := a.kubeClient.ReplicaSets(a.namespace)
+	label, err := kube_labels.Parse(fmt.Sprintf("app=%s", deploymentName))
+	if err != nil {
+		return err
+	}
+	rsList, err := rsInterface.List(api.ListOptions{
+		LabelSelector: label,
+	})
+	if err != nil {
+		return err
+	}
+	for _, rs := range rsList.Items {
+		if err := rsInterface.Delete(rs.Name, nil); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *apiServer) deleteWorkers(rcName string) error {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1799,12 +1799,11 @@ func (a *apiServer) createWorkersForPipeline(pipelineInfo *pps.PipelineInfo) err
 	return a.createWorkerDeployment(options)
 }
 
-func (a *apiServer) deleteWorkersForPipeline(pipelineInfo *pps.PipelineInfo) error {
+func (a *apiServer) deleteWorkers(deploymentName string) error {
 	falseVal := false
 	deleteOptions := &api.DeleteOptions{
 		OrphanDependents: &falseVal,
 	}
-	deploymentName := PipelineDeploymentName(pipelineInfo.Pipeline.Name, pipelineInfo.Version)
 	if err := a.kubeClient.Extensions().Deployments(a.namespace).Delete(deploymentName, deleteOptions); err != nil {
 		return err
 	}
@@ -1823,19 +1822,11 @@ func (a *apiServer) deleteWorkersForPipeline(pipelineInfo *pps.PipelineInfo) err
 		return err
 	}
 	for _, rs := range rsList.Items {
-		if err := rsInterface.Delete(rs.Name, nil); err != nil {
+		if err := rsInterface.Delete(rs.Name, deleteOptions); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func (a *apiServer) deleteWorkers(rcName string) error {
-	falseVal := false
-	deleteOptions := &api.DeleteOptions{
-		OrphanDependents: &falseVal,
-	}
-	return a.kubeClient.Extensions().Deployments(a.namespace).Delete(rcName, deleteOptions)
 }
 
 func (a *apiServer) AddShard(shard uint64) error {


### PR DESCRIPTION
One side effect of switching from using `ReplicationController` to `Deployment` for workers is that, when you delete the `Deployment` of a worker, the `ReplicaSet` is not automatically deleted, and thus the pods remain running.

Here is the relevant k8s issue: https://github.com/kubernetes/kubernetes/issues/34052

I believe [a fix for this issue](https://github.com/kubernetes/kubernetes/pull/35676) has been merged into k8s but it's only in the newest versions of k8s.  For instance, I was using k8s 1.5.1 and my replica sets were not automatically removed.