### PR TITLE
Fix an issue where deleting pre-1.5 style jobs can result in master stalling

### DIFF
--- a/src/server/pkg/collection/errors.go
+++ b/src/server/pkg/collection/errors.go
@@ -13,6 +13,11 @@ func (e ErrNotFound) Error() string {
 	return fmt.Sprintf("%s %s not found", e.Type, e.Key)
 }
 
+func IsErrNotFound(e error) bool {
+	_, ok := e.(ErrNotFound)
+	return ok
+}
+
 // ErrExists indicates that a key was found to exist when it was expected not
 // to.
 type ErrExists struct {
@@ -22,6 +27,11 @@ type ErrExists struct {
 
 func (e ErrExists) Error() string {
 	return fmt.Sprintf("%s %s already exists", e.Type, e.Key)
+}
+
+func IsErrExists(e error) bool {
+	_, ok := e.(ErrExists)
+	return ok
 }
 
 // ErrMalformedValue indicates that a value was malformed, such as when it was
@@ -34,4 +44,9 @@ type ErrMalformedValue struct {
 
 func (e ErrMalformedValue) Error() string {
 	return fmt.Sprintf("malformed value at %s/%s: %s", e.Type, e.Key, e.Val)
+}
+
+func IsErrMalformedValue(e error) bool {
+	_, ok := e.(ErrMalformedValue)
+	return ok
 }

--- a/src/server/pkg/collection/errors.go
+++ b/src/server/pkg/collection/errors.go
@@ -13,6 +13,7 @@ func (e ErrNotFound) Error() string {
 	return fmt.Sprintf("%s %s not found", e.Type, e.Key)
 }
 
+// IsErrNotFound determines if an error is an ErrNotFound error
 func IsErrNotFound(e error) bool {
 	_, ok := e.(ErrNotFound)
 	return ok
@@ -29,6 +30,7 @@ func (e ErrExists) Error() string {
 	return fmt.Sprintf("%s %s already exists", e.Type, e.Key)
 }
 
+// IsErrExists determines if an error is an ErrExists error
 func IsErrExists(e error) bool {
 	_, ok := e.(ErrExists)
 	return ok
@@ -46,6 +48,7 @@ func (e ErrMalformedValue) Error() string {
 	return fmt.Sprintf("malformed value at %s/%s: %s", e.Type, e.Key, e.Val)
 }
 
+// IsErrMalformedValue determines if an error is an ErrMalformedValue error
 func IsErrMalformedValue(e error) bool {
 	_, ok := e.(ErrMalformedValue)
 	return ok

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -212,15 +212,15 @@ nextInput:
 			var jobID string
 			var jobInfo pps.JobInfo
 			ok, err := jobIter.Next(&jobID, &jobInfo)
-			if err != nil && !col.IsErrNotFound(err) {
+			if err != nil {
 				return err
 			}
-			if !ok || col.IsErrNotFound(err) {
+			if !ok {
 				ok, err := oldJobIter.Next(&jobID, &jobInfo)
-				if err != nil && !col.IsErrNotFound(err) {
+				if err != nil {
 					return err
 				}
-				if !ok || col.IsErrNotFound(err) {
+				if !ok {
 					break
 				}
 			}

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -212,15 +212,15 @@ nextInput:
 			var jobID string
 			var jobInfo pps.JobInfo
 			ok, err := jobIter.Next(&jobID, &jobInfo)
-			if err != nil {
+			if err != nil && !col.IsErrNotFound(err) {
 				return err
 			}
-			if !ok {
+			if !ok || col.IsErrNotFound(err) {
 				ok, err := oldJobIter.Next(&jobID, &jobInfo)
-				if err != nil {
+				if err != nil && !col.IsErrNotFound(err) {
 					return err
 				}
-				if !ok {
+				if !ok || col.IsErrNotFound(err) {
 					break
 				}
 			}


### PR DESCRIPTION
This fixes a tricky edge case where an user has a job that's created with old-style `Inputs` as opposed to `Input`, then when the job is deleted, the corresponding indexes on `Inputs` are not deleted, and therefore the master ends up thinking that the job exists anyways (since it's scans for both `Inputs` and `Input` indexes), and crashes when the job turns out to not exist.