### PR TITLE
Fix weird two branches with one commit bugs

### DIFF
--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -376,7 +376,6 @@ func (c APIClient) DeleteBranch(repoName string, branch string, force bool) erro
 }
 
 // DeleteCommit deletes a commit.
-// Note it is currently not implemented.
 func (c APIClient) DeleteCommit(repoName string, commitID string) error {
 	_, err := c.PfsAPIClient.DeleteCommit(
 		c.Ctx(),


### PR DESCRIPTION
This fixes three bugs I ran into while thinking about the new `CommitProvenance` struct which has the branch. The test verifies that each of these issues has been fixed.

1. Propagate commit kept track of provenance in a map keyed by commit id. This resulted in the wrong behavior when a commit's provenance included two `CommitProvenance`s which had the same commit, but with two different branches.

2. Deleting a commit which was the head of two branches would fail. That's because the `DeleteCommit` function kept track of deleted information in a map. It loops through different branches in the commit's subvenance. So the second time around, the information about the deleted commit would get replaced by nil, since it no longer existed. This resulted in a segfault later on.

3. Say master has one commit, which is its head. Then, you can create a commit on a new branch with the master head commit as its parent. You could then delete master's head commit. After doing all of that, you could try to create a second commit on the new branch. As part of creating this commit, pfs would check to see if the repo size, it would try to dereference the head of master, which is still nil. 