### PR TITLE
Split misc tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ language: go
 go:
 - "1.11.1"
 env:
-- BUCKET=MISC_WITH_SECRETS
-- BUCKET=MISC_WITHOUT_SECRETS
+- BUCKET=AUTH
+- BUCKET=MISC
 # If you want to update the number of PPS workers, you'll also need to update
 # the value in ./etc/build/PPS_BUILD_BUCKET_COUNT
 - BUCKET=PPS1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ language: go
 go:
 - "1.11.1"
 env:
-- BUCKET=MISC
+- BUCKET=MISC1
+- BUCKET=MISC2
 # If you want to update the number of PPS workers, you'll also need to update
 # the value in ./etc/build/PPS_BUILD_BUCKET_COUNT
 - BUCKET=PPS1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ language: go
 go:
 - "1.11.1"
 env:
-- BUCKET=MISC1
-- BUCKET=MISC2
+- BUCKET=MISC_WITH_SECRETS
+- BUCKET=MISC_WITHOUT_SECRETS
 # If you want to update the number of PPS workers, you'll also need to update
 # the value in ./etc/build/PPS_BUILD_BUCKET_COUNT
 - BUCKET=PPS1

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -47,20 +47,31 @@ done
 
 go install ./src/testing/match
 
-if [[ "$BUCKET" == "MISC" ]]; then
+if [[ "$BUCKET" == "MISC1" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc test suite because secret env vars exist"
+        echo "Running the full misc1 test suite because secret env vars exist"
 
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds test-libs test-vault test-auth \
-            test-enterprise test-worker test-admin test-s3
+            test-pfs-cmds test-deploy-cmds
     else
-        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
+        echo "Running the misc1 test suite with some tests disabled because secret env vars have not been set"
 
         # Do not run some tests when we don't have access to secret
         # credentials
-        make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
+        make lint enterprise-code-checkin-test docker-build test-pfs-server
+    fi
+elif [[ "$BUCKET" == "MISC2" ]]; then
+    if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+        echo "Running the full misc2 test suite because secret env vars exist"
+
+        make test-libs test-vault test-auth test-enterprise test-worker \
+            test-admin test-s3
+    else
+        echo "Running the misc2 test suite with some tests disabled because secret env vars have not been set"
+
+        # Do not run some tests when we don't have access to secret
+        # credentials
+        make test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
     fi
 elif [[ "$BUCKET" == "EXAMPLES" ]]; then
     echo "Running the example test suite"

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -47,13 +47,13 @@ done
 
 go install ./src/testing/match
 
-if [[ "$BUCKET" == "MISC1" ]]; then
+if [[ "$BUCKET" == "MISC_WITH_SECRETS" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         make docker-build test-vault test-auth test-enterprise test-worker
     else
-        echo "Skipping misc1 because there are no secure env vars"
+        echo "Skipping MISC_WITH_SECRETS because there are no secure env vars"
     fi
-elif [[ "$BUCKET" == "MISC2" ]]; then
+elif [[ "$BUCKET" == "MISC_WITHOUT_SECRETS" ]]; then
     make lint enterprise-code-checkin-test docker-build test-pfs-server \
         test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
 elif [[ "$BUCKET" == "EXAMPLES" ]]; then

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -51,7 +51,8 @@ if [[ "$BUCKET" == "MISC1" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc test suite because secret env vars exist"
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds test-libs test-vault
+            test-pfs-cmds test-deploy-cmds test-libs test-vault \
+            test-enterprise
     else
         echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
@@ -60,7 +61,7 @@ if [[ "$BUCKET" == "MISC1" ]]; then
 elif [[ "$BUCKET" == "MISC2" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc test suite because secret env vars exist"
-        make test-auth test-enterprise test-worker test-admin test-s3
+        make test-auth test-worker test-admin test-s3
     else
         echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
         make test-admin test-s3

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -51,7 +51,7 @@ if [[ "$BUCKET" == "MISC1" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc test suite because secret env vars exist"
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds test-libs test-vault test-auth
+            test-pfs-cmds test-deploy-cmds test-libs test-vault
     else
         echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
@@ -60,7 +60,7 @@ if [[ "$BUCKET" == "MISC1" ]]; then
 elif [[ "$BUCKET" == "MISC2" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc test suite because secret env vars exist"
-        make test-enterprise test-worker test-admin test-s3
+        make test-auth test-enterprise test-worker test-admin test-s3
     else
         echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
         make test-admin test-s3

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -54,8 +54,8 @@ if [[ "$BUCKET" == "AUTH" ]]; then
         echo "Skipping auth tests because there are no secure env vars"
     fi
 elif [[ "$BUCKET" == "MISC" ]]; then
-    make lint enterprise-code-checkin-test docker-build test-pfs-server \
-        test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
+    make lint enterprise-code-checkin-test test-pfs-server test-pfs-cmds \
+        test-deploy-cmds test-libs test-admin test-s3
 
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         make test-vault test-enterprise test-worker

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -50,27 +50,19 @@ go install ./src/testing/match
 if [[ "$BUCKET" == "MISC1" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc1 test suite because secret env vars exist"
-
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
             test-pfs-cmds test-deploy-cmds
     else
         echo "Running the misc1 test suite with some tests disabled because secret env vars have not been set"
-
-        # Do not run some tests when we don't have access to secret
-        # credentials
         make lint enterprise-code-checkin-test docker-build test-pfs-server
     fi
 elif [[ "$BUCKET" == "MISC2" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc2 test suite because secret env vars exist"
-
         make test-libs test-vault test-auth test-enterprise test-worker \
             test-admin test-s3
     else
         echo "Running the misc2 test suite with some tests disabled because secret env vars have not been set"
-
-        # Do not run some tests when we don't have access to secret
-        # credentials
         make test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
     fi
 elif [[ "$BUCKET" == "EXAMPLES" ]]; then

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -49,23 +49,13 @@ go install ./src/testing/match
 
 if [[ "$BUCKET" == "MISC1" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc test suite because secret env vars exist"
-        make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds test-libs test-vault \
-            test-enterprise
+        make docker-build test-vault test-auth test-enterprise test-worker
     else
-        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
-        make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds test-libs
+        echo "Skipping misc1 because there are no secure env vars"
     fi
 elif [[ "$BUCKET" == "MISC2" ]]; then
-    if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc test suite because secret env vars exist"
-        make test-auth test-worker test-admin test-s3
-    else
-        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
-        make test-admin test-s3
-    fi
+    make lint enterprise-code-checkin-test docker-build test-pfs-server \
+        test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
 elif [[ "$BUCKET" == "EXAMPLES" ]]; then
     echo "Running the example test suite"
     ./etc/testing/examples.sh    

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -47,15 +47,21 @@ done
 
 go install ./src/testing/match
 
-if [[ "$BUCKET" == "MISC_WITH_SECRETS" ]]; then
+if [[ "$BUCKET" == "AUTH" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        make test-vault test-auth test-enterprise test-worker
+        make test-auth
     else
-        echo "Skipping MISC_WITH_SECRETS because there are no secure env vars"
+        echo "Skipping auth tests because there are no secure env vars"
     fi
-elif [[ "$BUCKET" == "MISC_WITHOUT_SECRETS" ]]; then
+elif [[ "$BUCKET" == "MISC" ]]; then
     make lint enterprise-code-checkin-test docker-build test-pfs-server \
         test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
+
+    if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+        make test-vault test-enterprise test-worker
+    else
+        echo "Skipping vault, enterprise, and worker tests because there are no secure env vars"
+    fi
 elif [[ "$BUCKET" == "EXAMPLES" ]]; then
     echo "Running the example test suite"
     ./etc/testing/examples.sh    

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -49,7 +49,7 @@ go install ./src/testing/match
 
 if [[ "$BUCKET" == "MISC_WITH_SECRETS" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        make docker-build test-vault test-auth test-enterprise test-worker
+        make test-vault test-auth test-enterprise test-worker
     else
         echo "Skipping MISC_WITH_SECRETS because there are no secure env vars"
     fi

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -49,21 +49,21 @@ go install ./src/testing/match
 
 if [[ "$BUCKET" == "MISC1" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc1 test suite because secret env vars exist"
+        echo "Running the full misc test suite because secret env vars exist"
         make lint enterprise-code-checkin-test docker-build test-pfs-server \
-            test-pfs-cmds test-deploy-cmds
+            test-pfs-cmds test-deploy-cmds test-libs test-vault test-auth
     else
-        echo "Running the misc1 test suite with some tests disabled because secret env vars have not been set"
-        make lint enterprise-code-checkin-test docker-build test-pfs-server
+        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
+        make lint enterprise-code-checkin-test docker-build test-pfs-server \
+            test-pfs-cmds test-deploy-cmds test-libs
     fi
 elif [[ "$BUCKET" == "MISC2" ]]; then
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc2 test suite because secret env vars exist"
-        make test-libs test-vault test-auth test-enterprise test-worker \
-            test-admin test-s3
+        echo "Running the full misc test suite because secret env vars exist"
+        make test-enterprise test-worker test-admin test-s3
     else
-        echo "Running the misc2 test suite with some tests disabled because secret env vars have not been set"
-        make test-pfs-cmds test-deploy-cmds test-libs test-admin test-s3
+        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
+        make test-admin test-s3
     fi
 elif [[ "$BUCKET" == "EXAMPLES" ]]; then
     echo "Running the example test suite"


### PR DESCRIPTION
The misc test suite takes by far the longest to run (~25 minutes). This splits the tests into two buckets. While this adds a new VM, it:

1) Allows misc to be run in parallel.
2) Misc tests are flaky. By splitting up the tests, it'll make it easier to re-run the subset of tests that failed for transient reasons.