### PR TITLE
Fixes #2130 - fix azure go sdk update

### DIFF
--- a/etc/microsoft/create-blank-vhd/create_blank_vhd.go
+++ b/etc/microsoft/create-blank-vhd/create_blank_vhd.go
@@ -91,8 +91,11 @@ Options:
 		log.Fatal(err)
 	}
 
-	url := client.GetBlobService().GetBlobURL(containerName, vhdName)
-
+	blobClient := client.GetBlobService()
+	container := blobClient.GetContainerReference(containerName)
+	blob := container.GetBlobReference(vhdName)
+	url := blob.GetURL()
+	
 	fmt.Print(url)
 
 	return


### PR DESCRIPTION
This PR fixes #2130 where `GetBlobURL` no longer exists as part of the Azure go sdk. 