### PR TITLE
Avoid mutating image name if there is no registry override

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -1306,7 +1306,9 @@ func WriteAssets(encoder Encoder, opts *AssetOpts, objectStoreBackend backend,
 	}
 	fillDefaultResourceRequests(opts, persistentDiskBackend)
 	if opts.DashOnly {
-		WriteDashboardAssets(encoder, opts)
+		if dashErr := WriteDashboardAssets(encoder, opts); dashErr != nil {
+			return dashErr
+		}
 		return nil
 	}
 
@@ -1450,7 +1452,9 @@ func WriteLocalAssets(encoder Encoder, opts *AssetOpts, hostPath string) error {
 	if err := WriteAssets(encoder, opts, localBackend, localBackend, 1 /* = volume size (gb) */, hostPath); err != nil {
 		return err
 	}
-	WriteSecret(encoder, LocalSecret(), opts)
+	if secretErr := WriteSecret(encoder, LocalSecret(), opts); secretErr != nil {
+		return secretErr
+	}
 	return nil
 }
 

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -1563,14 +1563,14 @@ func objectMeta(name string, labels, annotations map[string]string, namespace st
 	}
 }
 
-// AddRegistry switchs the registry that an image is targetting.
+// AddRegistry switches the registry that an image is targeting, unless registry is blank
 func AddRegistry(registry string, imageName string) string {
+	if registry == "" {
+		return imageName
+	}
 	parts := strings.Split(imageName, "/")
 	if len(parts) == 3 {
 		parts = parts[1:]
 	}
-	if registry != "" {
-		return path.Join(registry, parts[0], parts[1])
-	}
-	return path.Join(parts[0], parts[1])
+	return path.Join(registry, parts[0], parts[1])
 }

--- a/src/server/pkg/deploy/assets/assets_test.go
+++ b/src/server/pkg/deploy/assets/assets_test.go
@@ -1,0 +1,13 @@
+package assets
+
+import (
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+)
+
+func TestAddRegistry_NoSlash(t *testing.T) {
+	imageName := "busybox"
+	img := AddRegistry("", imageName)
+	require.Equal(t, imageName, img)
+}

--- a/src/server/pkg/deploy/assets/assets_test.go
+++ b/src/server/pkg/deploy/assets/assets_test.go
@@ -1,6 +1,7 @@
 package assets
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -10,4 +11,28 @@ func TestAddRegistry_NoSlash(t *testing.T) {
 	imageName := "busybox"
 	img := AddRegistry("", imageName)
 	require.Equal(t, imageName, img)
+}
+
+func TestAddRegistry_OneSlash(t *testing.T) {
+	imageName := "library/busybox"
+	img := AddRegistry("", imageName)
+	require.Equal(t, imageName, img)
+}
+
+func TestAddRegistry_WithRegistry(t *testing.T) {
+	imageName := "library/busybox"
+	registry := "example.com"
+	expected := fmt.Sprintf("%s/%s", registry, imageName)
+	img := AddRegistry(registry, imageName)
+	require.Equal(t, expected, img)
+}
+
+func TestAddRegistry_SwitchRegistry(t *testing.T) {
+	imageTag := "library/busybox"
+	originalRegistry := "example.org"
+	imageName := fmt.Sprintf("%s/%s", originalRegistry, imageTag)
+	registry := "example.com"
+	expected := fmt.Sprintf("%s/%s", registry, imageTag)
+	img := AddRegistry(registry, imageName)
+	require.Equal(t, expected, img)
 }


### PR DESCRIPTION
Aside from the bad news in #3457 this bad behavior is now blowing up jobs that are running my locally built images, too:

```console
$ k get -o yaml pods -l app=pachd | grep -A1 WORKER_IMAGE
      - name: WORKER_IMAGE
        value: 772228263286.dkr.ecr.us-west-2.amazonaws.com/forks/pachyderm:worker-2e80a33d8c3f041105979f907174ffd7e18b4a53
## ... launch pipeline
$ k get -o yaml pods -l pipelineName | grep image:
    - image: 772228263286.dkr.ecr.us-west-2.amazonaws.com/forks/pachyderm:pachd-2e80a33d8c3f041105979f907174ffd7e18b4a53
    - image: forks/pachyderm:worker-2e80a33d8c3f041105979f907174ffd7e18b4a53
```
one can see that it cheerfully nuked the AWS registry, leaving only the repo-less path, causing `ErrImagePull`