### PR TITLE
Prevent the creation of pipelines with invalid names

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -66,7 +66,7 @@ var (
 	zeroVal             = int64(0)
 	suite               = "pachyderm"
 	defaultGCMemory     = 20 * 1024 * 1024 // 20 MB
-	pipelineNameMatcher = regexp.MustCompile("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
+	pipelineNameMatcher = regexp.MustCompile("^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$")
 )
 
 func newErrJobNotFound(job string) error {
@@ -182,10 +182,6 @@ func validateNames(names map[string]bool, input *pps.Input) error {
 }
 
 func (a *apiServer) validateInput(pachClient *client.APIClient, pipelineName string, input *pps.Input, job bool) error {
-	if !pipelineNameMatcher.MatchString(pipelineName) {
-		return fmt.Errorf("Invalid pipeline name: a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345')")
-	}
-
 	if err := validateNames(make(map[string]bool), input); err != nil {
 		return err
 	}
@@ -1485,6 +1481,9 @@ func (a *apiServer) getLogsFromStats(pachClient *client.APIClient, request *pps.
 func (a *apiServer) validatePipeline(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) error {
 	if pipelineInfo.Pipeline == nil {
 		return fmt.Errorf("pipeline has no name")
+	}
+	if !pipelineNameMatcher.MatchString(pipelineInfo.Pipeline.Name) {
+		return fmt.Errorf("Invalid pipeline name: it must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345')")
 	}
 	if err := a.validateInput(pachClient, pipelineInfo.Pipeline.Name, pipelineInfo.Input, false); err != nil {
 		return err

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,9 +63,10 @@ const (
 )
 
 var (
-	zeroVal         = int64(0)
-	suite           = "pachyderm"
-	defaultGCMemory = 20 * 1024 * 1024 // 20 MB
+	zeroVal             = int64(0)
+	suite               = "pachyderm"
+	defaultGCMemory     = 20 * 1024 * 1024 // 20 MB
+	pipelineNameMatcher = regexp.MustCompile("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
 )
 
 func newErrJobNotFound(job string) error {
@@ -180,6 +182,10 @@ func validateNames(names map[string]bool, input *pps.Input) error {
 }
 
 func (a *apiServer) validateInput(pachClient *client.APIClient, pipelineName string, input *pps.Input, job bool) error {
+	if !pipelineNameMatcher.MatchString(pipelineName) {
+		return fmt.Errorf("Invalid pipeline name: a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345')")
+	}
+
 	if err := validateNames(make(map[string]bool), input); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #3216 by validating the pipeline name when created

I'm not sure if this is the right fix; #3216 implies to me that we're not propagating errors triggered by the creation of the pod (including invalid labels.) Is this on purpose?
