### PR TITLE
Bump grpc-proxy docker image version

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -34,7 +34,7 @@ var (
 	dashName                = "dash"
 	dashImage               = "pachyderm/dash"
 	grpcProxyName           = "grpc-proxy"
-	grpcProxyImage          = "pachyderm/grpc-proxy:0.3.1"
+	grpcProxyImage          = "pachyderm/grpc-proxy:0.4.0"
 	pachdName               = "pachd"
 	minioSecretName         = "minio-secret"
 	amazonSecretName        = "amazon-secret"


### PR DESCRIPTION
Adds support for GRPC metadata side channel

I think the only thing to verify is that the image exists here: https://hub.docker.com/r/pachyderm/grpc-proxy/tags/

(it does :P)