### PR TITLE
Change Node Size to Master Size

### DIFF
--- a/etc/deploy/aws.sh
+++ b/etc/deploy/aws.sh
@@ -125,7 +125,7 @@ deploy_k8s_on_aws() {
         --dns=private \
         --dns-zone=kubernetes.com \
         --node-size=${NODE_SIZE} \
-        --master-size=${NODE_SIZE} \
+        --master-size=${MASTER_SIZE} \
         --name=${NAME} \
         --yes
     kops update cluster ${NAME} --yes --state=${STATE_BUCKET}


### PR DESCRIPTION
The master-size flag was set to the Node_Size env variable instead of the Master_Size env variable.

Addresses:
- Fixes #2263