### PR TITLE
Put Pachd address information in .pachyderm/config

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -113,9 +113,10 @@ func GetAddressFromUserMachine(cfg *config.Config) string {
 // exists. This is primarily intended to be used with the pachctl binary, but
 // may also be useful in tests.
 //
-// TODO(msteffen) this logic is fairly linux/unix specific, and makes pachctl
-// incompatible with Windows. We may want to move this (and similar) logic into
-// src/server and have it call a NewFromOptions() constructor.
+// TODO(msteffen) this logic is fairly linux/unix specific, and makes the
+// pachyderm client library incompatible with Windows. We may want to move this
+// (and similar) logic into src/server and have it call a NewFromOptions()
+// constructor.
 func NewOnUserMachine(reportMetrics bool, prefix string) (*APIClient, error) {
 	return NewOnUserMachineWithConcurrency(reportMetrics, prefix, DefaultMaxConcurrentStreams)
 }

--- a/src/client/pkg/config/config.pb.go
+++ b/src/client/pkg/config/config.pb.go
@@ -8,6 +8,7 @@
 		client/pkg/config/config.proto
 
 	It has these top-level messages:
+		ConfigV1
 		Config
 */
 package config
@@ -30,14 +31,36 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
+// A proto message with v1 of the pachyderm config (June 30 2017 - present)
+// DO NOT change or remove field numbers from this proto, as if you do, user
+// configs will become unparseable.
+type ConfigV1 struct {
+	PachdAddress string `protobuf:"bytes,2,opt,name=pachd_address,json=pachdAddress,proto3" json:"pachd_address,omitempty"`
+}
+
+func (m *ConfigV1) Reset()                    { *m = ConfigV1{} }
+func (m *ConfigV1) String() string            { return proto.CompactTextString(m) }
+func (*ConfigV1) ProtoMessage()               {}
+func (*ConfigV1) Descriptor() ([]byte, []int) { return fileDescriptorConfig, []int{0} }
+
+func (m *ConfigV1) GetPachdAddress() string {
+	if m != nil {
+		return m.PachdAddress
+	}
+	return ""
+}
+
+// The proto that will be parsed
 type Config struct {
 	UserID string `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	// Configuration options. Exactly one of these fields should be set.
+	V1 *ConfigV1 `protobuf:"bytes,2,opt,name=v1" json:"v1,omitempty"`
 }
 
 func (m *Config) Reset()                    { *m = Config{} }
 func (m *Config) String() string            { return proto.CompactTextString(m) }
 func (*Config) ProtoMessage()               {}
-func (*Config) Descriptor() ([]byte, []int) { return fileDescriptorConfig, []int{0} }
+func (*Config) Descriptor() ([]byte, []int) { return fileDescriptorConfig, []int{1} }
 
 func (m *Config) GetUserID() string {
 	if m != nil {
@@ -46,9 +69,41 @@ func (m *Config) GetUserID() string {
 	return ""
 }
 
+func (m *Config) GetV1() *ConfigV1 {
+	if m != nil {
+		return m.V1
+	}
+	return nil
+}
+
 func init() {
+	proto.RegisterType((*ConfigV1)(nil), "ConfigV1")
 	proto.RegisterType((*Config)(nil), "Config")
 }
+func (m *ConfigV1) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ConfigV1) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.PachdAddress) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.PachdAddress)))
+		i += copy(dAtA[i:], m.PachdAddress)
+	}
+	return i, nil
+}
+
 func (m *Config) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -69,6 +124,16 @@ func (m *Config) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintConfig(dAtA, i, uint64(len(m.UserID)))
 		i += copy(dAtA[i:], m.UserID)
+	}
+	if m.V1 != nil {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintConfig(dAtA, i, uint64(m.V1.Size()))
+		n1, err := m.V1.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
 	}
 	return i, nil
 }
@@ -100,11 +165,25 @@ func encodeVarintConfig(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
+func (m *ConfigV1) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.PachdAddress)
+	if l > 0 {
+		n += 1 + l + sovConfig(uint64(l))
+	}
+	return n
+}
+
 func (m *Config) Size() (n int) {
 	var l int
 	_ = l
 	l = len(m.UserID)
 	if l > 0 {
+		n += 1 + l + sovConfig(uint64(l))
+	}
+	if m.V1 != nil {
+		l = m.V1.Size()
 		n += 1 + l + sovConfig(uint64(l))
 	}
 	return n
@@ -122,6 +201,85 @@ func sovConfig(x uint64) (n int) {
 }
 func sozConfig(x uint64) (n int) {
 	return sovConfig(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *ConfigV1) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowConfig
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ConfigV1: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ConfigV1: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PachdAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowConfig
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthConfig
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PachdAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipConfig(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthConfig
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *Config) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -180,6 +338,39 @@ func (m *Config) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.UserID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field V1", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowConfig
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthConfig
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.V1 == nil {
+				m.V1 = &ConfigV1{}
+			}
+			if err := m.V1.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -310,13 +501,17 @@ var (
 func init() { proto.RegisterFile("client/pkg/config/config.proto", fileDescriptorConfig) }
 
 var fileDescriptorConfig = []byte{
-	// 128 bytes of a gzipped FileDescriptorProto
+	// 182 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4b, 0xce, 0xc9, 0x4c,
 	0xcd, 0x2b, 0xd1, 0x2f, 0xc8, 0x4e, 0xd7, 0x4f, 0xce, 0xcf, 0x4b, 0xcb, 0x84, 0x51, 0x7a, 0x05,
 	0x45, 0xf9, 0x25, 0xf9, 0x52, 0x22, 0xe9, 0xf9, 0xe9, 0xf9, 0x60, 0xa6, 0x3e, 0x88, 0x05, 0x11,
-	0x55, 0xd2, 0xe5, 0x62, 0x73, 0x06, 0xab, 0x12, 0x52, 0xe6, 0x62, 0x2f, 0x2d, 0x4e, 0x2d, 0x8a,
-	0xcf, 0x4c, 0x91, 0x60, 0x54, 0x60, 0xd4, 0xe0, 0x74, 0xe2, 0x7a, 0x74, 0x4f, 0x9e, 0x2d, 0xb4,
-	0x38, 0xb5, 0xc8, 0xd3, 0x25, 0x88, 0x0d, 0x24, 0xe5, 0x99, 0xe2, 0x24, 0x70, 0xe2, 0x91, 0x1c,
-	0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0xce, 0x78, 0x2c, 0xc7, 0x90, 0xc4, 0x06,
-	0x36, 0xc7, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0x96, 0x5f, 0x1d, 0xc1, 0x7f, 0x00, 0x00, 0x00,
+	0x55, 0xd2, 0xe7, 0xe2, 0x70, 0x06, 0xab, 0x0a, 0x33, 0x14, 0x52, 0xe6, 0xe2, 0x2d, 0x48, 0x4c,
+	0xce, 0x48, 0x89, 0x4f, 0x4c, 0x49, 0x29, 0x4a, 0x2d, 0x2e, 0x96, 0x60, 0x52, 0x60, 0xd4, 0xe0,
+	0x0c, 0xe2, 0x01, 0x0b, 0x3a, 0x42, 0xc4, 0x94, 0x3c, 0xb8, 0xd8, 0x20, 0x1a, 0x84, 0x94, 0xb9,
+	0xd8, 0x4b, 0x8b, 0x53, 0x8b, 0xe2, 0x33, 0x53, 0x24, 0x18, 0x41, 0x0a, 0x9d, 0xb8, 0x1e, 0xdd,
+	0x93, 0x67, 0x0b, 0x2d, 0x4e, 0x2d, 0xf2, 0x74, 0x09, 0x62, 0x03, 0x49, 0x79, 0xa6, 0x08, 0x49,
+	0x72, 0x31, 0x95, 0x19, 0x82, 0x0d, 0xe2, 0x36, 0xe2, 0xd4, 0x83, 0x59, 0x15, 0xc4, 0x54, 0x66,
+	0xe8, 0x24, 0x70, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0xce,
+	0x78, 0x2c, 0xc7, 0x90, 0xc4, 0x06, 0x76, 0x93, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x34, 0x76,
+	0x08, 0x87, 0xcb, 0x00, 0x00, 0x00,
 }

--- a/src/client/pkg/config/config.proto
+++ b/src/client/pkg/config/config.proto
@@ -2,17 +2,17 @@ syntax = "proto3";
 
 import "gogoproto/gogo.proto";
 
-// ConfigV1 specifies v1 of the pachyderm config (June 30 2017 - present)
-// DO NOT change or remove field numbers from this proto, as if you do, v1 user
-// configs will become unparseable.
-message ConfigV1 {
-    string pachd_address = 2;
-}
-
-// Config specifies the pachyderm config. Different versions of the pachyderm
-// config are specified as optional subfields of this message. DO NOT change or
-// remove field numbers from this proto, otherwise ALL pachyderm user configs
-// will fail to parse.
+// Config specifies the pachyderm config that is read and interpreted by the
+// pachctl command-line tool. Right now, this is stored at
+// $HOME/.pachyderm/config.
+//
+// Different versions of the pachyderm config are specified as optional
+// subfields of this message. (this allows us to make significant changes to the
+// config structure without breaking existing users, by defining a new config
+// version).
+//
+// DO NOT change or remove field numbers from this proto, otherwise ALL
+// pachyderm user configs will fail to parse.
 message Config {
     string user_id = 1 [(gogoproto.customname) = "UserID"];
 
@@ -20,3 +20,11 @@ message Config {
     // (depending on which version of the config is being used)
     ConfigV1 v1 = 2;
 }
+
+// ConfigV1 specifies v1 of the pachyderm config (June 30 2017 - present)
+// DO NOT change or remove field numbers from this proto, as if you do, v1 user
+// configs will become unparseable.
+message ConfigV1 {
+    string pachd_address = 2;
+}
+

--- a/src/client/pkg/config/config.proto
+++ b/src/client/pkg/config/config.proto
@@ -2,6 +2,21 @@ syntax = "proto3";
 
 import "gogoproto/gogo.proto";
 
+// ConfigV1 specifies v1 of the pachyderm config (June 30 2017 - present)
+// DO NOT change or remove field numbers from this proto, as if you do, v1 user
+// configs will become unparseable.
+message ConfigV1 {
+    string pachd_address = 2;
+}
+
+// Config specifies the pachyderm config. Different versions of the pachyderm
+// config are specified as optional subfields of this message. DO NOT change or
+// remove field numbers from this proto, otherwise ALL pachyderm user configs
+// will fail to parse.
 message Config {
     string user_id = 1 [(gogoproto.customname) = "UserID"];
+
+    // Configuration options. Exactly one of these fields should be set
+    // (depending on which version of the config is being used)
+    ConfigV1 v1 = 2;
 }

--- a/src/server/cmd/pachctl-doc/main.go
+++ b/src/server/cmd/pachctl-doc/main.go
@@ -14,9 +14,7 @@ func main() {
 }
 
 func do(appEnvObj interface{}) error {
-	// passing empty addresses for pfsd and ppsd, that's fine because we're not
-	// going to execute the command but print docs with it
-	rootCmd, err := cmd.PachctlCmd("")
+	rootCmd, err := cmd.PachctlCmd()
 	if err != nil {
 		return err
 	}

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -37,8 +37,8 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-// PachctlCmd takes a pachd host-address and creates a cobra.Command
-// which may interact with the host.
+// PachctlCmd creates a cobra.Command which can deploy pachyderm clusters and
+// interact with them (it implements the pachctl binary).
 func PachctlCmd() (*cobra.Command, error) {
 	var verbose bool
 	var noMetrics bool

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -39,7 +39,7 @@ const (
 )
 
 // Cmds returns a slice containing pfs commands.
-func Cmds(address string, noMetrics *bool) []*cobra.Command {
+func Cmds(noMetrics *bool) []*cobra.Command {
 	metrics := !*noMetrics
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
@@ -64,7 +64,7 @@ func Cmds(address string, noMetrics *bool) []*cobra.Command {
 		Short: "Create a new repo.",
 		Long:  "Create a new repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func Cmds(address string, noMetrics *bool) []*cobra.Command {
 		Short: "Return info about a repo.",
 		Long:  "Return info about a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func Cmds(address string, noMetrics *bool) []*cobra.Command {
 		Short: "Return all repos.",
 		Long:  "Reutrn all repos.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -145,7 +145,7 @@ func Cmds(address string, noMetrics *bool) []*cobra.Command {
 		Short: "Delete a repo.",
 		Long:  "Delete a repo.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -214,7 +214,7 @@ $ pachctl start-commit test patch -p master
 $ pachctl start-commit test -p XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -237,7 +237,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Finish a started commit.",
 		Long:  "Finish a started commit. Commit-id must be a writeable commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -250,7 +250,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Return info about a commit.",
 		Long:  "Return info about a commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -294,7 +294,7 @@ $ pachctl list-commit foo XXX
 $ pachctl list-commit foo master --from XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) (retErr error) {
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -382,7 +382,7 @@ $ pachctl flush-commit foo/XXX -r bar -r baz
 				return err
 			}
 
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -426,7 +426,7 @@ $ pachctl subscribe-commit test master --new
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
 			repo, branch := args[0], args[1]
-			c, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			c, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -456,7 +456,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Delete an unfinished commit.",
 		Long:  "Delete an unfinished commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -469,7 +469,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Return all branches on a repo.",
 		Long:  "Return all branches on a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -510,7 +510,7 @@ $ pachctl set-branch foo XXX master
 # same commit.
 $ pachctl set-branch foo test master` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -523,7 +523,7 @@ $ pachctl set-branch foo test master` + codeend,
 		Short: "Delete a branch",
 		Long:  "Delete a branch, while leaving the commits intact",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -589,7 +589,7 @@ pachctl put-file repo branch -i file
 pachctl put-file repo branch -i http://host/path
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
-			client, err := client.NewMetricsClientFromAddressWithConcurrency(address, metrics, "user", parallelism)
+			client, err := client.NewOnUserMachineWithConcurrency(metrics, "user", parallelism)
 			if err != nil {
 				return err
 			}
@@ -692,7 +692,7 @@ pachctl put-file repo branch -i http://host/path
 		Short: "Return the contents of a file.",
 		Long:  "Return the contents of a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -727,7 +727,7 @@ pachctl put-file repo branch -i http://host/path
 		Short: "Return info about a file.",
 		Long:  "Return info about a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -751,7 +751,7 @@ pachctl put-file repo branch -i http://host/path
 		Short: "Return the files in a directory.",
 		Long:  "Return the files in a directory.",
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -798,7 +798,7 @@ $ pachctl glob-file foo master "A*"
 $ pachctl glob-file foo master "data/*"
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -837,7 +837,7 @@ $ pachctl diff-file foo master path
 $ pachctl diff-file foo master path1 bar master path2
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(3, 6, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -885,7 +885,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Delete a file.",
 		Long:  "Delete a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -898,7 +898,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of an object",
 		Long:  "Return the contents of an object",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -911,7 +911,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of a tag",
 		Long:  "Return the contents of a tag",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := client.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -926,12 +926,12 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Mount pfs locally. This command blocks.",
 		Long:  "Mount pfs locally. This command blocks.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewMetricsClientFromAddress(address, metrics, "fuse")
+			client, err := client.NewOnUserMachine(metrics, "fuse")
 			if err != nil {
 				return err
 			}
 			go func() { client.KeepConnected(nil) }()
-			mounter := fuse.NewMounter(address, client)
+			mounter := fuse.NewMounter(client.GetAddress(), client)
 			mountPoint := args[0]
 			ready := make(chan bool)
 			go func() {

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gogo/protobuf/jsonpb"
-	pach "github.com/pachyderm/pachyderm/src/client"
+	pachdclient "github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pkg/uuid"
 	ppsclient "github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/cmdutil"
@@ -33,7 +33,7 @@ const (
 )
 
 // Cmds returns a slice containing pps commands.
-func Cmds(address string, noMetrics *bool) ([]*cobra.Command, error) {
+func Cmds(noMetrics *bool) ([]*cobra.Command, error) {
 	metrics := !*noMetrics
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
@@ -68,7 +68,7 @@ The increase the throughput of a job increase the Shard paremeter.
 		Short: "Return info about a job.",
 		Long:  "Return info about a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ Examples:
 	$ pachctl list-job -p foo bar/YYY
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -152,7 +152,7 @@ Examples:
 		Short: "Delete a job.",
 		Long:  "Delete a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -168,7 +168,7 @@ Examples:
 		Short: "Stop a job.",
 		Long:  "Stop a job.  The job will be stopped immediately.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -184,7 +184,7 @@ Examples:
 		Short: "Restart a datum.",
 		Long:  "Restart a datum.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", sanitizeErr(err))
 			}
@@ -227,7 +227,7 @@ Examples:
 	$ pachctl get-logs --pipeline=filter --inputs=/apple.txt,123aef
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", sanitizeErr(err))
 			}
@@ -310,7 +310,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			if err != nil {
 				return err
 			}
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return sanitizeErr(err)
 			}
@@ -356,7 +356,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			if err != nil {
 				return err
 			}
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return sanitizeErr(err)
 			}
@@ -396,7 +396,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about a pipeline.",
 		Long:  "Return info about a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -420,7 +420,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about all pipelines.",
 		Long:  "Return info about all pipelines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -454,7 +454,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Delete a pipeline.",
 		Long:  "Delete a pipeline.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -492,7 +492,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Restart a stopped pipeline.",
 		Long:  "Restart a stopped pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -508,7 +508,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Stop a running pipeline.",
 		Long:  "Stop a running pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}
@@ -525,7 +525,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Run a pipeline once.",
 		Long:  "Run a pipeline once, optionally overriding some pipeline options by providing a [pipeline spec](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).  For example run a web scraper pipelien without any explicit input.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
-			client, err := pach.NewMetricsClientFromAddress(address, metrics, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, "user")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Setting address here will allow `etc/deploy/aws.sh` to pass pachyderm address info back up to the caller.

TODO (perhaps in config v2 depending on when we release 1.5): Specify multiple pachyderm clusters in .pachyderm/config, along with a current cluster (like `.kube/config`). Ideally the two would be kept in sync.