### PR TITLE
Properly sandbox 'put file' and 'copy file' paths

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1245,6 +1245,15 @@ func putFileHelper(c *client.APIClient, pfc client.PutFileClient,
 	limiter limit.ConcurrencyLimiter,
 	split string, targetFileDatums, targetFileBytes, headerRecords uint, // split
 	filesPut *gosync.Map) (retErr error) {
+	// Resolve the path, then trim any prefixed '../' to avoid sending bad paths
+	// to the server
+	path = filepath.Join(path)
+	for strings.HasPrefix(path, "../") {
+		path = strings.TrimPrefix(path, "../")
+	}
+
+	fmt.Printf("path: %s\n", path)
+
 	if _, ok := filesPut.LoadOrStore(path, nil); ok {
 		return fmt.Errorf("multiple files put with the path %s, aborting, "+
 			"some files may already have been put and should be cleaned up with "+

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1247,12 +1247,10 @@ func putFileHelper(c *client.APIClient, pfc client.PutFileClient,
 	filesPut *gosync.Map) (retErr error) {
 	// Resolve the path, then trim any prefixed '../' to avoid sending bad paths
 	// to the server
-	path = filepath.Join(path)
+	path = filepath.Clean(path)
 	for strings.HasPrefix(path, "../") {
 		path = strings.TrimPrefix(path, "../")
 	}
-
-	fmt.Printf("path: %s\n", path)
 
 	if _, ok := filesPut.LoadOrStore(path, nil); ok {
 		return fmt.Errorf("multiple files put with the path %s, aborting, "+

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1817,34 +1817,29 @@ func (d *driver) deleteBranchSTM(stm col.STM, branch *pfs.Branch, force bool) er
 	return nil
 }
 
-func (d *driver) scratchPrefix() string {
-	return path.Join(d.prefix, "scratch")
-}
-
 // scratchCommitPrefix returns an etcd prefix that's used to temporarily
 // store the state of a file in an open commit.  Once the commit is finished,
 // the scratch space is removed.
 func (d *driver) scratchCommitPrefix(commit *pfs.Commit) string {
-	// TODO(msteffen) this doesn't currenty (2018-2-4) use d.scratchPrefix(),
-	// but probably should? If this is changed, filepathFromEtcdPath will also
-	// need to change.
 	return path.Join(commit.Repo.Name, commit.ID)
+}
+
+func (d *driver) checkFilePath(path string) error {
+	path = filepath.Clean(path)
+	if strings.HasPrefix(path, "../") {
+		return fmt.Errorf("path (%s) invalid: traverses above root", path)
+	}
+	return nil
 }
 
 // scratchFilePrefix returns an etcd prefix that's used to temporarily
 // store the state of a file in an open commit.  Once the commit is finished,
 // the scratch space is removed.
 func (d *driver) scratchFilePrefix(file *pfs.File) (string, error) {
+	if err := d.checkFilePath(file.Path); err != nil {
+		return "", err
+	}
 	return path.Join(d.scratchCommitPrefix(file.Commit), file.Path), nil
-}
-
-func (d *driver) filePathFromEtcdPath(etcdPath string) string {
-	etcdPath = strings.TrimPrefix(etcdPath, d.prefix)
-	// etcdPath looks like /putFileRecords/repo/commit/path/to/file
-	split := strings.Split(etcdPath, "/")
-	// we only want /path/to/file so we use index 4 (note that there's an "" at
-	// the beginning of the slice because of the lead /)
-	return path.Join(split[4:]...)
 }
 
 func (d *driver) putFiles(pachClient *client.APIClient, s *putFileServer) error {
@@ -1897,6 +1892,9 @@ func (d *driver) putFile(pachClient *client.APIClient, file *pfs.File, delimiter
 	records := &pfs.PutFileRecords{}
 	if overwriteIndex != nil && overwriteIndex.Index == 0 {
 		records.Tombstone = true
+	}
+	if err := d.checkFilePath(file.Path); err != nil {
+		return nil, err
 	}
 	if err := hashtree.ValidatePath(file.Path); err != nil {
 		return nil, err
@@ -2149,6 +2147,9 @@ func (d *driver) copyFile(pachClient *client.APIClient, src *pfs.File, dst *pfs.
 		return err
 	}
 	if err := d.checkIsAuthorized(pachClient, dst.Commit.Repo, auth.Scope_WRITER); err != nil {
+		return err
+	}
+	if err := d.checkFilePath(dst.Path); err != nil {
 		return err
 	}
 	if err := hashtree.ValidatePath(dst.Path); err != nil {

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -354,6 +354,51 @@ func TestRegressionPutFileIntoOpenCommit(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPutFileDirectoryTraversal(t *testing.T) {
+	var fileInfos []*pfs.FileInfo
+	client := GetPachClient(t)
+	require.NoError(t, client.CreateRepo("repo"))
+
+	_, err := client.StartCommit("repo", "master")
+	require.NoError(t, err)
+
+	writer, err := client.NewPutFileClient()
+	require.NoError(t, err)
+	_, err = writer.PutFile("repo", "master", "../foo", strings.NewReader("foo\n"))
+	require.NoError(t, err)
+	err = writer.Close()
+	require.YesError(t, err)
+
+	fileInfos, err = client.ListFile("repo", "master", "")
+	require.NoError(t, err)
+	require.Equal(t, 0, len(fileInfos))
+
+	writer, err = client.NewPutFileClient()
+	require.NoError(t, err)
+	_, err = writer.PutFile("repo", "master", "foo/../../bar", strings.NewReader("foo\n"))
+	require.NoError(t, err)
+	err = writer.Close()
+	require.YesError(t, err)
+
+	fileInfos, err = client.ListFile("repo", "master", "")
+	require.NoError(t, err)
+	require.Equal(t, 0, len(fileInfos))
+
+	writer, err = client.NewPutFileClient()
+	require.NoError(t, err)
+	_, err = writer.PutFile("repo", "master", "foo/../bar", strings.NewReader("foo\n"))
+	require.NoError(t, err)
+	err = writer.Close()
+	require.NoError(t, err)
+
+	fileInfos, err = client.ListFile("repo", "master", "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(fileInfos))
+
+	err = client.Close()
+	require.NoError(t, err)
+}
+
 func TestCreateInvalidBranchName(t *testing.T) {
 
 	client := GetPachClient(t)


### PR DESCRIPTION
When putting or copying files into open commits, the etcd path that PFS would use was not sandboxed properly and could break out into other etcd state via a directory traversal exploit.  This PR prevents the `pachctl` client from passing such paths (by truncating leading '../' - after resolving the path), and changes the server to error if such a path is received.

This might be considered a breaking change, as a workflow which does not use open commits would probably succeed without hitting this bug.  For this to be breaking, a user would have to be using the PFS API directly rather than `pachctl`, I believe.  The `hashtree` implementation of paths basically does this already, but the PFS open commit "scratch" space did not.