### PR TITLE
Propagate errors when releasing

### DIFF
--- a/etc/build/release_pachd
+++ b/etc/build/release_pachd
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -z $VERSION ]
 then
         echo "No version found for this commit! Aborting release"


### PR DESCRIPTION
The current release process suppresses errors when tagging/pushing images, so it's not obvious if it fails. This fixes it.