### PR TITLE
Replace sanitizeErr

### DIFF
--- a/src/client/pkg/grpcutil/error.go
+++ b/src/client/pkg/grpcutil/error.go
@@ -6,13 +6,13 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// StripGRPCCode removes GRPC error code information from 'err' if it came from
+// ScrubGRPC removes GRPC error code information from 'err' if it came from
 // GRPC (and returns it unchanged otherwise)
-func StripGRPCCode(err error) error {
+func ScrubGRPC(err error) error {
 	if err == nil {
 		return nil
 	}
-	if s, ok := status.FromError(err); err != nil && ok {
+	if s, ok := status.FromError(err); ok {
 		return errors.New(s.Message())
 	}
 	return err

--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 
 	"github.com/gogo/protobuf/types"
@@ -197,7 +198,7 @@ func (c APIClient) CreateJob(
 			Service:         service,
 		},
 	)
-	return job, sanitizeErr(err)
+	return job, grpcutil.ScrubGRPC(err)
 }
 
 // InspectJob returns info about a specific job.
@@ -210,7 +211,7 @@ func (c APIClient) InspectJob(jobID string, blockState bool) (*pps.JobInfo, erro
 			Job:        NewJob(jobID),
 			BlockState: blockState,
 		})
-	return jobInfo, sanitizeErr(err)
+	return jobInfo, grpcutil.ScrubGRPC(err)
 }
 
 // ListJob returns info about all jobs.
@@ -231,7 +232,7 @@ func (c APIClient) ListJob(pipelineName string, inputCommit []*pfs.Commit, outpu
 			OutputCommit: outputCommit,
 		})
 	if err != nil {
-		return nil, sanitizeErr(err)
+		return nil, grpcutil.ScrubGRPC(err)
 	}
 	return jobInfos.JobInfo, nil
 }
@@ -244,7 +245,7 @@ func (c APIClient) DeleteJob(jobID string) error {
 			Job: NewJob(jobID),
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // StopJob stops a job.
@@ -255,7 +256,7 @@ func (c APIClient) StopJob(jobID string) error {
 			Job: NewJob(jobID),
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // RestartDatum restarts a datum that's being processed as part of a job.
@@ -269,7 +270,7 @@ func (c APIClient) RestartDatum(jobID string, datumFilter []string) error {
 			DataFilters: datumFilter,
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // ListDatum returns info about all datums in a Job
@@ -283,7 +284,7 @@ func (c APIClient) ListDatum(jobID string, pageSize int64, page int64) (*pps.Lis
 		},
 	)
 	if err != nil {
-		return nil, sanitizeErr(err)
+		return nil, grpcutil.ScrubGRPC(err)
 	}
 	return resp, nil
 }
@@ -300,7 +301,7 @@ func (c APIClient) InspectDatum(jobID string, datumID string) (*pps.DatumInfo, e
 		},
 	)
 	if err != nil {
-		return nil, sanitizeErr(err)
+		return nil, grpcutil.ScrubGRPC(err)
 	}
 	return datumInfo, nil
 }
@@ -415,7 +416,7 @@ func (c APIClient) CreatePipeline(
 			Update:          update,
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // InspectPipeline returns info about a specific pipeline.
@@ -426,7 +427,7 @@ func (c APIClient) InspectPipeline(pipelineName string) (*pps.PipelineInfo, erro
 			Pipeline: NewPipeline(pipelineName),
 		},
 	)
-	return pipelineInfo, sanitizeErr(err)
+	return pipelineInfo, grpcutil.ScrubGRPC(err)
 }
 
 // ListPipeline returns info about all pipelines.
@@ -436,7 +437,7 @@ func (c APIClient) ListPipeline() ([]*pps.PipelineInfo, error) {
 		&pps.ListPipelineRequest{},
 	)
 	if err != nil {
-		return nil, sanitizeErr(err)
+		return nil, grpcutil.ScrubGRPC(err)
 	}
 	return pipelineInfos.PipelineInfo, nil
 }
@@ -450,7 +451,7 @@ func (c APIClient) DeletePipeline(name string, deleteJobs bool) error {
 			DeleteJobs: deleteJobs,
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // StartPipeline restarts a stopped pipeline.
@@ -461,7 +462,7 @@ func (c APIClient) StartPipeline(name string) error {
 			Pipeline: NewPipeline(name),
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // StopPipeline prevents a pipeline from processing things, it can be restarted
@@ -473,7 +474,7 @@ func (c APIClient) StopPipeline(name string) error {
 			Pipeline: NewPipeline(name),
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // RerunPipeline reruns a pipeline over a given set of commits. Exclude and
@@ -489,7 +490,7 @@ func (c APIClient) RerunPipeline(name string, include []*pfs.Commit, exclude []*
 			Exclude:  exclude,
 		},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // GarbageCollect garbage collects unused data.  Currently GC needs to be
@@ -500,7 +501,7 @@ func (c APIClient) GarbageCollect() error {
 		c.Ctx(),
 		&pps.GarbageCollectRequest{},
 	)
-	return sanitizeErr(err)
+	return grpcutil.ScrubGRPC(err)
 }
 
 // GetDatumTotalTime sums the timing stats from a DatumInfo

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -204,7 +204,7 @@ func (a *apiServer) getEnterpriseTokenState() (enterpriseclient.State, error) {
 	resp, err := pachClient.Enterprise.GetState(context.Background(),
 		&enterpriseclient.GetStateRequest{})
 	if err != nil {
-		return 0, fmt.Errorf("could not get Enterprise status: %v", grpcutil.StripGRPCCode(err))
+		return 0, fmt.Errorf("could not get Enterprise status: %v", grpcutil.ScrubGRPC(err))
 	}
 	return resp.State, nil
 }
@@ -754,7 +754,7 @@ func (a *apiServer) SetACL(ctx context.Context, req *authclient.SetACLRequest) (
 				return false, fmt.Errorf("could not check if repo \"%s\" exists: %v", req.Repo, err)
 			}
 			_, err = pachClient.InspectRepo(req.Repo)
-			err = grpcutil.StripGRPCCode(err)
+			err = grpcutil.ScrubGRPC(err)
 			if err == nil {
 				// Repo exists -- user isn't authorized
 				return false, nil

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -254,7 +254,7 @@ func doFullMode(appEnvObj interface{}) error {
 	)
 	go func() {
 		if err := sharder.AssignRoles(address, nil); err != nil {
-			log.Printf("error from sharder.AssignRoles: %s", sanitizeErr(err))
+			log.Printf("error from sharder.AssignRoles: %s", grpcutil.ScrubGRPC(err))
 		}
 	}()
 	pfsCacheSize, err := strconv.Atoi(appEnv.PFSCacheSize)
@@ -292,12 +292,12 @@ func doFullMode(appEnvObj interface{}) error {
 	}
 	go func() {
 		if err := sharder.RegisterFrontends(nil, address, []shard.Frontend{cacheServer}); err != nil {
-			log.Printf("error from sharder.RegisterFrontend %s", sanitizeErr(err))
+			log.Printf("error from sharder.RegisterFrontend %s", grpcutil.ScrubGRPC(err))
 		}
 	}()
 	go func() {
 		if err := sharder.Register(nil, address, []shard.Server{cacheServer}); err != nil {
-			log.Printf("error from sharder.Register %s", sanitizeErr(err))
+			log.Printf("error from sharder.Register %s", grpcutil.ScrubGRPC(err))
 		}
 	}()
 	blockCacheBytes, err := units.RAMInBytes(appEnv.BlockCacheBytes)
@@ -375,7 +375,7 @@ func getClusterID(client discovery.Client) (string, error) {
 func getKubeClient(env *appEnv) (*kube.Client, error) {
 	kubeClient, err := kube.NewInCluster()
 	if err != nil {
-		log.Errorf("falling back to insecure kube client due to error from NewInCluster: %s", sanitizeErr(err))
+		log.Errorf("falling back to insecure kube client due to error from NewInCluster: %s", grpcutil.ScrubGRPC(err))
 	} else {
 		return kubeClient, err
 	}
@@ -393,12 +393,4 @@ func getNamespace() string {
 		return namespace
 	}
 	return api.NamespaceDefault
-}
-
-func sanitizeErr(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	return errors.New(grpc.ErrorDesc(err))
 }

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -193,7 +193,7 @@ func (d *driver) checkIsAuthorized(ctx context.Context, r *pfs.Repo, s auth.Scop
 		return &auth.NotAuthorizedError{Repo: r.Name, Required: s}
 	} else if err != nil && !auth.IsNotActivatedError(err) {
 		return fmt.Errorf("error during authorization check for operation on \"%s\": %v",
-			r.Name, grpcutil.StripGRPCCode(err))
+			r.Name, grpcutil.ScrubGRPC(err))
 	}
 	return nil
 }
@@ -236,7 +236,7 @@ func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, provenance []*p
 		if err != nil {
 			if !auth.IsNotActivatedError(err) {
 				return fmt.Errorf("authorization error while creating repo \"%s\": %v",
-					repo.Name, grpcutil.StripGRPCCode(err))
+					repo.Name, grpcutil.ScrubGRPC(err))
 			}
 		} else {
 			// auth is active, and user is logged in. Make user an owner of the new
@@ -252,7 +252,7 @@ func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, provenance []*p
 			})
 			if err != nil {
 				return fmt.Errorf("could not create ACL for new repo \"%s\": %v",
-					repo.Name, grpcutil.StripGRPCCode(err))
+					repo.Name, grpcutil.ScrubGRPC(err))
 			}
 		}
 	}
@@ -391,7 +391,7 @@ func (d *driver) inspectRepo(ctx context.Context, repo *pfs.Repo, includeAuth bo
 			&auth.GetScopeRequest{Repos: []string{repo.Name}})
 		if err != nil && !auth.IsNotActivatedError(err) {
 			return nil, fmt.Errorf("error getting scope for \"%s\": %v", repo.Name,
-				grpcutil.StripGRPCCode(err))
+				grpcutil.ScrubGRPC(err))
 		} else if err == nil {
 			if len(resp.Scopes) != 1 {
 				return nil, fmt.Errorf("unexpected result from GetScope(): %#v", resp)
@@ -448,7 +448,7 @@ nextRepo:
 				})
 			if err != nil && !auth.IsNotActivatedError(err) {
 				return nil, fmt.Errorf("error getting scopes: %v",
-					grpcutil.StripGRPCCode(err))
+					grpcutil.ScrubGRPC(err))
 			} else if err == nil {
 				if len(resp.Scopes) != 1 {
 					return nil, fmt.Errorf("unexpected result from GetScope(): %#v", resp)
@@ -513,7 +513,7 @@ func (d *driver) deleteRepo(ctx context.Context, repo *pfs.Repo, force bool) err
 	if _, err = d.pachClient.AuthAPIClient.SetACL(auth.In2Out(ctx), &auth.SetACLRequest{
 		Repo: repo.Name, // NewACL is unset, so this will clear the acl for 'repo'
 	}); err != nil && !auth.IsNotActivatedError(err) {
-		return grpcutil.StripGRPCCode(err)
+		return grpcutil.ScrubGRPC(err)
 	}
 	return nil
 }

--- a/src/server/pkg/cmdutil/cobra.go
+++ b/src/server/pkg/cmdutil/cobra.go
@@ -59,10 +59,13 @@ func ErrorAndExit(format string, args ...interface{}) {
 // ParseCommits takes a slice of arguments of the form "repo/commit-id" or
 // "repo" (in which case we consider the commit ID to be empty), and returns
 // a list of Commits
-func ParseCommits(args []string) ([]*pfs.Commit, error) {
+func ParseCommits(args []string) []*pfs.Commit {
 	var commits []*pfs.Commit
 	for _, arg := range args {
 		parts := strings.SplitN(arg, "/", 2)
+		if len(parts) == 0 {
+			continue
+		}
 		if parts[0] != "" {
 			commit := &pfs.Commit{
 				Repo: &pfs.Repo{
@@ -78,7 +81,7 @@ func ParseCommits(args []string) ([]*pfs.Commit, error) {
 		}
 	}
 
-	return commits, nil
+	return commits
 }
 
 // RepeatedStringArg is an alias for []string

--- a/src/server/pkg/cmdutil/cobra.go
+++ b/src/server/pkg/cmdutil/cobra.go
@@ -58,30 +58,27 @@ func ErrorAndExit(format string, args ...interface{}) {
 
 // ParseCommits takes a slice of arguments of the form "repo/commit-id" or
 // "repo" (in which case we consider the commit ID to be empty), and returns
-// a list of Commits
-func ParseCommits(args []string) []*pfs.Commit {
+// a list of *pfs.Commits
+func ParseCommits(args []string) ([]*pfs.Commit, error) {
 	var commits []*pfs.Commit
 	for _, arg := range args {
 		parts := strings.SplitN(arg, "/", 2)
-		if len(parts) == 0 {
-			continue
+		if len(parts) == 0 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid commit id \"%s\": repo cannot be empty", arg)
 		}
-		if parts[0] != "" {
-			commit := &pfs.Commit{
-				Repo: &pfs.Repo{
-					Name: parts[0],
-				},
-			}
-			if len(parts) == 2 {
-				commit.ID = parts[1]
-			} else {
-				commit.ID = ""
-			}
-			commits = append(commits, commit)
+		commit := &pfs.Commit{
+			Repo: &pfs.Repo{
+				Name: parts[0],
+			},
 		}
+		if len(parts) == 2 {
+			commit.ID = parts[1]
+		} else {
+			commit.ID = ""
+		}
+		commits = append(commits, commit)
 	}
-
-	return commits
+	return commits, nil
 }
 
 // RepeatedStringArg is an alias for []string

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pps/pretty"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -121,8 +120,10 @@ $ pachctl list-job -p foo bar/YYY
 			if err != nil {
 				return err
 			}
-
-			outputCommits := cmdutil.ParseCommits([]string{outputCommit})
+			outputCommits, err := cmdutil.ParseCommits([]string{outputCommit})
+			if err != nil {
+				return err
+			}
 			var outputCommit *pfs.Commit
 			if len(outputCommits) == 1 {
 				outputCommit = outputCommits[0]


### PR DESCRIPTION
Replace sanitizeErr (a small helper that was copy/pasted a few places) with a small grpcutil library that strips GRPC error code information from public errors, so that they're easier to read