### PR TITLE
Lower log level for implicit port forwarding

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -322,11 +322,11 @@ func portForwarder() *PortForwarder {
 	// `pachctl port-forward` should be explicitly called.
 	fw, err := NewPortForwarder("", ioutil.Discard, os.Stderr)
 	if err != nil {
-		log.Errorf("Implicit port forwarding was not enabled because the kubernetes config could not be read: %v", err)
+		log.Debugf("Implicit port forwarding was not enabled because the kubernetes config could not be read: %v", err)
 		return nil
 	}
 	if err = fw.Lock(); err != nil {
-		log.Warningf("Implicit port forwarding was not enabled because the pidfile could not be written to. Most likely this means that port forwarding is running in another instance of `pachctl`: %v", err)
+		log.Debugf("Implicit port forwarding was not enabled because the pidfile could not be written to. Most likely this means that port forwarding is running in another instance of `pachctl`: %v", err)
 		return nil
 	}
 
@@ -342,7 +342,7 @@ func portForwarder() *PortForwarder {
 
 	if err = eg.Wait(); err != nil {
 		fw.Close()
-		log.Errorf("Implicit port forwarding was not enabled because of an error: %v", err)
+		log.Debugf("Implicit port forwarding was not enabled because of an error: %v", err)
 		return nil
 	}
 


### PR DESCRIPTION
If the user has not disabled implicit port forwarding (either by setting `PACHD_ADDRESS` or by using `--no-port-forwarding`), there's a variety of ways in which implicit port forwarding can fail even though there's no actual issue:

1) They could be running explicit port forwarding (`pachctl port-forward`)
2) The k8s config may be stored in a non-default location (e.g., microk8s)
3) The cluster may be running locally (e.g., microk8s)
4) Port forwarding may be running through some other means (openshift)

Because of this, this PR lowers the log level for implicit port forwarding-related issues to debug.