### PR TITLE
Update docs for "inputs" -> "input"

### DIFF
--- a/doc/examples/opencv/edges.json
+++ b/doc/examples/opencv/edges.json
@@ -6,12 +6,10 @@
     "cmd": [ "python3", "/edges.py" ],
     "image": "pachyderm/opencv"
   },
-"inputs": [
-    {
-      "repo": {
-        "name": "images"
-      },
+  "input": {
+    "atom": {
+      "repo": "images",
       "glob": "/*"
     }
-  ]
+  }
 }

--- a/doc/fundamentals/creating_analysis_pipelines.md
+++ b/doc/fundamentals/creating_analysis_pipelines.md
@@ -40,14 +40,10 @@ Here's an example pipeline spec:
     "cmd": ["/binary", "/pfs/data", "/pfs/out"]
   },
   "input": {
-      "cross": [ 
-          {
-              "atom": {
-                  "repo": "data",
-                  "glob": "/*",
-              }
-          }
-      ]
+      "atom": {
+        "repo": "data",
+        "glob": "/*",
+      }
   }
 }
 ```

--- a/doc/fundamentals/creating_analysis_pipelines.md
+++ b/doc/fundamentals/creating_analysis_pipelines.md
@@ -27,7 +27,7 @@ Note, it is best practice to uniquely tag your Docker images with something othe
 
 ## 3. Creating a Pipeline
 
-Now that you've got your code and image built, the final step is to tell Pachyderm to run the code in your image on certain input data.  To do this, you need to supply Pachyderm with a JSON pipeline specification. There are four main components to a pipeline specification: name, transform, parallelism and inputs. Detailed explanations of the specification parameters and how they work can be found in the [pipeline specification docs](../reference/pipeline_spec.html). 
+Now that you've got your code and image built, the final step is to tell Pachyderm to run the code in your image on certain input data.  To do this, you need to supply Pachyderm with a JSON pipeline specification. There are four main components to a pipeline specification: name, transform, parallelism and input. Detailed explanations of the specification parameters and how they work can be found in the [pipeline specification docs](../reference/pipeline_spec.html). 
 
 Here's an example pipeline spec:
 ```json
@@ -39,14 +39,16 @@ Here's an example pipeline spec:
     "image": "wordcount-image",
     "cmd": ["/binary", "/pfs/data", "/pfs/out"]
   },
-  "inputs": [
-    {
-      "repo": {
-        "name": "data"
-      },
-      "glob": "/*"
-    }
-  ]
+  "input": {
+      "cross": [ 
+          {
+              "atom": {
+                  "repo": "data",
+                  "glob": "/*",
+              }
+          }
+      ]
+  }
 }
 ```
 

--- a/doc/fundamentals/distributed_computing.md
+++ b/doc/fundamentals/distributed_computing.md
@@ -58,7 +58,10 @@ Instead of confining users to just data-distribution patterns such as Map (split
                 "repo": "string",
                 "glob": "string",
             }
-        }
+        },
+
+        etc...
+
     ],
     "union": [
         {

--- a/doc/fundamentals/distributed_computing.md
+++ b/doc/fundamentals/distributed_computing.md
@@ -30,7 +30,7 @@ If you use the `CONSTANT` strategy, Pachyderm will start the number of workers t
 
 If you use the `COEFFICIENT` strategy, Pachyderm will start a number of workers that is a multiple of your Kubernetes cluster’s size. To use this strategy, set the field `coefficient` to a double. For example, if your Kubernetes cluster has 10 nodes, and you set `"coefficient": 0.5`, Pachyderm will start five workers. If you set it to 2.0, Pachyderm will start 20 workers (two per Kubernetes node).
 
-**NOTE:** The parallelism_spec is optional and will default to `“coefficient": 1”`, which means that it'll spawn one worker per Kubernetes node for this pipeline if left unset. 
+**NOTE:** The parallelism_spec is optional and will default to `“coefficient": 1`, which means that it'll spawn one worker per Kubernetes node for this pipeline if left unset. 
 
 ## Spreading Data Across Workers (Glob Patterns)
 
@@ -38,33 +38,57 @@ Defining how your data is spread out among workers is arguably the most importan
 
 Instead of confining users to just data-distribution patterns such as Map (split everything as much as possible) and Reduce (_all_ the data must be grouped together), Pachyderm uses [Glob Patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to offer incredible flexibility in defining your data distribution. 
 
- Glob patterns are defined by the user for each input of a pipeline and tell Pachyderm how to divide the input data into individual "datums" that can be processed independently. 
+ Glob patterns are defined by the user for each `atom` within the `input` of a pipeline, and they tell Pachyderm how to divide the input data into individual "datums" that can be processed independently. 
 
 ```
-"inputs": [
-    {
-      "repo": {
-        "name": "string"
-      },
-      "glob": "string"
+"input": {
+    "atom": {
+        "repo": "string",
+        "glob": "string",
     }
-  ]
+    "cross": [
+        {
+            "atom": {
+                "repo": "string",
+                "glob": "string",
+            }
+        },
+        {
+            "atom": {
+                "repo": "string",
+                "glob": "string",
+            }
+        }
+    ],
+    "union": [
+        {
+            "atom": {
+                "repo": "string",
+                "glob": "string",
+            }
+        },
+
+        etc...
+
+    ]
+}
 ```
-That means you could easily define two inputs, one with the data highly distributed and another where it's grouped together. 
+
+That means you could easily define multiple "atoms", one with the data highly distributed and another where it's grouped together.  You can then join the datums in these atoms via a cross product or union (as shown above) for combined, distributed processing. More information about "atoms," unions, and crosses can be found in our [Pipeline Specification](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).
 
 ### Datums
 
-Pachyderm uses the glob pattern to determine how many “datums” an input consists of. Datums are the unit of parallelism in Pachyderm. That is, Pachyderm attempts to process datums in parallel whenever possible.
+Pachyderm uses the glob pattern to determine how many “datums” an input atom consists of. Datums are the unit of parallelism in Pachyderm. That is, Pachyderm attempts to process datums in parallel whenever possible.
 
 If you have two workers and define 2 datums, Pachyderm will send one datum to each worker. In a scenario where there are more datums than workers, Pachyderm will queue up extra datums and send them to workers as they finish processing previous datums. 
 
 ### Defining Datums via Glob Patterns
 
-Intuitively, you should think of the input repo as a file system where the glob pattern is being applied to the root of the file system. The files and directories that match the glob pattern are considered datums.
+Intuitively, you should think of the input atom repo as a file system where the glob pattern is being applied to the root of the file system. The files and directories that match the glob pattern are considered datums.
 
 For example, a glob pattern of just `/` would denote the entire input repo as a single datum. All of the input data would be given to a single worker similar to a typical reduce-style operation.
 
-Another commonly used glob pattern is `/*`. `/*` would define each top level object (file or directory) in the input repo as its own datum. If you have a repo with just 10 files in it and no directory structure, every file would be a datum and could be processed independently. This is similar to a  typical map-style operation.
+Another commonly used glob pattern is `/*`. `/*` would define each top level object (file or directory) in the input atom repo as its own datum. If you have a repo with just 10 files in it and no directory structure, every file would be a datum and could be processed independently. This is similar to a  typical map-style operation.
 
 But Pachyderm can do anything in between too. If you have a directory structure with each state as a directory and a file for each city such as:
 
@@ -79,11 +103,12 @@ But Pachyderm can do anything in between too. If you have a directory structure 
    ...
 ...
 ```
-And you need to process all the data for a given state together, `/*` would also be the desired glob pattern. You'd have one datum per state, meaning all the cities for a given state would be processed together by a single worker, but each state can be processed independently. 
+
+and you need to process all the data for a given state together, `/*` would also be the desired glob pattern. You'd have one datum per state, meaning all the cities for a given state would be processed together by a single worker, but each state can be processed independently. 
 
 If we instead used the glob pattern `/*/*` for the states example above, each `<city>.json` would be it's own datum. 
 
-Glob patterns also let you take only a particular directory (or subset of directories) as inputs instead of the whole input repo. If we create a pipeline that is specifically only for California, we can use a glob pattern of `/California/*` to only use the data in that directory as input to our pipeline. 
+Glob patterns also let you take only a particular directory (or subset of directories) as an input atom instead of the whole input repo. If we create a pipeline that is specifically only for California, we can use a glob pattern of `/California/*` to only use the data in that directory as input to our pipeline. 
 
 ### Only Processing New Data
 
@@ -105,7 +130,7 @@ Let's look at our states example with a few different glob patterns to demonstra
 ...
 ```
 
-If our glob pattern is `/`, then the entire input is a single datum, which means anytime any file or directory is changed in our input, all the the data will be processed from scratch. There are plenty of usecases where this is exactly what we need (e.g. some machine learning training algorithms).
+If our glob pattern is `/`, then the entire input atom is a single datum, which means anytime any file or directory is changed in our input, all the the data will be processed from scratch. There are plenty of usecases where this is exactly what we need (e.g. some machine learning training algorithms).
 
 If our glob pattern is `/*`, then each state directory is it's own datum and we'll only process the ones that have changed. So if we add a  new city file, `Sacramento.json` to the `/California` directory, _only_ the California datum, will be reprocessed.
 

--- a/doc/fundamentals/distributed_computing.md
+++ b/doc/fundamentals/distributed_computing.md
@@ -46,38 +46,32 @@ Instead of confining users to just data-distribution patterns such as Map (split
         "repo": "string",
         "glob": "string",
     }
-    "cross": [
-        {
-            "atom": {
-                "repo": "string",
-                "glob": "string",
-            }
-        },
-        {
-            "atom": {
-                "repo": "string",
-                "glob": "string",
-            }
-        },
+}
+```
 
+That means you could easily define multiple "atoms", one with the data highly distributed and another where it's grouped together.  You can then join the datums in these atoms via a cross product or union (as shown above) for combined, distributed processing. 
+
+```
+"input": {
+    "cross" or "union": [
+        {
+            "atom": {
+                "repo": "string",
+                "glob": "string",
+            }
+        },
+        {
+            "atom": {
+                "repo": "string",
+                "glob": "string",
+            }
+        },
         etc...
-
-    ],
-    "union": [
-        {
-            "atom": {
-                "repo": "string",
-                "glob": "string",
-            }
-        },
-
-        etc...
-
     ]
 }
 ```
 
-That means you could easily define multiple "atoms", one with the data highly distributed and another where it's grouped together.  You can then join the datums in these atoms via a cross product or union (as shown above) for combined, distributed processing. More information about "atoms," unions, and crosses can be found in our [Pipeline Specification](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).
+More information about "atoms," unions, and crosses can be found in our [Pipeline Specification](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).
 
 ### Datums
 

--- a/doc/fundamentals/getting_data_out_of_pachyderm.md
+++ b/doc/fundamentals/getting_data_out_of_pachyderm.md
@@ -43,7 +43,7 @@ edges               026536b547a44a8daa2db9d25bf88b79   754542b89c1c47a5b657e6038
 edges               754542b89c1c47a5b657e60381c06c71   <none>                             2 minutes ago        Less than a second   22.22 KiB
 ```
 
-In this case, we have one output commit per input commit on `images`.  However, this might get more complicated for pipelines with multiple branches, multiple inputs, etc.  To confirm which commits correspond to which outputs, we can use `flush-commit`.  In particular, we can call `flush-commit` on any one of our commits into `images` to see which output came from this particular commmit:
+In this case, we have one output commit per input commit on `images`.  However, this might get more complicated for pipelines with multiple branches, multiple input atoms, etc.  To confirm which commits correspond to which outputs, we can use `flush-commit`.  In particular, we can call `flush-commit` on any one of our commits into `images` to see which output came from this particular commmit:
 
 ```sh
 $ pachctl flush-commit images/a9678d2a439648c59636688945f3c6b5

--- a/doc/getting_started/beginner_tutorial.rst
+++ b/doc/getting_started/beginner_tutorial.rst
@@ -104,18 +104,16 @@ Below is the pipeline spec and python code we're using. Let's walk through the d
       "cmd": [ "python3", "/edges.py" ],
       "image": "pachyderm/opencv"
     },
-    "inputs": [
-      {
-        "name": "images",
-        "repo": {
-          "name": "images"
-        },
+    "input": {
+      "atom": {
+        "repo": "images",
         "glob": "/*"
       }
-    ]
+    }
   }
 
-Our pipeline spec contains a few simple sections. First is the pipeline ``name``, edges. Then we have the ``transform`` which specifies the docker image we want to use, ``pachyderm/opencv`` (defaults to Dockerhub as the registry), and the entry point ``edges.py``. Lastly, we specify the inputs, our images repo and a glob pattern. 
+
+Our pipeline spec contains a few simple sections. First is the pipeline ``name``, edges. Then we have the ``transform`` which specifies the docker image we want to use, ``pachyderm/opencv`` (defaults to Dockerhub as the registry), and the entry point ``edges.py``. Lastly, we specify the input.  Here we only have one "atom" input, our images repo with a particular glob pattern. 
 
 The glob pattern defines how the input data can be broken up if we wanted to distribute our computation. ``/*`` means that each file can be processed individually, which makes sense for images. Glob patterns are one of the most powerful features of Pachyderm so when you start creating your own pipelines, check out the :doc:`../reference/pipeline_spec`.
 

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -258,12 +258,9 @@ the commit itself) will be processed.
 
 Union inputs take the union of other inputs. For example:
 
-| inputA | inputB | inputA ∪ inputB |
-| ------ | ------ | --------------- |
-| foo    | fizz   | foo             |
-| bar    | buzz   | fizz            |
-|        |        | bar             |
-|        |        | buzz            |
+- inputA: foo, bar
+- inputB: fizz, buzz
+- inputA ∪ inputB: foo, fizz, bar, buzz    
 
 Notice that union inputs, do not take a name and maintain the names of the sub-inputs.
 In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.
@@ -277,12 +274,9 @@ reason to take a union of unions since union is associative.
 Cross inputs take the cross product of other inputs, in other words it creates
 tuples of the datums in the inputs. For example:
 
-| inputA | inputB | inputA ⨯ inputB |
-| ------ | ------ | --------------- |
-| foo    | fizz   | (foo, fizz)     |
-| bar    | buzz   | (foo, buzz)     |
-|        |        | (bar, fizz)     |
-|        |        | (bar, buzz)     |
+- inputA: foo, bar
+- inputB: fizz, buzz
+- inputA ⨯ inputB: (foo, fizz), (foo, buzz), (bar, fizz), (bar, buzz)       
 
 Notice that cross inputs, do not take a name and maintain the names of the sub-inputs.
 In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -283,9 +283,14 @@ the commit itself) will be processed.
 
 Union inputs take the union of other inputs. For example:
 
-- inputA: foo, bar
-- inputB: fizz, buzz
-- inputA ∪ inputB: foo, fizz, bar, buzz    
+```
+| inputA | inputB | inputA ∪ inputB |
+| ------ | ------ | --------------- |
+| foo    | fizz   | foo             |
+| bar    | buzz   | fizz            |
+|        |        | bar             |
+|        |        | buzz            |
+```
 
 Notice that union inputs, do not take a name and maintain the names of the sub-inputs.
 In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.
@@ -299,9 +304,14 @@ reason to take a union of unions since union is associative.
 Cross inputs take the cross product of other inputs, in other words it creates
 tuples of the datums in the inputs. For example:
 
-- inputA: foo, bar
-- inputB: fizz, buzz
-- inputA ⨯ inputB: (foo, fizz), (foo, buzz), (bar, fizz), (bar, buzz)       
+```
+| inputA | inputB | inputA ⨯ inputB |
+| ------ | ------ | --------------- |
+| foo    | fizz   | (foo, fizz)     |
+| bar    | buzz   | (foo, buzz)     |
+|        |        | (bar, fizz)     |
+|        |        | (bar, buzz)     |
+```
 
 Notice that cross inputs, do not take a name and maintain the names of the sub-inputs.
 In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -35,7 +35,15 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
     "cpu": double
   },
   "input": {
-      "cross": [ {
+      "atom": {
+          "name": string,
+          "repo": string,
+          "branch": string,
+          "glob": string,
+          "lazy" bool,
+          "from_commit": string
+      },
+      "cross" or "union": [ {
           "atom": {
               "name": string,
               "repo": string,

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -35,24 +35,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
     "cpu": double
   },
   "input": {
-      "atom": {
-          "name": string,
-          "repo": string,
-          "branch": string,
-          "glob": string,
-          "lazy" bool,
-          "from_commit": string
-      },
-      "cross" or "union": [ {
-          "atom": {
-              "name": string,
-              "repo": string,
-              "branch": string,
-              "glob": string,
-              "lazy" bool,
-              "from_commit": string
-          }
-      } ]
+    <"atom" or "cross" or "union", see below> 
   },
   "outputBranch": string,
   "egress": {
@@ -60,6 +43,48 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
   },
   "scaleDownThreshold": string
 }
+
+------------------------------------
+"atom" input
+------------------------------------
+
+"atom": {
+  "name": string,
+  "repo": string,
+  "branch": string,
+  "glob": string,
+  "lazy" bool,
+  "from_commit": string
+}
+
+------------------------------------
+"cross" or "union" input
+------------------------------------
+
+"cross" or "union": [ 
+  {
+    "atom": {
+      "name": string,
+      "repo": string,
+      "branch": string,
+      "glob": string,
+      "lazy" bool,
+      "from_commit": string
+    }
+  },
+  {
+    "atom": {
+      "name": string,
+      "repo": string,
+      "branch": string,
+      "glob": string,
+      "lazy" bool,
+      "from_commit": string
+    }
+  }
+  etc...
+]
+
 ```
 
 In practice, you rarely need to specify all the fields.  Most fields either come with sensible defaults or can be nil.  Following is an example of a minimal spec:


### PR DESCRIPTION
Updates for the high priority docs to be consistent with the change from "inputs" to "input".  We need to follow up with the fixes for the other examples (wordcount and ML).