### PR TITLE
Disable aws on ci

### DIFF
--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-#echo "Running local tests"
-#make test
+echo "Running local tests"
+make test
+
+# Disable aws CI for now, see:
+# https://github.com/pachyderm/pachyderm/issues/2109
+exit 0
 
 set -e
 


### PR DESCRIPTION
AWS CI is slowing us down. For now we're going to disable it, until we can make the cleanup work better ... and ideally get the builds to work faster (we went from ~10m to ~25m build times).

More info is here:

https://github.com/pachyderm/pachyderm/issues/2109