### PR TITLE
Cleanup pachctl logs

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -30,6 +30,7 @@ import (
 	deploycmds "github.com/pachyderm/pachyderm/src/server/pkg/deploy/cmds"
 	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 	ppscmds "github.com/pachyderm/pachyderm/src/server/pps/cmds"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -153,14 +154,14 @@ Environment variables:
   PACHD_ADDRESS=<host>:<port>, the pachd server to connect to (e.g. 127.0.0.1:30650).
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			log.SetFormatter(new(prefixed.TextFormatter))
+
 			if !verbose {
+				log.SetLevel(log.ErrorLevel)
 				// Silence grpc logs
-				l := log.New()
-				l.Level = log.FatalLevel
 				grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 			} else {
 				log.SetLevel(log.DebugLevel)
-
 				// etcd overrides grpc's logs--there's no way to enable one without
 				// enabling both.
 				// Error and warning logs are discarded because they will be

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -162,12 +162,15 @@ Environment variables:
 				log.SetLevel(log.DebugLevel)
 
 				// etcd overrides grpc's logs--there's no way to enable one without
-				// enabling both
+				// enabling both.
+				// Error and warning logs are discarded because they will be
+				// redundantly sent to the info logger. See:
+				// https://godoc.org/google.golang.org/grpc/grpclog#NewLoggerV2
 				logger := log.StandardLogger()
 				etcd.SetLogger(grpclog.NewLoggerV2(
-					logutil.NewInfoWriter(logger, "etcd/grpc:"),
-					logutil.NewWarningWriter(logger, "etcd/grpc:"),
-					logutil.NewErrorWriter(logger, "etcd/grpc:"),
+					logutil.NewGRPCLogWriter(logger, "etcd/grpc"),
+					ioutil.Discard,
+					ioutil.Discard,
 				))
 			}
 

--- a/src/server/pkg/log/log.go
+++ b/src/server/pkg/log/log.go
@@ -271,3 +271,63 @@ func Pretty(entry *logrus.Entry) ([]byte, error) {
 	serialized = append(serialized, '\n')
 	return serialized, nil
 }
+
+// InfoWriter implements `io.Writer`. You can use this in places that work
+// with the stdlib logger (or just general `io.Writer`s) to proxy messages to
+// a logrus logger with an info level. 
+type InfoWriter struct {
+	logger *logrus.Logger
+	prefix string
+}
+
+func NewInfoWriter(logger *logrus.Logger, prefix string) *InfoWriter {
+	return &InfoWriter{
+		logger: logger,
+		prefix: prefix,
+	}
+}
+
+func (l *InfoWriter) Write(p []byte) (int, error) {
+	l.logger.Infof("%s%s", l.prefix, p)
+	return len(p), nil
+}
+
+// WarningWriter implements `io.Writer`. You can use this in places that work
+// with the stdlib logger (or just general `io.Writer`s) to proxy messages to
+// a logrus logger with a warning level. 
+type WarningWriter struct {
+	logger *logrus.Logger
+	prefix string
+}
+
+func NewWarningWriter(logger *logrus.Logger, prefix string) *WarningWriter {
+	return &WarningWriter{
+		logger: logger,
+		prefix: prefix,
+	}
+}
+
+func (l *WarningWriter) Write(p []byte) (int, error) {
+	l.logger.Warningf("%s%s", l.prefix, p)
+	return len(p), nil
+}
+
+// ErrorWriter implements `io.Writer`. You can use this in places that work
+// with the stdlib logger (or just general `io.Writer`s) to proxy messages to
+// a logrus logger with an error level. 
+type ErrorWriter struct {
+	logger *logrus.Logger
+	prefix string
+}
+
+func NewErrorWriter(logger *logrus.Logger, prefix string) *ErrorWriter {
+	return &ErrorWriter{
+		logger: logger,
+		prefix: prefix,
+	}
+}
+
+func (l *ErrorWriter) Write(p []byte) (int, error) {
+	l.logger.Errorf("%s%s", l.prefix, p)
+	return len(p), nil
+}

--- a/src/server/pkg/log/log.go
+++ b/src/server/pkg/log/log.go
@@ -281,6 +281,9 @@ type GRPCLogWriter struct {
 	source string
 }
 
+// NewGRPCLogWriter creates a new GRPC log writer. `logger` specifies the
+// underlying logger, and `source` specifies where these logs are coming from;
+// it is added as a entry field for all log messages.
 func NewGRPCLogWriter(logger *logrus.Logger, source string) *GRPCLogWriter {
 	return &GRPCLogWriter{
 		logger: logger,

--- a/src/server/vendor/github.com/mgutz/ansi/LICENSE
+++ b/src/server/vendor/github.com/mgutz/ansi/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+Copyright (c) 2013 Mario L. Gutierrez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/src/server/vendor/github.com/mgutz/ansi/README.md
+++ b/src/server/vendor/github.com/mgutz/ansi/README.md
@@ -1,0 +1,121 @@
+# ansi
+
+Package ansi is a small, fast library to create ANSI colored strings and codes.
+
+## Install
+
+Get it
+
+```sh
+go get -u github.com/mgutz/ansi
+```
+
+## Example
+
+```go
+import "github.com/mgutz/ansi"
+
+// colorize a string, SLOW
+msg := ansi.Color("foo", "red+b:white")
+
+// create a FAST closure function to avoid computation of ANSI code
+phosphorize := ansi.ColorFunc("green+h:black")
+msg = phosphorize("Bring back the 80s!")
+msg2 := phospohorize("Look, I'm a CRT!")
+
+// cache escape codes and build strings manually
+lime := ansi.ColorCode("green+h:black")
+reset := ansi.ColorCode("reset")
+
+fmt.Println(lime, "Bring back the 80s!", reset)
+```
+
+Other examples
+
+```go
+Color(s, "red")            // red
+Color(s, "red+b")          // red bold
+Color(s, "red+B")          // red blinking
+Color(s, "red+u")          // red underline
+Color(s, "red+bh")         // red bold bright
+Color(s, "red:white")      // red on white
+Color(s, "red+b:white+h")  // red bold on white bright
+Color(s, "red+B:white+h")  // red blink on white bright
+Color(s, "off")            // turn off ansi codes
+```
+
+To view color combinations, from project directory in terminal.
+
+```sh
+go test
+```
+
+## Style format
+
+```go
+"foregroundColor+attributes:backgroundColor+attributes"
+```
+
+Colors
+
+* black
+* red
+* green
+* yellow
+* blue
+* magenta
+* cyan
+* white
+* 0...255 (256 colors)
+
+Foreground Attributes
+
+* B = Blink
+* b = bold
+* h = high intensity (bright)
+* i = inverse
+* s = strikethrough
+* u = underline
+
+Background Attributes
+
+* h = high intensity (bright)
+
+## Constants
+
+* ansi.Reset
+* ansi.DefaultBG
+* ansi.DefaultFG
+* ansi.Black
+* ansi.Red
+* ansi.Green
+* ansi.Yellow
+* ansi.Blue
+* ansi.Magenta
+* ansi.Cyan
+* ansi.White
+* ansi.LightBlack
+* ansi.LightRed
+* ansi.LightGreen
+* ansi.LightYellow
+* ansi.LightBlue
+* ansi.LightMagenta
+* ansi.LightCyan
+* ansi.LightWhite
+
+## References
+
+Wikipedia ANSI escape codes [Colors](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
+
+General [tips and formatting](http://misc.flogisoft.com/bash/tip_colors_and_formatting)
+
+What about support on Windows? Use [colorable by mattn](https://github.com/mattn/go-colorable).
+Ansi and colorable are used by [logxi](https://github.com/mgutz/logxi) to support logging in
+color on Windows.
+
+## MIT License
+
+Copyright (c) 2013 Mario Gutierrez mario@mgutz.com
+
+See the file LICENSE for copying permission.
+

--- a/src/server/vendor/github.com/mgutz/ansi/ansi.go
+++ b/src/server/vendor/github.com/mgutz/ansi/ansi.go
@@ -1,0 +1,285 @@
+package ansi
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	black = iota
+	red
+	green
+	yellow
+	blue
+	magenta
+	cyan
+	white
+	defaultt = 9
+
+	normalIntensityFG = 30
+	highIntensityFG   = 90
+	normalIntensityBG = 40
+	highIntensityBG   = 100
+
+	start         = "\033["
+	bold          = "1;"
+	blink         = "5;"
+	underline     = "4;"
+	inverse       = "7;"
+	strikethrough = "9;"
+
+	// Reset is the ANSI reset escape sequence
+	Reset = "\033[0m"
+	// DefaultBG is the default background
+	DefaultBG = "\033[49m"
+	// DefaultFG is the default foreground
+	DefaultFG = "\033[39m"
+)
+
+// Black FG
+var Black string
+
+// Red FG
+var Red string
+
+// Green FG
+var Green string
+
+// Yellow FG
+var Yellow string
+
+// Blue FG
+var Blue string
+
+// Magenta FG
+var Magenta string
+
+// Cyan FG
+var Cyan string
+
+// White FG
+var White string
+
+// LightBlack FG
+var LightBlack string
+
+// LightRed FG
+var LightRed string
+
+// LightGreen FG
+var LightGreen string
+
+// LightYellow FG
+var LightYellow string
+
+// LightBlue FG
+var LightBlue string
+
+// LightMagenta FG
+var LightMagenta string
+
+// LightCyan FG
+var LightCyan string
+
+// LightWhite FG
+var LightWhite string
+
+var (
+	plain = false
+	// Colors maps common color names to their ANSI color code.
+	Colors = map[string]int{
+		"black":   black,
+		"red":     red,
+		"green":   green,
+		"yellow":  yellow,
+		"blue":    blue,
+		"magenta": magenta,
+		"cyan":    cyan,
+		"white":   white,
+		"default": defaultt,
+	}
+)
+
+func init() {
+	for i := 0; i < 256; i++ {
+		Colors[strconv.Itoa(i)] = i
+	}
+
+	Black = ColorCode("black")
+	Red = ColorCode("red")
+	Green = ColorCode("green")
+	Yellow = ColorCode("yellow")
+	Blue = ColorCode("blue")
+	Magenta = ColorCode("magenta")
+	Cyan = ColorCode("cyan")
+	White = ColorCode("white")
+	LightBlack = ColorCode("black+h")
+	LightRed = ColorCode("red+h")
+	LightGreen = ColorCode("green+h")
+	LightYellow = ColorCode("yellow+h")
+	LightBlue = ColorCode("blue+h")
+	LightMagenta = ColorCode("magenta+h")
+	LightCyan = ColorCode("cyan+h")
+	LightWhite = ColorCode("white+h")
+}
+
+// ColorCode returns the ANSI color color code for style.
+func ColorCode(style string) string {
+	return colorCode(style).String()
+}
+
+// Gets the ANSI color code for a style.
+func colorCode(style string) *bytes.Buffer {
+	buf := bytes.NewBufferString("")
+	if plain || style == "" {
+		return buf
+	}
+	if style == "reset" {
+		buf.WriteString(Reset)
+		return buf
+	} else if style == "off" {
+		return buf
+	}
+
+	foregroundBackground := strings.Split(style, ":")
+	foreground := strings.Split(foregroundBackground[0], "+")
+	fgKey := foreground[0]
+	fg := Colors[fgKey]
+	fgStyle := ""
+	if len(foreground) > 1 {
+		fgStyle = foreground[1]
+	}
+
+	bg, bgStyle := "", ""
+
+	if len(foregroundBackground) > 1 {
+		background := strings.Split(foregroundBackground[1], "+")
+		bg = background[0]
+		if len(background) > 1 {
+			bgStyle = background[1]
+		}
+	}
+
+	buf.WriteString(start)
+	base := normalIntensityFG
+	if len(fgStyle) > 0 {
+		if strings.Contains(fgStyle, "b") {
+			buf.WriteString(bold)
+		}
+		if strings.Contains(fgStyle, "B") {
+			buf.WriteString(blink)
+		}
+		if strings.Contains(fgStyle, "u") {
+			buf.WriteString(underline)
+		}
+		if strings.Contains(fgStyle, "i") {
+			buf.WriteString(inverse)
+		}
+		if strings.Contains(fgStyle, "s") {
+			buf.WriteString(strikethrough)
+		}
+		if strings.Contains(fgStyle, "h") {
+			base = highIntensityFG
+		}
+	}
+
+	// if 256-color
+	n, err := strconv.Atoi(fgKey)
+	if err == nil {
+		fmt.Fprintf(buf, "38;5;%d;", n)
+	} else {
+		fmt.Fprintf(buf, "%d;", base+fg)
+	}
+
+	base = normalIntensityBG
+	if len(bg) > 0 {
+		if strings.Contains(bgStyle, "h") {
+			base = highIntensityBG
+		}
+		// if 256-color
+		n, err := strconv.Atoi(bg)
+		if err == nil {
+			fmt.Fprintf(buf, "48;5;%d;", n)
+		} else {
+			fmt.Fprintf(buf, "%d;", base+Colors[bg])
+		}
+	}
+
+	// remove last ";"
+	buf.Truncate(buf.Len() - 1)
+	buf.WriteRune('m')
+	return buf
+}
+
+// Color colors a string based on the ANSI color code for style.
+func Color(s, style string) string {
+	if plain || len(style) < 1 {
+		return s
+	}
+	buf := colorCode(style)
+	buf.WriteString(s)
+	buf.WriteString(Reset)
+	return buf.String()
+}
+
+// ColorFunc creates a closure to avoid computation ANSI color code.
+func ColorFunc(style string) func(string) string {
+	if style == "" {
+		return func(s string) string {
+			return s
+		}
+	}
+	color := ColorCode(style)
+	return func(s string) string {
+		if plain || s == "" {
+			return s
+		}
+		buf := bytes.NewBufferString(color)
+		buf.WriteString(s)
+		buf.WriteString(Reset)
+		result := buf.String()
+		return result
+	}
+}
+
+// DisableColors disables ANSI color codes. The default is false (colors are on).
+func DisableColors(disable bool) {
+	plain = disable
+	if plain {
+		Black = ""
+		Red = ""
+		Green = ""
+		Yellow = ""
+		Blue = ""
+		Magenta = ""
+		Cyan = ""
+		White = ""
+		LightBlack = ""
+		LightRed = ""
+		LightGreen = ""
+		LightYellow = ""
+		LightBlue = ""
+		LightMagenta = ""
+		LightCyan = ""
+		LightWhite = ""
+	} else {
+		Black = ColorCode("black")
+		Red = ColorCode("red")
+		Green = ColorCode("green")
+		Yellow = ColorCode("yellow")
+		Blue = ColorCode("blue")
+		Magenta = ColorCode("magenta")
+		Cyan = ColorCode("cyan")
+		White = ColorCode("white")
+		LightBlack = ColorCode("black+h")
+		LightRed = ColorCode("red+h")
+		LightGreen = ColorCode("green+h")
+		LightYellow = ColorCode("yellow+h")
+		LightBlue = ColorCode("blue+h")
+		LightMagenta = ColorCode("magenta+h")
+		LightCyan = ColorCode("cyan+h")
+		LightWhite = ColorCode("white+h")
+	}
+}

--- a/src/server/vendor/github.com/mgutz/ansi/doc.go
+++ b/src/server/vendor/github.com/mgutz/ansi/doc.go
@@ -1,0 +1,65 @@
+/*
+Package ansi is a small, fast library to create ANSI colored strings and codes.
+
+Installation
+
+    # this installs the color viewer and the package
+    go get -u github.com/mgutz/ansi/cmd/ansi-mgutz
+
+Example
+
+	// colorize a string, SLOW
+	msg := ansi.Color("foo", "red+b:white")
+
+	// create a closure to avoid recalculating ANSI code compilation
+	phosphorize := ansi.ColorFunc("green+h:black")
+	msg = phosphorize("Bring back the 80s!")
+	msg2 := phospohorize("Look, I'm a CRT!")
+
+	// cache escape codes and build strings manually
+	lime := ansi.ColorCode("green+h:black")
+	reset := ansi.ColorCode("reset")
+
+	fmt.Println(lime, "Bring back the 80s!", reset)
+
+Other examples
+
+	Color(s, "red")            // red
+	Color(s, "red+b")          // red bold
+	Color(s, "red+B")          // red blinking
+	Color(s, "red+u")          // red underline
+	Color(s, "red+bh")         // red bold bright
+	Color(s, "red:white")      // red on white
+	Color(s, "red+b:white+h")  // red bold on white bright
+	Color(s, "red+B:white+h")  // red blink on white bright
+
+To view color combinations, from terminal
+
+	ansi-mgutz
+
+Style format
+
+	"foregroundColor+attributes:backgroundColor+attributes"
+
+Colors
+
+	black
+	red
+	green
+	yellow
+	blue
+	magenta
+	cyan
+	white
+
+Attributes
+
+	b = bold foreground
+	B = Blink foreground
+	u = underline foreground
+	h = high intensity (bright) foreground, background
+	i = inverse
+
+Wikipedia ANSI escape codes [Colors](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
+*/
+package ansi

--- a/src/server/vendor/github.com/mgutz/ansi/print.go
+++ b/src/server/vendor/github.com/mgutz/ansi/print.go
@@ -1,0 +1,57 @@
+package ansi
+
+import (
+	"fmt"
+	"sort"
+
+	colorable "github.com/mattn/go-colorable"
+)
+
+// PrintStyles prints all style combinations to the terminal.
+func PrintStyles() {
+	// for compatibility with Windows, not needed for *nix
+	stdout := colorable.NewColorableStdout()
+
+	bgColors := []string{
+		"",
+		":black",
+		":red",
+		":green",
+		":yellow",
+		":blue",
+		":magenta",
+		":cyan",
+		":white",
+	}
+
+	keys := make([]string, 0, len(Colors))
+	for k := range Colors {
+		keys = append(keys, k)
+	}
+
+	sort.Sort(sort.StringSlice(keys))
+
+	for _, fg := range keys {
+		for _, bg := range bgColors {
+			fmt.Fprintln(stdout, padColor(fg, []string{"" + bg, "+b" + bg, "+bh" + bg, "+u" + bg}))
+			fmt.Fprintln(stdout, padColor(fg, []string{"+s" + bg, "+i" + bg}))
+			fmt.Fprintln(stdout, padColor(fg, []string{"+uh" + bg, "+B" + bg, "+Bb" + bg /* backgrounds */, "" + bg + "+h"}))
+			fmt.Fprintln(stdout, padColor(fg, []string{"+b" + bg + "+h", "+bh" + bg + "+h", "+u" + bg + "+h", "+uh" + bg + "+h"}))
+		}
+	}
+}
+
+func pad(s string, length int) string {
+	for len(s) < length {
+		s += " "
+	}
+	return s
+}
+
+func padColor(color string, styles []string) string {
+	buffer := ""
+	for _, style := range styles {
+		buffer += Color(pad(color+style, 20), color+style)
+	}
+	return buffer
+}

--- a/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/LICENSE
+++ b/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Denis Parchenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/Makefile
+++ b/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/Makefile
@@ -1,0 +1,19 @@
+NAME=logrus-prefixed-formatter
+PACKAGES=$(shell go list ./...)
+
+deps:
+	@echo "--> Installing dependencies"
+	@go get -d -v -t ./...
+
+test-deps:
+	@which ginkgo 2>/dev/null ; if [ $$? -eq 1 ]; then \
+		go get -u -v github.com/onsi/ginkgo/ginkgo; \
+	fi
+
+test: test-deps
+	@echo "--> Running tests"
+	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race
+
+format:
+	@echo "--> Running go fmt"
+	@go fmt $(PACKAGES)

--- a/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/README.md
+++ b/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/README.md
@@ -1,0 +1,116 @@
+# Logrus Prefixed Log Formatter
+[![Build Status](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg?branch=master)](https://travis-ci.org/x-cray/logrus-prefixed-formatter)
+
+[Logrus](https://github.com/sirupsen/logrus) formatter mainly based on original `logrus.TextFormatter` but with slightly
+modified colored output and support for log entry prefixes, e.g. message source followed by a colon. In addition, custom
+color themes are supported.
+
+![Formatter screenshot](http://cl.ly/image/1w0B3F233F3z/formatter-screenshot@2x.png)
+
+Just like with the original `logrus.TextFormatter` when a TTY is not attached, the output is compatible with the
+[logfmt](http://godoc.org/github.com/kr/logfmt) format:
+
+```text
+time="Oct 27 00:44:26" level=debug msg="Started observing beach" animal=walrus number=8
+time="Oct 27 00:44:26" level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+time="Oct 27 00:44:26" level=warning msg="The group's number increased tremendously!" number=122 omg=true
+time="Oct 27 00:44:26" level=debug msg="Temperature changes" temperature=-4
+time="Oct 27 00:44:26" level=panic msg="It's over 9000!" animal=orca size=9009
+time="Oct 27 00:44:26" level=fatal msg="The ice breaks!" number=100 omg=true
+exit status 1
+```
+
+## Installation
+To install formatter, use `go get`:
+
+```sh
+$ go get github.com/x-cray/logrus-prefixed-formatter
+```
+
+## Usage
+Here is how it should be used:
+
+```go
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+)
+
+var log = logrus.New()
+
+func init() {
+	log.Formatter = new(prefixed.TextFormatter)
+	log.Level = logrus.DebugLevel
+}
+
+func main() {
+	log.WithFields(logrus.Fields{
+		"prefix": "main",
+		"animal": "walrus",
+		"number": 8,
+	}).Debug("Started observing beach")
+
+	log.WithFields(logrus.Fields{
+		"prefix":      "sensor",
+		"temperature": -4,
+	}).Info("Temperature changes")
+}
+```
+
+## API
+`prefixed.TextFormatter` exposes the following fields and methods.
+
+### Fields
+
+* `ForceColors bool` — set to true to bypass checking for a TTY before outputting colors.
+* `DisableColors bool` — force disabling colors. For a TTY colors are enabled by default.
+* `DisableUppercase bool` — set to true to turn off the conversion of the log level names to uppercase.
+* `ForceFormatting bool` — force formatted layout, even for non-TTY output.
+* `DisableTimestamp bool` — disable timestamp logging. Useful when output is redirected to logging system that already adds timestamps.
+* `FullTimestamp bool` — enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.
+* `TimestampFormat string` — timestamp format to use for display when a full timestamp is printed.
+* `DisableSorting bool` — the fields are sorted by default for a consistent output. For applications that log extremely frequently and don't use the JSON formatter this may not be desired.
+* `QuoteEmptyFields bool` — wrap empty fields in quotes if true.
+* `QuoteCharacter string` — can be set to the override the default quoting character `"` with something else. For example: `'`, or `` ` ``.
+* `SpacePadding int` — pad msg field with spaces on the right for display. The value for this parameter will be the size of padding. Its default value is zero, which means no padding will be applied.
+
+### Methods
+
+#### `SetColorScheme(colorScheme *prefixed.ColorScheme)`
+
+Sets an alternative color scheme for colored output. `prefixed.ColorScheme` struct supports the following fields:
+* `InfoLevelStyle string` — info level style.
+* `WarnLevelStyle string` — warn level style.
+* `ErrorLevelStyle string` — error style.
+* `FatalLevelStyle string` — fatal level style.
+* `PanicLevelStyle string` — panic level style.
+* `DebugLevelStyle string` — debug level style.
+* `PrefixStyle string` — prefix style.
+* `TimestampStyle string` — timestamp style.
+
+Color styles should be specified using [mgutz/ansi](https://github.com/mgutz/ansi#style-format) style syntax. For example, here is the default theme:
+
+```go
+InfoLevelStyle:  "green",
+WarnLevelStyle:  "yellow",
+ErrorLevelStyle: "red",
+FatalLevelStyle: "red",
+PanicLevelStyle: "red",
+DebugLevelStyle: "blue",
+PrefixStyle:     "cyan",
+TimestampStyle:  "black+h"
+```
+
+It's not necessary to specify all colors when changing color scheme if you want to change just specific ones:
+
+```go
+formatter.SetColorScheme(&prefixed.ColorScheme{
+    PrefixStyle:    "blue+b",
+    TimestampStyle: "white+h",
+})
+```
+
+# License
+MIT

--- a/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/formatter.go
+++ b/src/server/vendor/github.com/x-cray/logrus-prefixed-formatter/formatter.go
@@ -1,0 +1,366 @@
+package prefixed
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/mgutz/ansi"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+const defaultTimestampFormat = time.RFC3339
+
+var (
+	baseTimestamp      time.Time    = time.Now()
+	defaultColorScheme *ColorScheme = &ColorScheme{
+		InfoLevelStyle:  "green",
+		WarnLevelStyle:  "yellow",
+		ErrorLevelStyle: "red",
+		FatalLevelStyle: "red",
+		PanicLevelStyle: "red",
+		DebugLevelStyle: "blue",
+		PrefixStyle:     "cyan",
+		TimestampStyle:  "black+h",
+	}
+	noColorsColorScheme *compiledColorScheme = &compiledColorScheme{
+		InfoLevelColor:  ansi.ColorFunc(""),
+		WarnLevelColor:  ansi.ColorFunc(""),
+		ErrorLevelColor: ansi.ColorFunc(""),
+		FatalLevelColor: ansi.ColorFunc(""),
+		PanicLevelColor: ansi.ColorFunc(""),
+		DebugLevelColor: ansi.ColorFunc(""),
+		PrefixColor:     ansi.ColorFunc(""),
+		TimestampColor:  ansi.ColorFunc(""),
+	}
+	defaultCompiledColorScheme *compiledColorScheme = compileColorScheme(defaultColorScheme)
+)
+
+func miniTS() int {
+	return int(time.Since(baseTimestamp) / time.Second)
+}
+
+type ColorScheme struct {
+	InfoLevelStyle  string
+	WarnLevelStyle  string
+	ErrorLevelStyle string
+	FatalLevelStyle string
+	PanicLevelStyle string
+	DebugLevelStyle string
+	PrefixStyle     string
+	TimestampStyle  string
+}
+
+type compiledColorScheme struct {
+	InfoLevelColor  func(string) string
+	WarnLevelColor  func(string) string
+	ErrorLevelColor func(string) string
+	FatalLevelColor func(string) string
+	PanicLevelColor func(string) string
+	DebugLevelColor func(string) string
+	PrefixColor     func(string) string
+	TimestampColor  func(string) string
+}
+
+type TextFormatter struct {
+	// Set to true to bypass checking for a TTY before outputting colors.
+	ForceColors bool
+
+	// Force disabling colors. For a TTY colors are enabled by default.
+	DisableColors bool
+
+	// Force formatted layout, even for non-TTY output.
+	ForceFormatting bool
+
+	// Disable timestamp logging. useful when output is redirected to logging
+	// system that already adds timestamps.
+	DisableTimestamp bool
+
+	// Disable the conversion of the log levels to uppercase
+	DisableUppercase bool
+
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
+
+	// Timestamp format to use for display when a full timestamp is printed.
+	TimestampFormat string
+
+	// The fields are sorted by default for a consistent output. For applications
+	// that log extremely frequently and don't use the JSON formatter this may not
+	// be desired.
+	DisableSorting bool
+
+	// Wrap empty fields in quotes if true.
+	QuoteEmptyFields bool
+
+	// Can be set to the override the default quoting character "
+	// with something else. For example: ', or `.
+	QuoteCharacter string
+
+	// Pad msg field with spaces on the right for display.
+	// The value for this parameter will be the size of padding.
+	// Its default value is zero, which means no padding will be applied for msg.
+	SpacePadding int
+
+	// Color scheme to use.
+	colorScheme *compiledColorScheme
+
+	// Whether the logger's out is to a terminal.
+	isTerminal bool
+
+	sync.Once
+}
+
+func getCompiledColor(main string, fallback string) func(string) string {
+	var style string
+	if main != "" {
+		style = main
+	} else {
+		style = fallback
+	}
+	return ansi.ColorFunc(style)
+}
+
+func compileColorScheme(s *ColorScheme) *compiledColorScheme {
+	return &compiledColorScheme{
+		InfoLevelColor:  getCompiledColor(s.InfoLevelStyle, defaultColorScheme.InfoLevelStyle),
+		WarnLevelColor:  getCompiledColor(s.WarnLevelStyle, defaultColorScheme.WarnLevelStyle),
+		ErrorLevelColor: getCompiledColor(s.ErrorLevelStyle, defaultColorScheme.ErrorLevelStyle),
+		FatalLevelColor: getCompiledColor(s.FatalLevelStyle, defaultColorScheme.FatalLevelStyle),
+		PanicLevelColor: getCompiledColor(s.PanicLevelStyle, defaultColorScheme.PanicLevelStyle),
+		DebugLevelColor: getCompiledColor(s.DebugLevelStyle, defaultColorScheme.DebugLevelStyle),
+		PrefixColor:     getCompiledColor(s.PrefixStyle, defaultColorScheme.PrefixStyle),
+		TimestampColor:  getCompiledColor(s.TimestampStyle, defaultColorScheme.TimestampStyle),
+	}
+}
+
+func (f *TextFormatter) init(entry *logrus.Entry) {
+	if len(f.QuoteCharacter) == 0 {
+		f.QuoteCharacter = "\""
+	}
+	if entry.Logger != nil {
+		f.isTerminal = f.checkIfTerminal(entry.Logger.Out)
+	}
+}
+
+func (f *TextFormatter) checkIfTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
+func (f *TextFormatter) SetColorScheme(colorScheme *ColorScheme) {
+	f.colorScheme = compileColorScheme(colorScheme)
+}
+
+func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	var keys []string = make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+	lastKeyIdx := len(keys) - 1
+
+	if !f.DisableSorting {
+		sort.Strings(keys)
+	}
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	prefixFieldClashes(entry.Data)
+
+	f.Do(func() { f.init(entry) })
+
+	isFormatted := f.ForceFormatting || f.isTerminal
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = defaultTimestampFormat
+	}
+	if isFormatted {
+		isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
+		var colorScheme *compiledColorScheme
+		if isColored {
+			if f.colorScheme == nil {
+				colorScheme = defaultCompiledColorScheme
+			} else {
+				colorScheme = f.colorScheme
+			}
+		} else {
+			colorScheme = noColorsColorScheme
+		}
+		f.printColored(b, entry, keys, timestampFormat, colorScheme)
+	} else {
+		if !f.DisableTimestamp {
+			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat), true)
+		}
+		f.appendKeyValue(b, "level", entry.Level.String(), true)
+		if entry.Message != "" {
+			f.appendKeyValue(b, "msg", entry.Message, lastKeyIdx >= 0)
+		}
+		for i, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key], lastKeyIdx != i)
+		}
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys []string, timestampFormat string, colorScheme *compiledColorScheme) {
+	var levelColor func(string) string
+	var levelText string
+	switch entry.Level {
+	case logrus.InfoLevel:
+		levelColor = colorScheme.InfoLevelColor
+	case logrus.WarnLevel:
+		levelColor = colorScheme.WarnLevelColor
+	case logrus.ErrorLevel:
+		levelColor = colorScheme.ErrorLevelColor
+	case logrus.FatalLevel:
+		levelColor = colorScheme.FatalLevelColor
+	case logrus.PanicLevel:
+		levelColor = colorScheme.PanicLevelColor
+	default:
+		levelColor = colorScheme.DebugLevelColor
+	}
+
+	if entry.Level != logrus.WarnLevel {
+		levelText = entry.Level.String()
+	} else {
+		levelText = "warn"
+	}
+
+	if !f.DisableUppercase {
+		levelText = strings.ToUpper(levelText)
+	}
+
+	level := levelColor(fmt.Sprintf("%5s", levelText))
+	prefix := ""
+	message := entry.Message
+
+	if prefixValue, ok := entry.Data["prefix"]; ok {
+		prefix = colorScheme.PrefixColor(" " + prefixValue.(string) + ":")
+	} else {
+		prefixValue, trimmedMsg := extractPrefix(entry.Message)
+		if len(prefixValue) > 0 {
+			prefix = colorScheme.PrefixColor(" " + prefixValue + ":")
+			message = trimmedMsg
+		}
+	}
+
+	messageFormat := "%s"
+	if f.SpacePadding != 0 {
+		messageFormat = fmt.Sprintf("%%-%ds", f.SpacePadding)
+	}
+
+	if f.DisableTimestamp {
+		fmt.Fprintf(b, "%s%s "+messageFormat, level, prefix, message)
+	} else {
+		var timestamp string
+		if !f.FullTimestamp {
+			timestamp = fmt.Sprintf("[%04d]", miniTS())
+		} else {
+			timestamp = fmt.Sprintf("[%s]", entry.Time.Format(timestampFormat))
+		}
+		fmt.Fprintf(b, "%s %s%s "+messageFormat, colorScheme.TimestampColor(timestamp), level, prefix, message)
+	}
+	for _, k := range keys {
+		if k != "prefix" {
+			v := entry.Data[k]
+			fmt.Fprintf(b, " %s=%+v", levelColor(k), v)
+		}
+	}
+}
+
+func (f *TextFormatter) needsQuoting(text string) bool {
+	if f.QuoteEmptyFields && len(text) == 0 {
+		return true
+	}
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.') {
+			return true
+		}
+	}
+	return false
+}
+
+func extractPrefix(msg string) (string, string) {
+	prefix := ""
+	regex := regexp.MustCompile("^\\[(.*?)\\]")
+	if regex.MatchString(msg) {
+		match := regex.FindString(msg)
+		prefix, msg = match[1:len(match)-1], strings.TrimSpace(msg[len(match):])
+	}
+	return prefix, msg
+}
+
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}, appendSpace bool) {
+	b.WriteString(key)
+	b.WriteByte('=')
+	f.appendValue(b, value)
+
+	if appendSpace {
+		b.WriteByte(' ')
+	}
+}
+
+func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
+	switch value := value.(type) {
+	case string:
+		if !f.needsQuoting(value) {
+			b.WriteString(value)
+		} else {
+			fmt.Fprintf(b, "%s%v%s", f.QuoteCharacter, value, f.QuoteCharacter)
+		}
+	case error:
+		errmsg := value.Error()
+		if !f.needsQuoting(errmsg) {
+			b.WriteString(errmsg)
+		} else {
+			fmt.Fprintf(b, "%s%v%s", f.QuoteCharacter, errmsg, f.QuoteCharacter)
+		}
+	default:
+		fmt.Fprint(b, value)
+	}
+}
+
+// This is to not silently overwrite `time`, `msg` and `level` fields when
+// dumping it. If this code wasn't there doing:
+//
+//  logrus.WithField("level", 1).Info("hello")
+//
+// would just silently drop the user provided level. Instead with this code
+// it'll be logged as:
+//
+//  {"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
+func prefixFieldClashes(data logrus.Fields) {
+	if t, ok := data["time"]; ok {
+		data["fields.time"] = t
+	}
+
+	if m, ok := data["msg"]; ok {
+		data["fields.msg"] = m
+	}
+
+	if l, ok := data["level"]; ok {
+		data["fields.level"] = l
+	}
+}

--- a/src/server/vendor/vendor.json
+++ b/src/server/vendor/vendor.json
@@ -1109,6 +1109,12 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
+			"checksumSHA1": "CIK3BBNX3nuUQCmNqTQydNfMNKI=",
+			"path": "github.com/mgutz/ansi",
+			"revision": "9520e82c474b0a04dd04f8a40959027271bab992",
+			"revisionTime": "2017-02-06T15:57:36Z"
+		},
+		{
 			"checksumSHA1": "q8VfSvQ6fZY+QwtlMPtQsJrNews=",
 			"path": "github.com/minio/go-homedir",
 			"revision": "a7ee80e4c344cab722502d3f074c5b7245d0bbe7",
@@ -1469,6 +1475,12 @@
 			"path": "github.com/willf/bloom",
 			"revision": "54e3b963ee1652b06c4562cb9b6020ebc6e36e59",
 			"revisionTime": "2017-05-05T22:16:40Z"
+		},
+		{
+			"checksumSHA1": "L1vKtjhZ2Lej0kfsLaTUm7ps/Yg=",
+			"path": "github.com/x-cray/logrus-prefixed-formatter",
+			"revision": "bb2702d423886830dee131692131d35648c382e2",
+			"revisionTime": "2017-07-31T09:11:26Z"
 		},
 		{
 			"checksumSHA1": "iHiMTBffQvWYlOLu3130JXuQpgQ=",


### PR DESCRIPTION
This cleans up logs produced by pachctl itself:

1) gRPC and etcd logs are proxied through logrus.
2) Fixed a bug where, when verbose output was not set, we set the log level to fatal on an unused logger, rather than the default logger. **I have also reduced the log level for non-verbose output to be error instead of fatal - this seems like a better default to me, but let me know if I should keep it at a fatal level.**
3) Enabling verbose output used to just enable logging for etcd/grpc. Now, in addition to that, it also decreases the log level such that all log messages to the standard logger are output.
4) Added a lib to make the logs a little better looking than the default.

Here's what the logs now look like when listing repos with verbose output:

<img width="712" alt="screen shot 2019-02-18 at 1 48 04 pm" src="https://user-images.githubusercontent.com/127386/52971028-ece9fa00-3383-11e9-9e9b-d7bcc947d37a.png">

Fixes #3497