### PR TITLE
Store pipeline state in RC labels

### DIFF
--- a/src/client/pps/pps.pb.go
+++ b/src/client/pps/pps.pb.go
@@ -137,7 +137,8 @@ const (
 	// We have retried too many times and we have given up on this pipeline (or
 	// the pipeline image doesn't exist)
 	PipelineState_PIPELINE_FAILURE PipelineState = 3
-	// The pipeline has been explicitly paused by the user.
+	// The pipeline has been explicitly paused by the user (the pipeline spec's
+	// Stopped field should be true if the pipeline is in this state)
 	PipelineState_PIPELINE_PAUSED PipelineState = 4
 	// The pipeline is fully functional, but there are no commits to process.
 	PipelineState_PIPELINE_STANDBY PipelineState = 5

--- a/src/client/pps/pps.pb.go
+++ b/src/client/pps/pps.pb.go
@@ -123,19 +123,19 @@ func (WorkerState) EnumDescriptor() ([]byte, []int) {
 type PipelineState int32
 
 const (
-	// When the pipeline is not ready to be triggered by commits.
-	// This happens when either 1) a pipeline has been created but not
-	// yet picked up by a PPS server, or 2) the pipeline does not have
-	// any inputs and is meant to be triggered manually
+	// There is an EtcdPipelineInfo + spec commit, but no RC
+	// This happens when a pipeline has been created but not yet picked up by a
+	// PPS server.
 	PipelineState_PIPELINE_STARTING PipelineState = 0
-	// After this pipeline is picked up by a pachd node.  This is the normal
-	// state of a pipeline.
+	// A pipeline has a spec commit and a service + RC
+	// This is the normal state of a pipeline.
 	PipelineState_PIPELINE_RUNNING PipelineState = 1
-	// After some error caused runPipeline to exit, but before the
-	// pipeline is re-run.  This is when the exponential backoff is
-	// in effect.
+	// Equivalent to STARTING (there is an EtcdPipelineInfo + commit, but no RC)
+	// After some error caused runPipeline to exit, but before the pipeline is
+	// re-run. This is when the exponential backoff is in effect.
 	PipelineState_PIPELINE_RESTARTING PipelineState = 2
-	// We have retried too many times and we have given up on this pipeline.
+	// We have retried too many times and we have given up on this pipeline (or
+	// the pipeline image doesn't exist)
 	PipelineState_PIPELINE_FAILURE PipelineState = 3
 	// The pipeline has been explicitly paused by the user.
 	PipelineState_PIPELINE_PAUSED PipelineState = 4

--- a/src/client/pps/pps.proto
+++ b/src/client/pps/pps.proto
@@ -303,19 +303,19 @@ message PipelineInput {
 }
 
 enum PipelineState {
-  // When the pipeline is not ready to be triggered by commits.
-  // This happens when either 1) a pipeline has been created but not
-  // yet picked up by a PPS server, or 2) the pipeline does not have
-  // any inputs and is meant to be triggered manually
+  // There is an EtcdPipelineInfo + spec commit, but no RC
+  // This happens when a pipeline has been created but not yet picked up by a
+  // PPS server.
   PIPELINE_STARTING = 0;
-  // After this pipeline is picked up by a pachd node.  This is the normal
-  // state of a pipeline.
+  // A pipeline has a spec commit and a service + RC
+  // This is the normal state of a pipeline.
   PIPELINE_RUNNING = 1;
-  // After some error caused runPipeline to exit, but before the
-  // pipeline is re-run.  This is when the exponential backoff is
-  // in effect.
+  // Equivalent to STARTING (there is an EtcdPipelineInfo + commit, but no RC)
+  // After some error caused runPipeline to exit, but before the pipeline is
+  // re-run. This is when the exponential backoff is in effect.
   PIPELINE_RESTARTING = 2;
-  // We have retried too many times and we have given up on this pipeline.
+  // We have retried too many times and we have given up on this pipeline (or
+  // the pipeline image doesn't exist)
   PIPELINE_FAILURE = 3;
   // The pipeline has been explicitly paused by the user.
   PIPELINE_PAUSED = 4;

--- a/src/client/pps/pps.proto
+++ b/src/client/pps/pps.proto
@@ -317,7 +317,8 @@ enum PipelineState {
   // We have retried too many times and we have given up on this pipeline (or
   // the pipeline image doesn't exist)
   PIPELINE_FAILURE = 3;
-  // The pipeline has been explicitly paused by the user.
+  // The pipeline has been explicitly paused by the user (the pipeline spec's
+  // Stopped field should be true if the pipeline is in this state)
   PIPELINE_PAUSED = 4;
   // The pipeline is fully functional, but there are no commits to process.
   PIPELINE_STANDBY = 5;

--- a/src/server/pkg/collection/collection.go
+++ b/src/server/pkg/collection/collection.go
@@ -568,10 +568,6 @@ func (c *readonlyCollection) Watch() (watch.Watcher, error) {
 	return watch.NewWatcher(c.ctx, c.etcdClient, c.prefix, c.prefix, c.template)
 }
 
-func (c *readonlyCollection) WatchWithPrev() (watch.Watcher, error) {
-	return watch.NewWatcherWithPrev(c.ctx, c.etcdClient, c.prefix, c.prefix, c.template)
-}
-
 // WatchByIndex watches items in a collection that match a particular index
 func (c *readonlyCollection) WatchByIndex(index *Index, val interface{}) (watch.Watcher, error) {
 	eventCh := make(chan *watch.Event)

--- a/src/server/pkg/collection/types.go
+++ b/src/server/pkg/collection/types.go
@@ -108,7 +108,6 @@ type ReadonlyCollection interface {
 	Watch() (watch.Watcher, error)
 	// WatchWithPrev is like Watch, but the events will include the previous
 	// versions of the key/value.
-	WatchWithPrev() (watch.Watcher, error)
 	WatchOne(key string) (watch.Watcher, error)
 	WatchByIndex(index *Index, val interface{}) (watch.Watcher, error)
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2315,6 +2315,8 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 	if a.updatePipelineSpecCommit(pachClient, request.Pipeline.Name, commit); err != nil {
 		return nil, err
 	}
+	// TODO(msteffen): can I get rid of this and have the PPS master make the
+	// change?
 	if err := a.markPipelineRunning(pachClient, request.Pipeline.Name); err != nil {
 		return nil, err
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2236,6 +2236,9 @@ func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.De
 	if err := a.jobs.ReadOnly(ctx).GetByIndex(ppsdb.JobsPipelineIndex, request.Pipeline, jobPtr, col.DefaultOptions, func(jobID string) error {
 		eg.Go(func() error {
 			_, err := a.DeleteJob(ctx, &pps.DeleteJobRequest{Job: &pps.Job{ID: jobID}})
+			if isNotFoundErr(err) {
+				return nil
+			}
 			return err
 		})
 		return nil

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -18,17 +18,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_watch "k8s.io/apimachinery/pkg/watch"
-	kube "k8s.io/client-go/kubernetes"
 
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/tracing"
 	"github.com/pachyderm/pachyderm/src/client/pkg/tracing/extended"
 	"github.com/pachyderm/pachyderm/src/client/pps"
-	"github.com/pachyderm/pachyderm/src/client/version"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
-	"github.com/pachyderm/pachyderm/src/server/pkg/deploy/assets"
 	"github.com/pachyderm/pachyderm/src/server/pkg/dlock"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
 	"github.com/pachyderm/pachyderm/src/server/pkg/watch"
@@ -66,7 +63,7 @@ func (a *apiServer) master() {
 
 		log.Infof("PPS master: launching master process")
 
-		pipelineWatcher, err := a.pipelines.ReadOnly(ctx).WatchWithPrev()
+		pipelineWatcher, err := a.pipelines.ReadOnly(ctx).Watch()
 		if err != nil {
 			return fmt.Errorf("error creating watch: %+v", err)
 		}
@@ -118,165 +115,28 @@ func (a *apiServer) master() {
 				switch event.Type {
 				case watch.EventPut:
 					var pipelineName string
-					var prevPipelinePtr pps.EtcdPipelineInfo
 					var pipelinePtr pps.EtcdPipelineInfo
 					if err := event.Unmarshal(&pipelineName, &pipelinePtr); err != nil {
 						return err
 					}
-					if event.PrevKey != nil {
-						if err := event.UnmarshalPrev(&pipelineName, &prevPipelinePtr); err != nil {
-							return err
-						}
-					}
-					log.Infof("PPS master: pipeline %q: %s -> %s", pipelineName, prevPipelinePtr.State, pipelinePtr.State)
-					var prevSpecCommit string
-					if prevPipelinePtr.SpecCommit != nil {
-						prevSpecCommit = prevPipelinePtr.SpecCommit.ID
-					}
-					var curSpecCommit = pipelinePtr.SpecCommit.ID
+					log.Infof("PPS master: pipeline %q: -> %s", pipelineName, pipelinePtr.State)
 
 					// Handle tracing (pipelineRestarted is used to maybe delete trace)
 					if span, ctx = extended.AddPipelineSpanToAnyTrace(oldCtx,
 						a.etcdClient, pipelineName, "/pps.Master/ProcessPipelineUpdate",
 						"key-version", event.Ver,
 						"mod-revision", event.Rev,
-						"prev-key", string(event.PrevKey),
-						"old-state", prevPipelinePtr.State.String(),
-						"old-spec-commit", prevSpecCommit,
 						"new-state", pipelinePtr.State.String(),
-						"new-spec-commit", curSpecCommit,
+						"new-spec-commit", pipelinePtr.SpecCommit,
 					); span != nil {
 						pachClient = oldPachClient.WithCtx(ctx)
 					} else {
 						pachClient = oldPachClient
 					}
 
-					// Retrieve pipelineInfo (and prev pipeline's pipelineInfo) from the
-					// spec repo
-					var pipelineInfo, prevPipelineInfo *pps.PipelineInfo
-					if err := a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-						var err error
-						pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, &pipelinePtr)
-						if err != nil {
-							return err
-						}
-
-						if prevPipelinePtr.SpecCommit != nil {
-							prevPipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, &prevPipelinePtr)
-							if err != nil {
-								return err
-							}
-						}
-						return nil
-					}); err != nil {
-						return fmt.Errorf("watch event had no pipelineInfo: %v", err)
-					}
-
-					// True if the pipeline has a git input
-					var hasGitInput bool
-					pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {
-						if input.Git != nil {
-							hasGitInput = true
-						}
-					})
-					// True if the user has called StopPipeline, but the PPS master hasn't
-					// processed the update yet (PPS master sets the pipeline state to
-					// PAUSED)
-					pipelinePartiallyPaused := pipelineInfo.Stopped &&
-						pipelineInfo.State != pps.PipelineState_PIPELINE_PAUSED
-					// True if the pipeline has been restarted (regardless of any change
-					// to the pipeline spec)
-					pipelineRestarted := !pipelineInfo.Stopped &&
-						event.PrevKey != nil && prevPipelineInfo.Stopped
-					// True if auth has been activated or deactivated
-					authActivationChanged := (pipelinePtr.AuthToken == "") !=
-						(prevPipelinePtr.AuthToken == "")
-					// True if the pipeline has been created or updated
-					pipelineNewSpecCommit := func() bool {
-						var prevSpecCommit string
-						if prevPipelinePtr.SpecCommit != nil {
-							prevSpecCommit = prevPipelinePtr.SpecCommit.ID
-						}
-						return pipelinePtr.SpecCommit.ID != prevSpecCommit &&
-							!pipelineInfo.Stopped
-					}()
-
-					// Handle cases where pipeline isn't running anymore
-					if pipelineInfo.State == pps.PipelineState_PIPELINE_FAILURE {
-						// pipeline fails if docker image isn't found OR if pipeline RC is
-						// missing
-						if err := a.finishPipelineOutputCommits(pachClient, pipelineInfo); err != nil {
-							return err
-						}
-						if err := a.deletePipelineResources(ctx, pipelineName); err != nil {
-							return err
-						}
-						continue
-					} else if pipelineInfo.State == pps.PipelineState_PIPELINE_PAUSED {
-						continue // pipeline has already been paused -- nothing to do
-					} else if pipelinePartiallyPaused {
-						// Clusters can get into broken state where pipeline exists but
-						// RC is deleted by user--causes master() to crashloop trying to
-						// scale up/down workers repeatedly. Break the cycle here
-						if err := a.scaleDownWorkersForPipeline(ctx, pipelineInfo); err != nil {
-							if failErr := a.setPipelineFailure(ctx, pipelineInfo.Pipeline.Name, err.Error()); failErr != nil {
-								return failErr
-							}
-							return err
-						}
-						// Mark the pipeline paused, thus fully stopping it (Note: this will
-						// generate another etcd event, which is ignored below)
-						if err := a.setPipelineState(pachClient, pipelineInfo, pps.PipelineState_PIPELINE_PAUSED, ""); err != nil {
-							return err
-						}
-						continue
-					}
-
-					// Handle cases where pipeline is still running
-					if pipelineRestarted || authActivationChanged || pipelineNewSpecCommit {
-						if (pipelineNewSpecCommit || authActivationChanged) && event.PrevKey != nil {
-							if err := a.deletePipelineResources(ctx, prevPipelineInfo.Pipeline.Name); err != nil {
-								return err
-							}
-						}
-						if (pipelineNewSpecCommit || pipelineRestarted) && hasGitInput {
-							if err := a.checkOrDeployGithookService(ctx); err != nil {
-								return err
-							}
-						}
-						if err := a.upsertWorkersForPipeline(ctx, pipelineInfo); err != nil {
-							log.Errorf("error upserting workers for new/restarted pipeline %q: %v", pipelineName, err)
-							if err := a.setPipelineState(pachClient, pipelineInfo, pps.PipelineState_PIPELINE_STARTING, fmt.Sprintf("failed to create workers: %s", err.Error())); err != nil {
-								return err
-							}
-							// We return the error here, this causes us to go
-							// into backoff and try again from scratch. This
-							// means that we'll try creating this pipeline
-							// again and also gives a chance for another node,
-							// which might actually be able to talk to k8s, to
-							// get a chance at creating the workers.
-							return err
-						}
-					}
-					if pipelineInfo.State == pps.PipelineState_PIPELINE_RUNNING {
-						if err := a.scaleUpWorkersForPipeline(ctx, pipelineInfo); err != nil {
-							if isNotFoundErr(err) {
-								// See note above (under "if pipelinePartiallyStopped")
-								if failErr := a.setPipelineFailure(ctx, pipelineInfo.Pipeline.Name, err.Error()); failErr != nil {
-									return failErr
-								}
-							}
-							return err
-						}
-					}
-					if pipelineInfo.State == pps.PipelineState_PIPELINE_STANDBY {
-						if err := a.scaleDownWorkersForPipeline(ctx, pipelineInfo); err != nil {
-							// See note above (under "if pipelinePartiallyStopped")
-							if failErr := a.setPipelineFailure(ctx, pipelineInfo.Pipeline.Name, err.Error()); failErr != nil {
-								return failErr
-							}
-							return err
-						}
+					// Create/Modify/Delete pipeline resources as needed per new state
+					if err := a.step(pachClient, pipelineName, &pipelinePtr); err != nil {
+						return err
 					}
 				}
 			case event := <-watchChan:
@@ -327,7 +187,7 @@ func (a *apiServer) master() {
 			c()
 		}
 		a.monitorCancels = make(map[string]func())
-		log.Errorf("master: error running the master process: %v; retrying in %v", err, d)
+		log.Errorf("PPS master: error running the master process: %v; retrying in %v", err, d)
 		return nil
 	})
 	panic("internal error: PPS master has somehow exited. Restarting pod...")
@@ -337,186 +197,10 @@ func (a *apiServer) setPipelineFailure(ctx context.Context, pipelineName string,
 	return ppsutil.FailPipeline(ctx, a.etcdClient, a.pipelines, pipelineName, reason)
 }
 
-func (a *apiServer) checkOrDeployGithookService(ctx context.Context) error {
-	_, err := getGithookService(a.kubeClient, a.namespace)
-	if err != nil {
-		if _, ok := err.(*errGithookServiceNotFound); ok {
-			svc := assets.GithookService(a.namespace)
-			_, err = a.kubeClient.CoreV1().Services(a.namespace).Create(svc)
-			return err
-		}
-		return err
-	}
-	// service already exists
-	return nil
-}
-
-func getGithookService(kubeClient *kube.Clientset, namespace string) (*v1.Service, error) {
-	labels := map[string]string{
-		"app":   "githook",
-		"suite": suite,
-	}
-	serviceList, err := kubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ListOptions",
-			APIVersion: "v1",
-		},
-		LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(labels)),
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(serviceList.Items) != 1 {
-		return nil, &errGithookServiceNotFound{
-			fmt.Errorf("expected 1 githook service but found %v", len(serviceList.Items)),
-		}
-	}
-	return &serviceList.Items[0], nil
-}
-
-func (a *apiServer) upsertWorkersForPipeline(ctx context.Context, pipelineInfo *pps.PipelineInfo) (retErr error) {
-	log.Infof("PPS master: upserting workers for %q", pipelineInfo.Pipeline.Name)
-	span, ctx := tracing.AddSpanToAnyExisting(ctx, "/pps.Master/UpsertWorkersForPipeline", "pipeline", pipelineInfo.Pipeline.Name)
-	defer func(span opentracing.Span) {
-		if span != nil {
-			span.SetTag("err", fmt.Sprintf("%v", retErr))
-		}
-		tracing.FinishAnySpan(span)
-	}(span)
-	var errCount int
-	if err := backoff.RetryNotify(func() error {
-		var resourceRequests *v1.ResourceList
-		var resourceLimits *v1.ResourceList
-		if pipelineInfo.ResourceRequests != nil {
-			var err error
-			resourceRequests, err = ppsutil.GetRequestsResourceListFromPipeline(pipelineInfo)
-			if err != nil {
-				return err
-			}
-		}
-		if pipelineInfo.ResourceLimits != nil {
-			var err error
-			resourceLimits, err = ppsutil.GetLimitsResourceListFromPipeline(pipelineInfo)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Retrieve the current state of the RC.  If the RC is scaled down,
-		// we want to ensure that it remains scaled down.
-		span, _ = tracing.AddSpanToAnyExisting(ctx, "/kube.RC/Get", "pipeline", pipelineInfo.Pipeline.Name)
-		rc := a.kubeClient.CoreV1().ReplicationControllers(a.namespace)
-		workerRc, err := rc.Get(
-			ppsutil.PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version),
-			metav1.GetOptions{})
-		tracing.FinishAnySpan(span)
-		var rcFound bool
-		if err != nil && !isNotFoundErr(err) {
-			return err
-		} else if err == nil {
-			rcFound = true
-		}
-		newPachVersion := rcFound && workerRc.ObjectMeta.Labels["version"] != version.PrettyVersion()
-
-		// Generate options for new RC
-		options := a.getWorkerOptions(
-			pipelineInfo.Pipeline.Name,
-			pipelineInfo.Version,
-			0,
-			resourceRequests,
-			resourceLimits,
-			pipelineInfo.Transform,
-			pipelineInfo.CacheSize,
-			pipelineInfo.Service,
-			pipelineInfo.SpecCommit.ID,
-			pipelineInfo.SchedulingSpec,
-			pipelineInfo.PodSpec)
-		// Set the pipeline name env
-		options.workerEnv = append(options.workerEnv, v1.EnvVar{
-			Name:  client.PPSPipelineNameEnv,
-			Value: pipelineInfo.Pipeline.Name,
-		})
-
-		if newPachVersion {
-			if err := a.deletePipelineResources(ctx, pipelineInfo.Pipeline.Name); err != nil {
-				return err
-			}
-		}
-		span, _ = tracing.AddSpanToAnyExisting(ctx, "/kube.RC/Create", "pipeline", pipelineInfo.Pipeline.Name)
-		defer tracing.FinishAnySpan(span)
-		return a.createWorkerRc(options)
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		errCount++
-		if errCount >= 3 {
-			return err
-		}
-		log.Errorf("error creating workers for pipeline %v: %v; retrying in %v", pipelineInfo.Pipeline.Name, err, d)
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// Start monitorPipeline() for this pipeline, which controls the new workers
-	a.monitorCancelsMu.Lock()
-	defer a.monitorCancelsMu.Unlock()
-	if _, ok := a.monitorCancels[pipelineInfo.Pipeline.Name]; !ok {
-		ctx, cancel := context.WithCancel(a.pachClient.Ctx())
-		a.monitorCancels[pipelineInfo.Pipeline.Name] = cancel
-		pachClient := a.pachClient.WithCtx(ctx)
-
-		go a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-			a.monitorPipeline(superUserClient, pipelineInfo)
-			return nil
-		})
-	}
-	return nil
-}
-
-// finishPipelineOutputCommits finishes any output commits of
-// 'pipelineInfo.Pipeline' with an empty tree.
-// TODO(msteffen) Note that if the pipeline has any jobs (which can happen if
-// the user manually deletes the pipeline's RC, failing the pipeline, after it
-// has created jobs) those will not be updated. TODO is to mark jobs FAILED
-func (a *apiServer) finishPipelineOutputCommits(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) (retErr error) {
-	pipelineName := pipelineInfo.Pipeline.Name
-	log.Infof("PPS master: finishing output commits for pipeline %q", pipelineName)
-	span, _ctx := tracing.AddSpanToAnyExisting(pachClient.Ctx(), "/pps.Master/FinishPipelineOutputCommits", "pipeline", pipelineName)
-	if span != nil {
-		pachClient = pachClient.WithCtx(_ctx) // copy auth info from input to output
-	}
-	defer func(span opentracing.Span) {
-		if span != nil {
-			span.SetTag("err", fmt.Sprintf("%v", retErr))
-		}
-		tracing.FinishAnySpan(span)
-	}(span)
-
-	return a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-		commitInfos, err := superUserClient.ListCommit(pipelineName, pipelineInfo.OutputBranch, "", 0)
-		if err != nil {
-			return fmt.Errorf("could not list output commits of %q to finish them: %v", pipelineName, err)
-		}
-
-		var finishCommitErr error
-		for _, ci := range commitInfos {
-			if ci.Finished != nil {
-				continue // nothing needs to be done
-			}
-			if _, err := superUserClient.PfsAPIClient.FinishCommit(superUserClient.Ctx(),
-				&pfs.FinishCommitRequest{
-					Commit: client.NewCommit(pipelineName, ci.Commit.ID),
-					Empty:  true,
-				}); err != nil && finishCommitErr == nil {
-				finishCommitErr = err
-			}
-		}
-		return finishCommitErr
-	})
-}
-
 func (a *apiServer) deletePipelineResources(ctx context.Context, pipelineName string) (retErr error) {
 	log.Infof("PPS master: deleting resources for failed pipeline %q", pipelineName)
-	span, ctx := tracing.AddSpanToAnyExisting(ctx, "/pps.Master/DeletePipelineResources", "pipeline", pipelineName)
+	span, ctx := tracing.AddSpanToAnyExisting(ctx,
+		"/pps.Master/DeletePipelineResources", "pipeline", pipelineName)
 	defer func(span opentracing.Span) {
 		if span != nil {
 			span.SetTag("err", fmt.Sprintf("%v", retErr))
@@ -532,7 +216,8 @@ func (a *apiServer) deletePipelineResources(ctx context.Context, pipelineName st
 	}
 	a.monitorCancelsMu.Unlock()
 
-	selector := fmt.Sprintf("pipelineName=%s", pipelineName)
+	// Delete any services associated with op.pipeline
+	selector := fmt.Sprintf("%s=%s", pipelineNameLabel, pipelineName)
 	falseVal := false
 	opts := &metav1.DeleteOptions{
 		OrphanDependents: &falseVal,
@@ -560,59 +245,6 @@ func (a *apiServer) deletePipelineResources(ctx context.Context, pipelineName st
 		}
 	}
 	return nil
-}
-
-func (a *apiServer) scaleDownWorkersForPipeline(ctx context.Context, pipelineInfo *pps.PipelineInfo) (retErr error) {
-	log.Infof("scaling down workers for %q", pipelineInfo.Pipeline.Name)
-	span, ctx := tracing.AddSpanToAnyExisting(ctx, "/pps.Master/ScaleDownWorkersForPipeline", "pipeline", pipelineInfo.Pipeline.Name)
-	defer func(span opentracing.Span) {
-		if span != nil {
-			span.SetTag("err", fmt.Sprintf("%v", retErr))
-		}
-		tracing.FinishAnySpan(span)
-	}(span)
-
-	rc := a.kubeClient.CoreV1().ReplicationControllers(a.namespace)
-
-	workerRc, err := rc.Get(
-		ppsutil.PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version),
-		metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	workerRc.Spec.Replicas = &zero
-	_, err = rc.Update(workerRc)
-	if err != nil {
-		return fmt.Errorf("could not update scaled-down pipeline (%q) RC: %v",
-			pipelineInfo.Pipeline.Name, err)
-	}
-	return nil
-}
-
-func (a *apiServer) scaleUpWorkersForPipeline(ctx context.Context, pipelineInfo *pps.PipelineInfo) (retErr error) {
-	span, ctx := tracing.AddSpanToAnyExisting(ctx, "/pps.Master/ScaleUpWorkersForPipeline", "pipeline", pipelineInfo.Pipeline.Name)
-	defer func(span opentracing.Span) {
-		if span != nil {
-			span.SetTag("err", fmt.Sprintf("%v", retErr))
-		}
-		tracing.FinishAnySpan(span)
-	}(span)
-
-	rc := a.kubeClient.CoreV1().ReplicationControllers(a.namespace)
-	workerRc, err := rc.Get(
-		ppsutil.PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version),
-		metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	parallelism, err := ppsutil.GetExpectedNumWorkers(a.kubeClient, pipelineInfo.ParallelismSpec)
-	if err != nil {
-		log.Errorf("error getting number of workers, default to 1 worker: %v", err)
-		parallelism = 1
-	}
-	*workerRc.Spec.Replicas = int32(parallelism)
-	_, err = rc.Update(workerRc)
-	return err
 }
 
 func notifyCtx(ctx context.Context, name string) func(error, time.Duration) error {
@@ -665,10 +297,10 @@ func (a *apiServer) setPipelineState(pachClient *client.APIClient, pipelineInfo 
 func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) {
 	log.Printf("PPS master: monitoring pipeline %q", pipelineInfo.Pipeline.Name)
 	defer func(pipelineName string) {
-		// If this exits (e.g. b/c Standby is false), remove this fn's cancel() call
-		// from a.monitorCancels (if it hasn't already been removed, e.g. by
-		// deletePipelineResources cancelling this call), so that it can be called
-		// again
+		// If this exits (e.g. b/c Standby is false, and pipeline has no cron
+		// inputs), remove this fn's cancel() call from a.monitorCancels (if it
+		// hasn't already been removed, e.g. by deletePipelineResources cancelling
+		// this call), so that it can be called again
 		a.monitorCancelsMu.Lock()
 		if cancel, ok := a.monitorCancels[pipelineName]; ok {
 			cancel()
@@ -686,24 +318,7 @@ func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 			})
 		}
 	})
-	if !pipelineInfo.Standby {
-		// Standby is false so simply put it in RUNNING and leave it there.  This is
-		// only done with eg.Go so that we can handle all the errors in the
-		// same way below, it should be a very quick operation so there's no
-		// good reason to do it concurrently.
-		eg.Go(func() error {
-			return backoff.RetryNotify(func() error {
-				span, ctx := extended.AddPipelineSpanToAnyTrace(pachClient.Ctx(),
-					a.etcdClient, pipelineInfo.Pipeline.Name, "/pps.Master/MonitorPipeline",
-					"standby", pipelineInfo.Standby)
-				if span != nil {
-					pachClient = pachClient.WithCtx(ctx)
-				}
-				defer tracing.FinishAnySpan(span)
-				return a.setPipelineState(pachClient, pipelineInfo, pps.PipelineState_PIPELINE_RUNNING, "")
-			}, backoff.NewInfiniteBackOff(), notifyCtx(pachClient.Ctx(), "set running (Standby = false)"))
-		})
-	} else {
+	if pipelineInfo.Standby {
 		// Capacity 1 gives us a bit of buffer so we don't needlessly go into
 		// standby when SubscribeCommit takes too long to return.
 		ciChan := make(chan *pfs.CommitInfo, 1)

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -1,0 +1,371 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"github.com/pachyderm/pachyderm/src/client"
+	"strings"
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/client/pkg/tracing"
+	"github.com/pachyderm/pachyderm/src/client/pps"
+	"github.com/pachyderm/pachyderm/src/client/version"
+	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
+)
+
+const maxErrCount = 3
+
+type pipelineOp struct {
+	apiServer    *apiServer
+	pachClient   *client.APIClient
+	ptr          *pps.EtcdPipelineInfo
+	name         string // also in pipelineInfo, but that may not be set initially
+	pipelineInfo *pps.PipelineInfo
+	rc           *v1.ReplicationController
+}
+
+// step takes 'ptr', a newly-changed pipeline pointer in etcd, and
+// 1. converts it into the full pipeline spec and RC
+// 2. makes whatever changes are needed to bring the RC in line with the (new) spec
+// 3. updates 'ptr', if needed, to reflect the action it just took
+func (a *apiServer) step(pachClient *client.APIClient, pipelineName string, ptr *pps.EtcdPipelineInfo) error {
+	// Retrieve pipelineInfo from the spec repo
+	op := &pipelineOp{
+		apiServer:  a,
+		pachClient: pachClient,
+		ptr:        ptr,
+		name:       pipelineName,
+	}
+	if ptr.SpecCommit == nil || ptr.SpecCommit.ID == "" {
+		op.setPipelineFailure("no spec commit")
+	}
+
+	// set op.ppelineInfo
+	if err := op.getPipelineInfo(); err != nil {
+		return err
+	}
+	// set op.rc
+	if err := op.getRC(); err != nil && !isNotFoundErr(err) {
+		return fmt.Errorf("error reading RC for %q: %v", op.name, err)
+	}
+
+	// Take whatever actions are needed
+	switch ptr.State {
+	case pps.PipelineState_PIPELINE_STARTING, pps.PipelineState_PIPELINE_RESTARTING:
+		if op.rc != nil {
+			// overwrite etcdPipelineInfo with itself so that we re-process
+			// the pipeline after the RC is gone
+			return op.restartPipeline()
+		}
+		if err := op.createPipelineResources(); err != nil {
+			return err
+		}
+		// trigger another event--once pipeline is RUNNING, step() will scale it up
+		if err := op.setPipelineState(pps.PipelineState_PIPELINE_RUNNING); err != nil {
+			return err
+		}
+	case pps.PipelineState_PIPELINE_RUNNING:
+		specCommitB64, err := commitIDToB64(ptr.SpecCommit.ID)
+		if err != nil {
+			return err
+		}
+		if op.rc == nil ||
+			op.rc.ObjectMeta.Labels[hashedAuthTokenLabel] != hashAuthToken(ptr.AuthToken) ||
+			op.rc.ObjectMeta.Labels[specCommitLabel] != specCommitB64 ||
+			op.rc.ObjectMeta.Labels[pachVersionLabel] != version.PrettyVersion() {
+			return op.restartPipeline()
+		}
+		op.startPipelineMonitor()
+
+		if op.pipelineInfo.Stopped {
+			// StopPipeline has been called, but pipeline hasn't been paused yet
+			if err := op.scaleDownPipeline(); err != nil {
+				return err
+			}
+			return op.setPipelineState(pps.PipelineState_PIPELINE_PAUSED)
+		}
+		// pipeline has been unpaused or taken out of standby--scale up
+		if err := op.scaleUpPipeline(); err != nil {
+			return err
+		}
+	case pps.PipelineState_PIPELINE_STANDBY, pps.PipelineState_PIPELINE_PAUSED:
+		if op.rc == nil {
+			if err := op.restartPipeline(); err != nil {
+				return err
+			}
+			return nil
+		}
+		op.startPipelineMonitor()
+
+		// scale down is pause/standby hasn't been propagated to etcd yet
+		if err := op.scaleDownPipeline(); err != nil {
+			return err
+		}
+	case pps.PipelineState_PIPELINE_FAILURE:
+		// pipeline fails if docker image isn't found
+		if err := op.finishPipelineOutputCommits(); err != nil {
+			return err
+		}
+		return op.deletePipelineResources()
+	}
+	return nil
+}
+
+// getPipelineInfo reads the pipelineInfo associated with 'op's pipeline. This
+// should be one of the first calls made on 'op', as most other methods assume
+// that op.pipelineInfo is set
+func (op *pipelineOp) getPipelineInfo() error {
+	var errCount int
+	if err := backoff.RetryNotify(func() error {
+		return op.apiServer.sudo(op.pachClient, func(superUserClient *client.APIClient) error {
+			var err error
+			op.pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, op.ptr)
+			return err
+		})
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if errCount++; errCount >= maxErrCount {
+			return fmt.Errorf("error retrieving spec for %q after %d attempts: %v",
+				op.name, maxErrCount, err)
+		}
+		log.Errorf("PPS master: error retrieving spec for %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	}); err != nil {
+		// don't necessarily restart PPS master, which would not fix the problem
+		return op.setPipelineFailure(fmt.Sprintf("pipeline spec commit could not be read: %v", err))
+	}
+	return nil
+}
+
+// getRC reads the RC associated with 'op's pipeline. op.pipelineInfo must be
+// set already
+func (op *pipelineOp) getRC() error {
+	kubeClient := op.apiServer.kubeClient
+	namespace := op.apiServer.namespace
+	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(), "/kube.RC/Get",
+		"pipeline", op.name)
+	defer tracing.FinishAnySpan(span)
+	var err error
+	op.rc, err = kubeClient.CoreV1().ReplicationControllers(namespace).Get(
+		ppsutil.PipelineRcName(op.name, op.pipelineInfo.Version),
+		metav1.GetOptions{})
+	if err != nil {
+		op.rc = nil // unset; even with non-nil error Get() returns default RC
+	}
+	return err
+}
+
+func (op *pipelineOp) setPipelineState(state pps.PipelineState) error {
+	return op.apiServer.setPipelineState(op.pachClient, op.pipelineInfo, state, "")
+}
+
+func (op *pipelineOp) restartPipeline() error {
+	log.Infof("PPS master: restarting pipeline %q", op.name)
+	var errCount int
+	if err := backoff.RetryNotify(func() error {
+		if err := op.deletePipelineResources(); err != nil {
+			return err
+		}
+		return op.setPipelineState(pps.PipelineState_PIPELINE_RESTARTING)
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if errCount++; errCount >= maxErrCount {
+			return fmt.Errorf("could not restart pipeline %q after %d attempts: %v",
+				op.name, maxErrCount, err)
+		}
+		log.Errorf("PPS master: error restarting pipeline %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	}); err != nil {
+		// don't necessarily restart PPS master, which would not fix the problem
+		return op.setPipelineFailure(fmt.Sprintf("error during restart: %v", err))
+	}
+	return nil
+}
+
+func (op *pipelineOp) setPipelineFailure(reason string) error {
+	return op.apiServer.setPipelineFailure(op.pachClient.Ctx(),
+		op.name, reason)
+}
+
+func (op *pipelineOp) createPipelineResources() error {
+	log.Infof("PPS master: creating resources for pipeline %q", op.name)
+	var errCount int
+	if err := backoff.RetryNotify(func() error {
+		return op.apiServer.createWorkerSvcAndRc(op.pachClient.Ctx(), op.ptr, op.pipelineInfo)
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if errCount++; errCount >= maxErrCount {
+			return fmt.Errorf("could not create resources for pipeline %q after %d attempts: %v",
+				op.name, maxErrCount, err)
+		}
+		log.Errorf("PPS master: error creating resources for pipeline %q: %v; retrying in %v",
+			op.name, err, d)
+		return nil
+	}); err != nil {
+		// don't necessarily restart PPS master, which would not fix the problem
+		return op.setPipelineFailure(fmt.Sprintf("error creating resources: %v", err.Error()))
+	}
+	return nil
+}
+
+// startPipelineMonitor spawns a monitorPipeline() goro for this pipeline (if
+// one doesn't exist already), which manages standby and cron inputs, and
+// updates the the pipeline state.
+// Note: this is called by every run through step(), so must be idempotent
+func (op *pipelineOp) startPipelineMonitor() {
+	op.apiServer.monitorCancelsMu.Lock()
+	defer op.apiServer.monitorCancelsMu.Unlock()
+	if _, ok := op.apiServer.monitorCancels[op.name]; !ok {
+		// use context.Background because we expect this goro to run for the rest of
+		// pachd's lifetime
+		ctx, cancel := context.WithCancel(context.Background())
+		op.apiServer.monitorCancels[op.name] = cancel
+		pachClient := op.apiServer.pachClient.WithCtx(ctx)
+
+		go op.apiServer.sudo(pachClient, func(superUserClient *client.APIClient) error {
+			op.apiServer.monitorPipeline(superUserClient, op.pipelineInfo)
+			return nil
+		})
+	}
+}
+
+// finishPipelineOutputCommits finishes any output commits of
+// 'pipelineInfo.Pipeline' with an empty tree.
+// TODO(msteffen) Note that if the pipeline has any jobs (which can happen if
+// the user manually deletes the pipeline's RC, failing the pipeline, after it
+// has created jobs) those will not be updated, but they should be FAILED
+func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
+	log.Infof("PPS master: finishing output commits for pipeline %q", op.name)
+	span, _ctx := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/FinishPipelineOutputCommits", "pipeline", op.name)
+	pachClient := op.pachClient.WithCtx(_ctx) // copy span back into pachClient
+	defer func(span opentracing.Span) {
+		if span != nil {
+			span.SetTag("err", fmt.Sprintf("%v", retErr))
+		}
+		tracing.FinishAnySpan(span)
+	}(span)
+
+	return a.sudo(pachClient, func(superUserClient *client.APIClient) error {
+		commitInfos, err := superUserClient.ListCommit(pipelineName, pipelineInfo.OutputBranch, "", 0)
+		if err != nil {
+			return fmt.Errorf("could not list output commits of %q to finish them: %v", pipelineName, err)
+		}
+
+		var finishCommitErr error
+		for _, ci := range commitInfos {
+			if ci.Finished != nil {
+				continue // nothing needs to be done
+			}
+			if _, err := superUserClient.PfsAPIClient.FinishCommit(superUserClient.Ctx(),
+				&pfs.FinishCommitRequest{
+					Commit: client.NewCommit(pipelineName, ci.Commit.ID),
+					Empty:  true,
+				}); err != nil && finishCommitErr == nil {
+				finishCommitErr = err
+			}
+		}
+		return finishCommitErr
+	})
+}
+
+func (op *pipelineOp) deletePipelineResources() (retErr error) {
+	return op.apiServer.deletePipelineResources(op.pachClient.Ctx(), op.name)
+}
+
+func (op *pipelineOp) scaleUpPipeline() (retErr error) {
+	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/ScaleUpPipeline", "pipeline", op.name)
+	defer func(span opentracing.Span) {
+		if span != nil {
+			span.SetTag("err", fmt.Sprintf("%v", retErr))
+		}
+		tracing.FinishAnySpan(span)
+	}(span)
+
+	kubeClient := op.apiServer.kubeClient
+	namespace := op.apiServer.namespace
+	rc := kubeClient.CoreV1().ReplicationControllers(namespace)
+
+	// compute target pipeline parallelism
+	parallelism, err := ppsutil.GetExpectedNumWorkers(kubeClient, op.pipelineInfo.ParallelismSpec)
+	if err != nil {
+		log.Errorf("PPS master: error getting number of workers, default to 1 worker: %v", err)
+		parallelism = 1
+	}
+	parallelism32 := int32(parallelism)
+
+	// don't fail pipeline just because it won't scale up. In this case, prefer
+	// to restart PPS master
+	var errCount int
+	return backoff.RetryNotify(func() error {
+		if op.rc.Spec.Replicas != nil && *op.rc.Spec.Replicas == parallelism32 {
+			return nil // prior attempt succeeded
+		}
+		newRC := *op.rc
+		newRC.Spec.Replicas = &parallelism32
+		if _, err = rc.Update(&newRC); err != nil {
+			return fmt.Errorf("could not update scaled-up pipeline %q RC: %v",
+				op.name, err)
+		}
+		return nil
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if strings.Contains(err.Error(), "try again") {
+			if err := op.getRC(); err != nil && !isNotFoundErr(err) {
+				return fmt.Errorf("error reading RC for %q: %v", op.name, err)
+			}
+		} else if errCount++; errCount >= maxErrCount {
+			return fmt.Errorf("error scaling up %q after %d attempts: %v",
+				op.name, maxErrCount, err)
+		}
+		log.Errorf("PPS master: error scaling down %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	})
+}
+
+func (op *pipelineOp) scaleDownPipeline() (retErr error) {
+	log.Infof("PPS master: scaling down workers for %q", op.name)
+	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/ScaleDownPipeline", "pipeline", op.name)
+	defer func(span opentracing.Span) {
+		if span != nil {
+			span.SetTag("err", fmt.Sprintf("%v", retErr))
+		}
+		tracing.FinishAnySpan(span)
+	}(span)
+
+	kubeClient := op.apiServer.kubeClient
+	namespace := op.apiServer.namespace
+	rc := kubeClient.CoreV1().ReplicationControllers(namespace)
+	var zero int32
+
+	// don't fail pipeline just because it won't scale down. In this case, prefer
+	// to restart PPS master
+	var errCount int
+	return backoff.RetryNotify(func() error {
+		if op.rc.Spec.Replicas != nil && *op.rc.Spec.Replicas == 0 {
+			return nil // prior attempt succeeded
+		}
+		newRC := *op.rc
+		newRC.Spec.Replicas = &zero
+		if _, err := rc.Update(&newRC); err != nil {
+			return fmt.Errorf("could not update scaled-down pipeline %q RC: %v", op.name, err)
+		}
+		return nil
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if strings.Contains(err.Error(), "try again") {
+			if err := op.getRC(); err != nil && !isNotFoundErr(err) {
+				return fmt.Errorf("error reading RC for %q: %v", op.name, err)
+			}
+		} else if errCount++; errCount >= maxErrCount {
+			return fmt.Errorf("error scaling down %q after %d attempts: %v",
+				op.name, maxErrCount, err)
+		}
+		log.Errorf("PPS master: error scaling down %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	})
+}

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -52,7 +52,8 @@ func (a *apiServer) step(pachClient *client.APIClient, pipelineName string, keyV
 	// Retrieve pipelineInfo from the spec repo
 	op, err := a.newPipelineOp(pachClient, pipelineName)
 	if err != nil {
-		return op.setPipelineFailure(fmt.Sprintf("couldn't initialize pipeline op: %v", err))
+		return a.setPipelineFailure(pachClient.Ctx(), pipelineName,
+			fmt.Sprintf("couldn't initialize pipeline op: %v", err))
 	}
 	span, ctx := extended.AddPipelineSpanToAnyTrace(pachClient.Ctx(),
 		a.etcdClient, pipelineName, "/pps.Master/ProcessPipelineUpdate",

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -207,14 +207,24 @@ func hashAuthToken(token string) string {
 	return base64.RawURLEncoding.EncodeToString(hashBytes[:])
 }
 
-// commitiDToB64 converts 'id' from a hex string to a base64-string (to shorten
+// commitIDFromB64 converts 'id' from a base64-string (in the RC label) to a hex
+// string that can be compared with its stored format
+func commitIDFromB64(label string) (string, error) {
+	bts, err := base64.RawURLEncoding.DecodeString(label)
+	if err != nil {
+		return "", fmt.Errorf("couldn't decode commit ID %q as hex: %v", label, err)
+	}
+	return hex.EncodeToString(bts), nil
+}
+
+// commitIDToB64 converts 'id' from a hex string to a base64-string (to shorten
 // it, so that it fits in the RC label)
 func commitIDToB64(id string) (string, error) {
 	bts, err := hex.DecodeString(id)
 	if err != nil {
 		return "", fmt.Errorf("couldn't decode commit ID %q as hex: %v", id, err)
 	}
-	return string(base64.RawURLEncoding.EncodeToString(bts)), nil
+	return base64.RawURLEncoding.EncodeToString(bts), nil
 }
 
 func (a *apiServer) getWorkerOptions(ptr *pps.EtcdPipelineInfo, pipelineInfo *pps.PipelineInfo) (*workerOptions, error) {


### PR DESCRIPTION
- This eliminates the need for use to EtcdPipelineInfo previous state, which is not always available or accurate
- This makes the PPS master's model closer to that of a kubernetes controller: The `EtcdPipelineInfo` state is the *target*, and the pipeline RC is the current state. The master makes changes to attempt to bring the RC in line with the target (with a few exceptions, e.g. `pipelineInfo.Stopped`)
- It also makes the PPS master logic shorter and more robust in the presence of e.g. missing pipeline RCs: see `step()` in `pipeline_controller.go`