### PR TITLE
Allow calling Deactivate on a cluster where enterprise has already been deactivated

### DIFF
--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -310,7 +310,8 @@ func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (
 
 	if _, err := col.NewSTM(ctx, a.env.GetEtcdClient(), func(stm col.STM) error {
 		// blind delete
-		return a.enterpriseToken.ReadWrite(stm).Delete(enterpriseTokenKey)
+		a.enterpriseToken.ReadWrite(stm).Delete(enterpriseTokenKey)
+		return nil
 	}); err != nil {
 		return nil, err
 	}

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -309,8 +309,10 @@ func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (
 	}
 
 	if _, err := col.NewSTM(ctx, a.env.GetEtcdClient(), func(stm col.STM) error {
-		// blind delete
-		a.enterpriseToken.ReadWrite(stm).Delete(enterpriseTokenKey)
+		err := a.enterpriseToken.ReadWrite(stm).Delete(enterpriseTokenKey)
+		if err != nil && !col.IsErrNotFound(err) {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return nil, err

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -147,5 +147,39 @@ func TestDeactivate(t *testing.T) {
 		}
 		return nil
 	}, backoff.NewTestingBackOff()))
+}
 
+// TestDoubleDeactivate makes sure calling Deactivate() when there is no
+// enterprise token works. Fixes
+// https://github.com/pachyderm/pachyderm/issues/3013
+func TestDoubleDeactivate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	client := getPachClient(t)
+
+	// Deactivate cluster and make sure its state is NONE (enterprise might be
+	// active at the start of this test?)
+	_, err := client.Enterprise.Deactivate(context.Background(),
+		&enterprise.DeactivateRequest{})
+	require.NoError(t, err)
+	require.NoError(t, backoff.Retry(func() error {
+		resp, err := client.Enterprise.GetState(context.Background(),
+			&enterprise.GetStateRequest{})
+		if err != nil {
+			return err
+		}
+		if resp.State != enterprise.State_NONE {
+			return fmt.Errorf("expected enterprise state to be NONE but was %v", resp.State)
+		}
+		return nil
+	}, backoff.NewTestingBackOff()))
+
+	// Deactivate the cluster again to make sure deactivation with no token works
+	_, err = client.Enterprise.Deactivate(context.Background(),
+		&enterprise.DeactivateRequest{})
+	require.NoError(t, err)
+	resp, err := client.Enterprise.GetState(context.Background(),
+		&enterprise.GetStateRequest{})
+	require.Equal(t, enterprise.State_NONE, resp.State)
 }


### PR DESCRIPTION
Fix #3013