### PR TITLE
Run make with two jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
 # Install any deps used by our "batch test" cron
 - etc/testing/ci/travis_install_batch_deps.sh
 script:
-- make lint vet
+- make -j2 lint vet
 - etc/testing/travis.sh
 after_failure:
 - kubectl version


### PR DESCRIPTION
Should run faster because a build worker has two cores.