### PR TITLE
Renamed atom inputs to PFS inputs in docs and examples

### DIFF
--- a/doc/cookbook/gpus.md
+++ b/doc/cookbook/gpus.md
@@ -62,7 +62,7 @@ An example pipeline definition for a GPU enabled Pachyderm Pipeline is as follow
       "gpu": 1
   },
   "inputs": {
-    "atom": {
+    "pfs": {
       "repo": "data",
       "glob": "/*"
     }

--- a/doc/enterprise/stats.md
+++ b/doc/enterprise/stats.md
@@ -28,7 +28,7 @@ As mentioned above, enabling stats collection for a pipeline is as simple as add
     "name": "edges"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "glob": "/*",
       "repo": "images"
     }

--- a/doc/fundamentals/creating_analysis_pipelines.md
+++ b/doc/fundamentals/creating_analysis_pipelines.md
@@ -94,7 +94,7 @@ Here's an example pipeline spec:
     "cmd": ["/binary", "/pfs/data", "/pfs/out"]
   },
   "input": {
-      "atom": {
+      "pfs": {
         "repo": "data",
         "glob": "/*"
       }

--- a/doc/fundamentals/creating_services.md
+++ b/doc/fundamentals/creating_services.md
@@ -10,7 +10,7 @@ is an example of Jupyter service:
 ```json
 {
     "input": {
-        "atom": {
+        "pfs": {
             "glob": "/",
             "repo": "input"
         }

--- a/doc/fundamentals/getting_data_out_of_pachyderm.md
+++ b/doc/fundamentals/getting_data_out_of_pachyderm.md
@@ -43,7 +43,7 @@ edges               026536b547a44a8daa2db9d25bf88b79   754542b89c1c47a5b657e6038
 edges               754542b89c1c47a5b657e60381c06c71   <none>                             2 minutes ago        Less than a second   22.22 KiB
 ```
 
-In this case, we have one output commit per input commit on `images`.  However, this might get more complicated for pipelines with multiple branches, multiple input atoms, etc.  To confirm which commits correspond to which outputs, we can use `flush-commit`.  In particular, we can call `flush-commit` on any one of our commits into `images` to see which output came from this particular commit:
+In this case, we have one output commit per input commit on `images`.  However, this might get more complicated for pipelines with multiple branches, multiple PFS inputs, etc.  To confirm which commits correspond to which outputs, we can use `flush-commit`.  In particular, we can call `flush-commit` on any one of our commits into `images` to see which output came from this particular commit:
 
 ```sh
 $ pachctl flush-commit images/a9678d2a439648c59636688945f3c6b5

--- a/doc/fundamentals/incrementality.md
+++ b/doc/fundamentals/incrementality.md
@@ -23,7 +23,7 @@ an example. Suppose we have a pipeline with a single input that looks like this:
 
 ```json
 {
-  "atom": {
+  "pfs": {
     "repo": "R",
     "glob": "/*",
   }

--- a/doc/getting_started/beginner_tutorial.rst
+++ b/doc/getting_started/beginner_tutorial.rst
@@ -101,7 +101,7 @@ Below is the pipeline spec and python code we're using. Let's walk through the d
       "image": "pachyderm/opencv"
     },
     "input": {
-      "atom": {
+      "pfs": {
         "repo": "images",
         "glob": "/*"
       }
@@ -109,7 +109,7 @@ Below is the pipeline spec and python code we're using. Let's walk through the d
   }
 
 
-Our pipeline spec contains a few simple sections. First is the pipeline ``name``, edges. Then we have the ``transform`` which specifies the docker image we want to use, ``pachyderm/opencv`` (defaults to DockerHub as the registry), and the entry point ``edges.py``. Lastly, we specify the input.  Here we only have one "atom" input, our images repo with a particular glob pattern. 
+Our pipeline spec contains a few simple sections. First is the pipeline ``name``, edges. Then we have the ``transform`` which specifies the docker image we want to use, ``pachyderm/opencv`` (defaults to DockerHub as the registry), and the entry point ``edges.py``. Lastly, we specify the input.  Here we only have one PFS input, our images repo with a particular glob pattern. 
 
 The glob pattern defines how the input data can be broken up if we wanted to distribute our computation. ``/*`` means that each file can be processed individually, which makes sense for images. Glob patterns are one of the most powerful features of Pachyderm so when you start creating your own pipelines, check out the :doc:`../reference/pipeline_spec`.
 
@@ -245,13 +245,13 @@ Below is the pipeline spec for this new pipeline:
     },
     "input": {
       "cross": [ {
-        "atom": {
+        "pfs": {
           "glob": "/",
           "repo": "images"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "glob": "/",
           "repo": "edges"
         }

--- a/doc/managing_pachyderm/data_management.md
+++ b/doc/managing_pachyderm/data_management.md
@@ -26,7 +26,7 @@ ln -s /pfs/input/log.txt /pfs/out/logs/log.txt
 
 Under the hood, Pachyderm is smart enough to recognize that the output file simply symlinks to a file that already exists in Pachyderm, and therefore skips the upload altogether.
 
-Note that if your shuffling pipeline only needs the names of the input files but not their content, you can use [`lazy input`](http://pachyderm.readthedocs.io/en/latest/reference/pipeline_spec.html#atom-input).  That way, your shuffling pipeline can skip both the download and the upload. An example for this type of shuffle pipeline is [here](https://github.com/pachyderm/pachyderm/tree/master/examples/shuffle)
+Note that if your shuffling pipeline only needs the names of the input files but not their content, you can use [`lazy input`](http://pachyderm.readthedocs.io/en/latest/reference/pipeline_spec.html#pfs-input).  That way, your shuffling pipeline can skip both the download and the upload. An example for this type of shuffle pipeline is [here](https://github.com/pachyderm/pachyderm/tree/master/examples/shuffle)
 
 ## Garbage collection
 

--- a/doc/reference/pipeline_spec.md
+++ b/doc/reference/pipeline_spec.md
@@ -111,7 +111,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
 
 "cross" or "union": [
   {
-    "atom": {
+    "pfs": {
       "name": string,
       "repo": string,
       "branch": string,
@@ -121,7 +121,7 @@ create-pipeline](../pachctl/pachctl_create-pipeline.html) doc.
     }
   },
   {
-    "atom": {
+    "pfs": {
       "name": string,
       "repo": string,
       "branch": string,
@@ -168,7 +168,7 @@ In practice, you rarely need to specify all the fields.  Most fields either come
     "cmd": ["/binary", "/pfs/data", "/pfs/out"]
   },
   "input": {
-        "atom": {
+        "pfs": {
             "repo": "data",
             "glob": "/*"
         }
@@ -356,17 +356,22 @@ these fields be set for any instantiation of the object.
 ```
 {
     "atom": atom_input,
-    "union": [input],
-    "cross": [input],
+    "pfs": pfs_input,
+    "union": union_input,
+    "cross": cross_input,
     "cron": cron_input
 }
 ```
 
 #### Atom Input
 
-**Note:** Atom inputs are deprecated in Pachyderm 1.8.1+. They have been renamed to PFS inputs. The configuration is the same, but all instances of `atom` should be changed to `pfs`.
+Atom inputs are deprecated in Pachyderm 1.8.1+. They have been renamed to PFS inputs. The configuration is the same, but all instances of `atom` should be changed to `pfs`.
 
-Atom inputs are the simplest inputs, they take input from a single branch on a
+#### PFS Input
+
+**Note:** PFS inputs are only available in versions of Pachyderm 1.8.1+. If you are using an older version of Pachyderm, see atom inputs instead.
+
+PFS inputs are the simplest inputs, they take input from a single branch on a
 single repo.
 
 ```
@@ -380,20 +385,20 @@ single repo.
 }
 ```
 
-`input.atom.name` is the name of the input.  An input with name `XXX` will be
+`input.pfs.name` is the name of the input.  An input with name `XXX` will be
 visible under the path `/pfs/XXX` when a job runs.  Input names must be unique
-if the inputs are crossed, but they may be duplicated between `AtomInput`s that are unioned.  This is because when `AtomInput`s are unioned, you'll only ever see a datum from one input at a time. Overlapping the names of unioned inputs allows
+if the inputs are crossed, but they may be duplicated between `PFSInput`s that are unioned.  This is because when `PFSInput`s are unioned, you'll only ever see a datum from one input at a time. Overlapping the names of unioned inputs allows
 you to write simpler code since you no longer need to consider which input directory a particular datum come from.  If an input's name is not specified, it defaults to the name of the repo.  Therefore, if you have two crossed inputs from the same repo, you'll be required to give at least one of them a unique name.
 
-`input.atom.repo` is the `repo` to be used for the input.
+`input.pfs.repo` is the `repo` to be used for the input.
 
-`input.atom.branch` is the `branch` to watch for commits on, it may be left blank in
+`input.pfs.branch` is the `branch` to watch for commits on, it may be left blank in
 which case `"master"` will be used.
 
-`input.atom.glob` is a glob pattern that's used to determine how the input data
+`input.pfs.glob` is a glob pattern that's used to determine how the input data
 is partitioned.  It's explained in detail in the next section.
 
-`input.atom.lazy` controls how the data is exposed to jobs. The default is `false`
+`input.pfs.lazy` controls how the data is exposed to jobs. The default is `false`
 which means the job will eagerly download the data it needs to process and it
 will be exposed as normal files on disk. If lazy is set to `true`, data will be
 exposed as named pipes instead and no data will be downloaded until the job
@@ -405,15 +410,9 @@ be especially notable if the job only reads a subset of the files that are
 available to it.  Note that `lazy` currently doesn't support datums that
 contain more than 10000 files.
 
-`input.atom.empty_files` controls how files are exposed to jobs. If true, it will
-cause files from this atom to be presented as empty files. This is useful in shuffle
+`input.pfs.empty_files` controls how files are exposed to jobs. If true, it will
+cause files from this PFS to be presented as empty files. This is useful in shuffle
 pipelines where you want to read the names of files and reorganize them using symlinks.
-
-#### PFS Input
-
-**Note:** PFS inputs are only available in versions of Pachyderm 1.8.1+.
-
-PFS inputs are the new name for atom inputs, documented above. The configuration is the same, but all instances of `atom` should be changed to `pfs`.
 
 #### Union Input
 
@@ -439,7 +438,7 @@ directory. This, of course, only works if your code doesn't need to be
 aware of which of the underlying inputs the data comes from.
 
 `input.union` is an array of inputs to union, note that these need not be
-`atom` inputs, they can also be `union` and `cross` inputs. Although there's no
+`pfs` inputs, they can also be `union` and `cross` inputs. Although there's no
 reason to take a union of unions since union is associative.
 
 #### Cross Input
@@ -460,7 +459,7 @@ Notice that cross inputs, do not take a name and maintain the names of the sub-i
 In the above example you would see files under `/pfs/inputA/...` and `/pfs/inputB/...`.
 
 `input.cross` is an array of inputs to cross, note that these need not be
-`atom` inputs, they can also be `union` and `cross` inputs. Although there's no
+`pfs` inputs, they can also be `union` and `cross` inputs. Although there's no
 reason to take a cross of crosses since cross products are associative.
 
 #### Cron Input
@@ -483,7 +482,7 @@ satisfied the spec. The time is formatted according to [RFC
 ```
 
 `input.cron.name` is the name for the input, its semantics are similar to
-those of `input.atom.name`. Except that it's not optional.
+those of `input.pfs.name`. Except that it's not optional.
 
 `input.cron.spec` is a cron expression which specifies the schedule on
 which to trigger the pipeline. To learn more about how to write schedules
@@ -510,7 +509,7 @@ Git inputs allow you to pull code from a public git URL and execute that code as
 `input.git.URL` must be a URL of the form: `https://github.com/foo/bar.git`
 
 `input.git.name` is the name for the input, its semantics are similar to
-those of `input.atom.name`. It is optional.
+those of `input.pfs.name`. It is optional.
 
 `input.git.branch` is the name of the git branch to use as input
 
@@ -646,7 +645,7 @@ containers.
 
 ## The Input Glob Pattern
 
-Each atom input needs to specify a [glob pattern](../fundamentals/distributed_computing.html).
+Each PFS input needs to specify a [glob pattern](../fundamentals/distributed_computing.html).
 
 Pachyderm uses the glob pattern to determine how many "datums" an input
 consists of.  Datums are the unit of parallelism in Pachyderm.  That is,

--- a/examples/fruit_stand/pipeline.json
+++ b/examples/fruit_stand/pipeline.json
@@ -14,7 +14,7 @@
     "constant": 1
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "data",
       "glob": "/*"
     }
@@ -37,7 +37,7 @@
     "constant": 1
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "filter",
       "glob": "/*"
     }

--- a/examples/gatk/joint-call.json
+++ b/examples/gatk/joint-call.json
@@ -26,13 +26,13 @@
   "input": {
     "cross": [
       {
-        "atom": {
+        "pfs": {
           "repo": "reference",
           "glob": "/"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "repo": "likelihoods",
           "glob": "/"
         }

--- a/examples/gatk/likelihoods.json
+++ b/examples/gatk/likelihoods.json
@@ -14,7 +14,7 @@
         "then",
         "filename=\"${filename%.*}\"",
         "cd $samples",
-	"java -jar /usr/GenomeAnalysisTK.jar -T HaplotypeCaller -R /pfs/reference/ref.fasta -I $filename.bam -o /pfs/out/$filename.g.vcf -ERC GVCF -L 20:10,000,000-10,200,000",
+        "java -jar /usr/GenomeAnalysisTK.jar -T HaplotypeCaller -R /pfs/reference/ref.fasta -I $filename.bam -o /pfs/out/$filename.g.vcf -ERC GVCF -L 20:10,000,000-10,200,000",
         "fi",
         "done"
     ]
@@ -25,16 +25,16 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "reference",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "reference",
+          "glob": "/"
+        }
       },
       {
-	"atom": {
-	  "repo": "samples",
-	  "glob": "/*"
-	}
+        "pfs": {
+          "repo": "samples",
+          "glob": "/*"
+        }
       }
     ]
   }

--- a/examples/jupyter_notebook/jupyter.json
+++ b/examples/jupyter_notebook/jupyter.json
@@ -19,19 +19,19 @@
   "input": {
     "cross": [
       {
-        "atom": {
+        "pfs": {
           "repo": "trips",
           "glob": "/"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "repo": "weather",
           "glob": "/"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "repo": "sales",
           "glob": "/"
         }

--- a/examples/jupyter_notebook/sales_data/pipeline.json
+++ b/examples/jupyter_notebook/sales_data/pipeline.json
@@ -8,7 +8,7 @@
     "stdin": []
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "trips",
       "glob": "/"
     }

--- a/examples/ml/hyperparameter/model.json
+++ b/examples/ml/hyperparameter/model.json
@@ -24,20 +24,20 @@
   "input": {
     "cross": [
       {
-        "atom": {
+        "pfs": {
           "repo": "split",
           "glob": "/train.csv"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "name": "c-parameters",
           "repo": "parameters",
           "glob": "/c_parameters.txt/*"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "name": "gamma-parameters",
           "repo": "parameters",
           "glob": "/gamma_parameters.txt/*"

--- a/examples/ml/hyperparameter/select.json
+++ b/examples/ml/hyperparameter/select.json
@@ -35,15 +35,15 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "test",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "test",
+          "glob": "/"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/"
+        "pfs": {
+          "repo": "model",
+          "glob": "/"
         }
       }
     ]

--- a/examples/ml/hyperparameter/split.json
+++ b/examples/ml/hyperparameter/split.json
@@ -14,7 +14,7 @@
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "raw_data",
       "glob": "/"
     }

--- a/examples/ml/hyperparameter/test.json
+++ b/examples/ml/hyperparameter/test.json
@@ -23,15 +23,15 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "split",
-	  "glob": "/test.csv"
-	}
+        "pfs": {
+          "repo": "split",
+          "glob": "/test.csv"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/*"
+        "pfs": {
+          "repo": "model",
+          "glob": "/*"
         }
       }
     ]

--- a/examples/ml/iris/julia_infer.json
+++ b/examples/ml/iris/julia_infer.json
@@ -5,11 +5,11 @@
   "transform": {
     "image": "pachyderm/iris-infer:julia",
     "cmd": [
-	"julia",
-	"/infer.jl",
-	"/pfs/model/model.jld",
-	"/pfs/attributes/",
-	"/pfs/out/"
+      "julia",
+      "/infer.jl",
+      "/pfs/model/model.jld",
+      "/pfs/attributes/",
+      "/pfs/out/"
     ]
   },
   "parallelism_spec": {
@@ -18,16 +18,16 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "attributes",
-	  "glob": "/*"
-	}
+        "pfs": {
+          "repo": "attributes",
+          "glob": "/*"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "model",
+          "glob": "/"
+        }
       }
     ]
   }

--- a/examples/ml/iris/julia_train.json
+++ b/examples/ml/iris/julia_train.json
@@ -15,7 +15,7 @@
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/iris/python_infer.json
+++ b/examples/ml/iris/python_infer.json
@@ -5,11 +5,11 @@
   "transform": {
     "image": "pachyderm/iris-infer:python",
     "cmd": [
-	"python3",
-	"/code/pyinfer.py",
-	"/pfs/model/",
-	"/pfs/attributes/",
-	"/pfs/out/"
+      "python3",
+      "/code/pyinfer.py",
+      "/pfs/model/",
+      "/pfs/attributes/",
+      "/pfs/out/"
     ]
   },
   "parallelism_spec": {
@@ -18,16 +18,16 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "attributes",
-	  "glob": "/*"
-	}
+        "pfs": {
+          "repo": "attributes",
+          "glob": "/*"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "model",
+          "glob": "/"
+        }
       }
     ]
   }

--- a/examples/ml/iris/python_train.json
+++ b/examples/ml/iris/python_train.json
@@ -15,7 +15,7 @@
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/iris/rstats_infer.json
+++ b/examples/ml/iris/rstats_infer.json
@@ -5,8 +5,8 @@
   "transform": {
     "image": "pachyderm/iris-infer:rstats",
     "cmd": [
-	"Rscript",
-	"infer.R"
+      "Rscript",
+      "infer.R"
     ]
   },
   "parallelism_spec": {
@@ -15,16 +15,16 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "attributes",
-	  "glob": "/*"
-	}
+        "pfs": {
+          "repo": "attributes",
+          "glob": "/*"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "model",
+          "glob": "/"
+        }
       }
     ]
   }

--- a/examples/ml/iris/rstats_train.json
+++ b/examples/ml/iris/rstats_train.json
@@ -13,7 +13,7 @@
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/neon/infer.json
+++ b/examples/ml/neon/infer.json
@@ -5,16 +5,16 @@
   "transform": {
     "image": "dwhitena/neon-inference",
     "cmd": [
-	"python",
-	"examples/imdb/auto_inference.py",
-	"--model_weights",
-	"/pfs/model/imdb.p",
-	"--vocab_file",
-	"/pfs/model/imdb.vocab",
-	"--review_files",
-	"/pfs/reviews",
-	"--output_dir",
-	"/pfs/out"
+      "python",
+      "examples/imdb/auto_inference.py",
+      "--model_weights",
+      "/pfs/model/imdb.p",
+      "--vocab_file",
+      "/pfs/model/imdb.vocab",
+      "--review_files",
+      "/pfs/reviews",
+      "--output_dir",
+      "/pfs/out"
     ]
   },
   "parallelism_spec": {
@@ -23,16 +23,16 @@
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "reviews",
-	  "glob": "/*"
-	}
+        "pfs": {
+          "repo": "reviews",
+          "glob": "/*"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "model",
+          "glob": "/"
+        }
       }
     ]
   }

--- a/examples/ml/neon/train.json
+++ b/examples/ml/neon/train.json
@@ -5,25 +5,25 @@
   "transform": {
     "image": "kaixhin/neon",
     "cmd": [
-	"python",
-	"examples/imdb/train.py",
-	"-f",
-	"/pfs/training/labeledTrainData.tsv",
-	"-e",
-	"2",
-	"-eval",
-	"1",
-	"-s",
-	"/pfs/out/imdb.p",
-	"--vocab_file",
-	"/pfs/out/imdb.vocab"
+      "python",
+      "examples/imdb/train.py",
+      "-f",
+      "/pfs/training/labeledTrainData.tsv",
+      "-e",
+      "2",
+      "-eval",
+      "1",
+      "-s",
+      "/pfs/out/imdb.p",
+      "--vocab_file",
+      "/pfs/out/imdb.vocab"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "training",
       "glob": "/"
     }

--- a/examples/ml/object-detection/detect.json
+++ b/examples/ml/object-detection/detect.json
@@ -5,13 +5,13 @@
   "input": {
     "cross": [
       {
-        "atom": {
+        "pfs": {
           "glob": "/*",
           "repo": "images"
         }
       },
       {
-        "atom": {
+        "pfs": {
           "glob": "/",
           "repo": "model"
         }

--- a/examples/ml/object-detection/model.json
+++ b/examples/ml/object-detection/model.json
@@ -3,7 +3,7 @@
     "name": "model"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "glob": "/",
       "repo": "training"
     }

--- a/examples/ml/rnn/pipeline.json
+++ b/examples/ml/rnn/pipeline.json
@@ -17,7 +17,7 @@
        "constant" : 1
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "GoT_scripts",
       "glob": "/"
     }
@@ -41,7 +41,7 @@
        "constant" : 1
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "GoT_train",
       "glob": "/"
     }

--- a/examples/ml/tensorflow/pre-processing_and_generation.json
+++ b/examples/ml/tensorflow/pre-processing_and_generation.json
@@ -6,11 +6,11 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-	"python process.py --input_dir /pfs/input_images --operation resize --output_dir /pfs/out"	
+      "python process.py --input_dir /pfs/input_images --operation resize --output_dir /pfs/out"	
     ]
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "input_images",
       "glob": "/*"
     }
@@ -24,25 +24,25 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-	"for filename in /pfs/preprocess_images/*; do",
-		"rawname=$(basename $filename)",
-		"python process-local.py --model_dir /pfs/model --input_file $filename --output_file /pfs/out/$rawname",	
-	"done"
+      "for filename in /pfs/preprocess_images/*; do",
+      "rawname=$(basename $filename)",
+      "python process-local.py --model_dir /pfs/model --input_file $filename --output_file /pfs/out/$rawname",	
+      "done"
     ]
   },
   "input": {
     "cross": [
       {
-        "atom": {
-	  "repo": "preprocess_images",
-	  "glob": "/*"
-	}
+        "pfs": {
+          "repo": "preprocess_images",
+          "glob": "/*"
+        }
       },
       {
-	"atom": {
-	  "repo": "model",
-	  "glob": "/"
-	}
+        "pfs": {
+          "repo": "model",
+          "glob": "/"
+        }
       }
     ]
   }

--- a/examples/ml/tensorflow/training_and_export.json
+++ b/examples/ml/tensorflow/training_and_export.json
@@ -6,15 +6,15 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-	"python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
-	"sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
+      "python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
+      "sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "training",
       "glob": "/"
     }
@@ -28,15 +28,15 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-	"python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
-	"sed -i 's/out/model/g' /pfs/out/checkpoint"
+      "python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
+      "sed -i 's/out/model/g' /pfs/out/checkpoint"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "checkpoint",
       "glob": "/"
     }

--- a/examples/ml/tensorflow/training_and_export_gpu.json
+++ b/examples/ml/tensorflow/training_and_export_gpu.json
@@ -6,8 +6,8 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-	"python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
-	"sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
+      "python pix2pix.py --mode train --output_dir /pfs/out --max_epochs 1 --input_dir /pfs/training --which_direction BtoA",
+      "sed -i 's/out/checkpoint/g' /pfs/out/checkpoint"
     ],
     "env": {
       "LD_LIBRARY_PATH": "/usr/lib/nvidia:/usr/local/cuda/lib64:/rootfs/usr/lib/x86_64-linux-gnu"
@@ -22,7 +22,7 @@
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "training",
       "glob": "/"
     }
@@ -36,15 +36,15 @@
     "image": "dwhitena/pix2pix",
     "cmd": [ "/bin/bash" ],
     "stdin": [
-	"python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
-	"sed -i 's/out/model/g' /pfs/out/checkpoint"
+      "python pix2pix.py --mode export --output_dir /pfs/out --checkpoint /pfs/checkpoint",
+      "sed -i 's/out/model/g' /pfs/out/checkpoint"
     ]
   },
   "parallelism_spec": {
     "constant": "1"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "checkpoint",
       "glob": "/"
     }

--- a/examples/opencv/edges.json
+++ b/examples/opencv/edges.json
@@ -3,7 +3,7 @@
     "name": "edges"
   },
   "input": {
-    "atom": {
+    "pfs": {
       "glob": "/*",
       "repo": "images"
     }

--- a/examples/opencv/montage.json
+++ b/examples/opencv/montage.json
@@ -4,13 +4,13 @@
   },
   "input": {
     "cross": [ {
-      "atom": {
+      "pfs": {
         "glob": "/",
         "repo": "images"
       }
     },
     {
-      "atom": {
+      "pfs": {
         "glob": "/",
         "repo": "edges"
       }

--- a/examples/redshift/pipeline.json
+++ b/examples/redshift/pipeline.json
@@ -3,7 +3,7 @@
         "name": "upload_to_redshift"
     },
     "input": {
-      "atom": {
+      "pfs": {
         "repo": "data"
       }
     },

--- a/examples/run/config/pipeline.json
+++ b/examples/run/config/pipeline.json
@@ -20,7 +20,7 @@
         "image_pull_secrets": ["$PIPELINE_DOCKER_REGISTRY_SECRETS"]
     },
     "input": {
-        "atom": {
+        "pfs": {
             "repo": "$PIPELINE_REPO",
             "glob": "/*"
         }

--- a/examples/scraper/README.md
+++ b/examples/scraper/README.md
@@ -115,7 +115,7 @@ The `pipeline` we're creating can be found at [scraper.json](scraper.json).  The
   },
   "parallelism": "1",
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "urls"
     }
   }

--- a/examples/scraper/scraper.json
+++ b/examples/scraper/scraper.json
@@ -15,7 +15,7 @@
   },
   "input": {
     "cross": [ {
-      "atom": {
+      "pfs": {
         "glob": "urls/*",
         "repo": "urls"
       }

--- a/examples/shuffle/README.md
+++ b/examples/shuffle/README.md
@@ -29,14 +29,14 @@ Let's take a closer look at that pipeline:
   "input": {
     "union": [
       {
-        "atom": {
+        "pfs": {
           "glob": "/*.jpeg",
           "repo": "fruits",
           "empty_files": true
         }
       },
       {
-        "atom": {
+        "pfs": {
           "glob": "/*.json",
           "repo": "pricing",
           "empty_files": true

--- a/examples/shuffle/shuffle.json
+++ b/examples/shuffle/shuffle.json
@@ -2,14 +2,14 @@
   "input": {
     "union": [
       {
-        "atom": {
+        "pfs": {
           "glob": "/*.jpeg",
           "repo": "fruits",
           "empty_files": true
         }
       },
       {
-        "atom": {
+        "pfs": {
           "glob": "/*.json",
           "repo": "pricing",
           "empty_files": true

--- a/examples/spark/pi/estimate_pi_pipeline.json
+++ b/examples/spark/pi/estimate_pi_pipeline.json
@@ -10,7 +10,7 @@
     "constant": 1
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "estimate_pi_config",
       "glob": "/num_samples"
     }

--- a/examples/word_count/map.json
+++ b/examples/word_count/map.json
@@ -11,7 +11,7 @@
     ]
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "scraper",
       "glob": "/*"
     }

--- a/examples/word_count/reduce.json
+++ b/examples/word_count/reduce.json
@@ -9,7 +9,7 @@
     ]
   },
   "input": {
-    "atom": {
+    "pfs": {
       "repo": "map",
       "glob": "/*"
     }

--- a/examples/word_count/scraper.json
+++ b/examples/word_count/scraper.json
@@ -15,7 +15,7 @@
     "acceptReturnCode": [4,5,6,7,8]
   },
   "input": {
-      "atom": {
+      "pfs": {
         "repo": "urls",
         "glob": "/*"
       }


### PR DESCRIPTION
This reverts the revert for the atom/PFS rename, now that 1.8.1 is out. We have a few options here:

* Merge #3317, followed by this PR once 1.8.1 is in more hands. If we go down this path, I'll just fix conflicts once #3317 is merged. This would make sense if we suspect consumers of examples tend to be on the latest version.
* Close this PR and #3317 out for now and wait until 1.8.1 is in more hands before moving forward. This would minimize breakages for users on 1.8.0 or lower who are consuming 1.8.1 docs/examples.
* Just go ahead and merge this PR, changing both the docs and examples at the same time.
