### PR TITLE
Add details about pipeline naming requirements

### DIFF
--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -156,7 +156,11 @@ Following is a walk-through of all the fields.
 ### Name (required)
 
 `pipeline.name` is the name of the pipeline that you are creating.  Each
-pipeline needs to have a unique name.
+pipeline needs to have a unique name. Pipeline names must:
+
+- contain only alphanumeric characters, `_` and `-`
+- begin or end with only alphanumeric characters (not `_` or `-`)
+- be no more than 50 characters in length
 
 ### Description (optional)
 


### PR DESCRIPTION
re: #1497

i imagine i'm missing some details -- it seems the full list of requirements is a combination of things we explicitly enforce, and requirements imposed upon us by the various places we use these strings:

- use in k8s resource names imposes: length limit (64 char max, but other info is included), no starting/ending with `_` or `-`, others (see #1810)
- etcd key names(?)
- go mapping key names(?)
- others?

also, this is only for pipelines -- not sure if the same rules apply for repos, and where this repo naming info should go in the docs