### PR TITLE
Update node check

### DIFF
--- a/etc/deploy/aws.sh
+++ b/etc/deploy/aws.sh
@@ -214,12 +214,6 @@ check_all_nodes_ready() {
         return 1
     fi
 
-    master=`cat nodes.txt | grep master | wc -l`
-    if [ ${master} != "1" ]; then
-        echo "no master nodes found"
-        return 1
-    fi
-
     total_nodes=$((${NUM_NODES}+1))
     ready_nodes=`cat nodes.txt | grep -v NotReady | grep Ready | wc -l`
     echo "total ${total_nodes}, ready ${ready_nodes}"


### PR DESCRIPTION
in k8s 1.7 the master isn't listed as part of the node name, so
instead we just rely on the node count instead

This lets me deploy to AWS w kubectl 1.7.2 and kops 1.7.0