### PR TITLE
Refactor for TLS

### DIFF
--- a/etc/testing/ci/before_install.sh
+++ b/etc/testing/ci/before_install.sh
@@ -12,15 +12,24 @@ cp etc/build/fuse.conf /etc/fuse.conf
 chown root:$USER /etc/fuse.conf
 
 # Install kubectl
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bin/linux/amd64/kubectl && \
+# Latest as of 5/30/2018
+# To get the latest kubectl version:
+# curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
+KUBECTL_VERSION=v1.10.3
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     sudo mv ./kubectl /usr/local/bin/kubectl
+kubectl version --client
 
 # Install minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.24.1/minikube-linux-amd64 && \
+# Latest as of 5/30/2018
+# To get the latest minikube version:
+# curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[0].tag_name
+MINIKUBE_VERSION=v0.27.0
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
     chmod +x ./minikube && \
     sudo mv ./minikube /usr/local/bin/minikube
-    
+
 # Install vault
 curl -Lo vault.zip https://releases.hashicorp.com/vault/0.9.5/vault_0.9.5_linux_amd64.zip && \
     unzip vault.zip && \

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -225,10 +225,10 @@ func (c APIClient) SetMaxConcurrentStreams(n int) {
 	c.streamSemaphore = make(chan struct{}, n)
 }
 
-// EtcdDialOptions is a helper returning a slice of grpc.Dial options
+// DefaultDialOptions is a helper returning a slice of grpc.Dial options
 // such that grpc.Dial() is synchronous: the call doesn't return until
 // the connection has been established and it's safe to send RPCs
-func EtcdDialOptions() []grpc.DialOption {
+func DefaultDialOptions() []grpc.DialOption {
 	return []grpc.DialOption{
 		// Don't return from Dial() until the connection has been established
 		grpc.WithBlock(),
@@ -251,7 +251,7 @@ func EtcdDialOptions() []grpc.DialOption {
 //
 // This is primarily useful for Pachd and Worker clients
 func PachDialOptions() []grpc.DialOption {
-	return append(EtcdDialOptions(), grpc.WithInsecure())
+	return append(DefaultDialOptions(), grpc.WithInsecure())
 }
 
 func (c *APIClient) connect() error {

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -138,7 +138,7 @@ func (a *apiServer) getPachClient() *client.APIClient {
 func NewAuthServer(pachdAddress string, etcdAddress string, etcdPrefix string) (authclient.APIServer, error) {
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error constructing etcdClient: %v", err)

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -140,7 +140,7 @@ func doSidecarMode(appEnvObj interface{}) error {
 	etcdAddress := fmt.Sprintf("http://%s:2379", appEnv.EtcdAddress)
 	etcdClientV3, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return err
@@ -241,7 +241,7 @@ func doFullMode(appEnvObj interface{}) error {
 	etcdClientV2 := getEtcdClient(etcdAddress)
 	etcdClientV3, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: append(client.EtcdDialOptions(), grpc.WithTimeout(5*time.Minute)),
+		DialOptions: append(client.DefaultDialOptions(), grpc.WithTimeout(5*time.Minute)),
 	})
 	if err != nil {
 		return err

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -160,7 +160,7 @@ func do(appEnvObj interface{}) error {
 	// Get etcd client, so we can register our IP (so pachd can discover us)
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{fmt.Sprintf("%s:2379", appEnv.EtcdAddress)},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return fmt.Errorf("error constructing etcdClient: %v", err)

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -90,7 +90,7 @@ func (a *apiServer) LogReq(request interface{}) {
 func NewEnterpriseServer(pachdAddress, etcdAddress string, etcdPrefix string) (ec.APIServer, error) {
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error constructing etcdClient: %s", err.Error())

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -8223,7 +8223,7 @@ func getEtcdClient(t testing.TB) *etcd.Client {
 		var err error
 		etcdClient, err = etcd.New(etcd.Config{
 			Endpoints:   []string{etcdAddress},
-			DialOptions: client.EtcdDialOptions(),
+			DialOptions: client.DefaultDialOptions(),
 		})
 		require.NoError(t, err)
 	})

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -33,17 +33,6 @@ type apiServer struct {
 	driver *driver
 }
 
-func newLocalAPIServer(address string, etcdPrefix string) (*apiServer, error) {
-	d, err := newLocalDriver(address, etcdPrefix)
-	if err != nil {
-		return nil, err
-	}
-	return &apiServer{
-		Logger: log.NewLocalLogger("pfs.API"),
-		driver: d,
-	}, nil
-}
-
 func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheSize int64) (*apiServer, error) {
 	d, err := newDriver(address, etcdAddresses, etcdPrefix, cacheSize)
 	if err != nil {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -120,7 +120,7 @@ const (
 func newDriver(address string, etcdAddresses []string, etcdPrefix string, treeCacheSize int64) (*driver, error) {
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   etcdAddresses,
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to etcd: %v", err)

--- a/src/server/pfs/server/obj_block_api_server.go
+++ b/src/server/pfs/server/obj_block_api_server.go
@@ -109,7 +109,7 @@ func (s *objBlockAPIServer) watchGC(etcdAddress string) {
 	backoff.RetryNotify(func() error {
 		etcdClient, err := etcd.New(etcd.Config{
 			Endpoints:   []string{etcdAddress},
-			DialOptions: client.EtcdDialOptions(),
+			DialOptions: client.DefaultDialOptions(),
 		})
 		if err != nil {
 			return fmt.Errorf("error instantiating etcd client: %v", err)

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -92,7 +92,7 @@ func getPachClient(t *testing.T) *pclient.APIClient {
 		require.NoError(t, backoff.Retry(func() error {
 			_, err := etcd.New(etcd.Config{
 				Endpoints:   []string{etcdAddress},
-				DialOptions: pclient.EtcdDialOptions(),
+				DialOptions: pclient.DefaultDialOptions(),
 			})
 			if err != nil {
 				return fmt.Errorf("could not connect to etcd: %s", err.Error())

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -37,6 +37,101 @@ import (
 	"google.golang.org/grpc"
 )
 
+const (
+	etcdAddress                = "localhost:32379" // etcd must already be serving at this address
+	localBlockServerCacheBytes = 256 * 1024 * 1024
+)
+
+var (
+	port          int32     = 30653 // Initial port on which pachd server processes will serve
+	checkEtcdOnce sync.Once         // ensure we only test the etcd connection once
+)
+
+// generateRandomString is a helper function for getPachClient
+func generateRandomString(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+// runServers starts serving requests for the given apiServer & blockAPIServer
+// in a separate goroutine. Helper for getPachClient()
+func runServers(t *testing.T, port int32, apiServer pfs.APIServer,
+	blockAPIServer BlockAPIServer) {
+	ready := make(chan bool)
+	go func() {
+		err := grpcutil.Serve(
+			func(s *grpc.Server) {
+				pfs.RegisterAPIServer(s, apiServer)
+				pfs.RegisterObjectAPIServer(s, blockAPIServer)
+				auth.RegisterAPIServer(s, &authtesting.InactiveAPIServer{}) // PFS server uses auth API
+				close(ready)
+			},
+			grpcutil.ServeOptions{
+				Version:    version.Version,
+				MaxMsgSize: grpcutil.MaxMsgSize,
+			},
+			grpcutil.ServeEnv{GRPCPort: uint16(port)},
+		)
+		require.NoError(t, err)
+	}()
+	<-ready
+}
+
+// getPachClient initializes a new PFSAPIServer and blockAPIServer and begins
+// serving requests for them on a new port, and then returns a client connected
+// to the new servers (allows PFS tests to run in parallel without conflict)
+func getPachClient(t *testing.T) *pclient.APIClient {
+	// src/server/pfs/server/driver.go expects an etcd server at "localhost:32379"
+	// Try to establish a connection before proceeding with the test (which will
+	// fail if the connection can't be established)
+	checkEtcdOnce.Do(func() {
+		require.NoError(t, backoff.Retry(func() error {
+			_, err := etcd.New(etcd.Config{
+				Endpoints:   []string{etcdAddress},
+				DialOptions: pclient.EtcdDialOptions(),
+			})
+			if err != nil {
+				return fmt.Errorf("could not connect to etcd: %s", err.Error())
+			}
+			return nil
+		}, backoff.NewTestingBackOff()))
+	})
+
+	root := tu.UniqueString("/tmp/pach_test/run")
+	t.Logf("root %s", root)
+	servePort := atomic.AddInt32(&port, 1)
+	serveAddress := fmt.Sprintf("localhost:%d", port)
+
+	// initialize new BlockAPIServier
+	blockAPIServer, err := newLocalBlockAPIServer(root, localBlockServerCacheBytes, etcdAddress)
+	require.NoError(t, err)
+	etcdPrefix := generateRandomString(32)
+	apiServer, err := newAPIServer(serveAddress, []string{"localhost:32379"}, etcdPrefix, defaultTreeCacheSize)
+	require.NoError(t, err)
+	runServers(t, servePort, apiServer, blockAPIServer)
+	c, err := pclient.NewFromAddress(serveAddress)
+	require.NoError(t, err)
+	return c
+}
+
+func collectCommitInfos(commitInfoIter pclient.CommitInfoIterator) ([]*pfs.CommitInfo, error) {
+	var commitInfos []*pfs.CommitInfo
+	for {
+		commitInfo, err := commitInfoIter.Next()
+		if err == io.EOF {
+			return commitInfos, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		commitInfos = append(commitInfos, commitInfo)
+	}
+}
+
 func CommitToID(commit interface{}) interface{} {
 	return commit.(*pfs.Commit).ID
 }
@@ -53,10 +148,8 @@ func RepoToName(repo interface{}) interface{} {
 	return repo.(*pfs.Repo).Name
 }
 
-var testDBs []string
-
 func TestInvalidRepo(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 	require.YesError(t, client.CreateRepo("/repo"))
 
 	require.NoError(t, client.CreateRepo("lenny"))
@@ -71,7 +164,7 @@ func TestInvalidRepo(t *testing.T) {
 }
 
 func TestCreateSameRepoInParallel(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	numGoros := 1000
 	errCh := make(chan error)
@@ -96,7 +189,7 @@ func TestCreateSameRepoInParallel(t *testing.T) {
 }
 
 func TestCreateDifferentRepoInParallel(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	numGoros := 1000
 	errCh := make(chan error)
@@ -121,7 +214,7 @@ func TestCreateDifferentRepoInParallel(t *testing.T) {
 }
 
 func TestCreateRepoDeleteRepoRace(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	for i := 0; i < 100; i++ {
 		require.NoError(t, client.CreateRepo("foo"))
@@ -145,7 +238,7 @@ func TestCreateRepoDeleteRepoRace(t *testing.T) {
 }
 
 func TestBranch(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, c.CreateRepo(repo))
@@ -165,7 +258,7 @@ func TestBranch(t *testing.T) {
 }
 
 func TestCreateAndInspectRepo(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, client.CreateRepo(repo))
@@ -187,7 +280,7 @@ func TestCreateAndInspectRepo(t *testing.T) {
 }
 
 func TestRepoSize(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, client.CreateRepo(repo))
@@ -226,7 +319,7 @@ func TestRepoSize(t *testing.T) {
 }
 
 func TestListRepo(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	numRepos := 10
 	var repoNames []string
@@ -243,7 +336,7 @@ func TestListRepo(t *testing.T) {
 
 // Make sure that commits of deleted repos do not resurface
 func TestCreateDeletedRepo(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, client.CreateRepo(repo))
@@ -281,7 +374,7 @@ func TestCreateDeletedRepo(t *testing.T) {
 //   /    \
 // d1      d2
 func TestUpdateProvenance(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	prov1 := "prov1"
 	require.NoError(t, client.CreateRepo(prov1))
@@ -323,7 +416,7 @@ func TestUpdateProvenance(t *testing.T) {
 }
 
 func TestPutFileIntoOpenCommit(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -349,7 +442,7 @@ func TestPutFileIntoOpenCommit(t *testing.T) {
 
 func TestCreateInvalidBranchName(t *testing.T) {
 
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -360,7 +453,7 @@ func TestCreateInvalidBranchName(t *testing.T) {
 }
 
 func TestDeleteRepo(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	numRepos := 10
 	repoNames := make(map[string]bool)
@@ -391,7 +484,7 @@ func TestDeleteRepo(t *testing.T) {
 }
 
 func TestDeleteProvenanceRepo(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	// Create two repos, one as another's provenance
 	require.NoError(t, client.CreateRepo("A"))
@@ -423,7 +516,7 @@ func TestDeleteProvenanceRepo(t *testing.T) {
 }
 
 func TestInspectCommit(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -469,7 +562,7 @@ func TestInspectCommit(t *testing.T) {
 }
 
 func TestInspectCommitBlock(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "TestInspectCommitBlock"
 	require.NoError(t, client.CreateRepo(repo))
@@ -487,7 +580,7 @@ func TestInspectCommitBlock(t *testing.T) {
 }
 
 func TestDeleteCommit(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -521,7 +614,7 @@ func TestDeleteCommit(t *testing.T) {
 }
 
 func TestDeleteCommitOnlyCommitInBranch(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -546,7 +639,7 @@ func TestDeleteCommitOnlyCommitInBranch(t *testing.T) {
 }
 
 func TestDeleteCommitFinished(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -572,7 +665,7 @@ func TestDeleteCommitFinished(t *testing.T) {
 }
 
 func TestCleanPath(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := "TestCleanPath"
 	require.NoError(t, c.CreateRepo(repo))
 	commit, err := c.StartCommit(repo, "master")
@@ -585,7 +678,7 @@ func TestCleanPath(t *testing.T) {
 }
 
 func TestBasicFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, client.CreateRepo(repo))
@@ -609,7 +702,7 @@ func TestBasicFile(t *testing.T) {
 }
 
 func TestSimpleFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -649,7 +742,7 @@ func TestSimpleFile(t *testing.T) {
 }
 
 func TestStartCommitWithUnfinishedParent(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -666,7 +759,7 @@ func TestStartCommitWithUnfinishedParent(t *testing.T) {
 }
 
 func TestAncestrySyntax(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -745,7 +838,7 @@ func TestAncestrySyntax(t *testing.T) {
 //  E ────────╯
 
 func TestProvenance(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	require.NoError(t, client.CreateRepo("A"))
 	require.NoError(t, client.CreateRepo("B"))
@@ -788,7 +881,7 @@ func TestProvenance(t *testing.T) {
 }
 
 func TestSimple(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -818,7 +911,7 @@ func TestSimple(t *testing.T) {
 }
 
 func TestBranch1(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -859,7 +952,7 @@ func TestBranch1(t *testing.T) {
 }
 
 func TestPutFileBig(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -885,7 +978,7 @@ func TestPutFileBig(t *testing.T) {
 }
 
 func TestPutFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -946,7 +1039,7 @@ func TestPutFile(t *testing.T) {
 }
 
 func TestPutFile2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -999,7 +1092,7 @@ func TestPutFile2(t *testing.T) {
 }
 
 func TestPutFileLongName(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1017,7 +1110,7 @@ func TestPutFileLongName(t *testing.T) {
 }
 
 func TestPutSameFileInParallel(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1040,7 +1133,7 @@ func TestPutSameFileInParallel(t *testing.T) {
 }
 
 func TestInspectFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1099,7 +1192,7 @@ func TestInspectFile(t *testing.T) {
 }
 
 func TestInspectFile2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1144,7 +1237,7 @@ func TestInspectFile2(t *testing.T) {
 }
 
 func TestInspectDir(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1180,7 +1273,7 @@ func TestInspectDir(t *testing.T) {
 }
 
 func TestInspectDir2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1234,7 +1327,7 @@ func TestInspectDir2(t *testing.T) {
 }
 
 func TestListFileTwoCommits(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1279,7 +1372,7 @@ func TestListFileTwoCommits(t *testing.T) {
 }
 
 func TestListFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1311,7 +1404,7 @@ func TestListFile(t *testing.T) {
 }
 
 func TestListFile2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1357,7 +1450,7 @@ func TestListFile2(t *testing.T) {
 }
 
 func TestListFile3(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1412,7 +1505,7 @@ func TestListFile3(t *testing.T) {
 }
 
 func TestPutFileTypeConflict(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1433,7 +1526,7 @@ func TestPutFileTypeConflict(t *testing.T) {
 }
 
 func TestRootDirectory(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1457,7 +1550,7 @@ func TestRootDirectory(t *testing.T) {
 }
 
 func TestDeleteFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1537,7 +1630,7 @@ func TestDeleteFile(t *testing.T) {
 }
 
 func TestDeleteDir(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1621,7 +1714,7 @@ func TestDeleteDir(t *testing.T) {
 }
 
 func TestDeleteFile2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1662,7 +1755,7 @@ func TestDeleteFile2(t *testing.T) {
 }
 
 func TestListCommit(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1722,7 +1815,7 @@ func TestListCommit(t *testing.T) {
 }
 
 func TestOffsetRead(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "TestOffsetRead"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1746,7 +1839,7 @@ func TestOffsetRead(t *testing.T) {
 }
 
 func TestBranch2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1789,7 +1882,7 @@ func TestBranch2(t *testing.T) {
 }
 
 func TestDeleteNonexistantBranch(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "TestDeleteNonexistantBranch"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1797,7 +1890,7 @@ func TestDeleteNonexistantBranch(t *testing.T) {
 }
 
 func TestSubscribeCommit(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1847,7 +1940,7 @@ func TestSubscribeCommit(t *testing.T) {
 }
 
 func TestInspectRepoSimple(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1872,7 +1965,7 @@ func TestInspectRepoSimple(t *testing.T) {
 }
 
 func TestInspectRepoComplex(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1912,7 +2005,7 @@ func TestInspectRepoComplex(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1927,7 +2020,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 	repo := tu.UniqueString("test")
 	require.NoError(t, client.CreateRepo(repo))
 	commit, err := client.StartCommit(repo, "")
@@ -1954,7 +2047,7 @@ func TestManyPutsSingleFileSingleCommit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping long tests in short mode")
 	}
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -1997,7 +2090,7 @@ func TestManyPutsSingleFileSingleCommit(t *testing.T) {
 }
 
 func TestPutFileValidCharacters(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -2034,7 +2127,7 @@ func TestPutFileURL(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 
 	repo := "TestPutFileURL"
 	require.NoError(t, c.CreateRepo(repo))
@@ -2048,7 +2141,7 @@ func TestPutFileURL(t *testing.T) {
 }
 
 func TestBigListFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "TestBigListFile"
 	require.NoError(t, client.CreateRepo(repo))
@@ -2075,7 +2168,7 @@ func TestBigListFile(t *testing.T) {
 }
 
 func TestStartCommitLatestOnBranch(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -2098,7 +2191,7 @@ func TestStartCommitLatestOnBranch(t *testing.T) {
 }
 
 func TestSetBranchTwice(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "test"
 	require.NoError(t, client.CreateRepo(repo))
@@ -2122,7 +2215,7 @@ func TestSetBranchTwice(t *testing.T) {
 }
 
 func TestSyncPullPush(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo1 := "repo1"
 	require.NoError(t, client.CreateRepo(repo1))
@@ -2199,7 +2292,7 @@ func TestSyncPullPush(t *testing.T) {
 }
 
 func TestSyncFile(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, client.CreateRepo(repo))
@@ -2248,7 +2341,7 @@ func TestSyncFile(t *testing.T) {
 }
 
 func TestSyncEmptyDir(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 
 	repo := "repo"
 	require.NoError(t, client.CreateRepo(repo))
@@ -2272,111 +2365,8 @@ func TestSyncEmptyDir(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func generateRandomString(n int) string {
-	rand.Seed(time.Now().UnixNano())
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = byte('a' + rand.Intn(26))
-	}
-	return string(b)
-}
-
-func runServers(t *testing.T, port int32, apiServer pfs.APIServer,
-	blockAPIServer BlockAPIServer) {
-	ready := make(chan bool)
-	go func() {
-		err := grpcutil.Serve(
-			func(s *grpc.Server) {
-				pfs.RegisterAPIServer(s, apiServer)
-				pfs.RegisterObjectAPIServer(s, blockAPIServer)
-				auth.RegisterAPIServer(s, &authtesting.InactiveAPIServer{}) // PFS server uses auth API
-				close(ready)
-			},
-			grpcutil.ServeOptions{
-				Version:    version.Version,
-				MaxMsgSize: grpcutil.MaxMsgSize,
-			},
-			grpcutil.ServeEnv{GRPCPort: uint16(port)},
-		)
-		require.NoError(t, err)
-	}()
-	<-ready
-}
-
-const (
-	servers     = 2                 // Number of pachd server processes to run
-	etcdAddress = "localhost:32379" // etcd must already be serving at this address
-)
-
-var (
-	port int32 = 30653 // Initial port on which pachd server processes will serve
-
-	startPFSServersOnce sync.Once // ensure pachd servers are only started once
-)
-
-// src/server/pfs/server/driver.go expects an etcd server at "localhost:32379"
-// Try to establish a connection before proceeding with the test (which will
-// fail if the connection can't be established)
-func startPFSServers(t *testing.T) {
-	startPFSServersOnce.Do(func() {
-		require.NoError(t, backoff.Retry(func() error {
-			_, err := etcd.New(etcd.Config{
-				Endpoints:   []string{etcdAddress},
-				DialOptions: pclient.EtcdDialOptions(),
-			})
-			if err != nil {
-				return fmt.Errorf("could not connect to etcd: %s", err.Error())
-			}
-			return nil
-		}, backoff.NewTestingBackOff()))
-	})
-}
-
-func getClient(t *testing.T) *pclient.APIClient {
-	startPFSServers(t)
-	dbName := "pachyderm_test_" + uuid.NewWithoutDashes()[0:12]
-	testDBs = append(testDBs, dbName)
-
-	root := tu.UniqueString("/tmp/pach_test/run")
-	t.Logf("root %s", root)
-	var ports []int32
-	for i := 0; i < servers; i++ {
-		ports = append(ports, atomic.AddInt32(&port, 1))
-	}
-	var addresses []string
-	for _, port := range ports {
-		addresses = append(addresses, fmt.Sprintf("localhost:%d", port))
-	}
-	prefix := generateRandomString(32)
-	for i, port := range ports {
-		address := addresses[i]
-		blockAPIServer, err := newLocalBlockAPIServer(root, 256*1024*1024, etcdAddress)
-		require.NoError(t, err)
-		apiServer, err := newLocalAPIServer(address, prefix)
-		require.NoError(t, err)
-		runServers(t, port, apiServer, blockAPIServer)
-	}
-	c, err := pclient.NewFromAddress(addresses[0])
-	require.NoError(t, err)
-	return c
-}
-
-func collectCommitInfos(commitInfoIter pclient.CommitInfoIterator) ([]*pfs.CommitInfo, error) {
-	var commitInfos []*pfs.CommitInfo
-	for {
-		commitInfo, err := commitInfoIter.Next()
-		if err == io.EOF {
-			return commitInfos, nil
-		}
-		if err != nil {
-			return nil, err
-		}
-		commitInfos = append(commitInfos, commitInfo)
-	}
-}
-
 func TestFlush(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 	require.NoError(t, client.CreateRepo("A"))
 	require.NoError(t, client.CreateRepo("B"))
 	require.NoError(t, client.CreateBranch("B", "master", "", []*pfs.Branch{pclient.NewBranch("A", "master")}))
@@ -2394,7 +2384,7 @@ func TestFlush(t *testing.T) {
 // TestFlush2 implements the following DAG:
 // A ─▶ B ─▶ C ─▶ D
 func TestFlush2(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 	require.NoError(t, client.CreateRepo("A"))
 	require.NoError(t, client.CreateRepo("B"))
 	require.NoError(t, client.CreateRepo("C"))
@@ -2438,7 +2428,7 @@ func TestFlush2(t *testing.T) {
 //  ╱
 // B
 func TestFlush3(t *testing.T) {
-	client := getClient(t)
+	client := getPachClient(t)
 	require.NoError(t, client.CreateRepo("A"))
 	require.NoError(t, client.CreateRepo("B"))
 	require.NoError(t, client.CreateRepo("C"))
@@ -2469,7 +2459,7 @@ func TestFlush3(t *testing.T) {
 }
 
 func TestFlushCommitWithNoDownstreamRepos(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := "test"
 	require.NoError(t, c.CreateRepo(repo))
 	commit, err := c.StartCommit(repo, "master")
@@ -2484,7 +2474,7 @@ func TestFlushCommitWithNoDownstreamRepos(t *testing.T) {
 
 func TestFlushOpenCommit(t *testing.T) {
 
-	client := getClient(t)
+	client := getPachClient(t)
 	require.NoError(t, client.CreateRepo("A"))
 	require.NoError(t, client.CreateRepo("B"))
 	require.NoError(t, client.CreateBranch("B", "master", "", []*pfs.Branch{pclient.NewBranch("A", "master")}))
@@ -2508,7 +2498,7 @@ func TestFlushOpenCommit(t *testing.T) {
 
 func TestEmptyFlush(t *testing.T) {
 
-	client := getClient(t)
+	client := getPachClient(t)
 	commitIter, err := client.FlushCommit(nil, nil)
 	require.NoError(t, err)
 	_, err = collectCommitInfos(commitIter)
@@ -2517,7 +2507,7 @@ func TestEmptyFlush(t *testing.T) {
 
 func TestFlushNonExistentCommit(t *testing.T) {
 
-	c := getClient(t)
+	c := getPachClient(t)
 	iter, err := c.FlushCommit([]*pfs.Commit{pclient.NewCommit("fake-repo", "fake-commit")}, nil)
 	require.NoError(t, err)
 	_, err = collectCommitInfos(iter)
@@ -2535,7 +2525,7 @@ func TestPutFileSplit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	// create repos
 	repo := tu.UniqueString("TestPutFileSplit")
 	require.NoError(t, c.CreateRepo(repo))
@@ -2641,7 +2631,7 @@ func TestPutFileSplitBig(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	// create repos
 	repo := tu.UniqueString("TestPutFileSplitBig")
 	require.NoError(t, c.CreateRepo(repo))
@@ -2668,7 +2658,7 @@ func TestDiff(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := tu.UniqueString("TestDiff")
 	require.NoError(t, c.CreateRepo(repo))
 
@@ -2802,7 +2792,7 @@ func TestGlob(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := tu.UniqueString("TestGlob")
 	require.NoError(t, c.CreateRepo(repo))
 
@@ -2933,7 +2923,7 @@ func TestApplyWriteOrder(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := tu.UniqueString("TestApplyWriteOrder")
 	require.NoError(t, c.CreateRepo(repo))
 
@@ -2956,7 +2946,7 @@ func TestOverwrite(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := tu.UniqueString("TestGlob")
 	require.NoError(t, c.CreateRepo(repo))
 
@@ -2999,7 +2989,7 @@ func TestCopyFile(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := tu.UniqueString("TestCopyFile")
 	require.NoError(t, c.CreateRepo(repo))
 	_, err := c.StartCommit(repo, "master")
@@ -3036,7 +3026,7 @@ func TestBuildCommit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := tu.UniqueString("TestBuildCommit")
 	require.NoError(t, c.CreateRepo(repo))
 
@@ -3077,7 +3067,7 @@ func TestBuildCommit(t *testing.T) {
 }
 
 func TestPropagateCommit(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	repo1 := tu.UniqueString("TestPropagateCommit1")
 	require.NoError(t, c.CreateRepo(repo1))
 	repo2 := tu.UniqueString("TestPropagateCommit2")
@@ -3101,7 +3091,7 @@ func TestPropagateCommit(t *testing.T) {
 // 	╱   ◀
 // B ──▶ D
 func TestBackfillBranch(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	require.NoError(t, c.CreateRepo("A"))
 	require.NoError(t, c.CreateRepo("B"))
 	require.NoError(t, c.CreateRepo("C"))
@@ -3137,7 +3127,7 @@ func TestBackfillBranch(t *testing.T) {
 // D ───╯
 //
 func TestUpdateBranch(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	require.NoError(t, c.CreateRepo("A"))
 	require.NoError(t, c.CreateRepo("B"))
 	require.NoError(t, c.CreateRepo("C"))
@@ -3163,7 +3153,7 @@ func TestUpdateBranch(t *testing.T) {
 }
 
 func TestBranchProvenance(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	tests := [][]struct {
 		name       string
 		directProv []string
@@ -3264,7 +3254,7 @@ func TestBranchProvenance(t *testing.T) {
 		})
 	}
 	// t.Run("1", func(t *testing.T) {
-	// 	c := getClient(t)
+	// 	c := getPachClient(t)
 	// 	require.NoError(t, c.CreateRepo("A"))
 	// 	require.NoError(t, c.CreateRepo("B"))
 	// 	require.NoError(t, c.CreateRepo("C"))
@@ -3301,7 +3291,7 @@ func TestBranchProvenance(t *testing.T) {
 	// 	require.Equal(t, 3, len(dMaster.Provenance))
 	// })
 	// t.Run("2", func(t *testing.T) {
-	// 	c := getClient(t)
+	// 	c := getPachClient(t)
 	// 	require.NoError(t, c.CreateRepo("A"))
 	// 	require.NoError(t, c.CreateRepo("B"))
 	// 	require.NoError(t, c.CreateRepo("C"))
@@ -3314,7 +3304,7 @@ func TestBranchProvenance(t *testing.T) {
 }
 
 func TestChildCommits(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	require.NoError(t, c.CreateRepo("A"))
 	require.NoError(t, c.CreateBranch("A", "master", "", nil))
 
@@ -3408,7 +3398,7 @@ func TestChildCommits(t *testing.T) {
 }
 
 func TestStartCommitFork(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	require.NoError(t, c.CreateRepo("A"))
 	require.NoError(t, c.CreateBranch("A", "master", "", nil))
 	commit, err := c.StartCommit("A", "master")
@@ -3437,7 +3427,7 @@ func TestStartCommitFork(t *testing.T) {
 //
 // C should create a new output commit to process its unprocessed inputs in B
 func TestUpdateBranchNewOutputCommit(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	require.NoError(t, c.CreateRepo("A"))
 	require.NoError(t, c.CreateRepo("B"))
 	require.NoError(t, c.CreateRepo("C"))
@@ -3483,7 +3473,7 @@ func TestUpdateBranchNewOutputCommit(t *testing.T) {
 // 3. Delete branch HEAD   -> output branch rewritten to point to nil
 // 4. Delete parent commit -> child rewritten to point to nil
 func TestDeleteCommitBigSubvenance(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	// two input repos, one with many commits (logs), and one with few (schema)
 	require.NoError(t, c.CreateRepo("logs"))
@@ -3678,7 +3668,7 @@ func TestDeleteCommitBigSubvenance(t *testing.T) {
 //  ↘ ↙
 //   a
 func TestDeleteCommitMultipleChildrenSingleCommit(t *testing.T) {
-	cli := getClient(t)
+	cli := getPachClient(t)
 	require.NoError(t, cli.CreateRepo("repo"))
 	require.NoError(t, cli.CreateBranch("repo", "master", "", nil))
 
@@ -3756,7 +3746,7 @@ func TestDeleteCommitMultipleChildrenSingleCommit(t *testing.T) {
 //  ↘↓↙
 //  nil
 func TestDeleteCommitMultiLevelChildrenNilParent(t *testing.T) {
-	cli := getClient(t)
+	cli := getPachClient(t)
 	require.NoError(t, cli.CreateRepo("upstream1"))
 	require.NoError(t, cli.CreateRepo("upstream2"))
 	// commit to both inputs
@@ -3893,7 +3883,7 @@ func TestDeleteCommitMultiLevelChildrenNilParent(t *testing.T) {
 // This makes sure that multiple live children are re-pointed at a live parent
 // if appropriate
 func TestDeleteCommitMultiLevelChildren(t *testing.T) {
-	cli := getClient(t)
+	cli := getPachClient(t)
 	require.NoError(t, cli.CreateRepo("upstream1"))
 	require.NoError(t, cli.CreateRepo("upstream2"))
 	// commit to both inputs
@@ -4036,7 +4026,7 @@ func TestDeleteCommitMultiLevelChildren(t *testing.T) {
 // 3. Subvenance is not affected, because the deleted commit is between "Lower" and "Upper"
 // 4. The entire subvenance range is deleted
 func TestDeleteCommitShrinkSubvRange(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	// two input repos, one with many commits (logs), and one with few (schema)
 	require.NoError(t, c.CreateRepo("logs"))
@@ -4130,7 +4120,7 @@ func TestDeleteCommitShrinkSubvRange(t *testing.T) {
 }
 
 func TestCommitState(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	// two input repos, one with many commits (logs), and one with few (schema)
 	require.NoError(t, c.CreateRepo("A"))
@@ -4175,7 +4165,7 @@ func TestCommitState(t *testing.T) {
 }
 
 func TestSubscribeStates(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	require.NoError(t, c.CreateRepo("A"))
 	require.NoError(t, c.CreateRepo("B"))
@@ -4223,7 +4213,7 @@ func TestSubscribeStates(t *testing.T) {
 }
 
 func TestPutFileCommit(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	numFiles := 100
 	repo := "repo"
@@ -4278,7 +4268,7 @@ func TestPutFileCommit(t *testing.T) {
 }
 
 func TestPutFileCommitNilBranch(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 	repo := "repo"
 	require.NoError(t, c.CreateRepo(repo))
 	require.NoError(t, c.CreateBranch(repo, "master", "", nil))
@@ -4288,7 +4278,7 @@ func TestPutFileCommitNilBranch(t *testing.T) {
 }
 
 func TestPutFileCommitOverwrite(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	numFiles := 5
 	repo := "repo"
@@ -4305,7 +4295,7 @@ func TestPutFileCommitOverwrite(t *testing.T) {
 }
 
 func TestStartCommitOutputBranch(t *testing.T) {
-	c := getClient(t)
+	c := getPachClient(t)
 
 	require.NoError(t, c.CreateRepo("in"))
 	require.NoError(t, c.CreateRepo("out"))

--- a/src/server/pkg/collection/collection_test.go
+++ b/src/server/pkg/collection/collection_test.go
@@ -497,7 +497,7 @@ func getEtcdClient() *etcd.Client {
 		var err error
 		etcdClient, err = etcd.New(etcd.Config{
 			Endpoints:   []string{"localhost:32379"},
-			DialOptions: client.EtcdDialOptions(),
+			DialOptions: client.DefaultDialOptions(),
 		})
 		if err != nil {
 			panic(err)

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -620,7 +620,6 @@ Are you sure you want to proceed? yN
 				Stderr: os.Stderr,
 			}
 			assets := []string{
-				"job",
 				"service",
 				"replicationcontroller",
 				"deployment",

--- a/src/server/pkg/migration/one_four_to_one_five.go
+++ b/src/server/pkg/migration/one_four_to_one_five.go
@@ -26,7 +26,7 @@ const (
 func oneFourToOneFive(etcdAddress, pfsPrefix, ppsPrefix string) error {
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{fmt.Sprintf("%s:2379", etcdAddress)},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return fmt.Errorf("error constructing etcdClient: %v", err)

--- a/src/server/pps/server/githook/githook.go
+++ b/src/server/pps/server/githook/githook.go
@@ -60,7 +60,7 @@ func RunGitHookServer(address string, etcdAddress string, etcdPrefix string) err
 	}
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return err

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -33,7 +33,7 @@ func NewAPIServer(
 ) (ppsclient.APIServer, error) {
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not create etcd client: %v", err)
@@ -77,7 +77,7 @@ func NewSidecarAPIServer(
 ) (ppsclient.APIServer, error) {
 	etcdClient, err := etcd.New(etcd.Config{
 		Endpoints:   []string{etcdAddress},
-		DialOptions: client.EtcdDialOptions(),
+		DialOptions: client.DefaultDialOptions(),
 	})
 	if err != nil {
 		return nil, err

--- a/src/server/worker/worker_test.go
+++ b/src/server/worker/worker_test.go
@@ -79,7 +79,7 @@ func getEtcdClient(t *testing.T) *etcd.Client {
 			var err error
 			etcdClient, err = etcd.New(etcd.Config{
 				Endpoints:   []string{etcdAddress},
-				DialOptions: pclient.EtcdDialOptions(),
+				DialOptions: pclient.DefaultDialOptions(),
 			})
 			if err != nil {
 				return fmt.Errorf("could not connect to etcd: %s", err.Error())


### PR DESCRIPTION
Changes in this PR:
1) Remove driver#newLocalDriver() and refactor PFS test
This will make it easier to rewrite the pachd client initialization code in src/server/pfs/server/server_test.go (all client initialization needs to be rewritten to accept TLS certificates)

2) Rename EtcdDialOptions to DefaultDialOptions (used in several places)
PachdDialOptions previously include grpc.WithInsecure(), however connecting to Pachd may use TLS now, so the former PachdDialOptions isn't always appropriate for Pachd. Now callers pass EtcdDialOptions when initializating Pachd (and either include trusted TLS certs or grpc.WithInsecure), so I changed the name to make it less weird.

Based on: https://github.com/pachyderm/pachyderm/pull/2966, which should be submitted first