### PR TITLE
Removed not-really-true note

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -421,8 +421,6 @@ This resets the cluster to its initial state.`,
 
 			if failCount < 6 {
 				fmt.Println("CTRL-C to exit")
-				fmt.Println("NOTE: kubernetes port-forward often outputs benign error messages, these should be ignored unless they seem to be impacting your ability to connect over the forwarded port.")
-
 				ch := make(chan os.Signal, 1)
 				signal.Notify(ch, os.Interrupt)
 				<-ch


### PR DESCRIPTION
I don't think most error messages coming from k8s are benign, especially since we suppress stdout messages nowadays and only display those from stderr