### PR TITLE
Handle missing input field in pipeline specs without panicking

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -553,7 +553,7 @@ All jobs created by a pipeline will create commits in the pipeline's repo.
 			}
 			request.Update = true
 			request.Reprocess = reprocess
-			if request.Input.Atom != nil {
+			if request.Input != nil && request.Input.Atom != nil {
 				fmt.Fprintln(os.Stderr, "the `atom` input type is deprecated as of 1.8.1, please replace `atom` with `pfs`")
 			}
 			if _, err := client.PpsAPIClient.CreatePipeline(
@@ -775,7 +775,7 @@ func pipelineHelper(metrics bool, portForwarding bool, reprocess bool, build boo
 		} else if err != nil {
 			return err
 		}
-		if request.Input.Atom != nil {
+		if request.Input != nil && request.Input.Atom != nil {
 			fmt.Println("WARNING: The `atom` input type has been deprecated and will be removed in a future version. Please replace `atom` with `pfs`.")
 		}
 		if update {


### PR DESCRIPTION
On create/update pipeline, a panic will occur if the input field is missing. This fixes the issue.