### PR TITLE
Fix a few dangling bugs after merge

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6473,19 +6473,19 @@ func TestListJobInputCommits(t *testing.T) {
 
 	jobInfos, err := c.ListJob("", []*pfs.Commit{commita1}, nil)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(jobInfos))
+	require.Equal(t, 2, len(jobInfos)) // a1 + nil and a1 + b1
 
 	jobInfos, err = c.ListJob("", []*pfs.Commit{commitb1}, nil)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(jobInfos))
+	require.Equal(t, 2, len(jobInfos)) // a1 + b1 and a2 + b1
 
 	jobInfos, err = c.ListJob("", []*pfs.Commit{commita2}, nil)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(jobInfos))
+	require.Equal(t, 2, len(jobInfos)) // a2 + b1 and a2 + b2
 
 	jobInfos, err = c.ListJob("", []*pfs.Commit{commitb2}, nil)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(jobInfos))
+	require.Equal(t, 1, len(jobInfos)) // a2 + b2
 
 	jobInfos, err = c.ListJob("", []*pfs.Commit{commita1, commitb1}, nil)
 	require.NoError(t, err)

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -1132,16 +1132,14 @@ func TestPutSameFileInParallel(t *testing.T) {
 
 	commit, err := client.StartCommit(repo, "")
 	require.NoError(t, err)
-	var wg sync.WaitGroup
+	var eg errgroup.Group
 	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		go func() {
+		eg.Go(func() error {
 			_, err = client.PutFile(repo, commit.ID, "foo", strings.NewReader("foo\n"))
-			require.NoError(t, err)
-			wg.Done()
-		}()
+			return err
+		})
 	}
-	wg.Wait()
+	require.NoError(t, eg.Wait())
 	require.NoError(t, client.FinishCommit(repo, commit.ID))
 
 	var buffer bytes.Buffer


### PR DESCRIPTION
1) the object client races with itself if two threads write to the same
file concurrently
2) TestPutSameFileInParallel hangs if PutFile returns an error