### PR TITLE
Make NotAuthorizedError support admin-only ops

### DIFF
--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -64,11 +64,20 @@ func IsNotActivatedError(err error) bool {
 }
 
 // NotAuthorizedError is returned if the user is not authorized to perform
-// a certain operation on the repo 'Repo' (to do so, they would need to have the
-// authorization scope in 'Required').
+// a certain operation. Either
+// 1) the operation is a user operation, in which case 'Repo' and/or 'Required'
+// 		should be set (indicating that the user needs 'Required'-level access to
+// 		'Repo').
+// 2) the operation is an admin-only operation (e.g. DeleteAll), in which case
+//    AdminOp should be set
 type NotAuthorizedError struct {
-	Repo     string
-	Required Scope
+	Repo     string // Repo that the user is attempting to access
+	Required Scope  // Caller needs 'Required'-level access to 'Repo'
+
+	// Group 2:
+	// AdminOp indicates an operation that the caller couldn't perform because
+	// they're not an admin
+	AdminOp string
 }
 
 // This error message string is matched in the UI. If edited,
@@ -82,6 +91,9 @@ func (e *NotAuthorizedError) Error() string {
 	}
 	if e.Required != Scope_NONE {
 		msg += ", must have at least " + e.Required.String() + " access"
+	}
+	if e.AdminOp != "" {
+		msg += "; must be an admin to call " + e.AdminOp
 	}
 	return msg
 }

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -91,7 +91,6 @@ func activateAuth(t testing.TB) {
 // cluster, and then enable the auth service in that cluster
 func getPachClient(t testing.TB, subject string) *client.APIClient {
 	t.Helper()
-	fmt.Printf("subject: %s\n", subject)
 	clientMapMut.Lock()
 	defer clientMapMut.Unlock()
 

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2114,11 +2114,10 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (respon
 
 	if me, err := pachClient.WhoAmI(ctx, &auth.WhoAmIRequest{}); err == nil {
 		if !me.IsAdmin {
-			return nil, fmt.Errorf("not authorized to delete all cluster data, must " +
-				"be a cluster admin")
+			return nil, &auth.NotAuthorizedError{AdminOp: "DeleteAll"}
 		}
 	} else if !auth.IsNotActivatedError(err) {
-		return nil, fmt.Errorf("DeleteAll(): could not verify that caller is admin: %v", err)
+		return nil, fmt.Errorf("Error during authorization check: %v", err)
 	}
 
 	pipelineInfos, err := a.ListPipeline(ctx, &pps.ListPipelineRequest{})


### PR DESCRIPTION
As well, return a structured error when user is not authorized to
perform admin-only operation