### PR TITLE
Upgrade minikube version

### DIFF
--- a/etc/testing/ci/before_install.sh
+++ b/etc/testing/ci/before_install.sh
@@ -17,7 +17,7 @@ curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.
     sudo mv ./kubectl /usr/local/bin/kubectl
 
 # Install minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.23.0/minikube-linux-amd64 && \
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.24.1/minikube-linux-amd64 && \
     chmod +x ./minikube && \
     sudo mv ./minikube /usr/local/bin/minikube
 


### PR DESCRIPTION
Fixes the blocking issue breaking all of our CI builds.

This was caused by:

https://github.com/kubernetes/minikube/issues/2240

and resolved by:

https://github.com/kubernetes/minikube/commit/fc105d3328f576750adc52da934f81ad172bb236

in minikube `0.24.1`

It's still a bit unclear how this ever worked. We suspect the localkube server creates the cert, and after a VM restart, the cert was no longer valid for subsequent builds.
