### PR TITLE
Fix several bugs in etc/deploy/aws.sh and etc/testing/deploy/aws.sh

### DIFF
--- a/etc/testing/deploy/aws.sh
+++ b/etc/testing/deploy/aws.sh
@@ -25,7 +25,7 @@ eval "set -- ${new_opt}"
 case "${1}" in
   --delete-all)
     set -x
-    kops --state=${STATE_STORE} get clusters \
+    kops --state=${STATE_STORE} get clusters | tail -n+2 | awk '{print $1}' \
       | while read name; do
           kops --state=${STATE_STORE} delete cluster --name=${name} --yes
       done
@@ -43,7 +43,7 @@ case "${1}" in
     ;;
   --create)
     set -x
-    sudo $(dirname "${0}")/../../deploy/aws.sh --region=${REGION} --zone=${ZONE} --state=${STATE_STORE}
+    sudo $(dirname "${0}")/../../deploy/aws.sh --region=${REGION} --zone=${ZONE} --state=${STATE_STORE} --no-metrics
     set +x
     ;;
 esac


### PR DESCRIPTION
Specifically:
* if you pass `--no-metrics` to `etc/deploy/aws.sh`, then it will set `--no-metrics` to `pachctl deploy`. Also, set `--no-metrics` in `etc/testing/deploy/aws.sh` so that our tests don't pollute our cluster metrics
* Remove the `LimitRange` that kops creates by default in new clusters. This prevents our test clusters from filling up (kops's `LimitRange` assigns a default resource request of 100m CPU to all new pods in the `default` namespace)
* Fix `--delete-all` in `etc/testing/deploy/aws.sh` which simply didn't work previously
* Make `kops create cluster` more explicit: set `--cloud` (which was previously being inferred), `--name` (which was set by a positional argument) and `--yes` (which wasn't being set at all)