### PR TITLE
Cull metrics

### DIFF
--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -120,7 +120,7 @@ func doSidecarMode(appEnvObj interface{}) error {
 	if err != nil {
 		return err
 	}
-	pfsAPIServer, err := pfs_server.NewAPIServer(address, []string{etcdAddress}, appEnv.PFSEtcdPrefix, pfsCacheBytes, reporter)
+	pfsAPIServer, err := pfs_server.NewAPIServer(address, []string{etcdAddress}, appEnv.PFSEtcdPrefix, pfsCacheBytes)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func doFullMode(appEnvObj interface{}) error {
 		address,
 	)
 	cacheServer := cache_server.NewCacheServer(router, appEnv.NumShards)
-	pfsAPIServer, err := pfs_server.NewAPIServer(address, []string{etcdAddress}, appEnv.PFSEtcdPrefix, pfsCacheBytes, reporter)
+	pfsAPIServer, err := pfs_server.NewAPIServer(address, []string{etcdAddress}, appEnv.PFSEtcdPrefix, pfsCacheBytes)
 	if err != nil {
 		return err
 	}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -46,9 +46,8 @@ func newLocalAPIServer(address string, etcdPrefix string) (*apiServer, error) {
 		return nil, err
 	}
 	return &apiServer{
-		Logger:   protorpclog.NewLogger("pfs.API"),
-		driver:   d,
-		reporter: reporter,
+		Logger: protorpclog.NewLogger("pfs.API"),
+		driver: d,
 	}, nil
 }
 
@@ -58,9 +57,8 @@ func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, cac
 		return nil, err
 	}
 	return &apiServer{
-		Logger:   protorpclog.NewLogger("pfs.API"),
-		driver:   d,
-		reporter: reporter,
+		Logger: protorpclog.NewLogger("pfs.API"),
+		driver: d,
 	}, nil
 }
 

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -69,8 +69,6 @@ func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, cac
 func (a *apiServer) CreateRepo(ctx context.Context, request *pfs.CreateRepoRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "CreateRepo")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.driver.createRepo(ctx, request.Repo, request.Provenance, request.Description, request.Update); err != nil {
 		return nil, err
@@ -81,8 +79,6 @@ func (a *apiServer) CreateRepo(ctx context.Context, request *pfs.CreateRepoReque
 func (a *apiServer) InspectRepo(ctx context.Context, request *pfs.InspectRepoRequest) (response *pfs.RepoInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "InspectRepo")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	return a.driver.inspectRepo(ctx, request.Repo)
 }
@@ -90,8 +86,6 @@ func (a *apiServer) InspectRepo(ctx context.Context, request *pfs.InspectRepoReq
 func (a *apiServer) ListRepo(ctx context.Context, request *pfs.ListRepoRequest) (response *pfs.RepoInfos, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListRepo")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	repoInfos, err := a.driver.listRepo(ctx, request.Provenance)
 	return &pfs.RepoInfos{RepoInfo: repoInfos}, err
@@ -100,8 +94,6 @@ func (a *apiServer) ListRepo(ctx context.Context, request *pfs.ListRepoRequest) 
 func (a *apiServer) DeleteRepo(ctx context.Context, request *pfs.DeleteRepoRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "DeleteRepo")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if request.All {
 		if err := a.driver.deleteAll(ctx); err != nil {
@@ -119,8 +111,6 @@ func (a *apiServer) DeleteRepo(ctx context.Context, request *pfs.DeleteRepoReque
 func (a *apiServer) StartCommit(ctx context.Context, request *pfs.StartCommitRequest) (response *pfs.Commit, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "StartCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	commit, err := a.driver.startCommit(ctx, request.Parent, request.Branch, request.Provenance)
 	if err != nil {
@@ -132,8 +122,6 @@ func (a *apiServer) StartCommit(ctx context.Context, request *pfs.StartCommitReq
 func (a *apiServer) BuildCommit(ctx context.Context, request *pfs.BuildCommitRequest) (response *pfs.Commit, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "StartCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	commit, err := a.driver.buildCommit(ctx, request.Parent, request.Branch, request.Provenance, request.Tree)
 	if err != nil {
@@ -145,8 +133,6 @@ func (a *apiServer) BuildCommit(ctx context.Context, request *pfs.BuildCommitReq
 func (a *apiServer) FinishCommit(ctx context.Context, request *pfs.FinishCommitRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "FinishCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.driver.finishCommit(ctx, request.Commit); err != nil {
 		return nil, err
@@ -157,8 +143,6 @@ func (a *apiServer) FinishCommit(ctx context.Context, request *pfs.FinishCommitR
 func (a *apiServer) InspectCommit(ctx context.Context, request *pfs.InspectCommitRequest) (response *pfs.CommitInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "InspectCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	return a.driver.inspectCommit(ctx, request.Commit)
 }
@@ -166,8 +150,6 @@ func (a *apiServer) InspectCommit(ctx context.Context, request *pfs.InspectCommi
 func (a *apiServer) ListCommit(ctx context.Context, request *pfs.ListCommitRequest) (response *pfs.CommitInfos, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	commitInfos, err := a.driver.listCommit(ctx, request.Repo, request.To, request.From, request.Number)
 	if err != nil {
@@ -181,8 +163,6 @@ func (a *apiServer) ListCommit(ctx context.Context, request *pfs.ListCommitReque
 func (a *apiServer) ListBranch(ctx context.Context, request *pfs.ListBranchRequest) (response *pfs.Branches, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListBranch")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	branches, err := a.driver.listBranch(ctx, request.Repo)
 	if err != nil {
@@ -194,8 +174,6 @@ func (a *apiServer) ListBranch(ctx context.Context, request *pfs.ListBranchReque
 func (a *apiServer) SetBranch(ctx context.Context, request *pfs.SetBranchRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListBranch")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.driver.setBranch(ctx, request.Commit, request.Branch); err != nil {
 		return nil, err
@@ -206,8 +184,6 @@ func (a *apiServer) SetBranch(ctx context.Context, request *pfs.SetBranchRequest
 func (a *apiServer) DeleteBranch(ctx context.Context, request *pfs.DeleteBranchRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListBranch")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.driver.deleteBranch(ctx, request.Repo, request.Branch); err != nil {
 		return nil, err
@@ -218,8 +194,6 @@ func (a *apiServer) DeleteBranch(ctx context.Context, request *pfs.DeleteBranchR
 func (a *apiServer) DeleteCommit(ctx context.Context, request *pfs.DeleteCommitRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "DeleteCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.driver.deleteCommit(ctx, request.Commit); err != nil {
 		return nil, err
@@ -231,8 +205,6 @@ func (a *apiServer) FlushCommit(request *pfs.FlushCommitRequest, stream pfs.API_
 	ctx := stream.Context()
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "FlushCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	commitStream, err := a.driver.flushCommit(ctx, request.Commits, request.ToRepos)
 	if err != nil {
@@ -260,8 +232,6 @@ func (a *apiServer) SubscribeCommit(request *pfs.SubscribeCommitRequest, stream 
 	ctx := stream.Context()
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "SubscribeCommit")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	commitStream, err := a.driver.subscribeCommit(ctx, request.Repo, request.Branch, request.From)
 	if err != nil {
@@ -465,8 +435,6 @@ func (a *apiServer) GetFile(request *pfs.GetFileRequest, apiGetFileServer pfs.AP
 	ctx := apiGetFileServer.Context()
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(apiGetFileServer.Context(), a.reporter, "GetFile")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	file, err := a.driver.getFile(ctx, request.File, request.OffsetBytes, request.SizeBytes)
 	if err != nil {
@@ -478,8 +446,6 @@ func (a *apiServer) GetFile(request *pfs.GetFileRequest, apiGetFileServer pfs.AP
 func (a *apiServer) InspectFile(ctx context.Context, request *pfs.InspectFileRequest) (response *pfs.FileInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "InspectFile")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	return a.driver.inspectFile(ctx, request.File)
 }
@@ -494,8 +460,6 @@ func (a *apiServer) ListFile(ctx context.Context, request *pfs.ListFileRequest) 
 			a.Log(request, response, retErr, time.Since(start))
 		}
 	}(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListFile")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	fileInfos, err := a.driver.listFile(ctx, request.File)
 	if err != nil {
@@ -516,8 +480,6 @@ func (a *apiServer) GlobFile(ctx context.Context, request *pfs.GlobFileRequest) 
 			a.Log(request, response, retErr, time.Since(start))
 		}
 	}(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "GlobFile")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	fileInfos, err := a.driver.globFile(ctx, request.Commit, request.Pattern)
 	if err != nil {
@@ -554,8 +516,6 @@ func (a *apiServer) DiffFile(ctx context.Context, request *pfs.DiffFileRequest) 
 func (a *apiServer) DeleteFile(ctx context.Context, request *pfs.DeleteFileRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "DeleteFile")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	err := a.driver.deleteFile(ctx, request.File)
 	if err != nil {
@@ -567,8 +527,6 @@ func (a *apiServer) DeleteFile(ctx context.Context, request *pfs.DeleteFileReque
 func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "PFSDeleteAll")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.driver.deleteAll(ctx); err != nil {
 		return nil, err

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
-	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 
 	protolion "go.pedge.io/lion/proto"
@@ -38,11 +37,10 @@ const (
 
 type apiServer struct {
 	protorpclog.Logger
-	driver   *driver
-	reporter *metrics.Reporter
+	driver *driver
 }
 
-func newLocalAPIServer(address string, etcdPrefix string, reporter *metrics.Reporter) (*apiServer, error) {
+func newLocalAPIServer(address string, etcdPrefix string) (*apiServer, error) {
 	d, err := newLocalDriver(address, etcdPrefix)
 	if err != nil {
 		return nil, err
@@ -54,7 +52,7 @@ func newLocalAPIServer(address string, etcdPrefix string, reporter *metrics.Repo
 	}, nil
 }
 
-func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheBytes int64, reporter *metrics.Reporter) (*apiServer, error) {
+func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheBytes int64) (*apiServer, error) {
 	d, err := newDriver(address, etcdAddresses, etcdPrefix, cacheBytes)
 	if err != nil {
 		return nil, err

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -31,8 +31,8 @@ type BlockAPIServer interface {
 }
 
 // NewAPIServer creates an APIServer.
-func NewAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheBytes int64, reporter *metrics.Reporter) (APIServer, error) {
-	return newAPIServer(address, etcdAddresses, etcdPrefix, cacheBytes, reporter)
+func NewAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheBytes int64) (APIServer, error) {
+	return newAPIServer(address, etcdAddresses, etcdPrefix, cacheBytes)
 }
 
 // NewLocalBlockAPIServer creates a BlockAPIServer.

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
-	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 )
 

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -2207,7 +2207,7 @@ func getClient(t *testing.T) pclient.APIClient {
 		address := addresses[i]
 		blockAPIServer, err := NewLocalBlockAPIServer(root)
 		require.NoError(t, err)
-		apiServer, err := newLocalAPIServer(address, prefix, nil)
+		apiServer, err := newLocalAPIServer(address, prefix)
 		require.NoError(t, err)
 		runServers(t, port, apiServer, blockAPIServer)
 	}

--- a/src/server/pkg/metrics/segment.go
+++ b/src/server/pkg/metrics/segment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/segmentio/analytics-go"
 )
 
-const reportingInterval time.Duration = 15 * time.Second
+const reportingInterval time.Duration = 5 * time.Minute
 
 func newPersistentClient() *analytics.Client {
 	c := newSegmentClient()

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -247,8 +247,6 @@ func untranslateJobInputs(input *pps.Input) []*pps.JobInput {
 func (a *apiServer) CreateJob(ctx context.Context, request *pps.CreateJobRequest) (response *pps.Job, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "CreateJob")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	// First translate Inputs field to Input field.
 	if len(request.Inputs) > 0 {
@@ -311,8 +309,6 @@ func (a *apiServer) CreateJob(ctx context.Context, request *pps.CreateJobRequest
 func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobRequest) (response *pps.JobInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "InspectJob")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	jobs := a.jobs.ReadOnly(ctx)
 
@@ -378,8 +374,6 @@ func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobReque
 func (a *apiServer) ListJob(ctx context.Context, request *pps.ListJobRequest) (response *pps.JobInfos, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListJob")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	jobs := a.jobs.ReadOnly(ctx)
 	var iter col.Iterator
@@ -416,8 +410,6 @@ func (a *apiServer) ListJob(ctx context.Context, request *pps.ListJobRequest) (r
 func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "DeleteJob")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 		return a.jobs.ReadWrite(stm).Delete(request.Job.ID)
@@ -431,8 +423,6 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 func (a *apiServer) StopJob(ctx context.Context, request *pps.StopJobRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "StopJob")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 		jobs := a.jobs.ReadWrite(stm)
@@ -451,8 +441,6 @@ func (a *apiServer) StopJob(ctx context.Context, request *pps.StopJobRequest) (r
 func (a *apiServer) RestartDatum(ctx context.Context, request *pps.RestartDatumRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "RestartDatum")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	jobInfo, err := a.InspectJob(ctx, &pps.InspectJobRequest{
 		Job: request.Job,
@@ -828,8 +816,6 @@ func setPipelineDefaults(pipelineInfo *pps.PipelineInfo) {
 func (a *apiServer) InspectPipeline(ctx context.Context, request *pps.InspectPipelineRequest) (response *pps.PipelineInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "InspectPipeline")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	pipelineInfo := new(pps.PipelineInfo)
 	if err := a.pipelines.ReadOnly(ctx).Get(request.Pipeline.Name, pipelineInfo); err != nil {
@@ -844,8 +830,6 @@ func (a *apiServer) InspectPipeline(ctx context.Context, request *pps.InspectPip
 func (a *apiServer) ListPipeline(ctx context.Context, request *pps.ListPipelineRequest) (response *pps.PipelineInfos, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "ListPipeline")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	pipelineIter, err := a.pipelines.ReadOnly(ctx).List()
 	if err != nil {
@@ -876,8 +860,6 @@ func (a *apiServer) ListPipeline(ctx context.Context, request *pps.ListPipelineR
 func (a *apiServer) DeletePipeline(ctx context.Context, request *pps.DeletePipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "DeletePipeline")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if request.All {
 		pipelineInfos, err := a.ListPipeline(ctx, &pps.ListPipelineRequest{})
@@ -964,8 +946,6 @@ func (a *apiServer) deletePipeline(ctx context.Context, request *pps.DeletePipel
 func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "StartPipeline")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.updatePipelineState(ctx, request.Pipeline.Name, pps.PipelineState_PIPELINE_RUNNING); err != nil {
 		return nil, err
@@ -976,8 +956,6 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "StopPipeline")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	if err := a.updatePipelineState(ctx, request.Pipeline.Name, pps.PipelineState_PIPELINE_STOPPED); err != nil {
 		return nil, err
@@ -988,8 +966,6 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 func (a *apiServer) RerunPipeline(ctx context.Context, request *pps.RerunPipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "RerunPipeline")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	return nil, fmt.Errorf("TODO")
 }
@@ -997,8 +973,6 @@ func (a *apiServer) RerunPipeline(ctx context.Context, request *pps.RerunPipelin
 func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "PPSDeleteAll")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	pipelineInfos, err := a.ListPipeline(ctx, &pps.ListPipelineRequest{})
 	if err != nil {
@@ -1030,8 +1004,6 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (respon
 func (a *apiServer) GarbageCollect(ctx context.Context, request *pps.GarbageCollectRequest) (response *pps.GarbageCollectResponse, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "GC")
-	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
 
 	pfsClient, err := a.getPFSClient()
 	if err != nil {


### PR DESCRIPTION
- Removes 90% of the user metrics calls
- Up the reporting interval from 15s to 5m
- Keep the user reported actions around our funnel (version, deploy, createPipeline) ... but that's it