### PR TITLE
Downstream deferred

### DIFF
--- a/doc/cookbook/deferred_processing.md
+++ b/doc/cookbook/deferred_processing.md
@@ -150,3 +150,16 @@ $ pachctl finish-commit data master
 You can also, of course, issue `delete-file` and `put-file` while the commit is
 open if you want to remove something from the parent commit or add something
 that isn't stored anywhere else.
+
+### Deferred processing on pipeline outputs
+
+So far this document has focussed on deferred processing of data in input
+repos, however the same techniques apply to output repos. The only real
+difference is that rather than committing to a `staging` branch, you tell your
+pipeline to commit to that branch, by setting the `output_branch` field in your
+pipeline spec. Then when you want to process data you'd do:
+
+```sh
+$ pachctl create-branch pipeline master --head staging
+```
+

--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -422,7 +422,7 @@ func (c APIClient) FlushCommit(commits []*pfs.Commit, toRepos []*pfs.Repo) (Comm
 // will be considered, otherwise all repos are considered.
 //
 // Note that it's never necessary to call FlushCommit to run jobs, they'll run
-// no matter what, FlushCommit just allows you to wait for them to complete and
+// no matter what, FlushCommitF just allows you to wait for them to complete and
 // see their output once they do.
 func (c APIClient) FlushCommitF(commits []*pfs.Commit, toRepos []*pfs.Repo, f func(*pfs.CommitInfo) error) error {
 	stream, err := c.PfsAPIClient.FlushCommit(
@@ -447,6 +447,28 @@ func (c APIClient) FlushCommitF(commits []*pfs.Commit, toRepos []*pfs.Repo, f fu
 			return err
 		}
 	}
+}
+
+// FlushCommitAll returns commits that have the specified `commits` as
+// provenance. Note that it can block if jobs have not successfully
+// completed. This in effect waits for all of the jobs that are triggered by a
+// set of commits to complete.
+//
+// If toRepos is not nil then only the commits up to and including those repos
+// will be considered, otherwise all repos are considered.
+//
+// Note that it's never necessary to call FlushCommit to run jobs, they'll run
+// no matter what, FlushCommitAll just allows you to wait for them to complete and
+// see their output once they do.
+func (c APIClient) FlushCommitAll(commits []*pfs.Commit, toRepos []*pfs.Repo) ([]*pfs.CommitInfo, error) {
+	var result []*pfs.CommitInfo
+	if err := c.FlushCommitF(commits, toRepos, func(ci *pfs.CommitInfo) error {
+		result = append(result, ci)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // CommitInfoIterator wraps a stream of commits and makes them easy to iterate.

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -8591,23 +8591,20 @@ func TestDeferredProcessing(t *testing.T) {
 	require.NoError(t, err)
 
 	commit := client.NewCommit(dataRepo, "staging")
-	commitIter, err := c.FlushCommit([]*pfs.Commit{commit}, nil)
+	commitInfos, err := c.FlushCommitAll([]*pfs.Commit{commit}, nil)
 	require.NoError(t, err)
-	commitInfos := collectCommitInfos(t, commitIter)
 	require.Equal(t, 0, len(commitInfos))
 
 	c.CreateBranch(dataRepo, "master", "staging", nil)
 
-	commitIter, err = c.FlushCommit([]*pfs.Commit{commit}, nil)
+	commitInfos, err = c.FlushCommitAll([]*pfs.Commit{commit}, nil)
 	require.NoError(t, err)
-	commitInfos = collectCommitInfos(t, commitIter)
 	require.Equal(t, 1, len(commitInfos))
 
 	c.CreateBranch(pipeline1, "master", "staging", nil)
 
-	commitIter, err = c.FlushCommit([]*pfs.Commit{commit}, nil)
+	commitInfos, err = c.FlushCommitAll([]*pfs.Commit{commit}, nil)
 	require.NoError(t, err)
-	commitInfos = collectCommitInfos(t, commitIter)
 	require.Equal(t, 2, len(commitInfos))
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -818,6 +818,14 @@ func (d *driver) propagateCommit(stm col.STM, branch *pfs.Branch) error {
 		subvBranchInfos = append(subvBranchInfos, subvBranchInfo)
 	}
 
+	var head *pfs.CommitInfo
+	if branchInfo.Head != nil {
+		head = &pfs.CommitInfo{}
+		if err := d.commits(branch.Repo.Name).ReadWrite(stm).Get(branchInfo.Head.ID, head); err != nil {
+			return err
+		}
+	}
+
 	// Sort subvBranchInfos so that upstream branches are processed before their
 	// descendants. This guarantees that if branch B is provenant on branch A, we
 	// create a new commit in A before creating a new commit in B provenant on the
@@ -852,6 +860,11 @@ nextSubvBranch:
 			// Because of the 'propagateCommit' invariant, we don't need to inspect
 			// provBranchInfo.HEAD's provenance. Every commit in there will be the
 			// HEAD of some other provBranchInfo.
+		}
+		if head != nil {
+			for _, commitProv := range head.Provenance {
+				commitProvMap[key(commitProv.Commit.ID, commitProv.Branch.Name)] = commitProv
+			}
 		}
 		if len(commitProvMap) == 0 {
 			// no input commits to process; don't create a new output commit

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -4866,3 +4866,30 @@ func TestUpdateRepo(t *testing.T) {
 	require.Equal(t, created, newCreated)
 	require.Equal(t, desc, ri.Description)
 }
+
+func TestDeferredProcessing(t *testing.T) {
+	client := GetPachClient(t)
+	require.NoError(t, client.CreateRepo("input"))
+	require.NoError(t, client.CreateRepo("output1"))
+	require.NoError(t, client.CreateRepo("output2"))
+	require.NoError(t, client.CreateBranch("output1", "staging", "", []*pfs.Branch{pclient.NewBranch("input", "master")}))
+	require.NoError(t, client.CreateBranch("output2", "staging", "", []*pfs.Branch{pclient.NewBranch("output1", "master")}))
+	_, err := client.PutFile("input", "staging", "file", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	commits, err := client.FlushCommitAll([]*pfs.Commit{pclient.NewCommit("input", "staging")}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(commits))
+
+	require.NoError(t, client.CreateBranch("input", "master", "staging", nil))
+	require.NoError(t, client.FinishCommit("output1", "staging"))
+	commits, err = client.FlushCommitAll([]*pfs.Commit{pclient.NewCommit("input", "staging")}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(commits))
+
+	require.NoError(t, client.CreateBranch("output1", "master", "staging", nil))
+	require.NoError(t, client.FinishCommit("output2", "staging"))
+	commits, err = client.FlushCommitAll([]*pfs.Commit{pclient.NewCommit("input", "staging")}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(commits))
+}


### PR DESCRIPTION
This PR adds a test for a workflow that came up with a few users recently: deferred processing on downstream branches. If you'd like to know more about how it works checkout the docs added in this PR. The workflow already mostly works, with a small bug in the reported provenance, that this PR fixes.