### PR TITLE
Remove orphaned jobs

### DIFF
--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -41,19 +41,12 @@ type appEnv struct {
 	PPSWorkerIP string `env:"PPS_WORKER_IP,required"`
 
 	// Either pipeline name or job name must be set
-	PPSPipelineName string `env:"PPS_PIPELINE_NAME"`
+	PPSPipelineName string `env:"PPS_PIPELINE_NAME,required"`
 	PodName         string `env:"PPS_POD_NAME,required"`
 }
 
 func main() {
 	cmdutil.Main(do, &appEnv{})
-}
-
-func validateEnv(appEnv *appEnv) error {
-	if appEnv.PPSPipelineName == "" {
-		return fmt.Errorf("worker must recieve pipeline name")
-	}
-	return nil
 }
 
 // getPipelineInfo gets the PipelineInfo proto describing the pipeline that this
@@ -82,9 +75,6 @@ func do(appEnvObj interface{}) error {
 
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	appEnv := appEnvObj.(*appEnv)
-	if err := validateEnv(appEnv); err != nil {
-		return fmt.Errorf("error validating env: %v", err)
-	}
 
 	// get pachd client, so we can upload output data from the user binary
 	pachClient, err := client.NewFromAddress("localhost:650")

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1461,7 +1461,7 @@ func TestAcceptReturnCode(t *testing.T) {
 				AcceptReturnCode: []int64{1},
 			},
 			Inputs: []*pps.PipelineInput{{
-				Name: dataRepo,
+				Repo: &pfs.Repo{Name: dataRepo},
 				Glob: "/*",
 			}},
 		},
@@ -1476,7 +1476,10 @@ func TestAcceptReturnCode(t *testing.T) {
 	jobInfos, err := c.ListJob(pipelineName, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(jobInfos))
-	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfos[0].State)
+
+	jobInfo, err := c.InspectJob(jobInfos[0].Job.ID, true)
+	require.NoError(t, err)
+	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfo.State)
 }
 
 // TODO(msteffen): This test breaks the suite when run against cloud providers,

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1450,32 +1450,33 @@ func TestAcceptReturnCode(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.FinishCommit(dataRepo, commit.ID))
 
-	job, err := c.PpsAPIClient.CreateJob(
+	pipelineName := uniqueString("TestAcceptReturnCode")
+	_, err = c.PpsAPIClient.CreatePipeline(
 		context.Background(),
-		&pps.CreateJobRequest{
+		&pps.CreatePipelineRequest{
+			Pipeline: &pps.Pipeline{pipelineName},
 			Transform: &pps.Transform{
 				Cmd:              []string{"sh"},
 				Stdin:            []string{"exit 1"},
 				AcceptReturnCode: []int64{1},
 			},
-			Inputs: []*pps.JobInput{{
-				Name:   dataRepo,
-				Commit: commit,
-				Glob:   "/*",
+			Inputs: []*pps.PipelineInput{{
+				Name: dataRepo,
+				Glob: "/*",
 			}},
-			OutputBranch: "master",
 		},
 	)
 	require.NoError(t, err)
-	inspectJobRequest := &pps.InspectJobRequest{
-		Job:        job,
-		BlockState: true,
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel() //cleanup resources
-	jobInfo, err := c.PpsAPIClient.InspectJob(ctx, inspectJobRequest)
+
+	commitIter, err := c.FlushCommit([]*pfs.Commit{commit}, nil)
 	require.NoError(t, err)
-	require.Equal(t, pps.JobState_JOB_SUCCESS.String(), jobInfo.State.String())
+	commitInfos := collectCommitInfos(t, commitIter)
+	require.Equal(t, 1, len(commitInfos))
+
+	jobInfos, err := c.ListJob(pipelineName, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(jobInfos))
+	require.Equal(t, pps.JobState_JOB_SUCCESS, jobInfos[0].State)
 }
 
 // TODO(msteffen): This test breaks the suite when run against cloud providers,
@@ -3194,71 +3195,6 @@ func TestPipelineResourceRequest(t *testing.T) {
 	gpu, ok := container.Resources.Requests[api.ResourceNvidiaGPU]
 	require.True(t, ok)
 	require.Equal(t, "1", gpu.String())
-}
-
-// TestJobResourceRequest creates a stand-alone job with a resource request, and
-// makes sure it's passed to k8s (by inspecting the job's pods)
-func TestJobResourceRequest(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
-	t.Parallel()
-
-	c := getPachClient(t)
-	// create repos
-	dataRepo := uniqueString("TestJobResourceRequest")
-	require.NoError(t, c.CreateRepo(dataRepo))
-	commit := PutFileAndFlush(t, dataRepo, "master", "file", "foo\n")
-	// Resources are not yet in client.CreatePipeline() (we may add them later)
-	createJobResp, err := c.PpsAPIClient.CreateJob(
-		context.Background(),
-		&pps.CreateJobRequest{
-			Transform: &pps.Transform{
-				Cmd: []string{"cp", path.Join("/pfs", dataRepo, "file"), "/pfs/out/file"},
-			},
-			ParallelismSpec: &pps.ParallelismSpec{
-				Strategy: pps.ParallelismSpec_CONSTANT,
-				Constant: 1,
-			},
-			ResourceSpec: &pps.ResourceSpec{
-				Memory: "100M",
-				Cpu:    0.5,
-			},
-			Inputs: []*pps.JobInput{{
-				Name:   "foo-input",
-				Commit: commit,
-				Glob:   "/*",
-			}},
-		})
-	require.NoError(t, err)
-
-	// Get info about the job pods from k8s & check for resources
-	var container api.Container
-	rcName := pps_server.JobRcName(createJobResp.ID)
-	kubeClient := getKubeClient(t)
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = 10 * time.Second
-	err = backoff.Retry(func() error {
-		podList, err := kubeClient.Pods(api.NamespaceDefault).List(api.ListOptions{
-			LabelSelector: labels.SelectorFromSet(
-				map[string]string{"app": rcName}),
-		})
-		if err != nil {
-			return err // retry
-		}
-		if len(podList.Items) != 1 || len(podList.Items[0].Spec.Containers) == 0 {
-			return fmt.Errorf("could not find single container for job %s", createJobResp.ID)
-		}
-		container = podList.Items[0].Spec.Containers[0]
-		return nil // no more retries
-	}, b)
-	require.NoError(t, err)
-	cpu, ok := container.Resources.Requests[api.ResourceCPU]
-	require.True(t, ok)
-	require.Equal(t, "500m", cpu.String())
-	mem, ok := container.Resources.Requests[api.ResourceMemory]
-	require.True(t, ok)
-	require.Equal(t, "100M", mem.String())
 }
 
 func TestPipelineLargeOutput(t *testing.T) {

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -498,6 +498,60 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		}),
 	}
 
+	var specPath string
+	runPipeline := &cobra.Command{
+		Use:   "run-pipeline pipeline-name [-f job.json]",
+		Short: "Run a pipeline once.",
+		Long:  "Run a pipeline once, optionally overriding some pipeline options by providing a [pipeline spec](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).  For example run a web scraper pipelien without any explicit input.",
+		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
+			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			if err != nil {
+				return err
+			}
+
+			request := &ppsclient.CreateJobRequest{
+				Pipeline: &ppsclient.Pipeline{
+					Name: args[0],
+				},
+			}
+
+			var buf bytes.Buffer
+			var specReader io.Reader
+			if specPath == "-" {
+				specReader = io.TeeReader(os.Stdin, &buf)
+				fmt.Print("Reading from stdin.\n")
+			} else if specPath != "" {
+				specFile, err := os.Open(specPath)
+				if err != nil {
+					return err
+				}
+
+				defer func() {
+					if err := specFile.Close(); err != nil && retErr == nil {
+						retErr = err
+					}
+				}()
+
+				specReader = io.TeeReader(specFile, &buf)
+				decoder := json.NewDecoder(specReader)
+				if err := jsonpb.UnmarshalNext(decoder, request); err != nil {
+					return err
+				}
+			}
+
+			job, err := client.PpsAPIClient.CreateJob(
+				context.Background(),
+				request,
+			)
+			if err != nil {
+				return sanitizeErr(err)
+			}
+			fmt.Println(job.ID)
+			return nil
+		}),
+	}
+	runPipeline.Flags().StringVarP(&specPath, "file", "f", "", "The file containing the run-pipeline spec, - reads from stdin.")
+
 	garbageCollect := &cobra.Command{
 		Use:   "garbage-collect",
 		Short: "Garbage collect unused data.",
@@ -535,6 +589,7 @@ Currently "pachctl garbage-collect" can only be started when there are no active
 	result = append(result, deletePipeline)
 	result = append(result, startPipeline)
 	result = append(result, stopPipeline)
+	result = append(result, runPipeline)
 	result = append(result, garbageCollect)
 	return result, nil
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -467,12 +467,7 @@ func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobReque
 	if jobInfo.State != pps.JobState_JOB_RUNNING {
 		return jobInfo, nil
 	}
-	var workerPoolID string
-	if jobInfo.Pipeline != nil {
-		workerPoolID = PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion)
-	} else {
-		workerPoolID = JobRcName(jobInfo.Job.ID)
-	}
+	workerPoolID := PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion)
 	workerStatus, err := status(ctx, workerPoolID, a.etcdClient, a.etcdPrefix)
 	if err != nil {
 		protolion.Errorf("failed to get worker status with err: %s", err.Error())
@@ -574,12 +569,7 @@ func (a *apiServer) RestartDatum(ctx context.Context, request *pps.RestartDatumR
 	if err != nil {
 		return nil, err
 	}
-	var workerPoolID string
-	if jobInfo.Pipeline != nil {
-		workerPoolID = PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion)
-	} else {
-		workerPoolID = JobRcName(jobInfo.Job.ID)
-	}
+	workerPoolID := PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion)
 	if err := cancel(ctx, workerPoolID, a.etcdClient, a.etcdPrefix, request.Job.ID, request.DataFilters); err != nil {
 		return nil, err
 	}
@@ -618,22 +608,15 @@ func (a *apiServer) GetLogs(request *pps.GetLogsRequest, apiGetLogsServer pps.AP
 			return err
 		}
 	} else if request.Job != nil {
-		// If they only provided a job, get job info to see if it's an orphan job
 		var jobInfo pps.JobInfo
 		err := a.jobs.ReadOnly(ctx).Get(request.Job.ID, &jobInfo)
 		if err != nil {
 			return fmt.Errorf("could not get job information for %s: %s", request.Job.ID, err.Error())
 		}
 
-		// Get logs from either pipeline RC, or job RC if it's an orphan job
-		if jobInfo.Pipeline != nil {
-			var err error
-			rcName, err = a.lookupRcNameForPipeline(ctx, jobInfo.Pipeline)
-			if err != nil {
-				return err
-			}
-		} else {
-			rcName = JobRcName(request.Job.ID)
+		rcName, err = a.lookupRcNameForPipeline(ctx, jobInfo.Pipeline)
+		if err != nil {
+			return err
 		}
 	} else {
 		return fmt.Errorf("must specify either pipeline or job")
@@ -1960,42 +1943,6 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 			return err
 		}
 
-		// Create workers and output repo if 'jobInfo' belongs to an orphan job
-		if jobInfo.Pipeline == nil {
-			// Create output repo for this job
-			var provenance []*pfs.Repo
-			visit(jobInfo.Input, func(input *pps.Input) {
-				if input.Atom != nil {
-					provenance = append(provenance, client.NewRepo(input.Atom.Repo))
-				}
-			})
-			if _, err := pfsClient.CreateRepo(ctx, &pfs.CreateRepoRequest{
-				Repo:       jobInfo.OutputRepo,
-				Provenance: provenance,
-			}); err != nil {
-				// (if output repo already exists, do nothing)
-				if !isAlreadyExistsErr(err) {
-					return err
-				}
-			}
-
-			// Create workers in kubernetes (i.e. create replication controller)
-			if err := a.createWorkersForOrphanJob(jobInfo); err != nil {
-				if !isAlreadyExistsErr(err) {
-					return err
-				}
-			}
-			go func() {
-				// Clean up workers if the job gets cancelled
-				<-ctx.Done()
-				rcName := JobRcName(jobInfo.Job.ID)
-				if err := a.deleteWorkers(rcName); err != nil {
-					protolion.Errorf("error deleting workers for job: %v", jobID)
-				}
-				protolion.Infof("deleted workers for job: %v", jobID)
-			}()
-		}
-
 		// Set the state of this job to 'RUNNING'
 		_, err = col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 			jobs := a.jobs.ReadWrite(stm)
@@ -2009,19 +1956,14 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 			return err
 		}
 
-		// Start worker pool
-		var rcName string
-		if jobInfo.Pipeline != nil {
-			// We scale up the workers before we run a job, to ensure
-			// that the job will have workers to use.  Note that scaling
-			// a RC is idempotent: nothing happens if the workers have
-			// already been scaled.
-			rcName = PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion)
-			if err := a.scaleUpWorkers(ctx, rcName, jobInfo.ParallelismSpec); err != nil {
-				return err
-			}
-		} else {
-			rcName = JobRcName(jobInfo.Job.ID)
+		// Start worker pool.
+		// We scale up the workers before we run a job, to ensure
+		// that the job will have workers to use.  Note that scaling
+		// a RC is idempotent: nothing happens if the workers have
+		// already been scaled.
+		rcName := PipelineRcName(jobInfo.Pipeline.Name, jobInfo.PipelineVersion)
+		if err := a.scaleUpWorkers(ctx, rcName, jobInfo.ParallelismSpec); err != nil {
+			return err
 		}
 
 		failed := false
@@ -2036,9 +1978,8 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 			return err
 		}
 		var newBranchParentCommit *pfs.Commit
-		// If this is an incremental job we need to find the parent commit of
-		// the new branch.  jobInfo.NewBranch is nil when we're dealing with an
-		// orphan job rather than a pipeline job.
+		// If this is an incremental job we need to find the parent
+		// commit of the new branch.
 		if jobInfo.Incremental && jobInfo.NewBranch != nil {
 			newBranchCommitInfo, err := pfsClient.InspectCommit(ctx, &pfs.InspectCommitRequest{
 				Commit: jobInfo.NewBranch.Head,
@@ -2122,7 +2063,7 @@ func (a *apiServer) jobManager(ctx context.Context, jobInfo *pps.JobInfo) {
 					parentFiles = append(parentFiles, parentFile)
 				}
 				if len(parentFiles) == len(files) {
-					_parentOutputTag, err := workerpkg.HashDatum(pipelineInfo, nil, parentFiles)
+					_parentOutputTag, err := workerpkg.HashDatum(pipelineInfo, parentFiles)
 					if err != nil {
 						return err
 					}
@@ -2354,31 +2295,6 @@ func parseResourceList(resources *pps.ResourceSpec) (*api.ResourceList, error) {
 		api.ResourceNvidiaGPU: gpuQuantity,
 	}
 	return &result, nil
-}
-
-func (a *apiServer) createWorkersForOrphanJob(jobInfo *pps.JobInfo) error {
-	parallelism, err := GetExpectedNumWorkers(a.kubeClient, jobInfo.ParallelismSpec)
-	if err != nil {
-		return err
-	}
-	var resources *api.ResourceList
-	if jobInfo.ResourceSpec != nil {
-		resources, err = parseResourceList(jobInfo.ResourceSpec)
-		if err != nil {
-			return err
-		}
-	}
-	options := a.getWorkerOptions(
-		JobRcName(jobInfo.Job.ID),
-		int32(parallelism),
-		resources,
-		jobInfo.Transform)
-	// Set the job name env
-	options.workerEnv = append(options.workerEnv, api.EnvVar{
-		Name:  client.PPSJobIDEnv,
-		Value: jobInfo.Job.ID,
-	})
-	return a.createWorkerRc(options)
 }
 
 func (a *apiServer) createWorkersForPipeline(pipelineInfo *pps.PipelineInfo) error {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -740,13 +740,11 @@ func translatePipelineInputs(inputs []*pps.PipelineInput) *pps.Input {
 		}
 		atomInput := &pps.AtomInput{
 			Name:       input.Name,
+			Repo:       input.Repo.Name,
 			Branch:     input.Branch,
 			Glob:       input.Glob,
 			Lazy:       input.Lazy,
 			FromCommit: fromCommitID,
-		}
-		if input.Repo != nil {
-			atomInput.Repo = input.Repo.Name
 		}
 		result.Cross = append(result.Cross, &pps.Input{
 			Atom: atomInput,

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -738,17 +738,19 @@ func translatePipelineInputs(inputs []*pps.PipelineInput) *pps.Input {
 		if input.From != nil {
 			fromCommitID = input.From.ID
 		}
-		result.Cross = append(result.Cross,
-			&pps.Input{
-				Atom: &pps.AtomInput{
-					Name:       input.Name,
-					Repo:       input.Repo.Name,
-					Branch:     input.Branch,
-					Glob:       input.Glob,
-					Lazy:       input.Lazy,
-					FromCommit: fromCommitID,
-				},
-			})
+		atomInput := &pps.AtomInput{
+			Name:       input.Name,
+			Branch:     input.Branch,
+			Glob:       input.Glob,
+			Lazy:       input.Lazy,
+			FromCommit: fromCommitID,
+		}
+		if input.Repo != nil {
+			atomInput.Repo = input.Repo.Name
+		}
+		result.Cross = append(result.Cross, &pps.Input{
+			Atom: atomInput,
+		})
 	}
 	return result
 }

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -40,16 +40,6 @@ func PipelineRcName(name string, version uint64) string {
 	return fmt.Sprintf("pipeline-%s-v%d", strings.ToLower(name), version)
 }
 
-// JobRcName generates the name of the k8s replication controller that manages
-// an orphan job's workers
-func JobRcName(id string) string {
-	// k8s won't allow RC names that contain upper-case letters
-	// or underscores
-	// TODO: deal with name collision
-	id = strings.Replace(id, "_", "-", -1)
-	return fmt.Sprintf("job-%s", strings.ToLower(id))
-}
-
 func (a *apiServer) workerPodSpec(options *workerOptions) api.PodSpec {
 	pullPolicy := a.workerImagePullPolicy
 	if pullPolicy == "" {


### PR DESCRIPTION
This PR removes support for "orphaned jobs", i.e. jobs without pipelines.  The reasons why we decided to remove them are:

* The feature is rarely, if ever, used.
* The feature is not well tested, if at all.
* The implementation of the feature complicates the codebase.

Fix #1289 
