### PR TITLE
Replace 'ctx' args in driver.go with pachClient

### DIFF
--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -1,12 +1,9 @@
 package auth
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
-
-	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -44,22 +41,6 @@ func ParseScope(s string) (Scope, error) {
 		}
 	}
 	return Scope_NONE, fmt.Errorf("unrecognized scope: %s", s)
-}
-
-// In2Out converts an incoming context containing auth information into an
-// outgoing context containing auth information, stripping other keys (e.g.
-// for metrics) in the process. If the incoming context doesn't have any auth
-// information, then the returned context won't either.
-func In2Out(ctx context.Context) context.Context {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return ctx
-	}
-	mdOut := make(metadata.MD)
-	if value, ok := md[ContextTokenKey]; ok {
-		mdOut[ContextTokenKey] = value
-	}
-	return metadata.NewOutgoingContext(ctx, mdOut)
 }
 
 var (

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -102,13 +102,7 @@ func getPachClient(t testing.TB, subject string) *client.APIClient {
 
 	// Check if seed client exists -- if not, create it
 	if seedClient == nil {
-		var err error
-		if _, ok := os.LookupEnv("PACHD_PORT_650_TCP_ADDR"); ok {
-			seedClient, err = client.NewInCluster()
-		} else {
-			seedClient, err = client.NewOnUserMachine(false, "user")
-		}
-		require.NoError(t, err)
+		seeClient := tu.GetPachClient(t)
 		// discard any credentials from the user's machine (seedClient is
 		// anonymous)
 		seedClient = seedClient.WithCtx(context.Background())

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -102,7 +101,7 @@ func getPachClient(t testing.TB, subject string) *client.APIClient {
 
 	// Check if seed client exists -- if not, create it
 	if seedClient == nil {
-		seeClient := tu.GetPachClient(t)
+		seedClient = tu.GetPachClient(t)
 		// discard any credentials from the user's machine (seedClient is
 		// anonymous)
 		seedClient = seedClient.WithCtx(context.Background())

--- a/src/server/examples/examples_test.go
+++ b/src/server/examples/examples_test.go
@@ -11,13 +11,8 @@ import (
 	"github.com/pachyderm/pachyderm/src/client"
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	tu "github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 )
-
-func getPachClient(t testing.TB) *client.APIClient {
-	client, err := client.NewFromAddress("0.0.0.0:30650")
-	require.NoError(t, err)
-	return client
-}
 
 func toRepoNames(pfsRepos []*pfsclient.RepoInfo) []interface{} {
 	repoNames := make([]interface{}, len(pfsRepos))
@@ -33,7 +28,7 @@ func TestWordCount(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c := getPachClient(t)
+	c := tu.GetPachClient(t)
 
 	exampleDir := "../../../doc/examples/word_count"
 	newURL := "https://news.ycombinator.com/newsfaq.html"

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1599,7 +1599,6 @@ func (d *driver) createBranch(pachClient *client.APIClient, branch *pfs.Branch, 
 			}
 		}
 
-		var oldDirectProvenance []*pfs.Branch
 		// Retrieve (and create, if necessary) the current version of this branch
 		branches := d.branches(branch.Repo.Name).ReadWrite(stm)
 		branchInfo := &pfs.BranchInfo{}
@@ -1607,7 +1606,6 @@ func (d *driver) createBranch(pachClient *client.APIClient, branch *pfs.Branch, 
 			branchInfo.Name = branch.Name // set in case 'branch' is new
 			branchInfo.Branch = branch
 			branchInfo.Head = commit
-			oldDirectProvenance = branchInfo.DirectProvenance
 			branchInfo.DirectProvenance = nil
 			for _, provBranch := range provenance {
 				add(&branchInfo.DirectProvenance, provBranch)

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -52,8 +52,6 @@ func RepoToName(repo interface{}) interface{} {
 	return repo.(*pfs.Repo).Name
 }
 
-var testDBs []string
-
 func TestInvalidRepo(t *testing.T) {
 	client := getClient(t)
 	require.YesError(t, client.CreateRepo("/repo"))
@@ -2310,17 +2308,17 @@ const (
 var (
 	port int32 = 30653 // Initial port on which pachd server processes will serve
 
-	startPFSServersOnce sync.Once // ensure pachd servers are only started once
+	checkEtcdOnce sync.Once // ensure we only test the etcd connection once
 )
 
-// src/server/pfs/server/driver.go expects an etcd server at "localhost:32379"
-// Try to establish a connection before proceeding with the test (which will
-// fail if the connection can't be established)
-func startPFSServers(t *testing.T) {
-	startPFSServersOnce.Do(func() {
+func getClient(t *testing.T) *pclient.APIClient {
+	// src/server/pfs/server/driver.go expects an etcd server at "localhost:32379"
+	// Try to establish a connection before proceeding with the test (which will
+	// fail if the connection can't be established)
+	checkEtcdOnce.Do(func() {
 		require.NoError(t, backoff.Retry(func() error {
 			_, err := etcd.New(etcd.Config{
-				Endpoints:   []string{etcdAddress},
+				Endpoints:   []string{tu.GetEtcdAddress()},
 				DialOptions: pclient.EtcdDialOptions(),
 			})
 			if err != nil {
@@ -2329,12 +2327,6 @@ func startPFSServers(t *testing.T) {
 			return nil
 		}, backoff.NewTestingBackOff()))
 	})
-}
-
-func getClient(t *testing.T) *pclient.APIClient {
-	startPFSServers(t)
-	dbName := "pachyderm_test_" + uuid.NewWithoutDashes()[0:12]
-	testDBs = append(testDBs, dbName)
 
 	root := tu.UniqueString("/tmp/pach_test/run")
 	t.Logf("root %s", root)
@@ -2349,9 +2341,9 @@ func getClient(t *testing.T) *pclient.APIClient {
 	prefix := generateRandomString(32)
 	for i, port := range ports {
 		address := addresses[i]
-		blockAPIServer, err := newLocalBlockAPIServer(root, 256*1024*1024, etcdAddress)
+		blockAPIServer, err := newLocalBlockAPIServer(root, 256*1024*1024, tu.GetEtcdAddress())
 		require.NoError(t, err)
-		apiServer, err := newLocalAPIServer(address, prefix)
+		apiServer, err := newAPIServer(address, []string{tu.GetEtcdAddress()}, prefix, -1)
 		require.NoError(t, err)
 		runServers(t, port, apiServer, blockAPIServer)
 	}

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -1252,7 +1252,7 @@ func objectMeta(name string, labels, annotations map[string]string, namespace st
 	}
 }
 
-// AddRegistry switchs the registry that an image is targetting.
+// AddRegistry switches the registry that an image is targetting.
 func AddRegistry(registry string, imageName string) string {
 	parts := strings.Split(imageName, "/")
 	if len(parts) == 3 {

--- a/src/server/pkg/pachrpc/pachrpc.go
+++ b/src/server/pkg/pachrpc/pachrpc.go
@@ -1,0 +1,58 @@
+package pachrpc
+
+import (
+	"fmt"
+	"sync"
+
+	"golang.org/x/net/context"
+
+	"github.com/pachyderm/pachyderm/src/client"
+)
+
+var (
+	// pachClient is the "template" client that contains the original GRPC
+	// connection and that other clients returned by this library are based on. It
+	// has no ctx and therefore no auth credentials or cancellation
+	pachClient *client.APIClient
+
+	// pachClientMu guards pachClient
+	pachClientOnce sync.Once
+
+	// pachClientReady is closed once pachClient has been initialized
+	pachClientReady = make(chan struct{})
+)
+
+// InitPachRPC initializes the PachRPC library. This creates the template
+// pachClient used by future calls to GetPachClient and dials a GRPC connection
+// to 'address'.
+//
+// This should be called by packages that receive incoming ctxs (which must be
+// transformed to pachClients to propagate e.g. auth info). For example,
+// {pfs,pps}.NewAPIServer should call this, as they receive incoming RPCs with
+// attached ctxs, but newDriver, which only receives internal calls, should
+// not (its caller--pps or any tests--would do that).
+func InitPachRPC(address string) {
+	pachClientOnce.Do(func() {
+		if address == "" {
+			panic("cannot initialize pach client with empty address")
+		}
+		if pachClient != nil {
+			return // already initialized
+		}
+		var err error
+		pachClient, err = client.NewFromAddress(address)
+		if err != nil {
+			panic(fmt.Sprintf("pps failed to initialize pach client: %v", err))
+		}
+		close(pachClientReady)
+	})
+}
+
+// GetPachClient returns a pachd client with the same authentication credentials
+// and cancellation as 'ctx' (ensuring that auth credentials are propagated
+// through downstream RPCs). Internal Pachyderm calls accept clients returned
+// by this call.
+func GetPachClient(ctx context.Context) *client.APIClient {
+	<-pachClientReady // wait until InitPachRPC is finished
+	return pachClient.WithCtx(ctx)
+}

--- a/src/server/pkg/testutil/pachclient.go
+++ b/src/server/pkg/testutil/pachclient.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client"
+)
+
+var (
+	// pachClient is the "template" client that contains the original GRPC
+	// connection and that other clients returned by this library are based on. It
+	// has no ctx and therefore no auth credentials or cancellation
+	pachClient *client.APIClient
+
+	// pachClientOnce ensures that 'pachClient' is only initialized once
+	pachClientOnce sync.Once
+
+	// etcdAddress is a hostport pointing (hopefully) to etcd. This library
+	// guesses an etcd hostport from the environment
+	etcdAddress string
+
+	// etcdAddressOnce ensures that etcdAddress is only initialized once
+	etcdAddressOnce sync.Once
+)
+
+// GetPachClient returns a pachd client to tests. It's initialized once and then
+// reused for future tests
+func GetPachClient(tb testing.TB) *client.APIClient {
+	tb.Helper()
+	pachClientOnce.Do(func() {
+		var err error
+		if _, ok := os.LookupEnv("PACHD_PORT_650_TCP_ADDR"); ok {
+			pachClient, err = client.NewInCluster()
+		} else {
+			pachClient, err = client.NewOnUserMachine(false, "user")
+		}
+		if err != nil {
+			panic(fmt.Sprintf("pps failed to initialize pach client: %v", err))
+		}
+	})
+	return pachClient
+}
+
+// GetEtcdAddress guesses an etcd hostport based on this process's environment
+// variables, caches it, and then returns it in this and subsequent calls
+func GetEtcdAddress() string {
+	etcdAddressOnce.Do(func() {
+		var err error
+		if val, ok := os.LookupEnv("ETCD_PORT_2379_TCP_ADDR"); ok {
+			etcdAddress = val + ":2379"
+		} else if val, ok := os.LookupEnv("ADDRESS"); ok {
+			idx := strings.LastIndex(val, ":")
+			if idx < 0 {
+				panic("ADDRESS does not contain \":\": %s", val)
+			}
+			etcdAddress = val[:idx] + ":32379"
+		} else {
+			etcdAddress = "127.0.0.1:32379"
+		}
+	})
+	return etcdAddress
+}

--- a/src/server/pkg/testutil/pachclient.go
+++ b/src/server/pkg/testutil/pachclient.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -47,13 +49,12 @@ func GetPachClient(tb testing.TB) *client.APIClient {
 // variables, caches it, and then returns it in this and subsequent calls
 func GetEtcdAddress() string {
 	etcdAddressOnce.Do(func() {
-		var err error
 		if val, ok := os.LookupEnv("ETCD_PORT_2379_TCP_ADDR"); ok {
 			etcdAddress = val + ":2379"
 		} else if val, ok := os.LookupEnv("ADDRESS"); ok {
 			idx := strings.LastIndex(val, ":")
 			if idx < 0 {
-				panic("ADDRESS does not contain \":\": %s", val)
+				panic(fmt.Sprintf("ADDRESS does not contain \":\": %s", val))
 			}
 			etcdAddress = val[:idx] + ":32379"
 		} else {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/hashtree"
 	"github.com/pachyderm/pachyderm/src/server/pkg/log"
 	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
+	"github.com/pachyderm/pachyderm/src/server/pkg/pachrpc"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsconsts"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsdb"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
@@ -104,11 +105,8 @@ type apiServer struct {
 	log.Logger
 	etcdPrefix            string
 	hasher                *ppsserver.Hasher
-	address               string
 	etcdClient            *etcd.Client
 	kubeClient            *kube.Clientset
-	pachClient            *client.APIClient
-	pachClientOnce        sync.Once
 	namespace             string
 	workerImage           string
 	workerSidecarImage    string
@@ -339,7 +337,7 @@ func (a *apiServer) validateKube() {
 func (a *apiServer) CreateJob(ctx context.Context, request *pps.CreateJobRequest) (response *pps.Job, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	ctx = pachClient.Ctx() // pachClient will propagate auth info
 
 	job := &pps.Job{uuid.NewWithoutDashes()}
@@ -361,7 +359,7 @@ func (a *apiServer) CreateJob(ctx context.Context, request *pps.CreateJobRequest
 func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobRequest) (response *pps.JobInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 
 	jobs := a.jobs.ReadOnly(ctx)
 
@@ -572,7 +570,7 @@ func (a *apiServer) ListJob(ctx context.Context, request *pps.ListJobRequest) (r
 			a.Log(request, response, retErr, time.Since(start))
 		}
 	}(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	jobInfos, err := a.listJob(pachClient, request.Pipeline, request.OutputCommit, request.InputCommit)
 	if err != nil {
 		return nil, err
@@ -586,7 +584,7 @@ func (a *apiServer) ListJobStream(request *pps.ListJobRequest, resp pps.API_List
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("stream containing %d JobInfos", sent), retErr, time.Since(start))
 	}(time.Now())
-	pachClient := a.getPachClient().WithCtx(resp.Context())
+	pachClient := pachrpc.GetPachClient(resp.Context())
 	jobInfos, err := a.listJob(pachClient, request.Pipeline, request.OutputCommit, request.InputCommit)
 	if err != nil {
 		return err
@@ -606,7 +604,7 @@ func (a *apiServer) FlushJob(request *pps.FlushJobRequest, resp pps.API_FlushJob
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("stream containing %d JobInfos", sent), retErr, time.Since(start))
 	}(time.Now())
-	pachClient := a.getPachClient().WithCtx(resp.Context())
+	pachClient := pachrpc.GetPachClient(resp.Context())
 	var toRepos []*pfs.Repo
 	for _, pipeline := range request.ToPipelines {
 		toRepos = append(toRepos, client.NewRepo(pipeline.Name))
@@ -648,7 +646,7 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 func (a *apiServer) StopJob(ctx context.Context, request *pps.StopJobRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	jobPtr := &pps.EtcdJobInfo{}
 	if err := a.jobs.ReadOnly(ctx).Get(request.Job.ID, jobPtr); err != nil {
 		return nil, err
@@ -860,7 +858,7 @@ func (a *apiServer) ListDatum(ctx context.Context, request *pps.ListDatumRequest
 			a.Log(request, response, retErr, time.Since(start))
 		}
 	}(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	return a.listDatum(pachClient, request.Job, request.Page, request.PageSize)
 }
 
@@ -870,7 +868,7 @@ func (a *apiServer) ListDatumStream(req *pps.ListDatumRequest, resp pps.API_List
 	defer func(start time.Time) {
 		a.Log(req, fmt.Sprintf("stream containing %d DatumInfos", sent), retErr, time.Since(start))
 	}(time.Now())
-	pachClient := a.getPachClient().WithCtx(resp.Context())
+	pachClient := pachrpc.GetPachClient(resp.Context())
 	ldr, err := a.listDatum(pachClient, req.Job, req.Page, req.PageSize)
 	if err != nil {
 		return err
@@ -976,7 +974,7 @@ func (a *apiServer) getDatum(pachClient *client.APIClient, repo string, commit *
 func (a *apiServer) InspectDatum(ctx context.Context, request *pps.InspectDatumRequest) (response *pps.DatumInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	ctx = pachClient.Ctx() // pachClient will propagate auth info
 	jobInfo, err := a.InspectJob(ctx, &pps.InspectJobRequest{
 		Job: &pps.Job{
@@ -1010,7 +1008,7 @@ func (a *apiServer) InspectDatum(ctx context.Context, request *pps.InspectDatumR
 func (a *apiServer) GetLogs(request *pps.GetLogsRequest, apiGetLogsServer pps.API_GetLogsServer) (retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(apiGetLogsServer.Context())
+	pachClient := pachrpc.GetPachClient(apiGetLogsServer.Context())
 	ctx := pachClient.Ctx() // pachClient will propagate auth info
 
 	// Authorize request and get list of pods containing logs we're interested in
@@ -1675,7 +1673,7 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
 	metricsFn := metrics.ReportUserAction(ctx, a.reporter, "CreatePipeline")
 	defer func(start time.Time) { metricsFn(start, retErr) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	ctx = pachClient.Ctx() // pachClient will propagate auth info
 	pfsClient := pachClient.PfsAPIClient
 	if request.Salt == "" {
@@ -1920,7 +1918,7 @@ func setPipelineDefaults(pipelineInfo *pps.PipelineInfo) {
 func (a *apiServer) InspectPipeline(ctx context.Context, request *pps.InspectPipelineRequest) (response *pps.PipelineInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	return a.inspectPipeline(pachClient, request.Pipeline.Name)
 }
 
@@ -1992,7 +1990,7 @@ func (a *apiServer) ListPipeline(ctx context.Context, request *pps.ListPipelineR
 			a.Log(request, response, retErr, time.Since(start))
 		}
 	}(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 
 	pipelineIter, err := a.pipelines.ReadOnly(pachClient.Ctx()).List()
 	if err != nil {
@@ -2026,7 +2024,7 @@ func (a *apiServer) ListPipeline(ctx context.Context, request *pps.ListPipelineR
 func (a *apiServer) DeletePipeline(ctx context.Context, request *pps.DeletePipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 
 	// Possibly list pipelines in etcd (skip PFS read--don't need it) and delete them
 	if request.All {
@@ -2184,7 +2182,7 @@ func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.De
 func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 
 	// Get request.Pipeline's info
 	pipelineInfo, err := a.inspectPipeline(pachClient, request.Pipeline.Name)
@@ -2218,7 +2216,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineRequest) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 
 	// Get request.Pipeline's info
 	pipelineInfo, err := a.inspectPipeline(pachClient, request.Pipeline.Name)
@@ -2259,7 +2257,7 @@ func (a *apiServer) RerunPipeline(ctx context.Context, request *pps.RerunPipelin
 func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	ctx = pachClient.Ctx() // pachClient will propagate auth info
 
 	if me, err := pachClient.WhoAmI(ctx, &auth.WhoAmIRequest{}); err == nil {
@@ -2308,7 +2306,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (respon
 func (a *apiServer) GarbageCollect(ctx context.Context, request *pps.GarbageCollectRequest) (response *pps.GarbageCollectResponse, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	ctx = pachClient.Ctx() // pachClient will propagate auth info
 	pfsClient := pachClient.PfsAPIClient
 	objClient := pachClient.ObjectAPIClient
@@ -2501,7 +2499,7 @@ func (a *apiServer) GarbageCollect(ctx context.Context, request *pps.GarbageColl
 func (a *apiServer) ActivateAuth(ctx context.Context, req *pps.ActivateAuthRequest) (resp *pps.ActivateAuthResponse, retErr error) {
 	func() { a.Log(req, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(req, resp, retErr, time.Since(start)) }(time.Now())
-	pachClient := a.getPachClient().WithCtx(ctx)
+	pachClient := pachrpc.GetPachClient(ctx)
 	ctx = pachClient.Ctx() // pachClient will propagate auth info
 
 	// TODO: block creating of pipelines until this is done, so that ListPipelines
@@ -2647,23 +2645,6 @@ func (a *apiServer) updateJobState(stm col.STM, jobPtr *pps.EtcdJobInfo, state p
 	jobs := a.jobs.ReadWrite(stm)
 	jobs.Put(jobPtr.Job.ID, jobPtr)
 	return nil
-}
-
-func (a *apiServer) getPachClient() *client.APIClient {
-	a.pachClientOnce.Do(func() {
-		var err error
-		a.pachClient, err = client.NewFromAddress(a.address)
-		if err != nil {
-			panic(fmt.Sprintf("pps failed to initialize pach client: %v", err))
-		}
-		// Initialize spec repo
-		if err := a.pachClient.CreateRepo(ppsconsts.SpecRepo); err != nil {
-			if !isAlreadyExistsErr(err) {
-				panic(fmt.Sprintf("could not create pipeline spec repo: %v", err))
-			}
-		}
-	})
-	return a.pachClient
 }
 
 // RepoNameToEnvString is a helper which uppercases a repo name for

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/client/version"
 	"github.com/pachyderm/pachyderm/src/server/pkg/deploy/assets"
+	"github.com/pachyderm/pachyderm/src/server/pkg/pachrpc"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
 
 	v1 "k8s.io/api/core/v1"
@@ -105,11 +106,12 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 	})
 	zeroVal := int64(0)
 	workerImage := a.workerImage
-	resp, err := a.getPachClient().Enterprise.GetState(context.Background(), &enterprise.GetStateRequest{})
+	pachClient := pachrpc.GetPachClient(context.Background())
+	resp, err := pachClient.Enterprise.GetState(context.Background(), &enterprise.GetStateRequest{})
 	if err != nil {
 		return v1.PodSpec{}, err
 	}
-	if resp.State != enterprise.State_ACTIVE {
+	if resp.State == enterprise.State_ACTIVE {
 		workerImage = assets.AddRegistry("", workerImage)
 	}
 	podSpec := v1.PodSpec{

--- a/src/server/worker/worker_test.go
+++ b/src/server/worker/worker_test.go
@@ -15,11 +15,12 @@ import (
 	pclient "github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/client/pkg/uuid"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsdb"
-	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
+	tu "github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 )
 
 var (
@@ -27,7 +28,7 @@ var (
 )
 
 // func TestAcquireDatums(t *testing.T) {
-// 	c := getPachClient(t)
+// 	c := tu.GetPachClient(t)
 // 	etcdClient := getEtcdClient(t)
 //
 // 	chunks := col.NewCollection(etcdClient, path.Join("", chunksPrefix), []col.Index{}, &Chunks{}, nil)
@@ -72,12 +73,11 @@ func getEtcdClient(t *testing.T) *etcd.Client {
 	// src/server/pfs/server/driver.go expects an etcd server at "localhost:32379"
 	// Try to establish a connection before proceeding with the test (which will
 	// fail if the connection can't be established)
-	etcdAddress := "localhost:32379"
 	etcdOnce.Do(func() {
 		require.NoError(t, backoff.Retry(func() error {
 			var err error
 			etcdClient, err = etcd.New(etcd.Config{
-				Endpoints:   []string{etcdAddress},
+				Endpoints:   []string{tu.GetEtcdAddress()},
 				DialOptions: pclient.EtcdDialOptions(),
 			})
 			if err != nil {
@@ -87,22 +87,6 @@ func getEtcdClient(t *testing.T) *etcd.Client {
 		}, backoff.NewTestingBackOff()))
 	})
 	return etcdClient
-}
-
-var pachClient *client.APIClient
-var getPachClientOnce sync.Once
-
-func getPachClient(t testing.TB) *client.APIClient {
-	getPachClientOnce.Do(func() {
-		var err error
-		if addr := os.Getenv("PACHD_PORT_650_TCP_ADDR"); addr != "" {
-			pachClient, err = client.NewInCluster()
-		} else {
-			pachClient, err = client.NewOnUserMachine(false, "user")
-		}
-		require.NoError(t, err)
-	})
-	return pachClient
 }
 
 func newTestAPIServer(pachClient *client.APIClient, etcdClient *etcd.Client, etcdPrefix string, t *testing.T) *APIServer {


### PR DESCRIPTION
Also, create a new pachrpc library that initializes the pachyderm GRPC
connection, and remove that code from all of our API server
implementations