### PR TITLE
uuid.NewV4 only returns 1 value

### DIFF
--- a/src/client/pkg/config/config.go
+++ b/src/client/pkg/config/config.go
@@ -33,10 +33,7 @@ func Read() (*Config, error) {
 	if c.UserID == "" {
 		fmt.Printf("No UserID present in config. Generating new UserID and "+
 			"updating config at %s\n", configPath)
-		uuid, err := uuid.NewV4()
-		if err != nil {
-			return nil, err
-		}
+		uuid := uuid.NewV4()
 		c.UserID = uuid.String()
 		if err := c.Write(); err != nil {
 			return nil, err


### PR DESCRIPTION
Fix this:

```
vendor/github.com/pachyderm/pachyderm/src/client/pkg/config/config.go:36:16: cannot initialize 2 variables with 1 values (typecheck)
		uuid, err := uuid.NewV4()
```