### PR TITLE
Enable running aws tests concurrently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ src/cmd/pps/pps
 src/cmd/ppsd/ppsd
 /.goxc.local.json
 /build/
+
+.bucket
+.cluster_name

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ launch-dev-test: docker-build-test docker-push-test
 	    ./test -test.v
 
 aws-test:
-	etc/deploy/clear_kops_resources_in_aws.sh --zone=sa-east-1a 
+	ZONE=sa-east-1a etc/testing/deploy/aws.sh --delete
 	ZONE=sa-east-1a etc/testing/deploy/aws.sh --create
 	$(MAKE) launch-dev-test
 

--- a/etc/deploy/aws.sh
+++ b/etc/deploy/aws.sh
@@ -114,6 +114,7 @@ deploy_k8s_on_aws() {
     export MASTER_SIZE=r4.xlarge
     export NUM_NODES=3
     export NAME=$(uuid | cut -f 1 -d-)-pachydermcluster.kubernetes.com
+    echo ${NAME} > .cluster_name
     echo "kops state store: ${STATE_BUCKET}"
     kops create cluster \
         --state=${STATE_BUCKET} \
@@ -249,6 +250,8 @@ deploy_pachyderm_on_aws() {
     # shared with k8s deploy script:
     export STORAGE_SIZE=100
     export BUCKET_NAME=${RANDOM}-pachyderm-store
+
+    echo ${BUCKET_NAME} > .bucket
 
     create_s3_bucket "${BUCKET_NAME}" ${USE_CLOUDFRONT}
 


### PR DESCRIPTION
With this PR, multiple developers can run `make aws-test` concurrently without stepping on each other's toes.