### PR TITLE
No datum downstream fix

### DIFF
--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -556,26 +556,6 @@ func (a *APIServer) waitJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, 
 				}
 			}
 		}()
-		// Handle the case when there are no datums
-		if df.Len() == 0 {
-			if err := a.updateJobState(ctx, jobInfo, nil, pps.JobState_JOB_SUCCESS, ""); err != nil {
-				return err
-			}
-			if jobInfo.EnableStats {
-				if _, err = pachClient.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
-					Commit:    statsCommit,
-					Trees:     statsTrees,
-					SizeBytes: statsSize,
-				}); err != nil {
-					return err
-				}
-			}
-			_, err := pachClient.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
-				Commit: jobInfo.OutputCommit,
-				Empty:  true,
-			})
-			return err
-		}
 		// Watch the chunks in order
 		chunks := a.chunks(jobInfo.Job.ID).ReadOnly(ctx)
 		var failedDatumID string


### PR DESCRIPTION
This fixes the issue where jobs downstream of (successful) "no datum" jobs are failing.

I'm a little confused/concerned that something else might be breaking silently, because all I did was remove some logic that was specifically meant to handle the edge case of "no datums", despite the fact that all tests still pass. 

Was there testing done originally to confirm that the no datum logic actually prevents something erroneous from happening, that has since been removed?  