### PR TITLE
Removed `message` and `description` flags for `put-file`

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -764,8 +764,6 @@ want to consider using commit IDs directly.
 	putFile.Flags().UintVar(&headerRecords, "header-records", 0, "the number of records that will be converted to a PFS 'header', and prepended to future retrievals of any subset of data from PFS; needs to be used with --split=(json|line|csv)")
 	putFile.Flags().BoolVarP(&putFileCommit, "commit", "c", false, "DEPRECATED: Put file(s) in a new commit.")
 	putFile.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "Overwrite the existing content of the file, either from previous commits or previous calls to put-file within this commit.")
-	putFile.Flags().StringVarP(&description, "message", "m", "", "A description of this commit's contents (only allowed with -c)")
-	putFile.Flags().StringVar(&description, "description", "", "A description of this commit's contents (synonym for --message)")
 
 	copyFile := &cobra.Command{
 		Use:   "copy-file src-repo src-commit src-path dst-repo dst-commit dst-path",


### PR DESCRIPTION
The `message` and `description` flags were ignored for `put-file`. If they weren't, they would have to act differently depending on whether `put-file` is an atomic commit or not. Instead, this removes the flags all-together.