### PR TITLE
Few last debug dump fixes.

### DIFF
--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -531,6 +531,7 @@ func doFullMode(appEnvObj interface{}) (retErr error) {
 					deployclient.RegisterAPIServer(s, deployserver.NewDeployServer(kubeClient, kubeNamespace))
 					healthclient.RegisterHealthServer(s, peerHealthServer)
 					versionpb.RegisterAPIServer(s, version.NewAPIServer(version.Version, version.APIServerOptions{}))
+					adminclient.RegisterAPIServer(s, adminserver.NewAPIServer(address, &adminclient.ClusterInfo{clusterID}))
 					return nil
 				},
 			},
@@ -540,9 +541,6 @@ func doFullMode(appEnvObj interface{}) (retErr error) {
 		}
 		return err
 	})
-	if err := migrate(address, kubeClient); err != nil {
-		return fmt.Errorf("migrate: %v", err)
-	}
 	// TODO(msteffen): Is it really necessary to indicate that the peer service is
 	// healthy? Presumably migrate() will call the peer service no matter what.
 	publicHealthServer.Ready()

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -134,7 +134,7 @@ func doReadinessCheck(appEnvObj interface{}) error {
 func doSidecarMode(appEnvObj interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
-			pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
 		}
 	}()
 	appEnv := appEnvObj.(*appEnv)
@@ -260,7 +260,7 @@ func doSidecarMode(appEnvObj interface{}) (retErr error) {
 func doFullMode(appEnvObj interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
-			pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
 		}
 	}()
 	appEnv := appEnvObj.(*appEnv)


### PR DESCRIPTION
We want to write to Stderr instead of Stdout. Also migration has been breaking for people and doesn't seem to work between 1.7.4 and 1.6.9. So I removed it.