### PR TITLE
Update HTTP getfile handler to pass along metadata

### DIFF
--- a/src/server/pfs/server/http.go
+++ b/src/server/pfs/server/http.go
@@ -67,11 +67,8 @@ func (s *HTTPServer) getFileHandler(w http.ResponseWriter, r *http.Request, ps h
 		if cookie.Name == auth.ContextTokenKey {
 			ctx = metadata.NewIncomingContext(
 				ctx,
-				metadata.New(
-					map[string]string{
-						auth.ContextTokenKey: cookie.Value,
-					},
-				))
+				metadata.Pairs(auth.ContextTokenKey, cookie.Value),
+			)
 		}
 	}
 


### PR DESCRIPTION
When testing:

```
$curl http://localhost:30652/v1/pfs/repos/test/commits/4cc12ebb8bd24a2d8909ce93878ab7c3/files/Makefile -H "Cookie: authn-token=abbazabbadoo"
```

I see (from some added instrumentation in auth.In2Out) the incoming context specified appropriately:

```
incoming context: context.Background.WithValue(metadata.mdIncomingKey{}, metadata.MD{"authn-token":[]string{"abbazabbadoo"}})
```