### PR TITLE
Do not append registry to the repo name when building/pushing images

### DIFF
--- a/doc/cookbook/example_developer_workflow.md
+++ b/doc/cookbook/example_developer_workflow.md
@@ -10,7 +10,7 @@ Pachyderm is a powerful system for providing data provenance and scalable proces
 
 ![alt tag](developer_workflow.png)
 
-As you write code, you test it in containers and notebooks against sample data in Pachyderm repos.  You can also run your code in development pipelines in Pachyderm.  Pachyderm provides facilities to help with day-to-day development practices, including the ``--build`` and ``--push`` flags to the ``update-pipeline`` command, which can build & push or just push images to a local docker registry.
+As you write code, you test it in containers and notebooks against sample data in Pachyderm repos.  You can also run your code in development pipelines in Pachyderm.  Pachyderm provides facilities to help with day-to-day development practices, including the ``--build`` and ``--push-images`` flags to the ``update-pipeline`` command, which can build & push or just push images to a docker registry.
 
 There are a couple of things to note about the files shown in git, in the left-hand side of the diagram above.  The pipeline.json template file, in addition to being used for CI/CD as noted below,  could be used with local build targets in a makefile for development purposes: the local build uses DOCKERFILE and creates a pipeline.json for use in development pipelines.  This is optional, of course, but may fit in with some workflows.
 

--- a/doc/fundamentals/creating_analysis_pipelines.md
+++ b/doc/fundamentals/creating_analysis_pipelines.md
@@ -69,8 +69,8 @@ than welcome to use any other public or private Docker registry.
 Note, it is best practice to uniquely tag your Docker images with something
 other than `:latest`.  This allows you to track which Docker images were used
 to process which data, and will help you as you update your pipelines.  You can
-also utilize the `--push-images` flag on `update-pipeline` to help you tag your
-images as they are updated.  See the [updating pipelines
+also utilize the `--build` or `--push-images` flags on `update-pipeline` to
+help you tag your images as they are updated.  See the [updating pipelines
 docs](updating_pipelines.html) for more information.
 
 ## 3. Creating a Pipeline

--- a/doc/fundamentals/updating_pipelines.md
+++ b/doc/fundamentals/updating_pipelines.md
@@ -26,25 +26,21 @@ You can also use `update-pipeline` to update the code you are using in one or
 more of your pipelines.  To update the code in your pipeline:
 
 1. Make the code changes.
-2. Re-build your Docker image.
-3. Call `update-pipeline` with the `--push-images` flag.
+2. Call `update-pipeline` with the `--build` flag.
 
-You need to call `update-pipeline` with the `--push-images` flag because, if
-you have already run your pipeline, Pachyderm has already pulled the specified
-images.  It won't re-pull new versions of the images, unless we tell it to
-(which ensures that we don't waste time pulling images when we don't need to).
-When `--push-images` is specified, Pachyderm will do the following:
+When `--build` is specified, Pachyderm will do the following:
 
-1. Tag your image with a new unique tag.
-2. Push that tagged image to your registry (e.g., DockerHub).
-3. Update the pipeline specification that you previously gave to Pachyderm with
-   the new unique tag.
+1. Rebuild the docker image.
+2. Tag your image with a new unique name.
+3. Push that tagged image to your registry (e.g., DockerHub).
+4. Update the pipeline specification that you previously gave to Pachyderm to
+   use the new unique tag.
 
 For example, you could update the Python code used in the [OpenCV
 pipeline](../getting_started/beginner_tutorial.html) via:
 
 ```sh
-pachctl update-pipeline -f edges.json --push-images -u <registry user>
+pachctl update-pipeline -f edges.json --build -u <registry user>
 ```
 
 You'll then be prompted for your docker registry password.


### PR DESCRIPTION
When `--build` or `--push-images` are run, the input `--registry` is automatically added to the image specified in the pipeline spec's `image` field. This does not work when the registry is already specified in the `image` field.

Note that this solution is not ideal either, because:
1) We stiil need the `--registry` flag to get the correct docker config for authentication.
2) Some users will probably expect the `--registry` flag also specifies the registry that the image will be pushed to, which will no longer be the case.

But I don't see a workaround because docker client's `ParseRepositoryTag` doesn't separate out the registry from the repo, so we don't know if the `image` field includes a registry.

Fixes #3525 
Fixes #3520 