### PR TITLE
Use 'ag' in enterprise-code-checkin-test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,10 @@ docker-push-test:
 docker-wait-pachd:
 	etc/compile/wait.sh pachd_compile
 
-docker-build-helper: enterprise-code-checkin-test docker-build-worker docker-build-pachd docker-wait-worker docker-wait-pachd
+docker-build-helper: enterprise-code-checkin-test
+	@# run these in separate make process so that if
+	@# 'enterprise-code-checkin-test' fails, the rest of the build process aborts
+	@make docker-build-worker docker-build-pachd docker-wait-worker docker-wait-pachd
 
 docker-build:
 	docker pull $(COMPILE_IMAGE)
@@ -436,9 +439,10 @@ local-test: docker-build launch-dev test-pfs clean-launch-dev
 test: clean-launch-dev launch-dev lint enterprise-code-checkin-test docker-build test-pfs-server test-pfs-cmds test-deploy-cmds test-libs test-vault test-auth test-enterprise test-worker test-admin test-pps
 
 enterprise-code-checkin-test:
+	which ag
 	# Check if our test activation code is anywhere in the repo
 	@echo "Files containing test Pachyderm Enterprise activation token:"; \
-	if grep --files-with-matches --exclude=Makefile --exclude-from=.gitignore -r -e 'RM2o1Qit6YlZhS1RGdXVac' . ; \
+	if ag --ignore=Makefile -p .gitignore 'RM2o1Qit6YlZhS1RGdXVac'; \
 	then \
 	  $$( which echo ) -e "\n*** It looks like Pachyderm Engineering's test activation code may be in this repo. Please remove it before committing! ***\n"; \
 	  false; \

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ local-test: docker-build launch-dev test-pfs clean-launch-dev
 test: clean-launch-dev launch-dev lint enterprise-code-checkin-test docker-build test-pfs-server test-pfs-cmds test-deploy-cmds test-libs test-vault test-auth test-enterprise test-worker test-admin test-pps
 
 enterprise-code-checkin-test:
-	which ag
+	@which ag || { printf "'ag' not found. Run:\n  sudo apt-get install -y silversearcher-ag\n  brew install the_silver_searcher\nto install it\n\n"; exit 1; }
 	# Check if our test activation code is anywhere in the repo
 	@echo "Files containing test Pachyderm Enterprise activation token:"; \
 	if ag --ignore=Makefile -p .gitignore 'RM2o1Qit6YlZhS1RGdXVac'; \

--- a/etc/testing/travis_before_install.sh
+++ b/etc/testing/travis_before_install.sh
@@ -5,6 +5,7 @@ set -ex
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -s devicemapper"' | tee /etc/default/docker > /dev/null
 
 # Install jq and ag
+sudo apt-get update -y
 sudo apt-get install jq silversearcher-ag
 
 # Install fuse

--- a/etc/testing/travis_before_install.sh
+++ b/etc/testing/travis_before_install.sh
@@ -5,7 +5,7 @@ set -ex
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -s devicemapper"' | tee /etc/default/docker > /dev/null
 
 # Install jq and ag
-sudo apt-get install jq ag
+sudo apt-get install jq silversearcher-ag
 
 # Install fuse
 apt-get install -qq pkg-config fuse

--- a/etc/testing/travis_before_install.sh
+++ b/etc/testing/travis_before_install.sh
@@ -4,8 +4,8 @@ set -ex
 
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -s devicemapper"' | tee /etc/default/docker > /dev/null
 
-# Install jq
-sudo apt-get install jq
+# Install jq and ag
+sudo apt-get install jq ag
 
 # Install fuse
 apt-get install -qq pkg-config fuse


### PR DESCRIPTION
Two changes:
- `enterprise-code-checkin-test` now kills builds if it fails (currently, `make` exits with a non-zero exit code but still runs the entire build, and the output of enterprise-code-checkin-test is often buried)
- `enterprise-code-checkin-test` should work on mac (uses `ag` instead of `grep --exclude-from`)