### PR TITLE
Make url warning message more stringent.

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -663,7 +663,7 @@ want to consider using commit IDs directly.
 			var path string
 			if len(args) == 3 {
 				path = args[2]
-				if _, err := url.Parse(path); err == nil {
+				if url, err := url.Parse(path); err == nil && url.Scheme != "" {
 					fmt.Fprintf(os.Stderr, "warning: PFS destination \"%s\" looks like a URL; did you mean -f %s?\n", path, path)
 				}
 			}


### PR DESCRIPTION
Currently `put-file` will give you this error message basically everytime you use it because almost everything parses as a URL. This makes it so it has to actually look a bit like a url to parse.