### PR TITLE
Pipeline versions

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	pfspretty "github.com/pachyderm/pachyderm/src/server/pfs/pretty"
+	"github.com/pachyderm/pachyderm/src/server/pkg/ancestry"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsconsts"
@@ -8098,13 +8099,9 @@ func TestPipelineVersions(t *testing.T) {
 	}
 
 	for i := 0; i < nVersions; i++ {
-		pi, err := c.InspectPipeline(fmt.Sprintf("%s~%d", pipeline, nVersions-1-i))
+		pi, err := c.InspectPipeline(ancestry.Add(pipeline, nVersions-1-i))
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("%d", i), pi.Transform.Cmd)
-
-		pi, err = c.InspectPipeline(fmt.Sprintf("%s%s", pipeline, strings.Repeat("^", nVersions-1-i)))
-		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("%d", i), pi.Transform.Cmd)
+		require.Equal(t, fmt.Sprintf("%d", i), pi.Transform.Cmd[0])
 	}
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1021,7 +1021,7 @@ func (d *driver) resolveCommit(stm col.STM, userCommit *pfs.Commit) (*pfs.Commit
 	if userCommit == nil {
 		return nil, fmt.Errorf("cannot resolve nil commit")
 	}
-	commit := userCommit // back up user commit, for error reporting
+	commit := proto.Clone(userCommit).(*pfs.Commit) // back up user commit, for error reporting
 	// Extract any ancestor tokens from 'commit.ID' (i.e. ~ and ^)
 	var ancestryLength int
 	commit.ID, ancestryLength = ancestry.Parse(commit.ID)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1059,6 +1059,7 @@ func (d *driver) resolveCommit(stm col.STM, userCommit *pfs.Commit) (*pfs.Commit
 		}
 		commit = commitInfo.ParentCommit
 	}
+	userCommit.ID = commitInfo.Commit.ID
 	return commitInfo, nil
 }
 

--- a/src/server/pkg/ancestry/ancestry.go
+++ b/src/server/pkg/ancestry/ancestry.go
@@ -1,6 +1,7 @@
 package ancestry
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -47,4 +48,9 @@ func Parse(s string) (string, int) {
 	// (the same) separators and therefore uses the correct ancestry
 	// syntax.
 	return s[:sepIndex], len(s) - sepIndex
+}
+
+// Add adds an ancestry reference to the given string.
+func Add(s string, ancestors int) string {
+	return fmt.Sprintf("%s~%d", s, ancestors)
 }

--- a/src/server/pkg/ancestry/ancestry.go
+++ b/src/server/pkg/ancestry/ancestry.go
@@ -1,0 +1,50 @@
+package ancestry
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Parse parses s for git ancestry references.
+// It supports special characters ^ ~, both of which are supported by git.
+// Note in git ^ and ~ have different meanings on commits that have multiple
+// parent commits. In Pachyderm there's only 1 parent possible so they have
+// identical meanings. We support both simply for familiarity sake.
+// ParseAncestry returns the base reference and how many ancestors back to go.
+// For example:
+// foo^ -> foo, 1
+// foo^^ -> foo, 2
+// foo^3 -> foo 3
+// (all examples apply with ~ in place of ^ as well
+func Parse(s string) (string, int) {
+	sepIndex := strings.IndexAny(s, "^~")
+	if sepIndex == -1 {
+		return s, 0
+	}
+
+	// Find the separator, which is either "^" or "~"
+	sep := s[sepIndex]
+	strAfterSep := s[sepIndex+1:]
+
+	// Try convert the string after the separator to an int.
+	intAfterSep, err := strconv.Atoi(strAfterSep)
+	// If it works, return
+	if err == nil {
+		return s[:sepIndex], intAfterSep
+	}
+
+	// Otherwise, we check if there's a sequence of separators, as in
+	// "master^^^^" or "master~~~~"
+	for i := sepIndex + 1; i < len(s); i++ {
+		if s[i] != sep {
+			// If we find a character that's not the separator, as in
+			// "master~whatever", then we return.
+			return s, 0
+		}
+	}
+
+	// Here we've confirmed that the commit ID ends with a sequence of
+	// (the same) separators and therefore uses the correct ancestry
+	// syntax.
+	return s[:sepIndex], len(s) - sepIndex
+}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 	"github.com/pachyderm/pachyderm/src/client/pps"
+	"github.com/pachyderm/pachyderm/src/server/pkg/ancestry"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/hashtree"
@@ -1849,8 +1850,7 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 			}
 		}
 	} else {
-		// Create output repo, where we'll store the pipeline spec, future pipeline
-		// output, and pipeline stats
+		// Create output repo, pipeline output, and stats
 		if _, err := pfsClient.CreateRepo(ctx, &pfs.CreateRepoRequest{
 			Repo: &pfs.Repo{pipelineName},
 		}); err != nil && !isAlreadyExistsErr(err) {
@@ -2000,6 +2000,7 @@ func (a *apiServer) inspectPipeline(pachClient *client.APIClient, name string) (
 	if err := checkLoggedIn(pachClient); err != nil {
 		return nil, err
 	}
+	name, ancestors := ancestry.Parse(name)
 	pipelinePtr := pps.EtcdPipelineInfo{}
 	if err := a.pipelines.ReadOnly(pachClient.Ctx()).Get(name, &pipelinePtr); err != nil {
 		if col.IsErrNotFound(err) {
@@ -2007,6 +2008,7 @@ func (a *apiServer) inspectPipeline(pachClient *client.APIClient, name string) (
 		}
 		return nil, err
 	}
+	pipelinePtr.SpecCommit.ID = ancestry.Add(pipelinePtr.SpecCommit.ID, ancestors)
 	pipelineInfo, err := ppsutil.GetPipelineInfo(pachClient, &pipelinePtr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds initial support for ancestry references in pipelines. I.e. you can do:

```
pachctl inspect-pipeline foo^
```

to see what the previous version of foo looked like.