### PR TITLE
Make getPachClient() in pachyderm_test.go() work inside a cluster

### DIFF
--- a/src/server/object_bench_test.go
+++ b/src/server/object_bench_test.go
@@ -8,7 +8,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 	"github.com/pachyderm/pachyderm/src/server/pkg/workload"
 )
@@ -25,7 +24,7 @@ func BenchmarkManyObjects(b *testing.B) {
 			var eg errgroup.Group
 			for i := 0; i < clients; i++ {
 				i := i
-				c := getPachClientInCluster(b)
+				c := getPachClient(b)
 				rand := rand.New(rand.NewSource(int64(i)))
 				eg.Go(func() error {
 					for j := 0; j < objectsPerClient; j++ {
@@ -52,7 +51,7 @@ func BenchmarkManyObjects(b *testing.B) {
 			var eg errgroup.Group
 			for i := 0; i < clients; i++ {
 				i := i
-				c := getPachClientInCluster(b)
+				c := getPachClient(b)
 				eg.Go(func() error {
 					for j := 0; j < objectsPerClient; j++ {
 						err := c.GetTag(fmt.Sprintf("%d.%d", i, j), ioutil.Discard)
@@ -72,7 +71,7 @@ func BenchmarkManyObjects(b *testing.B) {
 			var eg errgroup.Group
 			for i := 0; i < clients; i++ {
 				i := i
-				c := getPachClientInCluster(b)
+				c := getPachClient(b)
 				eg.Go(func() error {
 					for j := 0; j < objectsPerClient; j++ {
 						err := c.GetTag(fmt.Sprintf("%d.%d", i, j), ioutil.Discard)
@@ -87,10 +86,4 @@ func BenchmarkManyObjects(b *testing.B) {
 			require.NoError(b, eg.Wait())
 		}
 	})
-}
-
-func getPachClientInCluster(t testing.TB) *client.APIClient {
-	client, err := client.NewInCluster()
-	require.NoError(t, err)
-	return client
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3608,9 +3608,15 @@ func getKubeClient(t testing.TB) *kube.Client {
 }
 
 func getPachClient(t testing.TB) *client.APIClient {
-	client, err := client.NewFromAddress("0.0.0.0:30650")
+	var c *client.APIClient
+	var err error
+	if addr := os.Getenv("PACHD_PORT_650_TCP_ADDR"); addr != "" {
+		c, err = client.NewInCluster()
+	} else {
+		c, err = client.NewFromAddress("0.0.0.0:30650")
+	}
 	require.NoError(t, err)
-	return client
+	return c
 }
 
 func uniqueString(prefix string) string {


### PR DESCRIPTION
Also: make other tests depend on getPachClient()