### PR TITLE
Fix in-cluster testing harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 LABEL maintainer="jdoliner@pachyderm.io"
 
 RUN \

--- a/etc/compile/compile_test.sh
+++ b/etc/compile/compile_test.sh
@@ -2,16 +2,26 @@
 
 set -Ee
 
-DIR="$(cd "$(dirname "${0}")/../.." && pwd)"
-cd "${DIR}"
+# Builds a docker container that is just golang + docker client
+if [ "${1}" = "--make-env" ]; then
+	docker build -t pachyderm_test_buildenv - <<EOF
+FROM golang:1.11.1
+RUN curl -fsSL https://get.docker.com/builds/Linux/x86_64/docker-1.12.1.tgz \
+  | tar -C /bin -xz docker/docker --strip-components=1 \
+ && chmod +x /bin/docker
+EOF
+  exit 0
+fi
 
-mkdir -p _tmp
+# Runs inside docker container built above -- compiles pachyderm test
+rm -rf ./_tmp/*
+echo "Building test"
 go test \
-  -c -o _tmp/test \
+  -c -o /go/src/github.com/pachyderm/pachyderm/_tmp/test \
   ./src/server
 
 cp Dockerfile.test _tmp/Dockerfile
 cp etc/testing/artifacts/giphy.gif _tmp/
 docker build -t pachyderm_test _tmp
-docker tag pachyderm_test:latest pachyderm/test:latest
-docker tag pachyderm_test:latest pachyderm/test:local
+docker tag pachyderm_test pachyderm/test:latest
+docker tag pachyderm_test pachyderm/test:local


### PR DESCRIPTION
While working on tracing, I tried to run `make launch-dev-test` and found that it didn't work for me. I got it working so that I could keep working on tracing, and this PR pulls what I had in my tracing branch into its own PR.

Because I was focused on tracing, though, it's fairly unprincipled; e.g. it builds the test using a slightly different docker image than the one used to build pachd, the docker image is created by `etc/compile/compile_test.sh` etc.) I'm very open to alternative approaches