### PR TITLE
Update OpenCV image

### DIFF
--- a/examples/opencv/Dockerfile
+++ b/examples/opencv/Dockerfile
@@ -1,29 +1,31 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 # Install opencv and matplotlib.
-RUN apt-get update \
-	&& apt-get upgrade -y \
-	&& apt-get install -y unzip wget build-essential \
-		cmake git pkg-config libswscale-dev \
-		python3-dev python3-numpy python3-tk \
-		libtbb2 libtbb-dev libjpeg-dev \
-		libpng-dev libtiff-dev libjasper-dev \
-		bpython python3-pip libfreetype6-dev \
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    export DEBCONF_NONINTERACTIVE_SEEN=true; \
+    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
+    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections; \
+    apt-get update -qqy \
+    && apt-get install -qqy make git pkg-config libswscale-dev python3-dev \
+    	python3-numpy python3-tk libtbb2 libtbb-dev libjpeg-dev libpng-dev \
+    	libtiff-dev bpython python3-pip libfreetype6-dev wget unzip cmake \
+    	sudo \
     && apt-get clean \
     && rm -rf /var/lib/apt
+
 RUN cd \
-	&& wget https://github.com/Itseez/opencv/archive/3.1.0.zip \
-	&& unzip 3.1.0.zip \
-	&& cd opencv-3.1.0 \
+	&& wget https://github.com/Itseez/opencv/archive/3.4.5.zip \
+	&& unzip 3.4.5.zip \
+	&& cd opencv-3.4.5 \
 	&& mkdir build \
 	&& cd build \
 	&& cmake .. \
 	&& make -j \
 	&& make install \
 	&& cd \
-	&& rm 3.1.0.zip \
-    && rm -rf opencv-3.1.0
-RUN sudo pip3 install matplotlib
+	&& rm 3.4.5.zip \
+    && rm -rf opencv-3.4.5
+RUN python3 --version && pip3 --version && sudo pip3 install matplotlib
 
 # Add our own code.
 ADD edges.py /edges.py

--- a/examples/opencv/README.md
+++ b/examples/opencv/README.md
@@ -2,3 +2,6 @@
 
 A detailed walkthrough of this example is included in our docs [here](http://pachyderm.readthedocs.io/en/latest/getting_started/beginner_tutorial.html). Please follow that guide to deploy this pipeline.
 
+## Building docker images
+
+You shouldn't need to build docker images, as this example will pull our pre-built ones. If for some reason you do need to, make sure to allocate 12gb (or more), as compiling OpenCV will otherwise fail.


### PR DESCRIPTION
Currently, the OpenCV docker image fails to build due to bitrot. This updates its `Dockerfile` to be buildable, by switching to ubuntu 18.04 and OpenCV 3.4.5.

Discovered while working on #3293.