### PR TITLE
Remove test enterprise activation code from tests

### DIFF
--- a/src/server/auth/server/admin_test.go
+++ b/src/server/auth/server/admin_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+	"github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 )
 
 // adminsEqual returns nil if the elements of the slice "expecteds" are
@@ -447,7 +448,7 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testActivationCode,
+			ActivationCode: testutil.GetTestEnterpriseCode(),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -524,7 +525,7 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	year := 365 * 24 * time.Hour
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testActivationCode,
+			ActivationCode: testutil.GetTestEnterpriseCode(),
 			// This will stop working some time in 2026
 			Expires: TSProtoOrDie(t, time.Now().Add(year)),
 		})
@@ -618,7 +619,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testActivationCode,
+			ActivationCode: testutil.GetTestEnterpriseCode(),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -670,7 +671,7 @@ func TestGetSetScopeAndAclWithExpiredToken(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testActivationCode,
+			ActivationCode: testutil.GetTestEnterpriseCode(),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -12,24 +12,8 @@ import (
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 )
-
-const testActivationCode = `eyJ0b2tlbiI6IntcImV4cGlyeVwiOlwiMjAyNy0wNy0xMlQwM` +
-	`zowOTowNi4xODBaXCIsXCJzY29wZXNcIjp7XCJiYXNpY1wiOnRydWV9LFwibmFtZVwiOlwicGF` +
-	`jaHlkZXJtRW5naW5lZXJpbmdcIn0iLCJzaWduYXR1cmUiOiJWdjZQbEkrL3RJamlWYUNHMGw0T` +
-	`Ud6WldDS2YrUFMyWS9WUzFkZ3plcVdjS3RETlJvdkRnSnd3TXFXbWdCOUs5a2lPemVQRlh4eTh` +
-	`3U2dMbTJ4dnBlTHN2bGlsTlc5MEhKbGxxcjhKWEVTbVV4R2tKQldMTHZHak5mYUlHZ0IvZTFEM` +
-	`zQzMi95eUVnSW1LZDlpZ3J3RXZsRCtGdW0wa1hqS3Rrb2pPRmhkMDR6RHFEMSt5ZWpsTmRtUzB` +
-	`TaDJKWHRTMnFqWk0zTE5lWlpTRldLcEVJTmlXa2dhOTdTNUw2ZVlCdXFZcFJLMTkwd1pXNTVCO` +
-	`VFJSHJNNWtDWGQrWUN5aTh0QU9kcFY2a3FMSDNoVGgxVDIwVjYveFNZNUVheHZObm8yRmFYbDU` +
-	`yQzRFSWIvZ05RWW8xVExDd1hJN0FYL2lpL0VTckVBQmYzdDlYZmlwWGxleE9OMmhJaWY5dDROZ` +
-	`FBaQ1pmYlErbW8vSlQ3Um5VTGpTb2J3alNWVk1qMUozLzZKbmhQRFpFSWNDdlVvUnMyL2M2WUZ` +
-	`xOVo1TFRJNkUxV2Q0bE1RczRJYXVsTHVQOEFVa3R3ejBiQmY2dUhPd3VvTlk4UjJ3ZTA1MmUxW` +
-	`VVGbmNyUE4wd2ZJVHo5Vm51M1dNcktpaDhhRzNmMzRLb2x0R3hpWXJHL2JZQjgweUFaTytCbzF` +
-	`mTTJwaDB0emRXejFLR0lNQUlEbjBFWHU2V0duSUFFUWN1NHVFc1pSVXRzNFhuYk5PTC9vYU1NK` +
-	`3RLV3UzdnFMdEhMWWlPaWZHNHpEcUxwYnNNN2NhZGNXWjJ3QzNoZVh6Y1loaUwzMHJlOGJ4MFc` +
-	`3Vm1FOSt4elJHZisyNEdvRjFaS1BvaDNhY3hCS0dsZzRxN2JQd0c3QWJESmxkak1HbkVEdz0if` +
-	`Q==`
 
 var (
 	pachClient *client.APIClient
@@ -56,7 +40,7 @@ func getPachClient(t testing.TB) *client.APIClient {
 }
 
 func TestValidateActivationCode(t *testing.T) {
-	_, err := validateActivationCode(testActivationCode)
+	_, err := validateActivationCode(testutil.GetTestEnterpriseCode())
 	require.NoError(t, err)
 }
 
@@ -68,8 +52,9 @@ func TestGetState(t *testing.T) {
 
 	// Activate Pachyderm Enterprise and make sure the state is ACTIVE
 	_, err := client.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: testActivationCode})
-	resp, err := client.Enterprise.GetState(context.Background(), &enterprise.GetStateRequest{})
+		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode()})
+	resp, err := client.Enterprise.GetState(context.Background(),
+		&enterprise.GetStateRequest{})
 	require.NoError(t, err)
 	require.Equal(t, resp.State, enterprise.State_ACTIVE)
 	expires, err := types.TimestampFromProto(resp.Info.Expires)
@@ -81,10 +66,11 @@ func TestGetState(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.Enterprise.Activate(context.Background(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testActivationCode,
+			ActivationCode: testutil.GetTestEnterpriseCode(),
 			Expires:        expiresProto,
 		})
-	resp, err = client.Enterprise.GetState(context.Background(), &enterprise.GetStateRequest{})
+	resp, err = client.Enterprise.GetState(context.Background(),
+		&enterprise.GetStateRequest{})
 	require.NoError(t, err)
 	require.Equal(t, enterprise.State_EXPIRED, resp.State)
 	require.Equal(t, expiresProto, resp.Info.Expires)

--- a/src/server/pkg/testutil/token.go
+++ b/src/server/pkg/testutil/token.go
@@ -1,0 +1,54 @@
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+var (
+	cachedEnterpriseCodeMut sync.Mutex
+	cachedEnterpriseCode    string
+)
+
+// GetTestEnterpriseCode gets a Pachyderm Enterprise activation code from a
+// private S3 bucket, and provides it to tests that use Pachyderm Enterprise
+// features
+func GetTestEnterpriseCode() string {
+	cachedEnterpriseCodeMut.Lock()
+	defer cachedEnterpriseCodeMut.Unlock()
+
+	if cachedEnterpriseCode != "" {
+		return cachedEnterpriseCode
+	}
+
+	// Get test enterprise code from s3. The Pachyderm Enterprise test activation
+	// token is stored in
+	// s3://pachyderm-engineering/test_enterprise_activation_code.txt
+	s3client := s3.New(session.Must(session.NewSessionWithOptions(
+		session.Options{
+			Config: aws.Config{
+				Region: aws.String("us-west-1"), // contains s3://pachyderm-engineering
+			},
+		})))
+	// S3 client requires string pointers. Go does not allow programs to take the
+	// address of constants, so we must create strings here
+	output, err := s3client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String("pachyderm-engineering"),
+		Key:    aws.String("test_enterprise_activation_code.txt"),
+	})
+	if err != nil {
+		// tests can't run without credentials -- just crash
+		panic(fmt.Sprintf("cannot get test enterprise token from s3: %v", err))
+	}
+	buf := &bytes.Buffer{}
+	if _, err = buf.ReadFrom(output.Body); err != nil {
+		panic(fmt.Sprintf("cannot copy test enterprise token to buffer: %v", err))
+	}
+	cachedEnterpriseCode = buf.String()
+	return cachedEnterpriseCode
+}


### PR DESCRIPTION
add a library to fetch our activation code from a private S3 bucket

(also, finish TestListRepoNoAuthInfoIfDeactivated, which I foolishly left unfinished in a previous PR)