### PR TITLE
Make several changes to batch testing in gke:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CLUSTER_NAME?=pachyderm
 CLUSTER_MACHINE_TYPE?=n1-standard-4
 CLUSTER_SIZE?=4
 
-BENCH_CLOUD_PROVIDER=gcp
+BENCH_CLOUD_PROVIDER=gke
 
 ifdef TRAVIS_BUILD_NUMBER
 	# Upper bound for travis test timeout
@@ -160,12 +160,12 @@ push-bench-images: install-bench
 	docker push pachyderm/bench:`git rev-list HEAD --max-count=1`
 
 launch-bench:
-	# Make launches each process in its own shell process, so we have to structure
-	# these to run these as one command
-	ID=$$( etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --create ); \
+	@# Make launches each process in its own shell process, so we have to structure
+	@# these to run these as one command
+	ID=$$( etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --create | tail -n 1); \
+	@echo To delete this cluster, run etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --delete=$${ID}
 	until timeout 10s ./etc/kube/check_ready.sh app=pachd; do sleep 1; done; \
-	cat ~/.kube/config; \
-	etc/testing/deploy$(BENCH_CLOUD_PROVIDER).sh --delete=$${ID}
+	cat ~/.kube/config;
 
 install-bench: install
 	@# Since bench is run as sudo, pachctl needs to be under
@@ -178,14 +178,8 @@ run-bench:
 	echo "waiting for pachd to scale up" && sleep 15
 	kubectl delete --ignore-not-found po/bench && kubectl run bench --image=pachyderm/bench:`git rev-list HEAD --max-count=1` --image-pull-policy=Always --restart=Never --attach=true -- ./test -test.v -test.bench=BenchmarkDaily -test.run=XXX
 
-clean-launch-bench:
-	if [ -e tmp/current-benchmark-cluster.txt ]; then \
-	  { \
-	    kops delete cluster `cat tmp/current-benchmark-cluster.txt` --yes --state `cat tmp/current-benchmark-state-store.txt`; \
-	    aws s3 del --recursive --force `cat tmp/current-benchmark-state-store.txt`; \
-	    aws s3 rb `cat tmp/current-benchmark-state-store.txt`; \
-	  } || true; \
-	fi
+delete-all-launch-bench:
+	etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --delete-all
 
 bench: clean-launch-bench build-bench-images push-bench-images launch-bench run-bench clean-launch-bench
 

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -28,7 +28,7 @@ if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
     docker login -u pachydermbuildbot -p ${DOCKER_PWD}
 
     # Deploy cluster and run benchmark
-    sudo -E make bench
+    sudo -E PATH="${PATH}" GOPATH="${GOPATH}" make bench
 else
 	echo "Running tests"
 	make test

--- a/etc/testing/travis_install_batch_deps.sh
+++ b/etc/testing/travis_install_batch_deps.sh
@@ -27,4 +27,4 @@ mv google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
 sudo bash -Ec 'echo $PATH'
 sudo ln -s `which aws` /usr/local/bin/aws
 sudo ln -s `which go` /usr/local/bin/go
-sudo apt-get install uuid
+sudo apt-get install -yq uuid


### PR DESCRIPTION
1) Fix "make launch-dev" (which deletes the cluster before it can be used) and "make clean-launch-dev" (which doesn't delete the right things)
2) Use encrypted gke credentials in etc/testing/deploy/gke.sh
3) (minor) use -yq when installing "uuid" in travis_install_batch_deps.sh