### PR TITLE
Assign pipeline with admin capability if auth is disabled

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -711,7 +711,7 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	}
 
 	capabilityResp, err := authClient.GetCapability(ctx, &auth.GetCapabilityRequest{})
-	if err != nil && !auth.IsNotActivatedError(err) {
+	if err != nil {
 		return nil, fmt.Errorf("error getting capability for the user: %v", err)
 	}
 
@@ -740,14 +740,11 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 		EnableStats:        request.EnableStats,
 		Salt:               uuid.NewWithoutDashes(),
 		Batch:              request.Batch,
+		Capability:         capabilityResp.Capability,
 	}
 	setPipelineDefaults(pipelineInfo)
 	if err := a.validatePipeline(ctx, pipelineInfo); err != nil {
 		return nil, err
-	}
-
-	if capabilityResp != nil {
-		pipelineInfo.Capability = capabilityResp.Capability
 	}
 
 	pfsClient, err := a.getPFSClient()


### PR DESCRIPTION
…so that the pipeline is still usable after auth is enabled.