### PR TITLE
Fix the examples Makefile

### DIFF
--- a/doc/examples/Makefile
+++ b/doc/examples/Makefile
@@ -1,18 +1,20 @@
+.PHONY: opencv object_detection delete minikube
+
 opencv:
 	pachctl create-repo images
-	pachctl create-pipeline -f ~/pachyderm/doc/examples/opencv/edges.json
-	pachctl create-pipeline -f ~/pachyderm/doc/examples/opencv/montage.json
-	pachctl put-file images master -i ~/pachyderm/doc/examples/opencv/images.txt
-	pachctl put-file images master -i ~/pachyderm/doc/examples/opencv/images2.txt
+	pachctl create-pipeline -f opencv/edges.json
+	pachctl create-pipeline -f opencv/montage.json
+	pachctl put-file images master -i opencv/images.txt
+	pachctl put-file images master -i opencv/images2.txt
 
 object_detection:
 	pachctl create-repo images
 	pachctl create-repo training
-	pachctl create-pipeline -f ~/pachyderm/doc/examples/ml/object-detection/model.json
-	pachctl create-pipeline -f ~/pachyderm/doc/examples/ml/object-detection/detect.json
+	pachctl create-pipeline -f ml/object-detection/model.json
+	pachctl create-pipeline -f ml/object-detection/detect.json
 	pachctl put-file training master frozen_inference_graph.pb -f ~/ssd_mobilenet_v1_coco_11_06_2017/frozen_inference_graph.pb
-	pachctl put-file images master dogs.jpg -f ~/pachyderm/doc/examples/ml/object-detection/images/dogs.jpg
-	pachctl put-file images master kites.jpg -f ~/pachyderm/doc/examples/ml/object-detection/images/kites.jpg
+	pachctl put-file images master dogs.jpg -f ml/object-detection/images/dogs.jpg
+	pachctl put-file images master kites.jpg -f ml/object-detection/images/kites.jpg
 
 
 delete:


### PR DESCRIPTION
Fix example Makefile:

* Mark targets as phony
* Avoid the use of hardcoded paths. Note that there's still one hardcoded path; I wasn't sure how best to handle that.