### PR TITLE
Fix an issue where paused pipelines are automatically restarted

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -58,6 +58,7 @@ const (
 
 var (
 	trueVal = true
+	zeroVal = int64(0)
 	suite   = "pachyderm"
 )
 

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -134,7 +134,7 @@ func (a *apiServer) master() {
 }
 
 func (a *apiServer) setPipelineFailure(ctx context.Context, pipelineInfo *pps.PipelineInfo) error {
-	// Set pipeline state to running
+	// Set pipeline state to failure
 	_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 		pipelineName := pipelineInfo.Pipeline.Name
 		pipelines := a.pipelines.ReadWrite(stm)

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -108,9 +108,10 @@ func (a *apiServer) workerPodSpec(options *workerOptions) api.PodSpec {
 				VolumeMounts:    sidecarVolumeMounts,
 			},
 		},
-		RestartPolicy:    "Always",
-		Volumes:          options.volumes,
-		ImagePullSecrets: options.imagePullSecrets,
+		RestartPolicy:                 "Always",
+		Volumes:                       options.volumes,
+		ImagePullSecrets:              options.imagePullSecrets,
+		TerminationGracePeriodSeconds: &zeroVal,
 	}
 	if options.resources != nil {
 		podSpec.Containers[0].Resources = api.ResourceRequirements{

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -79,7 +79,7 @@ func (a *APIServer) master() {
 	// bring the pipeline state from PAUSED to RUNNING.  By setting a high
 	// retry interval, the master would be deleted before it gets a chance
 	// to restart.
-	b.InitialInterval = 5 * time.Second
+	b.InitialInterval = 10 * time.Second
 	backoff.RetryNotify(func() error {
 		ctx, cancel := context.WithCancel(a.pachClient.AddMetadata(context.Background()))
 		defer cancel()


### PR DESCRIPTION
The issue is that by default, pods have a grace period of 30 seconds
before they are deleted.  During that time, the worker master would
restart and set the pipeline's state to "RUNNING" again, causing workers
to be recreated.