### PR TITLE
Fix some typos in docs and strings

### DIFF
--- a/doc/contributing/coding-conventions.md
+++ b/doc/contributing/coding-conventions.md
@@ -51,7 +51,7 @@ commit).
 ### Third-party Code
 
 - Go dependencies are managed with govendor. See
-[src/server/readme.md](https://github.com/pachyderm/pachyderm/blob/master/src/server/readme.md)
+[src/server/README.md](/src/server/README.md)
 for more info.
 
 ### Docs

--- a/doc/contributing/setup.md
+++ b/doc/contributing/setup.md
@@ -27,14 +27,6 @@ Then update your `~/.bash_profile` by adding the line:
 
 And you'll stay up to date!
 
-## Protocol buffers
-
-Install protoc 3+. On macOS, this can be done via `brew install protobuf`. Then installed protoc-gen-go by doing:
-
-    go get -u -v github.com/golang/protobuf/proto
-    go get -u -v github.com/golang/protobuf/protoc-gen-go
-    go get -u -v github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway
-
 ## Special macOS configuration
 
 ### File Descriptor Limit

--- a/examples/run/config/pipeline.conf
+++ b/examples/run/config/pipeline.conf
@@ -1,4 +1,4 @@
-# Build configuration file for pachderm pipeline
+# Build configuration file for pachyderm pipeline
 
 # Name of pachyderm repository that serves as input to the pipeline
 PIPELINE_REPO=input_repository

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -369,7 +369,7 @@ func NewOnUserMachine(reportMetrics bool, portForward bool, prefix string, optio
 	cfg, err := config.Read()
 	if err != nil {
 		// metrics errors are non fatal
-		log.Warningf("error loading user config from ~/.pachderm/config: %v", err)
+		log.Warningf("error loading user config from ~/.pachyderm/config: %v", err)
 	}
 
 	// create new pachctl client

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -60,7 +60,7 @@ parent. If the job is created with a parent it will use the same repo as its
 parent job and the commit it creates will use the parent job's commit as a
 parent.
 If the job fails the commit it creates will not be finished.
-The increase the throughput of a job increase the Shard paremeter.
+To increase the throughput of a job increase the 'shard' parameter.
 `,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
 			return nil

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -55,12 +55,12 @@ func Cmds(noMetrics *bool, noPortForwarding *bool) ([]*cobra.Command, error) {
 
 Jobs run a containerized workload over a set of finished input commits.
 Creating a job will also create a new repo and a commit in that repo which
-contains the output of the job. Unless the job is created with another job as a
-parent. If the job is created with a parent it will use the same repo as its
+contains the output of the job, unless the job is created with another job as a
+parent. If the job is created with a parent, it will use the same repo as its
 parent job and the commit it creates will use the parent job's commit as a
 parent.
-If the job fails the commit it creates will not be finished.
-To increase the throughput of a job increase the 'shard' parameter.
+If the job fails, the commit it creates will not be finished.
+To increase the throughput of a job, increase the 'shard' parameter.
 `,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
 			return nil


### PR DESCRIPTION
Noticed a few typos and errors when running through the setup instructions and crawling code.