### PR TITLE
Fix edge case w kubePipelineWatch failure

### DIFF
--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -161,7 +161,9 @@ func (a *apiServer) master() {
 				// "" we treat these as errors since otherwise we get an
 				// endless stream of them and can't do anything.
 				if event.Type == kube_watch.Error || event.Type == "" {
-					kubePipelineWatch.Stop()
+					if kubePipelineWatch != nil {
+						kubePipelineWatch.Stop()
+					}
 					kubePipelineWatch, err = a.kubeClient.Pods(a.namespace).Watch(api.ListOptions{
 						LabelSelector: labelspkg.SelectorFromSet(map[string]string{
 							"component": "worker",
@@ -170,6 +172,7 @@ func (a *apiServer) master() {
 					})
 					if err != nil {
 						log.Errorf("failed to watch kuburnetes pods: %v", err)
+						watchChan = nil
 					} else {
 						watchChan = kubePipelineWatch.ResultChan()
 						defer kubePipelineWatch.Stop()


### PR DESCRIPTION
Make sure to nil out the watch channel, and defensively don't call stop unless
the watcher isn't nil


---

running pachd 1.6.0 on VM got a segafult

```
e\u003e/pfs/out/$fruit","done"]},"pipeline":{"name":"filter"},"pipeline_version":1,"parallelism_spec":{"constant":1},"started":{"seconds":1507239978,"nanos":529184417},"finished":{"seconds":1507239978,"nanos":633245633},"output_commit":{"repo":{"name":"filter"},"id":"823bbdedb6d0490a8b671276bac2aaae"},"state":3,"output_repo":{"name":"filter"},"output_branch":"master","data_processed":1,"data_total":1,"stats":{"download_time":{"nanos":11679970},"process_time":{"nanos":5067130},"upload_time":{"nanos":18569610},"download_bytes":874,"upload_bytes":200},"resource_spec":{"memory":"64M"},"input":{"atom":{"name":"data","repo":"data","branch":"master","commit":"1ccffc60dc094035817723bd27a4efd6","glob":"/*"}},"new_branch":{"name":"master","head":{"repo":{"name":"data"},"id":"1ccffc60dc094035817723bd27a4efd6"}},"salt":"ca65bd11f8d9448893708c674acfa4d9"}]}} 
2017-10-05T21:52:24Z INFO authclient.API.WhoAmI {"request":{}} 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x17fafef]

goroutine 42 [running]:
github.com/pachyderm/pachyderm/src/server/pps/server.(*apiServer).master.func1(0x0, 0x0)
        /go/src/github.com/pachyderm/pachyderm/src/server/pps/server/master.go:164 +0x13ef
        github.com/pachyderm/pachyderm/src/server/pkg/backoff.RetryNotify(0xc4203252a0, 0x2998280, 0xc420111440, 0x1cc3d58, 0x1a, 0x0)
        /go/src/github.com/pachyderm/pachyderm/src/server/pkg/backoff/retry.go:35 +0x4a
        github.com/pachyderm/pachyderm/src/server/pps/server.(*apiServer).master(0xc42037a240)
        /go/src/github.com/pachyderm/pachyderm/src/server/pps/server/master.go:40 +0x1ab
        created by github.com/pachyderm/pachyderm/src/server/pps/server.NewAPIServer
            /go/src/github.com/pachyderm/pachyderm/src/server/pps/server/server.go:57 +0x50f
```

looking at the logs we do see this err message

time="2017-10-05T21:54:02Z" level=error msg="failed to watch kuburnetes pods: Get https://10.0.0.1:443/api/v1/watch/namespaces/default/pods?labelSelector=component%3Dworker&watch=true: dial tcp 10.0.0.1:443: getsockopt: connection refused" 

which suggests taht the kubepipelineWatcher is nil
