### PR TITLE
Bump GRPC Proxy version to 0.4.1

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -37,7 +37,7 @@ var (
 	dashName                = "dash"
 	dashImage               = "pachyderm/dash"
 	grpcProxyName           = "grpc-proxy"
-	grpcProxyImage          = "pachyderm/grpc-proxy:0.4.0"
+	grpcProxyImage          = "pachyderm/grpc-proxy:0.4.1"
 	pachdName               = "pachd"
 	minioSecretName         = "minio-secret"
 	amazonSecretName        = "amazon-secret"


### PR DESCRIPTION
Allows use of metadata for client streaming