### PR TITLE
Chunk Storage CopyN

### DIFF
--- a/src/server/pkg/storage/chunk/chunk_test.go
+++ b/src/server/pkg/storage/chunk/chunk_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 )
 
-func Write(t *testing.T, chunks *Storage, n int) ([]*DataRef, []byte) {
+func Write(t *testing.T, chunks *Storage, n, rangeSize int) ([]*DataRef, []byte) {
 	var finalDataRefs []*DataRef
 	var seq []byte
 	t.Run("Write", func(t *testing.T) {
@@ -19,9 +19,9 @@ func Write(t *testing.T, chunks *Storage, n int) ([]*DataRef, []byte) {
 			return nil
 		}
 		seq = RandSeq(n * MB)
-		for i := 0; i < n; i++ {
+		for i := 0; i < n/rangeSize; i++ {
 			w.StartRange(cb)
-			_, err := w.Write(seq[i*MB : (i+1)*MB])
+			_, err := w.Write(seq[i*MB*rangeSize : (i+1)*MB*rangeSize])
 			require.NoError(t, err)
 		}
 		require.NoError(t, w.Close())
@@ -32,7 +32,7 @@ func Write(t *testing.T, chunks *Storage, n int) ([]*DataRef, []byte) {
 func TestWriteThenRead(t *testing.T) {
 	objC, chunks := LocalStorage(t)
 	defer Cleanup(objC, chunks)
-	finalDataRefs, seq := Write(t, chunks, 100)
+	finalDataRefs, seq := Write(t, chunks, 100, 1)
 	mid := len(finalDataRefs) / 2
 	initialRefs := finalDataRefs[:mid]
 	streamRefs := finalDataRefs[mid:]
@@ -77,8 +77,8 @@ func TestCopyN(t *testing.T) {
 	objC, chunks := LocalStorage(t)
 	defer Cleanup(objC, chunks)
 	// Write the initial data and count the chunks.
-	dataRefs1, seq1 := Write(t, chunks, 50)
-	dataRefs2, seq2 := Write(t, chunks, 50)
+	dataRefs1, seq1 := Write(t, chunks, 60, 20)
+	dataRefs2, seq2 := Write(t, chunks, 60, 20)
 	var initialChunkCount int64
 	require.NoError(t, chunks.List(context.Background(), func(_ string) error {
 		initialChunkCount++

--- a/src/server/pkg/storage/chunk/chunk_test.go
+++ b/src/server/pkg/storage/chunk/chunk_test.go
@@ -9,9 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 )
 
-func TestWriteThenRead(t *testing.T) {
-	objC, chunks := LocalStorage(t)
-	defer Cleanup(objC, chunks)
+func Write(t *testing.T, chunks *Storage, n int) ([]*DataRef, []byte) {
 	var finalDataRefs []*DataRef
 	var seq []byte
 	t.Run("Write", func(t *testing.T) {
@@ -20,14 +18,21 @@ func TestWriteThenRead(t *testing.T) {
 			finalDataRefs = append(finalDataRefs, dataRefs...)
 			return nil
 		}
-		seq = RandSeq(100 * MB)
-		for i := 0; i < 100; i++ {
+		seq = RandSeq(n * MB)
+		for i := 0; i < n; i++ {
 			w.StartRange(cb)
 			_, err := w.Write(seq[i*MB : (i+1)*MB])
 			require.NoError(t, err)
 		}
 		require.NoError(t, w.Close())
 	})
+	return finalDataRefs, seq
+}
+
+func TestWriteThenRead(t *testing.T) {
+	objC, chunks := LocalStorage(t)
+	defer Cleanup(objC, chunks)
+	finalDataRefs, seq := Write(t, chunks, 100)
 	mid := len(finalDataRefs) / 2
 	initialRefs := finalDataRefs[:mid]
 	streamRefs := finalDataRefs[mid:]
@@ -66,4 +71,47 @@ func BenchmarkWriter(b *testing.B) {
 		}
 		require.NoError(b, w.Close())
 	}
+}
+
+func TestCopyN(t *testing.T) {
+	objC, chunks := LocalStorage(t)
+	defer Cleanup(objC, chunks)
+	// Write the initial data and count the chunks.
+	dataRefs1, seq1 := Write(t, chunks, 50)
+	dataRefs2, seq2 := Write(t, chunks, 50)
+	var initialChunkCount int64
+	require.NoError(t, chunks.List(context.Background(), func(_ string) error {
+		initialChunkCount++
+		return nil
+	}))
+	// Copy data from readers into new writer.
+	w := chunks.NewWriter(context.Background())
+	r1 := chunks.NewReader(context.Background(), dataRefs1...)
+	r2 := chunks.NewReader(context.Background(), dataRefs2...)
+	var finalDataRefs []*DataRef
+	cb := func(dataRefs []*DataRef) error {
+		finalDataRefs = append(finalDataRefs, dataRefs...)
+		return nil
+	}
+	w.StartRange(cb)
+	mid := r1.Len() / 2
+	require.NoError(t, CopyN(w, r1, r1.Len()-mid))
+	require.NoError(t, CopyN(w, r1, mid))
+	mid = r2.Len() / 2
+	require.NoError(t, CopyN(w, r2, r2.Len()-mid))
+	require.NoError(t, CopyN(w, r2, mid))
+	require.NoError(t, w.Close())
+	// Check that the initial data equals the final data.
+	buf := &bytes.Buffer{}
+	finalR := chunks.NewReader(context.Background(), finalDataRefs...)
+	_, err := io.Copy(buf, finalR)
+	require.NoError(t, err)
+	require.Equal(t, append(seq1, seq2...), buf.Bytes())
+	// Only one extra chunk should get created when connecting the two sets of data.
+	var finalChunkCount int64
+	require.NoError(t, chunks.List(context.Background(), func(_ string) error {
+		finalChunkCount++
+		return nil
+	}))
+	require.Equal(t, initialChunkCount+1, finalChunkCount)
 }

--- a/src/server/pkg/storage/chunk/reader.go
+++ b/src/server/pkg/storage/chunk/reader.go
@@ -18,28 +18,41 @@ type Reader struct {
 	dataRefs []*DataRef
 	curr     *DataRef
 	buf      *bytes.Buffer
-	r        io.Reader
+	r        *bytes.Reader
+	len      int64
 }
 
 func newReader(ctx context.Context, objC obj.Client, dataRefs ...*DataRef) *Reader {
-	return &Reader{
-		ctx:      ctx,
-		objC:     objC,
-		dataRefs: dataRefs,
-		buf:      &bytes.Buffer{},
-		r:        bytes.NewReader([]byte{}),
+	r := &Reader{
+		ctx:  ctx,
+		objC: objC,
+		buf:  &bytes.Buffer{},
 	}
+	r.NextRange(dataRefs)
+	return r
 }
 
 // NextRange sets the next range for the reader.
 func (r *Reader) NextRange(dataRefs []*DataRef) {
 	r.dataRefs = dataRefs
 	r.r = bytes.NewReader([]byte{})
+	r.len = 0
+	for _, dataRef := range dataRefs {
+		r.len += dataRef.SizeBytes
+	}
+}
+
+// Len returns the number of bytes left.
+func (r *Reader) Len() int64 {
+	return r.len
 }
 
 // Read reads from the byte stream produced by the set of DataRefs.
 func (r *Reader) Read(data []byte) (int, error) {
 	var totalRead int
+	defer func() {
+		r.len -= int64(totalRead)
+	}()
 	for len(data) > 0 {
 		n, err := r.r.Read(data)
 		data = data[n:]
@@ -49,19 +62,26 @@ func (r *Reader) Read(data []byte) (int, error) {
 			if len(r.dataRefs) == 0 {
 				return totalRead, io.EOF
 			}
-			// Get next chunk if necessary.
-			if r.curr == nil || r.curr.Chunk.Hash != r.dataRefs[0].Chunk.Hash {
-				if err := r.readChunk(r.dataRefs[0].Chunk); err != nil {
-					return totalRead, err
-				}
+			if err := r.nextDataRef(); err != nil {
+				return totalRead, err
 			}
-			r.curr = r.dataRefs[0]
-			r.dataRefs = r.dataRefs[1:]
-			r.r = bytes.NewReader(r.buf.Bytes()[r.curr.OffsetBytes : r.curr.OffsetBytes+r.curr.SizeBytes])
 		}
 	}
 	return totalRead, nil
 
+}
+
+func (r *Reader) nextDataRef() error {
+	// Get next chunk if necessary.
+	if r.curr == nil || r.curr.Chunk.Hash != r.dataRefs[0].Chunk.Hash {
+		if err := r.readChunk(r.dataRefs[0].Chunk); err != nil {
+			return err
+		}
+	}
+	r.curr = r.dataRefs[0]
+	r.dataRefs = r.dataRefs[1:]
+	r.r = bytes.NewReader(r.buf.Bytes()[r.curr.OffsetBytes : r.curr.OffsetBytes+r.curr.SizeBytes])
+	return nil
 }
 
 func (r *Reader) readChunk(chunk *Chunk) error {

--- a/src/server/pkg/storage/chunk/storage.go
+++ b/src/server/pkg/storage/chunk/storage.go
@@ -38,6 +38,11 @@ func (s *Storage) NewWriter(ctx context.Context) *Writer {
 	return newWriter(ctx, s.objC)
 }
 
+// List lists all of the chunks in object storage.
+func (s *Storage) List(ctx context.Context, f func(string) error) error {
+	return s.objC.Walk(ctx, prefix, f)
+}
+
 // DeleteAll deletes all of the chunks in object storage.
 func (s *Storage) DeleteAll(ctx context.Context) error {
 	return s.objC.Walk(ctx, prefix, func(hash string) error {

--- a/src/server/pkg/storage/chunk/util.go
+++ b/src/server/pkg/storage/chunk/util.go
@@ -2,6 +2,9 @@ package chunk
 
 import (
 	"context"
+	fmt "fmt"
+	"io"
+	"math"
 	"math/rand"
 	"os"
 	"testing"
@@ -35,4 +38,41 @@ func RandSeq(n int) []byte {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return []byte(string(b))
+}
+
+// CopyN is an efficient copy function that turns full chunk copies into data reference writes.
+func CopyN(w *Writer, r *Reader, n int64) error {
+	if r.Len() < n {
+		// (bryce) this should be an internal error.
+		return fmt.Errorf("number of bytes to copy (%v) is greater than reader length (%v)", n, r.Len())
+	}
+	for {
+		// Read from the current data reference first.
+		if r.r.Len() > 0 {
+			nCopied, err := io.CopyN(w, r, int64(math.Min(float64(n), float64(r.r.Len()))))
+			n -= nCopied
+			if err != nil {
+				return err
+			}
+		}
+		// Done when there are no bytes left to read.
+		if n == 0 {
+			return nil
+		}
+		// A data reference can be cheaply copied when:
+		// - The writer is at a split point.
+		// - The data reference is a full chunk reference.
+		// - The size of the chunk is less than or equal to the number of bytes left.
+		for w.buf.Len() == 0 && r.dataRefs[0].Hash == "" && r.dataRefs[0].SizeBytes <= n {
+			w.dataRefs[len(w.dataRefs)-1] = r.dataRefs[0]
+			w.dataRefs = append(w.dataRefs, &DataRef{})
+			w.rangeSize += r.dataRefs[0].SizeBytes
+			n -= r.dataRefs[0].SizeBytes
+			r.dataRefs = r.dataRefs[1:]
+		}
+		// Setup next data reference for reading.
+		if err := r.nextDataRef(); err != nil {
+			return err
+		}
+	}
 }


### PR DESCRIPTION
This is the first implementation of cheap copies in Pachyderm's new storage layer. This utility is going to be used when copying data within a file, which happens during the merge process. When merging data into a large file, we will avoid reading/writing chunks of data that will not be changed by the merge process. The merge process will simply shuffle data references for these chunks.