### PR TITLE
Fix bugs in ModifyAdmins:

### DIFF
--- a/src/client/version/client.go
+++ b/src/client/version/client.go
@@ -18,8 +18,11 @@ const (
 var (
 	// AdditionalVersion is the string provided at release time
 	// The value is passed to the linker at build time
-	// DO NOT set the value of this variable here
-	AdditionalVersion = "rc1"
+	//
+	// DO NOT set the value of this variable here. For some reason, if
+	// AdditionalVersion is set here, the go linker will not overwrite it.
+	AdditionalVersion string
+
 	// Version is the current version for pachyderm.
 	Version = &pb.Version{
 		Major:      MajorVersion,

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -143,16 +143,34 @@ func TestAdmins(t *testing.T) {
 	// (so that deactivateAuth() runs), and call 'list-admin' (to make sure it
 	// works for non-admins)
 	require.NoError(t, tu.Cmd("pachctl", "auth", "login", "-u", "admin2").Run())
-	cmd := tu.BashCmd(`
+	require.NoError(t, tu.BashCmd(`
 		pachctl auth modify-admins --add admin --remove admin2
 		pachctl auth list-admins \
 			| match -v "admin2" \
 			| match "admin"
-		`,
-		"alice", tu.UniqueString("alice"),
-		"bob", tu.UniqueString("bob"),
-	)
-	require.NoError(t, cmd.Run())
+		`).Run())
+}
+
+func TestModifyAdminsPropagateError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	activateAuth(t)
+	defer deactivateAuth(t)
+
+	// Add admin2, and then try to remove it along with a fake admin. Make sure we
+	// get an error
+	require.NoError(t, tu.Cmd("pachctl", "auth", "login", "-u", "admin").Run())
+	require.NoError(t, tu.BashCmd(`
+		pachctl auth list-admins \
+			| match "admin"
+		pachctl auth modify-admins --add admin2
+		pachctl auth list-admins \
+			| match  "admin2"
+
+ 		# cmd should fail
+		! pachctl auth modify-admins --remove admin1,not_in_list
+		`).Run())
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
1) Adding/removing multiple admins didn't work
2) Error messages were not returned to caller

Also reset versionAdditional in version/client.go so that Makefile can set it