### PR TITLE
Remove branch flag

### DIFF
--- a/doc/fundamentals/getting_data_into_pachyderm.md
+++ b/doc/fundamentals/getting_data_into_pachyderm.md
@@ -33,7 +33,7 @@ Add a single file to a new branch:
 
 ```sh
 # first start a commit
-$ pachctl start-commit <repo> -b <branch>
+$ pachctl start-commit <repo> <branch>
 
 # then utilize the returned <commit-id> in the put-file request
 # to put <file> at <path> in the <repo>


### PR DESCRIPTION
There does not seem to be a branch flag any more

```
Error: unknown shorthand flag: 'b' in -b
Usage:
  pachctl start-commit repo-name [branch] [flags]

Flags:
  -p, --parent string   The parent of the new commit, unneeded if branch is specified and you want to use the previous head of the branch as the parent.

Global Flags:
      --no-metrics   Don't report user metrics for this command
  -v, --verbose      Output verbose logs

unknown shorthand flag: 'b' in -b
```

Closes #2272