### PR TITLE
Bump default dash version to 1.7-preview-4

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var defaultDashImage = "pachyderm/dash:0.5.13"
+var defaultDashImage = "pachyderm/dash:1.7-preview-4"
 
 func maybeKcCreate(dryRun bool, manifest *bytes.Buffer, opts *assets.AssetOpts, metrics bool) error {
 	if dryRun {


### PR DESCRIPTION
We want new installs of 1.7 RCs to get the new dash preview by default