### PR TITLE
Use consistent deprecation warning message

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -457,7 +457,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 					return err
 				}
 				if request.Input.Atom != nil {
-					fmt.Println("WARNING: The `atom` input type has been deprecated and will be removed in a future version. Please replace `atom` with `pfs`.")
+					fmt.Fprintf(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`\n")
 				}
 				if pushImages {
 					pushedImage, err := pushImage(registry, username, password, request.Transform.Image)
@@ -507,7 +507,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 				request.Update = true
 				request.Reprocess = reprocess
 				if request.Input.Atom != nil {
-					fmt.Println("WARNING: The `atom` input type has been deprecated and will be removed in a future version. Please replace `atom` with `pfs`.")
+					fmt.Fprintf(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`\n")
 				}
 				if pushImages {
 					pushedImage, err := pushImage(registry, username, password, request.Transform.Image)
@@ -631,7 +631,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			request.Update = true
 			request.Reprocess = reprocess
 			if request.Input.Atom != nil {
-				fmt.Println("WARNING: The `atom` input type has been deprecated and will be removed in a future version. Please replace `atom` with `pfs`.")
+				fmt.Fprintf(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`\n")
 			}
 			if _, err := client.PpsAPIClient.CreatePipeline(
 				client.Ctx(),

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -457,7 +457,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 					return err
 				}
 				if request.Input.Atom != nil {
-					fmt.Fprintf(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`\n")
+					fmt.Fprintln(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`")
 				}
 				if pushImages {
 					pushedImage, err := pushImage(registry, username, password, request.Transform.Image)
@@ -507,7 +507,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 				request.Update = true
 				request.Reprocess = reprocess
 				if request.Input.Atom != nil {
-					fmt.Fprintf(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`\n")
+					fmt.Fprintln(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`")
 				}
 				if pushImages {
 					pushedImage, err := pushImage(registry, username, password, request.Transform.Image)
@@ -631,7 +631,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			request.Update = true
 			request.Reprocess = reprocess
 			if request.Input.Atom != nil {
-				fmt.Fprintf(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`\n")
+				fmt.Fprintln(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`")
 			}
 			if _, err := client.PpsAPIClient.CreatePipeline(
 				client.Ctx(),


### PR DESCRIPTION
I noticed that deprecated warning messages elsewhere used a different style than what I had added: they're printing to stderr and not prefixed by a big ol' WARNING. This changes the atom-to-pfs deprecation notice to be consistent with other notices.