### PR TITLE
bump dash version number to 0.5.9

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -21,7 +21,7 @@ import (
 	"go.pedge.io/pkg/cobra"
 )
 
-var defaultDashImage = "pachyderm/dash:0.5.7"
+var defaultDashImage = "pachyderm/dash:0.5.9"
 
 func maybeKcCreate(dryRun bool, manifest *bytes.Buffer, opts *assets.AssetOpts) error {
 	if dryRun {


### PR DESCRIPTION
image is here: https://hub.docker.com/r/pachyderm/dash/tags/