### PR TITLE
Strip any gs:// prefix from GCS buckets

### DIFF
--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -255,7 +255,8 @@ func DeployCmd(noMetrics *bool, noPortForwarding *bool) *cobra.Command {
 				}
 				cred = string(credBytes)
 			}
-			if err = assets.WriteGoogleAssets(manifest, opts, args[0], cred, volumeSize); err != nil {
+			bucket := strings.TrimPrefix(args[0], "gs://")
+			if err = assets.WriteGoogleAssets(manifest, opts, bucket, cred, volumeSize); err != nil {
 				return err
 			}
 			return kubectlCreate(dryRun, manifest, opts, metrics)

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -437,7 +437,9 @@ func DeployCmd(noMetrics *bool, noPortForwarding *bool) *cobra.Command {
 				return fmt.Errorf("volume size needs to be an integer; instead got %v", args[3])
 			}
 			manifest := getEncoder(outputFormat)
-			if err = assets.WriteMicrosoftAssets(manifest, opts, args[0], args[1], args[2], volumeSize); err != nil {
+			container := strings.TrimPrefix(args[0], "wasb://")
+			accountName, accountKey := args[1], args[2]
+			if err = assets.WriteMicrosoftAssets(manifest, opts, container, accountName, accountKey, volumeSize); err != nil {
 				return err
 			}
 			return kubectlCreate(dryRun, manifest, opts, metrics)


### PR DESCRIPTION
This is similar to how we handle the `s3://` prefix for S3 buckets

(tested manually)