### PR TITLE
Make sure we delete symlinks from last run.

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -42,7 +42,7 @@ const (
 	PPSInputPrefix = "/pfs"
 	// PPSScratchSpace is where pps workers store data while it's waiting to be
 	// processed.
-	PPSScratchSpace = "/pfs/.scratch"
+	PPSScratchSpace = ".scratch"
 	// PPSWorkerPortEnv is environment variable name for the port that workers
 	// use for their gRPC server
 	PPSWorkerPortEnv = "PPS_WORKER_GRPC_PORT"

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -525,7 +525,7 @@ func (a *APIServer) downloadData(pachClient *client.APIClient, logger *taggedLog
 			logger.Logf("finished downloading data after %v", time.Since(start))
 		}
 	}(time.Now())
-	dir := filepath.Join(client.PPSScratchSpace, uuid.NewWithoutDashes())
+	dir := filepath.Join(client.PPSInputPrefix, client.PPSScratchSpace, uuid.NewWithoutDashes())
 	// Create output directory (currently /pfs/out)
 	outPath := filepath.Join(dir, "out")
 	if a.pipelineInfo.Spout != nil {
@@ -584,6 +584,9 @@ func (a *APIServer) unlinkData(inputs []*Input) error {
 		return fmt.Errorf("ioutil.ReadDir: %v", err)
 	}
 	for _, d := range dirs {
+		if d.Name() == client.PPSScratchSpace {
+			continue // don't delete scratch space
+		}
 		if err := os.RemoveAll(filepath.Join(client.PPSInputPrefix, d.Name())); err != nil {
 			return err
 		}

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -564,6 +564,10 @@ func (a *APIServer) downloadData(pachClient *client.APIClient, logger *taggedLog
 }
 
 func (a *APIServer) linkData(inputs []*Input, dir string) error {
+	// Make sure that previously symlinked outputs are removed.
+	if err := a.unlinkData(inputs); err != nil {
+		return err
+	}
 	for _, input := range inputs {
 		src := filepath.Join(dir, input.Name)
 		dst := filepath.Join(client.PPSInputPrefix, input.Name)
@@ -575,12 +579,16 @@ func (a *APIServer) linkData(inputs []*Input, dir string) error {
 }
 
 func (a *APIServer) unlinkData(inputs []*Input) error {
-	for _, input := range inputs {
-		if err := os.RemoveAll(filepath.Join(client.PPSInputPrefix, input.Name)); err != nil {
+	dirs, err := ioutil.ReadDir(client.PPSInputPrefix)
+	if err != nil {
+		return fmt.Errorf("ioutil.ReadDir: %v", err)
+	}
+	for _, d := range dirs {
+		if err := os.RemoveAll(filepath.Join(client.PPSInputPrefix, d.Name())); err != nil {
 			return err
 		}
 	}
-	return os.RemoveAll(filepath.Join(client.PPSInputPrefix, "out"))
+	return nil
 }
 
 func (a *APIServer) reportUserCodeStats(logger *taggedLogger) {


### PR DESCRIPTION
This fixes an issue we see occasionally where a datum won't run because we can't  symlink the data because there's already symlinks there from the last run.