### PR TITLE
Initialize tree cache outside of driver

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -5364,7 +5364,7 @@ func TestPipelineBadImage(t *testing.T) {
 
 	c := getPachClient(t)
 	require.NoError(t, c.DeleteAll())
-	pipeline1 := tu.UniqueString("bad_pipeline")
+	pipeline1 := tu.UniqueString("bad_pipeline_1_")
 	require.NoError(t, c.CreatePipeline(
 		pipeline1,
 		"BadImage",
@@ -5375,7 +5375,7 @@ func TestPipelineBadImage(t *testing.T) {
 		"",
 		false,
 	))
-	pipeline2 := tu.UniqueString("bad_pipeline")
+	pipeline2 := tu.UniqueString("bad_pipeline_2_")
 	require.NoError(t, c.CreatePipeline(
 		pipeline2,
 		"bs/badimage:vcrap",

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/log"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 
+	"github.com/hashicorp/golang-lru"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -33,8 +34,8 @@ type apiServer struct {
 	driver *driver
 }
 
-func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheSize int64) (*apiServer, error) {
-	d, err := newDriver(address, etcdAddresses, etcdPrefix, cacheSize)
+func newAPIServer(address string, etcdAddresses []string, etcdPrefix string, treeCache *lru.Cache) (*apiServer, error) {
+	d, err := newDriver(address, etcdAddresses, etcdPrefix, treeCache)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
+
+	"github.com/hashicorp/golang-lru"
 )
 
 // Valid object storage backends
@@ -24,9 +26,8 @@ type BlockAPIServer interface {
 }
 
 // NewAPIServer creates an APIServer.
-// cacheSize is the number of commit trees which will be cached in the server.
-func NewAPIServer(address string, etcdAddresses []string, etcdPrefix string, cacheSize int64) (APIServer, error) {
-	return newAPIServer(address, etcdAddresses, etcdPrefix, cacheSize)
+func NewAPIServer(address string, etcdAddresses []string, etcdPrefix string, treeCache *lru.Cache) (APIServer, error) {
+	return newAPIServer(address, etcdAddresses, etcdPrefix, treeCache)
 }
 
 // NewBlockAPIServer creates a BlockAPIServer using the credentials it finds in


### PR DESCRIPTION
Two PFS servers (and therefore, currently, two drivers) will have to be
instantiated in main.go. The driver creates a large, in-memory data
structure--the tree cache--that now needs to be shared between the two
instances to avoid memory overhead. This change allows pachd/main.go to
instantiate one tree cache and pass it to the two PFS driver instances
to share