### PR TITLE
Support macOS `grep`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ test: clean-launch-dev launch-dev test-misc test-pps
 enterprise-code-checkin-test:
 	# Check if our test activation code is anywhere in the repo
 	@echo "Files containing test Pachyderm Enterprise activation token:"; \
-	if grep --files-with-matches --exclude=Makefile --exclude-from=.gitignore -r -e 'RM2o1Qit6YlZhS1RGdXVac' . ; \
+	if grep --files-with-matches --exclude=Makefile --exclude-dir=.git -r -e 'RM2o1Qit6YlZhS1RGdXVac' . ; \
 	then \
 	  $$( which echo ) -e "\n*** It looks like Pachyderm Engineering's test activation code may be in this repo. Please remove it before committing! ***\n"; \
 	  false; \


### PR DESCRIPTION
Changes a call to grep to work with macOS' version. There's a couple of possible alternatives to this:

1) Just allow this call to grep to fail on macOS. It doesn't break anything otherwise.
2) Switch to ripgrep or silver searcher, which has cross-platform support for the required functionality here. Both tend to be faster than grep, but would require yet another tool to be installed for developers.
