### PR TITLE
Custom release update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ point-release:
 	@echo "Release completed"
 
 # Run via 'make VERSION_ADDITIONAL=RC release-custom' to specify a version string
-release-custom: 
+release-candidate:
 	@make release-helper
 	@# Run pachctl release script w deploy branch name
 	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
@@ -103,8 +103,12 @@ release-custom:
 	@rm VERSION
 	@echo "Release completed"
 
-release-custom-sha:
-	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-custom
+release-custom:
+	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-helper
+	@# Run pachctl release script w deploy branch name
+	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
+	@rm VERSION
+	@echo "Release completed"
 
 release-helper: check-docker-version release-version release-pachd release-worker
 

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ custom-release:
 	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-helper
 	@make release-pachctl-custom
 	@echo 'For brew install, do:'
-	@echo "$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb"
+	@echo "$$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb"
 	@echo 'For linux install, do:'
-	@echo "$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
+	@echo "$$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
 	@rm VERSION
 	@echo "Release completed"
 

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,6 @@ point-release:
 release-custom: 
 	@make release-helper
 	@# Run pachctl release script w deploy branch name
-	cat VERSION
-	echo "catting VERSION $$(cat VERSION)"
-	@VERSION="$$(cat VERSION)" echo "version is $$VERSION"
 	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
 	@make doc-custom
 	@rm VERSION

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ check-docker-version:
 point-release:
 	@make VERSION_ADDITIONAL= release-helper
 	@# Run pachctl release script w deploy branch name
-	@VERSION="$(shell cat VERSION)" ./etc/build/release_pachctl master
+	@VERSION="$$(shell cat VERSION)" ./etc/build/release_pachctl master
 	@make doc
 	@rm VERSION
 	@echo "Release completed"
@@ -98,8 +98,10 @@ point-release:
 release-custom: 
 	@make release-helper
 	@# Run pachctl release script w deploy branch name
-	@VERSION="$(shell cat VERSION)" echo "version is $$VERSION"
-	@VERSION="$(shell cat VERSION)" ./etc/build/release_pachctl $$VERSION
+	cat VERSION
+	echo "catting VERSION $$(shell cat VERSION)"
+	@VERSION="$$(shell cat VERSION)" echo "version is $$VERSION"
+	@VERSION="$$(shell cat VERSION)" ./etc/build/release_pachctl $$VERSION
 	@make doc-custom
 	@rm VERSION
 	@echo "Release completed"

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ point-release:
 release-custom: 
 	@make release-helper
 	@# Run pachctl release script w deploy branch name
+	@VERSION="$(shell cat VERSION)" echo "version is $$VERSION"
 	@VERSION="$(shell cat VERSION)" ./etc/build/release_pachctl $$VERSION
 	@make doc-custom
 	@rm VERSION

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ point-release:
 	@make VERSION_ADDITIONAL= release-helper
 	@make release-pachctl
 	@make doc
+	@rm VERSION
 	@echo "Release completed"
 
 # Run via 'make VERSION_ADDITIONAL=RC release-custom' to specify a version string
@@ -97,26 +98,26 @@ release-candidate:
 	@make release-helper
 	@make release-pachctl-custom
 	@make doc
+	@rm VERSION
 	@echo "Release completed"
 
-release-custom:
+custom-release:
 	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-helper
 	@make release-pachctl-custom
 	@echo 'For brew install, do:'
 	@echo "$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb"
 	@echo 'For linux install, do:'
 	@echo "$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
+	@rm VERSION
 	@echo "Release completed"
 
 release-pachctl-custom:
 	@# Run pachctl release script w deploy branch name
 	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
-	@rm VERSION
 
 release-pachctl:
 	@# Run pachctl release script w deploy branch name
 	@VERSION="$$(shell cat VERSION)" ./etc/build/release_pachctl master
-	@rm VERSION
 
 release-helper: check-docker-version release-version release-pachd release-worker
 

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ release-custom:
 	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-helper
 	@make release-pachctl-custom
 	@echo 'For brew install, do:'
-	@echo '\$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb'
+	@echo "$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb"
 	@echo 'For linux install, do:'
-	@echo '\$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb'
+	@echo "$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
 	@echo "Release completed"
 
 release-pachctl-custom:

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ point-release:
 	@rm VERSION
 	@echo "Release completed"
 
-# Run via 'make VERSION_ADDITIONAL=RC release-custom' to specify a version string
+# Run via 'make VERSION_ADDITIONAL=rc2 release-custom' to specify a version string
 release-candidate:
 	@make release-helper
 	@make release-pachctl-custom

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,9 @@ release-custom:
 	@make release-helper
 	@# Run pachctl release script w deploy branch name
 	cat VERSION
-	echo "catting VERSION $$(shell cat VERSION)"
-	@VERSION="$$(shell cat VERSION)" echo "version is $$VERSION"
-	@VERSION="$$(shell cat VERSION)" ./etc/build/release_pachctl $$VERSION
+	echo "catting VERSION $$(cat VERSION)"
+	@VERSION="$$(cat VERSION)" echo "version is $$VERSION"
+	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
 	@make doc-custom
 	@rm VERSION
 	@echo "Release completed"

--- a/Makefile
+++ b/Makefile
@@ -88,27 +88,35 @@ check-docker-version:
 
 point-release:
 	@make VERSION_ADDITIONAL= release-helper
-	@# Run pachctl release script w deploy branch name
-	@VERSION="$$(shell cat VERSION)" ./etc/build/release_pachctl master
+	@make release-pachctl
 	@make doc
-	@rm VERSION
 	@echo "Release completed"
 
 # Run via 'make VERSION_ADDITIONAL=RC release-custom' to specify a version string
 release-candidate:
 	@make release-helper
-	@# Run pachctl release script w deploy branch name
-	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
-	@make doc-custom
-	@rm VERSION
+	@make release-pachctl-custom
+	@make doc
 	@echo "Release completed"
 
 release-custom:
 	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-helper
+	@make release-pachctl-custom
+	@echo 'For brew install, do:'
+	@echo '\$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb'
+	@echo 'For linux install, do:'
+	@echo '\$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb'
+	@echo "Release completed"
+
+release-pachctl-custom:
 	@# Run pachctl release script w deploy branch name
 	@VERSION="$$(cat VERSION)" ./etc/build/release_pachctl $$(cat VERSION)
 	@rm VERSION
-	@echo "Release completed"
+
+release-pachctl:
+	@# Run pachctl release script w deploy branch name
+	@VERSION="$$(shell cat VERSION)" ./etc/build/release_pachctl master
+	@rm VERSION
 
 release-helper: check-docker-version release-version release-pachd release-worker
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ release-custom:
 	@echo "Release completed"
 
 release-custom-sha:
-	@make VERSION_ADDITIONAL=$$(git log --pretty=format:%H | head -n 1) release-custom
+	@make VERSION_ADDITIONAL=-$$(git log --pretty=format:%H | head -n 1) release-custom
 
 release-helper: check-docker-version release-version release-pachd release-worker
 

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -5,7 +5,7 @@ Types of Releases
 |ReleaseType|Example Version|Built off master|Can build off any branch| Updates docs| Can host multiple install versions |
 |---|---|---|---|---|---|
 |Point Release| v1.7.2| Y | N | Y | N |
-|Release Candidate| v1.8.0-RC1 | Y | N | Y | N |
+|Release Candidate| v1.8.0rc1 | Y | N | Y | N |
 |Custom Release | v1.8.1-aeeff234982735987affee | N | Y | N | Y |
 
 ## Requirements:
@@ -58,7 +58,7 @@ You'll need the following credentials / tools:
 
 6) Run `docker login` (as the release script pushes new versions of the pachd and job-shim binaries to dockerhub)
 
-7) Run `make point-release` or `make VERSION_ADDITIONAL=RC1 release-candidate`
+7) Run `make point-release` or `make VERSION_ADDITIONAL=rc1 release-candidate`
 
 8) Commit the changes (the dash compatibility file will have been newly created), e.g.:
 

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -1,5 +1,15 @@
 # Release procedure
 
+Types of Releases
+
+|ReleaseType|Example Version|Built off master|Can build off any branch| Updates docs| Can host multiple install versions |
+|---|---|---|---|---|---|
+|Point Release| v1.7.2| Y | N | Y | N |
+|Release Candidate| v1.8.0-RC1 | Y | N | Y | N |
+|Custom Release | v1.8.1-aeeff234982735987affee | N | Y | N | Y |
+
+## Requirements:
+
 NOTE! At the moment, we require the release script to be run on an ubuntu machine.
 
 This is because of a dependency on CGO via [this bug](https://github.com/opencontainers/runc/issues/841)
@@ -7,8 +17,6 @@ This is because of a dependency on CGO via [this bug](https://github.com/opencon
 (We don't want to enable CGO in part because it doesn't play nice w OSX for us)
 
 If you're doing a custom release (off a branch that isn't master), [skip to the section at the bottom](#custom-release)
-
-## Requirements:
 
 You'll need the following credentials / tools:
 
@@ -50,7 +58,7 @@ You'll need the following credentials / tools:
 
 6) Run `docker login` (as the release script pushes new versions of the pachd and job-shim binaries to dockerhub)
 
-7) Run `make point-release` or `make VERSION_ADDITIONAL=<rc/version suffix> release-custom`
+7) Run `make point-release` or `make VERSION_ADDITIONAL=RC1 release-candidate`
 
 8) Commit the changes (the dash compatibility file will have been newly created), e.g.:
 
@@ -111,7 +119,28 @@ All of these can be accomplished by:
 
 Occasionally we have a need for a custom release off a non master branch. This is usually because some features we need to supply to users that are incompatible w features on master, but the features on master we need to keep longer term.
 
-Follow the instructions above, just run the make script off of your branch.
+Often times we can simply cut custom pachd/worker images for a customer. To do that, just run `make custom-images`. Otherwise, if the user needs a custom version of `pachctl`, do the following:
+
+1) Run `docker login` (as the release script pushes new versions of the pachd and job-shim binaries to dockerhub)
+
+2) Run `make custom-release`
+
+Which will create a release like `v1.2.3-2342345aefda9879e87ad`
+
+Which can be installed like:
+
+```
+$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.7.0-5a590ad9d8e9a09d4029f0f7379462620cf589ee/pachctl_1.7.0-5a590ad9d8e9a09d4029f0f7379462620cf589ee_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+```
+
+Or for mac/brew:
+
+```
+# Where 1.7 is the major.minor version of the release you just did,
+# and you use the right commit SHA as well in the URL
+$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/1.7.0-5a590ad9d8e9a09d4029f0f7379462620cf589ee/pachctl@1.7.rb
+```
+
 
 Then _after a successful release_:
 

--- a/etc/build/release_pachctl
+++ b/etc/build/release_pachctl
@@ -2,6 +2,13 @@
 
 set -e
 
+BRANCH=master
+
+if [ -n $1 ]
+then
+    BRANCH=$VERSION
+fi
+
 if [ -z $VERSION ]
 then
         echo "No version found for this commit! Aborting release"
@@ -48,11 +55,12 @@ echo "--- Updating homebrew formula to use binaries at version $VERSION"
 rm -rf homebrew-tap || true
 git clone git@github.com:pachyderm/homebrew-tap
 cd homebrew-tap
+    git checkout -b $BRANCH || git checkout $BRANCH
     VERSION=$VERSION ./update-formula.sh
     git add pachctl@$MAJOR_MINOR.rb
     git commit -a -m "[Automated] Update formula to release version $VERSION"
-    git pull origin master
-    git push origin master
+    git pull origin $BRANCH
+    git push origin $BRANCH
 cd ..
 rm -rf homebrew-tap
 

--- a/etc/build/release_pachctl
+++ b/etc/build/release_pachctl
@@ -4,15 +4,15 @@ set -e
 
 BRANCH=master
 
-if [ -n $1 ]
-then
-    BRANCH=$VERSION
-fi
-
 if [ -z $VERSION ]
 then
         echo "No version found for this commit! Aborting release"
         exit 1
+fi
+
+if [ -n $1 ]
+then
+    BRANCH=$VERSION
 fi
 
 echo "--- Releasing pachctl w version: $VERSION"

--- a/etc/build/release_pachctl
+++ b/etc/build/release_pachctl
@@ -59,7 +59,7 @@ cd homebrew-tap
     VERSION=$VERSION ./update-formula.sh
     git add pachctl@$MAJOR_MINOR.rb
     git commit -a -m "[Automated] Update formula to release version $VERSION"
-    git pull origin $BRANCH
+    git pull origin $BRANCH || true
     git push origin $BRANCH
 cd ..
 rm -rf homebrew-tap


### PR DESCRIPTION
Adds a new make task for truly custom releases. Now we can cut custom releases that host homebrew pachctl installs for as many custom versions as we want.

[I also updated the release docs and provided an overview of the release types](https://github.com/pachyderm/pachyderm/blob/8a79ef61b69cb7d169c1c1ce39e07040e32c0fe6/doc/release_instructions.md)