### PR TITLE
Added .rgignore

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,4 @@
+**/vendor/**
+*.pb.go
+*.ipynb
+examples/jupyter_notebook/weather_data

--- a/.rgignore
+++ b/.rgignore
@@ -2,3 +2,4 @@
 *.pb.go
 *.ipynb
 examples/jupyter_notebook/weather_data
+examples/jupyter_notebook/citibike_data


### PR DESCRIPTION
Added .rgignore to give better search results when using [ripgrep](https://github.com/BurntSushi/ripgrep).

I'm not sure if it's worth adding yet another ignore file to the repo root, but figured it's worth posting this PR to see what you think.

This is not complete. If this gets merged, I'll just amend it as bad search results come up.
