### PR TITLE
Match install versions

### DIFF
--- a/doc/getting_started/local_installation.md
+++ b/doc/getting_started/local_installation.md
@@ -77,8 +77,8 @@ Try `pachctl version` to make sure everything is working.
 ```shell
 $ pachctl version
 COMPONENT           VERSION
-pachctl             1.7.0
-pachd               1.7.0
+pachctl             1.8.2
+pachd               1.8.2
 ```
 We're good to go!
 


### PR DESCRIPTION
elsewhere, the guide recommends `brew install pachyderm/tap/pachctl@1.8`, might as well reflect that down the line.