### PR TITLE
bump GRPC WebSocket Proxy version

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -34,7 +34,7 @@ var (
 	dashName                = "dash"
 	dashImage               = "pachyderm/dash"
 	grpcProxyName           = "grpc-proxy"
-	grpcProxyImage          = "pachyderm/grpc-proxy:0.3.0"
+	grpcProxyImage          = "pachyderm/grpc-proxy:0.3.1"
 	pachdName               = "pachd"
 	minioSecretName         = "minio-secret"
 	amazonSecretName        = "amazon-secret"


### PR DESCRIPTION
This version of the proxy should properly pass error messages to the client

I think the only thing to check really is that the image exists: https://hub.docker.com/r/pachyderm/grpc-proxy/tags/  (it does :P)