### PR TITLE
Add make target to start minikube in a VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ bench: clean-launch-bench build-bench-images push-bench-images launch-bench run-
 launch-kube: check-kubectl
 	etc/kube/start-minikube.sh -r
 
-launch-kube-vm: check-kubectl
+launch-dev-vm: check-kubectl
 	@# Make sure the caller sets address to avoid confusion later
 	@if [ -z "${ADDRESS}" ]; then \
 	  echo "Must set ADDRESS"; \
@@ -303,7 +303,7 @@ launch-kube-vm: check-kubectl
 
 clean-launch-kube:
 	@# clean up both of the following cases:
-	@# make launch-kube-vm - minikube config is owned by $USER
+	@# make launch-dev-vm - minikube config is owned by $USER
 	@# make launch-kube - minikube config is owned by root
 	minikube ip >/dev/null && minikube delete || true
 	sudo minikube ip >/dev/null && sudo minikube delete || true

--- a/Makefile
+++ b/Makefile
@@ -205,8 +205,11 @@ docker-build-test-entrypoint:
 	docker build -t pachyderm_entrypoint etc/testing/entrypoint
 
 check-kubectl:
-	# check that kubectl is installed
-	which kubectl
+	@# check that kubectl is installed
+	@which kubectl >/dev/null || { \
+		echo "error: kubectl not found"; \
+		exit 1; \
+	}
 
 check-kubectl-connection:
 	kubectl $(KUBECTLFLAGS) get all > /dev/null
@@ -283,8 +286,27 @@ bench: clean-launch-bench build-bench-images push-bench-images launch-bench run-
 launch-kube: check-kubectl
 	etc/kube/start-minikube.sh -r
 
+launch-kube-vm: check-kubectl
+	@# Make sure the caller sets address to avoid confusion later
+	@if [ -z "${ADDRESS}" ]; then \
+	  echo "Must set ADDRESS"; \
+	  echo "Run"; \
+	  echo "export ADDRESS=192.168.99.100:30650"; \
+	  exit 1; \
+	fi
+	@# Make sure minikube isn't still up from a previous run
+	@minikube ip >/dev/null && { \
+		echo "minikube is still up. Run 'make clean-launch-kube'"; \
+		exit 1; \
+	} || true
+	etc/kube/start-minikube-vm.sh
+
 clean-launch-kube:
-	sudo minikube delete
+	@# clean up both of the following cases:
+	@# make launch-kube-vm - minikube config is owned by $USER
+	@# make launch-kube - minikube config is owned by root
+	minikube ip >/dev/null && minikube delete || true
+	sudo minikube ip >/dev/null && sudo minikube delete || true
 
 launch: install check-kubectl
 	$(eval STARTTIME := $(shell date +%s))

--- a/etc/kube/push-to-minikube.sh
+++ b/etc/kube/push-to-minikube.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script pushes docker images to the minikube vm so that they can be
+# pulled/run by kubernetes pods
+
+if [[ $# -ne 1 ]]; then
+  echo "error: need the name of the docker image to push"
+fi
+
+# Detect if minikube was started with --vm-driver=none by inspecting the output
+# from 'minikube docker-env'
+if minikube docker-env \
+    | grep -q "'none' driver does not support 'minikube docker-env' command"
+then
+  exit 0 # Nothing to push -- vm-driver=none uses the system docker daemon
+fi
+
+docker save "${1}" | pv | (
+  eval $(minikube docker-env)
+  docker load
+)

--- a/etc/kube/start-minikube-vm.sh
+++ b/etc/kube/start-minikube-vm.sh
@@ -4,17 +4,6 @@ set -x
 
 cd ${GOPATH}/src/github.com/pachyderm/pachyderm
 
-# push_to_minikube pushes dockers images to the minikube vm
-function push_to_minikube {
-  if [[ $# -ne 1 ]]; then
-    echo "error: need the name of the docker image to push"
-  fi
-  docker save "${1}" | pv | (
-    eval $(minikube docker-env)
-    docker load
-  )
-}
-
 # get_images builds or download pachd and worker images
 function get_images {
   if [[ "${PACH_VERSION}" = local ]]; then
@@ -52,9 +41,9 @@ minikube start
 EOF
 
 # Push pachyderm images (and etcd) to minikube VM
-push_to_minikube pachyderm/pachd:${PACH_VERSION}
-push_to_minikube pachyderm/worker:${PACH_VERSION}
-push_to_minikube pachyderm/etcd:v3.2.7
+etc/kube/push-to-minikube.sh pachyderm/pachd:${PACH_VERSION}
+etc/kube/push-to-minikube.sh pachyderm/worker:${PACH_VERSION}
+etc/kube/push-to-minikube.sh pachyderm/etcd:v3.2.7
 
 # Deploy Pachyderm
 export ADDRESS=$(minikube ip):30650

--- a/etc/kube/start-minikube-vm.sh
+++ b/etc/kube/start-minikube-vm.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -x
+
+cd ${GOPATH}/src/github.com/pachyderm/pachyderm
+
+# push_to_minikube pushes dockers images to the minikube vm
+function push_to_minikube {
+  if [[ $# -ne 1 ]]; then
+    echo "error: need the name of the docker image to push"
+  fi
+  docker save "${1}" | pv | (
+    eval $(minikube docker-env)
+    docker load
+  )
+}
+
+# get_images builds or download pachd and worker images
+function get_images {
+  if [[ "${PACH_VERSION}" = local ]]; then
+    make docker-build
+  else
+    for i in pachd worker; do
+      echo docker pull pachyderm/${i}:${PACH_VERSION}
+      docker pull pachyderm/${i}:${PACH_VERSION}
+    done
+  fi
+}
+export -f get_images
+
+## If the caller provided a tag, build and use that
+export PACH_VERSION=local
+eval "set -- $( getopt -l "tag:" "--" "${0}" "${@:-}" )"
+while true; do
+  case "${1}" in
+    --tag)
+      export PACH_VERSION=${2##v}  # remove "v" prefix, e.g. v1.7.0
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+  esac
+done
+
+# In parallel, start minikube, build pachctl, and get/build the pachd and worker images
+cat <<EOF | tail -c+1 | xargs -d\\n -n1 -P3 -- /bin/bash -c
+make install
+get_images
+minikube start
+EOF
+
+# Push pachyderm images (and etcd) to minikube VM
+push_to_minikube pachyderm/pachd:${PACH_VERSION}
+push_to_minikube pachyderm/worker:${PACH_VERSION}
+push_to_minikube pachyderm/etcd:v3.2.7
+
+# Deploy Pachyderm
+export ADDRESS=$(minikube ip):30650
+echo "ADDRESS is ${ADDRESS}"
+if [[ "${PACH_VERSION}" = "local" ]]; then
+  pachctl deploy local -d
+else
+  # deploy with -d (disable auth, small footprint), but use official version
+  pachctl deploy local -d --dry-run | sed "s/:local/:${PACH_VERSION}/g" | kubectl create -f -
+fi
+
+# Wait for pachyderm to come up
+until pachctl version; do
+  export ADDRESS=$(minikube ip):30650
+  echo "ADDRESS is ${ADDRESS}"
+  sleep 1
+done
+
+# Kill pachctl port-forward and kubectl proxy
+killall kubectl || true


### PR DESCRIPTION
Note that this will not affect travis (which still uses `--vm-driver=none`). This adds a new target for devs that want to run Pachyderm/Kubernetes in a VM, for easy recovery when things break.