### PR TITLE
Serve back non-reversed keys when walking s3 buckets

### DIFF
--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -238,7 +238,7 @@ func (c *amazonClient) Walk(name string, fn func(name string) error) error {
 					key = reverse(key)
 				}
 				if strings.HasPrefix(key, name) {
-					if err := fn(*object.Key); err != nil {
+					if err := fn(key); err != nil {
 						fnErr = err
 						return false
 					}


### PR DESCRIPTION
Currently, Amazon client's `Walk` method can serve back reversed keys. This fix it such that the key is always non-reversed. I _think_ this is the right behavior; my presumption is that `Walk` should not expose an underlying implementation detail such as if paths are stored reversed. But not sure as I'm not familiar with the code that uses `Walk`.