### PR TITLE
Job logging upgrade

### DIFF
--- a/src/server/pkg/worker/api_server.go
+++ b/src/server/pkg/worker/api_server.go
@@ -190,8 +190,9 @@ func NewAPIServer(pachClient *client.APIClient, etcdClient *etcd.Client, etcdPre
 }
 
 func (a *APIServer) downloadData(logger *taggedLogger, inputs []*Input, puller *filesync.Puller, parentTag *pfs.Tag) error {
+	logger.Logf("input has not been processed, downloading data")
 	defer func(start time.Time) {
-		logger.Logf("download took %v\n", time.Since(start))
+		logger.Logf("input data download took (%v)\n", time.Since(start))
 	}(time.Now())
 	for _, input := range inputs {
 		file := input.FileInfo.File
@@ -553,7 +554,6 @@ func (a *APIServer) Process(ctx context.Context, req *ProcessRequest) (resp *Pro
 	}
 
 	// Download input data
-	logger.Logf("input has not been processed, downloading data")
 	puller := filesync.NewPuller()
 	err = a.downloadData(logger, req.Data, puller, req.ParentOutput)
 	// We run these cleanup functions no matter what, so that if

--- a/src/server/pkg/worker/api_server.go
+++ b/src/server/pkg/worker/api_server.go
@@ -616,7 +616,7 @@ func (a *APIServer) Process(ctx context.Context, req *ProcessRequest) (resp *Pro
 }
 
 // Status returns the status of the current worker.
-func (a *APIServer) Status(ctx context.Context, _ *types.Empty) (status *pps.WorkerStatus, retErr error) {
+func (a *APIServer) Status(ctx context.Context, _ *types.Empty) (*pps.WorkerStatus, error) {
 	a.statusMu.Lock()
 	defer a.statusMu.Unlock()
 	started, err := types.TimestampProto(a.started)
@@ -633,7 +633,7 @@ func (a *APIServer) Status(ctx context.Context, _ *types.Empty) (status *pps.Wor
 }
 
 // Cancel cancels the currently running datum
-func (a *APIServer) Cancel(ctx context.Context, request *CancelRequest) (resp *CancelResponse, retErr error) {
+func (a *APIServer) Cancel(ctx context.Context, request *CancelRequest) (*CancelResponse, error) {
 	a.statusMu.Lock()
 	defer a.statusMu.Unlock()
 	if request.JobID != a.jobID {

--- a/src/server/pkg/worker/master.go
+++ b/src/server/pkg/worker/master.go
@@ -452,7 +452,7 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 					}
 					protolion.Infof("Issuing Process() call for datum (%v)\n", processReq)
 					processStart := time.Now()
-					resp, err := workerClient.Process(ctx, &processReq)
+					resp, err := workerClient.Process(ctx, processReq)
 					protolion.Infof("Received Process() response (%v) err (%v) for datum (%v)\n", resp, err, processReq)
 					protolion.Infof("Process() took (%v) for datum (%v)\n", time.Since(processStart))
 					if err != nil {

--- a/src/server/pkg/worker/master.go
+++ b/src/server/pkg/worker/master.go
@@ -265,6 +265,9 @@ nextInput:
 
 // jobManager feeds datums to jobs
 func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpcutil.Pool) error {
+	jobStart := time.Now()
+	defer func() { protolion.Infof("running job (%v) took (%v)\n", jobInfo, time.Since(jobStart)) }()
+	protolion.Infof("running job (%v)\n", jobInfo)
 	pfsClient := a.pachClient.PfsAPIClient
 	objectClient := a.pachClient.ObjectAPIClient
 	ppsClient := a.pachClient.PpsAPIClient
@@ -272,7 +275,10 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 	jobID := jobInfo.Job.ID
 	var jobStopped bool
 	var jobStoppedMutex sync.Mutex
+	retryCount := 0
 	backoff.RetryNotify(func() error {
+		defer func() { retryCount += 1 }()
+		protolion.Infof("running job (%v), retry (%v)\n", jobInfo, retryCount)
 		// We use a new context for this particular instance of the retry
 		// loop, to ensure that all resources are released properly when
 		// this job retries.
@@ -283,12 +289,14 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 			// Wait for the parent job to finish, to ensure that output
 			// commits are ordered correctly, and that this job doesn't
 			// contend for workers with its parent.
+			protolion.Infof("job (%v) waiting on parent job to complete\n", jobInfo)
 			if _, err := ppsClient.InspectJob(ctx, &pps.InspectJobRequest{
 				Job:        jobInfo.ParentJob,
 				BlockState: true,
 			}); err != nil {
 				return err
 			}
+			protolion.Infof("parent job (%v) completed\n", jobInfo)
 		}
 
 		// Cancel the context and move on to the next job if this job
@@ -391,6 +399,7 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 		}
 		// set the initial values
 		updateProgress(0)
+		protolion.Infof("Updated initial job state (%v)\n", jobInfo)
 
 		for i := 0; i < df.Len(); i++ {
 			limiter.Acquire()
@@ -436,11 +445,16 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 						return fmt.Errorf("error from connection pool: %v", err)
 					}
 					workerClient := NewWorkerClient(conn)
-					resp, err := workerClient.Process(ctx, &ProcessRequest{
+					processReq := &ProcessRequest{
 						JobID:        jobInfo.Job.ID,
 						Data:         files,
 						ParentOutput: parentOutputTag,
-					})
+					}
+					protolion.Infof("Issuing Process() call for datum (%v)\n", processReq)
+					processStart := time.Now()
+					resp, err := workerClient.Process(ctx, &processReq)
+					protolion.Infof("Received Process() response (%v) err (%v) for datum (%v)\n", resp, err, processReq)
+					protolion.Infof("Process() took (%v) for datum (%v)\n", time.Since(processStart))
 					if err != nil {
 						if err := conn.Close(); err != nil {
 							protolion.Errorf("error closing conn: %+v", err)
@@ -549,6 +563,8 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 		}
 
 		if jobInfo.Egress != nil {
+			protolion.Infof("Starting egress upload for job (%v)\n", jobInfo)
+			start := time.Now()
 			objClient, err := obj.NewClientFromURLAndSecret(ctx, jobInfo.Egress.URL)
 			if err != nil {
 				return err
@@ -564,6 +580,7 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 			if err := pfs_sync.PushObj(client, outputCommit, objClient, strings.TrimPrefix(url.Path, "/")); err != nil {
 				return err
 			}
+			protolion.Infof("Completed egress upload for job (%v), duration (%v)\n", jobInfo, time.Since(start))
 		}
 
 		// Record the job's output commit and 'Finished' timestamp, and mark the job

--- a/src/server/pkg/worker/master.go
+++ b/src/server/pkg/worker/master.go
@@ -432,13 +432,11 @@ func (a *APIServer) runJob(ctx context.Context, jobInfo *pps.JobInfo, pool *grpc
 						return fmt.Errorf("error from connection pool: %v", err)
 					}
 					workerClient := NewWorkerClient(conn)
-					protolion.Infof("issuing Process() request for job (%v)\n", jobInfo)
 					resp, err := workerClient.Process(ctx, &ProcessRequest{
 						JobID:        jobInfo.Job.ID,
 						Data:         files,
 						ParentOutput: parentOutputTag,
 					})
-					protolion.Infof("received Process() response for job (%v)\n", jobInfo)
 					if err != nil {
 						if err := conn.Close(); err != nil {
 							protolion.Errorf("error closing conn: %+v", err)

--- a/src/server/pkg/worker/master.go
+++ b/src/server/pkg/worker/master.go
@@ -63,6 +63,10 @@ func (a *APIServer) master() {
 			return nil
 		})
 
+		if err != nil {
+			return err
+		}
+
 		return a.jobSpawner(ctx)
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 		protolion.Errorf("master: error running the master process: %v; retrying in %v", err, d)


### PR DESCRIPTION
Adds logs for:

- the timing of downloading user input
- the timing of running user code
- the timing of uploading user results (to obj store)
- the total timing of running a job (including restarts)
- outputting the restart count in the logs (for easier debugging)
- the timing of egress uploads
- worker Process/Status/Cancel API logs (like we have for pfs/pps)

Also caught a bug where we weren't returning a non nil error