### PR TITLE
Disable restart tests on CI

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1504,9 +1504,7 @@ func TestAcceptReturnCode(t *testing.T) {
 // TODO(msteffen): This test breaks the suite when run against cloud providers,
 // because killing the pachd pod breaks the connection with pachctl port-forward
 func TestRestartAll(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
+	t.Skip("This is causing intermittent CI failures")
 	// this test cannot be run in parallel because it restarts everything which breaks other tests.
 	c := getPachClient(t)
 	// create repos
@@ -1556,9 +1554,7 @@ func TestRestartAll(t *testing.T) {
 // TODO(msteffen): This test breaks the suite when run against cloud providers,
 // because killing the pachd pod breaks the connection with pachctl port-forward
 func TestRestartOne(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
+	t.Skip("This is causing intermittent CI failures")
 	// this test cannot be run in parallel because it restarts everything which breaks other tests.
 	c := getPachClient(t)
 	// create repos


### PR DESCRIPTION
We've been seeing a bunch of errors like:

```
2017/06/26 15:13:02 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 0.0.0.0:30650: getsockopt: connection refused"; Reconnecting to {0.0.0.0:30650 <nil>}
```

On CI. Unclear why this started to popup. Travis may turn off our premium VMs around now (we need to decide if we're going to pay them), or it could be their recent upgrade (https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch)

Either way ... these tests should probably be run serially as part of a different test suite so as not to interfere w other tests.

---

example of failure:

https://travis-ci.org/pachyderm/pachyderm/builds/247139268

example of success:

https://travis-ci.org/pachyderm/pachyderm/builds/247140699