### PR TITLE
whitespace, blanklines or comments in config file leads to fails pach…

### DIFF
--- a/doc/deployment/amazon_web_services.md
+++ b/doc/deployment/amazon_web_services.md
@@ -283,4 +283,4 @@ You can delete your Pachyderm cluster using `kops`:
 $ kops delete cluster
 ```
 
-In addition, there is the entry in `/etc/hosts` pointing to the cluster that will need to be manually removed.
+In addition, there is the entry in `/etc/hosts` pointing to the cluster that will need to be manually removed. Similarly, kubernetes state s3 bucket and pachyderm storage bucket will need to be manually removed.

--- a/etc/deploy/aws.sh
+++ b/etc/deploy/aws.sh
@@ -263,8 +263,9 @@ deploy_pachyderm_on_aws() {
     create_s3_bucket "${PACHYDERM_BUCKET}" ${USE_CLOUDFRONT}
 
     # Since my user should have the right access:
-    AWS_KEY=`cat ~/.aws/credentials | grep aws_secret_access_key | cut -d " " -f 3`
-    AWS_ID=`cat ~/.aws/credentials | grep aws_access_key_id  | cut -d " " -f 3`
+    AWS_ID=`cat ~/.aws/credentials | tr -s [:space:] | grep -m1 ^aws_access_key_id  | cut -d " " -f 3`
+    AWS_KEY=`cat ~/.aws/credentials | tr -s [:space:] | grep -m1 ^aws_secret_access_key | cut -d " " -f 3`
+
 
     # Omit token since im using my personal creds
     cmd=( pachctl deploy amazon ${PACHYDERM_BUCKET} ${AWS_REGION} ${STORAGE_SIZE} --dynamic-etcd-nodes=1 --no-dashboard --credentials=${AWS_ID},${AWS_KEY},)


### PR DESCRIPTION
The bash script to grab aws credentials from `~/.aws/credential` file does not work when you are working with more accounts or if your file is manually crafted with new lines or has more white space.

Also, the delete steps are a bit misleading because the state bucket and storage bucket had to be removed manually. 

This PR fixes both minor issues. 