### PR TITLE
Remove unnecessary line breaks

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -65,7 +65,7 @@ func NewMetricsClientFromAddressWithConcurrency(addr string, metrics bool, prefi
 	cfg, err := config.Read()
 	if err != nil {
 		// metrics errors are non fatal
-		log.Errorf("error loading user config from ~/.pachderm/config: %v\n", err)
+		log.Errorf("error loading user config from ~/.pachderm/config: %v", err)
 	} else {
 		c.config = cfg
 	}
@@ -203,7 +203,7 @@ func (c *APIClient) addMetadata(ctx context.Context) context.Context {
 		if err != nil {
 			// Don't report error if config fails to read
 			// metrics errors are non fatal
-			log.Errorf("Error loading config: %v\n", err)
+			log.Errorf("Error loading config: %v", err)
 			return ctx
 		}
 		c.config = cfg

--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -82,7 +82,7 @@ func (r *Reporter) reportUserAction(ctx context.Context, action string, value in
 			r.clusterID,
 		)
 	} else {
-		log.Errorf("Error extracting userid metadata from context: %v\n", ctx)
+		log.Errorf("Error extracting userid metadata from context: %v", ctx)
 	}
 }
 
@@ -106,7 +106,7 @@ func reportAndFlushUserAction(action string, value interface{}) {
 	defer client.Close()
 	cfg, err := config.Read()
 	if err != nil {
-		log.Errorf("Error reading userid from ~/.pachyderm/config: %v\n", err)
+		log.Errorf("Error reading userid from ~/.pachyderm/config: %v", err)
 		// metrics errors are non fatal
 		return
 	}


### PR DESCRIPTION
log: Remove unnecessary line breaks

log.Errorf is supposed to contain line break by default. This patch
removes the unnecessary line break.