### PR TITLE
Fix bugs in Makefile and etc/deploy/aws.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,13 @@ launch-bench:
 	@# Make launches each process in its own shell process, so we have to structure
 	@# these to run these as one command
 	ID=$$( etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --create | tail -n 1); \
-	@echo To delete this cluster, run etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --delete=$${ID}
+	@echo To delete this cluster, run etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --delete=$${ID}; \
+	echo etc/testing/deploy/$(BENCH_CLOUD_PROVIDER).sh --delete=$${ID} >./clean_current_bench_cluster.sh; \
 	until timeout 10s ./etc/kube/check_ready.sh app=pachd; do sleep 1; done; \
 	cat ~/.kube/config;
+
+clean-launch-bench:
+	./clean_current_bench_cluster.sh || true
 
 install-bench: install
 	@# Since bench is run as sudo, pachctl needs to be under

--- a/etc/testing/deploy/aws.sh
+++ b/etc/testing/deploy/aws.sh
@@ -6,7 +6,7 @@
 
 ## Parse command-line flags
 if [[ "$#" -lt 1 ]]; then
-  echo "Must pass --delete-all or --create to testing/deploy/aws.sh"
+  echo "Must pass --create, --delete, --delete-all or --list to testing/deploy/aws.sh"
   exit 1
 fi
 
@@ -15,7 +15,7 @@ ZONE=us-west-1b
 STATE_STORE=s3://pachyderm-travis-state-store-v1
 
 # Process args
-new_opt="$( getopt --long="create,delete:,delete-all" -- ${0} "${@}" )"
+new_opt="$( getopt --long="create,delete:,delete-all,list" -- ${0} "${@}" )"
 [[ "$?" -eq 0 ]] || exit 1
 eval "set -- ${new_opt}"
 
@@ -31,6 +31,9 @@ case "${1}" in
       done
     exit 0
     set +x
+    ;;
+  --list)
+    kops --state=${STATE_STORE} get clusters
     ;;
   --delete)
     set -x


### PR DESCRIPTION
and add --list to etc/testing/deploy/aws.sh

* parse_args needs to recieve a copy of the parent script's arguments
* I left out a trailing right slash in Makefile.
* The make target "clean-launch-bench" is being added back.
* To avoid ambiguity in whether --state needs an s3:// prefix, aws.sh
simply checks that one is always present
* getopt quotes the arguments that it prints at the end. To unquote
them, its output is passed to "eval". Otherwise, setting --region to
"us-east-1" might cause the variable to contain "\"us-east-1\""