### PR TITLE
Update GCP deployment doc to reflect changes and fix typos

### DIFF
--- a/doc/deployment/google_cloud_platform.md
+++ b/doc/deployment/google_cloud_platform.md
@@ -12,7 +12,7 @@ If this is the first time you use the SDK, make sure to follow the [quick start 
 
 Note, you can also install `kubectl` installed via the SDK using:
 
-```shell
+```sh
 $ gcloud components install kubectl
 ```
 
@@ -38,18 +38,18 @@ $ gcloud container clusters create ${CLUSTER_NAME} --scopes storage-rw --machine
 ```
 Note that you must create the Kubernetes cluster via the gcloud command-line tool rather than the Google Cloud Console, as it's currently only possible to grant the `storage-rw` scope via the command-line tool.
 
-This may take a few minutes to start up. You can check the status on the [GCP Console](https://console.cloud.google.com/compute/instances).  Then, after the cluster is up, you can point `kubectl` to this cluster via:
+This may take a few minutes to start up. You can check the status on the [GCP Console](https://console.cloud.google.com/compute/instances).  A `kubeconfig` entry will automatically be generated and set as the current context.  As a sanity check, make sure your cluster is up and running via `kubectl`:
+
+```sh
+# List all resources in the kube-system namespace
+$ kubectl get all -n kube-system
+```
+
+If a list of Deployments, Replica Sets, and Pods are *not* displayed after the cluster is up, you can point `kubectl` to the new cluster via:
 
 ```sh
 # Update your kubeconfig to point at your newly created cluster
 $ gcloud container clusters get-credentials ${CLUSTER_NAME}
-```
-
-As a sanity check, make sure your cluster is up and running via `kubectl`:
-```sh
-$ kubectl get all
-NAME             CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
-svc/kubernetes   10.0.0.1     <none>        443/TCP   22s
 ```
 
 ### Deploy Pachyderm
@@ -64,7 +64,7 @@ To deploy Pachyderm we will need to:
 
 Pachyderm needs a [GCS bucket](https://cloud.google.com/storage/docs/) and a [persistent disk](https://cloud.google.com/compute/docs/disks/) to function correctly.  We can specify the size of the persistent disk, the bucket name, and create the bucket as follows:
 
-```shell
+```sh
 # For a demo you should only need 10 GB. This stores PFS metadata. For reference, 1GB
 # should work for 1000 commits on 1000 files.
 $ STORAGE_SIZE=[the size of the volume that you are going to create, in GBs. e.g. "10"]
@@ -78,8 +78,7 @@ $ gsutil mb gs://${BUCKET_NAME}
 
 To check that everything has been set up correctly, try:
 
-
-```shell
+```sh
 $ gcloud compute instances list
 # should see a number of instances
 
@@ -91,8 +90,7 @@ $ gsutil ls
 
 `pachctl` is a command-line utility for interacting with a Pachyderm cluster.
 
-
-```shell
+```sh
 # For OSX:
 $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 
@@ -100,15 +98,11 @@ $ brew tap pachyderm/tap && brew install pachyderm/tap/pachctl@1.6
 $ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 
-You can try running `pachctl version` to check that this worked correctly, but Pachyderm itself isn't deployed yet so you won't get a `pachd` version.
+You can run `pachctl version --client-only` to check that the installation was successful.
 
 ```sh
-$ pachctl version
-COMPONENT           VERSION             
-pachctl             1.6.0           
-pachd               (version unknown) : error connecting to pachd server at address (0.0.0.0:30650): context deadline exceeded
-
-please make sure pachd is up (`kubectl get all`) and portforwarding is enabled
+$ pachctl version --client-only
+1.6.6
 ```
 
 #### Deploy Pachyderm
@@ -119,39 +113,34 @@ Now we're ready to deploy Pachyderm itself.  This can be done in one command:
 $ pachctl deploy google ${BUCKET_NAME} ${STORAGE_SIZE} --dynamic-etcd-nodes=1 --dashboard
 ```
 
-Note, here we are using 3 etcd nodes to manage Pachyderm metadata. The number of etcd nodes can be adjusted as needed.
+Note, here we are using 1 etcd node to manage Pachyderm metadata. The number of etcd nodes can be adjusted as needed.
 
 It may take a few minutes for the pachd nodes to be running because it's pulling containers from DockerHub. You can see the cluster status by using:
 
 ```sh
 $ kubectl get all
-NAME                        READY     STATUS    RESTARTS   AGE
-po/dash-4171841423-rsg4r    2/2       Running   0          1m
-po/etcd-0                   1/1       Running   0          1m
-po/etcd-1                   1/1       Running   0          1m
-po/etcd-2                   1/1       Running   0          56s
-po/pachd-2566441599-g2d1q   1/1       Running   2          1m
-
-NAME                CLUSTER-IP      EXTERNAL-IP   PORT(S)                                     AGE
-svc/dash            10.55.252.198   <nodes>       8080:30080/TCP,8081:30081/TCP               1m
-svc/etcd            10.55.254.232   <nodes>       2379:30408/TCP                              1m
-svc/etcd-headless   None            <none>        2380/TCP                                    1m
-svc/kubernetes      10.55.240.1     <none>        443/TCP                                     24m
-svc/pachd           10.55.248.19    <nodes>       650:30650/TCP,651:30651/TCP,652:30652/TCP   1m
-
-NAME                DESIRED   CURRENT   AGE
-statefulsets/etcd   3         3         1m
-
 NAME           DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 deploy/dash    1         1         1            1           1m
 deploy/pachd   1         1         1            1           1m
 
 NAME                  DESIRED   CURRENT   READY     AGE
-rs/dash-4171841423    1         1         1         1m
-rs/pachd-2566441599   1         1         1         1m
+rs/dash-3149425249    1         1         1         1m
+rs/pachd-4216341626   1         1         1         1m
+
+NAME           DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deploy/dash    1         1         1            1           1m
+deploy/pachd   1         1         1            1           1m
+
+NAME                DESIRED   CURRENT   AGE
+statefulsets/etcd   1         1         1m
+
+NAME                        READY     STATUS    RESTARTS   AGE
+po/dash-3149425249-s5kdw    2/2       Running   0          1m
+po/etcd-0                   1/1       Running   0          1m
+po/pachd-4216341626-zxf5g   1/1       Running   0          1m
 ```
 
-Note: If you see a few restarts on the pachd nodes, that's totally ok. That simply means that Kubernetes tried to bring up those containers before other components were ready so it restarted them.
+Note: If you see a few restarts on the pachd nodes, that's totally ok. That simply means that Kubernetes tried to bring up those containers before other components were ready, so it restarted them.
 
 Finally, assuming your `pachd` is running as shown above, we need to set up forward a port so that `pachctl` can talk to the cluster.
 
@@ -165,6 +154,6 @@ And you're done! You can test to make sure the cluster is working by trying `pac
 ```sh
 $ pachctl version
 COMPONENT           VERSION
-pachctl             1.6.0
-pachd               1.6.0
+pachctl             1.6.6
+pachd               1.6.6
 ```


### PR DESCRIPTION
The noteworthy changes include:
* `gcloud container clusters create` now automatically generates a `kubeconfig` entry and activates the new context.  This means `gcloud container clusters get-credentials` can be an optional step if there are issues.
* With a newly created cluster, there won't be any output from the `kubectl get all` command suggested as a "sanity check."  This may lead a novice to believe their Kubernetes cluster isn't working.  I changed it to `kubectl get all -n kube-system` to view the status of the cluster system controllers, etc.
* I changed the command after initially installing `pachctl` to `pachctl version --client-only` so that a user doesn't experience a delay, timeout, and error, which are all expected since Pachyderm has not yet been deployed.
* The `pachctl deploy ...` command had been changed to 1 etcd node in a previous commit, but the text below it still read "3 etcd nodes."
* The output of `kubectl get all` has changed from previous versions, so I updated it to match what a user installing `kubectl` would see.