### PR TITLE
STM DeletePrefix improvements

### DIFF
--- a/src/server/pkg/collection/collection_test.go
+++ b/src/server/pkg/collection/collection_test.go
@@ -120,11 +120,15 @@ func TestDeletePrefix(t *testing.T) {
 		Pipeline: client.NewPipeline("p"),
 	}
 	j2 := &pps.JobInfo{
-		Job:      client.NewJob("prefix/job"),
+		Job:      client.NewJob("prefix/suffix/job2"),
 		Pipeline: client.NewPipeline("p"),
 	}
 	j3 := &pps.JobInfo{
-		Job:      client.NewJob("job"),
+		Job:      client.NewJob("prefix/job3"),
+		Pipeline: client.NewPipeline("p"),
+	}
+	j4 := &pps.JobInfo{
+		Job:      client.NewJob("job4"),
 		Pipeline: client.NewPipeline("p"),
 	}
 
@@ -133,6 +137,7 @@ func TestDeletePrefix(t *testing.T) {
 		jobInfos.Put(j1.Job.ID, j1)
 		jobInfos.Put(j2.Job.ID, j2)
 		jobInfos.Put(j3.Job.ID, j3)
+		jobInfos.Put(j4.Job.ID, j4)
 		return nil
 	})
 	require.NoError(t, err)
@@ -145,10 +150,13 @@ func TestDeletePrefix(t *testing.T) {
 		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
 			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j1.Job.ID, err)
 		}
-		if err := jobInfos.Get(j2.Job.ID, job); err != nil {
-			return err
+		if err := jobInfos.Get(j2.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j2.Job.ID, err)
 		}
 		if err := jobInfos.Get(j3.Job.ID, job); err != nil {
+			return err
+		}
+		if err := jobInfos.Get(j4.Job.ID, job); err != nil {
 			return err
 		}
 
@@ -159,7 +167,10 @@ func TestDeletePrefix(t *testing.T) {
 		if err := jobInfos.Get(j2.Job.ID, job); !IsErrNotFound(err) {
 			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j2.Job.ID, err)
 		}
-		if err := jobInfos.Get(j3.Job.ID, job); err != nil {
+		if err := jobInfos.Get(j3.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j3.Job.ID, err)
+		}
+		if err := jobInfos.Get(j4.Job.ID, job); err != nil {
 			return err
 		}
 
@@ -167,17 +178,29 @@ func TestDeletePrefix(t *testing.T) {
 		if err := jobInfos.Get(j1.Job.ID, job); err != nil {
 			return err
 		}
+
+		jobInfos.DeleteAllPrefix("prefix/suffix")
+		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j1.Job.ID, err)
+		}
+
+		jobInfos.Put(j2.Job.ID, j2)
+		if err := jobInfos.Get(j2.Job.ID, job); err != nil {
+			return err
+		}
+
 		return nil
 	})
 	require.NoError(t, err)
 
 	job := &pps.JobInfo{}
 	jobs := jobInfos.ReadOnly(context.Background())
-	require.NoError(t, jobs.Get(j1.Job.ID, job))
-	require.Equal(t, j1, job)
-	require.True(t, IsErrNotFound(jobs.Get(j2.Job.ID, job)))
-	require.NoError(t, jobs.Get(j3.Job.ID, job))
-	require.Equal(t, j3, job)
+	require.True(t, IsErrNotFound(jobs.Get(j1.Job.ID, job)))
+	require.NoError(t, jobs.Get(j2.Job.ID, job))
+	require.Equal(t, j2, job)
+	require.True(t, IsErrNotFound(jobs.Get(j3.Job.ID, job)))
+	require.NoError(t, jobs.Get(j4.Job.ID, job))
+	require.Equal(t, j4, job)
 }
 
 func TestIndex(t *testing.T) {

--- a/src/server/pkg/collection/collection_test.go
+++ b/src/server/pkg/collection/collection_test.go
@@ -36,7 +36,7 @@ func TestDryrun(t *testing.T) {
 	etcdClient := getEtcdClient()
 	uuidPrefix := uuid.NewWithoutDashes()
 
-	jobInfos := NewCollection(etcdClient, uuidPrefix, []*Index{pipelineIndex}, &pps.JobInfo{}, nil, nil)
+	jobInfos := NewCollection(etcdClient, uuidPrefix, nil, &pps.JobInfo{}, nil, nil)
 
 	job := &pps.JobInfo{
 		Job:      client.NewJob("j1"),
@@ -52,6 +52,127 @@ func TestDryrun(t *testing.T) {
 	jobInfosReadonly := jobInfos.ReadOnly(context.Background())
 	err = jobInfosReadonly.Get("j1", job)
 	require.True(t, IsErrNotFound(err))
+}
+
+func TestGetAfterDel(t *testing.T) {
+	etcdClient := getEtcdClient()
+	uuidPrefix := uuid.NewWithoutDashes()
+
+	jobInfos := NewCollection(etcdClient, uuidPrefix, nil, &pps.JobInfo{}, nil, nil)
+
+	j1 := &pps.JobInfo{
+		Job:      client.NewJob("j1"),
+		Pipeline: client.NewPipeline("p1"),
+	}
+	j2 := &pps.JobInfo{
+		Job:      client.NewJob("j2"),
+		Pipeline: client.NewPipeline("p1"),
+	}
+	j3 := &pps.JobInfo{
+		Job:      client.NewJob("j3"),
+		Pipeline: client.NewPipeline("p2"),
+	}
+	_, err := NewSTM(context.Background(), etcdClient, func(stm STM) error {
+		jobInfos := jobInfos.ReadWrite(stm)
+		jobInfos.Put(j1.Job.ID, j1)
+		jobInfos.Put(j2.Job.ID, j2)
+		jobInfos.Put(j3.Job.ID, j3)
+		return nil
+	})
+	require.NoError(t, err)
+
+	_, err = NewSTM(context.Background(), etcdClient, func(stm STM) error {
+		job := &pps.JobInfo{}
+		jobInfos := jobInfos.ReadWrite(stm)
+		require.NoError(t, jobInfos.Get(j1.Job.ID, job))
+		require.Equal(t, j1, job)
+
+		if err := jobInfos.Get("j4", job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", "j4", err)
+		}
+
+		jobInfos.DeleteAll()
+
+		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j1.Job.ID, err)
+		}
+		if err := jobInfos.Get(j2.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j2.Job.ID, err)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	count, err := jobInfos.ReadOnly(context.Background()).Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+}
+
+func TestDeletePrefix(t *testing.T) {
+	etcdClient := getEtcdClient()
+	uuidPrefix := uuid.NewWithoutDashes()
+
+	jobInfos := NewCollection(etcdClient, uuidPrefix, nil, &pps.JobInfo{}, nil, nil)
+
+	j1 := &pps.JobInfo{
+		Job:      client.NewJob("prefix/suffix/job"),
+		Pipeline: client.NewPipeline("p"),
+	}
+	j2 := &pps.JobInfo{
+		Job:      client.NewJob("prefix/job"),
+		Pipeline: client.NewPipeline("p"),
+	}
+	j3 := &pps.JobInfo{
+		Job:      client.NewJob("job"),
+		Pipeline: client.NewPipeline("p"),
+	}
+
+	_, err := NewSTM(context.Background(), etcdClient, func(stm STM) error {
+		jobInfos := jobInfos.ReadWrite(stm)
+		jobInfos.Put(j1.Job.ID, j1)
+		jobInfos.Put(j2.Job.ID, j2)
+		jobInfos.Put(j3.Job.ID, j3)
+		return nil
+	})
+	require.NoError(t, err)
+
+	_, err = NewSTM(context.Background(), etcdClient, func(stm STM) error {
+		job := &pps.JobInfo{}
+		jobInfos := jobInfos.ReadWrite(stm)
+
+		jobInfos.DeleteAllPrefix("prefix/suffix")
+		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j1.Job.ID, err)
+		}
+		require.NoError(t, jobInfos.Get(j2.Job.ID, job))
+		require.Equal(t, j2, job)
+		require.NoError(t, jobInfos.Get(j3.Job.ID, job))
+		require.Equal(t, j3, job)
+
+		jobInfos.DeleteAllPrefix("prefix")
+		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j1.Job.ID, err)
+		}
+		if err := jobInfos.Get(j2.Job.ID, job); !IsErrNotFound(err) {
+			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j2.Job.ID, err)
+		}
+		require.NoError(t, jobInfos.Get(j3.Job.ID, job))
+		require.Equal(t, j3, job)
+
+		jobInfos.Put(j1.Job.ID, j1)
+		require.NoError(t, jobInfos.Get(j1.Job.ID, job))
+		require.Equal(t, j1, job)
+		return nil
+	})
+	require.NoError(t, err)
+
+	job := &pps.JobInfo{}
+	jobs := jobInfos.ReadOnly(context.Background())
+	require.NoError(t, jobs.Get(j1.Job.ID, job))
+	require.Equal(t, j1, job)
+	require.True(t, IsErrNotFound(jobs.Get(j1.Job.ID, job)))
+	require.NoError(t, jobs.Get(j3.Job.ID, job))
+	require.Equal(t, j3, job)
 }
 
 func TestIndex(t *testing.T) {

--- a/src/server/pkg/collection/collection_test.go
+++ b/src/server/pkg/collection/collection_test.go
@@ -145,10 +145,12 @@ func TestDeletePrefix(t *testing.T) {
 		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
 			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j1.Job.ID, err)
 		}
-		require.NoError(t, jobInfos.Get(j2.Job.ID, job))
-		require.Equal(t, j2, job)
-		require.NoError(t, jobInfos.Get(j3.Job.ID, job))
-		require.Equal(t, j3, job)
+		if err := jobInfos.Get(j2.Job.ID, job); err != nil {
+			return err
+		}
+		if err := jobInfos.Get(j3.Job.ID, job); err != nil {
+			return err
+		}
 
 		jobInfos.DeleteAllPrefix("prefix")
 		if err := jobInfos.Get(j1.Job.ID, job); !IsErrNotFound(err) {
@@ -157,12 +159,14 @@ func TestDeletePrefix(t *testing.T) {
 		if err := jobInfos.Get(j2.Job.ID, job); !IsErrNotFound(err) {
 			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", j2.Job.ID, err)
 		}
-		require.NoError(t, jobInfos.Get(j3.Job.ID, job))
-		require.Equal(t, j3, job)
+		if err := jobInfos.Get(j3.Job.ID, job); err != nil {
+			return err
+		}
 
 		jobInfos.Put(j1.Job.ID, j1)
-		require.NoError(t, jobInfos.Get(j1.Job.ID, job))
-		require.Equal(t, j1, job)
+		if err := jobInfos.Get(j1.Job.ID, job); err != nil {
+			return err
+		}
 		return nil
 	})
 	require.NoError(t, err)

--- a/src/server/pkg/collection/collection_test.go
+++ b/src/server/pkg/collection/collection_test.go
@@ -84,8 +84,9 @@ func TestGetAfterDel(t *testing.T) {
 	_, err = NewSTM(context.Background(), etcdClient, func(stm STM) error {
 		job := &pps.JobInfo{}
 		jobInfos := jobInfos.ReadWrite(stm)
-		require.NoError(t, jobInfos.Get(j1.Job.ID, job))
-		require.Equal(t, j1, job)
+		if err := jobInfos.Get(j1.Job.ID, job); err != nil {
+			return err
+		}
 
 		if err := jobInfos.Get("j4", job); !IsErrNotFound(err) {
 			return fmt.Errorf("Expected ErrNotFound for key '%s', but got '%v'", "j4", err)
@@ -170,7 +171,7 @@ func TestDeletePrefix(t *testing.T) {
 	jobs := jobInfos.ReadOnly(context.Background())
 	require.NoError(t, jobs.Get(j1.Job.ID, job))
 	require.Equal(t, j1, job)
-	require.True(t, IsErrNotFound(jobs.Get(j1.Job.ID, job)))
+	require.True(t, IsErrNotFound(jobs.Get(j2.Job.ID, job)))
 	require.NoError(t, jobs.Get(j3.Job.ID, job))
 	require.Equal(t, j3, job)
 }

--- a/src/server/pkg/collection/transaction.go
+++ b/src/server/pkg/collection/transaction.go
@@ -232,6 +232,7 @@ func (s *stm) DelAll(prefix string) {
 	for _, deletedPrefix := range s.deletedPrefixes {
 		if !strings.HasPrefix(deletedPrefix, prefix) {
 			s.deletedPrefixes[i] = deletedPrefix
+			i++
 		}
 	}
 	s.deletedPrefixes = s.deletedPrefixes[:i]


### PR DESCRIPTION
Currently, performing `Get` on an STM after deleting keys with `DeleteAll` or `DeleteAllPrefix` will return stale values.  In addition, writing a new key after performing a range delete covering that key will result in an etcd error: `duplicate key given in txn request`.  This PR aims to fix both.

First, we track deleted prefixes separately from other writes.  When deleting a prefix, we will go through and remove any existing puts or range deletions under that prefix.  Subsequent puts are still valid.

Second, when collecting the set of writes to send to etcd, we merge the puts and deleted prefixes.  It is important how this is done because etcd will error if two writes touch the same key (e.g. a range delete followed by a put to a key within the range).  In order to get by this, we break up any prefix deletes into multiple ranges, specifically excluding the keys which were put.