### PR TITLE
fixes #3151 corrected link to ml examples page

### DIFF
--- a/doc/cookbook/ml.md
+++ b/doc/cookbook/ml.md
@@ -18,4 +18,4 @@ Any new input data coming into the “Input data” repository will be processed
 
 ## Examples
 
-We have implemented this machine learning workflow in [some example pipelines](http://docs.pachyderm.io/en/latest/examples/readme.html#machine-learning) using a couple of different frameworks.  These examples are a great starting point if you are trying to implement ML in Pachyderm.  
+We have implemented this machine learning workflow in [some example pipelines](https://pachyderm.readthedocs.io/en/latest/examples/README.html#machine-learning) using a couple of different frameworks.  These examples are a great starting point if you are trying to implement ML in Pachyderm.  


### PR DESCRIPTION
Updated the link on the Machine Learning Workflows page to the "Machine Learning" section of the "Examples" page.