### PR TITLE
Ignore files blocked by .gitignore when checking for test enterprise code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ test: clean-launch-dev launch-dev test-misc test-pps
 enterprise-code-checkin-test:
 	# Check if our test activation code is anywhere in the repo
 	@echo "Files containing test Pachyderm Enterprise activation token:"; \
-	if grep --files-with-matches --exclude=Makefile -r -e 'eyJ0b2tl' . ; \
+	if grep --files-with-matches --exclude=Makefile --exclude-from=.gitignore -r -e 'eyJ0b2tl' . ; \
 	then \
 	  $$( which echo ) -e "\n*** It looks like Pachyderm Engineering's test activation code may be in this repo. Please remove it before committing! ***\n"; \
 	  false; \


### PR DESCRIPTION
These won't be checked in to git anyway, and it avoids annoying errors where pachd won't build because e.g. a vim swap file contains it (particularly `Makefile.swp`)