### PR TITLE
Fix 'pachctl list-file' errors

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -923,7 +923,7 @@ $ pachctl list-file foo master --history -1
 				pretty.PrintFileInfo(writer, fi, fullTimestamps)
 				return nil
 			}); err != nil {
-				return nil
+				return err
 			}
 			return writer.Flush()
 		}),


### PR DESCRIPTION
`pachctl list-file` wasn't returning errors unless `--raw` was used.