### PR TITLE
Gh issue upgrades

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,31 @@
+<!-- This form is for bug reports and feature requests ONLY! 
+
+If you're looking for help, please check:
+
+Docs: http://docs.pachyderm.io/en/latest/
+Slack: http://slack.pachyderm.io/
+
+-->
+
+**Is this a BUG REPORT or FEATURE REQUEST?**:
+
+> Uncomment only one, leave it on its own line: 
+>
+> bug
+> feature
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- Pachyderm CLI version (use `pachctl version`):
+- Cloud provider (e.g. aws, azure, gke) or local deployment (e.g. minikube vs dockerized k8s):
+- OS (e.g. from /etc/os-release):
+- Others:

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -15,15 +15,15 @@ Slack: http://slack.pachyderm.io/
 > feature
 
 
-**What happened**:
+**What happened?**:
 
-**What you expected to happen**:
+**What you expected to happen?**:
 
-**How to reproduce it (as minimally and precisely as possible)**:
+**How to reproduce it (as minimally and precisely as possible)?**:
 
 **Anything else we need to know?**:
 
-**Environment**:
+**Environment?**:
 - Kubernetes version (use `kubectl version`):
 - Pachyderm CLI version (use `pachctl version`):
 - Cloud provider (e.g. aws, azure, gke) or local deployment (e.g. minikube vs dockerized k8s):

--- a/.github/no-response.yaml
+++ b/.github/no-response.yaml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please respond if you can provide the information, and the 
+  issue will be re-opened.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - core-feature
+  - the whole point
+  - user priority
+  - docs
+  - help wanted
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  any recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This PR:

- adds an issue template to our repo
- adds a git bot to close issues if they become stale [more info here](https://probot.github.io/apps/no-response/)
- adds a git bot to close issues if we mark them as `more-information-needed` and the user doesn't respond w/in 2 weeks. [more info here](https://probot.github.io/apps/no-response/)