### PR TITLE
Fix incorrect command-line parsing in 'list commit' when a branch is passed

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -365,17 +365,18 @@ $ {{alias}} foo@master --from XXX`,
 			}
 			defer c.Close()
 
-			var to string
-			if len(args) == 2 {
-				to = args[1]
+			branch, err := cmdutil.ParseBranch(args[0])
+			if err != nil {
+				return err
 			}
+
 			if raw {
-				return c.ListCommitF(args[0], to, from, uint64(number), func(ci *pfsclient.CommitInfo) error {
+				return c.ListCommitF(branch.Repo.Name, branch.Name, from, uint64(number), func(ci *pfsclient.CommitInfo) error {
 					return marshaller.Marshal(os.Stdout, ci)
 				})
 			}
 			writer := tabwriter.NewWriter(os.Stdout, pretty.CommitHeader)
-			if err := c.ListCommitF(args[0], to, from, uint64(number), func(ci *pfsclient.CommitInfo) error {
+			if err := c.ListCommitF(branch.Repo.Name, branch.Name, from, uint64(number), func(ci *pfsclient.CommitInfo) error {
 				pretty.PrintCommitInfo(writer, ci, fullTimestamps)
 				return nil
 			}); err != nil {


### PR DESCRIPTION
Part of #3679 - the arg-handling code here wasn't updated properly to handle `repo@branch` - fixed here.  Also did a quick sweep of other commands and didn't see anything else with a similar problem.