### PR TITLE
Avoid k8s 1.8 incompatibility issues in aws.sh

### DIFF
--- a/etc/deploy/aws.sh
+++ b/etc/deploy/aws.sh
@@ -127,6 +127,7 @@ deploy_k8s_on_aws() {
         --node-size=${NODE_SIZE} \
         --master-size=${MASTER_SIZE} \
         --name=${NAME} \
+        --kubernetes-version=1.7.10 \
         --yes
     kops update cluster ${NAME} --yes --state=${STATE_BUCKET}
 
@@ -235,6 +236,16 @@ get_k8s_master_domain() {
     return 1
 }
 
+check_kops_version() {
+  which kops
+  KOPS_VERSION="$( kops version | awk '{print $2}' )"
+  echo "${KOPS_VERSION#1.} >= 7.1" | bc
+  if [[ "$( echo "${KOPS_VERSION#1.} >= 7.1" | bc )" -ne 1 ]]; then
+    set +x
+    echo "Your kops version is too old--must have at least 1.7.1"
+    exit 1
+  fi
+}
 
 ##################################
 ###### Deploy Pach cluster #######
@@ -273,6 +284,7 @@ fi
 parse_flags "${@:-}"
 
 which pachctl
+check_kops_version
 
 deploy_k8s_on_aws
 deploy_pachyderm_on_aws


### PR DESCRIPTION
- Check kops version in aws.sh
- deploy new aws k8s cluster with k8s 1.7.10 (to avoid incompatibility issues with k8s 1.8)