### PR TITLE
Fix 3203 premature jobs

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -104,95 +104,6 @@ func TestSimplePipeline(t *testing.T) {
 	require.Equal(t, "foo", buf.String())
 }
 
-func TestStopPipelineWithoutGeneratingCommits(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
-
-	c := getPachClient(t)
-	require.NoError(t, c.DeleteAll())
-	aRepo := tu.UniqueString("A")
-	require.NoError(t, c.CreateRepo(aRepo))
-	bPipeline := tu.UniqueString("B")
-	require.NoError(t, c.CreatePipeline(
-		bPipeline,
-		"",
-		[]string{"cp", path.Join("/pfs", aRepo, "file"), "/pfs/out/file"},
-		nil,
-		&pps.ParallelismSpec{
-			Constant: 1,
-		},
-		client.NewPFSInput(aRepo, "/*"),
-		"",
-		false,
-	))
-	cPipeline := tu.UniqueString("C")
-	require.NoError(t, c.CreatePipeline(
-		cPipeline,
-		"",
-		[]string{"sh"},
-		[]string{fmt.Sprintf("diff %s %s >/pfs/out/file",
-			path.Join("/pfs", aRepo, "file"), path.Join("/pfs", bPipeline, "file"))},
-		&pps.ParallelismSpec{
-			Constant: 1,
-		},
-		client.NewCrossInput(
-			client.NewPFSInput(aRepo, "/*"),
-			client.NewPFSInput(bPipeline, "/*"),
-		),
-		"",
-		false,
-	))
-	// commit to aRepo
-	commit1, err := c.StartCommit(aRepo, "master")
-	require.NoError(t, err)
-	_, err = c.PutFile(aRepo, commit1.ID, "file", strings.NewReader("foo\n"))
-	require.NoError(t, err)
-	require.NoError(t, c.FinishCommit(aRepo, commit1.ID))
-
-	commit2, err := c.StartCommit(aRepo, "master")
-	require.NoError(t, err)
-	_, err = c.PutFile(aRepo, commit2.ID, "file", strings.NewReader("bar\n"))
-	require.NoError(t, err)
-	require.NoError(t, c.FinishCommit(aRepo, commit2.ID))
-
-	aCommit := commit2
-	commitIter, err := c.FlushCommit([]*pfs.Commit{aCommit}, []*pfs.Repo{client.NewRepo(bPipeline)})
-	require.NoError(t, err)
-	commitInfos := collectCommitInfos(t, commitIter)
-	require.Equal(t, 1, len(commitInfos))
-	bCommit := commitInfos[0].Commit
-	commitIter, err = c.FlushCommit([]*pfs.Commit{aCommit, bCommit}, nil)
-	require.NoError(t, err)
-	commitInfos = collectCommitInfos(t, commitIter)
-	require.Equal(t, 1, len(commitInfos))
-	cCommitInfo := commitInfos[0]
-	require.Equal(t, uint64(0), cCommitInfo.SizeBytes)
-
-	// We should only see two commits in aRepo
-	commitInfos, err = c.ListCommit(aRepo, "master", "", 0)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(commitInfos))
-
-	// There are three commits in the pipeline repos (two from input commits, and
-	// one from the CreatePipeline call that created each repo)
-	commitInfos, err = c.ListCommit(bPipeline, "master", "", 0)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(commitInfos))
-
-	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(commitInfos))
-
-	// Stop the Pipeline, if propagateCommit is working correctly,
-	// cPipeline will not have a new commit.
-	require.NoError(t, c.StopPipeline(bPipeline))
-	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(commitInfos))
-
-}
-
 // TestRepoSize ensures that a repo's size is equal to it's master branch's
 // HEAD's size. This test should prevent a regression where output repos would
 // incorrectly report their size to be 0B. See here for more details:
@@ -1109,6 +1020,14 @@ func TestProvenance(t *testing.T) {
 	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(commitInfos))
+
+	// Stop bPipeline, confirm no new commits on cPipeline.
+	t.Run("NoCommitOnStopPipeline", func(t *testing.T) {
+		require.NoError(t, c.StopPipeline(bPipeline))
+		commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(commitInfos))
+	})
 }
 
 // TestProvenance2 tests the following DAG:

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -104,6 +104,95 @@ func TestSimplePipeline(t *testing.T) {
 	require.Equal(t, "foo", buf.String())
 }
 
+func TestStopPipelineWithoutGeneratingCommits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c := getPachClient(t)
+	require.NoError(t, c.DeleteAll())
+	aRepo := tu.UniqueString("A")
+	require.NoError(t, c.CreateRepo(aRepo))
+	bPipeline := tu.UniqueString("B")
+	require.NoError(t, c.CreatePipeline(
+		bPipeline,
+		"",
+		[]string{"cp", path.Join("/pfs", aRepo, "file"), "/pfs/out/file"},
+		nil,
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewPFSInput(aRepo, "/*"),
+		"",
+		false,
+	))
+	cPipeline := tu.UniqueString("C")
+	require.NoError(t, c.CreatePipeline(
+		cPipeline,
+		"",
+		[]string{"sh"},
+		[]string{fmt.Sprintf("diff %s %s >/pfs/out/file",
+			path.Join("/pfs", aRepo, "file"), path.Join("/pfs", bPipeline, "file"))},
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewCrossInput(
+			client.NewPFSInput(aRepo, "/*"),
+			client.NewPFSInput(bPipeline, "/*"),
+		),
+		"",
+		false,
+	))
+	// commit to aRepo
+	commit1, err := c.StartCommit(aRepo, "master")
+	require.NoError(t, err)
+	_, err = c.PutFile(aRepo, commit1.ID, "file", strings.NewReader("foo\n"))
+	require.NoError(t, err)
+	require.NoError(t, c.FinishCommit(aRepo, commit1.ID))
+
+	commit2, err := c.StartCommit(aRepo, "master")
+	require.NoError(t, err)
+	_, err = c.PutFile(aRepo, commit2.ID, "file", strings.NewReader("bar\n"))
+	require.NoError(t, err)
+	require.NoError(t, c.FinishCommit(aRepo, commit2.ID))
+
+	aCommit := commit2
+	commitIter, err := c.FlushCommit([]*pfs.Commit{aCommit}, []*pfs.Repo{client.NewRepo(bPipeline)})
+	require.NoError(t, err)
+	commitInfos := collectCommitInfos(t, commitIter)
+	require.Equal(t, 1, len(commitInfos))
+	bCommit := commitInfos[0].Commit
+	commitIter, err = c.FlushCommit([]*pfs.Commit{aCommit, bCommit}, nil)
+	require.NoError(t, err)
+	commitInfos = collectCommitInfos(t, commitIter)
+	require.Equal(t, 1, len(commitInfos))
+	cCommitInfo := commitInfos[0]
+	require.Equal(t, uint64(0), cCommitInfo.SizeBytes)
+
+	// We should only see two commits in aRepo
+	commitInfos, err = c.ListCommit(aRepo, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(commitInfos))
+
+	// There are three commits in the pipeline repos (two from input commits, and
+	// one from the CreatePipeline call that created each repo)
+	commitInfos, err = c.ListCommit(bPipeline, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(commitInfos))
+
+	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(commitInfos))
+
+	// Stop the Pipeline, if propagateCommit is working correctly,
+	// cPipeline will not have a new commit.
+	require.NoError(t, c.StopPipeline(bPipeline))
+	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(commitInfos))
+
+}
+
 // TestRepoSize ensures that a repo's size is equal to it's master branch's
 // HEAD's size. This test should prevent a regression where output repos would
 // incorrectly report their size to be 0B. See here for more details:

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1020,14 +1020,6 @@ func TestProvenance(t *testing.T) {
 	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(commitInfos))
-
-	// Stop bPipeline, confirm no new commits on cPipeline.
-	t.Run("NoCommitOnStopPipeline", func(t *testing.T) {
-		require.NoError(t, c.StopPipeline(bPipeline))
-		commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(commitInfos))
-	})
 }
 
 // TestProvenance2 tests the following DAG:
@@ -1130,6 +1122,75 @@ func TestProvenance2(t *testing.T) {
 		require.NoError(t, c.GetFile(commit.Repo.Name, commit.ID, "file", 0, 0, &buffer))
 		require.Equal(t, "", buffer.String())
 	}
+}
+
+// TestStopPipelineExtraCommit generates the following DAG:
+// A -> B -> C
+// and ensures that calling StopPipeline on B does not create an commit in C.
+func TestStopPipelineExtraCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c := getPachClient(t)
+	require.NoError(t, c.DeleteAll())
+	aRepo := tu.UniqueString("A")
+	require.NoError(t, c.CreateRepo(aRepo))
+	bPipeline := tu.UniqueString("B")
+	require.NoError(t, c.CreatePipeline(
+		bPipeline,
+		"",
+		[]string{"cp", path.Join("/pfs", aRepo, "file"), "/pfs/out/file"},
+		nil,
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewPFSInput(aRepo, "/*"),
+		"",
+		false,
+	))
+	cPipeline := tu.UniqueString("C")
+	require.NoError(t, c.CreatePipeline(
+		cPipeline,
+		"",
+		[]string{"cp", path.Join("/pfs", aRepo, "file"), "/pfs/out/file"},
+		nil,
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewPFSInput(bPipeline, "/*"),
+		"",
+		false,
+	))
+	// commit to aRepo
+	commit1, err := c.StartCommit(aRepo, "master")
+	require.NoError(t, err)
+	_, err = c.PutFile(aRepo, commit1.ID, "file", strings.NewReader("foo\n"))
+	require.NoError(t, err)
+	require.NoError(t, c.FinishCommit(aRepo, commit1.ID))
+
+	commitIter, err := c.FlushCommit([]*pfs.Commit{commit1}, []*pfs.Repo{client.NewRepo(bPipeline), client.NewRepo(cPipeline)})
+	require.NoError(t, err)
+	commitInfos := collectCommitInfos(t, commitIter)
+	require.Equal(t, 2, len(commitInfos))
+
+	// We should only see one commit in aRepo, bPipeline, and cPipeline
+	commitInfos, err = c.ListCommit(aRepo, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(commitInfos))
+
+	commitInfos, err = c.ListCommit(bPipeline, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(commitInfos))
+
+	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(commitInfos))
+
+	require.NoError(t, c.StopPipeline(bPipeline))
+	commitInfos, err = c.ListCommit(cPipeline, "master", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(commitInfos))
 }
 
 // TestFlushCommit
@@ -1870,7 +1931,7 @@ func TestPrettyPrinting(t *testing.T) {
 	require.True(t, len(jobInfos) > 0)
 	jobInfo, err := c.InspectJob(jobInfos[0].Job.ID, false)
 	require.NoError(t, err)
-  require.NoError(t, ppspretty.PrintDetailedJobInfo(ppspretty.NewPrintableJobInfo(jobInfo)))
+	require.NoError(t, ppspretty.PrintDetailedJobInfo(ppspretty.NewPrintableJobInfo(jobInfo)))
 }
 
 func TestDeleteAll(t *testing.T) {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -814,12 +814,29 @@ func (d *driver) propagateCommit(stm col.STM, branch *pfs.Branch) error {
 		return err
 	}
 	subvBranchInfos = append(subvBranchInfos, branchInfo) // add 'branch' itself
+	// fmt.Println("Subv length", len(branchInfo.Subvenance))
 	for _, subvBranch := range branchInfo.Subvenance {
 		subvBranchInfo := &pfs.BranchInfo{}
 		if err := d.branches(subvBranch.Repo.Name).ReadWrite(stm).Get(subvBranch.Name, subvBranchInfo); err != nil {
 			return err
 		}
+		// fmt.Println("Current subv repo", subvBranch.Repo, "name", subvBranch.Name, "prov", subvBranchInfo.Provenance)
 		subvBranchInfos = append(subvBranchInfos, subvBranchInfo)
+
+		// // Direct subv means branchInfo exists in subvBranchInfo.DirectProvenance
+		// directSubv := true
+		// fmt.Println("Bout to iterate through direct prov branch rep", branch.Repo, "branch name", branch.Name)
+		// fmt.Println("Current subv repo", subvBranch.Repo, "name", subvBranch.Name)
+		// for _, b := range subvBranchInfo.DirectProvenance {
+		// 	fmt.Println("b repo", b.Repo, "b name", b.Name)
+		// 	if branch.Repo.Name == b.Repo.Name && branch.Name == b.Name {
+		// 		fmt.Println("direct subv", b.Name, b.Repo)
+		// 		directSubv = true
+		// 	}
+		// }
+		// if directSubv {
+		// 	subvBranchInfos = append(subvBranchInfos, subvBranchInfo)
+		// }
 	}
 
 	// Sort subvBranchInfos so that upstream branches are processed before their
@@ -829,21 +846,28 @@ func (d *driver) propagateCommit(stm col.STM, branch *pfs.Branch) error {
 	sort.Slice(subvBranchInfos, func(i, j int) bool { return len(subvBranchInfos[i].Provenance) < len(subvBranchInfos[j].Provenance) })
 
 	// Iterate through downstream branches and determine which need a new commit.
+	// for _, sbi := range subvBranchInfos {
+	// 	// fmt.Println("subv", sbi.Branch)
+	// }
+	// fmt.Println("subv branch infos", subvBranchInfos)
 nextSubvBranch:
 	for _, branchInfo := range subvBranchInfos {
 		branch := branchInfo.Branch
 		repo := branch.Repo
 		commits := d.commits(repo.Name).ReadWrite(stm)
 		branches := d.branches(repo.Name).ReadWrite(stm)
+		// fmt.Println("branchInfo branch", branchInfo.Branch) //, "head", branchInfo.Head.ID)
 
 		// Compute the full provenance of hypothetical new output commit to decide
 		// if we need it
 		commitProvMap := make(map[string]*branchCommit)
+		// fmt.Println("branchInfo provenance", branchInfo.Provenance)
 		for _, provBranch := range branchInfo.Provenance {
 			provBranchInfo := &pfs.BranchInfo{}
 			if err := d.branches(provBranch.Repo.Name).ReadWrite(stm).Get(provBranch.Name, provBranchInfo); err != nil && !col.IsErrNotFound(err) {
 				return fmt.Errorf("could not read branch %s/%s: %v", provBranch.Repo.Name, provBranch.Name, err)
 			}
+			// fmt.Println("prove branch info", provBranchInfo)
 			if provBranchInfo.Head == nil {
 				continue
 			}
@@ -857,6 +881,7 @@ nextSubvBranch:
 		}
 		if len(commitProvMap) == 0 {
 			// no input commits to process; don't create a new output commit
+			// fmt.Println("nil map")
 			continue nextSubvBranch
 		}
 
@@ -869,14 +894,20 @@ nextSubvBranch:
 			if err := commits.Get(branchInfo.Head.ID, branchHeadInfo); err != nil {
 				return pfsserver.ErrCommitNotFound{branchInfo.Head}
 			}
-			headIsSubset := true
-			for _, c := range branchHeadInfo.Provenance {
-				if _, ok := commitProvMap[c.ID]; !ok {
-					headIsSubset = false
+			headIsSubset := false
+			for k := range commitProvMap {
+				matched := false
+				for _, c := range branchHeadInfo.Provenance {
+					if c.ID == k {
+						matched = true
+					}
+				}
+				headIsSubset = matched
+				if !headIsSubset {
 					break
 				}
 			}
-			if len(branchHeadInfo.Provenance) == len(commitProvMap) && headIsSubset {
+			if len(branchHeadInfo.Provenance) >= len(commitProvMap) && headIsSubset {
 				// existing HEAD commit is the same new output commit would be; don't
 				// create new commit
 				continue nextSubvBranch
@@ -888,14 +919,18 @@ nextSubvBranch:
 		// "dummy" job with no non-spec input data. If this is the case, don't
 		// create a new output commit
 		allSpec := true
+		fmt.Println("iterating on commitProvMap")
 		for _, b := range commitProvMap {
+			fmt.Println("branch is", b.branch, "commit is", b.commit)
 			if b.branch.Repo.Name != ppsconsts.SpecRepo {
+				fmt.Println("not all spec")
 				allSpec = false
 				break
 			}
 		}
 		if allSpec {
 			// Only input data is PipelineInfo; don't create new output commit
+			fmt.Println("ALL SPEC")
 			continue nextSubvBranch
 		}
 
@@ -945,6 +980,7 @@ nextSubvBranch:
 		}
 
 		// finally create open 'commit'
+		fmt.Println("Creating new commit", newCommitInfo)
 		if err := commits.Create(newCommit.ID, newCommitInfo); err != nil {
 			return err
 		}
@@ -1579,6 +1615,7 @@ func (d *driver) deleteCommit(pachClient *client.APIClient, userCommit *pfs.Comm
 		// processed yet
 		// TODO(msteffen) propagate all changed branches? Use heap to topologically
 		// sort them?
+		// fmt.Println("Calling propagate from 1607")
 		return d.propagateCommit(stm, shortestBranch)
 	}); err != nil {
 		return fmt.Errorf("error rewriting commit graph: %v", err)


### PR DESCRIPTION
This fixes #3203 by ensuring that the head is actually a subset of the commit provenance map rather than checking that the commit provenance map keyset is a subset of the branch head provenance (and creating erroneous commits when it is not).