### PR TITLE
Add options to client.go

### DIFF
--- a/etc/testing/ci/before_install.sh
+++ b/etc/testing/ci/before_install.sh
@@ -16,7 +16,7 @@ chown root:$USER /etc/fuse.conf
 # To get the latest kubectl version:
 # curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
 KUBECTL_VERSION=v1.10.3
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+curl -L -o kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     sudo mv ./kubectl /usr/local/bin/kubectl
 kubectl version --client
@@ -24,9 +24,9 @@ kubectl version --client
 # Install minikube
 # Latest as of 5/30/2018
 # To get the latest minikube version:
-# curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[0].tag_name
+# curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[].tag_name | sort | tail -n1
 MINIKUBE_VERSION=v0.27.0
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
+curl -L -o minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
     chmod +x ./minikube && \
     sudo mv ./minikube /usr/local/bin/minikube
 
@@ -34,5 +34,13 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VE
 curl -Lo vault.zip https://releases.hashicorp.com/vault/0.9.5/vault_0.9.5_linux_amd64.zip && \
     unzip vault.zip && \
     sudo mv ./vault /usr/local/bin/vault
-
 which vault
+
+# Install etcdctl
+# To get the latest etcd version:
+# curl -s https://api.github.com/repos/coreos/etcd/releases | jq -r .[].tag_name | sort | tail -n1
+ETCD_VERSION=v3.3.6
+curl -L https://storage.googleapis.com/etcd/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | \
+  tar xzf - --strip-components=1 && \
+  sudo mv ./etcdctl /usr/local/bin
+etcdctl --version

--- a/src/plugin/vault/pachyderm/version.go
+++ b/src/plugin/vault/pachyderm/version.go
@@ -62,7 +62,8 @@ func (b *backend) pathVersion(ctx context.Context, req *logical.Request, d *fram
 	}
 
 	// Create version API client
-	clientConn, err := grpc.Dial(config.PachdAddress, client.PachDialOptions()...)
+	clientConn, err := grpc.Dial(config.PachdAddress,
+		append(client.DefaultDialOptions(), grpc.WithInsecure())...)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/src/client"
-	"github.com/pachyderm/pachyderm/src/client/pkg/config"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 	"github.com/pachyderm/pachyderm/src/client/version"
 	"github.com/pachyderm/pachyderm/src/client/version/versionpb"
@@ -35,7 +34,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 )
 
@@ -231,23 +229,18 @@ Environment variables:
 				}
 			}
 
-			cfg, err := config.Read()
-			if err != nil {
-				log.Warningf("error loading user config from ~/.pachderm/config: %v", err)
-			}
-			pachdAddress := client.GetAddressFromUserMachine(cfg)
-			versionClient, err := getVersionAPIClient(pachdAddress)
+			pachClient, err := client.NewOnUserMachine(false, "user")
 			if err != nil {
 				return err
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-			version, err := versionClient.GetVersion(ctx, &types.Empty{})
+			version, err := pachClient.GetVersion(ctx, &types.Empty{})
 
 			if err != nil {
 				buf := bytes.NewBufferString("")
 				errWriter := tabwriter.NewWriter(buf, 20, 1, 3, ' ', 0)
-				fmt.Fprintf(errWriter, "pachd\t(version unknown) : error connecting to pachd server at address (%v): %v\n\nplease make sure pachd is up (`kubectl get all`) and portforwarding is enabled\n", pachdAddress, grpcutil.ScrubGRPC(err))
+				fmt.Fprintf(errWriter, "pachd\t(version unknown) : error connecting to pachd server at address (%v): %v\n\nplease make sure pachd is up (`kubectl get all`) and portforwarding is enabled\n", pachClient.GetAddress(), grpcutil.ScrubGRPC(err))
 				errWriter.Flush()
 				return errors.New(buf.String())
 			}
@@ -452,14 +445,6 @@ Currently "pachctl garbage-collect" can only be started when there are no active
 	rootCmd.AddCommand(garbageCollect)
 	rootCmd.AddCommand(completion)
 	return rootCmd, nil
-}
-
-func getVersionAPIClient(address string) (versionpb.APIClient, error) {
-	clientConn, err := grpc.Dial(address, client.PachDialOptions()...)
-	if err != nil {
-		return nil, err
-	}
-	return versionpb.NewAPIClient(clientConn), nil
 }
 
 func printVersionHeader(w io.Writer) {

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -649,7 +649,7 @@ negligible, but if you are putting a large number of small files, you might
 want to consider using commit IDs directly.
 `,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
-			cli, err := client.NewOnUserMachineWithConcurrency(metrics, "user", parallelism)
+			cli, err := client.NewOnUserMachine(metrics, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -748,11 +748,11 @@ want to consider using commit IDs directly.
 		Short: "Copy files between pfs paths.",
 		Long:  "Copy files between pfs paths.",
 		Run: cmdutil.RunFixedArgs(6, func(args []string) (retErr error) {
-			client, err := client.NewOnUserMachineWithConcurrency(metrics, "user", parallelism)
+			c, err := client.NewOnUserMachine(metrics, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
-			return client.CopyFile(args[0], args[1], args[2], args[3], args[4], args[5], overwrite)
+			return c.CopyFile(args[0], args[1], args[2], args[3], args[4], args[5], overwrite)
 		}),
 	}
 	copyFile.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "Overwrite the existing content of the file, either from previous commits or previous calls to put-file within this commit.")

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/golang-lru"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -161,14 +160,12 @@ func newDriver(address string, etcdAddresses []string, etcdPrefix string, treeCa
 // once, and so that pps doesn't need to have its own initialization code
 func (d *driver) getPachClient(ctx context.Context) *client.APIClient {
 	d.pachClientOnce.Do(func() {
-		pachConn, err := grpc.Dial(d.address, client.PachDialOptions()...)
+		var err error
+		d._pachClient, err = client.NewFromAddress(d.address)
 		if err != nil {
 			panic(fmt.Sprintf("could not intiailize Pachyderm client in driver: %v", err))
 		}
-		d._pachClient = &client.APIClient{
-			AuthAPIClient:   auth.NewAPIClient(pachConn),
-			ObjectAPIClient: pfs.NewObjectAPIClient(pachConn),
-		}
+
 	})
 	return d._pachClient.WithCtx(ctx)
 }

--- a/src/server/pps/server/workers.go
+++ b/src/server/pps/server/workers.go
@@ -68,7 +68,7 @@ func workerClients(ctx context.Context, id string, etcdClient *etcd.Client, etcd
 	var result []workerpkg.WorkerClient
 	for _, kv := range resp.Kvs {
 		conn, err := grpc.Dial(fmt.Sprintf("%s:%d", path.Base(string(kv.Key)), client.PPSWorkerPort),
-			client.PachDialOptions()...)
+			append(client.DefaultDialOptions(), grpc.WithInsecure())...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds options to the various `client.New*` functions that are similar to GRPC's DialOptions. This will allow us to keep using e.g. NewFromAddress, but pass TLS certs in the places where we need to without changing existing call sites