### PR TITLE
Recompute options after watch disconnect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,9 @@ docker-build-gpu:
 	docker tag pachyderm_nvidia_driver_install pachyderm/nvidia_driver_install
 
 docker-build-kafka:
-	docker build -t kafka-demo etc/testing/kafka
+	cp -R src/server/vendor/github.com/segmentio/kafka-go etc/testing/kafka
+	docker build -t kafka-demo etc/testing/kafka || { rm -r etc/testing/kafka/kafka-go; exit 1; }
+	rm -r etc/testing/kafka/kafka-go
 
 docker-push-gpu:
 	docker push pachyderm/nvidia_driver_install

--- a/etc/testing/kafka/Dockerfile
+++ b/etc/testing/kafka/Dockerfile
@@ -2,6 +2,6 @@ FROM golang:1.12.1
 RUN mkdir /app 
 ADD . /app/ 
 WORKDIR /app 
-RUN go get github.com/segmentio/kafka-go
+ADD ./kafka-go /go/src/github.com/segmentio/kafka-go
 RUN go build -o main . 
 CMD ["/app/main"]

--- a/src/server/pkg/watch/watch.go
+++ b/src/server/pkg/watch/watch.go
@@ -152,6 +152,11 @@ func NewWatcher(ctx context.Context, client *etcd.Client, trimPrefix, prefix str
 					return err
 				}
 				etcdWatcher = etcd.NewWatcher(client)
+				// use new "nextRevision"
+				options := []etcd.OpOption{etcd.WithPrefix(), etcd.WithRev(nextRevision)}
+				for _, opt := range opts {
+					options = append(options, etcd.OpOption(opt))
+				}
 				rch = etcdWatcher.Watch(ctx, prefix, options...)
 				continue
 			}


### PR DESCRIPTION
Made a mistake in https://github.com/pachyderm/pachyderm/pull/3765 —we do need to recompute the options when reconnecting, because `nextRevision` is updated while the watch runs

**Update** also change how `make docker-build-kafka` works, as our test suite is currently unable to pull the kafka client from github