### PR TITLE
Fix list-file output for open commits

### DIFF
--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -179,11 +179,14 @@ func PrintFileInfo(w io.Writer, fileInfo *pfs.FileInfo, fullTimestamps bool) {
 	} else {
 		fmt.Fprint(w, "dir\t")
 	}
-	if fullTimestamps {
+	if fileInfo.Committed == nil {
+		fmt.Fprintf(w, "-\t")
+	} else if fullTimestamps {
 		fmt.Fprintf(w, "%s\t", fileInfo.Committed.String())
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(fileInfo.Committed))
 	}
+
 	fmt.Fprintf(w, "%s\t\n", units.BytesSize(float64(fileInfo.SizeBytes)))
 }
 

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -186,7 +186,6 @@ func PrintFileInfo(w io.Writer, fileInfo *pfs.FileInfo, fullTimestamps bool) {
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(fileInfo.Committed))
 	}
-
 	fmt.Fprintf(w, "%s\t\n", units.BytesSize(float64(fileInfo.SizeBytes)))
 }
 


### PR DESCRIPTION
Fixes #3600 

Before:
```
$ pachctl list-file a master
COMMIT                           NAME     TYPE COMMITTED    SIZE     
322067519456465ebe5fa088b80a3a74 /hunter2 file 49 years ago 1.382KiB 
```

After:
```
$ pachctl list-file a master
COMMIT                           NAME     TYPE COMMITTED SIZE     
322067519456465ebe5fa088b80a3a74 /hunter2 file -         1.382KiB 
```