### PR TITLE
Handle provenance correctly in update-pipeline

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -263,9 +263,6 @@ func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, provenance []*p
 			// +1 because we need to include ourselves.
 			myRefCount++
 
-			fmt.Printf("provToAdd: %v\n", provToAdd)
-			fmt.Printf("provToRemove: %v\n", provToRemove)
-
 			for newProv := range provToAdd {
 				fmt.Printf("incrementing %v by %v\n", newProv, myRefCount)
 				if err := repoRefCounts.IncrementBy(newProv, myRefCount); err != nil {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -261,7 +261,7 @@ func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, provenance []*p
 				return err
 			}
 			// +1 because we need to include ourselves.
-			myRefCount += 1
+			myRefCount++
 
 			fmt.Printf("provToAdd: %v\n", provToAdd)
 			fmt.Printf("provToRemove: %v\n", provToRemove)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -234,6 +234,88 @@ func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, provenance []*p
 		repos := d.repos.ReadWrite(stm)
 		repoRefCounts := d.repoRefCounts.ReadWriteInt(stm)
 
+		if update {
+			repoInfo := new(pfs.RepoInfo)
+			if err := repos.Get(repo.Name, repoInfo); err != nil {
+				return err
+			}
+
+			provToAdd := make(map[string]bool)
+			provToRemove := make(map[string]bool)
+			for _, newProv := range provenance {
+				provToAdd[newProv.Name] = true
+			}
+			for _, oldProv := range repoInfo.Provenance {
+				delete(provToAdd, oldProv.Name)
+				provToRemove[oldProv.Name] = true
+			}
+			for _, newProv := range provenance {
+				delete(provToRemove, newProv.Name)
+			}
+
+			// For each new provenance repo, we increase its ref count
+			// by N where N is this repo's ref count.
+			// For each old provenance repo we do the opposite.
+			myRefCount, err := repoRefCounts.Get(repo.Name)
+			if err != nil {
+				return err
+			}
+			// +1 because we need to include ourselves.
+			myRefCount += 1
+
+			fmt.Printf("provToAdd: %v\n", provToAdd)
+			fmt.Printf("provToRemove: %v\n", provToRemove)
+
+			for newProv := range provToAdd {
+				fmt.Printf("incrementing %v by %v\n", newProv, myRefCount)
+				if err := repoRefCounts.IncrementBy(newProv, myRefCount); err != nil {
+					return err
+				}
+			}
+
+			for oldProv := range provToRemove {
+				fmt.Printf("decrementing %v by %v\n", oldProv, myRefCount)
+				if err := repoRefCounts.DecrementBy(oldProv, myRefCount); err != nil {
+					return err
+				}
+			}
+
+			// We also add the new provenance repos to the provenance
+			// of all downstream repos, and remove the old provenance
+			// repos from their provenance.
+			downstreamRepos, err := d.listRepo(ctx, []*pfs.Repo{repo})
+			if err != nil {
+				return err
+			}
+
+			for _, repoInfo := range downstreamRepos {
+			nextNewProv:
+				for newProv := range provToAdd {
+					for _, prov := range repoInfo.Provenance {
+						if newProv == prov.Name {
+							continue nextNewProv
+						}
+					}
+					repoInfo.Provenance = append(repoInfo.Provenance, &pfs.Repo{newProv})
+				}
+			nextOldProv:
+				for oldProv := range provToRemove {
+					for i, prov := range repoInfo.Provenance {
+						if oldProv == prov.Name {
+							repoInfo.Provenance = append(repoInfo.Provenance[:i], repoInfo.Provenance[i+1:]...)
+							continue nextOldProv
+						}
+					}
+				}
+				repos.Put(repoInfo.Repo.Name, repoInfo)
+			}
+
+			repoInfo.Description = description
+			repoInfo.Provenance = provenance
+			repos.Put(repo.Name, repoInfo)
+			return nil
+		}
+
 		// compute the full provenance of this repo
 		fullProv := make(map[string]bool)
 		for _, prov := range provenance {
@@ -265,10 +347,6 @@ func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, provenance []*p
 			Created:     now(),
 			Provenance:  fullProvRepos,
 			Description: description,
-		}
-		if update {
-			repos.Put(repo.Name, repoInfo)
-			return nil
 		}
 		return repos.Create(repo.Name, repoInfo)
 	})

--- a/src/server/pkg/collection/collection.go
+++ b/src/server/pkg/collection/collection.go
@@ -247,7 +247,7 @@ func (c *readWriteIntCollection) Get(key string) (int, error) {
 }
 
 func (c *readWriteIntCollection) Increment(key string) error {
-	return c.IncrementBy(1)
+	return c.IncrementBy(key, 1)
 }
 
 func (c *readWriteIntCollection) IncrementBy(key string, n int) error {
@@ -265,7 +265,7 @@ func (c *readWriteIntCollection) IncrementBy(key string, n int) error {
 }
 
 func (c *readWriteIntCollection) Decrement(key string) error {
-	return c.DecrementBy(1)
+	return c.DecrementBy(key, 1)
 }
 
 func (c *readWriteIntCollection) DecrementBy(key string, n int) error {

--- a/src/server/pkg/collection/collection.go
+++ b/src/server/pkg/collection/collection.go
@@ -247,6 +247,10 @@ func (c *readWriteIntCollection) Get(key string) (int, error) {
 }
 
 func (c *readWriteIntCollection) Increment(key string) error {
+	return c.IncrementBy(1)
+}
+
+func (c *readWriteIntCollection) IncrementBy(key string, n int) error {
 	fullKey := c.path(key)
 	valStr := c.stm.Get(fullKey)
 	if valStr == "" {
@@ -256,11 +260,15 @@ func (c *readWriteIntCollection) Increment(key string) error {
 	if err != nil {
 		return ErrMalformedValue{c.prefix, key, valStr}
 	}
-	c.stm.Put(fullKey, strconv.Itoa(val+1))
+	c.stm.Put(fullKey, strconv.Itoa(val+n))
 	return nil
 }
 
 func (c *readWriteIntCollection) Decrement(key string) error {
+	return c.DecrementBy(1)
+}
+
+func (c *readWriteIntCollection) DecrementBy(key string, n int) error {
 	fullKey := c.path(key)
 	valStr := c.stm.Get(fullKey)
 	if valStr == "" {
@@ -270,7 +278,7 @@ func (c *readWriteIntCollection) Decrement(key string) error {
 	if err != nil {
 		return ErrMalformedValue{c.prefix, key, valStr}
 	}
-	c.stm.Put(fullKey, strconv.Itoa(val-1))
+	c.stm.Put(fullKey, strconv.Itoa(val-n))
 	return nil
 }
 

--- a/src/server/pkg/collection/types.go
+++ b/src/server/pkg/collection/types.go
@@ -68,7 +68,9 @@ type ReadWriteIntCollection interface {
 	Create(key string, val int) error
 	Get(key string) (int, error)
 	Increment(key string) error
+	IncrementBy(key string, n int) error
 	Decrement(key string) error
+	DecrementBy(key string, n int) error
 	Delete(key string) error
 }
 

--- a/src/server/pkg/dlock/dlock.go
+++ b/src/server/pkg/dlock/dlock.go
@@ -37,7 +37,9 @@ func NewDLock(client *etcd.Client, prefix string) DLock {
 }
 
 func (d *etcdImpl) Lock(ctx context.Context) (context.Context, error) {
-	session, err := concurrency.NewSession(d.client, concurrency.WithContext(ctx))
+	// The default TTL is 60 secs which means that if a node dies, it
+	// still holds the lock for 60 secs, which is too high.
+	session, err := concurrency.NewSession(d.client, concurrency.WithContext(ctx), concurrency.WithTTL(15))
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -677,6 +677,11 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 
 	pipelineName := pipelineInfo.Pipeline.Name
 
+	var provenance []*pfs.Repo
+	for _, commit := range pps.InputCommits(pipelineInfo.Input) {
+		provenance = append(provenance, commit.Repo)
+	}
+
 	pps.SortInput(pipelineInfo.Input)
 	if request.Update {
 		if _, err := a.StopPipeline(ctx, &pps.StopPipelineRequest{request.Pipeline}); err != nil {
@@ -721,6 +726,34 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 		if _, err := a.StartPipeline(ctx, &pps.StartPipelineRequest{request.Pipeline}); err != nil {
 			return nil, err
 		}
+
+		if _, err := pfsClient.CreateRepo(ctx, &pfs.CreateRepoRequest{
+			Repo:       &pfs.Repo{pipelineInfo.Pipeline.Name},
+			Provenance: provenance,
+			Update:     true,
+		}); err != nil && !isAlreadyExistsErr(err) {
+			return nil, err
+		}
+
+		// Restart all downstream pipelines so they relaunch with the
+		// correct provenance.
+		repoInfos, err := pfsClient.ListRepo(ctx, &pfs.ListRepoRequest{
+			Provenance: []*pfs.Repo{{request.Pipeline.Name}},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, repoInfo := range repoInfos.RepoInfo {
+			if _, err := a.StopPipeline(ctx, &pps.StopPipelineRequest{&pps.Pipeline{repoInfo.Repo.Name}}); err != nil {
+				if isNotFoundErr(err) {
+					continue
+				}
+				return nil, err
+			}
+			if _, err := a.StartPipeline(ctx, &pps.StartPipelineRequest{&pps.Pipeline{repoInfo.Repo.Name}}); err != nil {
+				return nil, err
+			}
+		}
 	} else {
 		_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 			pipelines := a.pipelines.ReadWrite(stm)
@@ -733,29 +766,22 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 		if err != nil {
 			return nil, err
 		}
+		// Create output repo
+		// The pipeline manager also creates the output repo, but we want to
+		// also create the repo here to make sure that the output repo is
+		// guaranteed to be there after CreatePipeline returns.  This is
+		// because it's a very common pattern to create many pipelines in a
+		// row, some of which depend on the existence of the output repos
+		// of upstream pipelines.
+		if _, err := pfsClient.CreateRepo(ctx, &pfs.CreateRepoRequest{
+			Repo:       &pfs.Repo{pipelineInfo.Pipeline.Name},
+			Provenance: provenance,
+		}); err != nil && !isAlreadyExistsErr(err) {
+			return nil, err
+		}
 	}
 
-	// Create output repo
-	// The pipeline manager also creates the output repo, but we want to
-	// also create the repo here to make sure that the output repo is
-	// guaranteed to be there after CreatePipeline returns.  This is
-	// because it's a very common pattern to create many pipelines in a
-	// row, some of which depend on the existence of the output repos
-	// of upstream pipelines.
-	var provenance []*pfs.Repo
-	for _, commit := range pps.InputCommits(pipelineInfo.Input) {
-		provenance = append(provenance, commit.Repo)
-	}
-
-	if _, err := pfsClient.CreateRepo(ctx, &pfs.CreateRepoRequest{
-		Repo:       &pfs.Repo{pipelineInfo.Pipeline.Name},
-		Provenance: provenance,
-		Update:     request.Update,
-	}); err != nil && !isAlreadyExistsErr(err) {
-		return nil, err
-	}
-
-	return &types.Empty{}, err
+	return &types.Empty{}, nil
 }
 
 // setPipelineDefaults sets the default values for a pipeline info


### PR DESCRIPTION
This PR makes it so that when a pipeline is updated, its downstream pipelines' provenance are updated correctly.