### PR TITLE
Remove the default image pull policy

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -302,6 +302,10 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend backend, hostPath strin
 									Value: fmt.Sprintf("pachyderm/worker:%s", opts.Version),
 								},
 								{
+									Name:  "WORKER_IMAGE_PULL_POLICY",
+									Value: "",
+								},
+								{
 									Name:  "PACHD_VERSION",
 									Value: opts.Version,
 								},

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -302,10 +302,6 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend backend, hostPath strin
 									Value: fmt.Sprintf("pachyderm/worker:%s", opts.Version),
 								},
 								{
-									Name:  "WORKER_IMAGE_PULL_POLICY",
-									Value: "IfNotPresent",
-								},
-								{
 									Name:  "PACHD_VERSION",
 									Value: opts.Version,
 								},

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -51,9 +51,6 @@ func JobRcName(id string) string {
 
 func (a *apiServer) workerPodSpec(options *workerOptions) api.PodSpec {
 	pullPolicy := a.workerImagePullPolicy
-	if pullPolicy == "" {
-		pullPolicy = "IfNotPresent"
-	}
 	podSpec := api.PodSpec{
 		InitContainers: []api.Container{
 			{
@@ -81,6 +78,10 @@ func (a *apiServer) workerPodSpec(options *workerOptions) api.PodSpec {
 		RestartPolicy:    "Always",
 		Volumes:          options.volumes,
 		ImagePullSecrets: options.imagePullSecrets,
+	}
+	if pullPolicy != "" {
+		podSpec.InitContainers[0].ImagePullPolicy = api.PullPolicy(pullPolicy)
+		podSpec.Containers[0].ImagePullPolicy = api.PullPolicy(pullPolicy)
 	}
 	if options.resources != nil {
 		podSpec.Containers[0].Resources = api.ResourceRequirements{


### PR DESCRIPTION
So that if a user uses the `latest` tag with their image, the image is pulled every time, which is probably what they want.

Fixes #1764 