### PR TITLE
Add grafana config for production deployment in AWS

### DIFF
--- a/etc/plugin/monitoring/production/grafana-deployment-aws.yaml
+++ b/etc/plugin/monitoring/production/grafana-deployment-aws.yaml
@@ -1,0 +1,87 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: monitoring-grafana
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
+        ports:
+          - containerPort: 3000
+            protocol: TCP
+        volumeMounts:
+        - mountPath: /var
+          name: grafana-storage
+        env:
+        - name: INFLUXDB_HOST
+          value: monitoring-influxdb
+        - name: GRAFANA_PORT
+          value: "3000"
+          # The following env variables are required to make Grafana accessible via
+          # the kubernetes api-server proxy. On production clusters, we recommend
+          # removing these env variables, setup auth for grafana, and expose the grafana
+          # service using a LoadBalancer or a public IP.
+        - name: GF_AUTH_BASIC_ENABLED
+          value: "false"
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: Admin
+        - name: GF_SERVER_ROOT_URL
+          # If you're only using the API Server proxy, set this value instead:
+          # value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+          value: /
+      volumes:
+      - name: grafana-storage
+        persistentVolumeClaim: 
+          claimName: grafana-storage-pvc
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+   name: grafana-storage-class
+   labels:
+     task: monitoring
+     k8s-app: grafana
+   namespace: kube-system
+parameters:
+   type: gp2
+provisioner: kubernetes.io/aws-ebs
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: grafana-storage
+  labels:
+    task: monitoring
+    k8s-app: grafana
+  namespace: kube-system
+spec:
+  storageClassName: grafana-storage-class
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: grafana-storage-pvc
+  namespace: kube-system
+spec:
+  storageClassName: grafana-storage-class
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
This PR:

- creates a PV, PVC, and SC k8s objects
- updates the grafana deployment to use this PVC, so that state (e.g. alerts / notification settings) persist across pod restarts

I put the manifest for the grafana config under the `etc/plugin/monitoring/production` directory, because as-is our make task does a `kubectl create -f etc/plugin/monitoring` command, which creates everything in that directory. So if I left the AWS specific one in that dir, there would be a conflict. I could separate out some of the config into a new file, but the grafana deployment would always need to reference the PVC (which references the SC), and the SC obj needs to be cloud specific. This seemed like a reasonable way to keep this manifest around for utility. If there's a simpler way to keep this organized, I'm open to that. I wish it was a bit simpler myself.