### PR TITLE
First pass at nightly batch tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,11 @@ before_script:
 - pip --version
 - pip install awscli --upgrade --user
 - aws --version
-- which aws
-- which go
 # because we need to run the bench as sudo, we need to make sure a few binaries are in
 # the secure path
 - sudo bash -Ec 'echo $PATH'
 - sudo ln -s `which aws` /usr/local/bin/aws
-- sudo -E which aws
 - sudo ln -s `which go` /usr/local/bin/go
-- sudo -E which go
 - sudo apt-get install uuid
 script:
 - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,14 @@ before_script:
 - pip install awscli --upgrade --user
 - aws --version
 - which aws
+- which go
+# because we need to run the bench as sudo, we need to make sure a few binaries are in
+# the secure path
 - sudo bash -Ec 'echo $PATH'
 - sudo ln -s `which aws` /usr/local/bin/aws
 - sudo -E which aws
+- sudo ln -s `which go` /usr/local/bin/go
+- sudo -E which go
 - sudo apt-get install uuid
 script:
 - make lint

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,4 @@
+FROM ubuntu:16.04
+MAINTAINER jdoliner@pachyderm.io
+
+ADD ./test .

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ push-bench-images: install
 	docker images
 	docker images | grep pachd
 	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker images | grep pachd
 	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,8 @@ push-bench-images: install
 	pachctl version
 	pachctl version 2>/dev/null
 	pachctl version 2>/dev/null | head -n 2 | tail -n 1
+	docker images
+	docker images | grep pachd
 	docker tag pachyderm_pachd pachyderm/pachd:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker push pachyderm/pachd:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker tag pachyderm_worker pachyderm/worker:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ install-bench: install
 run-bench:
 	kubectl scale --replicas=4 deploy/pachd
 	echo "waiting for pachd to scale up" && sleep 15
-	kubectl delete --ignore-not-found po/bench && kubectl run bench --image=pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "` --image-pull-policy=Always --restart=Never --attach=true -- -test.v -test.bench=BenchmarkDaily -test.run=XXX
+	kubectl delete --ignore-not-found po/bench && kubectl run bench --image=pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "` --image-pull-policy=Always --restart=Never --attach=true -- ./test -test.v -test.bench=BenchmarkDaily -test.run=XXX
 
 clean-launch-bench:
 	kops delete cluster `cat tmp/current-benchmark-cluster.txt` --yes --state `cat tmp/current-benchmark-state-store.txt` || true

--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,6 @@ push-bench-images: install
 	docker images | grep pachd
 	echo 'version string:'
 	$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'
-	echo 'version:'
-	$(GOPATH)/bin/pachctl version
 	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
 	docker images | grep pachd
 	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,9 @@ launch-dev-bench: docker-build docker-build-test install
 
 build-bench-images: docker-build docker-build-test
 
-push-bench-images: install
+push-bench-images: install-bench
 	# We need the pachyderm_compile image to be up to date
-	docker images
-	docker images | grep pachd
-	echo 'version string:'
-	$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'
 	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
-	docker images | grep pachd
 	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
 	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
 	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -153,14 +153,14 @@ push-bench-images: install
 	docker images
 	docker images | grep pachd
 	echo 'version string:'
-	$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'
+	$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'
 	echo 'version:'
 	$(GOPATH)/bin/pachctl version
-	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
 	docker images | grep pachd
-	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
-	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
-	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
+	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
+	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
 	docker tag pachyderm_test pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	docker push pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	

--- a/Makefile
+++ b/Makefile
@@ -148,15 +148,15 @@ launch-dev-bench: docker-build docker-build-test install
 
 push-bench-images: install
 	# We need the pachyderm_compile image to be up to date
-	pachctl version
-	pachctl version 2>/dev/null
-	pachctl version 2>/dev/null | head -n 2 | tail -n 1
+	$(GOPATH)/bin/pachctl version
+	$(GOPATH)/bin/pachctl version 2>/dev/null
+	$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1
 	docker images
 	docker images | grep pachd
-	docker tag pachyderm_pachd pachyderm/pachd:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
-	docker push pachyderm/pachd:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
-	docker tag pachyderm_worker pachyderm/worker:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
-	docker push pachyderm/worker:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
+	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker tag pachyderm_test pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	docker push pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	

--- a/Makefile
+++ b/Makefile
@@ -156,11 +156,15 @@ push-bench-images: install
 	docker push pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	
 launch-bench: docker-build docker-build-test
-	rm /usr/local/bin/pachctl || true
-	ln -s $(GOPATH)/bin/pachctl /usr/local/bin/pachctl
 	etc/deploy/aws.sh
 	until timeout 10s ./etc/kube/check_ready.sh app=pachd; do sleep 1; done
 	cat ~/.kube/config
+
+install-bench: install
+	@# Since bench is run as sudo, pachctl needs to be under
+	@# the secure path
+	rm /usr/local/bin/pachctl || true
+	sudo ln -s $(GOPATH)/bin/pachctl /usr/local/bin/pachctl
 
 run-bench:
 	kubectl scale --replicas=4 rc/pachd

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,9 @@ launch-dev-bench: docker-build docker-build-test install
 	ln -s $(GOPATH)/bin/pachctl /usr/local/bin/pachctl
 	make launch-bench
 
-push-bench-images: install docker-build docker-build-test
+build-bench-images: docker-build docker-build-test
+
+push-bench-images: install
 	# We need the pachyderm_compile image to be up to date
 	docker images
 	docker images | grep pachd
@@ -178,7 +180,7 @@ clean-launch-bench:
 	aws s3 del --recursive --force `cat tmp/current-benchmark-state-store.txt` || true
 	aws s3 rb `cat tmp/current-benchmark-state-store.txt` || true
 
-bench: clean-launch-bench push-bench-images launch-bench run-bench
+bench: clean-launch-bench build-bench-images push-bench-images launch-bench run-bench
 
 launch-kube: check-kubectl
 	etc/kube/start-kube-docker.sh

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,6 @@ launch-dev-bench: docker-build docker-build-test install
 
 push-bench-images: install
 	# We need the pachyderm_compile image to be up to date
-	$(GOPATH)/bin/pachctl version
-	$(GOPATH)/bin/pachctl version 2>/dev/null
-	$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1
 	docker images
 	docker images | grep pachd
 	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ push-bench-images: install
 	# We need the pachyderm_compile image to be up to date
 	docker images
 	docker images | grep pachd
+	echo 'version string:'
+	$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'
+	echo 'version:'
+	$(GOPATH)/bin/pachctl version
 	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker images | grep pachd
 	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,9 @@ launch-dev-bench: docker-build docker-build-test install
 
 push-bench-images: install
 	# We need the pachyderm_compile image to be up to date
+	pachctl version
+	pachctl version 2>/dev/null
+	pachctl version 2>/dev/null | head -n 2 | tail -n 1
 	docker tag pachyderm_pachd pachyderm/pachd:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker push pachyderm/pachd:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`
 	docker tag pachyderm_worker pachyderm/worker:`pachctl version 2>/dev/null | head -n 2 | tail -n 1 | awk -v N=2 '{print $$N}'`

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ launch-dev-bench: docker-build docker-build-test install
 	ln -s $(GOPATH)/bin/pachctl /usr/local/bin/pachctl
 	make launch-bench
 
-push-bench-images: install
+push-bench-images: install docker-build docker-build-test
 	# We need the pachyderm_compile image to be up to date
 	docker images
 	docker images | grep pachd
@@ -157,7 +157,7 @@ push-bench-images: install
 	docker tag pachyderm_test pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	docker push pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "`
 	
-launch-bench: docker-build docker-build-test
+launch-bench: 
 	etc/deploy/aws.sh
 	until timeout 10s ./etc/kube/check_ready.sh app=pachd; do sleep 1; done
 	cat ~/.kube/config

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ install-bench: install
 	sudo ln -s $(GOPATH)/bin/pachctl /usr/local/bin/pachctl
 
 run-bench:
-	kubectl scale --replicas=4 rc/pachd
-	echo "waiting for pachd to scale up" && sleep 10
+	kubectl scale --replicas=4 deploy/pachd
+	echo "waiting for pachd to scale up" && sleep 15
 	kubectl delete --ignore-not-found po/bench && kubectl run bench --image=pachyderm/bench:`git log | head -n 1 | cut -f 2 -d " "` --image-pull-policy=Always --restart=Never --attach=true -- -test.v -test.bench=BenchmarkDaily -test.run=XXX
 
 clean-launch-bench:

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ launch-bench: docker-build docker-build-test
 	ln -s $(GOPATH)/bin/pachctl /usr/local/bin/pachctl
 	etc/deploy/aws.sh
 	until timeout 10s ./etc/kube/check_ready.sh app=pachd; do sleep 1; done
+	cat ~/.kube/config
 
 run-bench:
 	kubectl scale --replicas=4 rc/pachd

--- a/etc/build/travis.sh
+++ b/etc/build/travis.sh
@@ -2,7 +2,7 @@
 
 # Check the cron value to see if this is a daily job
 
-if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+if [ "cron" == "cron" ]; then
 	echo "Running daily benchmarks"
     # Use the secrets in the travis environment to setup the aws creds for the aws command:
     echo "${AWS_ACCESS_KEY_ID}

--- a/etc/build/travis.sh
+++ b/etc/build/travis.sh
@@ -2,7 +2,7 @@
 
 # Check the cron value to see if this is a daily job
 
-if [ "cron" == "cron" ]; then
+if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
 	echo "Running daily benchmarks"
     # Use the secrets in the travis environment to setup the aws creds for the aws command:
     echo "${AWS_ACCESS_KEY_ID}


### PR DESCRIPTION
This change modifies our travis CI tests such that:
- `etc/build/travis.sh` detects if Travis is running as a cron job (vs testing a new commit), and if so:
- Creates a k8s cluster in AWS and deploys pachyderm on it
- Builds Pachyderm's tests under `src/server` into a binary (with `go test -c -o test src/server`)
  - The `docker-build-test` make target does this, by calling `etc/compile/compile_test.sh`
- Builds a docker container with this test binary
- Runs the tests (from inside the new container) inside the k8s cluster (this makes communication between pachyderm's tests and the AWS k8s cluster simple and natural)