### PR TITLE
Add pipelineName and pipelineVersion to pod labels

### DIFF
--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -345,7 +345,7 @@ func (a *apiServer) upsertWorkersForPipeline(pipelineInfo *pps.PipelineInfo) err
 
 		options := a.getWorkerOptions(
 			pipelineInfo.Pipeline.Name,
-			ppsutil.PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version),
+			pipelineInfo.Version,
 			int32(parallelism),
 			resourceRequests,
 			resourceLimits,

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"strconv"
 
 	client "github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/enterprise"
@@ -183,7 +182,6 @@ func (a *apiServer) getWorkerOptions(pipelineName string, pipelineVersion uint64
 	labels := labels(rcName)
 	labels["version"] = version.PrettyVersion()
 	labels["pipelineName"] = pipelineName
-	labels["pipelineVersion"] = strconv.FormatUint(pipelineVersion, 10)
 	userImage := transform.Image
 	if userImage == "" {
 		userImage = DefaultUserImage


### PR DESCRIPTION
The goal is to make them queryable, with the ability to add PodDisruptionBudgets specifically in mind.

Currently, the only way to get to a pod or replication controller hosting a worker is : 
1) to combine the pipeline name with the pipeline current version to get the RC name.
2) to list all the pipelines and get to the pipeline name by manually filtering out with the pipelineName annotation (annotations are not queryable in Kubernetes).

This makes it difficult to write additional policies in Kubernetes, such as PodDisruptionBudgets, NetworkPolicies, PodSecurityPolicies, PodPresets, ... as currently this must be done for each version of the pipeline.