### PR TITLE
Moved port location in generated manifests

### DIFF
--- a/doc/deployment/openshift.md
+++ b/doc/deployment/openshift.md
@@ -143,12 +143,6 @@ In the deployment manifest, which we called `manifest.json`, above, find the sta
 	"spec": {
 		"ports": [
 			{
-				"name": "s3gateway-port",
-				"port": 600,
-				"targetPort": 0,
-				"nodePort": 30600
-			},
-			{
 				"name": "api-grpc-port",
 				"port": 650,
 				"targetPort": 0,
@@ -177,6 +171,12 @@ In the deployment manifest, which we called `manifest.json`, above, find the sta
 				"port": 999,
 				"targetPort": 0,
 				"nodePort": 30999
+			},
+			{
+				"name": "s3gateway-port",
+				"port": 600,
+				"targetPort": 0,
+				"nodePort": 30600
 			}
 		],
 		"selector": {
@@ -193,12 +193,6 @@ While the nodePort declarations are fine, the port declarations are too low for 
 ```
 	"spec": {
 		"ports": [
-			{
-				"name": "s3gateway-port",
-				"port": 1600,
-				"targetPort": 0,
-				"nodePort": 30600
-			},
 			{
 				"name": "api-grpc-port",
 				"port": 1650,
@@ -228,6 +222,12 @@ While the nodePort declarations are fine, the port declarations are too low for 
 				"port": 1999,
 				"targetPort": 0,
 				"nodePort": 30999
+			},
+			{
+				"name": "s3gateway-port",
+				"port": 1600,
+				"targetPort": 0,
+				"nodePort": 30600
 			}
 		],
 ```

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -627,11 +627,8 @@ func PachdService(opts *AssetOpts) *v1.Service {
 				"app": pachdName,
 			},
 			Ports: []v1.ServicePort{
-				{
-					Port:     600, // also set in cmd/pachd/main.go
-					Name:     "s3gateway-port",
-					NodePort: 30600,
-				},
+				// NOTE: do not put any new ports before `api-grpc-port`, as
+				// it'll change k8s SERVICE_PORT env var values
 				{
 					Port:     650, // also set in cmd/pachd/main.go
 					Name:     "api-grpc-port",
@@ -656,6 +653,11 @@ func PachdService(opts *AssetOpts) *v1.Service {
 					Port:     githook.GitHookPort,
 					Name:     "api-git-port",
 					NodePort: githook.NodePort(),
+				},
+				{
+					Port:     600, // also set in cmd/pachd/main.go
+					Name:     "s3gateway-port",
+					NodePort: 30600,
 				},
 			},
 		},


### PR DESCRIPTION
to fix SERVICE_PORT k8s env vars

A new variant of #3802 