### PR TITLE
Union naming

### DIFF
--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -298,8 +298,15 @@ Union inputs take the union of other inputs. For example:
 |        |        | buzz            |
 ```
 
-Notice that union inputs, do not take a name and maintain the names of the sub-inputs.
-In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.
+Notice that union inputs, do not take a name and maintain the names of the
+sub-inputs. In the above example you would see files under
+`/pfs/inputA/...` or `/pfs/inputB/...`, but never both at the same time.
+This can be annoying to write code for since the first thing your code
+needs to do is figure out which input directory is present. As of 1.5.3
+the recommended way to fix this is to give your inputs the same `Name`,
+that way your code only needs to handle data being present in that
+directory. This, of course, only works if your code doesn't need to be
+aware of which of the underlying inputs the data comes from.
 
 `input.union` is an array of inputs to union, note that these need not be
 `atom` inputs, they can also be `union` and `cross` inputs. Although there's no

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3257,7 +3257,7 @@ func TestUnionInput(t *testing.T) {
 		require.Equal(t, 2, len(fileInfos))
 		for _, fi := range fileInfos {
 			// 1 byte per repo
-			require.Equal(t, fi.SizeBytes, uint64(len(repos)))
+			require.Equal(t, uint64(len(repos)), fi.SizeBytes)
 		}
 	})
 
@@ -3298,7 +3298,7 @@ func TestUnionInput(t *testing.T) {
 			require.Equal(t, 2, len(fileInfos))
 			for _, fi := range fileInfos {
 				// each file should be seen twice
-				require.Equal(t, fi.SizeBytes, uint64(2))
+				require.Equal(t, uint64(2), fi.SizeBytes)
 			}
 		}
 	})
@@ -3340,7 +3340,7 @@ func TestUnionInput(t *testing.T) {
 			require.Equal(t, 2, len(fileInfos))
 			for _, fi := range fileInfos {
 				// each file should be seen twice
-				require.Equal(t, fi.SizeBytes, uint64(4))
+				require.Equal(t, uint64(4), fi.SizeBytes)
 			}
 		}
 	})
@@ -3352,7 +3352,7 @@ func TestUnionInput(t *testing.T) {
 			"",
 			[]string{"bash"},
 			[]string{
-				"cp -r /pfs/in/* /pfs/out",
+				"cp -r /pfs/in /pfs/out",
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,
@@ -3372,14 +3372,11 @@ func TestUnionInput(t *testing.T) {
 		commitInfos := collectCommitInfos(t, commitIter)
 		require.Equal(t, 1, len(commitInfos))
 		outCommit := commitInfos[0].Commit
-		for _, repo := range repos {
-			fileInfos, err := c.ListFile(outCommit.Repo.Name, outCommit.ID, repo)
-			require.NoError(t, err)
-			require.Equal(t, 2, len(fileInfos))
-			for _, fi := range fileInfos {
-				// each file should be seen twice
-				require.Equal(t, fi.SizeBytes, uint64(4))
-			}
+		fileInfos, err := c.ListFile(outCommit.Repo.Name, outCommit.ID, "in")
+		require.NoError(t, err)
+		require.Equal(t, 2, len(fileInfos))
+		for _, fi := range fileInfos {
+			require.Equal(t, uint64(4), fi.SizeBytes)
 		}
 	})
 
@@ -3390,7 +3387,7 @@ func TestUnionInput(t *testing.T) {
 			"",
 			[]string{"bash"},
 			[]string{
-				"cp -r /pfs/in*/* /pfs/out",
+				"cp -r /pfs/in* /pfs/out",
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,
@@ -3413,7 +3410,7 @@ func TestUnionInput(t *testing.T) {
 			"",
 			[]string{"bash"},
 			[]string{
-				"cp -r /pfs/in*/* /pfs/out",
+				"cp -r /pfs/in* /pfs/out",
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,
@@ -3437,13 +3434,13 @@ func TestUnionInput(t *testing.T) {
 		commitInfos := collectCommitInfos(t, commitIter)
 		require.Equal(t, 1, len(commitInfos))
 		outCommit := commitInfos[0].Commit
-		for _, repo := range repos {
-			fileInfos, err := c.ListFile(outCommit.Repo.Name, outCommit.ID, repo)
+		for _, dir := range []string{"in1", "in2"} {
+			fileInfos, err := c.ListFile(outCommit.Repo.Name, outCommit.ID, dir)
 			require.NoError(t, err)
 			require.Equal(t, 2, len(fileInfos))
 			for _, fi := range fileInfos {
 				// each file should be seen twice
-				require.Equal(t, fi.SizeBytes, uint64(4))
+				require.Equal(t, uint64(4), fi.SizeBytes)
 			}
 		}
 	})
@@ -3454,7 +3451,7 @@ func TestUnionInput(t *testing.T) {
 			"",
 			[]string{"bash"},
 			[]string{
-				"cp -r /pfs/in*/* /pfs/out",
+				"cp -r /pfs/in* /pfs/out",
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,
@@ -3477,7 +3474,7 @@ func TestUnionInput(t *testing.T) {
 			"",
 			[]string{"bash"},
 			[]string{
-				"cp -r /pfs/in*/* /pfs/out",
+				"cp -r /pfs/in* /pfs/out",
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,
@@ -3501,13 +3498,13 @@ func TestUnionInput(t *testing.T) {
 		commitInfos := collectCommitInfos(t, commitIter)
 		require.Equal(t, 1, len(commitInfos))
 		outCommit := commitInfos[0].Commit
-		for _, repo := range repos {
-			fileInfos, err := c.ListFile(outCommit.Repo.Name, outCommit.ID, repo)
+		for _, dir := range []string{"in1", "in2"} {
+			fileInfos, err := c.ListFile(outCommit.Repo.Name, outCommit.ID, dir)
 			require.NoError(t, err)
 			require.Equal(t, 2, len(fileInfos))
 			for _, fi := range fileInfos {
 				// each file should be seen twice
-				require.Equal(t, fi.SizeBytes, uint64(4))
+				require.Equal(t, uint64(8), fi.SizeBytes)
 			}
 		}
 	})

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -127,10 +127,10 @@ func validateNames(names map[string]bool, input *pps.Input) error {
 		}
 		names[input.Atom.Name] = true
 	case input.Cron != nil:
-		if names[input.Atom.Name] {
+		if names[input.Cron.Name] {
 			return fmt.Errorf("name %s was used more than once", input.Cron.Name)
 		}
-		names[input.Atom.Name] = true
+		names[input.Cron.Name] = true
 	case input.Union != nil:
 		for _, input := range input.Union {
 			namesCopy := make(map[string]bool)


### PR DESCRIPTION
This PR makes it so that two inputs which are being unioned together can have the same name. This makes union inputs a lot more ergonomic because user code doesn't need to first figure out which directory of the many present in the union is currently present under `/pfs`