### PR TITLE
Report more info when cloudfront errs

### DIFF
--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -96,7 +96,7 @@ func (c *amazonClient) Reader(name string, offset uint64, size uint64) (io.ReadC
 		}
 		if resp.StatusCode >= 300 {
 			// Cloudfront returns 200s, and 206s as success codes
-			return nil, fmt.Errorf("cloudfront returned HTTP error code %v", resp.StatusCode)
+			return nil, fmt.Errorf("cloudfront returned HTTP error code %v for url %v", resp.Status, url)
 		}
 		reader = resp.Body
 	} else {


### PR DESCRIPTION
I got intermittent 500s and 503s yesterday and didn't know:

a) for which URLs / requests
b) the status message

Both of which would be helpful for debugging.