### PR TITLE
Backport #3757 to 1.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ env:
     - BUCKET=PPS2
     - BUCKET=PPS3
     - BUCKET=EXAMPLES
-branches:
-  except:
-    - /^v[0-9]/
 before_install:
 - sudo etc/testing/travis_before_install.sh
 before_script:


### PR DESCRIPTION
Backport #3757 to 1.8.x. This should get CI running for 1.8.x.

I was originally planning on waiting until this was merged to master, but CI instability is making that take too long. Opening this up preemptively in the hopes that most of the instability is specific to master, and does not apply to 1.8.x.