### PR TITLE
Make ReleaseCandidates show up as versions in ReadTheDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /protofix
 doc/_build
 
+# Release artifacts
+VERSION
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifdef VENDOR_ALL
 endif
 
 COMPILE_RUN_ARGS = -d -v /var/run/docker.sock:/var/run/docker.sock --privileged=true
-VERSION_ADDITIONAL = $(shell git log --pretty=format:%H | head -n 1)
+VERSION_ADDITIONAL = -$(shell git log --pretty=format:%H | head -n 1)
 LD_FLAGS = -X github.com/pachyderm/pachyderm/src/server/vendor/github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion=$(VERSION_ADDITIONAL)
 
 CLUSTER_NAME?=pachyderm

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -43,7 +43,7 @@ Note in particular:
 
 ```
 > git add <all docs files>
-> git commit -m"Update version and run make doc for VERSION (point release|release candidate|etc)"
+> git commit -m"Update version and run make doc for <version> (point release|release candidate|etc)" (e.g. "...run make doc for 1.0.0 point release" or "...run make doc for 1.0.0rc1 release candidate")
 > git push origin master
 ```
 
@@ -63,8 +63,6 @@ Otherwise,
 ```shell
 make point-release
 ```
-
-Afterwards, you'll note that the VERSION file has been deleted. Please create a git commit with this change (i.e. removing VERSION) and push it master.
 
 ### If the release failed
 You'll need to do two things: remove the relevant tags in GitHub, and re-build the docs in ReadTheDocs

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -23,42 +23,39 @@ You'll need the following credentials / tools:
 
 ## Releasing:
 
-1) Make sure your commit has a passing build on travis
+1) Make sure the HEAD commit (that you're about to release) has a passing build on travis.
 
-2) Update `src/client/version/client.go` version values, and **commit the change**
+2) Make sure that you have no uncommitted files in the current branch. Note that `make doc` (next step) will fail if there are any uncommited changes in the current branch
 
-Note that `make doc` (next step) will fail if there are any uncommited changes in the current branch
+3) Update `src/client/version/client.go` version values, and **commit the change** (locally—you'll push it to GitHub in the next step, but this allows `make doc` to run)
 
-3) Run `make doc` with the new version values. If you're doing an RC or need to specify an additional version string, run it like `make VERSION_ADDITIONAL=RC1 doc-custom`
+4) Run `make doc` with the new version values. If you're building a release candidate (rc) or need to specify an additional version string, run it like `make VERSION_ADDITIONAL=rc1 doc-custom`
 
-Make sure you add any new doc files, e.g:
+Note in particular:
 
-```
-$ git status
-...
-Untracked files:
-  (use "git add <file>..." to include in what will be committed)
+* `VERSION_ADDITIONAL` must be of the form `rc<N>` to comply with [PEP 440](https://www.python.org/dev/peps/pep-0440), which is needed to make ReadTheDocs create a new docs version for the release[\[1\]](http://docs.readthedocs.io/en/latest/versions.html).
 
-	doc/pachctl/pachctl_rerun-pipeline.md
-$ git add doc/pachctl/pachctl_rerun-pipeline.md
-```
+  If you're building a custom release for a client, you don't need follow this form, but if you're building a release candidate, you do.
+
+* Make sure you add any newly created (untracked) doc files, in addition to docs that have been updated (`git commit -a` might not get everything)
 
 4) At this point, all of our auto-generated documentation should be updated. Push a new commit (to master) with:
 
 ```
-> git commit -a -m"Update version and run make doc for VERSION point release"
+> git add <all docs files>
+> git commit -m"Update version and run make doc for VERSION (point release|release candidate|etc)"
 > git push origin master
 ```
 
 5) Run `docker login` (as the release script pushes new versions of the pachd and job-shim binaries to dockerhub)
 
-6) Run `make point-release` or `make VERSION_ADDITION=<RC version suffix> release-custom`
-(or just `make release-custom` to use the commit hash as the version suffix)
+6) Run `make point-release` or `make VERSION_ADDITION=<rc version suffix> release-custom`
+(or just `make release-custom` to use the commit hash as the version suffix. Note that this is not PEP 440-compliant)
 
-To specify an additional version string:
+For example:
 
 ```shell
-make VERSION_ADDITIONAL=RC1 release-custom
+make VERSION_ADDITIONAL=rc1 release-custom
 ```
 
 Otherwise,
@@ -67,9 +64,13 @@ Otherwise,
 make point-release
 ```
 
-Afterwards, you'll be prompted to push your changes to master. Please do so.
+Afterwards, you'll note that the VERSION file has been deleted. Please create a git commit with this change (i.e. removing VERSION) and push it master.
 
 ### If the release failed
+You'll need to do two things: remove the relevant tags in GitHub, and re-build the docs in ReadTheDocs
+
+1) Removing the tag in GitHub
+
 You'll need to delete the *release* and the *release tag* in github. Navigate to
 `https://www.github.com/pachyderm/pachyderm` and click on the *Releases* tab.
 Click on the big, blue version number corresponding to the release you want to
@@ -82,6 +83,12 @@ delete the tag.
 
 At this point, you can re-run the release process when you're ready.
 
+2) Updating ReadTheDocs
+
+* Repeat the release process until you're happy with the tagged release in GitHub.
+* Navigate to the [Builds](https://readthedocs.org/projects/pachyderm/builds/) page in ReadTheDocs, select the version corresponding to this release next to the "Build Version" button, and then click "Build Version".
+* Check the updated ReadTheDocs page for the release, and make the docs (particularly the download link under "Local Installation") are correct.
+
 ## Custom Release
 
 Occasionally we have a need for a custom release off a non master branch. This is usually because some features we need to supply to users that are incompatible w features on master, but the features on master we need to keep longer term.
@@ -89,7 +96,6 @@ Occasionally we have a need for a custom release off a non master branch. This i
 Follow the instructions above, just run the make script off of your branch.
 
 Then _after a successful release_:
-
 
 - The tag created by goxc will point to master, and this is wrong. Opened an issue for this: https://github.com/laher/goxc/issues/112
 - But the binaries built are correct (they're built off of your local code, on the branch you've checked out)
@@ -132,5 +138,6 @@ This will fail if you didn't delete the tag on Github in the previous step
 
 5) Check the docs
 
-The docs version may not show up. If this is the case, tag your version as 'active' on the readthedocs dashboard: https://readthedocs.org/projects/pachyderm/versions/
+Note that ReadTheDocs builds docs from our GitHub master branch. If the docs changes you made aren't checked into the Pachyderm master branch, they won't show up.
 
+If you have checked in your docs changes, but they're not showing up as the `latest` version of the docs, tag your version as 'active' on the readthedocs dashboard: https://readthedocs.org/projects/pachyderm/versions/

--- a/src/client/version/client.go
+++ b/src/client/version/client.go
@@ -30,11 +30,11 @@ var (
 )
 
 // PrettyPrintVersion returns a version string optionally tagged with metadata.
-// For example: "1.2.3", or "1.2.3-rc1" if version.Additional is "rc1".
+// For example: "1.2.3", or "1.2.3rc1" if version.Additional is "rc1".
 func PrettyPrintVersion(version *pb.Version) string {
 	result := PrettyPrintVersionNoAdditional(version)
 	if version.Additional != "" {
-		result += fmt.Sprintf("-%s", version.Additional)
+		result += fmt.Sprintf("%s", version.Additional)
 	}
 	return result
 }


### PR DESCRIPTION
Don't use a dash between version numbers and VersionAdditional, to conform with PEP 440 and ReadTheDocs (http://docs.readthedocs.io/en/latest/versions.html).

Update the release instructions so that we're labelling RCs with PEP 440-compatible versions