### PR TITLE
Enable running integration tests on AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ launch-dev-test: docker-build-test docker-push-test
 	    ./test -test.v
 
 aws-test:
-	REGION=sa-east-1 etc/deploy/clear_kops_resources_in_aws.sh --zone=sa-east-1a 
+	etc/deploy/clear_kops_resources_in_aws.sh --zone=sa-east-1a 
 	ZONE=sa-east-1a etc/testing/deploy/aws.sh --create
 	$(MAKE) launch-dev-test
 

--- a/etc/deploy/clear_kops_resources_in_aws.sh
+++ b/etc/deploy/clear_kops_resources_in_aws.sh
@@ -5,8 +5,6 @@
 # though, so that if we're ever trying to clean up after a kops cluster again, and we need to
 # figure out what to delete, we'll have a place to start.
 
-region="${REGION:-us-west-1}"
-
 # Parse flags
 eval "set -- $( getopt -l "region:,zone:" "--" "${0}" "${@}" )"
 while true; do
@@ -31,20 +29,20 @@ if [[ -z "${AWS_AVAILABILITY_ZONE}"  ]]; then
 fi
 
 # Delete autoscaling group
-aws --region=${region} autoscaling describe-auto-scaling-groups \
+aws --region=${AWS_REGION} autoscaling describe-auto-scaling-groups \
     | jq --raw-output '.AutoScalingGroups[].AutoScalingGroupName' \
     | while read g; do \
         echo "${g}"
-        aws --region=${region} autoscaling delete-auto-scaling-group --auto-scaling-group-name=${g} --force-delete; \
+        aws --region=${AWS_REGION} autoscaling delete-auto-scaling-group --auto-scaling-group-name=${g} --force-delete; \
       done
 
 # Delete launch configurations
-aws --region=${region} autoscaling describe-launch-configurations \
+aws --region=${AWS_REGION} autoscaling describe-launch-configurations \
     | jq --raw-output '.LaunchConfigurations[].LaunchConfigurationName' \
     | grep 'pachydermcluster' \
     | while read lc; do \
         echo "${lc}"; \
-        aws --region=${region} autoscaling delete-launch-configuration --launch-configuration-name=${lc}; \
+        aws --region=${AWS_REGION} autoscaling delete-launch-configuration --launch-configuration-name=${lc}; \
       done
 
 # Wait until all instances are terminated
@@ -57,7 +55,7 @@ spin() {
 first="true"
 while true; do
   group_count="$(
-    aws --region=${region} ec2 describe-instances \
+    aws --region=${AWS_REGION} ec2 describe-instances \
       | jq --raw-output '.Reservations[].Instances[] | select(.State.Name != "terminated") | .InstanceId' \
       | wc -l
   )"
@@ -72,93 +70,93 @@ while true; do
 done
 
 # Delete volumes
-aws --region=${region} ec2 describe-volumes \
+aws --region=${AWS_REGION} ec2 describe-volumes \
   | jq --raw-output .Volumes[].VolumeId \
   | while read v; do \
       echo ${v}; \
-      aws --region=${region} ec2 delete-volume --volume-id=${v}; \
+      aws --region=${AWS_REGION} ec2 delete-volume --volume-id=${v}; \
 done
 
 # Delete subnets
-aws --region=${region} ec2 describe-subnets \
+aws --region=${AWS_REGION} ec2 describe-subnets \
   | jq --raw-output '.Subnets[].SubnetId' \
   | while read s; \
       do echo ${s}; \
-      aws --region=${region} ec2 delete-subnet --subnet-id=${s}; \
+      aws --region=${AWS_REGION} ec2 delete-subnet --subnet-id=${s}; \
 done
 
 # Delete any routing tables that aren't the main routing table for their VPC
-aws --region=${region} ec2 describe-route-tables \
+aws --region=${AWS_REGION} ec2 describe-route-tables \
   | jq --raw-output '.RouteTables[]
                      | select([ .Associations[].Main | not ] | all)
                      | .RouteTableId' \
   | while read t; do \
       echo ${t}; \
-      aws --region=${region} ec2 delete-route-table --route-table-id=${t}; \
+      aws --region=${AWS_REGION} ec2 delete-route-table --route-table-id=${t}; \
 done
 
 # Delete key pairs
-aws --region=${region} ec2 describe-key-pairs \
+aws --region=${AWS_REGION} ec2 describe-key-pairs \
   | jq --raw-output '.KeyPairs[].KeyName' \
   | while read k; do \
       echo ${k}; \
-      aws --region=${region} ec2 delete-key-pair --key-name=${k}; \
+      aws --region=${AWS_REGION} ec2 delete-key-pair --key-name=${k}; \
 done
 
 # Detach internet gateways from their respective VPC, then delete them
-aws --region=${region} ec2 describe-internet-gateways \
+aws --region=${AWS_REGION} ec2 describe-internet-gateways \
   | jq --raw-output '.InternetGateways[].InternetGatewayId' \
   | while read g; do \
       echo ${g}; \
-      aws --region=${region} ec2 detach-internet-gateway \
+      aws --region=${AWS_REGION} ec2 detach-internet-gateway \
         --internet-gateway-id=${g} \
         --vpc-id=$( \
-            aws --region=${region} ec2 describe-internet-gateways \
+            aws --region=${AWS_REGION} ec2 describe-internet-gateways \
                 --internet-gateway-id=${g} \
               | jq --raw-output '.InternetGateways[].Attachments[0].VpcId'\
           ); \
 done
 
-aws --region=${region} ec2 describe-internet-gateways \
+aws --region=${AWS_REGION} ec2 describe-internet-gateways \
   | jq --raw-output '.InternetGateways[].InternetGatewayId' \
   | while read g; do \
       echo ${g}; \
-      aws --region=${region} ec2 delete-internet-gateway --internet-gateway-id=${g}; \
+      aws --region=${AWS_REGION} ec2 delete-internet-gateway --internet-gateway-id=${g}; \
 done
 
 # Clear all security group ACLs (so that no security group is referenced by
 # another security group) and then delete all non-default security groups
-aws --region=${region} ec2 describe-security-groups \
+aws --region=${AWS_REGION} ec2 describe-security-groups \
   | jq --raw-output '.SecurityGroups[].GroupId' \
   | while read sg; do \
-      aws --region=${region} ec2 describe-security-groups --group-id=${sg} \
+      aws --region=${AWS_REGION} ec2 describe-security-groups --group-id=${sg} \
         | jq --raw-output '.SecurityGroups[0].IpPermissions[].UserIdGroupPairs[].GroupId' \
         | while read other; do \
             echo "${other} -> ${sg}"; \
-            aws --region=${region} ec2 revoke-security-group-ingress --group-id=${sg} --source-group=${other} --protocol=all; \
+            aws --region=${AWS_REGION} ec2 revoke-security-group-ingress --group-id=${sg} --source-group=${other} --protocol=all; \
       done; \
 done
 
-aws --region=${region} ec2 describe-security-groups \
+aws --region=${AWS_REGION} ec2 describe-security-groups \
   | jq --raw-output '.SecurityGroups[] | select(.GroupName != "default") | .GroupId' \
   | while read sg; do \
       echo ${sg}; \
-      aws --region=${region} ec2 delete-security-group --group-id=${sg}; \
+      aws --region=${AWS_REGION} ec2 delete-security-group --group-id=${sg}; \
 done
 
 # Delete all VPCs
-aws --region=${region} ec2 describe-vpcs \
+aws --region=${AWS_REGION} ec2 describe-vpcs \
   | jq --raw-output .Vpcs[].VpcId \
   | while read v; do \
       echo ${v}; \
-      aws --region=${region} ec2 delete-vpc --vpc-id=${v}; \
+      aws --region=${AWS_REGION} ec2 delete-vpc --vpc-id=${v}; \
 done
 
 # Delete all VPC associations with the hosted zone 'kubernetes.com'
 zone_name=kubernetes.com # trailing period is omitted (here, not below)
 zone_id="$( aws route53 list-hosted-zones | jq --raw-output '.HostedZones[] | select(.Name == "'${zone_name}'.") | .Id' )"
 aws route53 get-hosted-zone  --id="${zone_id}" \
-  | jq -c --monochrome-output '.VPCs[] | select(.VPCRegion == "'${region}'")' \
+  | jq -c --monochrome-output '.VPCs[] | select(.VPCRegion == "'${AWS_REGION}'")' \
   | while read vpc; do \
       echo "${zone_id} -> ${vpc}"; \
       aws route53 disassociate-vpc-from-hosted-zone --hosted-zone-id="${zone_id}" --vpc="${vpc}"; \

--- a/etc/deploy/clear_kops_resources_in_aws.sh
+++ b/etc/deploy/clear_kops_resources_in_aws.sh
@@ -5,7 +5,7 @@
 # though, so that if we're ever trying to clean up after a kops cluster again, and we need to
 # figure out what to delete, we'll have a place to start.
 
-region=us-east-1
+region="${REGION:-us-west-1}"
 
 # Parse flags
 eval "set -- $( getopt -l "region:,zone:" "--" "${0}" "${@}" )"

--- a/etc/testing/deploy/aws.sh
+++ b/etc/testing/deploy/aws.sh
@@ -6,8 +6,8 @@
 
 ## Parse command-line flags
 
+ZONE="${ZONE:-us-west-1b}"
 STATE_STORE=s3://pachyderm-travis-state-store-v1
-ZONE=us-west-1b
 OP=-
 CLOUDFRONT=
 


### PR DESCRIPTION
With this PR, running `make aws-test` will run integration tests on an AWS cluster.

Caveat:

* Currently the test suite cannot be run concurrently.  That is, if two developers would like to both run the test suite, they have to coordinate with each other.
* The test suite runs in the `sa-east-1` (Source America) region.  The assumption is that we don't have anything else in that region, so the test harness is free to delete everything in that region.

Possible next steps:

* Make it possible to run the test suite concurrently.
* Run this test suite automatically on CI.