### PR TITLE
Fix PPS provenance issue & add manual test

### DIFF
--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -1132,8 +1133,13 @@ func TestPipelineRevoke(t *testing.T) {
 			[]*pfs.Repo{client.NewRepo(pipeline)},
 		)
 		require.NoError(t, err)
-		_, err = iter.Next()
-		require.NoError(t, err)
+		for { // flushCommit yields two output commits (one from the prev pipeline)
+			_, err = iter.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
 		close(doneCh)
 	}()
 	select {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -2806,7 +2806,10 @@ func TestUpdatePipelineRunningJob(t *testing.T) {
 
 	jobInfos, err := c.ListJob(pipelineName, nil, nil, -1, true)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(jobInfos))
+	// As of v1.9.0, a new job will be created for commit2 and immediately killed
+	// (as an expedient way of closing the job's output commit, which is necessary
+	// for job #3, based on the UpdatePipeline call, to run)
+	require.Equal(t, 3, len(jobInfos))
 	require.Equal(t, pps.JobState_JOB_SUCCESS.String(), jobInfos[0].State.String())
 	require.Equal(t, pps.JobState_JOB_KILLED.String(), jobInfos[1].State.String())
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -2574,7 +2574,7 @@ func TestManyPipelineUpdate(t *testing.T) {
 					},
 					client.NewPFSInput(dataRepo, "/*"),
 					"",
-					/*update: */ i > 0,
+					true,
 				))
 				fmt.Printf("flushing commit...")
 				require.NoErrorWithinTRetry(t, 60*time.Second, func() error {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1876,6 +1876,12 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 			update = true
 		}
 	}
+	var (
+		// provenance for the pipeline's output branch (includes the spec branch)
+		provenance = append(branchProvenance(pipelineInfo.Input),
+			client.NewBranch(ppsconsts.SpecRepo, pipelineName))
+		outputBranch = client.NewBranch(pipelineName, pipelineInfo.OutputBranch)
+	)
 	if update {
 		// Help user fix inconsistency if previous UpdatePipeline call failed
 		if ci, err := pachClient.InspectCommit(ppsconsts.SpecRepo, pipelineName); err != nil {
@@ -1886,10 +1892,6 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 				"call crashed. If you're sure no other CreatePipeline commands are " +
 				"running, you can run 'pachctl update pipeline --clean' which will " +
 				"delete this open commit")
-		}
-
-		if err := a.hardStopPipeline(pachClient, pipelineInfo); err != nil {
-			return nil, err
 		}
 
 		// Look up existing pipelineInfo and update it, writing updated
@@ -1914,19 +1916,54 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 					return newErrPipelineUpdate(pipelineInfo.Pipeline.Name, fmt.Errorf("cannot disable stats"))
 				}
 
+				var specCommit *pfs.Commit
 				// Modify pipelineInfo
 				pipelineInfo.Version = oldPipelineInfo.Version + 1
 				pipelineInfo.Stopped = oldPipelineInfo.Stopped
-				if !request.Reprocess {
+				// If we're reprocessing, recreate the output branch with nil head
+				// (break the output chain)
+				if request.Reprocess {
+					// remove provenance from existing output branch, so that updating the
+					// spec commit doesn't create an output commit in the old output branch
+					if err := a.hardStopPipeline(pachClient, pipelineInfo); err != nil {
+						return err
+					}
+					// Write new PipelineInfo back to PFS (will not create new output
+					// commit)
+					specCommit, err = a.makePipelineInfoCommit(pachClient, pipelineInfo)
+					if err != nil {
+						return err
+					}
+					// Recreate output branch & stats branch w/ nil head, to break output
+					// chain
+					// Note: Head MUST be nil, or propagateCommit will pull the existing
+					// outputBranch Head commit's provenance, including the old spec
+					// commit, into the new output commit's provenance, breaking this
+					// pipeline
+					if _, err := pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
+						Branch:     outputBranch,
+						Provenance: provenance,
+					}); err != nil {
+						return fmt.Errorf("could not create/update output branch: %v", err)
+					}
+					if pipelineInfo.EnableStats {
+						if _, err := pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
+							Branch:     client.NewBranch(pipelineName, "stats"),
+							Provenance: []*pfs.Branch{outputBranch},
+						}); err != nil {
+							return fmt.Errorf("could not create/update stats branch: %v", err)
+						}
+					}
+				} else {
 					pipelineInfo.Salt = oldPipelineInfo.Salt
-				}
-				// Write updated PipelineInfo back to PFS.
-				commit, err := a.makePipelineInfoCommit(pachClient, pipelineInfo)
-				if err != nil {
-					return err
+					// Write new PipelineInfo back to PFS, triggering new output commit
+					specCommit, err = a.makePipelineInfoCommit(pachClient, pipelineInfo)
+					if err != nil {
+						return err
+					}
 				}
 				// Update pipelinePtr to point to new commit
-				pipelinePtr.SpecCommit = commit
+				pipelinePtr.SpecCommit = specCommit
 				pipelinePtr.State = pps.PipelineState_PIPELINE_STARTING
 				// Clear any failure reasons
 				pipelinePtr.Reason = ""
@@ -1941,22 +1978,36 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 			}
 		}
 	} else {
+		// Create spec commit and update etcd ptr (must happen before creating
+		// output branch, so that no commits are created without a spec commit)
+		commit, err := a.makePipelineInfoCommit(pachClient, pipelineInfo)
+		if err != nil {
+			return nil, err
+		}
+		pipelinePtr := &pps.EtcdPipelineInfo{
+			SpecCommit: commit,
+			State:      pps.PipelineState_PIPELINE_STARTING,
+		}
+
 		// Create output repo, pipeline output, and stats
 		if _, err := pfsClient.CreateRepo(ctx, &pfs.CreateRepoRequest{
 			Repo: client.NewRepo(pipelineName),
 		}); err != nil && !isAlreadyExistsErr(err) {
 			return nil, err
 		}
-		commit, err := a.makePipelineInfoCommit(pachClient, pipelineInfo)
-		if err != nil {
-			return nil, err
+		if _, err := pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
+			Branch:     outputBranch,
+			Provenance: provenance,
+		}); err != nil {
+			return nil, fmt.Errorf("could not create/update output branch: %v", err)
 		}
-
-		// pipelinePtr will be written to etcd, pointing at 'commit'. May include an
-		// auth token
-		pipelinePtr := &pps.EtcdPipelineInfo{
-			SpecCommit: commit,
-			State:      pps.PipelineState_PIPELINE_STARTING,
+		if pipelineInfo.EnableStats {
+			if _, err := pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
+				Branch:     client.NewBranch(pipelineName, "stats"),
+				Provenance: []*pfs.Branch{outputBranch},
+			}); err != nil {
+				return nil, fmt.Errorf("could not create/update stats branch: %v", err)
+			}
 		}
 
 		// Generate pipeline's auth token & add pipeline to the ACLs of input/output
@@ -1996,39 +2047,6 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 			if err := a.fixPipelineInputRepoACLs(pachClient, pipelineInfo, nil); err != nil {
 				return nil, err
 			}
-		}
-	}
-
-	// Create a branch for the pipeline's output data (provenant on the spec branch)
-	provenance := append(branchProvenance(pipelineInfo.Input),
-		client.NewBranch(ppsconsts.SpecRepo, pipelineName))
-	outputBranch := client.NewBranch(pipelineName, pipelineInfo.OutputBranch)
-	var head *pfs.Commit
-	// If this is an update without reprocess then we don't want to break the output chain.
-	if request.Update && !request.Reprocess {
-		// First make sure that the branch exists
-		_, err := pfsClient.InspectBranch(ctx, &pfs.InspectBranchRequest{Branch: outputBranch})
-		if err != nil && !isNotFoundErr(err) {
-			return nil, err
-		}
-		if err == nil {
-			// Make the new head of the branch the current head (don't change the head)
-			head = client.NewCommit(pipelineName, pipelineInfo.OutputBranch)
-		}
-	}
-	if _, err := pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
-		Branch:     outputBranch,
-		Provenance: provenance,
-		Head:       head,
-	}); err != nil {
-		return nil, fmt.Errorf("could not create/update output branch: %v", err)
-	}
-	if pipelineInfo.EnableStats {
-		if _, err := pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
-			Branch:     client.NewBranch(pipelineName, "stats"),
-			Provenance: []*pfs.Branch{outputBranch},
-		}); err != nil {
-			return nil, fmt.Errorf("could not create/update stats branch: %v", err)
 		}
 	}
 

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -509,13 +509,13 @@ func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobReque
 	}
 	if request.Job == nil && request.OutputCommit == nil {
 		return nil, fmt.Errorf("must specify either a Job or an OutputCommit")
+	} else if request.Job != nil && request.OutputCommit != nil {
+		return nil, fmt.Errorf("can't set both Job and OutputCommit")
 	}
 
 	jobs := a.jobs.ReadOnly(ctx)
 	if request.OutputCommit != nil {
-		if request.Job != nil {
-			return nil, fmt.Errorf("can't set both Job and OutputCommit")
-		}
+		// lookup related job & put in request.Job
 		ci, err := pachClient.InspectCommit(request.OutputCommit.Repo.Name, request.OutputCommit.ID)
 		if err != nil {
 			return nil, err

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -1468,6 +1468,7 @@ func (a *APIServer) merge(pachClient *client.APIClient, objClient obj.Client, st
 }
 
 func (a *APIServer) getParentCommitInfo(ctx context.Context, pachClient *client.APIClient, commit *pfs.Commit) (*pfs.CommitInfo, error) {
+	outputCommitID := commit.ID
 	commitInfo, err := pachClient.PfsAPIClient.InspectCommit(ctx,
 		&pfs.InspectCommitRequest{
 			Commit: commit,
@@ -1476,6 +1477,8 @@ func (a *APIServer) getParentCommitInfo(ctx context.Context, pachClient *client.
 		return nil, err
 	}
 	for commitInfo.ParentCommit != nil {
+		logger.Logf("blocking on parent commit %q before writing to output commit %q",
+			commitInfo.ParentCommit.ID, outputCommitID)
 		parentCommitInfo, err := pachClient.PfsAPIClient.InspectCommit(ctx,
 			&pfs.InspectCommitRequest{
 				Commit:     commitInfo.ParentCommit,
@@ -1748,6 +1751,7 @@ func (a *APIServer) worker() {
 				return fmt.Errorf("error from InspectJob(%v): %+v", jobID, err)
 			}
 			if jobInfo.PipelineVersion < a.pipelineInfo.Version {
+				logger.Logf("skipping job %v as it uses old pipeline version %d", jobID, jobInfo.PipelineVersion)
 				continue
 			}
 			if jobInfo.PipelineVersion > a.pipelineInfo.Version {
@@ -1755,6 +1759,7 @@ func (a *APIServer) worker() {
 					"version (%d), this should automatically resolve when the worker "+
 					"is updated", jobID, jobInfo.PipelineVersion, a.pipelineInfo.Version)
 			}
+			logger.Logf("processing job %v", jobID)
 
 			// Read the chunks laid out by the master and create the datum factory
 			plan := &Plan{}

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -1477,7 +1477,7 @@ func (a *APIServer) getParentCommitInfo(ctx context.Context, pachClient *client.
 		return nil, err
 	}
 	for commitInfo.ParentCommit != nil {
-		logger.Logf("blocking on parent commit %q before writing to output commit %q",
+		a.getWorkerLogger().Logf("blocking on parent commit %q before writing to output commit %q",
 			commitInfo.ParentCommit.ID, outputCommitID)
 		parentCommitInfo, err := pachClient.PfsAPIClient.InspectCommit(ctx,
 			&pfs.InspectCommitRequest{

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -133,7 +133,7 @@ func (a *APIServer) jobSpawner(pachClient *client.APIClient) error {
 		}
 
 		// Check if a job was previously created for this commit. If not, make one
-		var jobInfo *pps.JobInfo // jobInfo = job for commitInfo (new or old)
+		var jobInfo *pps.JobInfo // job for commitInfo (new or old)
 		jobInfos, err := pachClient.ListJob("", nil, commitInfo.Commit, -1, true)
 		if err != nil {
 			return err

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -165,7 +165,7 @@ func (a *APIServer) jobSpawner(pachClient *client.APIClient) error {
 				// aren't killed, future jobs will hang indefinitely waiting for their
 				// parents to finish)
 				if err := a.updateJobState(pachClient.Ctx(), jobInfo, nil,
-					pps.JobState_JOB_KILLED, "stale job uses old pipeline"); err != nil {
+					pps.JobState_JOB_KILLED, "pipeline has been updated"); err != nil {
 					return fmt.Errorf("could not kill stale job: %v", err)
 				}
 				// waitJob isn't running for this job (as it's just been received) so

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -131,18 +131,16 @@ func (a *APIServer) jobSpawner(pachClient *client.APIClient) error {
 		if commitInfo.Finished != nil {
 			continue // commit finished after queueing
 		}
+
 		// Check if a job was previously created for this commit. If not, make one
-		var jobInfo *pps.JobInfo
+		var jobInfo *pps.JobInfo // jobInfo = job for commitInfo (new or old)
 		jobInfos, err := pachClient.ListJob("", nil, commitInfo.Commit, -1, true)
 		if err != nil {
 			return err
 		}
-		if len(jobInfos) > 0 {
-			if len(jobInfos) > 1 {
-				return fmt.Errorf("multiple jobs found for commit: %s/%s", commitInfo.Commit.Repo.Name, commitInfo.Commit.ID)
-			}
-			jobInfo = jobInfos[0]
-		} else {
+		if len(jobInfos) > 1 {
+			return fmt.Errorf("multiple jobs found for commit: %s/%s", commitInfo.Commit.Repo.Name, commitInfo.Commit.ID)
+		} else if len(jobInfos) < 1 {
 			job, err := pachClient.CreateJob(a.pipelineInfo.Pipeline.Name, commitInfo.Commit)
 			if err != nil {
 				return err
@@ -151,10 +149,49 @@ func (a *APIServer) jobSpawner(pachClient *client.APIClient) error {
 			if err != nil {
 				return err
 			}
-		}
-		if ppsutil.IsTerminal(jobInfo.State) {
-			// previously-created job has finished, but commit has not been closed yet
-			continue
+		} else {
+			// check job still exists & get latest state
+			jobInfo, err = pachClient.InspectJob(jobInfos[0].Job.ID, false)
+			if err != nil {
+				return err
+			}
+			switch {
+			case ppsutil.IsTerminal(jobInfo.State):
+				// ignore finished jobs (e.g. old pipeline & already killed)
+				continue
+			case jobInfo.PipelineVersion < a.pipelineInfo.Version:
+				// kill unfinished jobs from old pipelines (should generally be cleaned
+				// up by PPS master, but the PPS master can fail, and if these jobs
+				// aren't killed, future jobs will hang indefinitely waiting for their
+				// parents to finish)
+				if err := a.updateJobState(pachClient.Ctx(), jobInfo, nil,
+					pps.JobState_JOB_KILLED, "stale job uses old pipeline"); err != nil {
+					return fmt.Errorf("could not kill stale job: %v", err)
+				}
+				// waitJob isn't running for this job (as it's just been received) so
+				// finish output commit & any stats commit here
+				if _, err := pachClient.PfsAPIClient.FinishCommit(pachClient.Ctx(),
+					&pfs.FinishCommitRequest{
+						Commit: jobInfo.OutputCommit,
+						Empty:  true,
+					}); err != nil {
+					logger.Logf("Error finishing killed job output commit: %v", err)
+				}
+				if jobInfo.StatsCommit != nil {
+					if _, err := pachClient.PfsAPIClient.FinishCommit(pachClient.Ctx(),
+						&pfs.FinishCommitRequest{
+							Commit: jobInfo.StatsCommit,
+							Empty:  true,
+						}); err != nil {
+						logger.Logf("Error finishing killed job stats commit: %v", err)
+					}
+				}
+				continue
+			case jobInfo.PipelineVersion > a.pipelineInfo.Version:
+				return fmt.Errorf("job %s's version (%d) greater than pipeline's "+
+					"version (%d), this should automatically resolve when the worker "+
+					"is updated", jobInfo.Job.ID, jobInfo.PipelineVersion, a.pipelineInfo.Version)
+			}
 		}
 
 		// Now that the jobInfo is persisted, wait until all input commits are

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -145,6 +145,11 @@ func (a *APIServer) jobSpawner(pachClient *client.APIClient) error {
 			if err != nil {
 				return err
 			}
+			logger.Logf("creating new job %q for output commit %q", job.ID, commitInfo.Commit.ID)
+			// get jobInfo to look up spec commit, pipeline version, etc (if this
+			// worker is stale and about to be killed, the new job may have a newer
+			// pipeline version than the master. Or if the commit is stale, it may
+			// have an older pipeline version than the master)
 			jobInfo, err = pachClient.InspectJob(job.ID, false)
 			if err != nil {
 				return err
@@ -152,46 +157,49 @@ func (a *APIServer) jobSpawner(pachClient *client.APIClient) error {
 		} else {
 			// check job still exists & get latest state
 			jobInfo, err = pachClient.InspectJob(jobInfos[0].Job.ID, false)
+			logger.Logf("found existing job %q for output commit %q",
+				jobInfo.Job.ID, commitInfo.Commit.ID, jobInfo.PipelineVersion, a.pipelineInfo.Version)
 			if err != nil {
 				return err
 			}
-			switch {
-			case ppsutil.IsTerminal(jobInfo.State):
-				// ignore finished jobs (e.g. old pipeline & already killed)
-				continue
-			case jobInfo.PipelineVersion < a.pipelineInfo.Version:
-				// kill unfinished jobs from old pipelines (should generally be cleaned
-				// up by PPS master, but the PPS master can fail, and if these jobs
-				// aren't killed, future jobs will hang indefinitely waiting for their
-				// parents to finish)
-				if err := a.updateJobState(pachClient.Ctx(), jobInfo, nil,
-					pps.JobState_JOB_KILLED, "pipeline has been updated"); err != nil {
-					return fmt.Errorf("could not kill stale job: %v", err)
-				}
-				// waitJob isn't running for this job (as it's just been received) so
-				// finish output commit & any stats commit here
+		}
+
+		switch {
+		case ppsutil.IsTerminal(jobInfo.State):
+			// ignore finished jobs (e.g. old pipeline & already killed)
+			continue
+		case jobInfo.PipelineVersion < a.pipelineInfo.Version:
+			// kill unfinished jobs from old pipelines (should generally be cleaned
+			// up by PPS master, but the PPS master can fail, and if these jobs
+			// aren't killed, future jobs will hang indefinitely waiting for their
+			// parents to finish)
+			if err := a.updateJobState(pachClient.Ctx(), jobInfo, nil,
+				pps.JobState_JOB_KILLED, "pipeline has been updated"); err != nil {
+				return fmt.Errorf("could not kill stale job: %v", err)
+			}
+			// waitJob isn't running for this job (as it's just been received) so
+			// finish output commit & any stats commit here
+			if _, err := pachClient.PfsAPIClient.FinishCommit(pachClient.Ctx(),
+				&pfs.FinishCommitRequest{
+					Commit: jobInfo.OutputCommit,
+					Empty:  true,
+				}); err != nil {
+				logger.Logf("Error finishing killed job output commit: %v", err)
+			}
+			if jobInfo.StatsCommit != nil {
 				if _, err := pachClient.PfsAPIClient.FinishCommit(pachClient.Ctx(),
 					&pfs.FinishCommitRequest{
-						Commit: jobInfo.OutputCommit,
+						Commit: jobInfo.StatsCommit,
 						Empty:  true,
 					}); err != nil {
-					logger.Logf("Error finishing killed job output commit: %v", err)
+					logger.Logf("Error finishing killed job stats commit: %v", err)
 				}
-				if jobInfo.StatsCommit != nil {
-					if _, err := pachClient.PfsAPIClient.FinishCommit(pachClient.Ctx(),
-						&pfs.FinishCommitRequest{
-							Commit: jobInfo.StatsCommit,
-							Empty:  true,
-						}); err != nil {
-						logger.Logf("Error finishing killed job stats commit: %v", err)
-					}
-				}
-				continue
-			case jobInfo.PipelineVersion > a.pipelineInfo.Version:
-				return fmt.Errorf("job %s's version (%d) greater than pipeline's "+
-					"version (%d), this should automatically resolve when the worker "+
-					"is updated", jobInfo.Job.ID, jobInfo.PipelineVersion, a.pipelineInfo.Version)
 			}
+			continue
+		case jobInfo.PipelineVersion > a.pipelineInfo.Version:
+			return fmt.Errorf("job %s's version (%d) greater than pipeline's "+
+				"version (%d), this should automatically resolve when the worker "+
+				"is updated", jobInfo.Job.ID, jobInfo.PipelineVersion, a.pipelineInfo.Version)
 		}
 
 		// Now that the jobInfo is persisted, wait until all input commits are
@@ -425,7 +433,7 @@ func (a *APIServer) failedInputs(ctx context.Context, jobInfo *pps.JobInfo) ([]s
 // output from the job's workers and merges it into a commit (and may merge
 // stats into a commit in the stats branch as well)
 func (a *APIServer) waitJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, logger *taggedLogger) (retErr error) {
-	logger.Logf("waitJob: %s", jobInfo.Job.ID)
+	logger.Logf("waiting on job %q (pipeline version: %d, state: %s)", jobInfo.Job.ID, jobInfo.PipelineVersion, jobInfo.State)
 	ctx, cancel := context.WithCancel(pachClient.Ctx())
 	pachClient = pachClient.WithCtx(ctx)
 


### PR DESCRIPTION
Fixes PPS issue where `CreatePipeline` had to call `CreateBranch(outputBranch)`, which caused new pipeline output commits to have old spec commits in their provenance