### PR TITLE
Fix a bug where pipelines that specifies environment variables can fail to skip processed datums

### DIFF
--- a/doc/deployment/migrations.md
+++ b/doc/deployment/migrations.md
@@ -22,6 +22,8 @@ Note that the `pachctl migrate` command can be run either before or after you've
 
 Most importantly, you need to ensure that your cluster is "at rest" when you run `pachctl migrate`.  That is, there shouldn't be any ongoing activities that are changing the state of the cluster.  Examples would be running jobs or ongoing `put-file` requests.
 
+*Due to technical reasons, if you have a pipeline that specifies more than one environment variables in its pipeline spec, the first job that the pipeline spawns after the migration will re-process all input.* 
+
 ## Backup
 
 It’s paramount that you backup your data before running a migration.  While we’ve tested the migration code extensively, it’s still possible that they contain bugs, or that you accidentally use them in a wrong way.

--- a/doc/deployment/migrations.md
+++ b/doc/deployment/migrations.md
@@ -22,7 +22,7 @@ Note that the `pachctl migrate` command can be run either before or after you've
 
 Most importantly, you need to ensure that your cluster is "at rest" when you run `pachctl migrate`.  That is, there shouldn't be any ongoing activities that are changing the state of the cluster.  Examples would be running jobs or ongoing `put-file` requests.
 
-*Due to technical reasons, if you have a pipeline that specifies more than one environment variables in its pipeline spec, the first job that the pipeline spawns after the migration will re-process all input.* 
+*Note: For v1.4 pipelines that specify environment variables in their pipeline specs, you will unfortunately need to reprocess all data for those pipelines as part of the v1.5 migration. This will automatically happen as part of the first job that spawns after the migration. Sorry for inconvenience.* 
 
 ## Backup
 

--- a/src/server/pkg/worker/api_server.go
+++ b/src/server/pkg/worker/api_server.go
@@ -490,6 +490,9 @@ func HashDatum(pipelineInfo *pps.PipelineInfo, data []*Input) (string, error) {
 		hash.Write(datum.FileInfo.Hash)
 	}
 
+	// We set env to nil because if env contains more than one elements,
+	// since it's a map, the output of Marshal() can be non-deterministic.
+	pipelineInfo.Transform.Env = nil
 	bytes, err := pipelineInfo.Transform.Marshal()
 	if err != nil {
 		return "", err

--- a/src/server/pkg/worker/api_server.go
+++ b/src/server/pkg/worker/api_server.go
@@ -492,7 +492,11 @@ func HashDatum(pipelineInfo *pps.PipelineInfo, data []*Input) (string, error) {
 
 	// We set env to nil because if env contains more than one elements,
 	// since it's a map, the output of Marshal() can be non-deterministic.
+	env := pipelineInfo.Transform.Env
 	pipelineInfo.Transform.Env = nil
+	defer func() {
+		pipelineInfo.Transform.Env = env
+	}()
 	bytes, err := pipelineInfo.Transform.Marshal()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The issue is that as part of computing the hash of a datum, the generated protobuf code iterates through the environment variable field, which is a map.  Since the order of map iteration is nondeterministic in Go, we can end up with different hashes for the same datum, resulting in unnecessary re-processing.

This bug only affects pipelines that specify more than one environment variables in the `transform.env` field of their pipeline specs.

Fix #1999 