### PR TITLE
Benchmarking Cleanup

### DIFF
--- a/doc/reference/clients.md
+++ b/doc/reference/clients.md
@@ -25,9 +25,9 @@ cd $GOPATH/src/google.golang.org/grpc
 git checkout 21f8ed309495401e6fd79b3a9fd549582aed1b4c
 ```
 
-## Python Client - `pypachy`
+## Python Client -
 
-The Python client is a user contributed client that isn't officially maintained by the Pachyderm team.  However, it implements very similar functionality to that available in the Go client or CLI.  
+The Python client is a user contributed client that has jsut recently been brought under the Pachyderm umbrella and made into an official client. We're working on getting it fully up to date and will be supporting it full going forward.
 
 For more info, check out [`pypachy` on GitHub](https://github.com/kalugny/pypachy).
 

--- a/etc/testing/cleanup.go
+++ b/etc/testing/cleanup.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// ClusterInfo holds information about a cluster.
+type ClusterInfo struct {
+	KopsBucket      string `json:"kops_bucket"`
+	PachydermBucket string `json:"pachyderm_bucket"`
+	Created         string `json:"created"`
+}
+
+// KopsBucket is the s3 bucket used by kops.
+const KopsBucket = "pachyderm-travis-state-store-v1"
+
+// MaxClusterTime is the maximimum time a cluster can be up.
+const MaxClusterTime = time.Hour * 4
+
+// HandleRequest handles the deletion of old clusters.
+func HandleRequest() (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", "export PATH=$PATH:/var/task; kops --state=s3://"+KopsBucket+" get clusters | tail -n+2 | awk '{print $1}'")
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "Failed to get clusters", err
+	}
+	names := strings.Split(string(out), "\n")
+	names = names[:len(names)-1]
+	svc := s3.New(session.New())
+	for _, name := range names {
+		infoObject, err := svc.GetObject(
+			&s3.GetObjectInput{
+				Bucket: aws.String(KopsBucket),
+				Key:    aws.String(name + "-info.json"),
+			})
+		if err != nil {
+			return "Failed to get info file", err
+		}
+		var info ClusterInfo
+		if err := json.NewDecoder(infoObject.Body).Decode(&info); err != nil {
+			return "Failed to decode info file", err
+		}
+		createTime, err := time.Parse(time.UnixDate, info.Created)
+		if err != nil {
+			return "Failed to parse create time", err
+		}
+		// Cluster has been up for too long
+		if createTime.Add(MaxClusterTime).Before(time.Now()) {
+			fmt.Println("Cluster being deleted: " + name)
+			cmd := exec.Command("/bin/sh", "-c", "export PATH=$PATH:/var/task; kops --state=s3://"+KopsBucket+" delete cluster --name="+name+" --yes")
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return "Failed to delete cluster", err
+			}
+			_, err := svc.DeleteBucket(
+				&s3.DeleteBucketInput{
+					Bucket: aws.String(info.PachydermBucket),
+				})
+			if err != nil {
+				return "Failed to delete pachyderm bucket", err
+			}
+			_, err = svc.DeleteObject(
+				&s3.DeleteObjectInput{
+					Bucket: aws.String(KopsBucket),
+					Key:    aws.String(name + "-info.json"),
+				})
+			if err != nil {
+				return "Failed to delete info file", err
+			}
+		}
+	}
+	return "Succeeded", nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/etc/testing/deploy/aws.sh
+++ b/etc/testing/deploy/aws.sh
@@ -10,8 +10,17 @@ set -euxo pipefail
 
 set -e
 
+delete_resources() {
+  local name=${1}
+  [[ -e ${HOME}/.pachyderm/${name}-info.json ]] || aws s3 cp "${KOPS_BUCKET}/${name}-info.json" "${HOME}/.pachyderm/${name}-info.json" 
+  kops --state=${KOPS_BUCKET} delete cluster --name=${name} --yes
+  aws s3 rb --region ${REGION} --force "s3://$(jq --raw-output .pachyderm_bucket ${HOME}/.pachyderm/${name}-info.json)" >/dev/null 
+  aws s3 rm "${KOPS_BUCKET}/${name}-info.json"
+  sudo rm "${HOME}/.pachyderm/${name}-info.json"
+}
+
 ZONE="${ZONE:-us-west-1b}"
-STATE_STORE=s3://pachyderm-travis-state-store-v1
+KOPS_BUCKET=s3://pachyderm-travis-state-store-v1
 OP=-
 CLOUDFRONT=
 DEPLOY_PACHD="true"  # By default, aws.sh deploys pachyderm in its k8s cluster
@@ -19,22 +28,23 @@ len_zone_minus_one="$(( ${#ZONE} - 1 ))"
 REGION=${ZONE:0:${len_zone_minus_one}}
 
 # Process args
-new_opt="$( getopt --long="create,delete,delete-all,list,zone:,use-cloudfront,no-pachyderm" -- ${0} "${@}" )"
+new_opt="$( getopt --long="create,delete:,delete-all,list,zone:,use-cloudfront,no-pachyderm" -- ${0} "${@}" )"
 [[ "$?" -eq 0 ]] || exit 1
 eval "set -- ${new_opt}"
 
 while true; do
   case "${1}" in
-    --delete-all)
-      OP=delete-all
-      shift
-      ;;
     --list)
-      kops --state=${STATE_STORE} get clusters
+      kops --state=${KOPS_BUCKET} get clusters
       exit 0  # Shortcut
       ;;
     --delete)
       OP=delete
+      CLUSTER_NAME="${2}"
+      shift 2 
+      ;; 
+    --delete-all)
+      OP=delete-all
       shift
       ;;
     --create)
@@ -48,9 +58,9 @@ while true; do
     --use-cloudfront)
       # Default is not to provide the flag
       CLOUDFRONT="--use-cloudfront"
-      shift
-      ;;
-    --no-pachyderm)
+      shift 
+      ;; 
+    --no-pachyderm) 
       DEPLOY_PACHD="false" # default is true, see top of file
       shift
       ;;
@@ -70,7 +80,7 @@ case "${OP}" in
   create)
     aws_sh="$(dirname "${0}")/../../deploy/aws.sh"
     aws_sh="$(realpath "${aws_sh}")"
-    cmd=("${aws_sh}" --zone=${ZONE} --state=${STATE_STORE} --no-metrics)
+    cmd=("${aws_sh}" --zone=${ZONE} --state=${KOPS_BUCKET} --no-metrics)
     if [[ "${DEPLOY_PACHD}" == "false" ]]; then
       cmd+=("--no-pachyderm")
     fi
@@ -83,13 +93,12 @@ case "${OP}" in
     sudo env "PATH=${PATH}" "GOPATH=${GOPATH}" "bash -c 'until timeout 1s sudo ${check_ready} app=pachd; do sleep 1; done'"
     ;;
   delete)
-    kops --state=${STATE_STORE} delete cluster --name=$(cat .cluster_name) --yes
-    aws s3 rb --region ${REGION} --force s3://$(cat .bucket) >/dev/null
+    delete_resources ${CLUSTER_NAME}
     ;;
   delete-all)
-    kops --state=${STATE_STORE} get clusters | tail -n+2 | awk '{print $1}' \
+    kops --state=${KOPS_BUCKET} get clusters | tail -n+2 | awk '{print $1}' \
       | while read name; do
-          kops --state=${STATE_STORE} delete cluster --name=${name} --yes
+        delete_resources ${name}
       done
     ;;
   *)


### PR DESCRIPTION
This PR includes a program that runs in an aws lambda function that will cleanup clusters that have been deployed with kops and have been up for more than 4 hours. Also, some cluster metadata is stored under the .pachyderm directory as well as in info files in the kops bucket to keep track of cluster resources and creation time. This PR also includes changes to the testing deployment script which adds functionality to delete all of the cluster resources when doing a deletion.