### PR TITLE
Support for partial port forwarding, rather than all-or-none

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -327,13 +327,13 @@ func portForwarder() *PortForwarder {
 	// NOTE: this will always use the default namespace; if a custom
 	// namespace is required with port forwarding,
 	// `pachctl port-forward` should be explicitly called.
-	fw, err := NewPortForwarder("", ioutil.Discard, os.Stderr)
+	fw, err := NewPortForwarder("")
 	if err != nil {
-		log.Debugf("Implicit port forwarding was not enabled because the kubernetes config could not be read: %v", err)
+		log.Infof("Implicit port forwarding was not enabled because the kubernetes config could not be read: %v", err)
 		return nil
 	}
 	if err = fw.Lock(); err != nil {
-		log.Debugf("Implicit port forwarding was not enabled because the pidfile could not be written to. Most likely this means that port forwarding is running in another instance of `pachctl`: %v", err)
+		log.Infof("Implicit port forwarding was not enabled because the pidfile could not be written to. Most likely this means that port forwarding is running in another instance of `pachctl`: %v", err)
 		return nil
 	}
 

--- a/src/client/portforwarder.go
+++ b/src/client/portforwarder.go
@@ -64,14 +64,13 @@ func NewPortForwarder(namespace string) (*PortForwarder, error) {
 	}
 
 	core := client.CoreV1()
-	logger := log.StandardLogger()
 
 	return &PortForwarder{
 		core:          core,
 		client:        core.RESTClient(),
 		config:        config,
 		namespace:     namespace,
-		logger:        logger.Writer(),
+		logger:        log.StandardLogger().Writer(),
 		stopChansLock: &sync.Mutex{},
 		stopChans:     []chan struct{}{},
 		shutdown:      false,

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -370,7 +370,7 @@ This resets the cluster to its initial state.`,
 		Short: "Forward a port on the local machine to pachd. This command blocks.",
 		Long:  "Forward a port on the local machine to pachd. This command blocks.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			fw, err := client.NewPortForwarder(namespace, ioutil.Discard, os.Stderr)
+			fw, err := client.NewPortForwarder(namespace)
 			if err != nil {
 				return err
 			}

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -381,29 +381,36 @@ This resets the cluster to its initial state.`,
 			defer fw.Close()
 
 			failCount := 0
-			printResult := func(err error) {
-				if err != nil {
-					fmt.Printf("%v\n", err)
-					failCount += 1
-				} else {
-					fmt.Println("success")
-				}
+
+			fmt.Println("Forwarding the pachd (Pachyderm daemon) port...")
+			if err = fw.RunForDaemon(port, remotePort); err != nil {
+				fmt.Printf("%v\n", err)
+				failCount += 1
 			}
 
-			fmt.Print("Forwarding the pachd (Pachyderm daemon) port... ")
-			printResult(fw.RunForDaemon(port, remotePort))
+			fmt.Println("Forwarding the SAML ACS port...")
+			if err = fw.RunForSAMLACS(samlPort); err != nil {
+				fmt.Printf("%v\n", err)
+				failCount += 1
+			}
 
-			fmt.Print("Forwarding the SAML ACS port... ")
-			printResult(fw.RunForSAMLACS(samlPort))
+			fmt.Printf("Forwarding the dash (Pachyderm dashboard) UI port to http://localhost:%v...\n", uiPort)
+			if err = fw.RunForDashUI(uiPort); err != nil {
+				fmt.Printf("%v\n", err)
+				failCount += 1
+			}
 
-			fmt.Printf("Forwarding the dash (Pachyderm dashboard) UI port to http://localhost:%v... ", uiPort)
-			printResult(fw.RunForDashUI(uiPort))
+			fmt.Println("Forwarding the dash (Pachyderm dashboard) websocket port...")
+			if err = fw.RunForDashWebSocket(uiWebsocketPort); err != nil {
+				fmt.Printf("%v\n", err)
+				failCount += 1
+			}
 
-			fmt.Print("Forwarding the dash (Pachyderm dashboard) websocket port... ")
-			printResult(fw.RunForDashWebSocket(uiWebsocketPort))
-
-			fmt.Print("Forwarding the PFS port... ")
-			printResult(fw.RunForPFS(pfsPort))
+			fmt.Println("Forwarding the PFS port...")
+			if err = fw.RunForPFS(pfsPort); err != nil {
+				fmt.Printf("%v\n", err)
+				failCount += 1
+			}
 
 			if failCount < 5 {
 				fmt.Println("CTRL-C to exit")

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -385,31 +385,31 @@ This resets the cluster to its initial state.`,
 			fmt.Println("Forwarding the pachd (Pachyderm daemon) port...")
 			if err = fw.RunForDaemon(port, remotePort); err != nil {
 				fmt.Printf("%v\n", err)
-				failCount += 1
+				failCount++
 			}
 
 			fmt.Println("Forwarding the SAML ACS port...")
 			if err = fw.RunForSAMLACS(samlPort); err != nil {
 				fmt.Printf("%v\n", err)
-				failCount += 1
+				failCount++
 			}
 
 			fmt.Printf("Forwarding the dash (Pachyderm dashboard) UI port to http://localhost:%v...\n", uiPort)
 			if err = fw.RunForDashUI(uiPort); err != nil {
 				fmt.Printf("%v\n", err)
-				failCount += 1
+				failCount++
 			}
 
 			fmt.Println("Forwarding the dash (Pachyderm dashboard) websocket port...")
 			if err = fw.RunForDashWebSocket(uiWebsocketPort); err != nil {
 				fmt.Printf("%v\n", err)
-				failCount += 1
+				failCount++
 			}
 
 			fmt.Println("Forwarding the PFS port...")
 			if err = fw.RunForPFS(pfsPort); err != nil {
 				fmt.Printf("%v\n", err)
-				failCount += 1
+				failCount++
 			}
 
 			if failCount < 5 {


### PR DESCRIPTION
Fixes #3572

I also went ahead and changed the port forwarder to use logrus instead of stderr for output created by k8s itself, which fixes #3578