### PR TITLE
Implement delete-commit

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -377,6 +377,19 @@ $ pachctl flush-commit foo/XXX -r bar -r baz
 	flushCommit.Flags().VarP(&repos, "repos", "r", "Wait only for commits leading to a specific set of repos")
 	rawFlag(flushCommit)
 
+	deleteCommit := &cobra.Command{
+		Use:   "delete-commit repo-name commit-id",
+		Short: "Delete an unfinished commit.",
+		Long:  "Delete an unfinished commit.",
+		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
+			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			if err != nil {
+				return err
+			}
+			return client.DeleteCommit(args[0], args[1])
+		}),
+	}
+
 	listBranch := &cobra.Command{
 		Use:   "list-branch <repo-name>",
 		Short: "Return all branches on a repo.",
@@ -869,6 +882,7 @@ $ pachctl glob-file foo master "data/*"
 	result = append(result, inspectCommit)
 	result = append(result, listCommit)
 	result = append(result, flushCommit)
+	result = append(result, deleteCommit)
 	result = append(result, listBranch)
 	result = append(result, setBranch)
 	result = append(result, deleteBranch)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1051,7 +1051,9 @@ func (d *driver) deleteCommit(ctx context.Context, commit *pfs.Commit) error {
 		return err
 	}
 	_, err = d.etcdClient.Delete(ctx, prefix, etcd.WithPrefix())
-	return err
+	if err != nil {
+		return err
+	}
 
 	// If this commit is the head of a branch, make the commit's parent
 	// the head instead.

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -404,18 +404,17 @@ func TestDeleteCommit(t *testing.T) {
 	_, err = client.PutFile(repo, commit.ID, "foo", strings.NewReader(fileContent))
 	require.NoError(t, err)
 
-	require.NoError(t, client.FinishCommit(repo, commit.ID))
-
 	commitInfo, err := client.InspectCommit(repo, commit.ID)
 	require.NotNil(t, commitInfo)
 
 	require.NoError(t, client.DeleteCommit(repo, commit.ID))
 
 	commitInfo, err = client.InspectCommit(repo, commit.ID)
+	fmt.Printf("commitInfo: %v\n", commitInfo)
 	require.YesError(t, err)
 
 	repoInfo, err := client.InspectRepo(repo)
-	require.Equal(t, 0, repoInfo.SizeBytes)
+	require.Equal(t, 0, int(repoInfo.SizeBytes))
 }
 
 func TestCleanPath(t *testing.T) {

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -390,10 +390,7 @@ func TestInspectCommit(t *testing.T) {
 	require.True(t, finished.After(tFinished))
 }
 
-func TestDeleteCommitFuture(t *testing.T) {
-	// For when DeleteCommit gets implemented
-	t.Skip()
-
+func TestDeleteCommit(t *testing.T) {
 	t.Parallel()
 	client := getClient(t)
 
@@ -415,7 +412,7 @@ func TestDeleteCommitFuture(t *testing.T) {
 	require.NoError(t, client.DeleteCommit(repo, commit.ID))
 
 	commitInfo, err = client.InspectCommit(repo, commit.ID)
-	require.Nil(t, commitInfo)
+	require.YesError(t, err)
 
 	repoInfo, err := client.InspectRepo(repo)
 	require.Equal(t, 0, repoInfo.SizeBytes)


### PR DESCRIPTION
This PR implements `DeleteCommit` and exposes it in `pachctl` as `delete-commit`.  Currently it can only delete commits that are open (unfinished).