### PR TITLE
On prem 2a and stubs

### DIFF
--- a/doc/deployment/configuring_k8s_ingress.md
+++ b/doc/deployment/configuring_k8s_ingress.md
@@ -1,0 +1,4 @@
+# Configuring Kubernetes Ingress for Pachyderm
+
+Coming soon.
+This document, when complete, will detail the Kubernetes ingress configuration you'd need for using `pachctl` and the dashboard outside of the Kubernetes cluster.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -1,0 +1,24 @@
+# Custom Deployments
+
+Coming soon.
+This document, when complete, will detail the various options of the `pachctl deploy custom ...` command for an on-premises deployment.
+
+## Creating a Pachyderm manifest
+
+
+```sh
+
+pachctl deploy custom --persistent-disk google --object-store s3 foo 100 pach-minio-bucket OBSIJRBE0PP2NO4QOA27  tfteSlswRu7BJ86wekitnifILbZam1KYY3TG  localhost:9000 --static-etcd-volume=foo --local-roles --dry-run > local_roles.json
+
+
+pachctl deploy custom --persistent-disk google --object-store s3 <persistent disk name> <persistent disk size> <object store bucket> <object store id> <object store secret> <object store endpoint> --static-etcd-volume=${STORAGE_NAME} --dry-run > deployment.json
+```
+
+Then you can modify `deployment.json` to fit your environment and kubernetes deployment.  Once, you have your manifest ready, deploying Pachyderm is as simple as:
+
+```sh
+kubectl create -f deployment.json
+```
+
+## Editing a Pachyderm manifest
+

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -1,24 +1,74 @@
 # Custom Deployments
 
-Coming soon.
-This document, when complete, will detail the various options of the `pachctl deploy custom ...` command for an on-premises deployment.
+This document  details the various options of the `pachctl deploy custom ...` command for an on-premises deployment. 
+
+## Prerequisites
+
+### Software you will need 
+    
+1. [kubectl](https://kubernetes.io/docs/user-guide/prereqs/)
+2. [pachctl](http://docs.pachyderm.io/en/latest/pachctl/pachctl.html)
+
+### Preparing your environment
+
+Please see the [introduction to on-premises deployment](./on_premises.html) for steps you need to take prior to creating a Pachydemerm deployment manifest.
 
 ## Creating a Pachyderm manifest
 
+Please see the [introduction to on-premises deployment](./on_premises.html) for an explanation of the differences among static persistent volumes, StatefulSets and StatefulSets with StorageClasses, as well as the meanings of the variables, like  `PVC_STORAGE_SIZE` and `OS_ENDPOINT`, used below.
 
+### Configuring with a static persistent volume
+The command you'll want to run is 
 ```sh
+$ pachctl deploy custom --persistent-disk aws --object-store s3 
+         ${PVC STORAGE_NAME} ${PVC STORAGE_SIZE} ${OS_BUCKET_NAME} ${OS_ACCESS_KEY_ID} ${OS_SECRET_KEY} ${OS_ENDPOINT} \
+         --static-etcd-volume=${PVC_STORAGE_NAME}  \
+         --dry-run > pachyderm-with-static-volume.json
+```
+### Configuring with StatefulSets
+The command you'll want to run is 
+```sh
+$ pachctl deploy custom --object-store s3 any-string 
+         ${PVC_STORAGE_SIZE} ${OS_BUCKET_NAME} ${OS_ACCESS_KEY_ID} ${OS_SECRET_KEY} ${OS_ENDPOINT} \
+         --dynamic-etcd-nodes=1 \
+         --dry-run > pachyderm-with-statefulset.json
+```
+Note: we use `any-string` as the first argument above because, 
+while the `deploy custom` command expects 6 arguments, 
+it will ignore the first argument when deploying with StatefulSets.
+### Configuring with StatefulSets using StorageClasses
+```sh
+$ pachctl deploy custom --object-store s3 any-string 
+         ${PVC_STORAGE_SIZE} ${OS_BUCKET_NAME} ${OS_ACCESS_KEY_ID} ${OS_SECRET_KEY} ${OS_ENDPOINT} \
+         --dynamic-etcd-nodes=1  --etcd-storage-class $PVC_STORAGECLASS \
+         --dry-run > pachyderm-with-statefulset-using-storageclasses.json
+```
+Note: we use `any-string` as the first argument above because, 
+while the `deploy custom` command expects 6 arguments, 
+it will ignore the first argument when deploying with StatefulSets.
 
-pachctl deploy custom --persistent-disk google --object-store s3 foo 100 pach-minio-bucket OBSIJRBE0PP2NO4QOA27  tfteSlswRu7BJ86wekitnifILbZam1KYY3TG  localhost:9000 --static-etcd-volume=foo --local-roles --dry-run > local_roles.json
+## Next steps
 
+You may either deploy manifests you created above or edit them to customize them further, prior to deploying.
 
-pachctl deploy custom --persistent-disk google --object-store s3 <persistent disk name> <persistent disk size> <object store bucket> <object store id> <object store secret> <object store endpoint> --static-etcd-volume=${STORAGE_NAME} --dry-run > deployment.json
+### Editing your manifest to customize it further
+
+This should only be approached if you are an experienced Kubernetes administrator. 
+
+### Deploying
+The command you'll want to run depends on the command you ran, above.
+
+#### Deploying with a static persistent volume
+```sh
+$ kubectl apply -f ./pachyderm-with-static-volume.json
+```
+#### Deploying  with StatefulSets
+```sh
+$ kubectl apply -f ./pachyderm-with-statefulset.json
+```
+#### Deploying  with StatefulSets using StorageClasses
+```sh
+$ kubectl apply -f ./pachyderm-with-statefulset-using-storageclasses.json
 ```
 
-Then you can modify `deployment.json` to fit your environment and kubernetes deployment.  Once, you have your manifest ready, deploying Pachyderm is as simple as:
-
-```sh
-kubectl create -f deployment.json
-```
-
-## Editing a Pachyderm manifest
 

--- a/doc/deployment/deploy_troubleshooting.md
+++ b/doc/deployment/deploy_troubleshooting.md
@@ -19,6 +19,7 @@ Here are some common issues by symptom related to certain deploys.
 
 - [Pod stuck in `CrashLoopBackoff`](#pod-stuck-in-crashloopbackoff)
 - [Pod stuck in `CrashLoopBackoff` - with error attaching volume](#pod-stuck-in-crashloopbackoff-with-error-attaching-volume)
+- [
 
 ### Pod stuck in `CrashLoopBackoff`
 

--- a/doc/deployment/docker_registries.md
+++ b/doc/deployment/docker_registries.md
@@ -1,0 +1,6 @@
+# Working With Docker Registries
+
+Coming soon.
+This document, when complete, will take you through on-premises, private Docker registry configuration.
+
+

--- a/doc/deployment/non-cloud-object-stores.md
+++ b/doc/deployment/non-cloud-object-stores.md
@@ -1,0 +1,46 @@
+# Deploying Pachyderm On-Premises With Non-Cloud Object Stores
+
+Coming soon.
+This document, when complete, will discuss common configurations for on-premises objects stores.
+
+## Non-Cloud Object Stores
+### S3 API Signature Algorithms and Regions
+
+The S3 protocol has two different ways of authenticating requests through its api.
+`S3v2` has been [officially deprecated by Amazon](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#UsingAWSSDK-sig2-deprecation),
+so it's not likely that you'll run into it.
+You don't need to know the details of how they work
+(though you can follow these links, S3v2 & [S3v4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html), if you're curious),
+but you may run into issues with either mismatch of the signature method or availability regions.
+
+If you have trouble getting Pachyderm to run, 
+check your Kubernetes logs for the `pachd` pod. 
+Use `kubectl get pods` to find the name of the `pachd` pod and
+`kubectl logs <pachd-pod-name>` to get the logs.
+
+If you see an error beginning with
+```
+INFO error starting grpc server pfs.NewBlockAPIServer
+```
+
+It could have either of two causes.
+
+#### Availability Region Mismatch
+If the error is of the form
+```
+INFO error starting grpc server pfs.NewBlockAPIServer: storage is unable to discern NotExist errors, "The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'z1-a'" should count as NotExist
+```
+It may be [a known issue](https://github.com/pachyderm/pachyderm/issues/3544) with hardcoded region `us-east-1` in the minio libraries.
+You can correct this by either using the `--isS3V2` flag on your the `pachctl deploy custom ...` command 
+or by changing the region of your storage to `us-east-1`.
+
+#### Signature version mismatch
+
+You're not likely to run into this in an on-premises deployment 
+unless your object store has deliberately been set up to use the deprecated `S3v2` signature or 
+you are running your on-premises deployment against Google Cloud Storage, 
+which is not recommended (see the section [Infrastructure in general](./on_premises.html#infrastructure-in-general)).
+
+You'll need to determine what signature algorithm your object store uses in its S3-compatible API:  `S3v2` or `S3v4`.
+If it's `S3V2`, 
+you can solve this by using the `--isS3V2` flag on your the `pachctl deploy custom ...` command.

--- a/doc/deployment/non-cloud-object-stores.md
+++ b/doc/deployment/non-cloud-object-stores.md
@@ -3,7 +3,20 @@
 Coming soon.
 This document, when complete, will discuss common configurations for on-premises objects stores.
 
-## Non-Cloud Object Stores
+## General information on non-cloud object stores
+
+Please see [the on-premises introduction to object stores](./on-premises.html#deploying-an-object-store) for some general information on object stores and how they're used with Pachyderm.
+
+### EMC ECS
+Coming soon.
+
+### MinIO
+Coming soon.
+
+### SwiftStack
+Coming soon.
+
+## Notes
 ### S3 API Signature Algorithms and Regions
 
 The S3 protocol has two different ways of authenticating requests through its api.
@@ -44,3 +57,4 @@ which is not recommended (see the section [Infrastructure in general](./on_premi
 You'll need to determine what signature algorithm your object store uses in its S3-compatible API:  `S3v2` or `S3v4`.
 If it's `S3V2`, 
 you can solve this by using the `--isS3V2` flag on your the `pachctl deploy custom ...` command.
+

--- a/doc/deployment/on_premises.md
+++ b/doc/deployment/on_premises.md
@@ -1,33 +1,132 @@
 # On Premises
 
-Pachyderm is built on [Kubernetes](https://kubernetes.io/) and can be backed by an object store of your choice. As such, Pachyderm can run on any on premise platforms/frameworks that support Kubernetes, a persistent disk/volume, and an object store.
+This document is broken down into the following sections, available at the links below
+
+- [Introduction to on-premises deployments](#introduction) takes you through what you need to know about Kubernetes, persistent volumes, object stores and best practices.  That's this page.
+- [Customizing your Pachyderm deployment for on-premises use](./deploy_custom.html) details the various options of the `pachctl deploy custom ...` command for an on-premises deployment.
+- [Single-node Pachyderm deployment](./single-node.html) is the document you should read when deploying Pachyderm for personal, low-volume usage.
+- [Registries](./docker_registries.html) takes you through on-premises, private Docker registry configuration.
+- [Ingress](./configuring_k8s_ingress.html) details the Kubernetes ingress configuration you'd need for using `pachctl` and the dashboard outside of the Kubernetes cluster
+- [Non-cloud object stores](./non-cloud-object-stores.html) discusses common configurations for on-premises object stores.
+
+Need information on a particular flavor of Kubernetes or object store?  Check out the [see also](#see-also) section.
+
+Troubleshooting a deployment? Check out [Troubleshooting Deployments](./deploy_troubleshooting.html).
+
+## Introduction
+
+Deploying Pachyderm successfully on-premises requires a few prerequisites and some planning.
+Pachyderm is built on [Kubernetes](https://kubernetes.io/).
+Before you can deploy Pachyderm, you or your Kubernetes administrator will need to perform the following actions:
+1. [Deploy Kubernetes](#deploying-kubernetes) on-premises.
+1. [Deploy a Kubernetes persistent volume](#deploying-a-persistent-volume) that Pachyderm will use to store administrative data.
+1. [Deploy an on-premises object store](#deploying-an-object-store) using a storage provider like [MinIO](https://min.io/) EMC's ECS or Swift to provide S3-compatible access to your on-premises storage.
+1. [Create a Pachyderm manifest](./deploy_custom.html#creating-a-pachyderm-manifest) by running the `pachctl deploy custom` command with appropriate arguments and the `--dry-run` flag to create a Kubernetes manifest for the Pachyderm deployment.
+1. [Edit the Pachyderm manifest](#deploy_custom.html#editing-a-pachyderm-manifest) for your particular Kubernetes deployment
+
+In this series of documents, we'll take you through the steps unique to Pachyderm.
+We assume you have some Kubernetes knowledge.
+We will point you to external resources for the general Kubernetes steps to give you background.
+
+## Best practices
+### Infrastructure as code
+We highly encourage you to apply the best practices used in developing software to managing the deployment process.
+1. Create scripts that automate as much of your processes as possible and keep them under version control.
+1. Keep copies of all artifacts, such as manifests, produced by those scripts and keep those under version control.
+1. Document your practices in the code and outside it.
+### Infrastructure in general
+Be sure that you design your Kubernetes infrastructure in accordance with recommended guidelines.
+Don't mix on-premises Kubernetes and cloud-based storage.
+It's important that bandwidth to your storage deployment meet the guidelines of your storage provider.
 
 ## Prerequisites
 
+### Software you will need 
+    
 1. [kubectl](https://kubernetes.io/docs/user-guide/prereqs/)
 2. [pachctl](http://docs.pachyderm.io/en/latest/pachctl/pachctl.html)
 
-## Kubernetes
+### Deploying Kubernetes
 
-The Kubernetes docs have instructions for [deploying Kubernetes in a variety of on-premise scenarios](https://kubernetes.io/docs/getting-started-guides/#on-premises-vms).  We recommend following one of these guides to get Kubernetes running on premise.
+The Kubernetes docs have instructions for [deploying Kubernetes in a variety of on-premise scenarios](https://kubernetes.io/docs/getting-started-guides/#on-premises-vms).
+We recommend following one of these guides to get Kubernetes running on premise.
 
-## Object Store
+### Deploying a persistent volume
 
-Once you have Kubernetes up and running, deploying Pachyderm is a matter of supplying Kubernetes with a JSON/YAML manifest to create the Pachyderm resources.  This includes providing information that Pachyderm will use to connect to a backing object store.
+#### Persistent volumes: how do they work?
 
-For on premise deployments, we recommend using [Minio](https://minio.io/) as a backing object store.  However, at this point, you could utilize any backing object store that has an S3 compatible API.  To create a manifest template for your on premise deployment, run:
+A Kubernetes [persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) is used by Pachyderm's `etcd` for storage of system metatada. 
+In Kubernetes, [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) are a mechanism for providing storage for consumption by the users of the cluster.
+They are provisioned by the cluster administrators.
+In a typical enterprise Kubernetes deployment, the administrators have configured persistent volumes that your Pachyderm deployment will consume by means of a [persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) in the [Pachyderm manifest you generate](./deploy_custom.html#creating-a-pachyderm-manifest). 
+If your administrators require specification of [selectors](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector) or [classes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1) to consume persistent volumes, 
+you will need to find out the particulars of your cluster's PV configuration and [edit the Pachyderm manifest](./deploy_custom.html#editing-the-pachyderm-manifest) accordingly.
 
-```sh
-pachctl deploy custom --persistent-disk google --object-store s3 <persistent disk name> <persistent disk size> <object store bucket> <object store id> <object store secret> <object store endpoint> --static-etcd-volume=${STORAGE_NAME} --dry-run > deployment.json
-```
+#### Sizing the pv
 
-Then you can modify `deployment.json` to fit your environment and kubernetes deployment.  Once, you have your manifest ready, deploying Pachyderm is as simple as:
+You'll need to use a pv with enough space for the metadata associated with the data you plan to store in Pachyderm. 
+We're currently developing good rules of thumb for scaling this storage as your Pachyderm deployment grows,
+but it looks like 10G of disk space is sufficient for most purposes.
 
-```sh
-kubectl create -f deployment.json
-```
+#### Creating the pv
 
-## Need Help?
+In the case of cloud-based deployments, the `pachctl deploy` command for AWS, GCP and Azure creates persistent volumes for you, when you follow the instructions for those infrastructures.
+In the case of on-premises deployments, the kind of PV you provision will be dependent on what kind of storage your Kubernetes administrators have attached to your cluster and configured.
+For example, many on-premises deployments use Network File System (NFS) to access to some kind of enterprise storage.
+Persistent volumes are provisioned in Kubernetes like all things in Kubernetes: by means of a manifest.
+You can learn about creating [volumes](https://kubernetes.io/docs/concepts/storage/volumes/)  and [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) in the Kubernetes documentation.
 
-If you need help with your on premises deploy, please reach out to us on Pachyderm's [slack channel](https://pachyderm-users.slack.com/messages) or via email at support@pachyderm.io. We are happy to help!
+#### What you'll need for Pachyderm configuration of pv storage
+
+You'll need the name of the pv and the amount of space you can use, in gigabytes.  We'll refer to those as `PVC_STORAGE_NAME` and `PVC_STORAGE_SIZE` further on.
+
+Keep this information handy.
+   
+### Deploying an object store
+
+#### Object store: what's it for?
+An object store is used by Pachyderm's `pachd` for storing all your data. 
+The object store you use must be accessible via a low-latency, high-bandwidth connection like [Gigabit](https://en.wikipedia.org/wiki/Gigabit_Ethernet)  or [10G Ethernet](https://en.wikipedia.org/wiki/10_Gigabit_Ethernet).
+
+For an on-premises deployment, 
+it's not advisable to use a cloud-based storage mechanism.
+Don't deploy an on-premises Pachyderm cluster against cloud-based object stores such as S3 from [AWS](https://pachyderm.readthedocs.io/en/latest/deployment/amazon_web_services.html), GCS from [Google Cloud Platform](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), Azure Blob Storage from  [Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html).
+
+#### Object store prerequisites
+
+Object stores are accessible using the S3 protocol, created by Amazon. 
+Storage providers like MinIO, EMC's ECS or Swift provide S3-compatible access to enterprise storage for on-premises deployment. 
+You can find links to instructions for providers of particular object stores in the [See also](#see-also) section.
+
+#### Sizing the object store
+
+Size your object store generously.
+Once you start using Pachyderm, you'll start versioning all your data.
+We're currently developing good rules of thumb for scaling your object store as your Pachyderm deployment grows,
+but it's a good idea to start with a large multiple of your current data set size.
+
+#### What you'll need for Pachyderm configuration of the object store
+You'll need four items to configure the object store. 
+We're prefixing each item with how we'll refer to it further on.
+
+1. `OS_ENDPOINT`: The access endpoint.
+   For example, MinIO's endpoints are usually something like `minio-server:9000`. 
+   Don't begin it with the protocol; it's an endpoint, not an url.
+1. `OS_BUCKET_NAME`: The bucket name you're dedicating to Pachyderm. Pachyderm will need exclusive access to this bucket.
+1. `OS_ACCESS_KEY_ID`: The access key id for the object store.  This is like a user name for logging into the object store.
+1. `OS_SECRET_KEY`: The secret key for the object store.  This is like the above user's password.
+
+Keep this information handy.
+
+### Next step: creating a custom deploy manifest for Pachyderm
+Once you have Kubernetes deployed, your persistent volume created, and your object store configured, it's time to [create the Pachyderm manifest for deploying to Kubernetes](./deploy_custom.html).
+
+## See Also
+### Kubernetes variants
+- [OpenShift](./openshift.html)
+### Object storage variants
+- [ECS](./non-cloud-object-stores.html#ecs)
+- [MinIO](./non-cloud-object-stores.html#minio)
+- [SwiftStack](./non-cloud-object-stores.html#swiftstack)
+
 

--- a/doc/deployment/single-node.md
+++ b/doc/deployment/single-node.md
@@ -3,4 +3,6 @@
 Coming soon.
 This document, when complete, will take you through deploying Pachyderm for personal, low-volume usage.
 
+This is distinct from `pachctl deploy local`, which is not suitable for anything beyond training and evaluation.
+
 

--- a/doc/deployment/single-node.md
+++ b/doc/deployment/single-node.md
@@ -1,0 +1,6 @@
+# Single-node Pachyderm Deployments
+
+Coming soon.
+This document, when complete, will take you through deploying Pachyderm for personal, low-volume usage.
+
+


### PR DESCRIPTION
This is the first of a set of updates to the on-premises documentation, mapped out in this planning document: https://docs.google.com/document/d/1mfJIwxm1c5timsUTTMIMvfOaIZuJS8sB3lnsrxXfYuM/edit

This represents document 2.a only, with stubs for all the other documents.  2.b, in particular, is somewhat filled out but needs more work and will be worked on next.