### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Keep up to date and get Pachyderm support via:
 
 To get started, sign the [Contributor License Agreement](https://pachyderm.wufoo.com/forms/pachyderm-contributor-license-agreement).
 
-You should also check out our [contributing guide](./contributing).
+You should also check out our [contributing guide](./doc/contributing).
 
 Send us PRs, we would love to see what you do! You can also check our GH issues for things labeled "help-wanted" as a good place to start. We're sometimes bad about keeping that label up-to-date, so if you don't see any, just let us know.
 


### PR DESCRIPTION
The link in `README.md` to the "contributing" docs has been broken for a few months - point it to the new location.