### PR TITLE
Add ListAdmins and ModifyAdmins to Pachyderm auth API

### DIFF
--- a/src/client/auth/auth.pb.go
+++ b/src/client/auth/auth.pb.go
@@ -10,6 +10,10 @@
 	It has these top-level messages:
 		ActivateRequest
 		ActivateResponse
+		GetAdminsRequest
+		GetAdminsResponse
+		ModifyAdminsRequest
+		ModifyAdminsResponse
 		User
 		AuthenticateRequest
 		AuthenticateResponse
@@ -86,8 +90,13 @@ func (x Scope) String() string {
 func (Scope) EnumDescriptor() ([]byte, []int) { return fileDescriptorAuth, []int{0} }
 
 type ActivateRequest struct {
-	ActivationCode string   `protobuf:"bytes,1,opt,name=activation_code,json=activationCode,proto3" json:"activation_code,omitempty"`
-	Admins         []string `protobuf:"bytes,2,rep,name=admins" json:"admins,omitempty"`
+	// activation_code is a Pachyderm enterprise activation code. New users can
+	// obtain trial activation codes
+	ActivationCode string `protobuf:"bytes,1,opt,name=activation_code,json=activationCode,proto3" json:"activation_code,omitempty"`
+	// An initial list of cluster administraters. Pachyderm requires that if its
+	// auth system is activated, the cluster must have at least one
+	// administrator
+	Admins []string `protobuf:"bytes,2,rep,name=admins" json:"admins,omitempty"`
 }
 
 func (m *ActivateRequest) Reset()                    { *m = ActivateRequest{} }
@@ -117,28 +126,79 @@ func (m *ActivateResponse) String() string            { return proto.CompactText
 func (*ActivateResponse) ProtoMessage()               {}
 func (*ActivateResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{1} }
 
+// Get the current list of cluster admins
+type GetAdminsRequest struct {
+}
+
+func (m *GetAdminsRequest) Reset()                    { *m = GetAdminsRequest{} }
+func (m *GetAdminsRequest) String() string            { return proto.CompactTextString(m) }
+func (*GetAdminsRequest) ProtoMessage()               {}
+func (*GetAdminsRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{2} }
+
+type GetAdminsResponse struct {
+	Admins []string `protobuf:"bytes,1,rep,name=admins" json:"admins,omitempty"`
+}
+
+func (m *GetAdminsResponse) Reset()                    { *m = GetAdminsResponse{} }
+func (m *GetAdminsResponse) String() string            { return proto.CompactTextString(m) }
+func (*GetAdminsResponse) ProtoMessage()               {}
+func (*GetAdminsResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{3} }
+
+func (m *GetAdminsResponse) GetAdmins() []string {
+	if m != nil {
+		return m.Admins
+	}
+	return nil
+}
+
+// Add or remove cluster admins
+type ModifyAdminsRequest struct {
+	Add    []string `protobuf:"bytes,1,rep,name=add" json:"add,omitempty"`
+	Remove []string `protobuf:"bytes,2,rep,name=remove" json:"remove,omitempty"`
+}
+
+func (m *ModifyAdminsRequest) Reset()                    { *m = ModifyAdminsRequest{} }
+func (m *ModifyAdminsRequest) String() string            { return proto.CompactTextString(m) }
+func (*ModifyAdminsRequest) ProtoMessage()               {}
+func (*ModifyAdminsRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{4} }
+
+func (m *ModifyAdminsRequest) GetAdd() []string {
+	if m != nil {
+		return m.Add
+	}
+	return nil
+}
+
+func (m *ModifyAdminsRequest) GetRemove() []string {
+	if m != nil {
+		return m.Remove
+	}
+	return nil
+}
+
+type ModifyAdminsResponse struct {
+}
+
+func (m *ModifyAdminsResponse) Reset()                    { *m = ModifyAdminsResponse{} }
+func (m *ModifyAdminsResponse) String() string            { return proto.CompactTextString(m) }
+func (*ModifyAdminsResponse) ProtoMessage()               {}
+func (*ModifyAdminsResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{5} }
+
+// User is the 'value' of an auth token 'key' in the 'tokens' collection
 type User struct {
 	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
-	Admin    bool   `protobuf:"varint,2,opt,name=admin,proto3" json:"admin,omitempty"`
 }
 
 func (m *User) Reset()                    { *m = User{} }
 func (m *User) String() string            { return proto.CompactTextString(m) }
 func (*User) ProtoMessage()               {}
-func (*User) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{2} }
+func (*User) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{6} }
 
 func (m *User) GetUsername() string {
 	if m != nil {
 		return m.Username
 	}
 	return ""
-}
-
-func (m *User) GetAdmin() bool {
-	if m != nil {
-		return m.Admin
-	}
-	return false
 }
 
 type AuthenticateRequest struct {
@@ -152,7 +212,7 @@ type AuthenticateRequest struct {
 func (m *AuthenticateRequest) Reset()                    { *m = AuthenticateRequest{} }
 func (m *AuthenticateRequest) String() string            { return proto.CompactTextString(m) }
 func (*AuthenticateRequest) ProtoMessage()               {}
-func (*AuthenticateRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{3} }
+func (*AuthenticateRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{7} }
 
 func (m *AuthenticateRequest) GetGithubUsername() string {
 	if m != nil {
@@ -175,7 +235,7 @@ type AuthenticateResponse struct {
 func (m *AuthenticateResponse) Reset()                    { *m = AuthenticateResponse{} }
 func (m *AuthenticateResponse) String() string            { return proto.CompactTextString(m) }
 func (*AuthenticateResponse) ProtoMessage()               {}
-func (*AuthenticateResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{4} }
+func (*AuthenticateResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{8} }
 
 func (m *AuthenticateResponse) GetPachToken() string {
 	if m != nil {
@@ -190,7 +250,7 @@ type WhoAmIRequest struct {
 func (m *WhoAmIRequest) Reset()                    { *m = WhoAmIRequest{} }
 func (m *WhoAmIRequest) String() string            { return proto.CompactTextString(m) }
 func (*WhoAmIRequest) ProtoMessage()               {}
-func (*WhoAmIRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{5} }
+func (*WhoAmIRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{9} }
 
 type WhoAmIResponse struct {
 	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
@@ -199,7 +259,7 @@ type WhoAmIResponse struct {
 func (m *WhoAmIResponse) Reset()                    { *m = WhoAmIResponse{} }
 func (m *WhoAmIResponse) String() string            { return proto.CompactTextString(m) }
 func (*WhoAmIResponse) ProtoMessage()               {}
-func (*WhoAmIResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{6} }
+func (*WhoAmIResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{10} }
 
 func (m *WhoAmIResponse) GetUsername() string {
 	if m != nil {
@@ -216,7 +276,7 @@ type ACLEntry struct {
 func (m *ACLEntry) Reset()                    { *m = ACLEntry{} }
 func (m *ACLEntry) String() string            { return proto.CompactTextString(m) }
 func (*ACLEntry) ProtoMessage()               {}
-func (*ACLEntry) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{7} }
+func (*ACLEntry) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{11} }
 
 func (m *ACLEntry) GetUsername() string {
 	if m != nil {
@@ -240,7 +300,7 @@ type ACL struct {
 func (m *ACL) Reset()                    { *m = ACL{} }
 func (m *ACL) String() string            { return proto.CompactTextString(m) }
 func (*ACL) ProtoMessage()               {}
-func (*ACL) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{8} }
+func (*ACL) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{12} }
 
 func (m *ACL) GetEntries() map[string]Scope {
 	if m != nil {
@@ -257,7 +317,7 @@ type AuthorizeRequest struct {
 func (m *AuthorizeRequest) Reset()                    { *m = AuthorizeRequest{} }
 func (m *AuthorizeRequest) String() string            { return proto.CompactTextString(m) }
 func (*AuthorizeRequest) ProtoMessage()               {}
-func (*AuthorizeRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{9} }
+func (*AuthorizeRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{13} }
 
 func (m *AuthorizeRequest) GetRepo() string {
 	if m != nil {
@@ -280,7 +340,7 @@ type AuthorizeResponse struct {
 func (m *AuthorizeResponse) Reset()                    { *m = AuthorizeResponse{} }
 func (m *AuthorizeResponse) String() string            { return proto.CompactTextString(m) }
 func (*AuthorizeResponse) ProtoMessage()               {}
-func (*AuthorizeResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{10} }
+func (*AuthorizeResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{14} }
 
 func (m *AuthorizeResponse) GetAuthorized() bool {
 	if m != nil {
@@ -297,7 +357,7 @@ type GetScopeRequest struct {
 func (m *GetScopeRequest) Reset()                    { *m = GetScopeRequest{} }
 func (m *GetScopeRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetScopeRequest) ProtoMessage()               {}
-func (*GetScopeRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{11} }
+func (*GetScopeRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{15} }
 
 func (m *GetScopeRequest) GetUsername() string {
 	if m != nil {
@@ -320,7 +380,7 @@ type GetScopeResponse struct {
 func (m *GetScopeResponse) Reset()                    { *m = GetScopeResponse{} }
 func (m *GetScopeResponse) String() string            { return proto.CompactTextString(m) }
 func (*GetScopeResponse) ProtoMessage()               {}
-func (*GetScopeResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{12} }
+func (*GetScopeResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{16} }
 
 func (m *GetScopeResponse) GetScopes() []Scope {
 	if m != nil {
@@ -338,7 +398,7 @@ type SetScopeRequest struct {
 func (m *SetScopeRequest) Reset()                    { *m = SetScopeRequest{} }
 func (m *SetScopeRequest) String() string            { return proto.CompactTextString(m) }
 func (*SetScopeRequest) ProtoMessage()               {}
-func (*SetScopeRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{13} }
+func (*SetScopeRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{17} }
 
 func (m *SetScopeRequest) GetUsername() string {
 	if m != nil {
@@ -367,7 +427,7 @@ type SetScopeResponse struct {
 func (m *SetScopeResponse) Reset()                    { *m = SetScopeResponse{} }
 func (m *SetScopeResponse) String() string            { return proto.CompactTextString(m) }
 func (*SetScopeResponse) ProtoMessage()               {}
-func (*SetScopeResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{14} }
+func (*SetScopeResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{18} }
 
 type GetACLRequest struct {
 	Repo string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
@@ -376,7 +436,7 @@ type GetACLRequest struct {
 func (m *GetACLRequest) Reset()                    { *m = GetACLRequest{} }
 func (m *GetACLRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetACLRequest) ProtoMessage()               {}
-func (*GetACLRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{15} }
+func (*GetACLRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{19} }
 
 func (m *GetACLRequest) GetRepo() string {
 	if m != nil {
@@ -392,7 +452,7 @@ type GetACLResponse struct {
 func (m *GetACLResponse) Reset()                    { *m = GetACLResponse{} }
 func (m *GetACLResponse) String() string            { return proto.CompactTextString(m) }
 func (*GetACLResponse) ProtoMessage()               {}
-func (*GetACLResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{16} }
+func (*GetACLResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{20} }
 
 func (m *GetACLResponse) GetACL() *ACL {
 	if m != nil {
@@ -409,7 +469,7 @@ type SetACLRequest struct {
 func (m *SetACLRequest) Reset()                    { *m = SetACLRequest{} }
 func (m *SetACLRequest) String() string            { return proto.CompactTextString(m) }
 func (*SetACLRequest) ProtoMessage()               {}
-func (*SetACLRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{17} }
+func (*SetACLRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{21} }
 
 func (m *SetACLRequest) GetRepo() string {
 	if m != nil {
@@ -431,7 +491,7 @@ type SetACLResponse struct {
 func (m *SetACLResponse) Reset()                    { *m = SetACLResponse{} }
 func (m *SetACLResponse) String() string            { return proto.CompactTextString(m) }
 func (*SetACLResponse) ProtoMessage()               {}
-func (*SetACLResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{18} }
+func (*SetACLResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{22} }
 
 type GetCapabilityRequest struct {
 }
@@ -439,7 +499,7 @@ type GetCapabilityRequest struct {
 func (m *GetCapabilityRequest) Reset()                    { *m = GetCapabilityRequest{} }
 func (m *GetCapabilityRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetCapabilityRequest) ProtoMessage()               {}
-func (*GetCapabilityRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{19} }
+func (*GetCapabilityRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{23} }
 
 type GetCapabilityResponse struct {
 	Capability string `protobuf:"bytes,1,opt,name=capability,proto3" json:"capability,omitempty"`
@@ -448,7 +508,7 @@ type GetCapabilityResponse struct {
 func (m *GetCapabilityResponse) Reset()                    { *m = GetCapabilityResponse{} }
 func (m *GetCapabilityResponse) String() string            { return proto.CompactTextString(m) }
 func (*GetCapabilityResponse) ProtoMessage()               {}
-func (*GetCapabilityResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{20} }
+func (*GetCapabilityResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{24} }
 
 func (m *GetCapabilityResponse) GetCapability() string {
 	if m != nil {
@@ -464,7 +524,7 @@ type RevokeAuthTokenRequest struct {
 func (m *RevokeAuthTokenRequest) Reset()                    { *m = RevokeAuthTokenRequest{} }
 func (m *RevokeAuthTokenRequest) String() string            { return proto.CompactTextString(m) }
 func (*RevokeAuthTokenRequest) ProtoMessage()               {}
-func (*RevokeAuthTokenRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{21} }
+func (*RevokeAuthTokenRequest) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{25} }
 
 func (m *RevokeAuthTokenRequest) GetToken() string {
 	if m != nil {
@@ -479,11 +539,15 @@ type RevokeAuthTokenResponse struct {
 func (m *RevokeAuthTokenResponse) Reset()                    { *m = RevokeAuthTokenResponse{} }
 func (m *RevokeAuthTokenResponse) String() string            { return proto.CompactTextString(m) }
 func (*RevokeAuthTokenResponse) ProtoMessage()               {}
-func (*RevokeAuthTokenResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{22} }
+func (*RevokeAuthTokenResponse) Descriptor() ([]byte, []int) { return fileDescriptorAuth, []int{26} }
 
 func init() {
 	proto.RegisterType((*ActivateRequest)(nil), "auth.ActivateRequest")
 	proto.RegisterType((*ActivateResponse)(nil), "auth.ActivateResponse")
+	proto.RegisterType((*GetAdminsRequest)(nil), "auth.GetAdminsRequest")
+	proto.RegisterType((*GetAdminsResponse)(nil), "auth.GetAdminsResponse")
+	proto.RegisterType((*ModifyAdminsRequest)(nil), "auth.ModifyAdminsRequest")
+	proto.RegisterType((*ModifyAdminsResponse)(nil), "auth.ModifyAdminsResponse")
 	proto.RegisterType((*User)(nil), "auth.User")
 	proto.RegisterType((*AuthenticateRequest)(nil), "auth.AuthenticateRequest")
 	proto.RegisterType((*AuthenticateResponse)(nil), "auth.AuthenticateResponse")
@@ -520,6 +584,10 @@ const _ = grpc.SupportPackageIsVersion4
 
 type APIClient interface {
 	Activate(ctx context.Context, in *ActivateRequest, opts ...grpc.CallOption) (*ActivateResponse, error)
+	// GetAdmins returns the current list of cluster admins
+	GetAdmins(ctx context.Context, in *GetAdminsRequest, opts ...grpc.CallOption) (*GetAdminsResponse, error)
+	// ModifyAdmins adds or removes admins from the cluster
+	ModifyAdmins(ctx context.Context, in *ModifyAdminsRequest, opts ...grpc.CallOption) (*ModifyAdminsResponse, error)
 	Authenticate(ctx context.Context, in *AuthenticateRequest, opts ...grpc.CallOption) (*AuthenticateResponse, error)
 	Authorize(ctx context.Context, in *AuthorizeRequest, opts ...grpc.CallOption) (*AuthorizeResponse, error)
 	WhoAmI(ctx context.Context, in *WhoAmIRequest, opts ...grpc.CallOption) (*WhoAmIResponse, error)
@@ -542,6 +610,24 @@ func NewAPIClient(cc *grpc.ClientConn) APIClient {
 func (c *aPIClient) Activate(ctx context.Context, in *ActivateRequest, opts ...grpc.CallOption) (*ActivateResponse, error) {
 	out := new(ActivateResponse)
 	err := grpc.Invoke(ctx, "/auth.API/Activate", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *aPIClient) GetAdmins(ctx context.Context, in *GetAdminsRequest, opts ...grpc.CallOption) (*GetAdminsResponse, error) {
+	out := new(GetAdminsResponse)
+	err := grpc.Invoke(ctx, "/auth.API/GetAdmins", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *aPIClient) ModifyAdmins(ctx context.Context, in *ModifyAdminsRequest, opts ...grpc.CallOption) (*ModifyAdminsResponse, error) {
+	out := new(ModifyAdminsResponse)
+	err := grpc.Invoke(ctx, "/auth.API/ModifyAdmins", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -633,6 +719,10 @@ func (c *aPIClient) RevokeAuthToken(ctx context.Context, in *RevokeAuthTokenRequ
 
 type APIServer interface {
 	Activate(context.Context, *ActivateRequest) (*ActivateResponse, error)
+	// GetAdmins returns the current list of cluster admins
+	GetAdmins(context.Context, *GetAdminsRequest) (*GetAdminsResponse, error)
+	// ModifyAdmins adds or removes admins from the cluster
+	ModifyAdmins(context.Context, *ModifyAdminsRequest) (*ModifyAdminsResponse, error)
 	Authenticate(context.Context, *AuthenticateRequest) (*AuthenticateResponse, error)
 	Authorize(context.Context, *AuthorizeRequest) (*AuthorizeResponse, error)
 	WhoAmI(context.Context, *WhoAmIRequest) (*WhoAmIResponse, error)
@@ -662,6 +752,42 @@ func _API_Activate_Handler(srv interface{}, ctx context.Context, dec func(interf
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(APIServer).Activate(ctx, req.(*ActivateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _API_GetAdmins_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetAdminsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(APIServer).GetAdmins(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/auth.API/GetAdmins",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(APIServer).GetAdmins(ctx, req.(*GetAdminsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _API_ModifyAdmins_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ModifyAdminsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(APIServer).ModifyAdmins(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/auth.API/ModifyAdmins",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(APIServer).ModifyAdmins(ctx, req.(*ModifyAdminsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -837,6 +963,14 @@ var _API_serviceDesc = grpc.ServiceDesc{
 			Handler:    _API_Activate_Handler,
 		},
 		{
+			MethodName: "GetAdmins",
+			Handler:    _API_GetAdmins_Handler,
+		},
+		{
+			MethodName: "ModifyAdmins",
+			Handler:    _API_ModifyAdmins_Handler,
+		},
+		{
 			MethodName: "Authenticate",
 			Handler:    _API_Authenticate_Handler,
 		},
@@ -934,6 +1068,123 @@ func (m *ActivateResponse) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *GetAdminsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetAdminsRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *GetAdminsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetAdminsResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Admins) > 0 {
+		for _, s := range m.Admins {
+			dAtA[i] = 0xa
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	return i, nil
+}
+
+func (m *ModifyAdminsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ModifyAdminsRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Add) > 0 {
+		for _, s := range m.Add {
+			dAtA[i] = 0xa
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if len(m.Remove) > 0 {
+		for _, s := range m.Remove {
+			dAtA[i] = 0x12
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	return i, nil
+}
+
+func (m *ModifyAdminsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ModifyAdminsResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
 func (m *User) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -954,16 +1205,6 @@ func (m *User) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintAuth(dAtA, i, uint64(len(m.Username)))
 		i += copy(dAtA[i:], m.Username)
-	}
-	if m.Admin {
-		dAtA[i] = 0x10
-		i++
-		if m.Admin {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
 	}
 	return i, nil
 }
@@ -1548,15 +1789,54 @@ func (m *ActivateResponse) Size() (n int) {
 	return n
 }
 
+func (m *GetAdminsRequest) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *GetAdminsResponse) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Admins) > 0 {
+		for _, s := range m.Admins {
+			l = len(s)
+			n += 1 + l + sovAuth(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *ModifyAdminsRequest) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Add) > 0 {
+		for _, s := range m.Add {
+			l = len(s)
+			n += 1 + l + sovAuth(uint64(l))
+		}
+	}
+	if len(m.Remove) > 0 {
+		for _, s := range m.Remove {
+			l = len(s)
+			n += 1 + l + sovAuth(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *ModifyAdminsResponse) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
 func (m *User) Size() (n int) {
 	var l int
 	_ = l
 	l = len(m.Username)
 	if l > 0 {
 		n += 1 + l + sovAuth(uint64(l))
-	}
-	if m.Admin {
-		n += 2
 	}
 	return n
 }
@@ -1945,6 +2225,293 @@ func (m *ActivateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *GetAdminsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetAdminsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetAdminsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetAdminsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetAdminsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetAdminsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Admins", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Admins = append(m.Admins, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ModifyAdminsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ModifyAdminsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ModifyAdminsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Add", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Add = append(m.Add, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Remove", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Remove = append(m.Remove, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ModifyAdminsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ModifyAdminsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ModifyAdminsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *User) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2003,26 +2570,6 @@ func (m *User) Unmarshal(dAtA []byte) error {
 			}
 			m.Username = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowAuth
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.Admin = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipAuth(dAtA[iNdEx:])
@@ -3869,57 +4416,61 @@ var (
 func init() { proto.RegisterFile("client/auth/auth.proto", fileDescriptorAuth) }
 
 var fileDescriptorAuth = []byte{
-	// 832 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0x51, 0x6f, 0xe2, 0x46,
-	0x10, 0x8e, 0x31, 0x38, 0x30, 0x24, 0xe0, 0xee, 0x71, 0x1c, 0xe7, 0xf6, 0x38, 0x6e, 0xaf, 0x52,
-	0x51, 0x55, 0x71, 0x15, 0xd7, 0xf4, 0x4e, 0x3d, 0xa9, 0x92, 0x43, 0x11, 0xa2, 0x42, 0x24, 0xb2,
-	0x13, 0xe5, 0x31, 0x72, 0xcc, 0x2a, 0x58, 0x21, 0x36, 0xc5, 0x4b, 0xa2, 0xf4, 0xa9, 0x8f, 0xfd,
-	0x09, 0xfd, 0x49, 0x7d, 0xec, 0x2f, 0x88, 0x2a, 0xfa, 0x47, 0xaa, 0xf5, 0xee, 0x1a, 0xdb, 0x90,
-	0xa4, 0x7d, 0x41, 0xbb, 0xdf, 0xcc, 0x7c, 0xf3, 0xcd, 0x78, 0x66, 0x81, 0xba, 0x3b, 0xf3, 0x88,
-	0x4f, 0xdf, 0x39, 0x4b, 0x3a, 0x8d, 0x7e, 0x3a, 0xf3, 0x45, 0x40, 0x03, 0x94, 0x67, 0x67, 0xa3,
-	0x76, 0x19, 0x5c, 0x06, 0x11, 0xf0, 0x8e, 0x9d, 0xb8, 0x0d, 0x5b, 0x50, 0x35, 0x5d, 0xea, 0xdd,
-	0x38, 0x94, 0x58, 0xe4, 0x97, 0x25, 0x09, 0x29, 0xfa, 0x0a, 0xaa, 0x0e, 0x87, 0xbc, 0xc0, 0x3f,
-	0x77, 0x83, 0x09, 0x69, 0x28, 0x2d, 0xa5, 0x5d, 0xb2, 0x2a, 0x6b, 0xb8, 0x17, 0x4c, 0x08, 0xaa,
-	0x83, 0xe6, 0x4c, 0xae, 0x3d, 0x3f, 0x6c, 0xe4, 0x5a, 0x6a, 0xbb, 0x64, 0x89, 0x1b, 0x46, 0xa0,
-	0xaf, 0x39, 0xc3, 0x79, 0xe0, 0x87, 0x04, 0x7f, 0x84, 0xfc, 0x69, 0x48, 0x16, 0xc8, 0x80, 0xe2,
-	0x32, 0x24, 0x0b, 0xdf, 0xb9, 0x96, 0xac, 0xf1, 0x1d, 0xd5, 0xa0, 0x10, 0x31, 0x34, 0x72, 0x2d,
-	0xa5, 0x5d, 0xb4, 0xf8, 0x05, 0x3b, 0xf0, 0xcc, 0x5c, 0xd2, 0x29, 0xf1, 0xa9, 0xe7, 0x26, 0x54,
-	0xbe, 0x81, 0xbd, 0x4b, 0x8f, 0x4e, 0x97, 0x17, 0xe7, 0x34, 0xb8, 0x22, 0xbe, 0x20, 0x2b, 0x73,
-	0xec, 0x84, 0x41, 0xac, 0x10, 0xe1, 0x12, 0xa7, 0xcc, 0xf1, 0x42, 0x38, 0x7c, 0x2a, 0x50, 0x7c,
-	0x00, 0xb5, 0x74, 0x0a, 0x2e, 0x1a, 0xbd, 0x02, 0x98, 0x3b, 0xee, 0x34, 0x95, 0xa1, 0xc4, 0x90,
-	0x88, 0x1f, 0x57, 0x61, 0xff, 0x6c, 0x1a, 0x98, 0xd7, 0x43, 0xa1, 0x09, 0x7f, 0x03, 0x15, 0x09,
-	0x08, 0x86, 0x47, 0xca, 0xc5, 0x43, 0x28, 0x9a, 0xbd, 0x51, 0xdf, 0xa7, 0x8b, 0xbb, 0x47, 0xdb,
-	0xf2, 0x06, 0x0a, 0xa1, 0x1b, 0xcc, 0xb9, 0xf8, 0x4a, 0xb7, 0xdc, 0x89, 0x3e, 0xad, 0xcd, 0x20,
-	0x8b, 0x5b, 0xf0, 0x6f, 0x0a, 0xa8, 0x66, 0x6f, 0x84, 0xbe, 0x85, 0x5d, 0xe2, 0xd3, 0x85, 0x47,
-	0xc2, 0x86, 0xd2, 0x52, 0xdb, 0xe5, 0x6e, 0x9d, 0x3b, 0x9b, 0xbd, 0x51, 0xa7, 0xcf, 0x0d, 0x51,
-	0x3e, 0x4b, 0xba, 0x19, 0x03, 0xd8, 0x4b, 0x1a, 0x90, 0x0e, 0xea, 0x15, 0xb9, 0x13, 0x1a, 0xd8,
-	0x91, 0xa5, 0xbf, 0x71, 0x66, 0xcb, 0xed, 0xe9, 0x23, 0xcb, 0x0f, 0xb9, 0x8f, 0x0a, 0x1e, 0x82,
-	0xce, 0x7a, 0x18, 0x2c, 0xbc, 0x5f, 0xe3, 0x6f, 0x84, 0x20, 0xbf, 0x20, 0xf3, 0x40, 0xb0, 0x45,
-	0xe7, 0xff, 0x52, 0xcd, 0x7b, 0xf8, 0x2c, 0x41, 0x25, 0x3a, 0xd9, 0x04, 0x70, 0x24, 0x38, 0x89,
-	0x18, 0x8b, 0x56, 0x02, 0xc1, 0x3d, 0xa8, 0x0e, 0x08, 0xe5, 0x3c, 0x22, 0xfd, 0x13, 0xb3, 0xc6,
-	0xe4, 0xc8, 0xd1, 0xe5, 0x17, 0xfc, 0x01, 0xf4, 0x35, 0x89, 0x48, 0xfc, 0x16, 0xb4, 0x48, 0x16,
-	0x6f, 0x69, 0x46, 0xb1, 0x30, 0xe1, 0x09, 0x54, 0xed, 0xff, 0x91, 0x5d, 0x36, 0x26, 0xb7, 0xad,
-	0x31, 0xea, 0x83, 0x8d, 0x41, 0xa0, 0xdb, 0x19, 0x79, 0xf8, 0x2d, 0xec, 0x0f, 0x08, 0x35, 0x7b,
-	0xa3, 0x47, 0x9a, 0x8e, 0xbf, 0x87, 0x8a, 0x74, 0x12, 0x55, 0x7d, 0x09, 0xaa, 0xe3, 0xce, 0x22,
-	0xa7, 0x72, 0xb7, 0x14, 0x4f, 0xc9, 0xe1, 0xee, 0xea, 0xfe, 0x35, 0x1b, 0x25, 0x8b, 0x99, 0xb1,
-	0x0d, 0xfb, 0xf6, 0x53, 0xe4, 0xa8, 0x03, 0xbb, 0x3e, 0xb9, 0x3d, 0x67, 0x74, 0xb9, 0x2c, 0x1d,
-	0xac, 0xee, 0x5f, 0x6b, 0x63, 0x72, 0xcb, 0x28, 0x34, 0x9f, 0xdc, 0x9a, 0xee, 0x0c, 0xeb, 0x50,
-	0xb1, 0x53, 0x62, 0x70, 0x1d, 0x6a, 0x03, 0x42, 0x7b, 0xce, 0xdc, 0xb9, 0xf0, 0x66, 0x1e, 0xbd,
-	0x93, 0xfb, 0xf4, 0x01, 0x9e, 0x67, 0xf0, 0xf5, 0x30, 0xb8, 0x31, 0x2a, 0xc4, 0x24, 0x10, 0xdc,
-	0x81, 0xba, 0x45, 0x6e, 0x82, 0x2b, 0xc2, 0xe6, 0x28, 0x5a, 0x56, 0x59, 0x40, 0x0d, 0x0a, 0xc9,
-	0x6d, 0xe6, 0x17, 0xfc, 0x12, 0x5e, 0x6c, 0xf8, 0xf3, 0x54, 0x5f, 0x7f, 0x07, 0x85, 0xa8, 0xe1,
-	0xa8, 0x08, 0xf9, 0xf1, 0xd1, 0xb8, 0xaf, 0xef, 0x20, 0x00, 0xcd, 0xea, 0x9b, 0x3f, 0xf5, 0x2d,
-	0x5d, 0x61, 0xe7, 0x33, 0x6b, 0x78, 0xd2, 0xb7, 0xf4, 0x1c, 0x2a, 0x41, 0xe1, 0xe8, 0x6c, 0xdc,
-	0xb7, 0x74, 0xb5, 0xfb, 0x7b, 0x01, 0x54, 0xf3, 0x78, 0x88, 0x3e, 0x41, 0x51, 0x3e, 0x85, 0xe8,
-	0xb9, 0x68, 0x4b, 0xfa, 0xb9, 0x35, 0xea, 0x59, 0x58, 0x34, 0x65, 0x07, 0x0d, 0x60, 0x2f, 0xf9,
-	0x2c, 0xa1, 0x97, 0xc2, 0x73, 0xf3, 0x35, 0x34, 0x8c, 0x6d, 0xa6, 0x98, 0xe8, 0x47, 0x28, 0xc5,
-	0x0b, 0x85, 0xea, 0x6b, 0xd7, 0xe4, 0xb2, 0x1a, 0x2f, 0x36, 0xf0, 0x38, 0xfe, 0x00, 0x34, 0xfe,
-	0xae, 0xa1, 0x67, 0xdc, 0x29, 0xf5, 0xec, 0x19, 0xb5, 0x34, 0x18, 0x87, 0x7d, 0x82, 0xa2, 0xdc,
-	0x26, 0x59, 0x7c, 0x66, 0x45, 0x65, 0xf1, 0xd9, 0xa5, 0xe3, 0xc1, 0x76, 0x26, 0xd8, 0xde, 0x1e,
-	0x6c, 0x6f, 0x06, 0x1f, 0x80, 0xc6, 0xe7, 0x5d, 0x0a, 0x4e, 0xad, 0x88, 0x14, 0x9c, 0x5e, 0x09,
-	0x1e, 0x66, 0xa7, 0xc2, 0xec, 0x6d, 0x61, 0x76, 0x36, 0xec, 0xe7, 0x68, 0x05, 0xd7, 0x63, 0x8a,
-	0x8c, 0x98, 0x7f, 0x63, 0xa6, 0x8d, 0xcf, 0xb7, 0xda, 0x62, 0xae, 0x63, 0xa8, 0x66, 0x26, 0x11,
-	0x7d, 0xc1, 0x23, 0xb6, 0x0f, 0xb4, 0xf1, 0xea, 0x01, 0xab, 0x64, 0x3c, 0xd4, 0xff, 0x5c, 0x35,
-	0x95, 0xbf, 0x56, 0x4d, 0xe5, 0xef, 0x55, 0x53, 0xf9, 0xe3, 0x9f, 0xe6, 0xce, 0x85, 0x16, 0xfd,
-	0xf5, 0xbf, 0xff, 0x37, 0x00, 0x00, 0xff, 0xff, 0xb5, 0x1b, 0x19, 0xcb, 0x30, 0x08, 0x00, 0x00,
+	// 896 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x56, 0x5f, 0x6f, 0xdb, 0x54,
+	0x14, 0xaf, 0x93, 0xc6, 0x4d, 0x4e, 0xdb, 0xc4, 0xbb, 0xcd, 0xb2, 0xcd, 0xb0, 0x6c, 0xbb, 0x43,
+	0x62, 0x02, 0x94, 0xa1, 0x8e, 0x32, 0xc4, 0x24, 0x90, 0x17, 0xa2, 0x28, 0xa8, 0x74, 0x93, 0xbd,
+	0xa9, 0x8f, 0x95, 0x6b, 0x5f, 0x1a, 0xab, 0xa9, 0x6f, 0x70, 0x6e, 0x5a, 0x85, 0x27, 0xbe, 0x02,
+	0x6f, 0x7c, 0x24, 0x1e, 0xf9, 0x04, 0x13, 0x0a, 0x5f, 0x04, 0xdd, 0x7f, 0x8e, 0xed, 0x78, 0x81,
+	0xbd, 0x44, 0xf7, 0xfe, 0xce, 0x39, 0xbf, 0xf3, 0xc7, 0xf7, 0xfc, 0x14, 0xe8, 0x04, 0x93, 0x88,
+	0xc4, 0xec, 0xa9, 0x3f, 0x67, 0x63, 0xf1, 0xd3, 0x9b, 0x26, 0x94, 0x51, 0xb4, 0xcd, 0xcf, 0x76,
+	0xfb, 0x82, 0x5e, 0x50, 0x01, 0x3c, 0xe5, 0x27, 0x69, 0xc3, 0x2e, 0xb4, 0x9c, 0x80, 0x45, 0xd7,
+	0x3e, 0x23, 0x2e, 0xf9, 0x65, 0x4e, 0x66, 0x0c, 0x7d, 0x0a, 0x2d, 0x5f, 0x42, 0x11, 0x8d, 0xcf,
+	0x02, 0x1a, 0x92, 0xbb, 0xc6, 0x43, 0xe3, 0x49, 0xc3, 0x6d, 0xae, 0xe0, 0x3e, 0x0d, 0x09, 0xea,
+	0x80, 0xe9, 0x87, 0x57, 0x51, 0x3c, 0xbb, 0x5b, 0x79, 0x58, 0x7d, 0xd2, 0x70, 0xd5, 0x0d, 0x23,
+	0xb0, 0x56, 0x9c, 0xb3, 0x29, 0x8d, 0x67, 0x84, 0x63, 0x43, 0xc2, 0x1c, 0xe1, 0xa0, 0x12, 0xe1,
+	0xcf, 0xe1, 0x56, 0x06, 0x93, 0x8e, 0x19, 0x52, 0x23, 0x47, 0xfa, 0x3d, 0x1c, 0xfc, 0x44, 0xc3,
+	0xe8, 0xe7, 0x45, 0x8e, 0x03, 0x59, 0x50, 0xf5, 0xc3, 0x50, 0xf9, 0xf2, 0x23, 0x27, 0x48, 0xc8,
+	0x15, 0xbd, 0x26, 0xba, 0x2a, 0x79, 0xc3, 0x1d, 0x68, 0xe7, 0x09, 0x54, 0x65, 0x18, 0xb6, 0xdf,
+	0xce, 0x48, 0x82, 0x6c, 0xa8, 0xcf, 0x67, 0x24, 0x89, 0xfd, 0x2b, 0xdd, 0x6f, 0x7a, 0xc7, 0x3e,
+	0x1c, 0x38, 0x73, 0x36, 0x26, 0x31, 0x8b, 0x82, 0xcc, 0xa4, 0x1e, 0xc1, 0xde, 0x45, 0xc4, 0xc6,
+	0xf3, 0xf3, 0x33, 0x46, 0x2f, 0x49, 0xac, 0xc2, 0x76, 0x25, 0xf6, 0x86, 0x43, 0x7c, 0x98, 0xca,
+	0x25, 0x25, 0xaf, 0xc8, 0x61, 0x4a, 0xf8, 0xad, 0x4e, 0x71, 0x04, 0xed, 0x7c, 0x0a, 0x35, 0x8f,
+	0xfb, 0x00, 0x53, 0x3f, 0x18, 0xe7, 0x32, 0x34, 0x38, 0x22, 0xf8, 0x71, 0x0b, 0xf6, 0x4f, 0xc7,
+	0xd4, 0xb9, 0x1a, 0xe9, 0xa1, 0x7e, 0x01, 0x4d, 0x0d, 0x28, 0x86, 0x4d, 0x8d, 0x8d, 0xa0, 0xee,
+	0xf4, 0x8f, 0x07, 0x31, 0x4b, 0x16, 0x9b, 0xfc, 0xd0, 0x23, 0xa8, 0xcd, 0x02, 0x3a, 0x95, 0xc5,
+	0x37, 0x0f, 0x77, 0x7b, 0xe2, 0x79, 0x79, 0x1c, 0x72, 0xa5, 0x05, 0xff, 0x66, 0x40, 0xd5, 0xe9,
+	0x1f, 0xa3, 0x2f, 0x61, 0x87, 0xc4, 0x2c, 0x89, 0x88, 0xfc, 0x82, 0xbb, 0x87, 0x1d, 0xe9, 0xec,
+	0xf4, 0x8f, 0x7b, 0x03, 0x69, 0x10, 0xf9, 0x5c, 0xed, 0x66, 0x0f, 0x61, 0x2f, 0x6b, 0xe0, 0xdf,
+	0xf4, 0x92, 0x2c, 0x54, 0x0d, 0xfc, 0xc8, 0xd3, 0x5f, 0xfb, 0x93, 0x79, 0x79, 0x7a, 0x61, 0xf9,
+	0xb6, 0xf2, 0x8d, 0x81, 0x47, 0x60, 0xf1, 0x19, 0xd2, 0x24, 0xfa, 0x35, 0xfd, 0x46, 0x08, 0xb6,
+	0x13, 0x32, 0xa5, 0x8a, 0x4d, 0x9c, 0xff, 0x4f, 0x37, 0xcf, 0xe0, 0x56, 0x86, 0x4a, 0x4d, 0xb2,
+	0x0b, 0xe0, 0x6b, 0x30, 0x14, 0x8c, 0x75, 0x37, 0x83, 0xe0, 0x3e, 0xb4, 0x86, 0x84, 0x49, 0x1e,
+	0x95, 0x7e, 0xd3, 0x50, 0xdb, 0x50, 0xe3, 0xe5, 0xe8, 0xf5, 0x91, 0x17, 0xfc, 0x5c, 0x6c, 0x8a,
+	0x22, 0x51, 0x89, 0x1f, 0x83, 0x29, 0xca, 0x92, 0x23, 0x2d, 0x54, 0xac, 0x4c, 0x38, 0x84, 0x96,
+	0xf7, 0x01, 0xd9, 0xf5, 0x60, 0x2a, 0x65, 0x83, 0xa9, 0xbe, 0x77, 0x30, 0x08, 0x2c, 0xaf, 0x50,
+	0x1e, 0x7e, 0x0c, 0xfb, 0x7c, 0x91, 0xfb, 0xc7, 0x1b, 0x86, 0x8e, 0xbf, 0x86, 0xa6, 0x76, 0x52,
+	0x5d, 0x7d, 0x02, 0x55, 0x3f, 0x98, 0x08, 0xa7, 0xdd, 0xc3, 0x46, 0xfa, 0x4a, 0x5e, 0xee, 0x2c,
+	0xdf, 0x3d, 0xe0, 0x4f, 0xc9, 0xe5, 0x66, 0xec, 0xc1, 0xbe, 0xf7, 0x5f, 0xe4, 0xa8, 0x07, 0x3b,
+	0x31, 0xb9, 0x39, 0xe3, 0x74, 0x95, 0x22, 0x1d, 0x2c, 0xdf, 0x3d, 0x30, 0x4f, 0xc8, 0x0d, 0xa7,
+	0x30, 0x63, 0x72, 0xe3, 0x04, 0x13, 0x6c, 0x41, 0xd3, 0xcb, 0x15, 0xc3, 0xe5, 0x61, 0x48, 0x58,
+	0xdf, 0x9f, 0xfa, 0xe7, 0xd1, 0x24, 0x62, 0x0b, 0xbd, 0x4f, 0xcf, 0xe1, 0x76, 0x01, 0x5f, 0x3d,
+	0x86, 0x20, 0x45, 0x55, 0x31, 0x19, 0x04, 0xf7, 0xa0, 0xe3, 0x92, 0x6b, 0x7a, 0x49, 0xf8, 0x3b,
+	0x12, 0xcb, 0xaa, 0x1b, 0x68, 0x43, 0x2d, 0xbb, 0xcd, 0xf2, 0x82, 0xef, 0xc1, 0x9d, 0x35, 0x7f,
+	0x99, 0xea, 0xb3, 0xaf, 0xa0, 0x26, 0x06, 0x8e, 0xea, 0xb0, 0x7d, 0xf2, 0xea, 0x64, 0x60, 0x6d,
+	0x21, 0x00, 0xd3, 0x1d, 0x38, 0x3f, 0x0c, 0x5c, 0xcb, 0xe0, 0xe7, 0x53, 0x77, 0xf4, 0x66, 0xe0,
+	0x5a, 0x15, 0xd4, 0x80, 0xda, 0xab, 0xd3, 0x93, 0x81, 0x6b, 0x55, 0x0f, 0x7f, 0x37, 0xa1, 0xea,
+	0xbc, 0x1e, 0xa1, 0x17, 0x50, 0xd7, 0x72, 0x8c, 0x6e, 0xab, 0xb1, 0xe4, 0x25, 0xdf, 0xee, 0x14,
+	0x61, 0x35, 0x94, 0x2d, 0xf4, 0x1d, 0x34, 0x52, 0x8d, 0x46, 0xca, 0xad, 0x28, 0xe4, 0xf6, 0x9d,
+	0x35, 0x3c, 0x8d, 0x1f, 0xc2, 0x5e, 0x56, 0x75, 0xd1, 0x3d, 0xe9, 0x5a, 0x22, 0xe5, 0xb6, 0x5d,
+	0x66, 0xca, 0x12, 0x65, 0xf5, 0x51, 0x13, 0x95, 0xc8, 0xb2, 0x26, 0x2a, 0x93, 0x53, 0xd9, 0x51,
+	0xba, 0xd9, 0xba, 0xa3, 0xa2, 0x6a, 0xe8, 0x8e, 0xd6, 0x24, 0x00, 0x6f, 0xa1, 0x23, 0x30, 0xa5,
+	0xc0, 0xa2, 0x03, 0xe9, 0x94, 0xd3, 0x5f, 0xbb, 0x9d, 0x07, 0xd3, 0xb0, 0x17, 0x50, 0xd7, 0x6b,
+	0xad, 0xbf, 0x42, 0x41, 0x2b, 0xec, 0x4e, 0x11, 0xce, 0x06, 0x7b, 0x85, 0x60, 0xaf, 0x3c, 0xd8,
+	0x5b, 0x0f, 0x3e, 0x02, 0x53, 0x2e, 0x9e, 0x2e, 0x38, 0xb7, 0xab, 0xba, 0xe0, 0xfc, 0x6e, 0xca,
+	0x30, 0x2f, 0x17, 0xe6, 0x95, 0x85, 0x79, 0xc5, 0xb0, 0x1f, 0x85, 0x16, 0xac, 0xf6, 0x05, 0xd9,
+	0x29, 0xff, 0xda, 0x72, 0xd9, 0x1f, 0x95, 0xda, 0x52, 0xae, 0xd7, 0xd0, 0x2a, 0xac, 0x04, 0xfa,
+	0x58, 0x46, 0x94, 0x6f, 0x96, 0x7d, 0xff, 0x3d, 0x56, 0xcd, 0xf8, 0xd2, 0xfa, 0x73, 0xd9, 0x35,
+	0xfe, 0x5a, 0x76, 0x8d, 0xbf, 0x97, 0x5d, 0xe3, 0x8f, 0x7f, 0xba, 0x5b, 0xe7, 0xa6, 0xf8, 0x1f,
+	0xf4, 0xec, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x3d, 0x4e, 0x7a, 0x43, 0x3d, 0x09, 0x00, 0x00,
 }

--- a/src/client/auth/auth.proto
+++ b/src/client/auth/auth.proto
@@ -3,23 +3,41 @@ package auth;
 
 import "gogoproto/gogo.proto";
 
-// Auth Activation API
+//// Activation API
 
 message ActivateRequest {
+    // activation_code is a Pachyderm enterprise activation code. New users can
+    // obtain trial activation codes
     string activation_code = 1;
+
+    // An initial list of cluster administraters. Pachyderm requires that if its
+    // auth system is activated, the cluster must have at least one
+    // administrator
     repeated string admins = 2;
 }
-
 message ActivateResponse {}
 
-// Authentication data structures
-
-message User {
-    string username = 1;
-    bool admin = 2;
+// Get the current list of cluster admins
+message GetAdminsRequest{}
+message GetAdminsResponse{
+  repeated string admins = 1;
 }
 
-// Authentication API
+// Add or remove cluster admins
+message ModifyAdminsRequest {
+  repeated string add = 1;
+  repeated string remove = 2;
+}
+message ModifyAdminsResponse {}
+
+//// Authentication data structures
+
+// User is the 'value' of an auth token 'key' in the 'tokens' collection
+message User {
+    string username = 1;
+}
+
+//// Authentication API
 
 message AuthenticateRequest {
     // If set, Pachyderm will compare this username to the GitHub account that
@@ -39,7 +57,7 @@ message WhoAmIResponse {
   string username = 1;
 }
 
-// Authorization data structures
+//// Authorization data structures
 
 enum Scope {
     // To remove a user's scope from a repo, set their scope to NONE
@@ -59,7 +77,7 @@ message ACL {
     map<string, Scope> entries = 1;
 }
 
-// Authorization API
+//// Authorization API
 
 message AuthorizeRequest {
     string repo = 1;
@@ -102,7 +120,7 @@ message SetACLRequest {
 
 message SetACLResponse {}
 
-// Capability-token API (very limited -- for pipelines)
+//// Capability-token API (very limited -- for pipelines)
 
 message GetCapabilityRequest {}
 
@@ -118,6 +136,11 @@ message RevokeAuthTokenResponse {}
 
 service API {
     rpc Activate(ActivateRequest) returns (ActivateResponse) {}
+
+    // GetAdmins returns the current list of cluster admins
+    rpc GetAdmins(GetAdminsRequest) returns (GetAdminsResponse) {}
+    // ModifyAdmins adds or removes admins from the cluster
+    rpc ModifyAdmins(ModifyAdminsRequest) returns (ModifyAdminsResponse) {}
 
     rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse) {}
     rpc Authorize(AuthorizeRequest) returns (AuthorizeResponse) {}

--- a/src/client/pkg/require/require.go
+++ b/src/client/pkg/require/require.go
@@ -62,25 +62,18 @@ func EqualOneOf(tb testing.TB, expecteds []interface{}, actual interface{}, msgA
 // oneOfEquals is a helper function for OneOfEquals and NoneEquals, that simply
 // returns a bool indicating whether 'expected' is in the slice 'actuals'.
 func oneOfEquals(expected interface{}, actuals interface{}) (bool, error) {
-	switch v := actuals.(type) {
-	case []string:
-		expectedStr, ok := expected.(string)
-		if !ok {
-			return false, fmt.Errorf("\"expected\" should be string, but instead was %T (%#v)", expected, expected)
+	e := reflect.ValueOf(expected)
+	as := reflect.ValueOf(actuals)
+	if as.Kind() != reflect.Slice {
+		return false, fmt.Errorf("\"actuals\" must a be a slice, but instead was %s", as.Type().String())
+	}
+	if e.Type() != as.Type().Elem() {
+		return false, nil
+	}
+	for i := 0; i < as.Len(); i++ {
+		if e.Interface() == as.Index(i).Interface() {
+			return true, nil
 		}
-		for _, actual := range v {
-			if expectedStr == actual {
-				return true, nil
-			}
-		}
-	case []interface{}:
-		for _, actual := range v {
-			if reflect.DeepEqual(expected, actual) {
-				return true, nil
-			}
-		}
-	default:
-		return false, fmt.Errorf("invalid slice type %T", v)
 	}
 	return false, nil
 }
@@ -107,6 +100,62 @@ func NoneEquals(tb testing.TB, expected interface{}, actuals interface{}, msgAnd
 	if equal {
 		fatal(tb, msgAndArgs,
 			"Equal : %#v (expected)\n one of == %#v (actuals)", expected, actuals)
+	}
+}
+
+// ElementsEqual checks whether the elements of the slice "expecteds" are
+// exactly the elements of the slice "actuals", ignoring order (i.e.
+// setwise-equal)
+func ElementsEqual(tb testing.TB, expecteds interface{}, actuals interface{}, msgAndArgs ...interface{}) {
+	if equal := func() bool {
+		es := reflect.ValueOf(expecteds)
+		as := reflect.ValueOf(actuals)
+		if es.Kind() != reflect.Slice {
+			fatal(tb, msgAndArgs, "ElementsEqual must be called with a slice, but \"expected\" was %s", es.Type().String())
+			return false
+		}
+		if as.Kind() != reflect.Slice {
+			fatal(tb, msgAndArgs, "ElementsEqual must be called with a slice, but \"actual\" was %s", as.Type().String())
+			return false
+		}
+		if es.Type().Elem() != as.Type().Elem() {
+			return false
+		}
+		expectedCt := reflect.MakeMap(reflect.MapOf(es.Type().Elem(), reflect.TypeOf(int(0))))
+		actualCt := reflect.MakeMap(reflect.MapOf(as.Type().Elem(), reflect.TypeOf(int(0))))
+		for i := 0; i < es.Len(); i++ {
+			v := es.Index(i)
+			if !expectedCt.MapIndex(v).IsValid() {
+				expectedCt.SetMapIndex(v, reflect.ValueOf(1))
+			} else {
+				newCt := expectedCt.MapIndex(v).Int() + 1
+				expectedCt.SetMapIndex(v, reflect.ValueOf(newCt))
+			}
+		}
+		for i := 0; i < as.Len(); i++ {
+			v := as.Index(i)
+			if !actualCt.MapIndex(v).IsValid() {
+				actualCt.SetMapIndex(v, reflect.ValueOf(1))
+			} else {
+				newCt := actualCt.MapIndex(v).Int() + 1
+				actualCt.SetMapIndex(v, reflect.ValueOf(newCt))
+			}
+		}
+		if expectedCt.Len() != actualCt.Len() {
+			return false
+		}
+		for _, key := range expectedCt.MapKeys() {
+			ec := expectedCt.MapIndex(key)
+			ac := actualCt.MapIndex(key)
+			if !ec.IsValid() || !ac.IsValid() || ec.Interface() != ac.Interface() {
+				return false
+			}
+		}
+		return true
+	}(); !equal {
+		fatal(tb, msgAndArgs,
+			"Not equal: %#v (expecteds)\n"+
+				"      != %#v (actual)", expecteds, actuals)
 	}
 }
 

--- a/src/client/pkg/require/require.go
+++ b/src/client/pkg/require/require.go
@@ -103,62 +103,6 @@ func NoneEquals(tb testing.TB, expected interface{}, actuals interface{}, msgAnd
 	}
 }
 
-// ElementsEqual checks whether the elements of the slice "expecteds" are
-// exactly the elements of the slice "actuals", ignoring order (i.e.
-// setwise-equal)
-func ElementsEqual(tb testing.TB, expecteds interface{}, actuals interface{}, msgAndArgs ...interface{}) {
-	if equal := func() bool {
-		es := reflect.ValueOf(expecteds)
-		as := reflect.ValueOf(actuals)
-		if es.Kind() != reflect.Slice {
-			fatal(tb, msgAndArgs, "ElementsEqual must be called with a slice, but \"expected\" was %s", es.Type().String())
-			return false
-		}
-		if as.Kind() != reflect.Slice {
-			fatal(tb, msgAndArgs, "ElementsEqual must be called with a slice, but \"actual\" was %s", as.Type().String())
-			return false
-		}
-		if es.Type().Elem() != as.Type().Elem() {
-			return false
-		}
-		expectedCt := reflect.MakeMap(reflect.MapOf(es.Type().Elem(), reflect.TypeOf(int(0))))
-		actualCt := reflect.MakeMap(reflect.MapOf(as.Type().Elem(), reflect.TypeOf(int(0))))
-		for i := 0; i < es.Len(); i++ {
-			v := es.Index(i)
-			if !expectedCt.MapIndex(v).IsValid() {
-				expectedCt.SetMapIndex(v, reflect.ValueOf(1))
-			} else {
-				newCt := expectedCt.MapIndex(v).Int() + 1
-				expectedCt.SetMapIndex(v, reflect.ValueOf(newCt))
-			}
-		}
-		for i := 0; i < as.Len(); i++ {
-			v := as.Index(i)
-			if !actualCt.MapIndex(v).IsValid() {
-				actualCt.SetMapIndex(v, reflect.ValueOf(1))
-			} else {
-				newCt := actualCt.MapIndex(v).Int() + 1
-				actualCt.SetMapIndex(v, reflect.ValueOf(newCt))
-			}
-		}
-		if expectedCt.Len() != actualCt.Len() {
-			return false
-		}
-		for _, key := range expectedCt.MapKeys() {
-			ec := expectedCt.MapIndex(key)
-			ac := actualCt.MapIndex(key)
-			if !ec.IsValid() || !ac.IsValid() || ec.Interface() != ac.Interface() {
-				return false
-			}
-		}
-		return true
-	}(); !equal {
-		fatal(tb, msgAndArgs,
-			"Not equal: %#v (expecteds)\n"+
-				"      != %#v (actual)", expecteds, actuals)
-	}
-}
-
 // NoError checks for no error.
 func NoError(tb testing.TB, err error, msgAndArgs ...interface{}) {
 	if err != nil {

--- a/src/server/auth/server/auth.go
+++ b/src/server/auth/server/auth.go
@@ -12,12 +12,15 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/metadata"
 
 	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/gogo/protobuf/types"
 	"github.com/google/go-github/github"
 	logrus "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -42,7 +45,7 @@ const (
 	aclsPrefix   = "/auth/acls"
 	adminsPrefix = "/auth/admins"
 
-	defaultTokenTTLSecs = 24 * 60 * 60
+	defaultTokenTTLSecs = 14 * 24 * 60 * 60  // two weeks
 
 	publicKey = `-----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAoaPoEfv5RcVUbCuWNnOB
@@ -59,23 +62,54 @@ jFqnYeiDwdxU7CQD3oF9H+uVHqz8Jmmf9BxY9PhlMSUGPUsTpZ717ysL0UrBhQhW
 xYp8vpeQ3by9WxPBE/WrxN8CAwEAAQ==
 -----END PUBLIC KEY-----
 `
+
+	// magicUser is a special, unrevokable cluster administrator. It's not
+	// possible to log in as magicUser, but pipelines with no owner are run as
+	// magicUser when auth is activated.
+	magicUser = `GZD4jKDGcirJyWQt6HtK4hhRD6faOofP1mng34xNZsI`
 )
+
+type authState uint8
+
+const (
+	// If auth is disabled, authentication and authorization are disabled, and any
+	// RPCs sent to the cluster are executed.
+	authDisabled authState = iota
+
+	// If auth is expired, only admins can log in or perform any actions in the
+	// cluster. If an admin calls auth.Activate(), then the cluster will
+	// transition to the 'authEnabled' state. If all cluster admins are removed,
+	// the cluster will transition to the 'authDisabled' state.
+	authExpired
+
+	// If auth is enabled, users can log in, and users can manage access to repos
+	// repos with access control lists
+	authEnabled
+)
+
+// epsilon is small, nonempty protobuf to use as an etcd value (the etcd client
+// library can't distinguish between empty values and missing values, even
+// though empty values are still stored in etcd)
+var epsilon = &types.BoolValue{Value: true}
 
 type apiServer struct {
 	pachLogger log.Logger
 	etcdClient *etcd.Client
 
-	// 'activated' stores a timestamp that is effectively a cache of whether the
-	// auth service has been activated. If 'activated' is 1/1/1, then the auth
-	// service has been activated. Otherwise, return "NotActivatedError" until the
-	// timestamp in 'activated' passes and then re-check etc to see if it has been
-	activated atomic.Value
+	// 'activated' stores an authState value, indicating the state that the
+	// cluster is in.
+	clusterState atomic.Value
+
+	// admins is a cache of the current cluster administrators
+	adminMu    sync.Mutex
+	adminCache map[string]struct{}
 
 	// tokens is a collection of hashedToken -> User mappings.
 	tokens col.Collection
 	// acls is a collection of repoName -> ACL mappings.
 	acls col.Collection
-	// admins is a collection of username -> User mappings.
+	// admins is a collection of username -> Empty mappings (keys indicate which
+	// github users are cluster admins)
 	admins col.Collection
 }
 
@@ -109,12 +143,13 @@ func NewAuthServer(etcdAddress string, etcdPrefix string) (authclient.APIServer,
 		DialOptions: client.EtcdDialOptions(),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error constructing etcdClient: %v", err)
+		return nil, fmt.Errorf("error constructing etcdClient: %s", err.Error())
 	}
 
 	s := &apiServer{
 		pachLogger: log.NewLogger("auth.API"),
 		etcdClient: etcdClient,
+		adminCache: make(map[string]struct{}),
 		tokens: col.NewCollection(
 			etcdClient,
 			path.Join(etcdPrefix, tokensPrefix),
@@ -133,18 +168,17 @@ func NewAuthServer(etcdAddress string, etcdPrefix string) (authclient.APIServer,
 			etcdClient,
 			path.Join(etcdPrefix, adminsPrefix),
 			nil,
-			&authclient.User{},
+			&types.BoolValue{}, // typeof(epsilon) == types.BoolValue; epsilon is the only value
 			nil,
 		),
 	}
+	s.clusterState.Store(authDisabled) // must store initial value before starting watchAdmins
 
-	s.activated.Store(false)
-	go s.activationCheck()
-
+	go s.watchAdmins(path.Join(etcdPrefix, adminsPrefix))
 	return s, nil
 }
 
-func (a *apiServer) activationCheck() {
+func (a *apiServer) watchAdmins(fullAdminPrefix string) {
 	backoff.RetryNotify(func() error {
 		// Watch for the addition/removal of new admins. Note that this will return
 		// any existing admins, so if the auth service is already activated, it will
@@ -156,21 +190,39 @@ func (a *apiServer) activationCheck() {
 		defer watcher.Close()
 		// The auth service is activated if we have admins, and not
 		// activated otherwise.
-		var numAdmins int
 		for {
 			ev, ok := <-watcher.Watch()
 			if !ok {
 				return errors.New("admin watch closed unexpectedly")
 			}
-			switch ev.Type {
-			case watch.EventPut:
-				numAdmins++
-			case watch.EventDelete:
-				numAdmins--
-			case watch.EventError:
-				return ev.Err
+
+			if err := func() error {
+				// Lock a.adminMu in case we need to modify a.adminCache
+				a.adminMu.Lock()
+				defer a.adminMu.Unlock()
+
+				// Parse event data and potentially update adminCache
+				var key string
+				var boolProto types.BoolValue
+				switch ev.Type {
+				case watch.EventPut:
+					ev.Unmarshal(&key, &boolProto)
+					username := strings.TrimPrefix(key, fullAdminPrefix+"/")
+					a.adminCache[username] = struct{}{}
+				case watch.EventDelete:
+					ev.Unmarshal(&key, &boolProto)
+					username := strings.TrimPrefix(key, fullAdminPrefix+"/")
+					delete(a.adminCache, username)
+				case watch.EventError:
+					return ev.Err
+				}
+				if len(a.adminCache) > 0 && a.clusterState.Load().(authState) != authEnabled {
+					a.clusterState.Store(authEnabled)
+				}
+				return nil // unlock mu
+			}(); err != nil {
+				return err
 			}
-			a.activated.Store(numAdmins > 0)
 		}
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 		logrus.Printf("error from activation check: %v; retrying in %v", err, d)
@@ -191,31 +243,25 @@ func (a *apiServer) Activate(ctx context.Context, req *authclient.ActivateReques
 
 	// Validate the activation code
 	if err := validateActivationCode(req.ActivationCode); err != nil {
-		return nil, fmt.Errorf("error validating activation code: %v", err)
+		return nil, fmt.Errorf("error validating activation code: %s", err.Error())
 	}
 
-	// Initialize admins
+	// Initialize admins (watchAdmins() above will see the write)
 	_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 		admins := a.admins.ReadWrite(stm)
-
-		for _, admin := range req.Admins {
-			admins.Put(admin, &authclient.User{
-				Username: admin,
-				Admin:    true,
-			})
+		for _, user := range req.Admins {
+			admins.Put(user, epsilon)
 		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	a.activated.Store(true)
 	return &authclient.ActivateResponse{}, nil
 }
 
 func (a *apiServer) isActivated() bool {
-	return a.activated.Load().(bool)
+	return a.clusterState.Load().(authState) == authEnabled
 }
 
 // AccessTokenToUsername takes a OAuth access token issued by GitHub and uses
@@ -233,9 +279,95 @@ func AccessTokenToUsername(ctx context.Context, token string) (string, error) {
 	// Passing the empty string gets us the authenticated user
 	user, _, err := gclient.Users.Get(ctx, "")
 	if err != nil {
-		return "", fmt.Errorf("error getting the authenticated user: %v", err)
+		return "", fmt.Errorf("error getting the authenticated user: %s", err.Error())
 	}
 	return user.GetName(), nil
+}
+
+func (a *apiServer) GetAdmins(ctx context.Context, req *authclient.GetAdminsRequest) (resp *authclient.GetAdminsResponse, retErr error) {
+	a.LogReq(req)
+	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	if !a.isActivated() {
+		return nil, authclient.NotActivatedError{}
+	}
+
+	// Get calling user. There is no auth check to see the list of cluster admins,
+	// other than that the user must log in. Otherwise how will users know who to
+	// ask for admin privileges? Requiring the user to be logged in mitigates
+	// phishing
+	_, err := a.getAuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	a.adminMu.Lock()
+	defer a.adminMu.Unlock()
+	resp = &authclient.GetAdminsResponse{
+		Admins: make([]string, 0, len(a.adminCache)),
+	}
+	for admin := range a.adminCache {
+		resp.Admins = append(resp.Admins, admin)
+	}
+	return resp, nil
+}
+
+func (a *apiServer) validateModifyAdminsRequest(req *authclient.ModifyAdminsRequest) error {
+	// Check to make sure that req doesn't remove all cluster admins
+	m := make(map[string]struct{})
+	// copy existing admins into m
+	func() {
+		a.adminMu.Lock()
+		defer a.adminMu.Unlock()
+		for u := range a.adminCache {
+			m[u] = struct{}{}
+		}
+	}()
+	for _, u := range req.Add {
+		m[u] = struct{}{}
+	}
+	for _, u := range req.Remove {
+		delete(m, u)
+	}
+	if len(m) == 0 {
+		return fmt.Errorf("invalid request: cannot remove all cluster administrators while auth is active, to avoid unfixable cluster states")
+	}
+	return nil
+}
+
+func (a *apiServer) ModifyAdmins(ctx context.Context, req *authclient.ModifyAdminsRequest) (resp *authclient.ModifyAdminsResponse, retErr error) {
+	a.LogReq(req)
+	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	if !a.isActivated() {
+		return nil, authclient.NotActivatedError{}
+	}
+
+	// Get calling user. The user must be an admin to change the list of admins
+	user, err := a.getAuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !a.isAdmin(user.Username) {
+		return nil, fmt.Errorf("must be an admin to modify set of cluster admins")
+	}
+	if err := a.validateModifyAdminsRequest(req); err != nil {
+		return nil, err
+	}
+
+	_, err = col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
+		admins := a.admins.ReadWrite(stm)
+		// Update "admins" list (watchAdmins() will update admins cache)
+		for _, user := range req.Add {
+			admins.Put(user, epsilon)
+		}
+		for _, user := range req.Remove {
+			admins.Delete(user)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &authclient.ModifyAdminsResponse{}, nil
 }
 
 func (a *apiServer) Authenticate(ctx context.Context, req *authclient.AuthenticateRequest) (resp *authclient.AuthenticateResponse, retErr error) {
@@ -244,6 +376,9 @@ func (a *apiServer) Authenticate(ctx context.Context, req *authclient.Authentica
 	defer func(start time.Time) { a.LogResp(nil, nil, retErr, time.Since(start)) }(time.Now())
 	if !a.isActivated() {
 		return nil, authclient.NotActivatedError{}
+	}
+	if req.GithubUsername == magicUser {
+		return nil, fmt.Errorf("invalid user")
 	}
 
 	var username string
@@ -263,29 +398,14 @@ func (a *apiServer) Authenticate(ctx context.Context, req *authclient.Authentica
 		}
 	}
 
-	// Check if the user is an admin.  If they are, authenticate them as
-	// an admin.
-	var u authclient.User
-	var admin bool
-	if err := a.admins.ReadOnly(ctx).Get(username, &u); err != nil {
-		if _, ok := err.(col.ErrNotFound); !ok {
-			return nil, fmt.Errorf("error checking if user %v is an admin: %v", username, err)
-		}
-	} else {
-		admin = true
-	}
-
 	pachToken := uuid.NewWithoutDashes()
-
 	_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 		tokens := a.tokens.ReadWrite(stm)
-		return tokens.PutTTL(hashToken(pachToken), &authclient.User{
-			Username: username,
-			Admin:    admin,
-		}, defaultTokenTTLSecs)
+		return tokens.PutTTL(hashToken(pachToken), &authclient.User{username},
+			defaultTokenTTLSecs)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error storing auth token for user %v: %v", username, err)
+		return nil, fmt.Errorf("error storing auth token for user %v: %s", username, err.Error())
 	}
 
 	return &authclient.AuthenticateResponse{
@@ -305,7 +425,7 @@ func (a *apiServer) Authorize(ctx context.Context, req *authclient.AuthorizeRequ
 		return nil, err
 	}
 
-	if user.Admin {
+	if a.isAdmin(user.Username) {
 		// admins are always authorized
 		return &authclient.AuthorizeResponse{
 			Authorized: true,
@@ -317,7 +437,7 @@ func (a *apiServer) Authorize(ctx context.Context, req *authclient.AuthorizeRequ
 		if _, ok := err.(col.ErrNotFound); ok {
 			return nil, fmt.Errorf("ACL not found for repo %v", req.Repo)
 		}
-		return nil, fmt.Errorf("error getting ACL for repo %v: %v", req.Repo, err)
+		return nil, fmt.Errorf("error getting ACL for repo %v: %s", req.Repo, err.Error())
 	}
 
 	return &authclient.AuthorizeResponse{
@@ -351,6 +471,16 @@ func validateSetScopeRequest(req *authclient.SetScopeRequest) error {
 	return nil
 }
 
+func (a *apiServer) isAdmin(user string) bool {
+	if user == magicUser {
+		return true
+	}
+	a.adminMu.Lock()
+	defer a.adminMu.Unlock()
+	_, ok := a.adminCache[user]
+	return ok
+}
+
 func (a *apiServer) SetScope(ctx context.Context, req *authclient.SetScopeRequest) (resp *authclient.SetScopeResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
@@ -378,7 +508,7 @@ func (a *apiServer) SetScope(ctx context.Context, req *authclient.SetScopeReques
 			}
 			acl.Entries = make(map[string]authclient.Scope)
 		}
-		if len(acl.Entries) > 0 && !user.Admin &&
+		if len(acl.Entries) > 0 && !a.isAdmin(user.Username) &&
 			acl.Entries[user.Username] != authclient.Scope_OWNER {
 			return fmt.Errorf("user %v is not authorized to update ACL for repo %v", user, req.Repo)
 		}
@@ -464,7 +594,7 @@ func (a *apiServer) GetACL(ctx context.Context, req *authclient.GetACLRequest) (
 		}
 	}
 	// For now, require READER access to read repo metadata (commits, and ACLs)
-	if !user.Admin && resp.ACL.Entries[user.Username] < authclient.Scope_READER {
+	if !a.isAdmin(user.Username) && resp.ACL.Entries[user.Username] < authclient.Scope_READER {
 		return nil, fmt.Errorf("you must have at least READER access to %s to read its ACL", req.Repo)
 	}
 	return resp, nil
@@ -495,7 +625,7 @@ func (a *apiServer) SetACL(ctx context.Context, req *authclient.SetACLRequest) (
 		// Require OWNER access to modify repo ACL
 		var acl authclient.ACL
 		acls.Get(req.Repo, &acl)
-		if !user.Admin && acl.Entries[user.Username] < authclient.Scope_OWNER {
+		if !a.isAdmin(user.Username) && acl.Entries[user.Username] < authclient.Scope_OWNER {
 			return fmt.Errorf("you must have OWNER access to %s to modify its ACL", req.Repo)
 		}
 
@@ -506,7 +636,7 @@ func (a *apiServer) SetACL(ctx context.Context, req *authclient.SetACLRequest) (
 		return acls.Put(req.Repo, req.NewACL)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not put new ACL: %v", err)
+		return nil, fmt.Errorf("could not put new ACL: %s", err.Error())
 	}
 	return &authclient.SetACLResponse{}, nil
 }
@@ -521,9 +651,7 @@ func (a *apiServer) GetCapability(ctx context.Context, req *authclient.GetCapabi
 		// that's able to access any repo.  That way, when we create a
 		// pipeline, we can assign it with a capability that would allow
 		// it to access any repo after the auth service has been activated.
-		user = &authclient.User{
-			Admin: true,
-		}
+		user = &authclient.User{magicUser}
 	} else {
 		var err error
 		user, err = a.getAuthenticatedUser(ctx)
@@ -539,7 +667,7 @@ func (a *apiServer) GetCapability(ctx context.Context, req *authclient.GetCapabi
 		return tokens.Put(hashToken(capability), user)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error storing capability for user %v: %v", user.Username, err)
+		return nil, fmt.Errorf("error storing capability for user %v: %s", user.Username, err.Error())
 	}
 
 	return &authclient.GetCapabilityResponse{
@@ -573,7 +701,7 @@ func (a *apiServer) RevokeAuthToken(ctx context.Context, req *authclient.RevokeA
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error revoking token: %v", err)
+		return nil, fmt.Errorf("error revoking token: %s", err.Error())
 	}
 
 	return &authclient.RevokeAuthTokenResponse{}, nil
@@ -605,7 +733,7 @@ func (a *apiServer) getAuthenticatedUser(ctx context.Context) (*authclient.User,
 		if _, ok := err.(col.ErrNotFound); ok {
 			return nil, fmt.Errorf("token not found")
 		}
-		return nil, fmt.Errorf("error getting token: %v", err)
+		return nil, fmt.Errorf("error getting token: %s", err.Error())
 	}
 
 	return &user, nil
@@ -630,7 +758,7 @@ func validateActivationCode(code string) error {
 	}
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		panic(fmt.Sprintf("failed to parse DER encoded public key: %+v", err))
+		panic(fmt.Sprintf("failed to parse DER encoded public key: %s", err.Error()))
 	}
 	rsaPub, ok := pub.(*rsa.PublicKey)
 	if !ok {

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -925,7 +925,8 @@ func TestAdmin(t *testing.T) {
 	// The initial set of admins is just the user "admin"
 	resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
 	require.NoError(t, err)
-	require.ElementsEqual(t, resp.Admins, []string{"admin"})
+	require.Equal(t, len(resp.Admins), 1)
+	require.Equal(t, resp.Admins[0], "admin")
 
 	// alice creates a repo (that only she owns) and puts a file
 	repo := uniqueString("TestAdmin")

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -40,14 +40,12 @@ func uniqueString(prefix string) string {
 	return prefix + uuid.NewWithoutDashes()[0:12]
 }
 
-type user string
-
 var clientMapMut sync.Mutex
-var clientMap = make(map[user]*client.APIClient)
+var clientMap = make(map[string]*client.APIClient)
 
 // getPachClient creates a seed client with a grpc connection to a pachyderm
 // cluster, and then activates the auth service in that cluster
-func getPachClient(t testing.TB, u user) *client.APIClient {
+func getPachClient(t testing.TB, u string) *client.APIClient {
 	// Check if "u" already has a client -- if not create one, and block other
 	// concurrent tests from interfering
 	func() {
@@ -67,7 +65,7 @@ func getPachClient(t testing.TB, u user) *client.APIClient {
 			clientMap[""] = seedClient
 
 			// Since this is the first auth client, also activate the auth service
-			backoff.Retry(func() error {
+			require.NoError(t, backoff.Retry(func() error {
 				_, err = seedClient.Activate(context.Background(),
 					&auth.ActivateRequest{
 						ActivationCode: testActivationCode,
@@ -77,7 +75,7 @@ func getPachClient(t testing.TB, u user) *client.APIClient {
 					return fmt.Errorf("could not activate auth service: %s", err.Error())
 				}
 				return nil
-			}, backoff.NewTestingBackOff())
+			}, backoff.NewTestingBackOff()))
 		}
 
 		// Re-use old client for 'u', or create a new one if none exists
@@ -153,127 +151,127 @@ func TestGetSetBasic(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	alice := getPachClient(t, "alice")
-	bob := getPachClient(t, "bob")
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := uniqueString("TestGetSetBasic")
-	require.NoError(t, alice.CreateRepo(dataRepo))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo))
+	require.NoError(t, aliceClient.CreateRepo(dataRepo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo))
 
 	// Add data to repo (alice can write). Make sure alice can read also.
-	commit, err := alice.StartCommit(dataRepo, "master")
+	commit, err := aliceClient.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	_, err = alice.PutFile(dataRepo, commit.ID, "/file", strings.NewReader("lorem ipsum"))
+	_, err = aliceClient.PutFile(dataRepo, commit.ID, "/file", strings.NewReader("lorem ipsum"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(dataRepo, commit.ID)) // # commits = 1
+	require.NoError(t, aliceClient.FinishCommit(dataRepo, commit.ID)) // # commits = 1
 	buf := &bytes.Buffer{}
-	require.NoError(t, alice.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, aliceClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 
 	//////////
 	/// Initially, bob has no privileges
 	// bob can't read
-	err = bob.GetFile(dataRepo, "master", "/file", 0, 0, buf)
+	err = bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf)
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
 	// bob can't write
-	_, err = bob.StartCommit(dataRepo, "master")
+	_, err = bobClient.StartCommit(dataRepo, "master")
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, 1, CommitCnt(t, alice, dataRepo)) // check that no commits were created
+	require.Equal(t, 1, CommitCnt(t, aliceClient, dataRepo)) // check that no commits were created
 	// bob can't update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo)) // check that ACL wasn't updated
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo)) // check that ACL wasn't updated
 
 	//////////
 	/// alice adds bob to the ACL as a reader (alice can modify ACL)
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
 	// bob can read
 	buf.Reset()
-	require.NoError(t, bob.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 	// bob can't write
-	_, err = bob.StartCommit(dataRepo, "master")
+	_, err = bobClient.StartCommit(dataRepo, "master")
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, 1, CommitCnt(t, alice, dataRepo)) // check that no commits were created
+	require.Equal(t, 1, CommitCnt(t, aliceClient, dataRepo)) // check that no commits were created
 	// bob can't update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, acl("alice", "owner", "bob", "reader"),
-		GetACL(t, alice, dataRepo)) // check that ACL wasn't updated
+	require.Equal(t, acl(alice, "owner", bob, "reader"),
+		GetACL(t, aliceClient, dataRepo)) // check that ACL wasn't updated
 
 	//////////
 	/// alice adds bob to the ACL as a writer
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_WRITER,
 	})
 	require.NoError(t, err)
 	// bob can read
 	buf.Reset()
-	require.NoError(t, bob.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 	// bob can write
-	commit, err = bob.StartCommit(dataRepo, "master")
+	commit, err = bobClient.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	require.NoError(t, bob.FinishCommit(dataRepo, commit.ID))
-	require.Equal(t, 2, CommitCnt(t, alice, dataRepo)) // check that a new commit was created
+	require.NoError(t, bobClient.FinishCommit(dataRepo, commit.ID))
+	require.Equal(t, 2, CommitCnt(t, aliceClient, dataRepo)) // check that a new commit was created
 	// bob can't update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, acl("alice", "owner", "bob", "writer"),
-		GetACL(t, alice, dataRepo)) // check that ACL wasn't updated
+	require.Equal(t, acl(alice, "owner", bob, "writer"),
+		GetACL(t, aliceClient, dataRepo)) // check that ACL wasn't updated
 
 	//////////
 	/// alice adds bob to the ACL as an owner
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_OWNER,
 	})
 	require.NoError(t, err)
 	// bob can read
 	buf.Reset()
-	require.NoError(t, bob.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 	// bob can write
-	commit, err = bob.StartCommit(dataRepo, "master")
+	commit, err = bobClient.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	require.NoError(t, bob.FinishCommit(dataRepo, commit.ID))
-	require.Equal(t, 3, CommitCnt(t, alice, dataRepo)) // check that a new commit was created
+	require.NoError(t, bobClient.FinishCommit(dataRepo, commit.ID))
+	require.Equal(t, 3, CommitCnt(t, aliceClient, dataRepo)) // check that a new commit was created
 	// bob can update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
-	require.Equal(t, acl("alice", "owner", "bob", "owner", "carol", "reader"),
-		GetACL(t, alice, dataRepo)) // check that ACL was updated
+	require.Equal(t, acl(alice, "owner", bob, "owner", "carol", "reader"),
+		GetACL(t, aliceClient, dataRepo)) // check that ACL was updated
 }
 
 // TestGetSetReverse creates two users, alice and bob, and gives bob gradually
@@ -283,142 +281,142 @@ func TestGetSetReverse(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	alice := getPachClient(t, "alice")
-	bob := getPachClient(t, "bob")
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := uniqueString("TestGetSetReverse")
-	require.NoError(t, alice.CreateRepo(dataRepo))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo))
+	require.NoError(t, aliceClient.CreateRepo(dataRepo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo))
 
 	// Add data to repo (alice can write). Make sure alice can read also.
-	commit, err := alice.StartCommit(dataRepo, "master")
+	commit, err := aliceClient.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	_, err = alice.PutFile(dataRepo, commit.ID, "/file", strings.NewReader("lorem ipsum"))
+	_, err = aliceClient.PutFile(dataRepo, commit.ID, "/file", strings.NewReader("lorem ipsum"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(dataRepo, commit.ID)) // # commits = 1
+	require.NoError(t, aliceClient.FinishCommit(dataRepo, commit.ID)) // # commits = 1
 	buf := &bytes.Buffer{}
-	require.NoError(t, alice.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, aliceClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 
 	//////////
 	/// alice adds bob to the ACL as an owner
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_OWNER,
 	})
 	require.NoError(t, err)
 	// bob can read
 	buf.Reset()
-	require.NoError(t, bob.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 	// bob can write
-	commit, err = bob.StartCommit(dataRepo, "master")
+	commit, err = bobClient.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	require.NoError(t, bob.FinishCommit(dataRepo, commit.ID))
-	require.Equal(t, 2, CommitCnt(t, alice, dataRepo)) // check that a new commit was created
+	require.NoError(t, bobClient.FinishCommit(dataRepo, commit.ID))
+	require.Equal(t, 2, CommitCnt(t, aliceClient, dataRepo)) // check that a new commit was created
 	// bob can update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
-	require.Equal(t, acl("alice", "owner", "bob", "owner", "carol", "reader"),
-		GetACL(t, alice, dataRepo)) // check that ACL was updated
+	require.Equal(t, acl(alice, "owner", bob, "owner", "carol", "reader"),
+		GetACL(t, aliceClient, dataRepo)) // check that ACL was updated
 
 	// clear carol
-	alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_NONE,
 	})
-	require.Equal(t, acl("alice", "owner", "bob", "owner"),
-		GetACL(t, alice, dataRepo))
+	require.Equal(t, acl(alice, "owner", bob, "owner"),
+		GetACL(t, aliceClient, dataRepo))
 
 	//////////
 	/// alice adds bob to the ACL as a writer
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_WRITER,
 	})
 	require.NoError(t, err)
 	// bob can read
 	buf.Reset()
-	require.NoError(t, bob.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 	// bob can write
-	commit, err = bob.StartCommit(dataRepo, "master")
+	commit, err = bobClient.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	require.NoError(t, bob.FinishCommit(dataRepo, commit.ID))
-	require.Equal(t, 3, CommitCnt(t, alice, dataRepo)) // check that a new commit was created
+	require.NoError(t, bobClient.FinishCommit(dataRepo, commit.ID))
+	require.Equal(t, 3, CommitCnt(t, aliceClient, dataRepo)) // check that a new commit was created
 	// bob can't update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, acl("alice", "owner", "bob", "writer"),
-		GetACL(t, alice, dataRepo)) // check that ACL wasn't updated
+	require.Equal(t, acl(alice, "owner", bob, "writer"),
+		GetACL(t, aliceClient, dataRepo)) // check that ACL wasn't updated
 
 	//////////
 	/// alice adds bob to the ACL as a reader (alice can modify ACL)
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
 	// bob can read
 	buf.Reset()
-	require.NoError(t, bob.GetFile(dataRepo, "master", "/file", 0, 0, buf))
+	require.NoError(t, bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf))
 	require.Equal(t, "lorem ipsum", buf.String())
 	// bob can't write
-	_, err = bob.StartCommit(dataRepo, "master")
+	_, err = bobClient.StartCommit(dataRepo, "master")
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, 3, CommitCnt(t, alice, dataRepo)) // check that no commits were created
+	require.Equal(t, 3, CommitCnt(t, aliceClient, dataRepo)) // check that no commits were created
 	// bob can't update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, acl("alice", "owner", "bob", "reader"),
-		GetACL(t, alice, dataRepo)) // check that ACL wasn't updated
+	require.Equal(t, acl(alice, "owner", bob, "reader"),
+		GetACL(t, aliceClient, dataRepo)) // check that ACL wasn't updated
 
 	//////////
 	/// alice revokes all of bob's privileges
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_NONE,
 	})
 	require.NoError(t, err)
 	// bob can't read
-	err = bob.GetFile(dataRepo, "master", "/file", 0, 0, buf)
+	err = bobClient.GetFile(dataRepo, "master", "/file", 0, 0, buf)
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
 	// bob can't write
-	_, err = bob.StartCommit(dataRepo, "master")
+	_, err = bobClient.StartCommit(dataRepo, "master")
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, 3, CommitCnt(t, alice, dataRepo)) // check that no commits were created
+	require.Equal(t, 3, CommitCnt(t, aliceClient, dataRepo)) // check that no commits were created
 	// bob can't update the ACL
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
 		Username: "carol",
 		Scope:    auth.Scope_READER,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo)) // check that ACL wasn't updated
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo)) // check that ACL wasn't updated
 }
 
 func TestCreatePipeline(t *testing.T) {
@@ -443,31 +441,31 @@ func TestCreatePipeline(t *testing.T) {
 			args.update,
 		)
 	}
-	alice := getPachClient(t, "alice")
-	bob := getPachClient(t, "bob")
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := uniqueString("TestCreatePipeline")
-	require.NoError(t, alice.CreateRepo(dataRepo))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo))
+	require.NoError(t, aliceClient.CreateRepo(dataRepo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo))
 
 	// alice can create a pipeline (she owns the input repo)
 	pipelineName := uniqueString("alice-pipeline")
 	require.NoError(t, createPipeline(createArgs{
-		client: alice,
+		client: aliceClient,
 		name:   pipelineName,
 		repo:   dataRepo,
 	}))
-	require.OneOfEquals(t, pipelineName, PipelineNames(t, alice))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, pipelineName)) // check that alice owns the output repo too
+	require.OneOfEquals(t, pipelineName, PipelineNames(t, aliceClient))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, pipelineName)) // check that alice owns the output repo too
 
 	// Make sure alice's pipeline runs successfully
-	commit, err := alice.StartCommit(dataRepo, "master")
-	_, err = alice.PutFile(dataRepo, commit.ID, uniqueString("/file"),
+	commit, err := aliceClient.StartCommit(dataRepo, "master")
+	_, err = aliceClient.PutFile(dataRepo, commit.ID, uniqueString("/file"),
 		strings.NewReader("test data"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(dataRepo, commit.ID))
-	iter, err := alice.FlushCommit(
+	require.NoError(t, aliceClient.FinishCommit(dataRepo, commit.ID))
+	iter, err := aliceClient.FlushCommit(
 		[]*pfs.Commit{commit},
 		[]*pfs.Repo{{Name: pipelineName}},
 	)
@@ -478,18 +476,18 @@ func TestCreatePipeline(t *testing.T) {
 	// bob can't create a pipeline
 	badPipeline := uniqueString("bob-bad")
 	err = createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   badPipeline,
 		repo:   dataRepo,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.NoneEquals(t, badPipeline, PipelineNames(t, alice))
+	require.NoneEquals(t, badPipeline, PipelineNames(t, aliceClient))
 
 	// alice adds bob as a reader of the input repo
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
@@ -497,20 +495,20 @@ func TestCreatePipeline(t *testing.T) {
 	// now bob can create a pipeline
 	goodPipeline := uniqueString("bob-good")
 	require.NoError(t, createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   goodPipeline,
 		repo:   dataRepo,
 	}))
-	require.OneOfEquals(t, goodPipeline, PipelineNames(t, alice))
-	require.Equal(t, acl("bob", "owner"), GetACL(t, bob, goodPipeline)) // check that bob owns the output repo too
+	require.OneOfEquals(t, goodPipeline, PipelineNames(t, aliceClient))
+	require.Equal(t, acl(bob, "owner"), GetACL(t, bobClient, goodPipeline)) // check that bob owns the output repo too
 
 	// Make sure bob's pipeline runs successfully
-	commit, err = alice.StartCommit(dataRepo, "master")
-	_, err = alice.PutFile(dataRepo, commit.ID, uniqueString("/file"),
+	commit, err = aliceClient.StartCommit(dataRepo, "master")
+	_, err = aliceClient.PutFile(dataRepo, commit.ID, uniqueString("/file"),
 		strings.NewReader("test data"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(dataRepo, commit.ID))
-	iter, err = bob.FlushCommit(
+	require.NoError(t, aliceClient.FinishCommit(dataRepo, commit.ID))
+	iter, err = bobClient.FlushCommit(
 		[]*pfs.Commit{commit},
 		[]*pfs.Repo{{Name: goodPipeline}},
 	)
@@ -519,54 +517,55 @@ func TestCreatePipeline(t *testing.T) {
 	require.NoError(t, err)
 
 	// bob can't update alice's pipeline
-	infoBefore, err := alice.InspectPipeline(pipelineName)
+	infoBefore, err := aliceClient.InspectPipeline(pipelineName)
 	require.NoError(t, err)
-	err = createPipeline(createArgs{client: bob,
+	err = createPipeline(createArgs{
+		client: bobClient,
 		name:   pipelineName,
 		repo:   dataRepo,
 		update: true,
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	infoAfter, err := alice.InspectPipeline(pipelineName)
+	infoAfter, err := aliceClient.InspectPipeline(pipelineName)
 	require.NoError(t, err)
 	require.Equal(t, infoBefore.Version, infoAfter.Version)
 
 	// alice adds bob as a writer of the output repo
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     pipelineName,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_WRITER,
 	})
 	require.NoError(t, err)
 
 	// now bob can update alice's pipeline
-	infoBefore, err = alice.InspectPipeline(pipelineName)
+	infoBefore, err = aliceClient.InspectPipeline(pipelineName)
 	require.NoError(t, err)
-	err = createPipeline(createArgs{client: bob,
+	err = createPipeline(createArgs{
+		client: bobClient,
 		name:   pipelineName,
 		repo:   dataRepo,
 		update: true,
 	})
 	require.NoError(t, err)
-	infoAfter, err = alice.InspectPipeline(pipelineName)
+	infoAfter, err = aliceClient.InspectPipeline(pipelineName)
 	require.NoError(t, err)
 	require.NotEqual(t, infoBefore.Version, infoAfter.Version)
 
 	// Make sure the updated pipeline runs successfully
-	commit, err = alice.StartCommit(dataRepo, "master")
-	_, err = alice.PutFile(dataRepo, commit.ID, uniqueString("/file"),
+	commit, err = aliceClient.StartCommit(dataRepo, "master")
+	_, err = aliceClient.PutFile(dataRepo, commit.ID, uniqueString("/file"),
 		strings.NewReader("test data"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(dataRepo, commit.ID))
-	iter, err = bob.FlushCommit(
+	require.NoError(t, aliceClient.FinishCommit(dataRepo, commit.ID))
+	iter, err = bobClient.FlushCommit(
 		[]*pfs.Commit{commit},
 		[]*pfs.Repo{{Name: pipelineName}},
 	)
 	require.NoError(t, err)
 	_, err = iter.Next()
 	require.NoError(t, err)
-
 }
 
 func TestPipelineMultipleInputs(t *testing.T) {
@@ -592,47 +591,47 @@ func TestPipelineMultipleInputs(t *testing.T) {
 			args.update,
 		)
 	}
-	alice := getPachClient(t, "alice")
-	bob := getPachClient(t, "bob")
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create two repos, and check that alice is the owner of the new repos
 	dataRepo1 := uniqueString("TestPipelineMultipleInputs")
 	dataRepo2 := uniqueString("TestPipelineMultipleInputs")
-	require.NoError(t, alice.CreateRepo(dataRepo1))
-	require.NoError(t, alice.CreateRepo(dataRepo2))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo1))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, dataRepo2))
+	require.NoError(t, aliceClient.CreateRepo(dataRepo1))
+	require.NoError(t, aliceClient.CreateRepo(dataRepo2))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo1))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, dataRepo2))
 
 	// alice can create a cross-pipeline with both inputs
 	aliceCrossPipeline := uniqueString("alice-pipeline-cross")
 	require.NoError(t, createPipeline(createArgs{
-		client: alice,
+		client: aliceClient,
 		name:   aliceCrossPipeline,
 		input: client.NewCrossInput(
 			client.NewAtomInput(dataRepo1, "/*"),
 			client.NewAtomInput(dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, aliceCrossPipeline, PipelineNames(t, alice))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, aliceCrossPipeline)) // check that alice owns the output repo too
+	require.OneOfEquals(t, aliceCrossPipeline, PipelineNames(t, aliceClient))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, aliceCrossPipeline)) // check that alice owns the output repo too
 
 	// alice can create a union-pipeline with both inputs
 	aliceUnionPipeline := uniqueString("alice-pipeline-union")
 	require.NoError(t, createPipeline(createArgs{
-		client: alice,
+		client: aliceClient,
 		name:   aliceUnionPipeline,
 		input: client.NewUnionInput(
 			client.NewAtomInput(dataRepo1, "/*"),
 			client.NewAtomInput(dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, aliceUnionPipeline, PipelineNames(t, alice))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, aliceUnionPipeline)) // check that alice owns the output repo too
+	require.OneOfEquals(t, aliceUnionPipeline, PipelineNames(t, aliceClient))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, aliceUnionPipeline)) // check that alice owns the output repo too
 
 	// alice adds bob as a reader of one of the input repos, but not the other
-	_, err := alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err := aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo1,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
@@ -640,7 +639,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	// bob cannot create a cross-pipeline with both inputs
 	bobCrossPipeline := uniqueString("bob-pipeline-cross")
 	err = createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   bobCrossPipeline,
 		input: client.NewCrossInput(
 			client.NewAtomInput(dataRepo1, "/*"),
@@ -649,12 +648,12 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.NoneEquals(t, bobCrossPipeline, PipelineNames(t, alice))
+	require.NoneEquals(t, bobCrossPipeline, PipelineNames(t, aliceClient))
 
 	// bob cannot create a union-pipeline with both inputs
 	bobUnionPipeline := uniqueString("bob-pipeline-union")
 	err = createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   bobUnionPipeline,
 		input: client.NewUnionInput(
 			client.NewAtomInput(dataRepo1, "/*"),
@@ -663,20 +662,20 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.NoneEquals(t, bobUnionPipeline, PipelineNames(t, alice))
+	require.NoneEquals(t, bobUnionPipeline, PipelineNames(t, aliceClient))
 
 	// alice adds bob as a writer of her pipeline's output
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     aliceCrossPipeline,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_WRITER,
 	})
 	require.NoError(t, err)
 
 	// bob can update alice's pipeline if he removes one of the inputs
-	infoBefore, err := alice.InspectPipeline(aliceCrossPipeline)
+	infoBefore, err := aliceClient.InspectPipeline(aliceCrossPipeline)
 	require.NoError(t, createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   aliceCrossPipeline,
 		input: client.NewCrossInput(
 			// This cross input deliberately only has one element, to make sure it's
@@ -685,14 +684,14 @@ func TestPipelineMultipleInputs(t *testing.T) {
 		),
 		update: true,
 	}))
-	infoAfter, err := alice.InspectPipeline(aliceCrossPipeline)
+	infoAfter, err := aliceClient.InspectPipeline(aliceCrossPipeline)
 	require.NoError(t, err)
 	require.NotEqual(t, infoBefore.Version, infoAfter.Version)
 
 	// bob cannot update alice's to put the second input back
-	infoBefore, err = alice.InspectPipeline(aliceCrossPipeline)
+	infoBefore, err = aliceClient.InspectPipeline(aliceCrossPipeline)
 	err = createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   aliceCrossPipeline,
 		input: client.NewCrossInput(
 			client.NewAtomInput(dataRepo1, "/*"),
@@ -702,22 +701,22 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	infoAfter, err = alice.InspectPipeline(aliceCrossPipeline)
+	infoAfter, err = aliceClient.InspectPipeline(aliceCrossPipeline)
 	require.NoError(t, err)
 	require.Equal(t, infoBefore.Version, infoAfter.Version)
 
 	// alice adds bob as a reader of the second input
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     dataRepo2,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
 
 	// bob can now update alice's to put the second input back
-	infoBefore, err = alice.InspectPipeline(aliceCrossPipeline)
+	infoBefore, err = aliceClient.InspectPipeline(aliceCrossPipeline)
 	require.NoError(t, createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   aliceCrossPipeline,
 		input: client.NewCrossInput(
 			client.NewAtomInput(dataRepo1, "/*"),
@@ -725,31 +724,31 @@ func TestPipelineMultipleInputs(t *testing.T) {
 		),
 		update: true,
 	}))
-	infoAfter, err = alice.InspectPipeline(aliceCrossPipeline)
+	infoAfter, err = aliceClient.InspectPipeline(aliceCrossPipeline)
 	require.NoError(t, err)
 	require.NotEqual(t, infoBefore.Version, infoAfter.Version)
 
 	// bob can create a cross-pipeline with both inputs
 	require.NoError(t, createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   bobCrossPipeline,
 		input: client.NewCrossInput(
 			client.NewAtomInput(dataRepo1, "/*"),
 			client.NewAtomInput(dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, bobCrossPipeline, PipelineNames(t, alice))
+	require.OneOfEquals(t, bobCrossPipeline, PipelineNames(t, aliceClient))
 
 	// bob can create a union-pipeline with both inputs
 	require.NoError(t, createPipeline(createArgs{
-		client: bob,
+		client: bobClient,
 		name:   bobUnionPipeline,
 		input: client.NewUnionInput(
 			client.NewAtomInput(dataRepo1, "/*"),
 			client.NewAtomInput(dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, bobUnionPipeline, PipelineNames(t, alice))
+	require.OneOfEquals(t, bobUnionPipeline, PipelineNames(t, aliceClient))
 
 }
 
@@ -758,24 +757,23 @@ func TestPipelineRevoke(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	alice := getPachClient(t, "alice")
-	alice.AddMetadata(context.Background())
-	bob := getPachClient(t, "bob")
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo, and adds bob as a reader
 	repo := uniqueString("TestPipelineRevoke")
-	require.NoError(t, alice.CreateRepo(repo))
-	_, err := alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	_, err := aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_READER,
 	})
 	require.NoError(t, err)
-	require.Equal(t, acl("alice", "owner", "bob", "reader"), GetACL(t, alice, repo))
+	require.Equal(t, acl(alice, "owner", bob, "reader"), GetACL(t, aliceClient, repo))
 
 	// bob creates a pipeline
 	pipeline := uniqueString("bob-pipeline")
-	require.NoError(t, bob.CreatePipeline(
+	require.NoError(t, bobClient.CreatePipeline(
 		pipeline,
 		"", // default image: ubuntu:14.04
 		[]string{"bash"},
@@ -785,15 +783,15 @@ func TestPipelineRevoke(t *testing.T) {
 		"", // default output branch: master
 		false,
 	))
-	require.Equal(t, acl("bob", "owner"), GetACL(t, bob, pipeline))
+	require.Equal(t, acl(bob, "owner"), GetACL(t, bobClient, pipeline))
 
 	// alice commits to the input repo, and the pipeline runs successfully
-	commit, err := alice.StartCommit(repo, "master")
+	commit, err := aliceClient.StartCommit(repo, "master")
 	require.NoError(t, err)
-	_, err = alice.PutFile(repo, commit.ID, "/file1", strings.NewReader("test"))
+	_, err = aliceClient.PutFile(repo, commit.ID, "/file1", strings.NewReader("test"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(repo, commit.ID))
-	iter, err := bob.FlushCommit(
+	require.NoError(t, aliceClient.FinishCommit(repo, commit.ID))
+	iter, err := bobClient.FlushCommit(
 		[]*pfs.Commit{commit},
 		[]*pfs.Repo{{Name: pipeline}},
 	)
@@ -802,24 +800,24 @@ func TestPipelineRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	// alice removes bob as a reader of her repo
-	_, err = alice.SetScope(alice.Ctx(), &auth.SetScopeRequest{
+	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repo,
-		Username: "bob",
+		Username: bob,
 		Scope:    auth.Scope_NONE,
 	})
 	require.NoError(t, err)
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, repo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
 
 	// alice commits to the input repo, and bob's pipeline does not run
-	commit, err = alice.StartCommit(repo, "master")
+	commit, err = aliceClient.StartCommit(repo, "master")
 	require.NoError(t, err)
-	_, err = alice.PutFile(repo, commit.ID, "/file1", strings.NewReader("test"))
+	_, err = aliceClient.PutFile(repo, commit.ID, "/file1", strings.NewReader("test"))
 	require.NoError(t, err)
-	require.NoError(t, alice.FinishCommit(repo, commit.ID))
+	require.NoError(t, aliceClient.FinishCommit(repo, commit.ID))
 
 	doneCh := make(chan struct{})
 	go func() {
-		iter, err = alice.FlushCommit(
+		iter, err = aliceClient.FlushCommit(
 			[]*pfs.Commit{commit},
 			[]*pfs.Repo{{Name: pipeline}},
 		)
@@ -835,14 +833,14 @@ func TestPipelineRevoke(t *testing.T) {
 	}
 
 	// alice updates bob's pipline, and now it runs
-	_, err = bob.SetScope(bob.Ctx(), &auth.SetScopeRequest{
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     pipeline,
-		Username: "alice",
+		Username: alice,
 		Scope:    auth.Scope_WRITER,
 	})
 	require.NoError(t, err)
-	require.Equal(t, acl("bob", "owner", "alice", "writer"), GetACL(t, bob, pipeline))
-	require.NoError(t, alice.CreatePipeline(
+	require.Equal(t, acl(bob, "owner", alice, "writer"), GetACL(t, bobClient, pipeline))
+	require.NoError(t, aliceClient.CreatePipeline(
 		pipeline,
 		"", // default image: ubuntu:14.04
 		[]string{"bash"},
@@ -854,7 +852,7 @@ func TestPipelineRevoke(t *testing.T) {
 	))
 
 	// Pipeline now finishes successfully
-	iter, err = alice.FlushCommit(
+	iter, err = aliceClient.FlushCommit(
 		[]*pfs.Commit{commit},
 		[]*pfs.Repo{{Name: pipeline}},
 	)
@@ -868,16 +866,17 @@ func TestDeletePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	alice := getPachClient(t, "alice")
+	alice := uniqueString("alice")
+	aliceClient := getPachClient(t, alice)
 
 	// alice creates a repo
 	repo := uniqueString("TestPipelineRevoke")
-	require.NoError(t, alice.CreateRepo(repo))
-	require.Equal(t, acl("alice", "owner"), GetACL(t, alice, repo))
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
 
 	// alice creates a pipeline
 	pipeline := uniqueString("alice-pipeline")
-	require.NoError(t, alice.CreatePipeline(
+	require.NoError(t, aliceClient.CreatePipeline(
 		pipeline,
 		"", // default image: ubuntu:14.04
 		[]string{"bash"},
@@ -889,23 +888,106 @@ func TestDeletePipeline(t *testing.T) {
 	))
 
 	// alice deletes the pipeline
-	require.NoError(t, alice.DeletePipeline(pipeline, true))
+	require.NoError(t, aliceClient.DeletePipeline(pipeline, true))
 
 	// alice deletes the output repo
-	require.NoError(t, alice.DeleteRepo(pipeline, false))
+	require.NoError(t, aliceClient.DeleteRepo(pipeline, false))
 
 	// Make sure the repo's ACL is gone
-	_, err := alice.AuthAPIClient.GetACL(alice.Ctx(), &auth.GetACLRequest{
+	_, err := aliceClient.AuthAPIClient.GetACL(aliceClient.Ctx(), &auth.GetACLRequest{
 		Repo: pipeline,
 	})
 	require.YesError(t, err)
 
 	// alice deletes the input repo
-	require.NoError(t, alice.DeleteRepo(repo, false))
+	require.NoError(t, aliceClient.DeleteRepo(repo, false))
 
 	// Make sure the repo's ACL is gone
-	_, err = alice.AuthAPIClient.GetACL(alice.Ctx(), &auth.GetACLRequest{
+	_, err = aliceClient.AuthAPIClient.GetACL(aliceClient.Ctx(), &auth.GetACLRequest{
 		Repo: repo,
 	})
+	require.YesError(t, err)
+}
+
+// TestAdmins tests adding and removing cluster admins. Note that cluster admins
+// are global, unlike pipelines and repos, so while this test can run in
+// parallel with other auth tests, it cannot run in parallel with other cluster
+// admin tests. If any are added, t.Parallel() should be removed here.
+func TestAdmin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	t.Parallel()
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	adminClient := getPachClient(t, "admin")
+
+	// The initial set of admins is just the user "admin"
+	resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, resp.Admins, []string{"admin"})
+
+	// alice creates a repo (that only she owns) and puts a file
+	repo := uniqueString("TestAdmin")
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
+	commit, err := aliceClient.StartCommit(repo, "master")
+	require.NoError(t, err)
+	_, err = aliceClient.PutFile(repo, commit.ID, "/file", strings.NewReader("test data"))
+	require.NoError(t, err)
+	require.NoError(t, aliceClient.FinishCommit(repo, commit.ID))
+
+	// bob cannot get the file
+	buf := &bytes.Buffer{}
+	err = bobClient.GetFile(repo, "master", "/file", 0, 0, buf)
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+
+	// 'admin' makes bob an admin
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Add: []string{bob}})
+	require.NoError(t, err)
+	// wait until bob shows up in admin list
+	require.NoError(t, backoff.Retry(func() error {
+		resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+		require.NoError(t, err)
+		if len(resp.Admins) != 2 {
+			return fmt.Errorf("admins are \"%v\", but expected [\"bob\", \"admin\"]", resp.Admins)
+		}
+		if resp.Admins[0] != bob && resp.Admins[1] != bob {
+			return fmt.Errorf("admins are \"%v\", but expected at least one to be \"%s\"", resp.Admins, bob)
+		}
+		return nil
+	}, backoff.NewTestingBackOff()))
+
+	// now bob can get the file
+	buf.Reset()
+	require.NoError(t, bobClient.GetFile(repo, "master", "/file", 0, 0, buf))
+	require.Matches(t, "test data", buf.String())
+
+	// 'admin' revokes bob's admin status
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Remove: []string{bob}})
+	require.NoError(t, err)
+	// wait until bob is not in admin list
+	backoff.Retry(func() error {
+		resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+		require.NoError(t, err)
+		if len(resp.Admins) != 1 || resp.Admins[0] != "admin" {
+			return fmt.Errorf("admins are \"%v\", but expected [\"admin\"]", resp.Admins)
+		}
+		return nil
+	}, backoff.NewTestingBackOff())
+
+	// bob can no longer get the file
+	buf.Reset()
+	err = bobClient.GetFile(repo, "master", "/file", 0, 0, buf)
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+
+	// admin cannot remove themselves from the list of cluster admins (otherwise
+	// there would be no admins)
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Remove: []string{"admin"}})
 	require.YesError(t, err)
 }

--- a/src/server/auth/testing/auth.go
+++ b/src/server/auth/testing/auth.go
@@ -17,6 +17,16 @@ func (a *InactiveAPIServer) Activate(ctx context.Context, req *auth.ActivateRequ
 	return nil, auth.NotActivatedError{}
 }
 
+// GetAdmins implements the Pachdyerm Auth GetAdmins RPC, but just returns NotActivatedError
+func (a *InactiveAPIServer) GetAdmins(ctx context.Context, req *auth.GetAdminsRequest) (resp *auth.GetAdminsResponse, retErr error) {
+	return nil, auth.NotActivatedError{}
+}
+
+// ModifyAdmins implements the Pachdyerm Auth ModifyAdmins RPC, but just returns NotActivatedError
+func (a *InactiveAPIServer) ModifyAdmins(ctx context.Context, req *auth.ModifyAdminsRequest) (resp *auth.ModifyAdminsResponse, retErr error) {
+	return nil, auth.NotActivatedError{}
+}
+
 // Authenticate implements the Pachdyerm Auth Authenticate RPC, but just returns NotActivatedError
 func (a *InactiveAPIServer) Authenticate(ctx context.Context, req *auth.AuthenticateRequest) (resp *auth.AuthenticateResponse, retErr error) {
 	return nil, auth.NotActivatedError{}

--- a/src/server/pkg/collection/collection.go
+++ b/src/server/pkg/collection/collection.go
@@ -80,7 +80,7 @@ func (c *collection) indexDir(index Index, indexVal string) string {
 	indexDir := c.prefix
 	// remove trailing slash
 	indexDir = strings.TrimRight(indexDir, "/")
-	return fmt.Sprintf("%s__index_%s/%s", indexDir, index, indexVal)
+	return fmt.Sprintf("%s__index_%s/%v", indexDir, index, indexVal)
 }
 
 // See the documentation for `Index` for details.

--- a/src/server/pkg/collection/collection.go
+++ b/src/server/pkg/collection/collection.go
@@ -80,7 +80,7 @@ func (c *collection) indexDir(index Index, indexVal string) string {
 	indexDir := c.prefix
 	// remove trailing slash
 	indexDir = strings.TrimRight(indexDir, "/")
-	return fmt.Sprintf("%s__index_%s/%v", indexDir, index, indexVal)
+	return fmt.Sprintf("%s__index_%s/%s", indexDir, index, indexVal)
 }
 
 // See the documentation for `Index` for details.


### PR DESCRIPTION
The main change I made in this PR (besides adding ListAdmins and ModifyAdmins) is that auth.User no longer has an "Admin" field.

The reason is that if I'd kept it, then when U was removed as an admin, we'd need to update all of that user's tokens. That would mean building a secondary index for auth tokens keyed by username, and then when U's admin status was revoked, iterating through that user's tokens and updating them.

Unfortunately the etcd API doesn't allow you do call List() inside a transaction, which means there's no way to update all of a user's tokens transactionally. Rather than trying to update a user's tokens outside a transaction, and risking leaving a user's tokens unchanged (which would effectively give them unrevokable admin status until their token expires) I just took the "Admin" field out of user.

This means that a user's admin status is only stored in one place—the admin collection. To minimize read traffic to this collection, each pachd server keeps a local cache of the admin collection.