### PR TITLE
Fix auth activation bugs:

### DIFF
--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -112,6 +112,9 @@ func IsErrPartiallyActivated(err error) bool {
 
 // IsErrNotSignedIn returns true if 'err' is a ErrNotSignedIn
 func IsErrNotSignedIn(err error) bool {
+	if err == nil {
+		return false
+	}
 	// TODO(msteffen) This is unstructured because we have no way to propagate
 	// structured errors across GRPC boundaries. Fix
 	return strings.Contains(err.Error(), ErrNotSignedIn.Error())

--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -70,6 +70,11 @@ var (
 	// it also needs to be updated in the UI code
 	ErrNotActivated = errors.New("the auth service is not activated")
 
+	// ErrPartiallyActivated is returned by the auth API to indicated that it's
+	// in an intermediate state (in this state, users can retry Activate() or
+	// revert with Deactivate(), but not much else)
+	ErrPartiallyActivated = errors.New("the auth service is partially activated")
+
 	// ErrNotSignedIn indicates that the caller isn't signed in
 	//
 	// Note: This error message string is matched in the UI. If edited,
@@ -93,6 +98,40 @@ func IsErrNotActivated(err error) bool {
 	// TODO(msteffen) This is unstructured because we have no way to propagate
 	// structured errors across GRPC boundaries. Fix
 	return strings.Contains(err.Error(), ErrNotActivated.Error())
+}
+
+// IsErrPartiallyActivated checks if an error is a ErrPartiallyActivated
+func IsErrPartiallyActivated(err error) bool {
+	if err == nil {
+		return false
+	}
+	// TODO(msteffen) This is unstructured because we have no way to propagate
+	// structured errors across GRPC boundaries. Fix
+	return strings.Contains(err.Error(), ErrPartiallyActivated.Error())
+}
+
+// IsErrNotSignedIn returns true if 'err' is a ErrNotSignedIn
+func IsErrNotSignedIn(err error) bool {
+	// TODO(msteffen) This is unstructured because we have no way to propagate
+	// structured errors across GRPC boundaries. Fix
+	return strings.Contains(err.Error(), ErrNotSignedIn.Error())
+}
+
+// IsErrNoToken returns true if 'err' is a ErrNoToken (uses string
+// comparison to work across RPC boundaries)
+func IsErrNoToken(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), ErrNoToken.Error())
+}
+
+// IsErrBadToken returns true if 'err' is a ErrBadToken
+func IsErrBadToken(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), ErrBadToken.Error())
 }
 
 // ErrNotAuthorized is returned if the user is not authorized to perform
@@ -146,13 +185,6 @@ func IsErrNotAuthorized(err error) bool {
 	return strings.Contains(err.Error(), errNotAuthorizedMsg)
 }
 
-// IsErrNotSignedIn returns true if 'err' is a ErrNotSignedIn
-func IsErrNotSignedIn(err error) bool {
-	// TODO(msteffen) This is unstructured because we have no way to propagate
-	// structured errors across GRPC boundaries. Fix
-	return strings.Contains(err.Error(), ErrNotSignedIn.Error())
-}
-
 // ErrInvalidPrincipal indicates that a an argument to e.g. GetScope,
 // SetScope, or SetACL is invalid
 type ErrInvalidPrincipal struct {
@@ -170,23 +202,6 @@ func IsErrInvalidPrincipal(err error) bool {
 	}
 	return strings.Contains(err.Error(), "invalid principal \"") &&
 		strings.Contains(err.Error(), "\"; must start with one of \"pipeline:\", \"github:\", or \"robot:\", or have no \":\"")
-}
-
-// IsErrNoToken returns true if 'err' is a ErrNoToken (uses string
-// comparison to work across RPC boundaries)
-func IsErrNoToken(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), ErrNoToken.Error())
-}
-
-// IsErrBadToken returns true if 'err' is a ErrBadToken
-func IsErrBadToken(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), ErrBadToken.Error())
 }
 
 // ErrTooShortTTL is returned by the ExtendAuthToken if request.Token already

--- a/src/client/auth/auth_err_test.go
+++ b/src/client/auth/auth_err_test.go
@@ -14,26 +14,37 @@ func grpcify(err error) error {
 }
 
 func TestIsErrNotActivated(t *testing.T) {
+	require.False(t, IsErrNotActivated(nil))
 	require.True(t, IsErrNotActivated(ErrNotActivated))
 	require.True(t, IsErrNotActivated(grpcify(ErrNotActivated)))
 }
 
+func TestIsErrPartiallyActivated(t *testing.T) {
+	require.False(t, IsErrPartiallyActivated(nil))
+	require.True(t, IsErrPartiallyActivated(ErrPartiallyActivated))
+	require.True(t, IsErrPartiallyActivated(grpcify(ErrPartiallyActivated)))
+}
+
 func TestIsErrNotSignedIn(t *testing.T) {
+	require.False(t, IsErrNotSignedIn(nil))
 	require.True(t, IsErrNotSignedIn(ErrNotSignedIn))
 	require.True(t, IsErrNotSignedIn(grpcify(ErrNotSignedIn)))
 }
 
 func TestIsErrNoToken(t *testing.T) {
+	require.False(t, IsErrNoToken(nil))
 	require.True(t, IsErrNoToken(ErrNoToken))
 	require.True(t, IsErrNoToken(grpcify(ErrNoToken)))
 }
 
 func TestIsErrBadToken(t *testing.T) {
+	require.False(t, IsErrBadToken(nil))
 	require.True(t, IsErrBadToken(ErrBadToken))
 	require.True(t, IsErrBadToken(grpcify(ErrBadToken)))
 }
 
 func TestIsErrNotAuthorized(t *testing.T) {
+	require.False(t, IsErrNotAuthorized(nil))
 	require.True(t, IsErrNotAuthorized(&ErrNotAuthorized{
 		Subject:  "alice",
 		Repo:     "data",
@@ -55,6 +66,7 @@ func TestIsErrNotAuthorized(t *testing.T) {
 }
 
 func TestIsErrInvalidPrincipal(t *testing.T) {
+	require.False(t, IsErrInvalidPrincipal(nil))
 	require.True(t, IsErrInvalidPrincipal(&ErrInvalidPrincipal{
 		Principal: "alice",
 	}))
@@ -64,6 +76,7 @@ func TestIsErrInvalidPrincipal(t *testing.T) {
 }
 
 func TestIsErrTooShortTTL(t *testing.T) {
+	require.False(t, IsErrTooShortTTL(nil))
 	require.True(t, IsErrTooShortTTL(ErrTooShortTTL{
 		RequestTTL:  1234,
 		ExistingTTL: 2345,

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -159,6 +159,11 @@ func LoginCmd() *cobra.Command {
 				c.Ctx(),
 				&auth.AuthenticateRequest{GitHubToken: token})
 			if err != nil {
+				if auth.IsErrPartiallyActivated(err) {
+					return fmt.Errorf("%v: if pachyderm is stuck in this state, you "+
+						"can revert by running 'pachctl auth deactivate' or retry by "+
+						"running 'pachctl auth activate' again", err)
+				}
 				return fmt.Errorf("error authenticating with Pachyderm cluster: %v",
 					grpcutil.ScrubGRPC(err))
 			}
@@ -380,6 +385,11 @@ func ModifyAdminsCmd() *cobra.Command {
 				Add:    add,
 				Remove: remove,
 			})
+			if auth.IsErrPartiallyActivated(err) {
+				return fmt.Errorf("%v: if pachyderm is stuck in this state, you "+
+					"can revert by running 'pachctl auth deactivate' or retry by "+
+					"running 'pachctl auth activate' again", err)
+			}
 			return grpcutil.ScrubGRPC(err)
 		}),
 	}

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -179,7 +179,7 @@ const (
 	full
 )
 
-// activationState returns 'none' if auth is totally inactivate, 'partial' if
+// activationState returns 'none' if auth is totally inactive, 'partial' if
 // auth.Activate has been called, but hasn't finished or failed, and full
 // if auth.Activate has been called and succeeded.
 //

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -171,6 +171,33 @@ func NewAuthServer(pachdAddress string, etcdAddress string, etcdPrefix string) (
 	return s, nil
 }
 
+type activationState int
+
+const (
+	none activationState = iota
+	partial
+	full
+)
+
+// activationState returns 'none' if auth is totally inactivate, 'partial' if
+// auth.Activate has been called, but hasn't finished or failed, and full
+// if auth.Activate has been called and succeeded.
+//
+// When the activation state is 'partial' users cannot authenticate; the only
+// functioning auth API calls are Activate() (to retry activation) and
+// Deactivate() (to give up and revert to the 'none' state)
+func (a *apiServer) activationState() activationState {
+	a.adminMu.Lock()
+	defer a.adminMu.Unlock()
+	if len(a.adminCache) == 0 {
+		return none
+	}
+	if _, magicUserIsAdmin := a.adminCache[magicUser]; magicUserIsAdmin {
+		return partial
+	}
+	return full
+}
+
 // Retrieve the PPS master token, or generate it and put it in etcd.
 // TODO This is a hack. It avoids the need to return superuser tokens from
 // GetAuthToken (essentially, PPS and Auth communicate through etcd instead of
@@ -286,16 +313,12 @@ func (a *apiServer) Activate(ctx context.Context, req *authclient.ActivateReques
 	// otherwise anyone can just activate the service again and set
 	// themselves as an admin. If activation failed in PFS, calling auth.Activate
 	// again should work (in this state, the only admin will be 'magicUser')
-	if fullyActivated := func() bool {
-		a.adminMu.Lock()
-		defer a.adminMu.Unlock()
-		_, magicUserIsAdmin := a.adminCache[magicUser]
-		return len(a.adminCache) > 0 && !magicUserIsAdmin
-	}(); fullyActivated {
+	if a.activationState() == full {
 		return nil, fmt.Errorf("already activated")
 	}
 
-	// Determine caller's subject string
+	// Authenticate the caller (or generate a new auth token if req.Subject is a
+	// robot user)
 	if req.Subject != "" {
 		req.Subject, err = lenientCanonicalizeSubject(ctx, req.Subject)
 		if err != nil {
@@ -321,14 +344,28 @@ func (a *apiServer) Activate(ctx context.Context, req *authclient.ActivateReques
 		return nil, fmt.Errorf("invalid subject in request (must be a GitHub user or robot): \"%s\"", req.Subject)
 	}
 
-	// Hack: set the cluster admins to just {magicUser}. This ensures that no
-	// pipelines can be created while PPS is granting all existing pipelines auth
-	// tokens and adjusting the ACLs of input/output repos
+	// Hack: set the cluster admins to just {magicUser}. This puts the auth system
+	// in the "partial" activation state. Users cannot authenticate, but auth
+	// checks are now enforced, which means no pipelines or repos can be created
+	// while ACLs are being added to every repo for the existing pipelines
 	if _, err = col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
 		return a.admins.ReadWrite(stm).Put(magicUser, epsilon)
 	}); err != nil {
 		return nil, err
 	}
+	// wait until watchAdmins has updated the local cache (changing the activation
+	// state)
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = 30 * time.Second
+	if err := backoff.Retry(func() error {
+		if a.activationState() != partial {
+			return fmt.Errorf("auth never entered \"partial\" activation state")
+		}
+		return nil
+	}, b); err != nil {
+		return nil, err
+	}
+	time.Sleep(time.Second) // give other pachd nodes time to update their cache
 
 	// Call PPS.ActivateAuth to set up all affected pipelines and repos
 	if _, err := pachClient.ActivateAuth(ctx, &pps.ActivateAuthRequest{}); err != nil {
@@ -359,17 +396,18 @@ func (a *apiServer) Activate(ctx context.Context, req *authclient.ActivateReques
 		return nil, err
 	}
 
-	// wait until watchAdmins has activated auth, so that Activate() is less
-	// likely to race with subsequent calls that expect auth to be activated.
+	// wait until watchAdmins has updated the local cache (changing the
+	// activation state), so that Activate() is less likely to race with
+	// subsequent calls that expect auth to be activated.
 	// TODO this is a bit hacky (checking repeatedly in a spin loop) but
 	// Activate() is rarely called, and it helps avoid races due to other pachd
 	// pods being out of date.
 	if err := backoff.Retry(func() error {
-		if !a.isActivated() {
-			return authclient.ErrNotActivated
+		if a.activationState() != full {
+			return fmt.Errorf("auth never entered \"full\" activation state")
 		}
 		return nil
-	}, backoff.RetryEvery(time.Second)); err != nil {
+	}, b); err != nil {
 		return nil, err
 	}
 	time.Sleep(time.Second) // give other pachd nodes time to update their cache
@@ -379,8 +417,29 @@ func (a *apiServer) Activate(ctx context.Context, req *authclient.ActivateReques
 func (a *apiServer) Deactivate(ctx context.Context, req *authclient.DeactivateRequest) (resp *authclient.DeactivateResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
+		// users should be able to call "deactivate" from the "partial" activation
+		// state, in case activation fails and they need to revert to "none"
 		return nil, authclient.ErrNotActivated
+	}
+
+	// Check if the cluster is in a partially-activated state. If so, allow it to
+	// be completely deactivated so that it returns to normal
+	var magicUserIsAdmin bool
+	func() {
+		a.adminMu.Lock()
+		defer a.adminMu.Unlock()
+		_, magicUserIsAdmin = a.adminCache[magicUser]
+	}()
+	if magicUserIsAdmin {
+		_, err := col.NewSTM(ctx, a.etcdClient, func(stm col.STM) error {
+			a.admins.ReadWrite(stm).DeleteAll() // watchAdmins() will see the write
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &authclient.DeactivateResponse{}, nil
 	}
 
 	// Get calling user. The user must be a cluster admin to disable auth for the
@@ -411,7 +470,7 @@ func (a *apiServer) Deactivate(ctx context.Context, req *authclient.DeactivateRe
 	// Deactivate() is rarely called, and it helps avoid races due to other pachd
 	// pods being out of date.
 	if err := backoff.Retry(func() error {
-		if a.isActivated() {
+		if a.activationState() != none {
 			return fmt.Errorf("auth still activated")
 		}
 		return nil
@@ -420,12 +479,6 @@ func (a *apiServer) Deactivate(ctx context.Context, req *authclient.DeactivateRe
 	}
 	time.Sleep(time.Second) // give other pachd nodes time to update their cache
 	return &authclient.DeactivateResponse{}, nil
-}
-
-func (a *apiServer) isActivated() bool {
-	a.adminMu.Lock()
-	defer a.adminMu.Unlock()
-	return len(a.adminCache) > 0
 }
 
 // GitHubTokenToUsername takes a OAuth access token issued by GitHub and uses
@@ -462,17 +515,18 @@ func GitHubTokenToUsername(ctx context.Context, oauthToken string) (string, erro
 func (a *apiServer) GetAdmins(ctx context.Context, req *authclient.GetAdminsRequest) (resp *authclient.GetAdminsResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	switch a.activationState() {
+	case none:
 		return nil, authclient.ErrNotActivated
-	}
-
-	// Get calling user. There is no auth check to see the list of cluster admins,
-	// other than that the user must log in. Otherwise how will users know who to
-	// ask for admin privileges? Requiring the user to be logged in mitigates
-	// phishing
-	_, err := a.getAuthenticatedUser(ctx)
-	if err != nil {
-		return nil, err
+	case full:
+		// Get calling user. There is no auth check to see the list of cluster
+		// admins, other than that the user must log in. Otherwise how will users
+		// know who to ask for admin privileges? Requiring the user to be logged in
+		// mitigates phishing
+		_, err := a.getAuthenticatedUser(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	a.adminMu.Lock()
@@ -527,8 +581,11 @@ func (a *apiServer) validateModifyAdminsRequest(add []string, remove []string) e
 func (a *apiServer) ModifyAdmins(ctx context.Context, req *authclient.ModifyAdminsRequest) (resp *authclient.ModifyAdminsResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	switch a.activationState() {
+	case none:
 		return nil, authclient.ErrNotActivated
+	case partial:
+		return nil, authclient.ErrPartiallyActivated
 	}
 
 	// Get calling user. The user must be an admin to change the list of admins
@@ -601,12 +658,19 @@ func (a *apiServer) ModifyAdmins(ctx context.Context, req *authclient.ModifyAdmi
 }
 
 func (a *apiServer) Authenticate(ctx context.Context, req *authclient.AuthenticateRequest) (resp *authclient.AuthenticateResponse, retErr error) {
+	switch a.activationState() {
+	case none:
+		// PPS is authenticated by a token read from etcd. It never calls or needs
+		// to call authenticate, even while the cluster is partway through the
+		// activation process
+		return nil, authclient.ErrNotActivated
+	case partial:
+		return nil, authclient.ErrPartiallyActivated
+	}
+
 	// We don't want to actually log the request/response since they contain
 	// credentials.
 	defer func(start time.Time) { a.LogResp(nil, nil, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
-		return nil, authclient.ErrNotActivated
-	}
 
 	// Determine caller's Pachyderm/GitHub username
 	username, err := GitHubTokenToUsername(ctx, req.GitHubToken)
@@ -648,7 +712,7 @@ func (a *apiServer) Authenticate(ctx context.Context, req *authclient.Authentica
 func (a *apiServer) Authorize(ctx context.Context, req *authclient.AuthorizeRequest) (resp *authclient.AuthorizeResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 
@@ -697,7 +761,7 @@ func (a *apiServer) Authorize(ctx context.Context, req *authclient.AuthorizeRequ
 func (a *apiServer) WhoAmI(ctx context.Context, req *authclient.WhoAmIRequest) (resp *authclient.WhoAmIResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 
@@ -734,7 +798,7 @@ func (a *apiServer) isAdmin(user string) bool {
 func (a *apiServer) SetScope(ctx context.Context, req *authclient.SetScopeRequest) (resp *authclient.SetScopeResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 	pachClient := a.getPachClient().WithCtx(ctx)
@@ -827,7 +891,7 @@ func (a *apiServer) SetScope(ctx context.Context, req *authclient.SetScopeReques
 func (a *apiServer) GetScope(ctx context.Context, req *authclient.GetScopeRequest) (resp *authclient.GetScopeResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 
@@ -886,7 +950,7 @@ func (a *apiServer) GetScope(ctx context.Context, req *authclient.GetScopeReques
 func (a *apiServer) GetACL(ctx context.Context, req *authclient.GetACLRequest) (resp *authclient.GetACLResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 
@@ -933,7 +997,7 @@ func (a *apiServer) GetACL(ctx context.Context, req *authclient.GetACLRequest) (
 func (a *apiServer) SetACL(ctx context.Context, req *authclient.SetACLRequest) (resp *authclient.SetACLResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 
@@ -1053,7 +1117,7 @@ func (a *apiServer) SetACL(ctx context.Context, req *authclient.SetACLRequest) (
 func (a *apiServer) GetAuthToken(ctx context.Context, req *authclient.GetAuthTokenRequest) (resp *authclient.GetAuthTokenResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() == none {
 		return nil, authclient.ErrNotActivated
 	}
 	if req.Subject == "" {
@@ -1102,7 +1166,7 @@ func (a *apiServer) GetAuthToken(ctx context.Context, req *authclient.GetAuthTok
 func (a *apiServer) ExtendAuthToken(ctx context.Context, req *authclient.ExtendAuthTokenRequest) (resp *authclient.ExtendAuthTokenResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() != full {
 		return nil, authclient.ErrNotActivated
 	}
 	if req.TTL == 0 {
@@ -1161,7 +1225,7 @@ func (a *apiServer) ExtendAuthToken(ctx context.Context, req *authclient.ExtendA
 func (a *apiServer) RevokeAuthToken(ctx context.Context, req *authclient.RevokeAuthTokenRequest) (resp *authclient.RevokeAuthTokenResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
-	if !a.isActivated() {
+	if a.activationState() != full {
 		return nil, authclient.ErrNotActivated
 	}
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -209,6 +209,7 @@ func absent(key string) etcd.Cmp {
 }
 
 func (d *driver) createRepo(ctx context.Context, repo *pfs.Repo, description string, update bool) error {
+	d.initializePachConn()
 	// Check that the user is logged in (user doesn't need any access level to
 	// create a repo, but they must be authenticated if auth is active)
 	whoAmI, err := d.pachClient.AuthAPIClient.WhoAmI(auth.In2Out(ctx),


### PR DESCRIPTION
1) If a user's github token is invalid, auth activation discovers that
before getting stuck in an intermediate state

2) If a user's cluster does get stuck in an intermediate auth state,
it's now possible to escape that state