### PR TITLE
Add rm to 'docker run' in pfs test

### DIFF
--- a/etc/testing/pfs_server.sh
+++ b/etc/testing/pfs_server.sh
@@ -7,6 +7,7 @@ export TIMEOUT=$2
 # If etcd is not available, start it in a docker container
 if ! ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 get "testkey"; then
     docker run \
+        --rm \
         --publish 32379:2379 \
         --ulimit nofile=2048 \
         $ETCD_IMAGE \

--- a/etc/testing/pfs_server.sh
+++ b/etc/testing/pfs_server.sh
@@ -5,7 +5,7 @@ export ETCD_IMAGE=$1
 export TIMEOUT=$2
 
 # If etcd is not available, start it in a docker container
-if ! ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 get "testkey"; then
+if ! ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:32379 get "testkey"; then
     docker run \
         --rm \
         --publish 32379:2379 \

--- a/etc/testing/travis_before_install.sh
+++ b/etc/testing/travis_before_install.sh
@@ -44,9 +44,9 @@ fi
 
 # Install etcdctl
 # To get the latest etcd version:
-# curl -s https://api.github.com/repos/coreos/etcd/releases | jq -r .[].tag_name | sort | tail -n1
+# curl -Ls https://api.github.com/repos/etcd-io/etcd/releases | jq -r .[].tag_name
 if [ ! -f ~/cached-deps/etcdctl ] ; then
-    ETCD_VERSION=v3.3.6
+    ETCD_VERSION=v3.3.12
     curl -L https://storage.googleapis.com/etcd/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | \
         tar xzf - --strip-components=1 && \
         mv ./etcdctl ~/cached-deps/etcdctl


### PR DESCRIPTION
This causes the container to automatically be deleted when it exits, which makes it possible to run `make test-pfs-server` many times in a row without having to delete the docker container in between

Also:
- The `etcdctl` check at the beginning of `etc/testing/pfs_server.sh` now uses the right localhost port (`32379`, like the test, instead of `2379`, which is the port inside the container)
- The comment in `etc/testing/pfs_server.sh` for getting the latest etcd version is slightly more useful
- Upgrade the version of etcdctl we use