### PR TITLE
Add --client-only to pachctl version, and use it in our Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,12 @@ push-bench-images: install-bench tag-images push-images
 	docker push pachyderm/bench:`git rev-list HEAD --max-count=1`
 
 tag-images: install
-	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
-	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
+	docker tag pachyderm_pachd pachyderm/pachd:`$(GOPATH)/bin/pachctl version --client-only`
+	docker tag pachyderm_worker pachyderm/worker:`$(GOPATH)/bin/pachctl version --client-only`
 
 push-images: tag-images
-	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
-	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version 2>/dev/null | grep pachctl | awk -v N=2 '{print $$N}'`
+	docker push pachyderm/pachd:`$(GOPATH)/bin/pachctl version --client-only`
+	docker push pachyderm/worker:`$(GOPATH)/bin/pachctl version --client-only`
 
 launch-bench:
 	@# Make launches each process in its own shell process, so we have to structure

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -95,11 +95,16 @@ Environment variables:
 		rootCmd.AddCommand(cmd)
 	}
 
+	var clientOnly bool
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Return version information.",
 		Long:  "Return version information.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
+			if clientOnly {
+				fmt.Println(version.PrettyPrintVersion(version.Version))
+				return nil
+			}
 			if !noMetrics {
 				start := time.Now()
 				startMetricsWait := metrics.StartReportAndFlushUserAction("Version", start)
@@ -139,6 +144,10 @@ Environment variables:
 			return writer.Flush()
 		}),
 	}
+	versionCmd.Flags().BoolVar(&clientOnly, "client-only", false, "If set, "+
+		"only print pachctl's version, but don't make any RPCs to pachd. Useful "+
+		"if pachd is unavailable")
+
 	deleteAll := &cobra.Command{
 		Use:   "delete-all",
 		Short: "Delete everything.",


### PR DESCRIPTION
 In case pachd is unavailable when running e.g. 'make tag-images'.

This replaces https://github.com/pachyderm/pachyderm/pull/2466