### PR TITLE
Prefix scan keys where possible in S3

### DIFF
--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -227,9 +227,18 @@ func (c *amazonClient) Writer(name string) (io.WriteCloser, error) {
 
 func (c *amazonClient) Walk(name string, fn func(name string) error) error {
 	var fnErr error
+	var prefix *string
+
+	if c.reversed {
+		prefix = nil
+	} else {
+		prefix = &name
+	}
+
 	if err := c.s3.ListObjectsPages(
 		&s3.ListObjectsInput{
 			Bucket: aws.String(c.bucket),
+			Prefix: prefix,
 		},
 		func(listObjectsOutput *s3.ListObjectsOutput, lastPage bool) bool {
 			for _, object := range listObjectsOutput.Contents {


### PR DESCRIPTION
Currently the Amazon client `Walk` implementation scans all keys, when it could do prefix scanning when reversing is disabled. With this change, `Walk` should execute faster when reversing is disabled.