### PR TITLE
Handle missing pipeline output repo

### DIFF
--- a/src/server/auth/server/admin_test.go
+++ b/src/server/auth/server/admin_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -1506,4 +1507,124 @@ func TestDeleteRCInStandby(t *testing.T) {
 		_, err := iter.Next()
 		return err
 	})
+}
+
+// TestNoOutputRepoDoesntCrashPPSMaster creates a pipeline, then deletes its
+// output repo while it's running (failing the pipeline and preventing the PPS
+// master from finishing the pipeline's output commit) and makes sure new
+// pipelines can be created (i.e. that the PPS master doesn't crashloop due to
+// the missing output repo)
+//
+// Note: arguably deleting the output repo of a pipeline, even one that's
+// stopped, should be prevented. However, the way that PPS currently uses PFS
+// (stopping a pipeline = removing output branch subvenance) we have no way to
+// prevent that. Thus, this test at least makes sure that doing such a thing
+// doesn't break the PPS master.
+//
+// Note: This test actually doesn't use the admin client or admin privileges
+// anywhere. However, it restarts pachd, so it shouldn't be run in parallel with
+// any other test
+func TestNoOutputRepoDoesntCrashPPSMaster(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	deleteAll(t)
+	alice := tu.UniqueString("alice")
+	aliceClient := getPachClient(t, alice)
+
+	// Create input repo w/ initial commit
+	repo := tu.UniqueString(t.Name())
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	_, err := aliceClient.PutFile(repo, "master", "/file.1", strings.NewReader("1"))
+	require.NoError(t, err)
+
+	// Create pipeline
+	pipeline := tu.UniqueString("pipeline")
+	require.NoError(t, aliceClient.CreatePipeline(
+		pipeline,
+		"", // default image: ubuntu:16.04
+		[]string{"bash"},
+		[]string{
+			"sleep 10",
+			"cp /pfs/*/* /pfs/out/",
+		},
+		&pps.ParallelismSpec{Constant: 1},
+		client.NewAtomInput(repo, "/*"),
+		"", // default output branch: master
+		false,
+	))
+
+	// force-delete output repo while 'sleep 10' is running, failing the pipeline
+	require.NoError(t, aliceClient.DeleteRepo(pipeline, true))
+
+	// make sure the pipeline is failed
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		pi, err := aliceClient.InspectPipeline(pipeline)
+		if err != nil {
+			return err
+		}
+		if pi.State == pps.PipelineState_PIPELINE_FAILURE {
+			return fmt.Errorf("%q should be in state FAILURE but is in %q", pipeline, pi.State.String())
+		}
+		return nil
+	})
+
+	// Delete the pachd pod, so that it restarts and the PPS master has to process
+	// the failed pipeline
+	tu.DeletePachdPod(t) // delete the pachd pod
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		_, err := aliceClient.Version() // wait for pachd to come back
+		return err
+	})
+
+	// Create a new input commit, and flush its output to 'pipeline', to make sure
+	// the pipeline either restarts the RC and recreates the output repo, or fails
+	_, err = aliceClient.PutFile(repo, "master", "/file.2", strings.NewReader("2"))
+	require.NoError(t, err)
+	iter, err := aliceClient.FlushCommit(
+		[]*pfs.Commit{client.NewCommit(repo, "master")},
+		[]*pfs.Repo{client.NewRepo(pipeline)})
+	require.NoError(t, err)
+	require.NoErrorWithinT(t, 30*time.Second, func() error {
+		_, err := iter.Next()
+		// TODO(msteffen): While not currently possible, PFS could return
+		// CommitDeleted here. This should detect that error, but first:
+		// - src/server/pfs/pfs.go should be moved to src/client/pfs (w/ other err
+		//   handling code)
+		// - packages depending on that code should be migrated
+		// Then this could add "|| pfs.IsCommitDeletedErr(err)" and satisfy the todo
+		if err == io.EOF {
+			return nil // expected--with no output repo, FlushCommit can't return anything
+		}
+		return fmt.Errorf("unexpected error value: %v", err)
+	})
+
+	// Create a new pipeline, make sure FlushCommit eventually returns, and check
+	// pipeline output (i.e. the PPS master does not crashloop--pipeline2
+	// eventually starts successfully)
+	pipeline2 := tu.UniqueString("pipeline")
+	require.NoError(t, aliceClient.CreatePipeline(
+		pipeline2,
+		"", // default image: ubuntu:16.04
+		[]string{"bash"},
+		[]string{"cp /pfs/*/* /pfs/out/"},
+		&pps.ParallelismSpec{Constant: 1},
+		client.NewAtomInput(repo, "/*"),
+		"", // default output branch: master
+		false,
+	))
+	iter, err = aliceClient.FlushCommit(
+		[]*pfs.Commit{client.NewCommit(repo, "master")},
+		[]*pfs.Repo{client.NewRepo(pipeline2)})
+	require.NoError(t, err)
+	require.NoErrorWithinT(t, 30*time.Second, func() error {
+		_, err := iter.Next()
+		return err
+	})
+	buf := &bytes.Buffer{}
+	require.NoError(t, aliceClient.GetFile(pipeline2, "master", "/file.1", 0, 0, buf))
+	require.Equal(t, "1", buf.String())
+	buf.Reset()
+	require.NoError(t, aliceClient.GetFile(pipeline2, "master", "/file.2", 0, 0, buf))
+	require.Equal(t, "2", buf.String())
 }

--- a/src/server/auth/server/admin_test.go
+++ b/src/server/auth/server/admin_test.go
@@ -1432,3 +1432,78 @@ func TestDeleteAllAfterDeactivate(t *testing.T) {
 	// Make sure DeleteAll() succeeds
 	require.NoError(t, aliceClient.DeleteAll())
 }
+
+// TestDeleteRCInStandby creates a pipeline, waits for it to enter standby, and
+// then deletes its RC. This should not crash the PPS master, and the
+// flush-commit run on an input commit should eventually return (though the
+// pipeline may fail rather than processing anything in this state)
+//
+// Note: Like 'TestNoOutputRepoDoesntCrashPPSMaster', this test doesn't use the
+// admin client at all, but it uses the kubernetes client, so out of prudence it
+// shouldn't be run in parallel with any other test
+func TestDeleteRCInStandby(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	deleteAll(t)
+	alice := tu.UniqueString("alice")
+	c := getPachClient(t, alice)
+
+	// Create input repo w/ initial commit
+	repo := tu.UniqueString(t.Name())
+	require.NoError(t, c.CreateRepo(repo))
+	_, err := c.PutFile(repo, "master", "/file.1", strings.NewReader("1"))
+	require.NoError(t, err)
+
+	// Create pipeline
+	pipeline := tu.UniqueString("pipeline")
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(pipeline),
+			Transform: &pps.Transform{
+				Image: "ubuntu:16.04",
+				Cmd:   []string{"bash"},
+				Stdin: []string{"cp /pfs/*/* /pfs/out"},
+			},
+			ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
+			Input:           client.NewAtomInput(repo, "/*"),
+			Standby:         true,
+		})
+	require.NoError(t, err)
+
+	// Wait for pipeline to process input commit & go into standby
+	iter, err := c.FlushCommit(
+		[]*pfs.Commit{client.NewCommit(repo, "master")},
+		[]*pfs.Repo{client.NewRepo(pipeline)})
+	require.NoError(t, err)
+	require.NoErrorWithinT(t, 30*time.Second, func() error {
+		_, err := iter.Next()
+		return err
+	})
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		pi, err := c.InspectPipeline(pipeline)
+		if err != nil {
+			return err
+		}
+		if pi.State != pps.PipelineState_PIPELINE_STANDBY {
+			return fmt.Errorf("pipeline should be in standby, but is in %s", pi.State.String())
+		}
+		return nil
+	})
+
+	// delete pipeline RC
+	tu.DeletePipelineRC(t, pipeline)
+
+	// Create new input commit (to force pipeline out of standby) & make sure
+	// flush-commit returns (pipeline either fails or restarts RC & finishes)
+	_, err = c.PutFile(repo, "master", "/file.2", strings.NewReader("1"))
+	require.NoError(t, err)
+	iter, err = c.FlushCommit(
+		[]*pfs.Commit{client.NewCommit(repo, "master")},
+		[]*pfs.Repo{client.NewRepo(pipeline)})
+	require.NoError(t, err)
+	require.NoErrorWithinT(t, 30*time.Second, func() error {
+		_, err := iter.Next()
+		return err
+	})
+}

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -332,7 +332,7 @@ func TestGetSetBasic(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
-	dataRepo := tu.UniqueString("TestGetSetBasic")
+	dataRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, dataRepo))
@@ -480,7 +480,7 @@ func TestGetSetReverse(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
-	dataRepo := tu.UniqueString("TestGetSetReverse")
+	dataRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, dataRepo))
@@ -659,7 +659,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
-	dataRepo := tu.UniqueString("TestCreateAndUpdatePipeline")
+	dataRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, dataRepo))
@@ -855,8 +855,8 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create two repos, and check that alice is the owner of the new repos
-	dataRepo1 := tu.UniqueString("TestPipelineMultipleInputs")
-	dataRepo2 := tu.UniqueString("TestPipelineMultipleInputs")
+	dataRepo1 := tu.UniqueString(t.Name())
+	dataRepo2 := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo1))
 	require.NoError(t, aliceClient.CreateRepo(dataRepo2))
 	require.ElementsEqual(t,
@@ -1041,7 +1041,7 @@ func TestPipelineRevoke(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo, and adds bob as a reader
-	repo := tu.UniqueString("TestPipelineRevoke")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	_, err := aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repo,
@@ -1199,7 +1199,7 @@ func TestStopAndDeletePipeline(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestDeletePipeline")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 
@@ -1239,7 +1239,7 @@ func TestStopAndDeletePipeline(t *testing.T) {
 	require.ElementsEqual(t, entries(), getACL(t, aliceClient, repo))
 
 	// alice creates another repo
-	repo = tu.UniqueString("TestDeletePipeline")
+	repo = tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 
@@ -1363,7 +1363,7 @@ func TestListAndInspectRepo(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo and makes Bob a writer
-	repoWriter := tu.UniqueString("TestListRepo")
+	repoWriter := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoWriter))
 	_, err := aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repoWriter,
@@ -1375,7 +1375,7 @@ func TestListAndInspectRepo(t *testing.T) {
 		entries(alice, "owner", bob, "writer"), getACL(t, aliceClient, repoWriter))
 
 	// alice creates a repo and makes Bob a reader
-	repoReader := tu.UniqueString("TestListRepo")
+	repoReader := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoReader))
 	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repoReader,
@@ -1387,13 +1387,13 @@ func TestListAndInspectRepo(t *testing.T) {
 		entries(alice, "owner", bob, "reader"), getACL(t, aliceClient, repoReader))
 
 	// alice creates a repo and gives Bob no access privileges
-	repoNone := tu.UniqueString("TestListRepo")
+	repoNone := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoNone))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, repoNone))
 
 	// bob creates a repo
-	repoOwner := tu.UniqueString("TestListRepo")
+	repoOwner := tu.UniqueString(t.Name())
 	require.NoError(t, bobClient.CreateRepo(repoOwner))
 	require.ElementsEqual(t, entries(bob, "owner"), getACL(t, bobClient, repoOwner))
 
@@ -1431,7 +1431,7 @@ func TestUnprivilegedUserCannotMakeSelfOwner(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestUnprivilegedUserCannotMakeSelfOwner")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, repo))
@@ -1456,7 +1456,7 @@ func TestGetScopeRequiresReader(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestGetScopeRequiresReader")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 
@@ -1489,7 +1489,7 @@ func TestListRepoNotLoggedInError(t *testing.T) {
 	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestListRepo")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, repo))
@@ -1515,7 +1515,7 @@ func TestListRepoNoAuthInfoIfDeactivated(t *testing.T) {
 	adminClient := getPachClient(t, "admin")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestListRepo")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// bob calls ListRepo, but has NONE access to all repos
@@ -1558,7 +1558,7 @@ func TestCreateRepoAlreadyExistsError(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestCreateRepoAlreadyExistsError")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// bob creates the same repo, and should get an error to the effect that the
@@ -1578,7 +1578,7 @@ func TestCreateRepoNotLoggedInError(t *testing.T) {
 	anonClient := getPachClient(t, "")
 
 	// anonClient tries and fails to create a repo
-	repo := tu.UniqueString("TestCreateRepo")
+	repo := tu.UniqueString(t.Name())
 	err := anonClient.CreateRepo(repo)
 	require.YesError(t, err)
 	require.Matches(t, "no authentication token", err.Error())
@@ -1596,7 +1596,7 @@ func TestCreatePipelineRepoAlreadyExistsError(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	inputRepo := tu.UniqueString("TestCreatePipelineRepoAlreadyExistsError")
+	inputRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(inputRepo))
 	aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Username: bob,
@@ -1645,7 +1645,7 @@ func TestAuthorizedNoneRole(t *testing.T) {
 	}, backoff.NewTestingBackOff()))
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestAuthorizedNoneRole")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, adminClient.CreateRepo(repo))
 
 	// Get new pach clients, re-activating auth
@@ -1674,7 +1674,7 @@ func TestDeleteAll(t *testing.T) {
 	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, "admin")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestAuthorizedNoneRole")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, adminClient.CreateRepo(repo))
 
 	// alice calls DeleteAll, but it fails
@@ -1697,9 +1697,9 @@ func TestListDatum(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repoA := tu.UniqueString("TestListDatum")
+	repoA := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoA))
-	repoB := tu.UniqueString("TestListDatum")
+	repoB := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoB))
 
 	// alice creates a pipeline
@@ -1817,7 +1817,7 @@ func TestListJob(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestListJob")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline
@@ -1909,7 +1909,7 @@ func TestInspectDatum(t *testing.T) {
 	aliceClient := getPachClient(t, alice)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestInspectDatum")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline (we must enable stats for InspectDatum, which
@@ -1972,7 +1972,7 @@ func TestGetLogs(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestGetLogs")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline
@@ -2068,7 +2068,7 @@ func TestGetLogsFromStats(t *testing.T) {
 	aliceClient := getPachClient(t, alice)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestGetLogsFromStats")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline (we must enable stats for InspectDatum, which
@@ -2459,7 +2459,7 @@ func TestGetJobsBugFix(t *testing.T) {
 	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestDeletePipeline")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 	_, err := aliceClient.PutFile(repo, "master", "/file", strings.NewReader("lorem ipsum"))

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1276,6 +1276,8 @@ func (d *driver) flushCommit(ctx context.Context, fromCommits []*pfs.Commit, toR
 		if err != nil {
 			if _, ok := err.(pfsserver.ErrCommitNotFound); ok {
 				continue // just skip this
+			} else if auth.IsErrNotAuthorized(err) {
+				continue // again, just skip
 			}
 			return err
 		}

--- a/src/server/pkg/testutil/kubeclient.go
+++ b/src/server/pkg/testutil/kubeclient.go
@@ -16,6 +16,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var (
+	zero int64
+)
+
 // GetKubeClient connects to the Kubernetes API server either from inside the
 // cluster or from a test binary running on a machine with kubectl (it will
 // connect to the same cluster as kubectl)
@@ -35,4 +39,110 @@ func GetKubeClient(t testing.TB) *kube.Clientset {
 	k, err := kube.NewForConfig(config)
 	require.NoError(t, err)
 	return k
+}
+
+// DeletePachdPod deletes the pachd pod in a test cluster (restarting it, e.g.
+// to retart the PPS master)
+func DeletePachdPod(t testing.TB) {
+	kubeClient := GetKubeClient(t)
+	podList, err := kubeClient.CoreV1().Pods(v1.NamespaceDefault).List(
+		metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
+				map[string]string{"app": "pachd", "suite": "pachyderm"},
+			)),
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(podList.Items))
+	require.NoError(t, kubeClient.CoreV1().Pods(v1.NamespaceDefault).Delete(
+		podList.Items[0].ObjectMeta.Name, &metav1.DeleteOptions{}))
+
+	// Make sure pachd goes down
+	startTime := time.Now()
+	require.NoError(t, backoff.Retry(func() error {
+		podList, err := kubeClient.CoreV1().Pods(v1.NamespaceDefault).List(
+			metav1.ListOptions{
+				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
+					map[string]string{"app": "pachd", "suite": "pachyderm"},
+				)),
+			})
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) == 0 {
+			return nil
+		}
+		if time.Now().Sub(startTime) > 10*time.Second {
+			return nil
+		}
+		return fmt.Errorf("waiting for old pachd pod to be killed")
+	}, backoff.NewTestingBackOff()))
+
+	// Make sure pachd comes back up
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		podList, err := kubeClient.CoreV1().Pods(v1.NamespaceDefault).List(
+			metav1.ListOptions{
+				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
+					map[string]string{"app": "pachd", "suite": "pachyderm"},
+				)),
+			})
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) == 0 {
+			return fmt.Errorf("no pachd pod up yet")
+		}
+		return nil
+	})
+
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		podList, err := kubeClient.CoreV1().Pods(v1.NamespaceDefault).List(
+			metav1.ListOptions{
+				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
+					map[string]string{"app": "pachd", "suite": "pachyderm"},
+				)),
+			})
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) == 0 {
+			return fmt.Errorf("no pachd pod up yet")
+		}
+		if podList.Items[0].Status.Phase != v1.PodRunning {
+			return fmt.Errorf("pachd not running yet")
+		}
+		return err
+	})
+}
+
+// DeletePipelineRC deletes the RC belonging to the pipeline 'pipeline'. This
+// can be used to test PPS's robustness
+func DeletePipelineRC(t testing.TB, pipeline string) {
+	kubeClient := GetKubeClient(t)
+	rcs, err := kubeClient.CoreV1().ReplicationControllers(v1.NamespaceDefault).List(
+		metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
+				map[string]string{"pipelineName": pipeline},
+			)),
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rcs.Items))
+	require.NoError(t, kubeClient.CoreV1().ReplicationControllers(v1.NamespaceDefault).Delete(
+		rcs.Items[0].ObjectMeta.Name, &metav1.DeleteOptions{
+			GracePeriodSeconds: &zero,
+		}))
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		rcs, err := kubeClient.CoreV1().ReplicationControllers(v1.NamespaceDefault).List(
+			metav1.ListOptions{
+				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
+					map[string]string{"pipelineName": pipeline},
+				)),
+			})
+		if err != nil {
+			return err
+		}
+		if len(rcs.Items) != 0 {
+			return fmt.Errorf("RC %q not deleted yet", pipeline)
+		}
+		return nil
+	})
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2159,6 +2159,24 @@ func (a *apiServer) DeletePipeline(ctx context.Context, request *pps.DeletePipel
 	return a.deletePipeline(pachClient, request)
 }
 
+// cleanUpSpecBranch handles the corner case where a spec branch was created for
+// a new pipeline, but the etcdPipelineInfo was never created successfully (and
+// the pipeline is in an inconsistent state). It's called if a pipeline's
+// etcdPipelineInfo wasn't found, checks if an orphaned branch exists, and if
+// so, deletes the orphaned branch.
+func (a *apiServer) cleanUpSpecBranch(pachClient *client.APIClient, pipeline string) error {
+	specBranchInfo, err := pachClient.InspectBranch(ppsconsts.SpecRepo, pipeline)
+	if err != nil || specBranchInfo.Head != nil {
+		// No spec branch (and no etcd pointer) => the pipeline doesn't exist
+		return fmt.Errorf("pipeline %v was not found: %v", pipeline, err)
+	}
+	// branch exists but head is nil => pipeline creation never finished/
+	// pps state is invalid. Delete nil branch
+	return grpcutil.ScrubGRPC(a.sudo(pachClient, func(superUserClient *client.APIClient) error {
+		return superUserClient.DeleteBranch(ppsconsts.SpecRepo, pipeline, true)
+	}))
+}
+
 func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.DeletePipelineRequest) (response *types.Empty, retErr error) {
 	ctx := pachClient.Ctx() // pachClient will propagate auth info
 
@@ -2167,27 +2185,18 @@ func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.De
 	pipelinePtr := pps.EtcdPipelineInfo{}
 	if err := a.pipelines.ReadOnly(ctx).Get(request.Pipeline.Name, &pipelinePtr); err != nil {
 		if col.IsErrNotFound(err) {
-			// There's no etcd pointer. Check if there's an pipeline branch in the
-			// Spec repo (i.e. pipeline creation failed & left pps in invalid state).
-			specBranchInfo, err := pachClient.InspectBranch(ppsconsts.SpecRepo, request.Pipeline.Name)
-			if err == nil && specBranchInfo.Head == nil {
-				// branch exists but head is nil => pipeline creation never finished/
-				// pps state is invalid. Delete nil branch
-				if err := a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-					return superUserClient.DeleteBranch(ppsconsts.SpecRepo, request.Pipeline.Name, true)
-				}); err != nil {
-					return nil, grpcutil.ScrubGRPC(err)
-				}
-				return &types.Empty{}, nil
+			if err := a.cleanUpSpecBranch(pachClient, request.Pipeline.Name); err != nil {
+				return nil, err
 			}
-			// No spec branch (and no etcd pointer) => the pipeline doesn't exist
-			return nil, fmt.Errorf("pipeline %v was not found: %v", request.Pipeline.Name, err)
+			return &types.Empty{}, nil
 		}
 		return nil, err
 	}
 
-	// Get current pipeline info from EtcdPipelineInfo (which may not be the spec
-	// branch HEAD)
+	// Get current pipeline info from:
+	// - etcdPipelineInfo
+	// - spec commit in etcdPipelineInfo (which may not be the spec branch HEAD)
+	// - kubernetes services (for service pipelines, githook pipelines, etc)
 	pipelineInfo, err := a.inspectPipeline(pachClient, request.Pipeline.Name)
 	if err != nil {
 		logrus.Errorf("error inspecting pipeline: %v", err)
@@ -2212,12 +2221,13 @@ func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.De
 
 	// If necessary, revoke the pipeline's auth token and remove it from its inputs' ACLs
 	if pipelinePtr.AuthToken != "" {
-		// If auth was deactivated after the pipeline was created, don't try to revoke
+		// If auth was deactivated after the pipeline was created, don't bother
+		// revoking
 		if _, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{}); err == nil {
 			if err := a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-				// pipelineInfo = nil -> remove pipeline from all inputs in pipelineInfo
+				// pipelineInfo arg = nil => remove pipeline from all inputs
 				if err := a.fixPipelineInputRepoACLs(superUserClient, nil, pipelineInfo); err != nil {
-					return grpcutil.ScrubGRPC(err)
+					return err
 				}
 				_, err := superUserClient.RevokeAuthToken(superUserClient.Ctx(),
 					&auth.RevokeAuthTokenRequest{

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -378,7 +378,7 @@ func (a *apiServer) authorizePipelineOp(pachClient *client.APIClient, operation 
 		return err
 	}
 
-	if input != nil {
+	if input != nil && operation != pipelineOpDelete {
 		// Check that the user is authorized to read all input repos, and write to the
 		// output repo (which the pipeline needs to be able to do on the user's
 		// behalf)
@@ -435,6 +435,11 @@ func (a *apiServer) authorizePipelineOp(pachClient *client.APIClient, operation 
 	case pipelineOpUpdate:
 		required = auth.Scope_WRITER
 	case pipelineOpDelete:
+		if _, err := pachClient.InspectRepo(output); isNotFoundErr(err) {
+			// special case: the pipeline output repo has been deleted (so the
+			// pipeline is now invalid). It should be possible to delete the pipeline.
+			return nil
+		}
 		required = auth.Scope_OWNER
 	default:
 		return fmt.Errorf("internal error, unrecognized operation %v", operation)
@@ -1721,6 +1726,10 @@ func (a *apiServer) fixPipelineInputRepoACLs(pachClient *client.APIClient, pipel
 					Username: auth.PipelinePrefix + pipelineName,
 					Scope:    auth.Scope_NONE,
 				})
+				if isNotFoundErr(err) {
+					// can happen if input repo is force-deleted; nothing to remove
+					return nil
+				}
 				return grpcutil.ScrubGRPC(err)
 			})
 		})
@@ -2203,15 +2212,22 @@ func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.De
 		pipelineInfo = &pps.PipelineInfo{Pipeline: request.Pipeline, OutputBranch: "master"}
 	}
 
-	// Check if the caller is authorized to delete this pipeline. This must be
-	// done after cleaning up the spec branch HEAD commit, because the
-	// authorization condition depends on the pipeline's PipelineInfo
-	if err := a.authorizePipelineOp(pachClient, pipelineOpDelete, pipelineInfo.Input, pipelineInfo.Pipeline.Name); err != nil {
+	// check if the output repo exists--if not, the pipeline is non-functional and
+	// the rest of the delete operation continues without any auth checks
+	if _, err := pachClient.InspectRepo(request.Pipeline.Name); err != nil && !isNotFoundErr(err) {
 		return nil, err
-	}
+	} else if !isNotFoundErr(err) {
+		// Check if the caller is authorized to delete this pipeline. This must be
+		// done after cleaning up the spec branch HEAD commit, because the
+		// authorization condition depends on the pipeline's PipelineInfo
+		if err := a.authorizePipelineOp(pachClient, pipelineOpDelete, pipelineInfo.Input, pipelineInfo.Pipeline.Name); err != nil {
+			return nil, err
+		}
 
-	if err := pachClient.DeleteRepo(request.Pipeline.Name, request.Force); err != nil {
-		return nil, err
+		// Delete the pipeline's output repo
+		if err := pachClient.DeleteRepo(request.Pipeline.Name, request.Force); err != nil {
+			return nil, err
+		}
 	}
 
 	// Delete pipeline's workers

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -327,7 +327,7 @@ func (a *apiServer) master() {
 			c()
 		}
 		a.monitorCancels = make(map[string]func())
-		log.Errorf("master: error running the master process: %v; retrying in %v", err, d)
+		log.Errorf("PPS master: error running the master process: %v; retrying in %v", err, d)
 		return nil
 	})
 	panic("internal error: PPS master has somehow exited. Restarting pod...")

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -493,6 +493,9 @@ func (a *apiServer) finishPipelineOutputCommits(pachClient *client.APIClient, pi
 
 	return a.sudo(pachClient, func(superUserClient *client.APIClient) error {
 		commitInfos, err := superUserClient.ListCommit(pipelineName, pipelineInfo.OutputBranch, "", 0)
+		if isNotFoundErr(err) {
+			return nil
+		}
 		if err != nil {
 			return fmt.Errorf("could not list output commits of %q to finish them: %v", pipelineName, err)
 		}


### PR DESCRIPTION
Currently, if a pipeline's output repo is deleted while auth is on, then:
- The PPS master crashloops, preventing new pipelines from starting
- `DeletePipeline` cannot delete the broken pipeline

This PR adds tests and fixes for these cases (as well as cases where a pipeline's RC is deleted, a prior bug whose fix had no tests)