### PR TITLE
Check for bad docker config error on macOS

### DIFF
--- a/examples/opencv/edges.json
+++ b/examples/opencv/edges.json
@@ -10,7 +10,6 @@
   },
   "transform": {
     "cmd": [ "python3", "/edges.py" ],
-    "image": "pachyderm/opencv"
+    "image": "ysimonson/opencv"
   }
 }
-

--- a/examples/opencv/edges.json
+++ b/examples/opencv/edges.json
@@ -10,6 +10,6 @@
   },
   "transform": {
     "cmd": [ "python3", "/edges.py" ],
-    "image": "ysimonson/opencv"
+    "image": "pachyderm/opencv"
   }
 }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -847,7 +847,7 @@ func pushImage(registry string, username string, password string, image string) 
 	} else {
 		authConfigs, err := docker.NewAuthConfigurationsFromDockerCfg()
 		if err != nil {
-			if isBrokenPushImagesOnMac() {
+			if isDockerUsingKeychain() {
 				return "", fmt.Errorf("error parsing auth: %s. It looks like you may have a docker configuration not supported by the client library that we use. Please see here for remedial steps: https://github.com/pachyderm/pachyderm/issues/3293.", err.Error())
 			} else {
 				return "", fmt.Errorf("error parsing auth: %s, try running `docker login`", err.Error())
@@ -891,7 +891,7 @@ func pushImage(registry string, username string, password string, image string) 
 // readable by our current docker client library.
 // TODO(ys): remove if/when this issue is addressed:
 // https://github.com/fsouza/go-dockerclient/issues/677
-func isBrokenPushImagesOnMac() bool {
+func isDockerUsingKeychain() bool {
 	user, err := user.Current()
 	if err != nil {
 		return false

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -848,10 +848,10 @@ func pushImage(registry string, username string, password string, image string) 
 		authConfigs, err := docker.NewAuthConfigurationsFromDockerCfg()
 		if err != nil {
 			if isDockerUsingKeychain() {
-				return "", fmt.Errorf("error parsing auth: %s. It looks like you may have a docker configuration not supported by the client library that we use. Please see here for remedial steps: https://github.com/pachyderm/pachyderm/issues/3293#issuecomment-448012383.", err.Error())
-			} else {
-				return "", fmt.Errorf("error parsing auth: %s, try running `docker login`", err.Error())
+				return "", fmt.Errorf("error parsing auth: %s; it looks like you may have a docker configuration not supported by the client library that we use. Please see here for remedial steps: https://github.com/pachyderm/pachyderm/issues/3293#issuecomment-448012383", err.Error())
 			}
+			
+			return "", fmt.Errorf("error parsing auth: %s, try running `docker login`", err.Error())
 		}
 		for _, _authConfig := range authConfigs.Configs {
 			serverAddress := _authConfig.ServerAddress

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -848,7 +848,7 @@ func pushImage(registry string, username string, password string, image string) 
 		authConfigs, err := docker.NewAuthConfigurationsFromDockerCfg()
 		if err != nil {
 			if isDockerUsingKeychain() {
-				return "", fmt.Errorf("error parsing auth: %s. It looks like you may have a docker configuration not supported by the client library that we use. Please see here for remedial steps: https://github.com/pachyderm/pachyderm/issues/3293.", err.Error())
+				return "", fmt.Errorf("error parsing auth: %s. It looks like you may have a docker configuration not supported by the client library that we use. Please see here for remedial steps: https://github.com/pachyderm/pachyderm/issues/3293#issuecomment-448012383.", err.Error())
 			} else {
 				return "", fmt.Errorf("error parsing auth: %s, try running `docker login`", err.Error())
 			}


### PR DESCRIPTION
`--push-images` does not work on macOS by default, because docker is configured to use keychain access, and our docker client library does not support it. Luckily, there is a workaround. In order to ensure users are aware of this workaround, this will check if keychain-based access is in use, and warn the user about remedial steps. See discussion in #3293 for full details.

Fixes #3293.