### PR TITLE
aws.sh use existing KOPS_BUCKET env var if set

### DIFF
--- a/etc/testing/deploy/aws.sh
+++ b/etc/testing/deploy/aws.sh
@@ -14,15 +14,15 @@ which jq
 
 delete_resources() {
   local name=${1}
-  [[ -e ${HOME}/.pachyderm/${name}-info.json ]] || aws s3 cp "${KOPS_BUCKET}/${name}-info.json" "${HOME}/.pachyderm/${name}-info.json" 
+  [[ -e ${HOME}/.pachyderm/${name}-info.json ]] || aws s3 cp "${KOPS_BUCKET}/${name}-info.json" "${HOME}/.pachyderm/${name}-info.json"
   kops --state=${KOPS_BUCKET} delete cluster --name=${name} --yes
-  aws s3 rb --region ${REGION} --force "s3://$(jq --raw-output .pachyderm_bucket ${HOME}/.pachyderm/${name}-info.json)" >/dev/null 
+  aws s3 rb --region ${REGION} --force "s3://$(jq --raw-output .pachyderm_bucket ${HOME}/.pachyderm/${name}-info.json)" >/dev/null
   aws s3 rm "${KOPS_BUCKET}/${name}-info.json"
   sudo rm "${HOME}/.pachyderm/${name}-info.json"
 }
 
 ZONE="${ZONE:-us-west-1b}"
-KOPS_BUCKET=s3://pachyderm-travis-state-store-v1
+KOPS_BUCKET=${KOPS_BUCKET:-s3://pachyderm-travis-state-store-v1}
 OP=-
 CLOUDFRONT=
 DEPLOY_PACHD="true"  # By default, aws.sh deploys pachyderm in its k8s cluster
@@ -43,8 +43,8 @@ while true; do
     --delete)
       OP=delete
       CLUSTER_NAME="${2}"
-      shift 2 
-      ;; 
+      shift 2
+      ;;
     --delete-all)
       OP=delete-all
       shift
@@ -60,9 +60,9 @@ while true; do
     --use-cloudfront)
       # Default is not to provide the flag
       CLOUDFRONT="--use-cloudfront"
-      shift 
-      ;; 
-    --no-pachyderm) 
+      shift
+      ;;
+    --no-pachyderm)
       DEPLOY_PACHD="false" # default is true, see top of file
       shift
       ;;


### PR DESCRIPTION
This makes it easier to use kops with direnv (also `s3://pachyderm-travis-state-store-v1` seems to have gotten into a pretty broken state, with lots of clusters in it that don't exist anymore, but I don't want to clear it until we're done with the nearmap work)

This also removed all trailing whitespace from the file because vim automatically removes trailing spaces whenever I save. I would change my .vimrc to minimize this delta, but the actual change is only one line and I actually think removing trailing whitespace is a positive, if negligible, change)