### PR TITLE
Delete temporary metadata in etcd

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -602,6 +602,12 @@ func (d *driver) finishCommit(ctx context.Context, commit *pfs.Commit) error {
 		repos.Put(commit.Repo.Name, repoInfo)
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Delete the scratch space for this commit
+	_, err = d.etcdClient.Delete(ctx, prefix, etcd.WithPrefix())
 	return err
 }
 


### PR DESCRIPTION
Currently `PutFile` stores some temporary metadata in etcd that's of no use after the commit has been finished.  This PR makes it so that `FinishCommit` actually deletes the temporary metadata.