### PR TITLE
Update tensor_flow example for v1.5.2

### DIFF
--- a/doc/examples/tensor_flow/pipeline.json
+++ b/doc/examples/tensor_flow/pipeline.json
@@ -16,14 +16,12 @@
   "parallelism_spec": {
        "constant" : 1
   },
-  "inputs": [
-    {
-      "repo": {
-        "name": "GoT_scripts"
-      },
-      "method": "global"
+  "input": {
+    "atom": {
+      "repo": "GoT_scripts",
+      "glob": "/"
     }
-  ]
+  }
 }
 {
   "pipeline": {
@@ -42,12 +40,10 @@
   "parallelism_spec": {
        "constant" : 1
   },
-  "inputs": [
-    {
-      "repo": {
-        "name": "GoT_train"
-      },
-      "method": "global"
+  "input": {
+    "atom": {
+      "repo": "GoT_train",
+      "glob": "/"
     }
-  ]
+  }
 }

--- a/doc/examples/tensor_flow/readme.md
+++ b/doc/examples/tensor_flow/readme.md
@@ -1,4 +1,4 @@
-**Note**: This is a Pachyderm pre version 1.4 tutorial.  It needs to be updated for the latest versions of Pachyderm.
+**Note**: This example has been tested on Pachyderm version 1.5.2. It needs to be updated for the latest versions of Pachyderm.
 
 # Game of Thrones / Tensor Flow Example
 
@@ -200,7 +200,7 @@ Actually, you can see how 'dumb' the model is. If you [read through the Tensor F
 
 ```
 $pachctl list-job
-$pachctl get-logs {job ID from GoT_generate job}
+$pachctl get-logs {job ID from GoT_train job}
 0 | Epoch: 1 Learning rate: 1.000
 0 | 0.002 perplexity: 8526.820 speed: 1558 wps
 0 | 0.102 perplexity: 880.494 speed: 1598 wps


### PR DESCRIPTION
- Updating the tensor_flow example to work with Pachyderm version 1.5.2
- Fixing few errors in the README