### PR TITLE
Run AWS tests in a CI cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,8 @@ script:
 - travis_wait 30 ./etc/testing/travis.sh
 notifications:
   slack: pachyderm:qmSCZSX1Q2yWxc6DjNZZFLGd
+  email:
+    recipients:
+      - dev@pachyderm.io
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ notifications:
   slack: pachyderm:qmSCZSX1Q2yWxc6DjNZZFLGd
   email:
     recipients:
-      - dev@pachyderm.io
+      - derek@pachyderm.io
     on_success: never
     on_failure: always

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -27,8 +27,8 @@ if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
     # Need to login so that travis can push the bench image
     docker login -u pachydermbuildbot -p ${DOCKER_PWD}
 
-    # Deploy cluster and run benchmark
-    sudo -E PATH="${PATH}" GOPATH="${GOPATH}" make bench
+    # Run tests in the cloud  
+    sudo -E PATH="${PATH}" GOPATH="${GOPATH}" make aws-test
 else
 	echo "Running tests"
 	make test


### PR DESCRIPTION
With this PR, Travis runs AWS tests once a day, and send emails to dev@pachyderm.io if the tests fail.