### PR TITLE
fix version error in pachctl install docs

### DIFF
--- a/doc/deployment/amazon_web_services.md
+++ b/doc/deployment/amazon_web_services.md
@@ -52,7 +52,7 @@ To deploy and interact with Pachyderm, you will need `pachctl`, a command-line u
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.5
 
 # For Linux (64 bit):
-$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022/pachctl_1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2/pachctl_1.5.2_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 
 You can try running `pachctl version` to check that this worked correctly, but Pachyderm itself isn't deployed yet so you won't get a `pachd` version.

--- a/doc/deployment/azure.md
+++ b/doc/deployment/azure.md
@@ -92,7 +92,7 @@ $ az storage blob list \
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.5
 
 # For Linux (64 bit):
-$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022/pachctl_1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2/pachctl_1.5.2_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 
 You can try running `pachctl version` to check that this worked correctly, but Pachyderm itself isn't deployed yet so you won't get a `pachd` version.

--- a/doc/deployment/google_cloud_platform.md
+++ b/doc/deployment/google_cloud_platform.md
@@ -105,7 +105,7 @@ $ gcloud compute disks list
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.5
 
 # For Linux (64 bit):
-$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022/pachctl_1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2/pachctl_1.5.2_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 
 You can try running `pachctl version` to check that this worked correctly, but Pachyderm itself isn't deployed yet so you won't get a `pachd` version.

--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -23,7 +23,7 @@ Note: Any time you want to stop and restart Pachyderm, you should start fresh wi
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.5
 
 # For Linux (64 bit):
-$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022/pachctl_1.5.2-07ccf39dbb38486b917dd32fda71fd0767c1e022_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.5.2/pachctl_1.5.2_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 
 


### PR DESCRIPTION
The version number for installing pachctl got messed up in the docs with the 1.5.2 release.