### PR TITLE
Replace 'pachctl version' with 'git rev-list HEAD' in docker targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,12 +186,12 @@ push-bench-images: install-bench tag-images push-images
 	docker push pachyderm/bench:`git rev-list HEAD --max-count=1`
 
 tag-images: install
-	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
-	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
+	docker tag pachyderm_pachd pachyderm/pachd:`git rev-list HEAD --max-count=1`
+	docker tag pachyderm_worker pachyderm/worker:`git rev-list HEAD --max-count=1`
 
 push-images: tag-images
-	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
-	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
+	docker push pachyderm/pachd:`git rev-list HEAD --max-count=1`
+	docker push pachyderm/worker:`git rev-list HEAD --max-count=1`
 
 launch-bench:
 	@# Make launches each process in its own shell process, so we have to structure


### PR DESCRIPTION
The latter works when pachctl isn't connected, while the former doesn't