### PR TITLE
bump dash version to 0.5.10

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -23,7 +23,7 @@ import (
 	"go.pedge.io/pkg/cobra"
 )
 
-var defaultDashImage = "pachyderm/dash:0.5.9"
+var defaultDashImage = "pachyderm/dash:0.5.10"
 
 func maybeKcCreate(dryRun bool, manifest *bytes.Buffer, opts *assets.AssetOpts, metrics bool) error {
 	if dryRun {


### PR DESCRIPTION
Image is here: https://hub.docker.com/r/pachyderm/dash/tags/