### PR TITLE
Fix for Minio data fetch race conditions

### DIFF
--- a/src/server/pkg/obj/minio_client.go
+++ b/src/server/pkg/obj/minio_client.go
@@ -91,6 +91,9 @@ func (l *limitReadCloser) Close() (err error) {
 }
 
 func (c *minioClient) Reader(name string, offset uint64, size uint64) (io.ReadCloser, error) {
+	if _, err := c.StatObject(c.bucket, name); err != nil {
+		return nil, err
+	}
 	obj, err := c.GetObject(c.bucket, name)
 	if err != nil {
 		return nil, err

--- a/src/server/pkg/obj/minio_client.go
+++ b/src/server/pkg/obj/minio_client.go
@@ -91,9 +91,6 @@ func (l *limitReadCloser) Close() (err error) {
 }
 
 func (c *minioClient) Reader(name string, offset uint64, size uint64) (io.ReadCloser, error) {
-	if _, err := c.StatObject(c.bucket, name); err != nil {
-		return nil, err
-	}
 	obj, err := c.GetObject(c.bucket, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There was a race condition while fetching data from Minio server. Reads were attempted before write finished. We added `newMinioWriter` as done in other object stores to fix this. 

Ref: https://github.com/minio/minio/issues/4077