### PR TITLE
Add a dryrun collections.STM for read operations in transactions

### DIFF
--- a/doc/contributing/setup.md
+++ b/doc/contributing/setup.md
@@ -10,6 +10,25 @@ First, go through the general local installation instructions [here](http://docs
 - [jq](https://stedolan.github.io/jq/)
 - [pv](http://ivarch.com/programs/pv.shtml)
 
+## Testing
+
+In order to run some tests locally, you will need the AWS CLI installed and
+configured to access Pachyderm S3 buckets.  In order to set this up:
+
+1. Message an owner of the Pachyderm AWS account (@jdoliner) to get AWS credentials
+2. Get back a login link and initial username/password - log in
+3. Configure your own password
+4. Go to your account settings => My Security Credentials
+5. In "Access keys for CLI [...]", click "Create Access Key"
+6. On the command-line, run `sudo apt install awscli` (or equivalent for your platform)
+7. Run `aws configure` and fill in these fields:
+  * `AWS Access Key ID` - the ID for the new Access Key you created
+  * `AWS Secret Access Key` - the secret for the new Access Key you created
+  * `Default region name` - `us-west-1` might be a good choice
+  * `Default output format` - `json` because why not?
+8. Test that you can access a Pachyderm S3 bucket:
+  * `aws s3 ls s3://pachyderm-engineering/`
+
 ## Bash helpers
 
 To stay up to date, we recommend doing the following.

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1616,7 +1616,7 @@ func (a *apiServer) SetACLInTransaction(
 	// Set new ACL
 	if len(newACL.Entries) == 0 {
 		err := acls.Delete(req.Repo)
-		if !col.IsErrNotFound(err) {
+		if err != nil && !col.IsErrNotFound(err) {
 			return nil, err
 		}
 	}

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1619,10 +1619,11 @@ func (a *apiServer) SetACLInTransaction(
 		if err != nil && !col.IsErrNotFound(err) {
 			return nil, err
 		}
-	}
-	err = acls.Put(req.Repo, newACL)
-	if err != nil {
-		return nil, fmt.Errorf("could not put new ACL: %v", err)
+	} else {
+		err = acls.Put(req.Repo, newACL)
+		if err != nil {
+			return nil, fmt.Errorf("could not put new ACL: %v", err)
+		}
 	}
 	return &authclient.SetACLResponse{}, nil
 }


### PR DESCRIPTION
The diff is best viewed with whitespace disabled.

This adds a new call `col.NewDryrunSTM`, which works exactly like `col.NewSTM` except the final commit is skipped and thus all writes are discarded.  This lets us provide a lower-level interface than an RPC that can run read operations in an existing transaction by accepting a `col.STM` object.

This is a prerequisite for #3658.    I added this to a few calls in the auth server which will need to be ported because they are run from existing PFS RPCs, but they are not _fully_ transactional.  Verifying the current user/groups still just uses the latest committed etcd state because (a) it's not really needed, and (b) refactoring that interface would be a much larger task.