### PR TITLE
Use force when deleting pipelines for pachctl delete-all

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2428,7 +2428,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (respon
 		return nil, fmt.Errorf("Error during authorization check: %v", err)
 	}
 
-	if _, err := a.DeletePipeline(ctx, &pps.DeletePipelineRequest{All: true}); err != nil {
+	if _, err := a.DeletePipeline(ctx, &pps.DeletePipelineRequest{All: true, Force: true}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #3225.

This was reproduced via three repos:

* `A` - upstream repo
* `B` - output repo for pipeline `B`
* `C` - downstream repo

Created a branch on `C` listing `B` as its provenance, and then `delete-all` could no longer run successfully:

```
delete branch repo:<name:"B" > : branch  has [repo:<name:"C" > name:"master" ] as subvenance, deleting it would break those branches
```

This is because we run the delete-all through PPS first, which attempts to delete all pipelines.  It was not specifying `Force=true` for this delete (like PFS does in its own `deleteAll`), so it was choking on this error.