### PR TITLE
Make pachctl fix configs with no UserID

### DIFF
--- a/src/client/pkg/config/config.go
+++ b/src/client/pkg/config/config.go
@@ -16,32 +16,38 @@ var configPath = filepath.Join(configDirPath, "config.json")
 //Read loads pachyderm user config
 //If an existing configuration cannot be found, it sets up the defaults
 func Read() (*Config, error) {
-	raw, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		// File doesn't exist, so create the UID
-		return createDefaults()
-	}
 	var c *Config
-	err = json.Unmarshal(raw, &c)
-	return c, err
+
+	// Read json file
+	if raw, err := ioutil.ReadFile(configPath); err == nil {
+		err = json.Unmarshal(raw, &c)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// File doesn't exist, so create a new config
+		fmt.Println("No config detected. Generating new config...")
+		c = &Config{}
+	}
+	if c.UserID == "" {
+		fmt.Printf("No UserID present in config. Generating new UserID and "+
+			"updating config at %s\n", configPath)
+		c.UserID = uuid.NewWithoutDashes()
+		if err := c.Write(); err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
 }
 
-func createDefaults() (*Config, error) {
-	c := &Config{
-		UserID: uuid.NewWithoutDashes(),
-	}
-	rawConfig, err := json.Marshal(c)
+func (c *Config) Write() error {
+	rawConfig, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		return nil, err
+		return err
 	}
 	err = os.MkdirAll(configDirPath, 0755)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	fmt.Printf("No config detected.\nDefault config created at %v\n", configPath)
-	err = ioutil.WriteFile(configPath, rawConfig, 0644)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return ioutil.WriteFile(configPath, rawConfig, 0644)
 }

--- a/src/client/pkg/config/config.proto
+++ b/src/client/pkg/config/config.proto
@@ -6,10 +6,9 @@ import "gogoproto/gogo.proto";
 // pachctl command-line tool. Right now, this is stored at
 // $HOME/.pachyderm/config.
 //
-// Different versions of the pachyderm config are specified as optional
-// subfields of this message. (this allows us to make significant changes to the
-// config structure without breaking existing users, by defining a new config
-// version).
+// Different versions of the pachyderm config are specified as subfields of this
+// message (this allows us to make significant changes to the config structure
+// without breaking existing users by defining a new config version).
 //
 // DO NOT change or remove field numbers from this proto, otherwise ALL
 // pachyderm user configs will fail to parse.


### PR DESCRIPTION
- This may happen if aws.sh runs on a system with no `$HOME/.pachyderm/config`. Rather than have `aws.sh` generate user IDs, it simply generates a config without a user ID and pachctl will fix the config next time it runs.
- In the (hopefully near) future, `pachctl` will be able to manipulate the config itself, and `aws.sh` will simply call `pachctl config add-cluster ${NAME} ${MASTER_NODE}:30650`. However, until that command exists, this will accomplish the goal of letting `aws.sh` pass cluster info back to pachctl
- Finally, I expanded the comments in `config.proto` somewhat (I meant to submit this with the previous PR but forgot to push it)