### PR TITLE
Add "JOIN" to the title of the "Combining" docs

### DIFF
--- a/doc/cookbook/combining.md
+++ b/doc/cookbook/combining.md
@@ -1,4 +1,4 @@
-# Combining or Merging Data
+# Combining/Merging/JOINing Data
 
 There are a variety of use cases in which you would want to match datums from multiple data repositories to do some combined processing, joining, or aggregation.  For example, you may need to process multiple records corresponding to a certain user, a certain experiment, or a certain device together.  In these scenarios, we recommend a 2-stage method of merging your data:
 

--- a/doc/cookbook/combining.md
+++ b/doc/cookbook/combining.md
@@ -1,4 +1,4 @@
-# Combining/Merging/JOINing Data
+# Combining/Merging/Joining Data
 
 There are a variety of use cases in which you would want to match datums from multiple data repositories to do some combined processing, joining, or aggregation.  For example, you may need to process multiple records corresponding to a certain user, a certain experiment, or a certain device together.  In these scenarios, we recommend a 2-stage method of merging your data:
 


### PR DESCRIPTION
Currently this doesn't show up in google results if you're looking for "pachyderm join", and if you're looking through the sidebar/docs index for the pachyderm equivalent of a JOIN, this doesn't jump out