### PR TITLE
Fix examples documentation being removed from sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ for a way to "productionize" them, Pachyderm can make this easy for you.
 You can also refer to our complete [developer docs](http://pachyderm.readthedocs.io/en/latest) to see tutorials, check out example projects, and learn about advanced features of Pachyderm.
 
 If you'd like to see some examples and learn about core use cases for Pachyderm:
-- [Examples](http://pachyderm.readthedocs.io/en/latest/examples/README.html)
+- [Examples](http://pachyderm.readthedocs.io/en/latest/examples/examples.html)
 - [Use Cases](http://www.pachyderm.io/use_cases.html)
 - [Case Studies](http://www.pachyderm.io/usecases/generalfusion.html): Learn how [General Fusion](http://www.generalfusion.com/) uses Pachyderm to power commercial fusion research.
 

--- a/doc/cookbook/ml.md
+++ b/doc/cookbook/ml.md
@@ -18,4 +18,4 @@ Any new input data coming into the “Input data” repository will be processed
 
 ## Examples
 
-We have implemented this machine learning workflow in [some example pipelines](https://pachyderm.readthedocs.io/en/latest/examples/README.html#machine-learning) using a couple of different frameworks.  These examples are a great starting point if you are trying to implement ML in Pachyderm.  
+We have implemented this machine learning workflow in [some example pipelines](https://pachyderm.readthedocs.io/en/latest/examples/examples.html#machine-learning) using a couple of different frameworks.  These examples are a great starting point if you are trying to implement ML in Pachyderm.  

--- a/doc/examples/examples.md
+++ b/doc/examples/examples.md
@@ -22,7 +22,7 @@ This example pipeline executes a query periodically against a MongoDB database o
 
 This example demonstrates how lazy shuffle pipeline i.e. a pipeline that shuffles, combines files without downloading/uploading can be created. These types of pipelines are useful for intermediate processing step that aggregates or rearranges data from one or many sources. For more information [see](https://pachyderm.readthedocs.io/en/latest/managing_pachyderm/data_management.html)
 
-[Lazy Shuffle pipeline ](https://github.com/pachyderm/pachyderm/tree/master/examples/shuffle)
+[Lazy Shuffle pipeline](https://github.com/pachyderm/pachyderm/tree/master/examples/shuffle)
 
 ## Variant Calling and Joint Genotyping with GATK
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -74,7 +74,7 @@ Note: if you are using a Pachyderm version < 1.4, you can find relevant docs `he
     :maxdepth: 1
     :caption: Full Examples
 
-    examples/README
+    examples/examples
     
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This fixes the examples being removed from sphinx, caused by #3257, by moving `./examples/README.md` to `./doc/examples/examples.md`. This means that, with this change, the examples directory does not have a README. A couple of alternative fixes:

* Fully reverting #3257 
* Symlinking `./doc/examples/examples.md` -> `./examples/README.md`

... I did try getting `index.rst` to reference `./examples/README.md`, but that did not work.