### PR TITLE
Remove .rgignore

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,5 +1,0 @@
-**/vendor/**
-*.pb.go
-*.ipynb
-examples/jupyter_notebook/weather_data
-examples/jupyter_notebook/citibike_data


### PR DESCRIPTION
`.rgignore` is used for ripgrep. Now that [silver searcher](https://github.com/pachyderm/pachyderm/pull/3503) is a requirement for dev work, it seems like overkill to also have support for ripgrep.