### PR TITLE
Fix `--no-metrics` and `--no-port-forwarding`

### DIFF
--- a/src/server/admin/cmds/cmds.go
+++ b/src/server/admin/cmds/cmds.go
@@ -17,7 +17,7 @@ const (
 )
 
 // Cmds returns a slice containing admin commands.
-func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
+func Cmds(noMetrics *bool, noPortForwarding *bool) []*cobra.Command {
 	var noObjects bool
 	var url string
 	extract := &cobra.Command{
@@ -30,7 +30,7 @@ pachctl extract >backup
 # Extract to s3:
 pachctl extract -u s3://bucket/backup` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -59,7 +59,7 @@ pachctl restore <backup
 # Restore from s3:
 pachctl restore -u s3://bucket/backup` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -83,7 +83,7 @@ pachctl restore -u s3://bucket/backup` + codeend,
 		Short: "Returns info about the pachyderm cluster",
 		Long:  "Returns info about the pachyderm cluster",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -51,7 +51,7 @@ func writePachTokenToCfg(token string) error {
 }
 
 // ActivateCmd returns a cobra.Command to activate Pachyderm's auth system
-func ActivateCmd(portForwarding bool) *cobra.Command {
+func ActivateCmd(noPortForwarding *bool) *cobra.Command {
 	var initialAdmin string
 	activate := &cobra.Command{
 		Use:   "activate",
@@ -72,7 +72,7 @@ first cluster admin`[1:],
 			fmt.Println("Retrieving Pachyderm token...")
 
 			// Exchange GitHub token for Pachyderm token
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -110,7 +110,7 @@ cluster`[1:])
 
 // DeactivateCmd returns a cobra.Command to delete all ACLs, tokens, and admins,
 // deactivating Pachyderm's auth system
-func DeactivateCmd(portForwarding bool) *cobra.Command {
+func DeactivateCmd(noPortForwarding *bool) *cobra.Command {
 	deactivate := &cobra.Command{
 		Use:   "deactivate",
 		Short: "Delete all ACLs, tokens, and admins, and deactivate Pachyderm auth",
@@ -124,7 +124,7 @@ func DeactivateCmd(portForwarding bool) *cobra.Command {
 			if !strings.Contains("yY", confirm[:1]) {
 				return fmt.Errorf("operation aborted")
 			}
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -139,7 +139,7 @@ func DeactivateCmd(portForwarding bool) *cobra.Command {
 // LoginCmd returns a cobra.Command to login to a Pachyderm cluster with your
 // GitHub account. Any resources that have been restricted to the email address
 // registered with your GitHub account will subsequently be accessible.
-func LoginCmd(portForwarding bool) *cobra.Command {
+func LoginCmd(noPortForwarding *bool) *cobra.Command {
 	var useOTP bool
 	login := &cobra.Command{
 		Use:   "login",
@@ -148,7 +148,7 @@ func LoginCmd(portForwarding bool) *cobra.Command {
 			"the account you have with your ID provider (e.g. GitHub, Okta) " +
 			"account will subsequently be accessible.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -229,13 +229,13 @@ func LogoutCmd() *cobra.Command {
 // WhoamiCmd returns a cobra.Command that deletes your local Pachyderm
 // credential, logging you out of your cluster. Note that this is not necessary
 // to do before logging in as another user, but is useful for testing.
-func WhoamiCmd(portForwarding bool) *cobra.Command {
+func WhoamiCmd(noPortForwarding *bool) *cobra.Command {
 	whoami := &cobra.Command{
 		Use:   "whoami",
 		Short: "Print your Pachyderm identity",
 		Long:  "Print your Pachyderm identity.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -259,7 +259,7 @@ func WhoamiCmd(portForwarding bool) *cobra.Command {
 
 // CheckCmd returns a cobra command that sends an "Authorize" RPC to Pachd, to
 // determine whether the specified user has access to the specified repo.
-func CheckCmd(portForwarding bool) *cobra.Command {
+func CheckCmd(noPortForwarding *bool) *cobra.Command {
 	check := &cobra.Command{
 		Use:   "check (none|reader|writer|owner) repo",
 		Short: "Check whether you have reader/writer/etc-level access to 'repo'",
@@ -275,7 +275,7 @@ func CheckCmd(portForwarding bool) *cobra.Command {
 				return err
 			}
 			repo := args[1]
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -296,7 +296,7 @@ func CheckCmd(portForwarding bool) *cobra.Command {
 
 // GetCmd returns a cobra command that gets either the ACL for a Pachyderm
 // repo or another user's scope of access to that repo
-func GetCmd(portForwarding bool) *cobra.Command {
+func GetCmd(noPortForwarding *bool) *cobra.Command {
 	setScope := &cobra.Command{
 		Use:   "get [username] repo",
 		Short: "Get the ACL for 'repo' or the access that 'username' has to 'repo'",
@@ -307,7 +307,7 @@ func GetCmd(portForwarding bool) *cobra.Command {
 			"Pachyderm authentication uses GitHub OAuth, so 'username' must be a " +
 			"GitHub username",
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -343,7 +343,7 @@ func GetCmd(portForwarding bool) *cobra.Command {
 
 // SetScopeCmd returns a cobra command that lets a user set the level of access
 // that another user has to a repo
-func SetScopeCmd(portForwarding bool) *cobra.Command {
+func SetScopeCmd(noPortForwarding *bool) *cobra.Command {
 	setScope := &cobra.Command{
 		Use:   "set username (none|reader|writer|owner) repo",
 		Short: "Set the scope of access that 'username' has to 'repo'",
@@ -361,7 +361,7 @@ func SetScopeCmd(portForwarding bool) *cobra.Command {
 				return err
 			}
 			username, repo := args[0], args[2]
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -378,13 +378,13 @@ func SetScopeCmd(portForwarding bool) *cobra.Command {
 }
 
 // ListAdminsCmd returns a cobra command that lists the current cluster admins
-func ListAdminsCmd(portForwarding bool) *cobra.Command {
+func ListAdminsCmd(noPortForwarding *bool) *cobra.Command {
 	listAdmins := &cobra.Command{
 		Use:   "list-admins",
 		Short: "List the current cluster admins",
 		Long:  "List the current cluster admins",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -404,7 +404,7 @@ func ListAdminsCmd(portForwarding bool) *cobra.Command {
 
 // ModifyAdminsCmd returns a cobra command that modifies the set of current
 // cluster admins
-func ModifyAdminsCmd(portForwarding bool) *cobra.Command {
+func ModifyAdminsCmd(noPortForwarding *bool) *cobra.Command {
 	var add []string
 	var remove []string
 	modifyAdmins := &cobra.Command{
@@ -414,7 +414,7 @@ func ModifyAdminsCmd(portForwarding bool) *cobra.Command {
 			"separated list of users to grant admin status, and --remove accepts a " +
 			"comma-separated list of users to revoke admin status",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -440,7 +440,7 @@ func ModifyAdminsCmd(portForwarding bool) *cobra.Command {
 
 // GetAuthTokenCmd returns a cobra command that lets a user get a pachyderm
 // token on behalf of themselves or another user
-func GetAuthTokenCmd(portForwarding bool) *cobra.Command {
+func GetAuthTokenCmd(noPortForwarding *bool) *cobra.Command {
 	var quiet bool
 	getAuthToken := &cobra.Command{
 		Use:   "get-auth-token username",
@@ -449,7 +449,7 @@ func GetAuthTokenCmd(portForwarding bool) *cobra.Command {
 			"this can only be called by cluster admins",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			subject := args[0]
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -498,23 +498,23 @@ func UseAuthTokenCmd() *cobra.Command {
 
 // Cmds returns a list of cobra commands for authenticating and authorizing
 // users in an auth-enabled Pachyderm cluster.
-func Cmds(portForwarding bool) []*cobra.Command {
+func Cmds(noPortForwarding *bool) []*cobra.Command {
 	auth := &cobra.Command{
 		Use:   "auth",
 		Short: "Auth commands manage access to data in a Pachyderm cluster",
 		Long:  "Auth commands manage access to data in a Pachyderm cluster",
 	}
-	auth.AddCommand(ActivateCmd(portForwarding))
-	auth.AddCommand(DeactivateCmd(portForwarding))
-	auth.AddCommand(LoginCmd(portForwarding))
+	auth.AddCommand(ActivateCmd(noPortForwarding))
+	auth.AddCommand(DeactivateCmd(noPortForwarding))
+	auth.AddCommand(LoginCmd(noPortForwarding))
 	auth.AddCommand(LogoutCmd())
-	auth.AddCommand(WhoamiCmd(portForwarding))
-	auth.AddCommand(CheckCmd(portForwarding))
-	auth.AddCommand(SetScopeCmd(portForwarding))
-	auth.AddCommand(GetCmd(portForwarding))
-	auth.AddCommand(ListAdminsCmd(portForwarding))
-	auth.AddCommand(ModifyAdminsCmd(portForwarding))
-	auth.AddCommand(GetAuthTokenCmd(portForwarding))
+	auth.AddCommand(WhoamiCmd(noPortForwarding))
+	auth.AddCommand(CheckCmd(noPortForwarding))
+	auth.AddCommand(SetScopeCmd(noPortForwarding))
+	auth.AddCommand(GetCmd(noPortForwarding))
+	auth.AddCommand(ListAdminsCmd(noPortForwarding))
+	auth.AddCommand(ModifyAdminsCmd(noPortForwarding))
+	auth.AddCommand(GetAuthTokenCmd(noPortForwarding))
 	auth.AddCommand(UseAuthTokenCmd())
 	auth.AddCommand(GetConfig())
 	auth.AddCommand(SetConfig())

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -185,34 +185,34 @@ Environment variables:
 	rootCmd.PersistentFlags().BoolVarP(&noMetrics, "no-metrics", "", false, "Don't report user metrics for this command")
 	rootCmd.PersistentFlags().BoolVarP(&noPortForwarding, "no-port-forwarding", "", false, "Disable implicit port forwarding")
 
-	pfsCmds := pfscmds.Cmds(!noMetrics, !noPortForwarding)
+	pfsCmds := pfscmds.Cmds(&noMetrics, &noPortForwarding)
 	for _, cmd := range pfsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	ppsCmds, err := ppscmds.Cmds(!noMetrics, !noPortForwarding)
+	ppsCmds, err := ppscmds.Cmds(&noMetrics, &noPortForwarding)
 	if err != nil {
 		return nil, err
 	}
 	for _, cmd := range ppsCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	deployCmds := deploycmds.Cmds(!noMetrics, !noPortForwarding)
+	deployCmds := deploycmds.Cmds(&noMetrics, &noPortForwarding)
 	for _, cmd := range deployCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	authCmds := authcmds.Cmds(!noPortForwarding)
+	authCmds := authcmds.Cmds(&noPortForwarding)
 	for _, cmd := range authCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	enterpriseCmds := enterprisecmds.Cmds(!noPortForwarding)
+	enterpriseCmds := enterprisecmds.Cmds(&noPortForwarding)
 	for _, cmd := range enterpriseCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	adminCmds := admincmds.Cmds(!noMetrics, !noPortForwarding)
+	adminCmds := admincmds.Cmds(&noMetrics, &noPortForwarding)
 	for _, cmd := range adminCmds {
 		rootCmd.AddCommand(cmd)
 	}
-	debugCmds := debugcmds.Cmds(!noMetrics, !noPortForwarding)
+	debugCmds := debugcmds.Cmds(&noMetrics, &noPortForwarding)
 	for _, cmd := range debugCmds {
 		rootCmd.AddCommand(cmd)
 	}

--- a/src/server/cmd/pachctl/cmd/cmd_test.go
+++ b/src/server/cmd/pachctl/cmd/cmd_test.go
@@ -15,22 +15,22 @@ var stdoutMutex = &sync.Mutex{}
 
 func TestMetricsNormalDeployment(t *testing.T) {
 	// Run deploy normally, should see METRICS=true
-	testDeploy(t, false, true, true)
+	testDeploy(t, false, false, true)
 }
 
 func TestMetricsNormalDeploymentNoMetricsFlagSet(t *testing.T) {
 	// Run deploy normally, should see METRICS=true
-	testDeploy(t, false, false, false)
+	testDeploy(t, false, true, false)
 }
 
 func TestMetricsDevDeployment(t *testing.T) {
 	// Run deploy w dev flag, should see METRICS=false
-	testDeploy(t, true, true, false)
+	testDeploy(t, true, false, false)
 }
 
 func TestMetricsDevDeploymentNoMetricsFlagSet(t *testing.T) {
 	// Run deploy w dev flag, should see METRICS=false
-	testDeploy(t, true, false, false)
+	testDeploy(t, true, true, false)
 }
 
 func TestPortForwardError(t *testing.T) {
@@ -66,7 +66,7 @@ func TestWeirdPortError(t *testing.T) {
 	require.Matches(t, "30650", errMsg.String())
 }
 
-func testDeploy(t *testing.T, devFlag bool, metrics bool, expectedEnvValue bool) {
+func testDeploy(t *testing.T, devFlag bool, noMetrics bool, expectedEnvValue bool) {
 	//t.Parallel()
 	//stdoutMutex.Lock()
 	//defer stdoutMutex.Unlock()
@@ -86,7 +86,7 @@ func testDeploy(t *testing.T, devFlag bool, metrics bool, expectedEnvValue bool)
 	//"--dry-run",
 	//fmt.Sprintf("-d=%v", devFlag),
 	//}
-	//err = deploycmds.DeployCmd(&metrics).Execute()
+	//err = deploycmds.DeployCmd(&noMetrics).Execute()
 	//require.NoError(t, err)
 	//require.NoError(t, w.Close())
 	//// restore stdout

--- a/src/server/debug/cmds/cmds.go
+++ b/src/server/debug/cmds/cmds.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Cmds returns a slice containing debug commands.
-func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
+func Cmds(noMetrics *bool, noPortForwarding *bool) []*cobra.Command {
 	debugDump := &cobra.Command{
 		Use:   "debug-dump",
 		Short: "Return a dump of running goroutines.",
 		Long:  "Return a dump of running goroutines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "debug-dump")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "debug-dump")
 			if err != nil {
 				return err
 			}

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -32,7 +32,7 @@ func parseISO8601(s string) (time.Time, error) {
 // Pachyderm within a Pachyderm cluster. All repos will go from
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
-func ActivateCmd(portForwarding bool) *cobra.Command {
+func ActivateCmd(noPortForwarding *bool) *cobra.Command {
 	var expires string
 	activate := &cobra.Command{
 		Use: "activate activation-code",
@@ -41,7 +41,7 @@ func ActivateCmd(portForwarding bool) *cobra.Command {
 		Long: "Activate the enterprise features of Pachyderm with an activation " +
 			"code",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
@@ -84,7 +84,7 @@ func ActivateCmd(portForwarding bool) *cobra.Command {
 // Pachyderm within a Pachyderm cluster. All repos will go from
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
-func GetStateCmd(portForwarding bool) *cobra.Command {
+func GetStateCmd(noPortForwarding *bool) *cobra.Command {
 	getState := &cobra.Command{
 		Use: "get-state",
 		Short: "Check whether the Pachyderm cluster has enterprise features " +
@@ -92,7 +92,7 @@ func GetStateCmd(portForwarding bool) *cobra.Command {
 		Long: "Check whether the Pachyderm cluster has enterprise features " +
 			"activated",
 		Run: cmdutil.Run(func(args []string) error {
-			c, err := client.NewOnUserMachine(true, portForwarding, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %s", err.Error())
 			}
@@ -119,13 +119,13 @@ func GetStateCmd(portForwarding bool) *cobra.Command {
 }
 
 // Cmds returns pachctl commands related to Pachyderm Enterprise
-func Cmds(portForwarding bool) []*cobra.Command {
+func Cmds(noPortForwarding *bool) []*cobra.Command {
 	enterprise := &cobra.Command{
 		Use:   "enterprise",
 		Short: "Enterprise commands enable Pachyderm Enterprise features",
 		Long:  "Enterprise commands enable Pachyderm Enterprise features",
 	}
-	enterprise.AddCommand(ActivateCmd(portForwarding))
-	enterprise.AddCommand(GetStateCmd(portForwarding))
+	enterprise.AddCommand(ActivateCmd(noPortForwarding))
+	enterprise.AddCommand(GetStateCmd(noPortForwarding))
 	return []*cobra.Command{enterprise}
 }

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Cmds returns a slice containing pfs commands.
-func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
+func Cmds(noMetrics *bool, noPortForwarding *bool) []*cobra.Command {
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&raw, "raw", false, "disable pretty printing, print raw json")
@@ -65,7 +65,7 @@ func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 		Short: "Create a new repo.",
 		Long:  "Create a new repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 		Short: "Update a repo.",
 		Long:  "Update a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -110,7 +110,7 @@ func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 		Short: "Return info about a repo.",
 		Long:  "Return info about a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -135,7 +135,7 @@ func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 		Short: "Return all repos.",
 		Long:  "Return all repos.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -173,7 +173,7 @@ func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
 		Short: "Delete a repo.",
 		Long:  "Delete a repo.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -244,7 +244,7 @@ $ pachctl start-commit test patch -p master
 $ pachctl start-commit test -p XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {
-			cli, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			cli, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -275,7 +275,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Finish a started commit.",
 		Long:  "Finish a started commit. Commit-id must be a writeable commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			cli, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			cli, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -299,7 +299,7 @@ $ pachctl start-commit test -p XXX
 		Short: "Return info about a commit.",
 		Long:  "Return info about a commit.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -344,7 +344,7 @@ $ pachctl list-commit foo XXX
 $ pachctl list-commit foo master --from XXX
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -422,7 +422,7 @@ $ pachctl flush-commit foo/XXX -r bar -r baz
 				return err
 			}
 
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -467,7 +467,7 @@ $ pachctl subscribe-commit test master --new
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
 			repo, branch := args[0], args[1]
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -498,7 +498,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Delete an input commit.",
 		Long:  "Delete an input commit. An input is a commit which is not the output of a pipeline.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -514,7 +514,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Create a new branch, or update an existing branch, on a repo.",
 		Long:  "Create a new branch, or update an existing branch, on a repo, starting a commit on the branch will also create it, so there's often no need to call this.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -534,7 +534,7 @@ $ pachctl subscribe-commit test master --new
 		Short: "Return all branches on a repo.",
 		Long:  "Return all branches on a repo.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -576,7 +576,7 @@ $ pachctl set-branch foo XXX master
 $ pachctl set-branch foo test master` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
 			fmt.Fprintf(os.Stderr, "set-branch is DEPRECATED, use create-branch instead.\n")
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -590,7 +590,7 @@ $ pachctl set-branch foo test master` + codeend,
 		Short: "Delete a branch",
 		Long:  "Delete a branch, while leaving the commits intact",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -666,7 +666,7 @@ $ pachctl put-file repo branch -i file
 $ pachctl put-file repo branch -i http://host/path
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -781,7 +781,7 @@ $ pachctl put-file repo branch -i http://host/path
 		Short: "Copy files between pfs paths.",
 		Long:  "Copy files between pfs paths.",
 		Run: cmdutil.RunFixedArgs(6, func(args []string) (retErr error) {
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user", client.WithMaxConcurrentStreams(parallelism))
 			if err != nil {
 				return err
 			}
@@ -808,7 +808,7 @@ $ pachctl get-file foo master^ XXX
 $ pachctl get-file foo master^2 XXX
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -844,7 +844,7 @@ $ pachctl get-file foo master^2 XXX
 		Short: "Return info about a file.",
 		Long:  "Return info about a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -893,7 +893,7 @@ $ pachctl list-file foo master --history n
 $ pachctl list-file foo master --history -1
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -938,7 +938,7 @@ $ pachctl glob-file foo master "A*"
 $ pachctl glob-file foo master "data/*"
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -978,7 +978,7 @@ $ pachctl diff-file foo master path
 $ pachctl diff-file foo master path1 bar master path2
 ` + codeend,
 		Run: cmdutil.RunBoundedArgs(3, 6, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1026,7 +1026,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Delete a file.",
 		Long:  "Delete a file.",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1040,7 +1040,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of an object",
 		Long:  "Return the contents of an object",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1054,7 +1054,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Return the contents of a tag",
 		Long:  "Return the contents of a tag",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -1070,7 +1070,7 @@ $ pachctl diff-file foo master path1 bar master path2
 		Short: "Mount pfs locally. This command blocks.",
 		Long:  "Mount pfs locally. This command blocks.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := client.NewOnUserMachine(metrics, portForwarding, "fuse")
+			client, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "fuse")
 			if err != nil {
 				return err
 			}

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -146,7 +146,7 @@ func containsEmpty(vals []string) bool {
 }
 
 // DeployCmd returns a cobra.Command to deploy pachyderm.
-func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
+func DeployCmd(noMetrics *bool, noPortForwarding *bool) *cobra.Command {
 	var pachdShards int
 	var hostPath string
 	var dev bool
@@ -184,6 +184,8 @@ func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
 		Short: "Deploy a single-node Pachyderm cluster with local metadata storage.",
 		Long:  "Deploy a single-node Pachyderm cluster with local metadata storage.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
+			metrics := !*noMetrics
+
 			if metrics && !dev {
 				start := time.Now()
 				startMetricsWait := _metrics.StartReportAndFlushUserAction("Deploy", start)
@@ -228,6 +230,8 @@ func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
 			"  <size of disks>: Size of GCE persistent disks in GB (assumed to all be the same).\n" +
 			"  <service account creds file>: a file contain a private key for a service account (downloaded from GCE).\n",
 		Run: cmdutil.RunBoundedArgs(2, 3, func(args []string) (retErr error) {
+			metrics := !*noMetrics
+
 			if metrics && !dev {
 				start := time.Now()
 				startMetricsWait := _metrics.StartReportAndFlushUserAction("Deploy", start)
@@ -265,6 +269,8 @@ func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
 			"If <object store backend> is \"s3\", then the arguments are:\n" +
 			"    <volumes> <size of volumes (in GB)> <bucket> <id> <secret> <endpoint>\n",
 		Run: cmdutil.RunBoundedArgs(4, 7, func(args []string) (retErr error) {
+			metrics := !*noMetrics
+
 			if metrics && !dev {
 				start := time.Now()
 				startMetricsWait := _metrics.StartReportAndFlushUserAction("Deploy", start)
@@ -304,6 +310,8 @@ func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
 			"  <region>: The aws region where pachyderm is being deployed (e.g. us-west-1)\n" +
 			"  <size of volumes>: Size of EBS volumes, in GB (assumed to all be the same).\n",
 		Run: cmdutil.RunFixedArgs(3, func(args []string) (retErr error) {
+			metrics := !*noMetrics
+
 			if metrics && !dev {
 				start := time.Now()
 				startMetricsWait := _metrics.StartReportAndFlushUserAction("Deploy", start)
@@ -402,6 +410,8 @@ func DeployCmd(metrics bool, portForwarding bool) *cobra.Command {
 			"  <container>: An Azure container where Pachyderm will store PFS data.\n" +
 			"  <size of volumes>: Size of persistent volumes, in GB (assumed to all be the same).\n",
 		Run: cmdutil.RunFixedArgs(4, func(args []string) (retErr error) {
+			metrics := !*noMetrics
+
 			if metrics && !dev {
 				start := time.Now()
 				startMetricsWait := _metrics.StartReportAndFlushUserAction("Deploy", start)
@@ -471,7 +481,7 @@ particular backend, run "pachctl deploy storage <backend>"`,
 				data = assets.MicrosoftSecret("", args[1], args[2])
 			}
 
-			c, err := client.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := client.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error constructing pachyderm client: %v", err)
 			}
@@ -545,7 +555,7 @@ particular backend, run "pachctl deploy storage <backend>"`,
 				PachdShards:             uint64(pachdShards),
 				Version:                 version.PrettyPrintVersion(version.Version),
 				LogLevel:                logLevel,
-				Metrics:                 metrics,
+				Metrics:                 !*noMetrics,
 				PachdCPURequest:         pachdCPURequest,
 				PachdNonCacheMemRequest: pachdNonCacheMemRequest,
 				BlockCacheSize:          blockCacheSize,
@@ -642,8 +652,8 @@ particular backend, run "pachctl deploy storage <backend>"`,
 }
 
 // Cmds returns a list of cobra commands for deploying Pachyderm clusters.
-func Cmds(metrics bool, portForwarding bool) []*cobra.Command {
-	deploy := DeployCmd(metrics, portForwarding)
+func Cmds(noMetrics *bool, noPortForwarding *bool) []*cobra.Command {
+	deploy := DeployCmd(noMetrics, noPortForwarding)
 	var all bool
 	var namespace string
 	undeploy := &cobra.Command{

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -38,7 +38,7 @@ const (
 )
 
 // Cmds returns a slice containing pps commands.
-func Cmds(metrics bool, portForwarding bool) ([]*cobra.Command, error) {
+func Cmds(noMetrics *bool, noPortForwarding *bool) ([]*cobra.Command, error) {
 	raw := false
 	rawFlag := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&raw, "raw", false, "disable pretty printing, print raw json")
@@ -75,7 +75,7 @@ The increase the throughput of a job increase the Shard paremeter.
 		Short: "Return info about a job.",
 		Long:  "Return info about a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -119,7 +119,7 @@ $ pachctl list-job foo/XXX bar/YYY
 $ pachctl list-job -p foo bar/YYY
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -188,7 +188,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 				return err
 			}
 
-			c, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			c, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -223,7 +223,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Delete a job.",
 		Long:  "Delete a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Stop a job.",
 		Long:  "Stop a job.  The job will be stopped immediately.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -257,7 +257,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Restart a datum.",
 		Long:  "Restart a datum.",
 		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -283,7 +283,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Return the datums in a job.",
 		Long:  "Return the datums in a job.",
 		Run: cmdutil.RunBoundedArgs(1, 1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -320,7 +320,7 @@ $ pachctl flush-job foo/XXX -p bar -p baz
 		Short: "Display detailed info about a single datum.",
 		Long:  "Display detailed info about a single datum.",
 		Run: cmdutil.RunBoundedArgs(2, 2, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -363,7 +363,7 @@ $ pachctl get-logs --job=aedfa12aedf
 $ pachctl get-logs --pipeline=filter --inputs=/apple.txt,123aef
 ` + codeend,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -443,7 +443,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Create a new pipeline.",
 		Long:  fmt.Sprintf("Create a new pipeline from a %s", pipelineSpec),
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(metrics, portForwarding, false, build, pushImages, registry, username, pipelinePath, false)
+			return pipelineHelper(!*noMetrics, !*noPortForwarding, false, build, pushImages, registry, username, pipelinePath, false)
 		}),
 	}
 	createPipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The file containing the pipeline, it can be a url or local file. - reads from stdin.")
@@ -458,7 +458,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Update an existing Pachyderm pipeline.",
 		Long:  fmt.Sprintf("Update a Pachyderm pipeline with a new %s", pipelineSpec),
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(metrics, portForwarding, reprocess, build, pushImages, registry, username, pipelinePath, true)
+			return pipelineHelper(!*noMetrics, !*noPortForwarding, reprocess, build, pushImages, registry, username, pipelinePath, true)
 		}),
 	}
 	updatePipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The file containing the pipeline, it can be a url or local file. - reads from stdin.")
@@ -473,7 +473,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about a pipeline.",
 		Long:  "Return info about a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -498,7 +498,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return the manifest used to create a pipeline.",
 		Long:  "Return the manifest used to create a pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -517,7 +517,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Edit the manifest for a pipeline in your text editor.",
 		Long:  "Edit the manifest for a pipeline in your text editor.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -586,7 +586,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Return info about all pipelines.",
 		Long:  "Return info about all pipelines.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("error connecting to pachd: %v", err)
 			}
@@ -628,7 +628,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Delete a pipeline.",
 		Long:  "Delete a pipeline.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -663,7 +663,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Restart a stopped pipeline.",
 		Long:  "Restart a stopped pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -680,7 +680,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 		Short: "Stop a running pipeline.",
 		Long:  "Stop a running pipeline.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}
@@ -720,7 +720,7 @@ you can increase the amount of memory used for the bloom filters with the
 --memory flag. The default value is 10MB.
 `,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			client, err := pachdclient.NewOnUserMachine(metrics, portForwarding, "user")
+			client, err := pachdclient.NewOnUserMachine(!*noMetrics, !*noPortForwarding, "user")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes `--no-metrics` and `--no-port-forwarding`, which currently always evaluate to false.

Context: in #3410, I introduced some last-minute changes to remove double negation logic by eagerly evaluating flag values. Because the flags weren't parsed yet, this broke `--no-port-forwarding`. Those changes were based off of places where we eagerly evaluated `--no-metrics`. It turns out that was broken as well, though #3410 introduce what was a breakage of `--no-metrics` in some commands to a breakage in all commands.

Fixes #3460