### PR TITLE
Refactor worker

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -2844,7 +2844,7 @@ func testGetLogs(t *testing.T, enableStats bool) {
 		require.True(t, iter.Message().Message != "")
 		logsData.WriteString(iter.Message().Message)
 	}
-	require.Equal(t, 8, numLogs, logsData)
+	require.Equal(t, 8, numLogs, logsData.String())
 	require.NoError(t, iter.Err())
 
 	// Get logs from pipeline, using pipeline

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -2,8 +2,10 @@ package pfs
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 )
 
 // ErrFileNotFound represents a file-not-found error.
@@ -93,4 +95,26 @@ func (e ErrParentCommitNotFound) Error() string {
 // ByteRangeSize returns byteRange.Upper - byteRange.Lower.
 func ByteRangeSize(byteRange *pfs.ByteRange) uint64 {
 	return byteRange.Upper - byteRange.Lower
+}
+
+var commitNotFoundRe = regexp.MustCompile("commit [^ ]+ not found in repo [^ ]+")
+
+// IsCommitNotFoundErr returns true if 'err' has an error message that matches
+// ErrCommitNotFound
+func IsCommitNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return commitNotFoundRe.MatchString(grpcutil.ScrubGRPC(err).Error())
+}
+
+var commitDeletedRe = regexp.MustCompile("commit [^ ]+/[^ ]+ was deleted")
+
+// IsCommitDeletedErr returns true if 'err' has an error message that matches
+// ErrCommitDeleted
+func IsCommitDeletedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return commitDeletedRe.MatchString(grpcutil.ScrubGRPC(err).Error())
 }

--- a/src/server/pkg/ppsutil/util.go
+++ b/src/server/pkg/ppsutil/util.go
@@ -199,10 +199,10 @@ func JobInput(pipelineInfo *pps.PipelineInfo, outputCommitInfo *pfs.CommitInfo) 
 	return jobInput
 }
 
-// IsDone returns 'true' if 'state' indicates that the job is done (i.e. the
-// state will not change later: SUCCESS, FAILURE, KILLED) and 'false'
+// IsTerminal returns 'true' if 'state' indicates that the job is done (i.e.
+// the state will not change later: SUCCESS, FAILURE, KILLED) and 'false'
 // otherwise.
-func IsDone(state pps.JobState) bool {
+func IsTerminal(state pps.JobState) bool {
 	switch state {
 	case pps.JobState_JOB_SUCCESS, pps.JobState_JOB_FAILURE, pps.JobState_JOB_KILLED:
 		return true

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -390,7 +390,7 @@ func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobReque
 				if err := ev.Unmarshal(&jobID, jobPtr); err != nil {
 					return nil, err
 				}
-				if ppsutil.IsDone(jobPtr.State) {
+				if ppsutil.IsTerminal(jobPtr.State) {
 					return a.jobInfoFromPtr(pachClient, jobPtr)
 				}
 			}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -610,15 +610,18 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 func (a *apiServer) StopJob(ctx context.Context, request *pps.StopJobRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
-		jobs := a.jobs.ReadWrite(stm)
-		jobPtr := &pps.EtcdJobInfo{}
-		if err := jobs.Get(request.Job.ID, jobPtr); err != nil {
-			return err
-		}
-		return a.updateJobState(stm, jobPtr, pps.JobState_JOB_KILLED)
-	})
-	if err != nil {
+	pachClient := a.getPachClient().WithCtx(ctx)
+	jobPtr := &pps.EtcdJobInfo{}
+	if err := a.jobs.ReadOnly(ctx).Get(request.Job.ID, jobPtr); err != nil {
+		return nil, err
+	}
+	// Finish the job's output commit without a tree -- worker/master will mark
+	// the job 'killed'
+	if _, err := pachClient.PfsAPIClient.FinishCommit(ctx,
+		&pfs.FinishCommitRequest{
+			Commit: jobPtr.OutputCommit,
+			Empty:  true,
+		}); err != nil {
 		return nil, err
 	}
 	return &types.Empty{}, nil
@@ -2096,7 +2099,15 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (respon
 			return nil, err
 		}
 	}
-	return &types.Empty{}, err
+
+	// PFS doesn't delete the spec repo, so do it here
+	if err := pachClient.DeleteRepo(ppsconsts.SpecRepo, true); err != nil {
+		return nil, err
+	}
+	if err := pachClient.CreateRepo(ppsconsts.SpecRepo); err != nil {
+		return nil, err
+	}
+	return &types.Empty{}, nil
 }
 
 func (a *apiServer) GarbageCollect(ctx context.Context, request *pps.GarbageCollectRequest) (response *pps.GarbageCollectResponse, retErr error) {

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -988,6 +988,9 @@ func (a *APIServer) cancelCtxIfJobFails(jobCtx context.Context, jobCancel func()
 			}
 		}
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if jobCtx.Err() == context.Canceled {
+			return err // worker is done, nothing else to do
+		}
 		logger.Logf("worker: error watching job %s (%v); retrying in %v", jobID, err, d)
 		return nil
 	})


### PR DESCRIPTION
Changes:
1) worker/api_server watches for new jobs concurrently with processing
existing jobs. This makes it possible for worker to kill user binaries
if the job is killed or the output commit is deleted.

2) Make worker/master delete in-progress jobs if their output commit is
deleted