### PR TITLE
Implement the ancestry syntax for commit IDs

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -700,7 +700,6 @@ func (d *driver) inspectCommit(ctx context.Context, commit *pfs.Commit) (*pfs.Co
 	}
 
 	commitID, ancestryLength := parseCommitID(commit.ID)
-	fmt.Printf("commitID: %s; ancestry: %v\n", commitID, ancestryLength)
 
 	// Check if the commitID is a branch name
 	_, err := col.NewSTM(ctx, d.etcdClient, func(stm col.STM) error {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -689,11 +689,8 @@ func (d *driver) finishCommit(ctx context.Context, commit *pfs.Commit) error {
 
 // inspectCommit takes a Commit and returns the corresponding CommitInfo.
 //
-// As a side effect, it sets the commit ID to the real commit ID, if the
-// original commit ID is actually a branch.
-//
-// This side effect is used internally by other APIs to resolve branch
-// names to real commit IDs.
+// As a side effect, this function also replaces the ID in the given commit
+// with a real commit ID.
 func (d *driver) inspectCommit(ctx context.Context, commit *pfs.Commit) (*pfs.CommitInfo, error) {
 	if commit == nil {
 		return nil, fmt.Errorf("cannot inspect nil commit")
@@ -701,31 +698,86 @@ func (d *driver) inspectCommit(ctx context.Context, commit *pfs.Commit) (*pfs.Co
 	if err := d.checkIsAuthorized(ctx, commit.Repo, auth.Scope_READER); err != nil {
 		return nil, err
 	}
+
+	commitID, ancestryLength := parseCommitID(commit.ID)
+	fmt.Printf("commitID: %s; ancestry: %v\n", commitID, ancestryLength)
+
+	// Check if the commitID is a branch name
 	_, err := col.NewSTM(ctx, d.etcdClient, func(stm col.STM) error {
 		branches := d.branches(commit.Repo.Name).ReadWrite(stm)
 
 		head := new(pfs.Commit)
 		// See if we are given a branch
-		if err := branches.Get(commit.ID, head); err != nil {
+		if err := branches.Get(commitID, head); err != nil {
 			if _, ok := err.(col.ErrNotFound); !ok {
 				return err
 			}
 			// If it's not a branch, use it as it is
 			return nil
 		}
-		commit.ID = head.ID
+		commitID = head.ID
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	commits := d.commits(commit.Repo.Name).ReadOnly(ctx)
-	commitInfo := &pfs.CommitInfo{}
-	if err := commits.Get(commit.ID, commitInfo); err != nil {
-		return nil, err
+	var commitInfo *pfs.CommitInfo
+	nextCommit := &pfs.Commit{
+		Repo: commit.Repo,
+		ID:   commitID,
 	}
+	for i := 0; i <= ancestryLength; i++ {
+		if nextCommit == nil {
+			return nil, pfsserver.ErrCommitNotFound{commit}
+		}
+		commits := d.commits(commit.Repo.Name).ReadOnly(ctx)
+		commitInfo = new(pfs.CommitInfo)
+		if err := commits.Get(nextCommit.ID, commitInfo); err != nil {
+			return nil, pfsserver.ErrCommitNotFound{nextCommit}
+		}
+		nextCommit = commitInfo.ParentCommit
+	}
+
+	commit.ID = commitInfo.Commit.ID
 	return commitInfo, nil
+}
+
+// parseCommitID accepts a commit ID that might contain the Git ancestry
+// syntax, such as "master^2", "master~~", "master^^", "master~5", etc.
+// It then returns the ID component such as "master" and the depth of the
+// ancestor.  For instance, for "master^2" it'd return "master" and 2.
+func parseCommitID(commitID string) (string, int) {
+	sepIndex := strings.IndexAny(commitID, "^~")
+	if sepIndex == -1 {
+		return commitID, 0
+	}
+
+	// Find the separator, which is either "^" or "~"
+	sep := commitID[sepIndex]
+	strAfterSep := commitID[sepIndex+1:]
+
+	// Try convert the string after the separator to an int.
+	intAfterSep, err := strconv.Atoi(strAfterSep)
+	// If it works, return
+	if err == nil {
+		return commitID[:sepIndex], intAfterSep
+	}
+
+	// Otherwise, we check if there's a sequence of separators, as in
+	// "master^^^^" or "master~~~~"
+	for i := sepIndex + 1; i < len(commitID); i++ {
+		if commitID[i] != sep {
+			// If we find a character that's not the separator, as in
+			// "master~whatever", then we return.
+			return commitID, 0
+		}
+	}
+
+	// Here we've confirmed that the commit ID ends with a sequence of
+	// (the same) separators and therefore uses the correct ancestry
+	// syntax.
+	return commitID[:sepIndex], len(commitID) - sepIndex
 }
 
 func (d *driver) listCommit(ctx context.Context, repo *pfs.Repo, to *pfs.Commit, from *pfs.Commit, number uint64) ([]*pfs.CommitInfo, error) {
@@ -744,18 +796,16 @@ func (d *driver) listCommit(ctx context.Context, repo *pfs.Repo, to *pfs.Commit,
 
 	// Make sure that both from and to are valid commits
 	if from != nil {
-		fromCommitInfo, err := d.inspectCommit(ctx, from)
+		_, err = d.inspectCommit(ctx, from)
 		if err != nil {
 			return nil, err
 		}
-		from = fromCommitInfo.Commit
 	}
 	if to != nil {
-		toCommitInfo, err := d.inspectCommit(ctx, to)
+		_, err = d.inspectCommit(ctx, to)
 		if err != nil {
 			return nil, err
 		}
-		to = toCommitInfo.Commit
 	}
 
 	// if number is 0, we return all commits that match the criteria


### PR DESCRIPTION
The following formats are accepted:

* `master^`
* `master~`
* `master^^` (any number of `^`)
* `master~~` (any number of `~`)
* `master^n`
* `master~n`

Note that the branch name (e.g. `master`) can also be a real commit ID.