### PR TITLE
Add test to validate dash image exists

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds_test.go
+++ b/src/server/pkg/deploy/cmds/cmds_test.go
@@ -1,0 +1,13 @@
+package cmds
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+)
+
+func TestDashImageExists(t *testing.T) {
+	c := exec.Command("docker", "pull", defaultDashImage)
+	require.NoError(t, c.Run())
+}


### PR DESCRIPTION
This will allow PRs that only bump the dash version to be merged after CI passes.

Fixes #1733 