### PR TITLE
Strip GOPATH from stack traces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,11 @@ worker:
 
 install:
 	# GOPATH/bin must be on your PATH to access these binaries:
-	GO15VENDOREXPERIMENT=1 go install -ldflags "$(LD_FLAGS)" ./src/server/cmd/pachctl
+	GO15VENDOREXPERIMENT=1 go install -ldflags "$(LD_FLAGS)" -gcflags "all=-trimpath=$GOPATH" ./src/server/cmd/pachctl
 
 install-mac:
 	# Result will be in $GOPATH/bin/darwin_amd64/pachctl (if building on linux)
-	GO15VENDOREXPERIMENT=1 GOOS=darwin GOARCH=amd64 go install -ldflags "$(LD_FLAGS)" ./src/server/cmd/pachctl
+	GO15VENDOREXPERIMENT=1 GOOS=darwin GOARCH=amd64 go install -ldflags "$(LD_FLAGS)" -gcflags "all=-trimpath=$GOPATH" ./src/server/cmd/pachctl
 
 install-clean:
 	@# Need to blow away pachctl binary if its already there
@@ -90,7 +90,7 @@ install-clean:
 	@make install
 
 install-doc:
-	GO15VENDOREXPERIMENT=1 go install ./src/server/cmd/pachctl-doc
+	GO15VENDOREXPERIMENT=1 go install -gcflags "all=-trimpath=$GOPATH" ./src/server/cmd/pachctl-doc
 
 check-docker-version:
 	# The latest docker client requires server api version >= 1.24.

--- a/etc/compile/compile.sh
+++ b/etc/compile/compile.sh
@@ -15,6 +15,7 @@ CGO_ENABLED=0 GOOS=linux go build \
   -tags netgo \
   -o _tmp/${BINARY} \
   -ldflags "${LD_FLAGS}" \
+  -gcflags "all=-trimpath=$GOPATH" \
   src/server/cmd/${BINARY}/main.go
 
 echo "LD_FLAGS=$LD_FLAGS"


### PR DESCRIPTION
based on https://itnext.io/trim-gopath-from-stack-trace-88b7402c8b47

This prevents our usernames from showing up in users' stack traces whenever we issue a release (and in general. Hopefully the part of each file's path that comes after the gopath (`src/github.com/pachyderm/pachyderm/...`) is clear