### PR TITLE
Address DeletePipeline and Admin issues in auth (and add tests)

### DIFF
--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -43,18 +43,26 @@ func IsNotActivatedError(e error) bool {
 // NotAuthorizedError is returned if the user is not authorized to perform
 // a certain operation on a given repo.
 type NotAuthorizedError struct {
-	Repo string
+	Repo     string
+	Required Scope
 }
 
-const notAuthorizedErrorMsg = "not authorized to perform this operation on the repo "
+const notAuthorizedErrorMsg = "not authorized to perform this operation"
 
-func (e NotAuthorizedError) Error() string {
-	return notAuthorizedErrorMsg + e.Repo
+func (e *NotAuthorizedError) Error() string {
+	msg := notAuthorizedErrorMsg
+	if e.Repo != "" {
+		msg += " on the repo " + e.Repo
+	}
+	if e.Required != Scope_NONE {
+		msg += ", must have at least " + e.Required.String() + " access"
+	}
+	return msg
 }
 
 // IsNotAuthorizedError checks if an error is a NotAuthorizedError
 func IsNotAuthorizedError(e error) bool {
-	return strings.Contains(e.Error(), notAuthorizedErrorMsg)
+	return strings.HasPrefix(e.Error(), notAuthorizedErrorMsg)
 }
 
 // In2Out converts an incoming context containing auth information into an

--- a/src/client/pkg/require/require.go
+++ b/src/client/pkg/require/require.go
@@ -103,63 +103,6 @@ func NoneEquals(tb testing.TB, expected interface{}, actuals interface{}, msgAnd
 	}
 }
 
-// ElementsEqual checks whether the elements of the slice "expecteds" are
-// exactly the elements of the slice "actuals", ignoring order (i.e.
-// setwise-equal)
-func ElementsEqual(tb testing.TB, expecteds interface{}, actuals interface{}, msgAndArgs ...interface{}) {
-	if equal := func() bool {
-		es := reflect.ValueOf(expecteds)
-		as := reflect.ValueOf(actuals)
-		if es.Kind() != reflect.Slice {
-			fatal(tb, msgAndArgs, "ElementsEqual must be called with a slice, but \"expected\" was %s", es.Type().String())
-			return false
-		}
-		if as.Kind() != reflect.Slice {
-			fatal(tb, msgAndArgs, "ElementsEqual must be called with a slice, but \"actual\" was %s", as.Type().String())
-			return false
-		}
-		if es.Type().Elem() != as.Type().Elem() {
-			return false
-		}
-		expectedCt := reflect.MakeMap(reflect.MapOf(es.Type().Elem(), reflect.TypeOf(int(0))))
-		actualCt := reflect.MakeMap(reflect.MapOf(as.Type().Elem(), reflect.TypeOf(int(0))))
-		for i := 0; i < es.Len(); i++ {
-			v := es.Index(i)
-			if !expectedCt.MapIndex(v).IsValid() {
-				expectedCt.SetMapIndex(v, reflect.ValueOf(1))
-			} else {
-				newCt := expectedCt.MapIndex(v).Int() + 1
-				expectedCt.SetMapIndex(v, reflect.ValueOf(newCt))
-			}
-		}
-		for i := 0; i < as.Len(); i++ {
-			v := as.Index(i)
-			if !actualCt.MapIndex(v).IsValid() {
-				actualCt.SetMapIndex(v, reflect.ValueOf(1))
-			} else {
-				newCt := actualCt.MapIndex(v).Int() + 1
-				actualCt.SetMapIndex(v, reflect.ValueOf(newCt))
-			}
-		}
-		if expectedCt.Len() != actualCt.Len() {
-			return false
-		}
-		for _, key := range expectedCt.MapKeys() {
-			ec := expectedCt.MapIndex(key)
-			ac := actualCt.MapIndex(key)
-			if !ec.IsValid() || !ac.IsValid() ||
-				!reflect.DeepEqual(ec.Interface(), ac.Interface()) {
-				return false
-			}
-		}
-		return true
-	}(); !equal {
-		fatal(tb, msgAndArgs,
-			"Not equal: %#v (expecteds)\n"+
-				"      != %#v (actual)", expecteds, actuals)
-	}
-}
-
 // NoError checks for no error.
 func NoError(tb testing.TB, err error, msgAndArgs ...interface{}) {
 	if err != nil {

--- a/src/server/auth/server/admin_test.go
+++ b/src/server/auth/server/admin_test.go
@@ -1,0 +1,238 @@
+// admin_test.go tests various features related to pachyderm's auth admins.
+// Because the cluster has one global set of admins, these tests can't be run in
+// parallel
+
+package auth
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/auth"
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+)
+
+// TestAdmins tests adding and removing cluster admins, as well as admins
+// reading, writing, and moderating clusters.
+func TestAdmin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	alice, bob := uniqueString("alice"), uniqueString("bob")
+	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	adminClient := getPachClient(t, "admin")
+
+	// The initial set of admins is just the user "admin"
+	resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, len(resp.Admins), 1)
+	require.Equal(t, resp.Admins[0], "admin")
+
+	// alice creates a repo (that only she owns) and puts a file
+	repo := uniqueString("TestAdmin")
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
+	commit, err := aliceClient.StartCommit(repo, "master")
+	require.NoError(t, err)
+	_, err = aliceClient.PutFile(repo, commit.ID, "/file", strings.NewReader("test data"))
+	require.NoError(t, err)
+	require.NoError(t, aliceClient.FinishCommit(repo, commit.ID))
+
+	// bob cannot read from the repo
+	buf := &bytes.Buffer{}
+	err = bobClient.GetFile(repo, "master", "/file", 0, 0, buf)
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+
+	// bob cannot write to the repo
+	_, err = bobClient.StartCommit(repo, "master")
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+	require.Equal(t, 1, CommitCnt(t, aliceClient, repo)) // check that no commits were created
+
+	// bob can't update the ACL
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
+		Repo:     repo,
+		Username: "carol",
+		Scope:    auth.Scope_READER,
+	})
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo)) // check that ACL wasn't updated
+
+	// 'admin' makes bob an admin
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Add: []string{bob}})
+	require.NoError(t, err)
+
+	// wait until bob shows up in admin list
+	require.NoError(t, backoff.Retry(func() error {
+		resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+		require.NoError(t, err)
+		if len(resp.Admins) != 2 {
+			return fmt.Errorf("admins are \"%v\", but expected [\"bob\", \"admin\"]", resp.Admins)
+		}
+		if resp.Admins[0] != bob && resp.Admins[1] != bob {
+			return fmt.Errorf("admins are \"%v\", but expected at least one to be \"%s\"", resp.Admins, bob)
+		}
+		return nil
+	}, backoff.NewTestingBackOff()))
+
+	// now bob can read from the repo
+	buf.Reset()
+	require.NoError(t, bobClient.GetFile(repo, "master", "/file", 0, 0, buf))
+	require.Matches(t, "test data", buf.String())
+
+	// bob can write to the repo
+	commit, err = bobClient.StartCommit(repo, "master")
+	require.NoError(t, err)
+	require.NoError(t, bobClient.FinishCommit(repo, commit.ID))
+	require.Equal(t, 2, CommitCnt(t, aliceClient, repo)) // check that a new commit was created
+
+	// bob can update the repo's ACL
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
+		Repo:     repo,
+		Username: "carol",
+		Scope:    auth.Scope_READER,
+	})
+	require.NoError(t, err)
+	require.Equal(t, acl(alice, "owner", "carol", "reader"),
+		GetACL(t, aliceClient, repo)) // check that ACL was updated
+
+	// 'admin' revokes bob's admin status
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Remove: []string{bob}})
+	require.NoError(t, err)
+
+	// wait until bob is not in admin list
+	backoff.Retry(func() error {
+		resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+		require.NoError(t, err)
+		if len(resp.Admins) != 1 || resp.Admins[0] != "admin" {
+			return fmt.Errorf("admins are \"%v\", but expected [\"admin\"]", resp.Admins)
+		}
+		return nil
+	}, backoff.NewTestingBackOff())
+
+	// bob can no longer read from the repo
+	buf.Reset()
+	err = bobClient.GetFile(repo, "master", "/file", 0, 0, buf)
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+
+	// bob cannot write to the repo
+	_, err = bobClient.StartCommit(repo, "master")
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+	require.Equal(t, 2, CommitCnt(t, aliceClient, repo)) // check that no commits were created
+
+	// bob can't update the ACL
+	_, err = bobClient.SetScope(bobClient.Ctx(), &auth.SetScopeRequest{
+		Repo:     repo,
+		Username: "carol",
+		Scope:    auth.Scope_WRITER,
+	})
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+	require.Equal(t, acl(alice, "owner", "carol", "reader"),
+		GetACL(t, aliceClient, repo)) // check that ACL wasn't updated
+}
+
+func TestAdminFixBrokenRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	alice := uniqueString("alice")
+	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, "admin")
+
+	// alice creates a repo (that only she owns) and puts a file
+	repo := uniqueString("TestAdmin")
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
+
+	// admin deletes the repo's ACL
+	_, err := adminClient.AuthAPIClient.SetACL(adminClient.Ctx(),
+		&auth.SetACLRequest{
+			Repo:   repo,
+			NewACL: &auth.ACL{},
+		})
+	require.NoError(t, err)
+
+	// Check that the ACL is empty
+	require.Equal(t, acl(), GetACL(t, adminClient, repo))
+
+	// admin can update the ACL to put Alice back, even though reading the ACL
+	// will fail
+	_, err = adminClient.SetACL(adminClient.Ctx(),
+		&auth.SetACLRequest{
+			Repo: repo,
+			NewACL: &auth.ACL{
+				Entries: map[string]auth.Scope{alice: auth.Scope_OWNER},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
+}
+
+func TestCannotRemoveAllClusterAdmins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	alice := uniqueString("alice")
+	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, "admin")
+
+	// Check that the initial set of admins is just "admin"
+	resp, err := adminClient.GetAdmins(adminClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, []string{"admin"}, resp.Admins)
+
+	// admin cannot remove themselves from the list of cluster admins (otherwise
+	// there would be no admins)
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Remove: []string{"admin"}})
+	require.YesError(t, err)
+	resp, err = adminClient.GetAdmins(adminClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, []string{"admin"}, resp.Admins)
+
+	// admin can make alice a cluster administrator
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{
+			Add: []string{alice},
+		})
+	require.NoError(t, err)
+	resp, err = adminClient.GetAdmins(adminClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, []string{"admin", alice}, resp.Admins)
+
+	// Now admin can remove themselves as a cluster admin
+	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
+		&auth.ModifyAdminsRequest{Remove: []string{"admin"}})
+	require.NoError(t, err)
+	resp, err = adminClient.GetAdmins(adminClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, []string{alice}, resp.Admins)
+
+	// now alice cannot remove herself as a cluster administrator
+	_, err = aliceClient.ModifyAdmins(aliceClient.Ctx(),
+		&auth.ModifyAdminsRequest{Remove: []string{alice}})
+	require.YesError(t, err)
+	resp, err = aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, []string{alice}, resp.Admins)
+
+	// alice can make admin the cluster administrator again (swapping herself and
+	// admin)
+	_, err = aliceClient.ModifyAdmins(aliceClient.Ctx(),
+		&auth.ModifyAdminsRequest{
+			Add:    []string{"admin"},
+			Remove: []string{alice},
+		})
+	require.NoError(t, err)
+	resp, err = adminClient.GetAdmins(adminClient.Ctx(), &auth.GetAdminsRequest{})
+	require.NoError(t, err)
+	require.ElementsEqual(t, []string{"admin"}, resp.Admins)
+}

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -100,6 +100,9 @@ func acl(items ...string) *auth.ACL {
 	if len(items)%2 != 0 {
 		panic("cannot create an ACL from an odd number of items")
 	}
+	if len(items) == 0 {
+		return &auth.ACL{}
+	}
 	result := &auth.ACL{Entries: make(map[string]auth.Scope)}
 	for i := 0; i < len(items); i += 2 {
 		scope, err := auth.ParseScope(items[i+1])
@@ -992,88 +995,4 @@ func TestDeletePipeline(t *testing.T) {
 
 	// finally bob can delete alice's pipeline
 	require.NoError(t, bobClient.DeletePipeline(pipeline, true))
-}
-
-// TestAdmins tests adding and removing cluster admins. Note that cluster admins
-// are global, unlike pipelines and repos, so while this test can run in
-// parallel with other auth tests, it cannot run in parallel with other cluster
-// admin tests. If any are added, t.Parallel() should be removed here.
-func TestAdmin(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
-	t.Parallel()
-	alice, bob := uniqueString("alice"), uniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
-	adminClient := getPachClient(t, "admin")
-
-	// The initial set of admins is just the user "admin"
-	resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
-	require.NoError(t, err)
-	require.Equal(t, len(resp.Admins), 1)
-	require.Equal(t, resp.Admins[0], "admin")
-
-	// alice creates a repo (that only she owns) and puts a file
-	repo := uniqueString("TestAdmin")
-	require.NoError(t, aliceClient.CreateRepo(repo))
-	require.Equal(t, acl(alice, "owner"), GetACL(t, aliceClient, repo))
-	commit, err := aliceClient.StartCommit(repo, "master")
-	require.NoError(t, err)
-	_, err = aliceClient.PutFile(repo, commit.ID, "/file", strings.NewReader("test data"))
-	require.NoError(t, err)
-	require.NoError(t, aliceClient.FinishCommit(repo, commit.ID))
-
-	// bob cannot get the file
-	buf := &bytes.Buffer{}
-	err = bobClient.GetFile(repo, "master", "/file", 0, 0, buf)
-	require.YesError(t, err)
-	require.Matches(t, "not authorized", err.Error())
-
-	// 'admin' makes bob an admin
-	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
-		&auth.ModifyAdminsRequest{Add: []string{bob}})
-	require.NoError(t, err)
-	// wait until bob shows up in admin list
-	require.NoError(t, backoff.Retry(func() error {
-		resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
-		require.NoError(t, err)
-		if len(resp.Admins) != 2 {
-			return fmt.Errorf("admins are \"%v\", but expected [\"bob\", \"admin\"]", resp.Admins)
-		}
-		if resp.Admins[0] != bob && resp.Admins[1] != bob {
-			return fmt.Errorf("admins are \"%v\", but expected at least one to be \"%s\"", resp.Admins, bob)
-		}
-		return nil
-	}, backoff.NewTestingBackOff()))
-
-	// now bob can get the file
-	buf.Reset()
-	require.NoError(t, bobClient.GetFile(repo, "master", "/file", 0, 0, buf))
-	require.Matches(t, "test data", buf.String())
-
-	// 'admin' revokes bob's admin status
-	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
-		&auth.ModifyAdminsRequest{Remove: []string{bob}})
-	require.NoError(t, err)
-	// wait until bob is not in admin list
-	backoff.Retry(func() error {
-		resp, err := aliceClient.GetAdmins(aliceClient.Ctx(), &auth.GetAdminsRequest{})
-		require.NoError(t, err)
-		if len(resp.Admins) != 1 || resp.Admins[0] != "admin" {
-			return fmt.Errorf("admins are \"%v\", but expected [\"admin\"]", resp.Admins)
-		}
-		return nil
-	}, backoff.NewTestingBackOff())
-
-	// bob can no longer get the file
-	buf.Reset()
-	err = bobClient.GetFile(repo, "master", "/file", 0, 0, buf)
-	require.YesError(t, err)
-	require.Matches(t, "not authorized", err.Error())
-
-	// admin cannot remove themselves from the list of cluster admins (otherwise
-	// there would be no admins)
-	_, err = adminClient.ModifyAdmins(adminClient.Ctx(),
-		&auth.ModifyAdminsRequest{Remove: []string{"admin"}})
-	require.YesError(t, err)
 }

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -186,7 +186,7 @@ func (d *driver) checkIsAuthorized(ctx context.Context, r *pfs.Repo, s auth.Scop
 		Scope: s,
 	})
 	if err == nil && !resp.Authorized {
-		return auth.NotAuthorizedError{r.Name}
+		return &auth.NotAuthorizedError{Repo: r.Name, Required: s}
 	} else if err != nil && !auth.IsNotActivatedError(err) {
 		return fmt.Errorf("error during authorization check for operation on %s: %s", r.Name, err.Error())
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1019,11 +1019,25 @@ func translatePipelineInputs(inputs []*pps.PipelineInput) *pps.Input {
 	return result
 }
 
-// AuthorizeCreatePipelineRequest checks if the user indicated by 'ctx' is authorized to create or update
-// the pipeline in 'request'
-func (a *apiServer) AuthorizeCreatePipeline(ctx context.Context, authClient auth.APIClient, update bool, info *pps.PipelineInfo) error {
-	_, err := authClient.WhoAmI(auth.In2Out(ctx), &auth.WhoAmIRequest{})
+// authorizing a pipeline modification varies slightly depending on whether the
+// pipeline is being created, updated, or deleted
+type pipelineModification uint8
+
+const (
+	pipelineCreate pipelineModification = iota
+	pipelineUpdate
+	pipelineDelete
+)
+
+// authorizeModifyPipeline checks if the user indicated by 'ctx' is authorized
+// to perform 'modification' on the pipeline in 'info'
+func (a *apiServer) authorizeModifyPipeline(ctx context.Context, modification pipelineModification, info *pps.PipelineInfo) error {
+	pachClient, err := a.getPachClient()
 	if err != nil {
+		return err
+	}
+	authClient := pachClient.AuthAPIClient
+	if _, err = authClient.WhoAmI(auth.In2Out(ctx), &auth.WhoAmIRequest{}); err != nil {
 		if auth.IsNotActivatedError(err) {
 			// TODO(msteffen): Think about how auth will degrade if auth is activated
 			// then deactivated. This is potentially insecure.
@@ -1037,7 +1051,7 @@ func (a *apiServer) AuthorizeCreatePipeline(ctx context.Context, authClient auth
 	// behalf)
 	// collect inputs by bfs info.Input (info.Inputs is no longer set)
 	if len(info.Inputs) > 0 {
-		return fmt.Errorf("cannot authorize PipelineInfo with 'Inputs' set")
+		return fmt.Errorf("cannot authorize using PipelineInfo with 'Inputs' field set")
 	}
 	inputRepos := make(map[string]struct{})
 	queue := []*pps.Input{info.Input}
@@ -1069,7 +1083,8 @@ func (a *apiServer) AuthorizeCreatePipeline(ctx context.Context, authClient auth
 				return err
 			}
 			if !resp.Authorized {
-				return fmt.Errorf("user is not authorized to read from input %s", inputRepo)
+				return fmt.Errorf("not authorized to perform this operation: "+
+					"insufficient access to the repo \"%s\"", inputRepo)
 			}
 			return nil
 		})
@@ -1078,13 +1093,25 @@ func (a *apiServer) AuthorizeCreatePipeline(ctx context.Context, authClient auth
 		return err
 	}
 
+	var req *auth.AuthorizeRequest
+	if modification == pipelineDelete {
+		// To delete a pipeline, you must own the output repo
+		req = &auth.AuthorizeRequest{
+			Repo:  info.Pipeline.Name,
+			Scope: auth.Scope_OWNER,
+		}
+	} else {
+		// Otherwise, you just need to be a writer of the output repo
+		req = &auth.AuthorizeRequest{
+			Repo:  info.Pipeline.Name,
+			Scope: auth.Scope_WRITER,
+		}
+	}
+
 	// Check that the user is authorized to write to the output repo
-	resp, err := authClient.Authorize(auth.In2Out(ctx), &auth.AuthorizeRequest{
-		Repo:  info.Pipeline.Name,
-		Scope: auth.Scope_WRITER,
-	})
+	resp, err := authClient.Authorize(auth.In2Out(ctx), req)
 	if err != nil {
-		if !update && strings.HasSuffix(
+		if modification == pipelineCreate && strings.HasSuffix(
 			err.Error(),
 			fmt.Sprintf("ACL not found for repo %s", info.Pipeline.Name)) {
 			// Output repo doesn't exist yet. It will be created
@@ -1096,7 +1123,8 @@ func (a *apiServer) AuthorizeCreatePipeline(ctx context.Context, authClient auth
 		return err
 	}
 	if !resp.Authorized {
-		return fmt.Errorf("user is not authorized to write to output repo %s", info.Pipeline.Name)
+		return fmt.Errorf("not authorized to perform this operation: "+
+			"insufficient access to the repo \"%s\"", info.Pipeline.Name)
 	}
 	return nil
 }
@@ -1158,7 +1186,11 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	if err != nil {
 		return nil, fmt.Errorf("error dialing auth client: %v", authClient)
 	}
-	if err := a.AuthorizeCreatePipeline(ctx, authClient, request.Update, pipelineInfo); err != nil {
+	modification := pipelineCreate
+	if request.Update {
+		modification = pipelineUpdate
+	}
+	if err := a.authorizeModifyPipeline(ctx, modification, pipelineInfo); err != nil {
 		return nil, err
 	}
 	capabilityResp, err := authClient.GetCapability(auth.In2Out(ctx), &auth.GetCapabilityRequest{})
@@ -1427,6 +1459,10 @@ func (a *apiServer) deletePipeline(ctx context.Context, request *pps.DeletePipel
 	pipelineInfo, err := a.InspectPipeline(ctx, &pps.InspectPipelineRequest{request.Pipeline})
 	if err != nil {
 		return nil, fmt.Errorf("pipeline %v was not found: %v", request.Pipeline.Name, err)
+	}
+	// Check if the caller is authorized to delete this pipeline
+	if err := a.authorizeModifyPipeline(ctx, pipelineDelete, pipelineInfo); err != nil {
+		return nil, err
 	}
 	// Revoke the pipeline's capability
 	if pipelineInfo.Capability != "" {


### PR DESCRIPTION
* Previously, DeletePipeline() didn't perform any auth checks. Now, you must be a READER of all of a pipeline's input repos, and an OWNER of its output repo, to delete the pipeline (slightly more access than is required to update the pipeline)
* Put auth admin tests into their own `admin_test.go` file, since they can't be run in parallel, and add some tests to make sure admins can fix broken repos, and that there's always at least one admin in the cluster (which wasn't previously enforced)