### PR TITLE
Clarify that dash fallback message isn't an error

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -579,7 +579,7 @@ func getDefaultOrLatestDashImage(dashImage string, dryRun bool) string {
 	version := version.PrettyPrintVersion(version.Version)
 	defer func() {
 		if err != nil && !dryRun {
-			fmt.Printf("Error retrieving latest dash image for pachctl %v: %v Falling back to dash image %v\n", version, err, defaultDashImage)
+			fmt.Printf("No updated dash image found for pachctl %v: %v Falling back to dash image %v\n", version, err, defaultDashImage)
 		}
 	}()
 	if dashImage != "" {


### PR DESCRIPTION
Pretty sure this is expected whenever a new pachctl version has been published more recently than the latest dash image