### PR TITLE
Pachctl auth/enterprise fixes

### DIFF
--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -23,7 +23,7 @@ func ActivateCmd() *cobra.Command {
 		Use:   "activate --admins=[admins...]",
 		Short: "Activate Pachyderm's auth system",
 		Long:  "Activate Pachyderm's auth system, and restrict access to existing data to cluster admins",
-		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
+		Run: cmdutil.Run(func(args []string) error {
 			if len(admins) == 0 {
 				return fmt.Errorf("must specify at least one cluster admin to enable " +
 					"auth")

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -2,7 +2,9 @@ package cmds
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/server/pkg/cmdutil"
@@ -15,6 +17,7 @@ import (
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
 func ActivateCmd() *cobra.Command {
+	var expires string
 	activate := &cobra.Command{
 		Use: "activate activation-code",
 		Short: "Activate the enterprise features of Pachyderm with an activation " +
@@ -22,16 +25,31 @@ func ActivateCmd() *cobra.Command {
 		Long: "Activate the enterprise features of Pachyderm with an activation " +
 			"code",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			activationCode := args[0]
 			c, err := client.NewOnUserMachine(true, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
-			_, err = c.Enterprise.Activate(c.Ctx(),
-				&enterprise.ActivateRequest{ActivationCode: activationCode})
+			req := &enterprise.ActivateRequest{}
+			req.ActivationCode = args[0]
+			if expires != "" {
+				t, err := time.Parse(time.RFC3339, expires)
+				if err != nil {
+					return fmt.Errorf("could not parse the timestamp \"%s\": %s", expires, err.Error())
+				}
+				req.Expires, err = types.TimestampProto(t)
+				if err != nil {
+					return fmt.Errorf("error convertin expiration time of \"%s\"; %s", t.String(), err.Error())
+				}
+			}
+			_, err = c.Enterprise.Activate(c.Ctx(), req)
 			return err
 		}),
 	}
+	activate.PersistentFlags().StringVar(&expires, "expires", "", "A timestamp "+
+		"indicating when the token provided above should expire (formatted as an "+
+		"RFC 3339/ISO 8601 timestamp). This is only applied if it's earlier than "+
+		"the signed expiration time encoded in 'activation-code', and therefore "+
+		"is only useful for testing.")
 	return activate
 }
 

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -38,7 +38,7 @@ func ActivateCmd() *cobra.Command {
 				}
 				req.Expires, err = types.TimestampProto(t)
 				if err != nil {
-					return fmt.Errorf("error convertin expiration time of \"%s\"; %s", t.String(), err.Error())
+					return fmt.Errorf("error converting expiration time \"%s\"; %s", t.String(), err.Error())
 				}
 			}
 			_, err = c.Enterprise.Activate(c.Ctx(), req)

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -47,7 +47,7 @@ func ActivateCmd() *cobra.Command {
 	}
 	activate.PersistentFlags().StringVar(&expires, "expires", "", "A timestamp "+
 		"indicating when the token provided above should expire (formatted as an "+
-		"RFC 3339/ISO 8601 timestamp). This is only applied if it's earlier than "+
+		"RFC 3339/ISO 8601 datetime). This is only applied if it's earlier than "+
 		"the signed expiration time encoded in 'activation-code', and therefore "+
 		"is only useful for testing.")
 	return activate


### PR DESCRIPTION
* Fix bug in 'pachctl auth activate'
* Allow enterprise expiration time to be shortened by the CLI in 'pachctl enterprise activate'