### PR TITLE
Call setPipelineDefaults when mastering pipeline.

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1023,7 +1023,13 @@ func (d *driver) subscribeCommit(ctx context.Context, repo *pfs.Repo, branch str
 				}
 
 				// We don't want to include the `from` commit itself
-				if !(seen[commit.ID] || (from != nil && from.ID == commit.ID)) {
+
+				// TODO we're check the branchName because right now WatchOne,
+				// like all collection watching commands returns prefixes which
+				// means we'll get back `master-v1` if we're looking for
+				// `master` once this is changed we should remove the
+				// comparison between branchName and branch.
+				if path.Base(branchName) == branch && (!(seen[commit.ID] || (from != nil && from.ID == commit.ID))) {
 					break
 				}
 			}

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -1909,6 +1909,14 @@ func TestSubscribeCommit(t *testing.T) {
 
 	numCommits := 10
 
+	// create some commits that shouldn't affect the below SubscribeCommit call
+	// reproduces #2469
+	for i := 0; i < numCommits; i++ {
+		commit, err := client.StartCommit(repo, "master-v1")
+		require.NoError(t, err)
+		require.NoError(t, client.FinishCommit(repo, commit.ID))
+	}
+
 	var commits []*pfs.Commit
 	for i := 0; i < numCommits; i++ {
 		commit, err := client.StartCommit(repo, "master")


### PR DESCRIPTION
This prevents a certain type of migration bug.