### PR TITLE
Automate a little more of the custom release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,6 @@ custom-release: release-helper release-pachctl-custom
 	@echo 'For linux install, do:'
 	@echo "$$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
 	# Workaround for https://github.com/laher/goxc/issues/112
-	@git pull origin --tags
-	@git tag -d v$$(cat VERSION)
 	@git push origin :v$$(cat VERSION)
 	@git tag v$$(cat VERSION)
 	@git push origin --tags

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,12 @@ custom-release: release-helper release-pachctl-custom
 	@echo "$$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$$(cat VERSION)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$$(cat VERSION | cut -f -2 -d\.).rb"
 	@echo 'For linux install, do:'
 	@echo "$$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$$(cat VERSION)/pachctl_$$(cat VERSION)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
+	# Workaround for https://github.com/laher/goxc/issues/112
+	@git pull origin --tags
+	@git tag -d v$$(cat VERSION)
+	@git push origin :v$$(cat VERSION)
+	@git tag v$$(cat VERSION)
+	@git push origin --tags
 	@rm VERSION
 	@echo "Release completed"
 

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -145,30 +145,6 @@ Or for mac/brew:
 $ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/1.7.0-5a590ad9d8e9a09d4029f0f7379462620cf589ee/pachctl@1.7.rb
 ```
 
+_After a successful release_, you'll need to manually update the [release](https://github.com/pachyderm/pachyderm/releases) with the tag and publish as a workaround for [this issue](https://github.com/laher/goxc/issues/112).
 
-Then _after a successful release_:
-
-- The tag created by goxc will point to master, and this is wrong. Opened an issue for this: https://github.com/laher/goxc/issues/112
-- But the binaries built are correct (they're built off of your local code, on the branch you've checked out)
-- So we'll delete the tag and re-create it to make it point to the correct commit 
-
-1) Delete the tag
-- [You can see a list of tags here](https://github.com/pachyderm/pachyderm/tags) or here's an [example release tag](https://github.com/pachyderm/pachyderm/releases/tag/v1.2.5)
-
-2) Manually tag your branch
-
-```
-git tag -d v1.2.6 # You may need to delete it locally
-git tag v1.2.6
-git push origin --tags
-```
-
-This will fail if you didn't delete the tag on Github in the previous step
-
-3) Manually update the release with the tag and publish 
-
-4) Check the docs
-
-Note that ReadTheDocs builds docs from our GitHub master branch. If the docs changes you made aren't checked into the Pachyderm master branch, they won't show up.
-
-If you have checked in your docs changes, but they're not showing up as the `latest` version of the docs, tag your version as 'active' on the readthedocs dashboard: https://readthedocs.org/projects/pachyderm/versions/
+Then check the docs. Note that ReadTheDocs builds docs from our GitHub master branch. If the docs changes you made aren't checked into the Pachyderm master branch, they won't show up. If you have checked in your docs changes, but they're not showing up as the `latest` version of the docs, tag your version as 'active' on the readthedocs dashboard: https://readthedocs.org/projects/pachyderm/versions/


### PR DESCRIPTION
The current process is a little error-prone, due to a workaround of a bug in goxc. This automates a little more of the process to help.