### PR TITLE
Make error message resulted from malformed pipeline spec more explicit

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -736,7 +736,7 @@ func newPipelineManifestReader(path string) (result *pipelineManifestReader, ret
 func (r *pipelineManifestReader) nextCreatePipelineRequest() (*ppsclient.CreatePipelineRequest, error) {
 	var result ppsclient.CreatePipelineRequest
 	if err := jsonpb.UnmarshalNext(r.decoder, &result); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("malformed pipeline spec: %s", err)
 	}
 	return &result, nil
 }


### PR DESCRIPTION
Fix #1904 