### PR TITLE
Rename spec repo to __spec__

### DIFF
--- a/src/server/pkg/ppsconsts/ppsconsts.go
+++ b/src/server/pkg/ppsconsts/ppsconsts.go
@@ -7,7 +7,7 @@ package ppsconsts
 
 const (
 	// SpecRepo contains every pipeline's PipelineInfo (in its own branch)
-	SpecRepo = "spec"
+	SpecRepo = "__spec__"
 
 	// SpecFile is the file in every SpecRepo commit containing the PipelineInfo
 	SpecFile = "spec"


### PR DESCRIPTION
Fix https://github.com/pachyderm/pachyderm/issues/2786