### PR TITLE
Check for nil configs

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -354,10 +354,10 @@ func NewOnUserMachine(reportMetrics bool, prefix string, options ...Option) (*AP
 
 	// Add metrics info & authentication token
 	client.metricsPrefix = prefix
-	if cfg.UserID != "" && reportMetrics {
+	if cfg != nil && cfg.UserID != "" && reportMetrics {
 		client.metricsUserID = cfg.UserID
 	}
-	if cfg.V1 != nil && cfg.V1.SessionToken != "" {
+	if cfg != nil && cfg.V1 != nil && cfg.V1.SessionToken != "" {
 		client.authenticationToken = cfg.V1.SessionToken
 	}
 	return client, nil


### PR DESCRIPTION
This prevents nil dereferencing when the config is malformed. I think this may make more sense than regenerating the config (as proposed in #3170) because it's unclear how that would interact with `PACH_CONFIG`, and could create perceived bugs if `PACH_CONFIG` is set.

Fixes #3170.