### PR TITLE
Clean up TLS script

### DIFF
--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -60,7 +60,6 @@ dns="${dns:-localhost}"
 if [[ -z "${port}" ]]; then
   echo -n "Warning, --port is unset. Assuming :30650 (cert will " >/dev/fd/2
   echo "not work if this is not the correct port)" >/dev/fd/2
-  exit 1
 fi
 port="${port:-30650}"
 

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -2,9 +2,13 @@
 # This script generates a self-signed TLS cert to be used by pachd in tests
 
 if [[ -n "${ADDRESS}" ]] || [[ -n "${PACHD_ADDRESS}" ]]; then
-  echo -n "must run 'unset ADDRESS; unset PACHD_ADDRESS' to use " >/dev/fd/2
-  echo "this script's cert" >/dev/fd/2
+  echo "must run 'unset ADDRESS; unset PACHD_ADDRESS' to use this" >/dev/fd/2
+  echo "script's cert. These variables prevent pachctl from trusting" >/dev/fd/2
+  echo "the cert that this script generates"
   exit 1
+else
+  echo "Note that \$ADDRESS and \$PACHD_ADDRESS prevent pachctl from trusting "
+  echo "the cert that this script generates--do not set them"
 fi
 
 eval "set -- $( getopt -l "dns:,ip:,port:" -o "o:" "--" "${0}" "${@:-}" )"
@@ -57,9 +61,19 @@ if [[ -z "${dns}" ]] && [[ -z "${ip}" ]]; then
   exit 1
 fi
 dns="${dns:-localhost}"
+if [[ -n "${dns}" ]] && [[ -n "${ip}" ]]; then
+  echo "both --dns and --ip are set. Note that if you connect to your "
+  echo "Pachyderm cluster via domain name, it MUST resolve to the IP set in "
+  echo "--ip (otherwise the connection will fail)"
+  echo
+  echo "(However, if you connect to your cluster via IP address, the domain "
+  echo "name in --dns does not need to resolve to the IP address in --ip. In "
+  echo "other words, pachctl won't resolve or verify the domain name in --dns "
+  echo "if it doesn't need it)"
+fi
 if [[ -z "${port}" ]]; then
-  echo -n "Warning, --port is unset. Assuming :30650 (cert will " >/dev/fd/2
-  echo "not work if this is not the correct port)" >/dev/fd/2
+  echo "Warning, --port is unset. Assuming :30650 (cert will not " >/dev/fd/2
+  echo "work if this is not the correct port)" >/dev/fd/2
 fi
 port="${port:-30650}"
 

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # This script generates a self-signed TLS cert to be used by pachd in tests
 
-eval "set -- $( getopt -l "dns:,ip:,port:" -o "o:" "--" "${0}" "${@:-}" )"
+if [[ -n "${ADDRESS}" ]] || [[ -n "${PACHD_ADDRESS}" ]]; then
+  echo -n "must run 'unset ADDRESS; unset PACHD_ADDRESS' to use " >/dev/fd/2
+  echo "this script's cert" >/dev/fd/2
+  exit 1
+fi
 
-dns="localhost"
-ip="127.0.0.1"
-port=650
+eval "set -- $( getopt -l "dns:,ip:,port:" -o "o:" "--" "${0}" "${@:-}" )"
 output_prefix=pachd
 while true; do
   case "${1}" in
@@ -48,6 +50,19 @@ Args:
 EOF
   esac
 done
+
+# Validate flags
+if [[ -z "${dns}" ]] && [[ -z "${ip}" ]]; then
+  echo "You must set either --dns or --ip" >/dev/fd/2
+  exit 1
+fi
+dns="${dns:-localhost}"
+ip="${ip:-127.0.0.1}"
+if [[ -z "${port}" ]]; then
+  echo -n "Warning, --port is unset. Assuming :30650 (cert will " >/dev/fd/2
+  echo "not work if this is not the correct port)" >/dev/fd/2
+  exit 1
+fi
 
 # Define a minimal openssl config for our micro-CA
 read -d '' -r tls_config <<EOF
@@ -101,5 +116,7 @@ tls_opts=(
 openssl req "${tls_opts[@]}" -config <(echo "${tls_config}")
 
 # Copy pachd public key to pachyderm config
+echo "Backing up Pachyderm config to \$HOME/.pachyderm/config.json.backup"
+echo "New config with address and cert is at \$HOME/.pachyderm/config.json"
 cp ~/.pachyderm/config.json ~/.pachyderm/config.json.backup
-cat ~/.pachyderm/config.json.backup | jq ".v1.pachd_address = \"${ip}:${port}\" | .v1.server_cas = \"$(cat ./pachd.pem | base64)\" | ." >~/.pachyderm/config.json
+jq ".v1.pachd_address = \"${dns}:${port}\" | .v1.server_cas = \"$(cat ./pachd.pem | base64)\"" ~/.pachyderm/config.json.backup >~/.pachyderm/config.json

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -4,7 +4,7 @@
 if [[ -n "${ADDRESS}" ]] || [[ -n "${PACHD_ADDRESS}" ]]; then
   echo "must run 'unset ADDRESS; unset PACHD_ADDRESS' to use this" >/dev/fd/2
   echo "script's cert. These variables prevent pachctl from trusting" >/dev/fd/2
-  echo "the cert that this script generates"
+  echo "the cert that this script generates" >/dev/fd/2
   exit 1
 else
   echo "Note that \$ADDRESS and \$PACHD_ADDRESS prevent pachctl from trusting "
@@ -60,19 +60,10 @@ if [[ -z "${dns}" ]] && [[ -z "${ip}" ]]; then
   echo "You must set either --dns or --ip" >/dev/fd/2
   exit 1
 fi
-if [[ -n "${dns}" ]] && [[ -n "${ip}" ]]; then
-  echo "both --dns and --ip are set. Note that if you connect to your "
-  echo "Pachyderm cluster via domain name, it MUST resolve to the IP set in "
-  echo "--ip (otherwise the connection will fail)"
-  echo
-  echo "(However, if you connect to your cluster via IP address, the domain "
-  echo "name in --dns does not need to resolve to the IP address in --ip. In "
-  echo "other words, pachctl won't resolve or verify the domain name in --dns "
-  echo "if it doesn't need it)"
-fi
 if [[ -z "${port}" ]]; then
-  echo "Warning, --port is unset. Assuming :30650 (cert will not " >/dev/fd/2
-  echo "work if this is not the correct port)" >/dev/fd/2
+  echo "Warning, --port is unset. Assuming :30650 (.v1.pachd_address in your "
+  echo "Pachyderm config must be updated if this is not the correct port, or "
+  echo "pachd will fail to connect)"
 fi
 port="${port:-30650}"
 

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -57,7 +57,6 @@ if [[ -z "${dns}" ]] && [[ -z "${ip}" ]]; then
   exit 1
 fi
 dns="${dns:-localhost}"
-ip="${ip:-127.0.0.1}"
 if [[ -z "${port}" ]]; then
   echo -n "Warning, --port is unset. Assuming :30650 (cert will " >/dev/fd/2
   echo "not work if this is not the correct port)" >/dev/fd/2

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -68,7 +68,6 @@ fi
 port="${port:-30650}"
 
 # Define a minimal openssl config for our micro-CA
-common_name="${dns:-localhost}"
 read -d '' -r tls_config <<EOF
 [ req ]
 default_md         = sha256 # MD = message digest. md5 is the openSSL default in 1.1.0 (see 'man req')
@@ -77,7 +76,7 @@ distinguished_name = dn
 x509_extensions    = exn    # Since we're making self-signed certs. For CSRs, use req_extensions
 
 [ dn ]
-CN = ${common_name}
+CN = ${dns:-localhost} # TODO(msteffen) better default domain name
 
 [ exn ]
 EOF

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -62,6 +62,7 @@ if [[ -z "${port}" ]]; then
   echo "not work if this is not the correct port)" >/dev/fd/2
   exit 1
 fi
+port="${port:-30650}"
 
 # Define a minimal openssl config for our micro-CA
 read -d '' -r tls_config <<EOF

--- a/etc/deploy/gen_pachd_tls.sh
+++ b/etc/deploy/gen_pachd_tls.sh
@@ -93,7 +93,7 @@ EOF
 
 # If 'ip' is set, include IP in TLS cert
 if [[ -n "${ip}" ]]; then
-  tls_config+=$'\n'"subjectAltName = IP:${ip}"
+  tls_config+=$'\n'"subjectAltName = DNS:${dns}, IP:${ip}"
 fi
 
 echo "${tls_config}"


### PR DESCRIPTION
Mainly, this fixes a bug in how this script generates its TLS certificate signing request. It turns out that if a cert includes a Subject Alternative Name extension, then the domain name for which the script is signed (usually stored in the subject/Common Name field at the beginning of the cert) also has to be one of the SubjectAlternativeNames (in addition to any IP addresses, etc).

Basically, if Subject Alternative Name is present, it overrides CN, instead of adding to it.[1]

Also:
- Add argument validation
- clean up jq query

[1] Sources, for posterity:
- https://stackoverflow.com/questions/43665243/invalid-self-signed-ssl-cert-subject-alternative-name-missing#comment82968723_43665243
- http://wiki.cacert.org/FAQ/subjectAltName