### PR TITLE
Go back to atom inputs in documentation & examples

### DIFF
--- a/doc/cookbook/gpus.md
+++ b/doc/cookbook/gpus.md
@@ -62,7 +62,7 @@ An example pipeline definition for a GPU enabled Pachyderm Pipeline is as follow
       "gpu": 1
   },
   "inputs": {
-    "pfs": {
+    "atom": {
       "repo": "data",
       "glob": "/*"
     }

--- a/doc/enterprise/stats.md
+++ b/doc/enterprise/stats.md
@@ -28,7 +28,7 @@ As mentioned above, enabling stats collection for a pipeline is as simple as add
     "name": "edges"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "glob": "/*",
       "repo": "images"
     }

--- a/doc/fundamentals/creating_analysis_pipelines.md
+++ b/doc/fundamentals/creating_analysis_pipelines.md
@@ -94,7 +94,7 @@ Here's an example pipeline spec:
     "cmd": ["/binary", "/pfs/data", "/pfs/out"]
   },
   "input": {
-      "pfs": {
+      "atom": {
         "repo": "data",
         "glob": "/*"
       }

--- a/doc/fundamentals/creating_services.md
+++ b/doc/fundamentals/creating_services.md
@@ -10,7 +10,7 @@ is an example of Jupyter service:
 ```json
 {
     "input": {
-        "pfs": {
+        "atom": {
             "glob": "/",
             "repo": "input"
         }

--- a/doc/fundamentals/distributed_computing.md
+++ b/doc/fundamentals/distributed_computing.md
@@ -38,30 +38,30 @@ Defining how your data is spread out among workers is arguably the most importan
 
 Instead of confining users to just data-distribution patterns such as Map (split everything as much as possible) and Reduce (_all_ the data must be grouped together), Pachyderm uses [Glob Patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to offer incredible flexibility in defining your data distribution.
 
- Glob patterns are defined by the user for each `pfs` within the `input` of a pipeline, and they tell Pachyderm how to divide the input data into individual "datums" that can be processed independently.
+ Glob patterns are defined by the user for each `atom` within the `input` of a pipeline, and they tell Pachyderm how to divide the input data into individual "datums" that can be processed independently.
 
 ```
 "input": {
-    "pfs": {
+    "atom": {
         "repo": "string",
         "glob": "string",
     }
 }
 ```
 
-That means you could easily define multiple PFS inputs, one with the data highly distributed and another where it's grouped together.  You can then join the datums in these PFS inputs via a cross product or union (as shown above) for combined, distributed processing.
+That means you could easily define multiple "atoms", one with the data highly distributed and another where it's grouped together.  You can then join the datums in these atoms via a cross product or union (as shown above) for combined, distributed processing.
 
 ```
 "input": {
     "cross" or "union": [
         {
-            "pfs": {
+            "atom": {
                 "repo": "string",
                 "glob": "string",
             }
         },
         {
-            "pfs": {
+            "atom": {
                 "repo": "string",
                 "glob": "string",
             }
@@ -71,21 +71,21 @@ That means you could easily define multiple PFS inputs, one with the data highly
 }
 ```
 
-More information about PFS inputs, unions, and crosses can be found in our [Pipeline Specification](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).
+More information about "atoms," unions, and crosses can be found in our [Pipeline Specification](http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html).
 
 ### Datums
 
-Pachyderm uses the glob pattern to determine how many “datums” a PFS input consists of. Datums are the unit of parallelism in Pachyderm. That is, Pachyderm attempts to process datums in parallel whenever possible.
+Pachyderm uses the glob pattern to determine how many “datums” an input atom consists of. Datums are the unit of parallelism in Pachyderm. That is, Pachyderm attempts to process datums in parallel whenever possible.
 
 If you have two workers and define 2 datums, Pachyderm will send one datum to each worker. In a scenario where there are more datums than workers, Pachyderm will queue up extra datums and send them to workers as they finish processing previous datums.
 
 ### Defining Datums via Glob Patterns
 
-Intuitively, you should think of the PFS input repo as a file system where the glob pattern is being applied to the root of the file system. The files and directories that match the glob pattern are considered datums.
+Intuitively, you should think of the input atom repo as a file system where the glob pattern is being applied to the root of the file system. The files and directories that match the glob pattern are considered datums.
 
 For example, a glob pattern of just `/` would denote the entire input repo as a single datum. All of the input data would be given to a single worker similar to a typical reduce-style operation.
 
-Another commonly used glob pattern is `/*`. `/*` would define each top level object (file or directory) in the PFS input repo as its own datum. If you have a repo with just 10 files in it and no directory structure, every file would be a datum and could be processed independently. This is similar to a  typical map-style operation.
+Another commonly used glob pattern is `/*`. `/*` would define each top level object (file or directory) in the input atom repo as its own datum. If you have a repo with just 10 files in it and no directory structure, every file would be a datum and could be processed independently. This is similar to a  typical map-style operation.
 
 But Pachyderm can do anything in between too. If you have a directory structure with each state as a directory and a file for each city such as:
 
@@ -105,7 +105,7 @@ and you need to process all the data for a given state together, `/*` would also
 
 If we instead used the glob pattern `/*/*` for the states example above, each `<city>.json` would be it's own datum.
 
-Glob patterns also let you take only a particular directory (or subset of directories) as a PFS input instead of the whole input repo. If we create a pipeline that is specifically only for California, we can use a glob pattern of `/California/*` to only use the data in that directory as input to our pipeline.
+Glob patterns also let you take only a particular directory (or subset of directories) as an input atom instead of the whole input repo. If we create a pipeline that is specifically only for California, we can use a glob pattern of `/California/*` to only use the data in that directory as input to our pipeline.
 
 ### Only Processing New Data
 
@@ -127,7 +127,7 @@ Let's look at our states example with a few different glob patterns to demonstra
 ...
 ```
 
-If our glob pattern is `/`, then the entire PFS input is a single datum, which means anytime any file or directory is changed in our input, all the the data will be processed from scratch. There are plenty of usecases where this is exactly what we need (e.g. some machine learning training algorithms).
+If our glob pattern is `/`, then the entire input atom is a single datum, which means anytime any file or directory is changed in our input, all the the data will be processed from scratch. There are plenty of usecases where this is exactly what we need (e.g. some machine learning training algorithms).
 
 If our glob pattern is `/*`, then each state directory is it's own datum and we'll only process the ones that have changed. So if we add a  new city file, `Sacramento.json` to the `/California` directory, _only_ the California datum, will be reprocessed.
 

--- a/doc/fundamentals/getting_data_out_of_pachyderm.md
+++ b/doc/fundamentals/getting_data_out_of_pachyderm.md
@@ -43,7 +43,7 @@ edges               026536b547a44a8daa2db9d25bf88b79   754542b89c1c47a5b657e6038
 edges               754542b89c1c47a5b657e60381c06c71   <none>                             2 minutes ago        Less than a second   22.22 KiB
 ```
 
-In this case, we have one output commit per input commit on `images`.  However, this might get more complicated for pipelines with multiple branches, multiple PFS inputs, etc.  To confirm which commits correspond to which outputs, we can use `flush-commit`.  In particular, we can call `flush-commit` on any one of our commits into `images` to see which output came from this particular commit:
+In this case, we have one output commit per input commit on `images`.  However, this might get more complicated for pipelines with multiple branches, multiple input atoms, etc.  To confirm which commits correspond to which outputs, we can use `flush-commit`.  In particular, we can call `flush-commit` on any one of our commits into `images` to see which output came from this particular commit:
 
 ```sh
 $ pachctl flush-commit images/a9678d2a439648c59636688945f3c6b5

--- a/doc/fundamentals/incrementality.md
+++ b/doc/fundamentals/incrementality.md
@@ -23,7 +23,7 @@ an example. Suppose we have a pipeline with a single input that looks like this:
 
 ```json
 {
-  "pfs": {
+  "atom": {
     "repo": "R",
     "glob": "/*",
   }

--- a/doc/getting_started/beginner_tutorial.rst
+++ b/doc/getting_started/beginner_tutorial.rst
@@ -101,7 +101,7 @@ Below is the pipeline spec and python code we're using. Let's walk through the d
       "image": "pachyderm/opencv"
     },
     "input": {
-      "pfs": {
+      "atom": {
         "repo": "images",
         "glob": "/*"
       }
@@ -109,7 +109,7 @@ Below is the pipeline spec and python code we're using. Let's walk through the d
   }
 
 
-Our pipeline spec contains a few simple sections. First is the pipeline ``name``, edges. Then we have the ``transform`` which specifies the docker image we want to use, ``pachyderm/opencv`` (defaults to DockerHub as the registry), and the entry point ``edges.py``. Lastly, we specify the input.  Here we only have one PFS input, our images repo with a particular glob pattern. 
+Our pipeline spec contains a few simple sections. First is the pipeline ``name``, edges. Then we have the ``transform`` which specifies the docker image we want to use, ``pachyderm/opencv`` (defaults to DockerHub as the registry), and the entry point ``edges.py``. Lastly, we specify the input.  Here we only have one "atom" input, our images repo with a particular glob pattern. 
 
 The glob pattern defines how the input data can be broken up if we wanted to distribute our computation. ``/*`` means that each file can be processed individually, which makes sense for images. Glob patterns are one of the most powerful features of Pachyderm so when you start creating your own pipelines, check out the :doc:`../reference/pipeline_spec`.
 
@@ -245,13 +245,13 @@ Below is the pipeline spec for this new pipeline:
     },
     "input": {
       "cross": [ {
-        "pfs": {
+        "atom": {
           "glob": "/",
           "repo": "images"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "glob": "/",
           "repo": "edges"
         }

--- a/doc/managing_pachyderm/data_management.md
+++ b/doc/managing_pachyderm/data_management.md
@@ -26,7 +26,7 @@ ln -s /pfs/input/log.txt /pfs/out/logs/log.txt
 
 Under the hood, Pachyderm is smart enough to recognize that the output file simply symlinks to a file that already exists in Pachyderm, and therefore skips the upload altogether.
 
-Note that if your shuffling pipeline only needs the names of the input files but not their content, you can use [`lazy input`](http://pachyderm.readthedocs.io/en/latest/reference/pipeline_spec.html#pfs-input).  That way, your shuffling pipeline can skip both the download and the upload. An example for this type of shuffle pipeline is [here](https://github.com/pachyderm/pachyderm/tree/master/examples/shuffle)
+Note that if your shuffling pipeline only needs the names of the input files but not their content, you can use [`lazy input`](http://pachyderm.readthedocs.io/en/latest/reference/pipeline_spec.html#atom-input).  That way, your shuffling pipeline can skip both the download and the upload. An example for this type of shuffle pipeline is [here](https://github.com/pachyderm/pachyderm/tree/master/examples/shuffle)
 
 ## Garbage collection
 

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -54,7 +54,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
   "datum_tries": int,
   "job_timeout": string,
   "input": {
-    <"pfs", "cross", "union", "cron", or "git" see below>
+    <"atom", "cross", "union", "cron", or "git" see below>
   },
   "output_branch": string,
   "egress": {
@@ -80,10 +80,10 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
 }
 
 ------------------------------------
-"pfs" input
+"atom" input
 ------------------------------------
 
-"pfs": {
+"atom": {
   "name": string,
   "repo": string,
   "branch": string,
@@ -98,7 +98,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
 
 "cross" or "union": [
   {
-    "pfs": {
+    "atom": {
       "name": string,
       "repo": string,
       "branch": string,
@@ -108,7 +108,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
     }
   },
   {
-    "pfs": {
+    "atom": {
       "name": string,
       "repo": string,
       "branch": string,
@@ -155,7 +155,7 @@ In practice, you rarely need to specify all the fields.  Most fields either come
     "cmd": ["/binary", "/pfs/data", "/pfs/out"]
   },
   "input": {
-        "pfs": {
+        "atom": {
             "repo": "data",
             "glob": "/*"
         }
@@ -342,15 +342,15 @@ these fields be set for any instantiation of the object.
 
 ```
 {
-    "pfs": pfs_input,
+    "atom": atom_input,
     "union": [input],
     "cross": [input],
     "cron": cron_input
 }
 ```
 
-#### PFS Input
-PFS inputs are the simplest inputs, they take input from a single branch on a
+#### Atom Input
+Atom inputs are the simplest inputs, they take input from a single branch on a
 single repo.
 
 ```
@@ -364,20 +364,20 @@ single repo.
 }
 ```
 
-`input.pfs.name` is the name of the input.  An input with name `XXX` will be
+`input.atom.name` is the name of the input.  An input with name `XXX` will be
 visible under the path `/pfs/XXX` when a job runs.  Input names must be unique
-if the inputs are crossed, but they may be duplicated between `PfsInput`s that are unioned.  This is because when `PfsInput`s are unioned, you'll only ever see a datum from one input at a time. Overlapping the names of unioned inputs allows
+if the inputs are crossed, but they may be duplicated between `AtomInput`s that are unioned.  This is because when `AtomInput`s are unioned, you'll only ever see a datum from one input at a time. Overlapping the names of unioned inputs allows
 you to write simpler code since you no longer need to consider which input directory a particular datum come from.  If an input's name is not specified, it defaults to the name of the repo.  Therefore, if you have two crossed inputs from the same repo, you'll be required to give at least one of them a unique name.
 
-`input.pfs.repo` is the `repo` to be used for the input.
+`input.atom.repo` is the `repo` to be used for the input.
 
-`input.pfs.branch` is the `branch` to watch for commits on, it may be left blank in
+`input.atom.branch` is the `branch` to watch for commits on, it may be left blank in
 which case `"master"` will be used.
 
-`input.pfs.glob` is a glob pattern that's used to determine how the input data
+`input.atom.glob` is a glob pattern that's used to determine how the input data
 is partitioned.  It's explained in detail in the next section.
 
-`input.pfs.lazy` controls how the data is exposed to jobs. The default is `false`
+`input.atom.lazy` controls how the data is exposed to jobs. The default is `false`
 which means the job will eagerly download the data it needs to process and it
 will be exposed as normal files on disk. If lazy is set to `true`, data will be
 exposed as named pipes instead and no data will be downloaded until the job
@@ -389,8 +389,8 @@ be especially notable if the job only reads a subset of the files that are
 available to it.  Note that `lazy` currently doesn't support datums that
 contain more than 10000 files.
 
-`input.pfs.empty_files` controls how files are exposed to jobs. If true, it will 
-cause files from this PFS input to be presented as empty files. This is useful in shuffle 
+`input.atom.empty_files` controls how files are exposed to jobs. If true, it will 
+cause files from this atom to be presented as empty files. This is useful in shuffle 
 pipelines where you want to read the names of files and reorganize them using symlinks.
 
 #### Union Input
@@ -417,7 +417,7 @@ directory. This, of course, only works if your code doesn't need to be
 aware of which of the underlying inputs the data comes from.
 
 `input.union` is an array of inputs to union, note that these need not be
-`pfs` inputs, they can also be `union` and `cross` inputs. Although there's no
+`atom` inputs, they can also be `union` and `cross` inputs. Although there's no
 reason to take a union of unions since union is associative.
 
 #### Cross Input
@@ -438,7 +438,7 @@ Notice that cross inputs, do not take a name and maintain the names of the sub-i
 In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.
 
 `input.cross` is an array of inputs to cross, note that these need not be
-`pfs` inputs, they can also be `union` and `cross` inputs. Although there's no
+`atom` inputs, they can also be `union` and `cross` inputs. Although there's no
 reason to take a cross of crosses since cross products are associative.
 
 #### Cron Input
@@ -461,7 +461,7 @@ satisfied the spec. The time is formatted according to [RFC
 ```
 
 `input.cron.name` is the name for the input, its semantics are similar to
-those of `input.pfs.name`. Except that it's not optional.
+those of `input.atom.name`. Except that it's not optional.
 
 `input.cron.spec` is a cron expression which specifies the schedule on
 which to trigger the pipeline. To learn more about how to write schedules
@@ -488,7 +488,7 @@ Git inputs allow you to pull code from a public git URL and execute that code as
 `input.git.URL` must be a URL of the form: `https://github.com/foo/bar.git`
 
 `input.git.name` is the name for the input, its semantics are similar to
-those of `input.pfs.name`. It is optional.
+those of `input.atom.name`. It is optional.
 
 `input.git.branch` is the name of the git branch to use as input
 
@@ -610,7 +610,7 @@ containers.
 
 ## The Input Glob Pattern
 
-Each PFS input needs to specify a [glob pattern](../fundamentals/distributed_computing.html).
+Each atom input needs to specify a [glob pattern](../fundamentals/distributed_computing.html).
 
 Pachyderm uses the glob pattern to determine how many "datums" an input
 consists of.  Datums are the unit of parallelism in Pachyderm.  That is,

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -54,7 +54,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
   "datum_tries": int,
   "job_timeout": string,
   "input": {
-    <"atom", "cross", "union", "cron", or "git" see below>
+    <"atom", "pfs", "cross", "union", "cron", or "git" see below>
   },
   "output_branch": string,
   "egress": {
@@ -84,6 +84,19 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
 ------------------------------------
 
 "atom": {
+  "name": string,
+  "repo": string,
+  "branch": string,
+  "glob": string,
+  "lazy" bool,
+  "empty_files": bool
+}
+
+------------------------------------
+"pfs" input
+------------------------------------
+
+"pfs": {
   "name": string,
   "repo": string,
   "branch": string,
@@ -350,6 +363,9 @@ these fields be set for any instantiation of the object.
 ```
 
 #### Atom Input
+
+**Note:** Atom inputs are deprecated in Pachyderm 1.8.1+. They have been renamed to PFS inputs. The configuration is the same, but all instances of `atom` should be changed to `pfs`.
+
 Atom inputs are the simplest inputs, they take input from a single branch on a
 single repo.
 
@@ -392,6 +408,12 @@ contain more than 10000 files.
 `input.atom.empty_files` controls how files are exposed to jobs. If true, it will 
 cause files from this atom to be presented as empty files. This is useful in shuffle 
 pipelines where you want to read the names of files and reorganize them using symlinks.
+
+#### PFS Input
+
+**Note:** PFS inputs are only available in versions of Pachyderm 1.8.1+.
+
+PFS inputs are the new name for atom inputs, documented above. The configuration is the same, but all instances of `atom` should be changed to `pfs`.
 
 #### Union Input
 

--- a/examples/fruit_stand/pipeline.json
+++ b/examples/fruit_stand/pipeline.json
@@ -14,7 +14,7 @@
     "constant": 1
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "data",
       "glob": "/*"
     }
@@ -37,7 +37,7 @@
     "constant": 1
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "filter",
       "glob": "/*"
     }

--- a/examples/gatk/joint-call.json
+++ b/examples/gatk/joint-call.json
@@ -26,13 +26,13 @@
   "input": {
     "cross": [
       {
-        "pfs": {
+        "atom": {
           "repo": "reference",
           "glob": "/"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "repo": "likelihoods",
           "glob": "/"
         }

--- a/examples/gatk/likelihoods.json
+++ b/examples/gatk/likelihoods.json
@@ -14,7 +14,7 @@
         "then",
         "filename=\"${filename%.*}\"",
         "cd $samples",
-        "java -jar /usr/GenomeAnalysisTK.jar -T HaplotypeCaller -R /pfs/reference/ref.fasta -I $filename.bam -o /pfs/out/$filename.g.vcf -ERC GVCF -L 20:10,000,000-10,200,000",
+	"java -jar /usr/GenomeAnalysisTK.jar -T HaplotypeCaller -R /pfs/reference/ref.fasta -I $filename.bam -o /pfs/out/$filename.g.vcf -ERC GVCF -L 20:10,000,000-10,200,000",
         "fi",
         "done"
     ]
@@ -25,16 +25,16 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "reference",
-          "glob": "/"
-        }
+        "atom": {
+	  "repo": "reference",
+	  "glob": "/"
+	}
       },
       {
-        "pfs": {
-          "repo": "samples",
-          "glob": "/*"
-        }
+	"atom": {
+	  "repo": "samples",
+	  "glob": "/*"
+	}
       }
     ]
   }

--- a/examples/jupyter_notebook/jupyter.json
+++ b/examples/jupyter_notebook/jupyter.json
@@ -19,19 +19,19 @@
   "input": {
     "cross": [
       {
-        "pfs": {
+        "atom": {
           "repo": "trips",
           "glob": "/"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "repo": "weather",
           "glob": "/"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "repo": "sales",
           "glob": "/"
         }

--- a/examples/jupyter_notebook/sales_data/pipeline.json
+++ b/examples/jupyter_notebook/sales_data/pipeline.json
@@ -8,7 +8,7 @@
     "stdin": []
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "trips",
       "glob": "/"
     }

--- a/examples/ml/hyperparameter/model.json
+++ b/examples/ml/hyperparameter/model.json
@@ -24,20 +24,20 @@
   "input": {
     "cross": [
       {
-        "pfs": {
+        "atom": {
           "repo": "split",
           "glob": "/train.csv"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "name": "c-parameters",
           "repo": "parameters",
           "glob": "/c_parameters.txt/*"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "name": "gamma-parameters",
           "repo": "parameters",
           "glob": "/gamma_parameters.txt/*"

--- a/examples/ml/hyperparameter/select.json
+++ b/examples/ml/hyperparameter/select.json
@@ -35,15 +35,15 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "test",
-          "glob": "/"
-        }
+        "atom": {
+	  "repo": "test",
+	  "glob": "/"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/"
+	"atom": {
+	  "repo": "model",
+	  "glob": "/"
         }
       }
     ]

--- a/examples/ml/hyperparameter/split.json
+++ b/examples/ml/hyperparameter/split.json
@@ -14,7 +14,7 @@
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "raw_data",
       "glob": "/"
     }

--- a/examples/ml/hyperparameter/test.json
+++ b/examples/ml/hyperparameter/test.json
@@ -23,15 +23,15 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "split",
-          "glob": "/test.csv"
-        }
+        "atom": {
+	  "repo": "split",
+	  "glob": "/test.csv"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/*"
+	"atom": {
+	  "repo": "model",
+	  "glob": "/*"
         }
       }
     ]

--- a/examples/ml/iris/julia_infer.json
+++ b/examples/ml/iris/julia_infer.json
@@ -5,11 +5,11 @@
   "transform": {
     "image": "pachyderm/iris-infer:julia",
     "cmd": [
-      "julia",
-      "/infer.jl",
-      "/pfs/model/model.jld",
-      "/pfs/attributes/",
-      "/pfs/out/"
+	"julia",
+	"/infer.jl",
+	"/pfs/model/model.jld",
+	"/pfs/attributes/",
+	"/pfs/out/"
     ]
   },
   "parallelism_spec": {
@@ -18,16 +18,16 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "attributes",
-          "glob": "/*"
-        }
+        "atom": {
+	  "repo": "attributes",
+	  "glob": "/*"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/"
-        }
+	"atom": {
+	  "repo": "model",
+	  "glob": "/"
+	}
       }
     ]
   }

--- a/examples/ml/iris/julia_train.json
+++ b/examples/ml/iris/julia_train.json
@@ -15,7 +15,7 @@
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/iris/python_infer.json
+++ b/examples/ml/iris/python_infer.json
@@ -5,11 +5,11 @@
   "transform": {
     "image": "pachyderm/iris-infer:python",
     "cmd": [
-      "python3",
-      "/code/pyinfer.py",
-      "/pfs/model/",
-      "/pfs/attributes/",
-      "/pfs/out/"
+	"python3",
+	"/code/pyinfer.py",
+	"/pfs/model/",
+	"/pfs/attributes/",
+	"/pfs/out/"
     ]
   },
   "parallelism_spec": {
@@ -18,16 +18,16 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "attributes",
-          "glob": "/*"
-        }
+        "atom": {
+	  "repo": "attributes",
+	  "glob": "/*"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/"
-        }
+	"atom": {
+	  "repo": "model",
+	  "glob": "/"
+	}
       }
     ]
   }

--- a/examples/ml/iris/python_train.json
+++ b/examples/ml/iris/python_train.json
@@ -15,7 +15,7 @@
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/iris/rstats_infer.json
+++ b/examples/ml/iris/rstats_infer.json
@@ -5,8 +5,8 @@
   "transform": {
     "image": "pachyderm/iris-infer:rstats",
     "cmd": [
-      "Rscript",
-      "infer.R"
+	"Rscript",
+	"infer.R"
     ]
   },
   "parallelism_spec": {
@@ -15,16 +15,16 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "attributes",
-          "glob": "/*"
-        }
+        "atom": {
+	  "repo": "attributes",
+	  "glob": "/*"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/"
-        }
+	"atom": {
+	  "repo": "model",
+	  "glob": "/"
+	}
       }
     ]
   }

--- a/examples/ml/iris/rstats_train.json
+++ b/examples/ml/iris/rstats_train.json
@@ -13,7 +13,7 @@
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/neon/infer.json
+++ b/examples/ml/neon/infer.json
@@ -5,16 +5,16 @@
   "transform": {
     "image": "dwhitena/neon-inference",
     "cmd": [
-      "python",
-      "examples/imdb/auto_inference.py",
-      "--model_weights",
-      "/pfs/model/imdb.p",
-      "--vocab_file",
-      "/pfs/model/imdb.vocab",
-      "--review_files",
-      "/pfs/reviews",
-      "--output_dir",
-      "/pfs/out"
+	"python",
+	"examples/imdb/auto_inference.py",
+	"--model_weights",
+	"/pfs/model/imdb.p",
+	"--vocab_file",
+	"/pfs/model/imdb.vocab",
+	"--review_files",
+	"/pfs/reviews",
+	"--output_dir",
+	"/pfs/out"
     ]
   },
   "parallelism_spec": {
@@ -23,16 +23,16 @@
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "reviews",
-          "glob": "/*"
-        }
+        "atom": {
+	  "repo": "reviews",
+	  "glob": "/*"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/"
-        }
+	"atom": {
+	  "repo": "model",
+	  "glob": "/"
+	}
       }
     ]
   }

--- a/examples/ml/neon/train.json
+++ b/examples/ml/neon/train.json
@@ -5,25 +5,25 @@
   "transform": {
     "image": "kaixhin/neon",
     "cmd": [
-      "python",
-      "examples/imdb/train.py",
-      "-f",
-      "/pfs/training/labeledTrainData.tsv",
-      "-e",
-      "2",
-      "-eval",
-      "1",
-      "-s",
-      "/pfs/out/imdb.p",
-      "--vocab_file",
-      "/pfs/out/imdb.vocab"
+	"python",
+	"examples/imdb/train.py",
+	"-f",
+	"/pfs/training/labeledTrainData.tsv",
+	"-e",
+	"2",
+	"-eval",
+	"1",
+	"-s",
+	"/pfs/out/imdb.p",
+	"--vocab_file",
+	"/pfs/out/imdb.vocab"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/object-detection/detect.json
+++ b/examples/ml/object-detection/detect.json
@@ -5,13 +5,13 @@
   "input": {
     "cross": [
       {
-        "pfs": {
+        "atom": {
           "glob": "/*",
           "repo": "images"
         }
       },
       {
-        "pfs": {
+        "atom": {
           "glob": "/",
           "repo": "model"
         }

--- a/examples/ml/object-detection/model.json
+++ b/examples/ml/object-detection/model.json
@@ -3,7 +3,7 @@
     "name": "model"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "glob": "/",
       "repo": "training"
     }

--- a/examples/ml/rnn/pipeline.json
+++ b/examples/ml/rnn/pipeline.json
@@ -17,7 +17,7 @@
        "constant" : 1
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "GoT_scripts",
       "glob": "/"
     }
@@ -41,7 +41,7 @@
        "constant" : 1
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "GoT_train",
       "glob": "/"
     }

--- a/examples/ml/tensorflow/pre-processing_and_generation.json
+++ b/examples/ml/tensorflow/pre-processing_and_generation.json
@@ -6,11 +6,11 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-      "python process.py --input_dir /pfs/input_images --operation resize --output_dir /pfs/out"	
+	"python process.py --input_dir /pfs/input_images --operation resize --output_dir /pfs/out"	
     ]
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "input_images",
       "glob": "/*"
     }
@@ -24,25 +24,25 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-      "for filename in /pfs/preprocess_images/*; do",
-      "rawname=$(basename $filename)",
-      "python process-local.py --model_dir /pfs/model --input_file $filename --output_file /pfs/out/$rawname",	
-      "done"
+	"for filename in /pfs/preprocess_images/*; do",
+		"rawname=$(basename $filename)",
+		"python process-local.py --model_dir /pfs/model --input_file $filename --output_file /pfs/out/$rawname",	
+	"done"
     ]
   },
   "input": {
     "cross": [
       {
-        "pfs": {
-          "repo": "preprocess_images",
-          "glob": "/*"
-        }
+        "atom": {
+	  "repo": "preprocess_images",
+	  "glob": "/*"
+	}
       },
       {
-        "pfs": {
-          "repo": "model",
-          "glob": "/"
-        }
+	"atom": {
+	  "repo": "model",
+	  "glob": "/"
+	}
       }
     ]
   }

--- a/examples/ml/tensorflow/training_and_export.json
+++ b/examples/ml/tensorflow/training_and_export.json
@@ -6,15 +6,15 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-      "python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
-      "sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
+	"python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
+	"sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "training",
       "glob": "/"
     }
@@ -28,15 +28,15 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-      "python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
-      "sed -i 's/out/model/g' /pfs/out/checkpoint"
+	"python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
+	"sed -i 's/out/model/g' /pfs/out/checkpoint"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "checkpoint",
       "glob": "/"
     }

--- a/examples/ml/tensorflow/training_and_export_gpu.json
+++ b/examples/ml/tensorflow/training_and_export_gpu.json
@@ -6,8 +6,8 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-      "python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
-      "sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
+	"python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
+	"sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
     ],
     "env": {
       "LD_LIBRARY_PATH": "/usr/lib/nvidia:/usr/local/cuda/lib64:/rootfs/usr/lib/x86_64-linux-gnu"
@@ -22,7 +22,7 @@
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "training",
       "glob": "/"
     }
@@ -36,15 +36,15 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-      "python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
-      "sed -i 's/out/model/g' /pfs/out/checkpoint"
+	"python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
+	"sed -i 's/out/model/g' /pfs/out/checkpoint"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "checkpoint",
       "glob": "/"
     }

--- a/examples/opencv/edges.json
+++ b/examples/opencv/edges.json
@@ -3,7 +3,7 @@
     "name": "edges"
   },
   "input": {
-    "pfs": {
+    "atom": {
       "glob": "/*",
       "repo": "images"
     }

--- a/examples/opencv/montage.json
+++ b/examples/opencv/montage.json
@@ -4,13 +4,13 @@
   },
   "input": {
     "cross": [ {
-      "pfs": {
+      "atom": {
         "glob": "/",
         "repo": "images"
       }
     },
     {
-      "pfs": {
+      "atom": {
         "glob": "/",
         "repo": "edges"
       }

--- a/examples/redshift/pipeline.json
+++ b/examples/redshift/pipeline.json
@@ -3,7 +3,7 @@
         "name": "upload_to_redshift"
     },
     "input": {
-      "pfs": {
+      "atom": {
         "repo": "data"
       }
     },

--- a/examples/run/config/pipeline.json
+++ b/examples/run/config/pipeline.json
@@ -20,7 +20,7 @@
         "image_pull_secrets": ["$PIPELINE_DOCKER_REGISTRY_SECRETS"]
     },
     "input": {
-        "pfs": {
+        "atom": {
             "repo": "$PIPELINE_REPO",
             "glob": "/*"
         }

--- a/examples/scraper/README.md
+++ b/examples/scraper/README.md
@@ -115,7 +115,7 @@ The `pipeline` we're creating can be found at [scraper.json](scraper.json).  The
   },
   "parallelism": "1",
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "urls"
     }
   }

--- a/examples/scraper/scraper.json
+++ b/examples/scraper/scraper.json
@@ -15,7 +15,7 @@
   },
   "input": {
     "cross": [ {
-      "pfs": {
+      "atom": {
         "glob": "urls/*",
         "repo": "urls"
       }

--- a/examples/shuffle/README.md
+++ b/examples/shuffle/README.md
@@ -29,14 +29,14 @@ Let's take a closer look at that pipeline:
   "input": {
     "union": [
       {
-        "pfs": {
+        "atom": {
           "glob": "/*.jpeg",
           "repo": "fruits",
           "empty_files": true
         }
       },
       {
-        "pfs": {
+        "atom": {
           "glob": "/*.json",
           "repo": "pricing",
           "empty_files": true

--- a/examples/shuffle/shuffle.json
+++ b/examples/shuffle/shuffle.json
@@ -2,14 +2,14 @@
   "input": {
     "union": [
       {
-        "pfs": {
+        "atom": {
           "glob": "/*.jpeg",
           "repo": "fruits",
           "empty_files": true
         }
       },
       {
-        "pfs": {
+        "atom": {
           "glob": "/*.json",
           "repo": "pricing",
           "empty_files": true

--- a/examples/spark/pi/estimate_pi_pipeline.json
+++ b/examples/spark/pi/estimate_pi_pipeline.json
@@ -10,7 +10,7 @@
     "constant": 1
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "estimate_pi_config",
       "glob": "/num_samples"
     }

--- a/examples/word_count/map.json
+++ b/examples/word_count/map.json
@@ -11,7 +11,7 @@
     ]
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "scraper",
       "glob": "/*"
     }

--- a/examples/word_count/reduce.json
+++ b/examples/word_count/reduce.json
@@ -9,7 +9,7 @@
     ]
   },
   "input": {
-    "pfs": {
+    "atom": {
       "repo": "map",
       "glob": "/*"
     }

--- a/examples/word_count/scraper.json
+++ b/examples/word_count/scraper.json
@@ -15,7 +15,7 @@
     "acceptReturnCode": [4,5,6,7,8]
   },
   "input": {
-      "pfs": {
+      "atom": {
         "repo": "urls",
         "glob": "/*"
       }


### PR DESCRIPTION
Users not on the latest builds of Pachyderm will not have PFS inputs. This reverts the documentation/examples to refer to atom inputs for now.

Note that because I used `git revert`, some innocuous tabbing/formatting fixes have been reverted as well.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/929603687556535/946339655260838)
