### PR TITLE
docs(local installation): add minikube start step

### DIFF
--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -9,7 +9,10 @@ If you hit any errors not covered in this guide, check our [troubleshooting](htt
 
 ### Minikube
 
-Kubernetes offers a fantastic guide to [install minikube](http://kubernetes.io/docs/getting-started-guides/minikube). Follow the Kubernetes installation guide to install Virtual Box, Minikube, and Kubectl. Then come back here to install Pachyderm.
+Kubernetes offers a fantastic guide to [install minikube](http://kubernetes.io/docs/getting-started-guides/minikube). Follow the Kubernetes installation guide to install Virtual Box, Minikube, and Kubectl. Then come back here to start Minikube:
+```shell
+minikube start
+```
 
 Note: Any time you want to stop and restart Pachyderm, you should start fresh with `minikube delete` and `minikube start`. Minikube isn't meant to be a production environment and doesn't handle being restarted well without a full wipe. 
 


### PR DESCRIPTION
Hi there 👋 ,

I wanted to test Pachyderm locally (attending @dwhitena 's workshop) and maybe the documentation could insist on having Minikube running before deploying Pachyderm.

I could have read the note below, but I skipped it :)

PS: I signed the CLA.