### PR TITLE
Remove travis_wait from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ before_script:
 - ./etc/testing/travis_install_batch_deps.sh
 script:
 - make lint vet
-- travis_wait 30 ./etc/testing/travis.sh
+# Don't use travis_wait, which can cause logs to take a long time to flush to s3
+# - travis_wait 30 ./etc/testing/travis.sh
+- ./etc/testing/travis.sh
 notifications:
   slack: pachyderm:qmSCZSX1Q2yWxc6DjNZZFLGd
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ before_script:
 - ./etc/testing/travis_install_batch_deps.sh
 script:
 - make lint vet
-# Don't use travis_wait, which can cause logs to take a long time to flush to s3
-# - travis_wait 30 ./etc/testing/travis.sh
 - ./etc/testing/travis.sh
 notifications:
   slack: pachyderm:qmSCZSX1Q2yWxc6DjNZZFLGd


### PR DESCRIPTION
Apparently travis_wait causes logs to buffer in a way that might be related to our logs-truncation problems in CI