### PR TITLE
bump dash version to 0.5.7

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -21,7 +21,7 @@ import (
 	"go.pedge.io/pkg/cobra"
 )
 
-var defaultDashImage = "pachyderm/dash:0.5.6"
+var defaultDashImage = "pachyderm/dash:0.5.7"
 
 func maybeKcCreate(dryRun bool, manifest *bytes.Buffer, opts *assets.AssetOpts) error {
 	if dryRun {


### PR DESCRIPTION
image is here: https://hub.docker.com/r/pachyderm/dash/tags/