### PR TITLE
Undeploy confirmation check

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -335,13 +335,14 @@ This resets the cluster to its initial state.`,
 			for _, pi := range pipelineInfos {
 				pipelines = append(pipelines, red(pi.Pipeline.Name))
 			}
-			fmt.Printf("Are you sure you want to delete all ACLs, repos, commits, files, pipelines and jobs?\nyN\n")
+			fmt.Println("All ACLs, repos, commits, files, pipelines and jobs will be deleted.")
 			if len(repos) > 0 {
 				fmt.Printf("Repos to delete: %s\n", strings.Join(repos, ", "))
 			}
 			if len(pipelines) > 0 {
 				fmt.Printf("Pipelines to delete: %s\n", strings.Join(pipelines, ", "))
 			}
+			fmt.Println("Are you sure you want to do this? (y/n):")
 			r := bufio.NewReader(os.Stdin)
 			bytes, err := r.ReadBytes('\n')
 			if err != nil {

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -673,42 +673,40 @@ flag), the underlying volumes will be removed, making metadata such repos,
 commits, pipelines, and jobs unrecoverable. If your persistent volume was
 manually provisioned (i.e. if you used the "--static-etcd-volume" flag), the
 underlying volume will not be removed.
-
-Are you sure you want to proceed? yN
 `)
-				r := bufio.NewReader(os.Stdin)
-				bytes, err := r.ReadBytes('\n')
-				if err != nil {
-					return err
+			}
+			fmt.Println("Are you sure you want to do this? (y/n):")
+			r := bufio.NewReader(os.Stdin)
+			bytes, err := r.ReadBytes('\n')
+			if err != nil {
+				return err
+			}
+			if bytes[0] == 'y' || bytes[0] == 'Y' {
+				io := cmdutil.IO{
+					Stdout: os.Stdout,
+					Stderr: os.Stderr,
 				}
-				if !(bytes[0] == 'y' || bytes[0] == 'Y') {
-					return nil
+				assets := []string{
+					"service",
+					"replicationcontroller",
+					"deployment",
+					"serviceaccount",
+					"secret",
+					"statefulset",
+					"clusterrole",
+					"clusterrolebinding",
 				}
-			}
-			io := cmdutil.IO{
-				Stdout: os.Stdout,
-				Stderr: os.Stderr,
-			}
-			assets := []string{
-				"service",
-				"replicationcontroller",
-				"deployment",
-				"serviceaccount",
-				"secret",
-				"statefulset",
-				"clusterrole",
-				"clusterrolebinding",
-			}
-			if all {
-				assets = append(assets, []string{
-					"storageclass",
-					"persistentvolumeclaim",
-					"persistentvolume",
-				}...)
-			}
-			for _, asset := range assets {
-				if err := cmdutil.RunIO(io, "kubectl", "delete", asset, "-l", "suite=pachyderm", "--namespace", namespace); err != nil {
-					return err
+				if all {
+					assets = append(assets, []string{
+						"storageclass",
+						"persistentvolumeclaim",
+						"persistentvolume",
+					}...)
+				}
+				for _, asset := range assets {
+					if err := cmdutil.RunIO(io, "kubectl", "delete", asset, "-l", "suite=pachyderm", "--namespace", namespace); err != nil {
+						return err
+					}
 				}
 			}
 			return nil


### PR DESCRIPTION
Two changes:

* Always ask for confirmation when running `pachctl undeploy` - fixes #3369.
* Changed the prompt for `pachctl delete-all` to have the `(y/n)` bit at the very end of the message, which is a bit more conventional.