### PR TITLE
Updated local_installation.md for windows support

### DIFF
--- a/doc/deployment/amazon_web_services.md
+++ b/doc/deployment/amazon_web_services.md
@@ -49,7 +49,7 @@ To deploy and interact with Pachyderm, you will need `pachctl`, a command-line u
 # For OSX:
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
-# For Linux (64 bit):
+# For Linux (64 bit) or Window 10+ on WSL:
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 

--- a/doc/deployment/azure.md
+++ b/doc/deployment/azure.md
@@ -72,7 +72,7 @@ $ STORAGE_KEY="$(az storage account keys list \
 # For OSX:
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
-# For Linux (64 bit):
+# For Linux (64 bit) or Window 10+ on WSL:
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 

--- a/doc/deployment/google_cloud_platform.md
+++ b/doc/deployment/google_cloud_platform.md
@@ -96,7 +96,7 @@ $ gsutil ls
 # For OSX:
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
-# For Linux (64 bit):
+# For Linux (64 bit) or Window 10+ on WSL:
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 

--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -24,9 +24,6 @@ $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
 # For Linux (64 bit) or Window 10+ on WSL:
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
-
-
-
 ```
 
 

--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -24,6 +24,15 @@ $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
 # For Linux (64 bit):
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+
+# For Windows10: enable Windows Subsystem for Linux by running this on Win shell & Restart the system.This will
+# enable a Linux-like bash shell in windows which can be triggered with `bash` .Thereafter you can run Linux command 
+# provided above
+
+> Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
+
+
+
 ```
 
 

--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -22,14 +22,8 @@ Note: Any time you want to stop and restart Pachyderm, you should start fresh wi
 # For OSX:
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
-# For Linux (64 bit):
+# For Linux (64 bit) or Window 10+ on WSL:
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
-
-# For Windows10: enable Windows Subsystem for Linux by running this on Win shell & Restart the system.This will
-# enable a Linux-like bash shell in windows which can be triggered with `bash` .Thereafter you can run Linux command 
-# provided above
-
-> Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
 
 
 


### PR DESCRIPTION
I added one piece of code in documentation that windows10 users can use to enable Linux Subsystem in Windows and continue to use linux commands given through Pachyderm docs