### PR TITLE
Update beginner_tutorial.rst

### DIFF
--- a/doc/getting_started/beginner_tutorial.rst
+++ b/doc/getting_started/beginner_tutorial.rst
@@ -301,7 +301,13 @@ And you can view the generated montage image via:
 Exploring your DAG in the Pachyderm dashboard
 --------------------------------------------
 
-When you deployed Pachyderm locally, the Pachyderm Enterprise dashboard was also deployed by default. This dashboard will let you interactively explore your pipeline, visualize the structure of the pipeline, explore your data, debug jobs, etc. To access the dashboard visit ``localhost:30080`` in an Internet browser (e.g., Google Chrome). You should see something similar to this:
+When you deployed Pachyderm locally, the Pachyderm Enterprise dashboard was also deployed by default. This dashboard will let you interactively explore your pipeline, visualize the structure of the pipeline, explore your data, debug jobs, etc. To access the dashboard, get the address of the ``dash`` pod running in minikube:
+
+.. code-block:: shell
+
+  $ minikube service dash --url | grep 30080
+
+And open it in an Internet browser (e.g., Google Chrome). You should see something similar to this:
 
 .. image:: dashboard1.png
 


### PR DESCRIPTION
The instructions as they were didn't work for me; I'm running minikube in virtualbox on Linux with host-based networking.

I would have liked this PR to be just `minikube service dash`, but because there are two endpoints exposed by `dash` the browser is opened twice; once for each URL. It's a better UX to just use grep, though maybe that can be improved upon further.