### PR TITLE
Flag to disable implicit port forwarding

### DIFF
--- a/src/server/admin/cmds/cmds.go
+++ b/src/server/admin/cmds/cmds.go
@@ -17,9 +17,7 @@ const (
 )
 
 // Cmds returns a slice containing admin commands.
-func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
-	metrics := !*noMetrics
-
+func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 	var noObjects bool
 	var url string
 	extract := &cobra.Command{
@@ -32,7 +30,7 @@ pachctl extract >backup
 # Extract to s3:
 pachctl extract -u s3://bucket/backup` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -61,7 +59,7 @@ pachctl restore <backup
 # Restore from s3:
 pachctl restore -u s3://bucket/backup` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -85,7 +83,7 @@ pachctl restore -u s3://bucket/backup` + codeend,
 		Short: "Returns info about the pachyderm cluster",
 		Long:  "Returns info about the pachyderm cluster",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}

--- a/src/server/admin/cmds/cmds.go
+++ b/src/server/admin/cmds/cmds.go
@@ -17,7 +17,7 @@ const (
 )
 
 // Cmds returns a slice containing admin commands.
-func Cmds(noMetrics *bool) []*cobra.Command {
+func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 	metrics := !*noMetrics
 
 	var noObjects bool
@@ -32,7 +32,7 @@ pachctl extract >backup
 # Extract to s3:
 pachctl extract -u s3://bucket/backup` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ pachctl restore <backup
 # Restore from s3:
 pachctl restore -u s3://bucket/backup` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -85,7 +85,7 @@ pachctl restore -u s3://bucket/backup` + codeend,
 		Short: "Returns info about the pachyderm cluster",
 		Long:  "Returns info about the pachyderm cluster",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -51,7 +51,7 @@ func writePachTokenToCfg(token string) error {
 }
 
 // ActivateCmd returns a cobra.Command to activate Pachyderm's auth system
-func ActivateCmd(noPortForwarding bool) *cobra.Command {
+func ActivateCmd(portForwarding bool) *cobra.Command {
 	var initialAdmin string
 	activate := &cobra.Command{
 		Use:   "activate",
@@ -72,7 +72,7 @@ first cluster admin`[1:],
 			fmt.Println("Retrieving Pachyderm token...")
 
 			// Exchange GitHub token for Pachyderm token
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -110,7 +110,7 @@ cluster`[1:])
 
 // DeactivateCmd returns a cobra.Command to delete all ACLs, tokens, and admins,
 // deactivating Pachyderm's auth system
-func DeactivateCmd(noPortForwarding bool) *cobra.Command {
+func DeactivateCmd(portForwarding bool) *cobra.Command {
 	deactivate := &cobra.Command{
 		Use:   "deactivate",
 		Short: "Delete all ACLs, tokens, and admins, and deactivate Pachyderm auth",
@@ -124,7 +124,7 @@ func DeactivateCmd(noPortForwarding bool) *cobra.Command {
 			if !strings.Contains("yY", confirm[:1]) {
 				return fmt.Errorf("operation aborted")
 			}
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -139,7 +139,7 @@ func DeactivateCmd(noPortForwarding bool) *cobra.Command {
 // LoginCmd returns a cobra.Command to login to a Pachyderm cluster with your
 // GitHub account. Any resources that have been restricted to the email address
 // registered with your GitHub account will subsequently be accessible.
-func LoginCmd(noPortForwarding bool) *cobra.Command {
+func LoginCmd(portForwarding bool) *cobra.Command {
 	var useOTP bool
 	login := &cobra.Command{
 		Use:   "login",
@@ -148,7 +148,7 @@ func LoginCmd(noPortForwarding bool) *cobra.Command {
 			"the account you have with your ID provider (e.g. GitHub, Okta) " +
 			"account will subsequently be accessible.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -229,13 +229,13 @@ func LogoutCmd() *cobra.Command {
 // WhoamiCmd returns a cobra.Command that deletes your local Pachyderm
 // credential, logging you out of your cluster. Note that this is not necessary
 // to do before logging in as another user, but is useful for testing.
-func WhoamiCmd(noPortForwarding bool) *cobra.Command {
+func WhoamiCmd(portForwarding bool) *cobra.Command {
 	whoami := &cobra.Command{
 		Use:   "whoami",
 		Short: "Print your Pachyderm identity",
 		Long:  "Print your Pachyderm identity.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -259,7 +259,7 @@ func WhoamiCmd(noPortForwarding bool) *cobra.Command {
 
 // CheckCmd returns a cobra command that sends an "Authorize" RPC to Pachd, to
 // determine whether the specified user has access to the specified repo.
-func CheckCmd(noPortForwarding bool) *cobra.Command {
+func CheckCmd(portForwarding bool) *cobra.Command {
 	check := &cobra.Command{
 		Use:   "check (none|reader|writer|owner) repo",
 		Short: "Check whether you have reader/writer/etc-level access to 'repo'",
@@ -275,7 +275,7 @@ func CheckCmd(noPortForwarding bool) *cobra.Command {
 				return err
 			}
 			repo := args[1]
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -296,7 +296,7 @@ func CheckCmd(noPortForwarding bool) *cobra.Command {
 
 // GetCmd returns a cobra command that gets either the ACL for a Pachyderm
 // repo or another user's scope of access to that repo
-func GetCmd(noPortForwarding bool) *cobra.Command {
+func GetCmd(portForwarding bool) *cobra.Command {
 	setScope := &cobra.Command{
 		Use:   "get [username] repo",
 		Short: "Get the ACL for 'repo' or the access that 'username' has to 'repo'",
@@ -307,7 +307,7 @@ func GetCmd(noPortForwarding bool) *cobra.Command {
 			"Pachyderm authentication uses GitHub OAuth, so 'username' must be a " +
 			"GitHub username",
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -343,7 +343,7 @@ func GetCmd(noPortForwarding bool) *cobra.Command {
 
 // SetScopeCmd returns a cobra command that lets a user set the level of access
 // that another user has to a repo
-func SetScopeCmd(noPortForwarding bool) *cobra.Command {
+func SetScopeCmd(portForwarding bool) *cobra.Command {
 	setScope := &cobra.Command{
 		Use:   "set username (none|reader|writer|owner) repo",
 		Short: "Set the scope of access that 'username' has to 'repo'",
@@ -361,7 +361,7 @@ func SetScopeCmd(noPortForwarding bool) *cobra.Command {
 				return err
 			}
 			username, repo := args[0], args[2]
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -378,13 +378,13 @@ func SetScopeCmd(noPortForwarding bool) *cobra.Command {
 }
 
 // ListAdminsCmd returns a cobra command that lists the current cluster admins
-func ListAdminsCmd(noPortForwarding bool) *cobra.Command {
+func ListAdminsCmd(portForwarding bool) *cobra.Command {
 	listAdmins := &cobra.Command{
 		Use:   "list-admins",
 		Short: "List the current cluster admins",
 		Long:  "List the current cluster admins",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -404,7 +404,7 @@ func ListAdminsCmd(noPortForwarding bool) *cobra.Command {
 
 // ModifyAdminsCmd returns a cobra command that modifies the set of current
 // cluster admins
-func ModifyAdminsCmd(noPortForwarding bool) *cobra.Command {
+func ModifyAdminsCmd(portForwarding bool) *cobra.Command {
 	var add []string
 	var remove []string
 	modifyAdmins := &cobra.Command{
@@ -414,7 +414,7 @@ func ModifyAdminsCmd(noPortForwarding bool) *cobra.Command {
 			"separated list of users to grant admin status, and --remove accepts a " +
 			"comma-separated list of users to revoke admin status",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -440,7 +440,7 @@ func ModifyAdminsCmd(noPortForwarding bool) *cobra.Command {
 
 // GetAuthTokenCmd returns a cobra command that lets a user get a pachyderm
 // token on behalf of themselves or another user
-func GetAuthTokenCmd(noPortForwarding bool) *cobra.Command {
+func GetAuthTokenCmd(portForwarding bool) *cobra.Command {
 	var quiet bool
 	getAuthToken := &cobra.Command{
 		Use:   "get-auth-token username",
@@ -449,7 +449,7 @@ func GetAuthTokenCmd(noPortForwarding bool) *cobra.Command {
 			"this can only be called by cluster admins",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			subject := args[0]
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -498,23 +498,23 @@ func UseAuthTokenCmd() *cobra.Command {
 
 // Cmds returns a list of cobra commands for authenticating and authorizing
 // users in an auth-enabled Pachyderm cluster.
-func Cmds(noPortForwarding bool) []*cobra.Command {
+func Cmds(portForwarding bool) []*cobra.Command {
 	auth := &cobra.Command{
 		Use:   "auth",
 		Short: "Auth commands manage access to data in a Pachyderm cluster",
 		Long:  "Auth commands manage access to data in a Pachyderm cluster",
 	}
-	auth.AddCommand(ActivateCmd(noPortForwarding))
-	auth.AddCommand(DeactivateCmd(noPortForwarding))
-	auth.AddCommand(LoginCmd(noPortForwarding))
+	auth.AddCommand(ActivateCmd(portForwarding))
+	auth.AddCommand(DeactivateCmd(portForwarding))
+	auth.AddCommand(LoginCmd(portForwarding))
 	auth.AddCommand(LogoutCmd())
-	auth.AddCommand(WhoamiCmd(noPortForwarding))
-	auth.AddCommand(CheckCmd(noPortForwarding))
-	auth.AddCommand(SetScopeCmd(noPortForwarding))
-	auth.AddCommand(GetCmd(noPortForwarding))
-	auth.AddCommand(ListAdminsCmd(noPortForwarding))
-	auth.AddCommand(ModifyAdminsCmd(noPortForwarding))
-	auth.AddCommand(GetAuthTokenCmd(noPortForwarding))
+	auth.AddCommand(WhoamiCmd(portForwarding))
+	auth.AddCommand(CheckCmd(portForwarding))
+	auth.AddCommand(SetScopeCmd(portForwarding))
+	auth.AddCommand(GetCmd(portForwarding))
+	auth.AddCommand(ListAdminsCmd(portForwarding))
+	auth.AddCommand(ModifyAdminsCmd(portForwarding))
+	auth.AddCommand(GetAuthTokenCmd(portForwarding))
 	auth.AddCommand(UseAuthTokenCmd())
 	auth.AddCommand(GetConfig())
 	auth.AddCommand(SetConfig())

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -51,7 +51,7 @@ func writePachTokenToCfg(token string) error {
 }
 
 // ActivateCmd returns a cobra.Command to activate Pachyderm's auth system
-func ActivateCmd() *cobra.Command {
+func ActivateCmd(noPortForwarding bool) *cobra.Command {
 	var initialAdmin string
 	activate := &cobra.Command{
 		Use:   "activate",
@@ -72,7 +72,7 @@ first cluster admin`[1:],
 			fmt.Println("Retrieving Pachyderm token...")
 
 			// Exchange GitHub token for Pachyderm token
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -110,7 +110,7 @@ cluster`[1:])
 
 // DeactivateCmd returns a cobra.Command to delete all ACLs, tokens, and admins,
 // deactivating Pachyderm's auth system
-func DeactivateCmd() *cobra.Command {
+func DeactivateCmd(noPortForwarding bool) *cobra.Command {
 	deactivate := &cobra.Command{
 		Use:   "deactivate",
 		Short: "Delete all ACLs, tokens, and admins, and deactivate Pachyderm auth",
@@ -124,7 +124,7 @@ func DeactivateCmd() *cobra.Command {
 			if !strings.Contains("yY", confirm[:1]) {
 				return fmt.Errorf("operation aborted")
 			}
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -139,7 +139,7 @@ func DeactivateCmd() *cobra.Command {
 // LoginCmd returns a cobra.Command to login to a Pachyderm cluster with your
 // GitHub account. Any resources that have been restricted to the email address
 // registered with your GitHub account will subsequently be accessible.
-func LoginCmd() *cobra.Command {
+func LoginCmd(noPortForwarding bool) *cobra.Command {
 	var useOTP bool
 	login := &cobra.Command{
 		Use:   "login",
@@ -148,7 +148,7 @@ func LoginCmd() *cobra.Command {
 			"the account you have with your ID provider (e.g. GitHub, Okta) " +
 			"account will subsequently be accessible.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -229,13 +229,13 @@ func LogoutCmd() *cobra.Command {
 // WhoamiCmd returns a cobra.Command that deletes your local Pachyderm
 // credential, logging you out of your cluster. Note that this is not necessary
 // to do before logging in as another user, but is useful for testing.
-func WhoamiCmd() *cobra.Command {
+func WhoamiCmd(noPortForwarding bool) *cobra.Command {
 	whoami := &cobra.Command{
 		Use:   "whoami",
 		Short: "Print your Pachyderm identity",
 		Long:  "Print your Pachyderm identity.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -259,7 +259,7 @@ func WhoamiCmd() *cobra.Command {
 
 // CheckCmd returns a cobra command that sends an "Authorize" RPC to Pachd, to
 // determine whether the specified user has access to the specified repo.
-func CheckCmd() *cobra.Command {
+func CheckCmd(noPortForwarding bool) *cobra.Command {
 	check := &cobra.Command{
 		Use:   "check (none|reader|writer|owner) repo",
 		Short: "Check whether you have reader/writer/etc-level access to 'repo'",
@@ -275,7 +275,7 @@ func CheckCmd() *cobra.Command {
 				return err
 			}
 			repo := args[1]
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -296,7 +296,7 @@ func CheckCmd() *cobra.Command {
 
 // GetCmd returns a cobra command that gets either the ACL for a Pachyderm
 // repo or another user's scope of access to that repo
-func GetCmd() *cobra.Command {
+func GetCmd(noPortForwarding bool) *cobra.Command {
 	setScope := &cobra.Command{
 		Use:   "get [username] repo",
 		Short: "Get the ACL for 'repo' or the access that 'username' has to 'repo'",
@@ -307,7 +307,7 @@ func GetCmd() *cobra.Command {
 			"Pachyderm authentication uses GitHub OAuth, so 'username' must be a " +
 			"GitHub username",
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -343,7 +343,7 @@ func GetCmd() *cobra.Command {
 
 // SetScopeCmd returns a cobra command that lets a user set the level of access
 // that another user has to a repo
-func SetScopeCmd() *cobra.Command {
+func SetScopeCmd(noPortForwarding bool) *cobra.Command {
 	setScope := &cobra.Command{
 		Use:   "set username (none|reader|writer|owner) repo",
 		Short: "Set the scope of access that 'username' has to 'repo'",
@@ -361,7 +361,7 @@ func SetScopeCmd() *cobra.Command {
 				return err
 			}
 			username, repo := args[0], args[2]
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -378,13 +378,13 @@ func SetScopeCmd() *cobra.Command {
 }
 
 // ListAdminsCmd returns a cobra command that lists the current cluster admins
-func ListAdminsCmd() *cobra.Command {
+func ListAdminsCmd(noPortForwarding bool) *cobra.Command {
 	listAdmins := &cobra.Command{
 		Use:   "list-admins",
 		Short: "List the current cluster admins",
 		Long:  "List the current cluster admins",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -404,7 +404,7 @@ func ListAdminsCmd() *cobra.Command {
 
 // ModifyAdminsCmd returns a cobra command that modifies the set of current
 // cluster admins
-func ModifyAdminsCmd() *cobra.Command {
+func ModifyAdminsCmd(noPortForwarding bool) *cobra.Command {
 	var add []string
 	var remove []string
 	modifyAdmins := &cobra.Command{
@@ -414,7 +414,7 @@ func ModifyAdminsCmd() *cobra.Command {
 			"separated list of users to grant admin status, and --remove accepts a " +
 			"comma-separated list of users to revoke admin status",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -440,7 +440,7 @@ func ModifyAdminsCmd() *cobra.Command {
 
 // GetAuthTokenCmd returns a cobra command that lets a user get a pachyderm
 // token on behalf of themselves or another user
-func GetAuthTokenCmd() *cobra.Command {
+func GetAuthTokenCmd(noPortForwarding bool) *cobra.Command {
 	var quiet bool
 	getAuthToken := &cobra.Command{
 		Use:   "get-auth-token username",
@@ -449,7 +449,7 @@ func GetAuthTokenCmd() *cobra.Command {
 			"this can only be called by cluster admins",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			subject := args[0]
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -498,23 +498,23 @@ func UseAuthTokenCmd() *cobra.Command {
 
 // Cmds returns a list of cobra commands for authenticating and authorizing
 // users in an auth-enabled Pachyderm cluster.
-func Cmds() []*cobra.Command {
+func Cmds(noPortForwarding bool) []*cobra.Command {
 	auth := &cobra.Command{
 		Use:   "auth",
 		Short: "Auth commands manage access to data in a Pachyderm cluster",
 		Long:  "Auth commands manage access to data in a Pachyderm cluster",
 	}
-	auth.AddCommand(ActivateCmd())
-	auth.AddCommand(DeactivateCmd())
-	auth.AddCommand(LoginCmd())
+	auth.AddCommand(ActivateCmd(noPortForwarding))
+	auth.AddCommand(DeactivateCmd(noPortForwarding))
+	auth.AddCommand(LoginCmd(noPortForwarding))
 	auth.AddCommand(LogoutCmd())
-	auth.AddCommand(WhoamiCmd())
-	auth.AddCommand(CheckCmd())
-	auth.AddCommand(SetScopeCmd())
-	auth.AddCommand(GetCmd())
-	auth.AddCommand(ListAdminsCmd())
-	auth.AddCommand(ModifyAdminsCmd())
-	auth.AddCommand(GetAuthTokenCmd())
+	auth.AddCommand(WhoamiCmd(noPortForwarding))
+	auth.AddCommand(CheckCmd(noPortForwarding))
+	auth.AddCommand(SetScopeCmd(noPortForwarding))
+	auth.AddCommand(GetCmd(noPortForwarding))
+	auth.AddCommand(ListAdminsCmd(noPortForwarding))
+	auth.AddCommand(ModifyAdminsCmd(noPortForwarding))
+	auth.AddCommand(GetAuthTokenCmd(noPortForwarding))
 	auth.AddCommand(UseAuthTokenCmd())
 	auth.AddCommand(GetConfig())
 	auth.AddCommand(SetConfig())

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -148,6 +148,7 @@ func (l *logWriter) Write(p []byte) (int, error) {
 func PachctlCmd() (*cobra.Command, error) {
 	var verbose bool
 	var noMetrics bool
+	var noPortForwarding bool
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&raw, "raw", false, "disable pretty printing, print raw json")
@@ -182,35 +183,36 @@ Environment variables:
 	}
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Output verbose logs")
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
+	rootCmd.PersistentFlags().BoolVarP(&noPortForwarding, "no-port-forwarding", "", false, "Disable implicit port forwarding")
 
-	pfsCmds := pfscmds.Cmds(&noMetrics)
+	pfsCmds := pfscmds.Cmds(&noMetrics, noPortForwarding)
 	for _, cmd := range pfsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	ppsCmds, err := ppscmds.Cmds(&noMetrics)
+	ppsCmds, err := ppscmds.Cmds(&noMetrics, noPortForwarding)
 	if err != nil {
 		return nil, err
 	}
 	for _, cmd := range ppsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	deployCmds := deploycmds.Cmds(&noMetrics)
+	deployCmds := deploycmds.Cmds(&noMetrics, noPortForwarding)
 	for _, cmd := range deployCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	authCmds := authcmds.Cmds()
+	authCmds := authcmds.Cmds(noPortForwarding)
 	for _, cmd := range authCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	enterpriseCmds := enterprisecmds.Cmds()
+	enterpriseCmds := enterprisecmds.Cmds(noPortForwarding)
 	for _, cmd := range enterpriseCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	adminCmds := admincmds.Cmds(&noMetrics)
+	adminCmds := admincmds.Cmds(&noMetrics, noPortForwarding)
 	for _, cmd := range adminCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	debugCmds := debugcmds.Cmds(&noMetrics)
+	debugCmds := debugcmds.Cmds(&noMetrics, noPortForwarding)
 	for _, cmd := range debugCmds {
 		rootCmd.AddCommand(cmd)
 	}
@@ -315,7 +317,7 @@ Environment variables:
 		Long: `Delete all repos, commits, files, pipelines and jobs.
 This resets the cluster to its initial state.`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := client.NewOnUserMachine(!noMetrics, true, "user")
+			client, err := client.NewOnUserMachine(!noMetrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -185,34 +185,34 @@ Environment variables:
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
 	rootCmd.PersistentFlags().BoolVarP(&noPortForwarding, "no-port-forwarding", "", false, "Disable implicit port forwarding")
 
-	pfsCmds := pfscmds.Cmds(&noMetrics, noPortForwarding)
+	pfsCmds := pfscmds.Cmds(!noMetrics, !noPortForwarding)
 	for _, cmd := range pfsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	ppsCmds, err := ppscmds.Cmds(&noMetrics, noPortForwarding)
+	ppsCmds, err := ppscmds.Cmds(!noMetrics, !noPortForwarding)
 	if err != nil {
 		return nil, err
 	}
 	for _, cmd := range ppsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	deployCmds := deploycmds.Cmds(&noMetrics, noPortForwarding)
+	deployCmds := deploycmds.Cmds(!noMetrics, !noPortForwarding)
 	for _, cmd := range deployCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	authCmds := authcmds.Cmds(noPortForwarding)
+	authCmds := authcmds.Cmds(!noPortForwarding)
 	for _, cmd := range authCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	enterpriseCmds := enterprisecmds.Cmds(noPortForwarding)
+	enterpriseCmds := enterprisecmds.Cmds(!noPortForwarding)
 	for _, cmd := range enterpriseCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	adminCmds := admincmds.Cmds(&noMetrics, noPortForwarding)
+	adminCmds := admincmds.Cmds(!noMetrics, !noPortForwarding)
 	for _, cmd := range adminCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	debugCmds := debugcmds.Cmds(&noMetrics, noPortForwarding)
+	debugCmds := debugcmds.Cmds(!noMetrics, !noPortForwarding)
 	for _, cmd := range debugCmds {
 		rootCmd.AddCommand(cmd)
 	}

--- a/src/server/cmd/pachctl/cmd/cmd_test.go
+++ b/src/server/cmd/pachctl/cmd/cmd_test.go
@@ -35,7 +35,7 @@ func TestMetricsDevDeploymentNoMetricsFlagSet(t *testing.T) {
 
 func TestPortForwardError(t *testing.T) {
 	os.Setenv("ADDRESS", "localhost:30650")
-	c := tu.Cmd("pachctl", "version", "--timeout=1ns")
+	c := tu.Cmd("pachctl", "version", "--timeout=1ns", "--no-port-forwarding")
 	var errMsg bytes.Buffer
 	c.Stdout = ioutil.Discard
 	c.Stderr = &errMsg
@@ -46,7 +46,7 @@ func TestPortForwardError(t *testing.T) {
 
 func TestNoPortError(t *testing.T) {
 	os.Setenv("ADDRESS", "127.127.127.0")
-	c := tu.Cmd("pachctl", "version", "--timeout=1ns")
+	c := tu.Cmd("pachctl", "version", "--timeout=1ns", "--no-port-forwarding")
 	var errMsg bytes.Buffer
 	c.Stdout = ioutil.Discard
 	c.Stderr = &errMsg
@@ -57,7 +57,7 @@ func TestNoPortError(t *testing.T) {
 
 func TestWeirdPortError(t *testing.T) {
 	os.Setenv("ADDRESS", "localhost:30560")
-	c := tu.Cmd("pachctl", "version", "--timeout=1ns")
+	c := tu.Cmd("pachctl", "version", "--timeout=1ns", "--no-port-forwarding")
 	var errMsg bytes.Buffer
 	c.Stdout = ioutil.Discard
 	c.Stderr = &errMsg

--- a/src/server/cmd/pachctl/cmd/cmd_test.go
+++ b/src/server/cmd/pachctl/cmd/cmd_test.go
@@ -15,22 +15,22 @@ var stdoutMutex = &sync.Mutex{}
 
 func TestMetricsNormalDeployment(t *testing.T) {
 	// Run deploy normally, should see METRICS=true
-	testDeploy(t, false, false, true)
+	testDeploy(t, false, true, true)
 }
 
 func TestMetricsNormalDeploymentNoMetricsFlagSet(t *testing.T) {
 	// Run deploy normally, should see METRICS=true
-	testDeploy(t, false, true, false)
+	testDeploy(t, false, false, false)
 }
 
 func TestMetricsDevDeployment(t *testing.T) {
 	// Run deploy w dev flag, should see METRICS=false
-	testDeploy(t, true, false, false)
+	testDeploy(t, true, true, false)
 }
 
 func TestMetricsDevDeploymentNoMetricsFlagSet(t *testing.T) {
 	// Run deploy w dev flag, should see METRICS=false
-	testDeploy(t, true, true, false)
+	testDeploy(t, true, false, false)
 }
 
 func TestPortForwardError(t *testing.T) {
@@ -66,7 +66,7 @@ func TestWeirdPortError(t *testing.T) {
 	require.Matches(t, "30650", errMsg.String())
 }
 
-func testDeploy(t *testing.T, devFlag bool, noMetrics bool, expectedEnvValue bool) {
+func testDeploy(t *testing.T, devFlag bool, metrics bool, expectedEnvValue bool) {
 	//t.Parallel()
 	//stdoutMutex.Lock()
 	//defer stdoutMutex.Unlock()
@@ -86,7 +86,7 @@ func testDeploy(t *testing.T, devFlag bool, noMetrics bool, expectedEnvValue boo
 	//"--dry-run",
 	//fmt.Sprintf("-d=%v", devFlag),
 	//}
-	//err = deploycmds.DeployCmd(&noMetrics).Execute()
+	//err = deploycmds.DeployCmd(&metrics).Execute()
 	//require.NoError(t, err)
 	//require.NoError(t, w.Close())
 	//// restore stdout

--- a/src/server/debug/cmds/cmds.go
+++ b/src/server/debug/cmds/cmds.go
@@ -9,15 +9,13 @@ import (
 )
 
 // Cmds returns a slice containing debug commands.
-func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
-	metrics := !*noMetrics
-
+func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 	debugDump := &cobra.Command{
 		Use:   "debug-dump",
 		Short: "Return a dump of running goroutines.",
 		Long:  "Return a dump of running goroutines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "debug-dump")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "debug-dump")
 			if err != nil {
 				return err
 			}

--- a/src/server/debug/cmds/cmds.go
+++ b/src/server/debug/cmds/cmds.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Cmds returns a slice containing debug commands.
-func Cmds(noMetrics *bool) []*cobra.Command {
+func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 	metrics := !*noMetrics
 
 	debugDump := &cobra.Command{
@@ -17,7 +17,7 @@ func Cmds(noMetrics *bool) []*cobra.Command {
 		Short: "Return a dump of running goroutines.",
 		Long:  "Return a dump of running goroutines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "debug-dump")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "debug-dump")
 			if err != nil {
 				return err
 			}

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -32,7 +32,7 @@ func parseISO8601(s string) (time.Time, error) {
 // Pachyderm within a Pachyderm cluster. All repos will go from
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
-func ActivateCmd() *cobra.Command {
+func ActivateCmd(noPortForwarding bool) *cobra.Command {
 	var expires string
 	activate := &cobra.Command{
 		Use: "activate activation-code",
@@ -41,7 +41,7 @@ func ActivateCmd() *cobra.Command {
 		Long: "Activate the enterprise features of Pachyderm with an activation " +
 			"code",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
@@ -84,7 +84,7 @@ func ActivateCmd() *cobra.Command {
 // Pachyderm within a Pachyderm cluster. All repos will go from
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
-func GetStateCmd() *cobra.Command {
+func GetStateCmd(noPortForwarding bool) *cobra.Command {
 	getState := &cobra.Command{
 		Use: "get-state",
 		Short: "Check whether the Pachyderm cluster has enterprise features " +
@@ -92,7 +92,7 @@ func GetStateCmd() *cobra.Command {
 		Long: "Check whether the Pachyderm cluster has enterprise features " +
 			"activated",
 		Run: cmdutil.Run(func(args []string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
@@ -119,13 +119,13 @@ func GetStateCmd() *cobra.Command {
 }
 
 // Cmds returns pachctl commands related to Pachyderm Enterprise
-func Cmds() []*cobra.Command {
+func Cmds(noPortForwarding bool) []*cobra.Command {
 	enterprise := &cobra.Command{
 		Use:   "enterprise",
 		Short: "Enterprise commands enable Pachyderm Enterprise features",
 		Long:  "Enterprise commands enable Pachyderm Enterprise features",
 	}
-	enterprise.AddCommand(ActivateCmd())
-	enterprise.AddCommand(GetStateCmd())
+	enterprise.AddCommand(ActivateCmd(noPortForwarding))
+	enterprise.AddCommand(GetStateCmd(noPortForwarding))
 	return []*cobra.Command{enterprise}
 }

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -32,7 +32,7 @@ func parseISO8601(s string) (time.Time, error) {
 // Pachyderm within a Pachyderm cluster. All repos will go from
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
-func ActivateCmd(noPortForwarding bool) *cobra.Command {
+func ActivateCmd(portForwarding bool) *cobra.Command {
 	var expires string
 	activate := &cobra.Command{
 		Use: "activate activation-code",
@@ -41,7 +41,7 @@ func ActivateCmd(noPortForwarding bool) *cobra.Command {
 		Long: "Activate the enterprise features of Pachyderm with an activation " +
 			"code",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
@@ -84,7 +84,7 @@ func ActivateCmd(noPortForwarding bool) *cobra.Command {
 // Pachyderm within a Pachyderm cluster. All repos will go from
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
-func GetStateCmd(noPortForwarding bool) *cobra.Command {
+func GetStateCmd(portForwarding bool) *cobra.Command {
 	getState := &cobra.Command{
 		Use: "get-state",
 		Short: "Check whether the Pachyderm cluster has enterprise features " +
@@ -92,7 +92,7 @@ func GetStateCmd(noPortForwarding bool) *cobra.Command {
 		Long: "Check whether the Pachyderm cluster has enterprise features " +
 			"activated",
 		Run: cmdutil.Run(func(args []string) error {
-			c, err := client.NewOnUserMachine(true, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(true, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
@@ -119,13 +119,13 @@ func GetStateCmd(noPortForwarding bool) *cobra.Command {
 }
 
 // Cmds returns pachctl commands related to Pachyderm Enterprise
-func Cmds(noPortForwarding bool) []*cobra.Command {
+func Cmds(portForwarding bool) []*cobra.Command {
 	enterprise := &cobra.Command{
 		Use:   "enterprise",
 		Short: "Enterprise commands enable Pachyderm Enterprise features",
 		Long:  "Enterprise commands enable Pachyderm Enterprise features",
 	}
-	enterprise.AddCommand(ActivateCmd(noPortForwarding))
-	enterprise.AddCommand(GetStateCmd(noPortForwarding))
+	enterprise.AddCommand(ActivateCmd(portForwarding))
+	enterprise.AddCommand(GetStateCmd(portForwarding))
 	return []*cobra.Command{enterprise}
 }

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -41,8 +41,7 @@ const (
 )
 
 // Cmds returns a slice containing pfs commands.
-func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
-	metrics := !*noMetrics
+func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&raw, "raw", false, "disable pretty printing, print raw json")
@@ -66,7 +65,7 @@ func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 		Short: "Create a new repo.",
 		Long:  "Create a new repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -88,7 +87,7 @@ func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 		Short: "Update a repo.",
 		Long:  "Update a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -111,7 +110,7 @@ func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 		Short: "Return info about a repo.",
 		Long:  "Return info about a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -136,7 +135,7 @@ func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 		Short: "Return all repos.",
 		Long:  "Return all repos.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -174,7 +173,7 @@ func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 		Short: "Delete a repo.",
 		Long:  "Delete a repo.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -245,7 +244,7 @@ $ pachctl start-commit test patch -p master
 $ pachctl start-commit test -p XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			cli, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			cli, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -276,7 +275,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Finish a started commit.",
 		Long:  "Finish a started commit. Commit-id must be a writeable commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			cli, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			cli, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -300,7 +299,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Return info about a commit.",
 		Long:  "Return info about a commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -345,7 +344,7 @@ $ pachctl list-commit foo XXX
 $ pachctl list-commit foo master --from XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -423,7 +422,7 @@ $ pachctl flush-commit foo/XXX -r bar -r baz
 				return err
 			}
 
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -468,7 +467,7 @@ $ pachctl subscribe-commit test master --new
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
 			repo, branch := args[0], args[1]
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -499,7 +498,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Delete an input commit.",
 		Long:  "Delete an input commit. An input is a commit which is not the output of a pipeline.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -515,7 +514,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Create a new branch, or update an existing branch, on a repo.",
 		Long:  "Create a new branch, or update an existing branch, on a repo, starting a commit on the branch will also create it, so there's often no need to call this.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -535,7 +534,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Return all branches on a repo.",
 		Long:  "Return all branches on a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -577,7 +576,7 @@ $ pachctl set-branch foo XXX master
 $ pachctl set-branch foo test master` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
 			fmt.Fprintf(os.Stderr, "set-branch is DEPRECATED, use create-branch instead.\n")
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -591,7 +590,7 @@ $ pachctl set-branch foo test master` + codeend,
 		Short: "Delete a branch",
 		Long:  "Delete a branch, while leaving the commits intact",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -667,7 +666,7 @@ $ pachctl put-file repo branch -i file
 $ pachctl put-file repo branch -i http://host/path
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -782,7 +781,7 @@ $ pachctl put-file repo branch -i http://host/path
 		Short: "Copy files between pfs paths.",
 		Long:  "Copy files between pfs paths.",
 		Run: cmdutil.RunFixedArgs(6, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -809,7 +808,7 @@ $ pachctl get-file foo master^ XXX
 $ pachctl get-file foo master^2 XXX
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -845,7 +844,7 @@ $ pachctl get-file foo master^2 XXX
 		Short: "Return info about a file.",
 		Long:  "Return info about a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -894,7 +893,7 @@ $ pachctl list-file foo master --history n
 $ pachctl list-file foo master --history -1
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -939,7 +938,7 @@ $ pachctl glob-file foo master "A*"
 $ pachctl glob-file foo master "data/*"
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -979,7 +978,7 @@ $ pachctl diff-file foo master path
 $ pachctl diff-file foo master path1 bar master path2
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(3, 6, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1027,7 +1026,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Delete a file.",
 		Long:  "Delete a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1041,7 +1040,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of an object",
 		Long:  "Return the contents of an object",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1055,7 +1054,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of a tag",
 		Long:  "Return the contents of a tag",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1071,7 +1070,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Mount pfs locally. This command blocks.",
 		Long:  "Mount pfs locally. This command blocks.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "fuse")
+			client, err := client.NewOnUserMachine(metrics, portForwarding, "fuse")
 			if err != nil {
 				return err
 			}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Cmds returns a slice containing pfs commands.
-func Cmds(noMetrics *bool) []*cobra.Command {
+func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
 	metrics := !*noMetrics
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
@@ -66,7 +66,7 @@ func Cmds(noMetrics *bool) []*cobra.Command {
 		Short: "Create a new repo.",
 		Long:  "Create a new repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func Cmds(noMetrics *bool) []*cobra.Command {
 		Short: "Update a repo.",
 		Long:  "Update a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func Cmds(noMetrics *bool) []*cobra.Command {
 		Short: "Return info about a repo.",
 		Long:  "Return info about a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ func Cmds(noMetrics *bool) []*cobra.Command {
 		Short: "Return all repos.",
 		Long:  "Return all repos.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -174,7 +174,7 @@ func Cmds(noMetrics *bool) []*cobra.Command {
 		Short: "Delete a repo.",
 		Long:  "Delete a repo.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -245,7 +245,7 @@ $ pachctl start-commit test patch -p master
 $ pachctl start-commit test -p XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			cli, err := client.NewOnUserMachine(metrics, true, "user")
+			cli, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -276,7 +276,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Finish a started commit.",
 		Long:  "Finish a started commit. Commit-id must be a writeable commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			cli, err := client.NewOnUserMachine(metrics, true, "user")
+			cli, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -300,7 +300,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Return info about a commit.",
 		Long:  "Return info about a commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -345,7 +345,7 @@ $ pachctl list-commit foo XXX
 $ pachctl list-commit foo master --from XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -423,7 +423,7 @@ $ pachctl flush-commit foo/XXX -r bar -r baz
 				return err
 			}
 
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ $ pachctl subscribe-commit test master --new
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
 			repo, branch := args[0], args[1]
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -499,7 +499,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Delete an input commit.",
 		Long:  "Delete an input commit. An input is a commit which is not the output of a pipeline.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -515,7 +515,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Create a new branch, or update an existing branch, on a repo.",
 		Long:  "Create a new branch, or update an existing branch, on a repo, starting a commit on the branch will also create it, so there's often no need to call this.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -535,7 +535,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Return all branches on a repo.",
 		Long:  "Return all branches on a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -577,7 +577,7 @@ $ pachctl set-branch foo XXX master
 $ pachctl set-branch foo test master` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
 			fmt.Fprintf(os.Stderr, "set-branch is DEPRECATED, use create-branch instead.\n")
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -591,7 +591,7 @@ $ pachctl set-branch foo test master` + codeend,
 		Short: "Delete a branch",
 		Long:  "Delete a branch, while leaving the commits intact",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -667,7 +667,7 @@ $ pachctl put-file repo branch -i file
 $ pachctl put-file repo branch -i http://host/path
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, true, "user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -782,7 +782,7 @@ $ pachctl put-file repo branch -i http://host/path
 		Short: "Copy files between pfs paths.",
 		Long:  "Copy files between pfs paths.",
 		Run: cmdutil.RunFixedArgs(6, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, true, "user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -809,7 +809,7 @@ $ pachctl get-file foo master^ XXX
 $ pachctl get-file foo master^2 XXX
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -845,7 +845,7 @@ $ pachctl get-file foo master^2 XXX
 		Short: "Return info about a file.",
 		Long:  "Return info about a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -894,7 +894,7 @@ $ pachctl list-file foo master --history n
 $ pachctl list-file foo master --history -1
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -939,7 +939,7 @@ $ pachctl glob-file foo master "A*"
 $ pachctl glob-file foo master "data/*"
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -979,7 +979,7 @@ $ pachctl diff-file foo master path
 $ pachctl diff-file foo master path1 bar master path2
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(3, 6, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1027,7 +1027,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Delete a file.",
 		Long:  "Delete a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1041,7 +1041,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of an object",
 		Long:  "Return the contents of an object",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1055,7 +1055,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of a tag",
 		Long:  "Return the contents of a tag",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "user")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1071,7 +1071,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Mount pfs locally. This command blocks.",
 		Long:  "Mount pfs locally. This command blocks.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, true, "fuse")
+			client, err := client.NewOnUserMachine(metrics, !noPortForwarding, "fuse")
 			if err != nil {
 				return err
 			}

--- a/src/server/pfs/cmds/cmds_test.go
+++ b/src/server/pfs/cmds/cmds_test.go
@@ -12,24 +12,24 @@ func TestCommit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	require.NoError(t, tu.BashCmd(`
-		pachctl create-repo {{.repo}}
+		pachctl create-repo {{.repo}} --no-port-forwarding
 
 		# Create a commit and put some data in it
-		commit1=$(pachctl start-commit {{.repo}} master)
-		echo "file contents" | pachctl put-file {{.repo}} ${commit1} /file -f -
-		pachctl finish-commit {{.repo}} ${commit1}
+		commit1=$(pachctl start-commit {{.repo}} master --no-port-forwarding)
+		echo "file contents" | pachctl put-file {{.repo}} ${commit1} /file -f --no-port-forwarding -
+		pachctl finish-commit {{.repo}} ${commit1} --no-port-forwarding
 
 		# Check that the commit above now appears in the output
-		pachctl list-commit {{.repo}} \
+		pachctl list-commit {{.repo}} --no-port-forwarding \
 		  | match ${commit1}
 
 		# Create a second commit and put some data in it
-		commit2=$(pachctl start-commit {{.repo}} master)
-		echo "file contents" | pachctl put-file {{.repo}} ${commit2} /file -f -
-		pachctl finish-commit {{.repo}} ${commit2}
+		commit2=$(pachctl start-commit {{.repo}} master --no-port-forwarding)
+		echo "file contents" | pachctl put-file {{.repo}} ${commit2} /file -f --no-port-forwarding -
+		pachctl finish-commit {{.repo}} ${commit2} --no-port-forwarding
 
 		# Check that the commit above now appears in the output
-		pachctl list-commit {{.repo}} \
+		pachctl list-commit {{.repo}} --no-port-forwarding \
 		  | match ${commit1} \
 		  | match ${commit2}
 		`,
@@ -42,25 +42,25 @@ func TestPutFileSplit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	require.NoError(t, tu.BashCmd(`
-		pachctl create-repo {{.repo}}
+		pachctl create-repo {{.repo}} --no-port-forwarding
 
-		pachctl put-file {{.repo}} master /data --split=csv --header-records=1 <<EOF
+		pachctl put-file {{.repo}} master /data --split=csv --header-records=1 --no-port-forwarding <<EOF
 		name,job
 		alice,accountant
 		bob,baker
 		EOF
 
-		pachctl get-file {{.repo}} master "/data/*0" \
+		pachctl get-file {{.repo}} master "/data/*0" --no-port-forwarding \
 		  | match "name,job" \
 			| match "alice,accountant" \
 			| match -v "bob,baker"
 
-		pachctl get-file {{.repo}} master "/data/*1" \
+		pachctl get-file {{.repo}} master "/data/*1" --no-port-forwarding \
 		  | match "name,job" \
 			| match -v "alice,accountant" \
 			| match "bob,baker"
 
-		pachctl get-file {{.repo}} master "/data/*" \
+		pachctl get-file {{.repo}} master "/data/*" --no-port-forwarding \
 		  | match "name,job" \
 			| match "alice,accountant" \
 			| match "bob,baker"

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -146,8 +146,7 @@ func containsEmpty(vals []string) bool {
 }
 
 // DeployCmd returns a cobra.Command to deploy pachyderm.
-func DeployCmd(noMetrics *bool, noPortForwarding bool) *cobra.Command {
-	metrics := !*noMetrics
+func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
 	var pachdShards int
 	var hostPath string
 	var dev bool
@@ -472,7 +471,7 @@ particular backend, run "pachctl deploy storage <backend>"`,
 				data = assets.MicrosoftSecret("", args[1], args[2])
 			}
 
-			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error constructing pachyderm client: %v", err)
 			}
@@ -643,8 +642,8 @@ particular backend, run "pachctl deploy storage <backend>"`,
 }
 
 // Cmds returns a list of cobra commands for deploying Pachyderm clusters.
-func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
-	deploy := DeployCmd(noMetrics, noPortForwarding)
+func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
+	deploy := DeployCmd(metrics, portForwarding)
 	var all bool
 	var namespace string
 	undeploy := &cobra.Command{

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -146,7 +146,7 @@ func containsEmpty(vals []string) bool {
 }
 
 // DeployCmd returns a cobra.Command to deploy pachyderm.
-func DeployCmd(noMetrics *bool) *cobra.Command {
+func DeployCmd(noMetrics *bool, noPortForwarding bool) *cobra.Command {
 	metrics := !*noMetrics
 	var pachdShards int
 	var hostPath string
@@ -472,7 +472,7 @@ particular backend, run "pachctl deploy storage <backend>"`,
 				data = assets.MicrosoftSecret("", args[1], args[2])
 			}
 
-			c, err := client.NewOnUserMachine(metrics, true, "user")
+			c, err := client.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error constructing pachyderm client: %v", err)
 			}
@@ -643,8 +643,8 @@ particular backend, run "pachctl deploy storage <backend>"`,
 }
 
 // Cmds returns a list of cobra commands for deploying Pachyderm clusters.
-func Cmds(noMetrics *bool) []*cobra.Command {
-	deploy := DeployCmd(noMetrics)
+func Cmds(noMetrics *bool, noPortForwarding bool) []*cobra.Command {
+	deploy := DeployCmd(noMetrics, noPortForwarding)
 	var all bool
 	var namespace string
 	undeploy := &cobra.Command{

--- a/src/server/pkg/deploy/cmds/cmds_test.go
+++ b/src/server/pkg/deploy/cmds/cmds_test.go
@@ -26,7 +26,7 @@ func TestDashImageExists(t *testing.T) {
 func TestWarnInvalidAmazonCreds(t *testing.T) {
 	c := tu.Cmd("pachctl", "deploy", "amazon", "bucket", "us-west-1", "10",
 		"--credentials=lol,wat",
-		"--dynamic-etcd-nodes=1", "--dry-run")
+		"--dynamic-etcd-nodes=1", "--dry-run", "--no-port-forwarding")
 	var warningMsg bytes.Buffer
 	c.Stdin = strings.NewReader(strings.Repeat("y\n", 10))
 	c.Stderr = ioutil.Discard
@@ -39,7 +39,7 @@ func TestWarnInvalidAmazonCreds(t *testing.T) {
 func TestWarnBadRegion(t *testing.T) {
 	c := tu.Cmd("pachctl", "deploy", "amazon", "bucket", "bad-region", "10",
 		fmt.Sprintf("--credentials=%s,%s", FakeAWSAccessKeyID, FakeAWSSecret),
-		"--dynamic-etcd-nodes=1", "--dry-run")
+		"--dynamic-etcd-nodes=1", "--dry-run", "--no-port-forwarding")
 	var warningMsg bytes.Buffer
 	c.Stdin = strings.NewReader(strings.Repeat("y\n", 10))
 	c.Stderr = ioutil.Discard
@@ -52,7 +52,7 @@ func TestWarnBadRegion(t *testing.T) {
 func TestStripS3Prefix(t *testing.T) {
 	c := tu.Cmd("pachctl", "deploy", "amazon", "s3://bucket", "us-west-1", "10",
 		fmt.Sprintf("--credentials=%s,%s", FakeAWSAccessKeyID, FakeAWSSecret),
-		"--dynamic-etcd-nodes=1", "--dry-run")
+		"--dynamic-etcd-nodes=1", "--dry-run", "--no-port-forwarding")
 	var k8sManifest bytes.Buffer
 	c.Stdout = &k8sManifest
 	err := c.Run()

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -36,7 +36,7 @@ const (
 )
 
 // Cmds returns a slice containing pps commands.
-func Cmds(noMetrics *bool) ([]*cobra.Command, error) {
+func Cmds(noMetrics *bool, noPortForwarding bool) ([]*cobra.Command, error) {
 	metrics := !*noMetrics
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
@@ -74,7 +74,7 @@ The increase the throughput of a job increase the Shard paremeter.
 		Short: "Return info about a job.",
 		Long:  "Return info about a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ $ pachctl list-job foo/XXX bar/YYY
 $ pachctl list-job -p foo bar/YYY
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -187,7 +187,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 				return err
 			}
 
-			c, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			c, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -222,7 +222,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Delete a job.",
 		Long:  "Delete a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -239,7 +239,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Stop a job.",
 		Long:  "Stop a job.  The job will be stopped immediately.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -256,7 +256,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Restart a datum.",
 		Long:  "Restart a datum.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -282,7 +282,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Return the datums in a job.",
 		Long:  "Return the datums in a job.",
 		Run: cmdutil.RunBoundedArgs(1, 1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -319,7 +319,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Display detailed info about a single datum.",
 		Long:  "Display detailed info about a single datum.",
 		Run: cmdutil.RunBoundedArgs(2, 2, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -362,7 +362,7 @@ $ pachctl get-logs --job=aedfa12aedf
 $ pachctl get-logs --pipeline=filter --inputs=/apple.txt,123aef
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -443,7 +443,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Create a new pipeline.",
 		Long:  fmt.Sprintf("Create a new pipeline from a %s", pipelineSpec),
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(metrics, false, build, pushImages, registry, username, password, pipelinePath, false)
+			return pipelineHelper(metrics, noPortForwarding, false, build, pushImages, registry, username, password, pipelinePath, false)
 		}),
 	}
 	createPipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The file containing the pipeline, it can be a url or local file. - reads from stdin.")
@@ -459,7 +459,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Update an existing Pachyderm pipeline.",
 		Long:  fmt.Sprintf("Update a Pachyderm pipeline with a new %s", pipelineSpec),
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(metrics, reprocess, build, pushImages, registry, username, password, pipelinePath, true)
+			return pipelineHelper(metrics, noPortForwarding, reprocess, build, pushImages, registry, username, password, pipelinePath, true)
 		}),
 	}
 	updatePipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The file containing the pipeline, it can be a url or local file. - reads from stdin.")
@@ -475,7 +475,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about a pipeline.",
 		Long:  "Return info about a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -500,7 +500,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return the manifest used to create a pipeline.",
 		Long:  "Return the manifest used to create a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -519,7 +519,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Edit the manifest for a pipeline in your text editor.",
 		Long:  "Edit the manifest for a pipeline in your text editor.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -588,7 +588,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about all pipelines.",
 		Long:  "Return info about all pipelines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -630,7 +630,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Delete a pipeline.",
 		Long:  "Delete a pipeline.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -665,7 +665,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Restart a stopped pipeline.",
 		Long:  "Restart a stopped pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -682,7 +682,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Stop a running pipeline.",
 		Long:  "Stop a running pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -722,7 +722,7 @@ you can increase the amount of memory used for the bloom filters with the
 --memory flag. The default value is 10MB.
 `,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -761,12 +761,12 @@ you can increase the amount of memory used for the bloom filters with the
 	return result, nil
 }
 
-func pipelineHelper(metrics bool, reprocess bool, build bool, pushImages bool, registry string, username string, password string, pipelinePath string, update bool) error {
+func pipelineHelper(metrics bool, noPortForwarding bool, reprocess bool, build bool, pushImages bool, registry string, username string, password string, pipelinePath string, update bool) error {
 	cfgReader, err := ppsutil.NewPipelineManifestReader(pipelinePath)
 	if err != nil {
 		return err
 	}
-	client, err := pachdclient.NewOnUserMachine(metrics, true, "user")
+	client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
 	if err != nil {
 		return fmt.Errorf("error connecting to pachd: %v", err)
 	}

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -36,8 +36,7 @@ const (
 )
 
 // Cmds returns a slice containing pps commands.
-func Cmds(noMetrics *bool, noPortForwarding bool) ([]*cobra.Command, error) {
-	metrics := !*noMetrics
+func Cmds(metrics bool, portForwarding bool) ([]*cobra.Command, error) {
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&raw, "raw", false, "disable pretty printing, print raw json")
@@ -74,7 +73,7 @@ The increase the throughput of a job increase the Shard paremeter.
 		Short: "Return info about a job.",
 		Long:  "Return info about a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -118,7 +117,7 @@ $ pachctl list-job foo/XXX bar/YYY
 $ pachctl list-job -p foo bar/YYY
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -187,7 +186,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 				return err
 			}
 
-			c, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			c, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -222,7 +221,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Delete a job.",
 		Long:  "Delete a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -239,7 +238,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Stop a job.",
 		Long:  "Stop a job.  The job will be stopped immediately.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -256,7 +255,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Restart a datum.",
 		Long:  "Restart a datum.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -282,7 +281,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Return the datums in a job.",
 		Long:  "Return the datums in a job.",
 		Run: cmdutil.RunBoundedArgs(1, 1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -319,7 +318,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Display detailed info about a single datum.",
 		Long:  "Display detailed info about a single datum.",
 		Run: cmdutil.RunBoundedArgs(2, 2, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -362,7 +361,7 @@ $ pachctl get-logs --job=aedfa12aedf
 $ pachctl get-logs --pipeline=filter --inputs=/apple.txt,123aef
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -443,7 +442,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Create a new pipeline.",
 		Long:  fmt.Sprintf("Create a new pipeline from a %s", pipelineSpec),
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(metrics, noPortForwarding, false, build, pushImages, registry, username, password, pipelinePath, false)
+			return pipelineHelper(metrics, portForwarding, false, build, pushImages, registry, username, password, pipelinePath, false)
 		}),
 	}
 	createPipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The file containing the pipeline, it can be a url or local file. - reads from stdin.")
@@ -459,7 +458,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Update an existing Pachyderm pipeline.",
 		Long:  fmt.Sprintf("Update a Pachyderm pipeline with a new %s", pipelineSpec),
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(metrics, noPortForwarding, reprocess, build, pushImages, registry, username, password, pipelinePath, true)
+			return pipelineHelper(metrics, portForwarding, reprocess, build, pushImages, registry, username, password, pipelinePath, true)
 		}),
 	}
 	updatePipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The file containing the pipeline, it can be a url or local file. - reads from stdin.")
@@ -475,7 +474,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about a pipeline.",
 		Long:  "Return info about a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -500,7 +499,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return the manifest used to create a pipeline.",
 		Long:  "Return the manifest used to create a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -519,7 +518,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Edit the manifest for a pipeline in your text editor.",
 		Long:  "Edit the manifest for a pipeline in your text editor.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -588,7 +587,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about all pipelines.",
 		Long:  "Return info about all pipelines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -630,7 +629,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Delete a pipeline.",
 		Long:  "Delete a pipeline.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -665,7 +664,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Restart a stopped pipeline.",
 		Long:  "Restart a stopped pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -682,7 +681,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Stop a running pipeline.",
 		Long:  "Stop a running pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -722,7 +721,7 @@ you can increase the amount of memory used for the bloom filters with the
 --memory flag. The default value is 10MB.
 `,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -761,12 +760,12 @@ you can increase the amount of memory used for the bloom filters with the
 	return result, nil
 }
 
-func pipelineHelper(metrics bool, noPortForwarding bool, reprocess bool, build bool, pushImages bool, registry string, username string, password string, pipelinePath string, update bool) error {
+func pipelineHelper(metrics bool, portForwarding bool, reprocess bool, build bool, pushImages bool, registry string, username string, password string, pipelinePath string, update bool) error {
 	cfgReader, err := ppsutil.NewPipelineManifestReader(pipelinePath)
 	if err != nil {
 		return err
 	}
-	client, err := pachdclient.NewOnUserMachine(metrics, !noPortForwarding, "user")
+	client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
 	if err != nil {
 		return fmt.Errorf("error connecting to pachd: %v", err)
 	}

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -51,11 +51,11 @@ const badJSON2 = `
 func TestJSONSyntaxErrorsReportedCreatePipeline(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo -n '{{.badJSON1}}' \
-		  | ( pachctl create-pipeline -f - 2>&1 || true ) \
+		  | ( pachctl create-pipeline --no-port-forwarding -f - 2>&1 || true ) \
 		  | match "malformed pipeline spec"
 
 		echo -n '{{.badJSON2}}' \
-		  | ( pachctl create-pipeline -f - 2>&1 || true ) \
+		  | ( pachctl create-pipeline --no-port-forwarding -f - 2>&1 || true ) \
 		  | match "malformed pipeline spec"
 		`,
 		"badJSON1", badJSON1,
@@ -66,11 +66,11 @@ func TestJSONSyntaxErrorsReportedCreatePipeline(t *testing.T) {
 func TestJSONSyntaxErrorsReportedUpdatePipeline(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo -n '{{.badJSON1}}' \
-		  | ( pachctl update-pipeline -f - 2>&1 || true ) \
+		  | ( pachctl update-pipeline --no-port-forwarding -f - 2>&1 || true ) \
 		  | match "malformed pipeline spec"
 
 		echo -n '{{.badJSON2}}' \
-		  | ( pachctl update-pipeline -f - 2>&1 || true ) \
+		  | ( pachctl update-pipeline --no-port-forwarding -f - 2>&1 || true ) \
 		  | match "malformed pipeline spec"
 		`,
 		"badJSON1", badJSON1,
@@ -91,6 +91,6 @@ func TestJSONSyntaxErrorsReportedUpdatePipeline(t *testing.T) {
 // 	"image": "test-job-shim"
 //   }
 // }`), 0644)
-// 	os.Args = []string{"pachctl", "create-pipeline", "--push-images", "-f", "test-push-images.json"}
+// 	os.Args = []string{"pachctl", "create-pipeline", "--push-images", "--no-port-forwarding", "-f", "test-push-images.json"}
 // 	require.NoError(t, rootCmd().Execute())
 // }


### PR DESCRIPTION
* Add a global flag to `pachctl` for disabling implicit port forwarding.
* Disable implicit port forwarding on cmd tests. This will make test runs a lot less noisy.
