### PR TITLE
Respect `--no-port-forwarding` everywhere

### DIFF
--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -516,7 +516,7 @@ func Cmds(noPortForwarding *bool) []*cobra.Command {
 	auth.AddCommand(ModifyAdminsCmd(noPortForwarding))
 	auth.AddCommand(GetAuthTokenCmd(noPortForwarding))
 	auth.AddCommand(UseAuthTokenCmd())
-	auth.AddCommand(GetConfig())
-	auth.AddCommand(SetConfig())
+	auth.AddCommand(GetConfig(noPortForwarding))
+	auth.AddCommand(SetConfig(noPortForwarding))
 	return []*cobra.Command{auth}
 }

--- a/src/server/auth/cmds/configure.go
+++ b/src/server/auth/cmds/configure.go
@@ -18,14 +18,14 @@ import (
 
 // GetConfig returns a cobra command that lets the caller see the configured
 // auth backends in Pachyderm
-func GetConfig() *cobra.Command {
+func GetConfig(noPortForwarding *bool) *cobra.Command {
 	var format string
 	getConfig := &cobra.Command{
 		Use:   "get-config",
 		Short: "Retrieve Pachyderm's current auth configuration",
 		Long:  "Retrieve Pachyderm's current auth configuration",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}
@@ -64,14 +64,14 @@ func GetConfig() *cobra.Command {
 
 // SetConfig returns a cobra command that lets the caller configure auth
 // backends in Pachyderm
-func SetConfig() *cobra.Command {
+func SetConfig(noPortForwarding *bool) *cobra.Command {
 	var file string
 	configure := &cobra.Command{
 		Use:   "set-config",
 		Short: "Set Pachyderm's current auth configuration",
 		Long:  "Set Pachyderm's current auth configuration",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine(true, true, "user")
+			c, err := client.NewOnUserMachine(true, !*noPortForwarding, "user")
 			if err != nil {
 				return fmt.Errorf("could not connect: %v", err)
 			}

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -267,9 +267,9 @@ Environment variables:
 				if err != nil {
 					return fmt.Errorf("could not parse timeout duration %q: %v", timeout, err)
 				}
-				pachClient, err = client.NewOnUserMachine(false, true, "user", client.WithDialTimeout(timeout))
+				pachClient, err = client.NewOnUserMachine(false, !noPortForwarding, "user", client.WithDialTimeout(timeout))
 			} else {
-				pachClient, err = client.NewOnUserMachine(false, true, "user")
+				pachClient, err = client.NewOnUserMachine(false, !noPortForwarding, "user")
 			}
 			if err != nil {
 				return err
@@ -416,7 +416,7 @@ This resets the cluster to its initial state.`,
 
 			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, os.Interrupt)
-			<- ch
+			<-ch
 			return nil
 		}),
 	}
@@ -446,7 +446,7 @@ This resets the cluster to its initial state.`,
 					}
 					return err
 				}
-				
+
 				defer func() {
 					if err := f.Close(); err != nil && retErr == nil {
 						retErr = err


### PR DESCRIPTION
While #3462 fixed the use of `--no-port-forwarding` where it was already used, it did not roll out that flag to commands that were previously ignoring them all-together. This changes it such that `--no-port-forwarding` is respected everywhere.
