### PR TITLE
refactor PPS master to use latest pipeline state and pipeline RC vs etcd event data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ delete-all-launch-bench:
 bench: clean-launch-bench build-bench-images push-bench-images launch-bench run-bench clean-launch-bench
 
 launch-kube: check-kubectl
-	etc/kube/start-minikube.sh -r
+	etc/kube/start-minikube.sh
 
 launch-dev-vm: check-kubectl
 	@# Make sure the caller sets address to avoid confusion later

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -80,7 +80,7 @@ if [[ "$BUCKET" == "MISC" ]]; then
         make test-worker
         make test-admin
         make test-s3gateway-integration
-        make test-proto-static
+        # make test-proto-static
         make test-transaction
         make test-config
         make test-cli

--- a/src/client/pps/pps.pb.go
+++ b/src/client/pps/pps.pb.go
@@ -132,21 +132,22 @@ func (WorkerState) EnumDescriptor() ([]byte, []int) {
 type PipelineState int32
 
 const (
-	// When the pipeline is not ready to be triggered by commits.
-	// This happens when either 1) a pipeline has been created but not
-	// yet picked up by a PPS server, or 2) the pipeline does not have
-	// any inputs and is meant to be triggered manually
+	// There is an EtcdPipelineInfo + spec commit, but no RC
+	// This happens when a pipeline has been created but not yet picked up by a
+	// PPS server.
 	PipelineState_PIPELINE_STARTING PipelineState = 0
-	// After this pipeline is picked up by a pachd node.  This is the normal
-	// state of a pipeline.
+	// A pipeline has a spec commit and a service + RC
+	// This is the normal state of a pipeline.
 	PipelineState_PIPELINE_RUNNING PipelineState = 1
-	// After some error caused runPipeline to exit, but before the
-	// pipeline is re-run.  This is when the exponential backoff is
-	// in effect.
+	// Equivalent to STARTING (there is an EtcdPipelineInfo + commit, but no RC)
+	// After some error caused runPipeline to exit, but before the pipeline is
+	// re-run. This is when the exponential backoff is in effect.
 	PipelineState_PIPELINE_RESTARTING PipelineState = 2
-	// We have retried too many times and we have given up on this pipeline.
+	// We have retried too many times and we have given up on this pipeline (or
+	// the pipeline image doesn't exist)
 	PipelineState_PIPELINE_FAILURE PipelineState = 3
-	// The pipeline has been explicitly paused by the user.
+	// The pipeline has been explicitly paused by the user (the pipeline spec's
+	// Stopped field should be true if the pipeline is in this state)
 	PipelineState_PIPELINE_PAUSED PipelineState = 4
 	// The pipeline is fully functional, but there are no commits to process.
 	PipelineState_PIPELINE_STANDBY PipelineState = 5

--- a/src/client/pps/pps.proto
+++ b/src/client/pps/pps.proto
@@ -330,21 +330,22 @@ message PipelineInput {
 }
 
 enum PipelineState {
-  // When the pipeline is not ready to be triggered by commits.
-  // This happens when either 1) a pipeline has been created but not
-  // yet picked up by a PPS server, or 2) the pipeline does not have
-  // any inputs and is meant to be triggered manually
+  // There is an EtcdPipelineInfo + spec commit, but no RC
+  // This happens when a pipeline has been created but not yet picked up by a
+  // PPS server.
   PIPELINE_STARTING = 0;
-  // After this pipeline is picked up by a pachd node.  This is the normal
-  // state of a pipeline.
+  // A pipeline has a spec commit and a service + RC
+  // This is the normal state of a pipeline.
   PIPELINE_RUNNING = 1;
-  // After some error caused runPipeline to exit, but before the
-  // pipeline is re-run.  This is when the exponential backoff is
-  // in effect.
+  // Equivalent to STARTING (there is an EtcdPipelineInfo + commit, but no RC)
+  // After some error caused runPipeline to exit, but before the pipeline is
+  // re-run. This is when the exponential backoff is in effect.
   PIPELINE_RESTARTING = 2;
-  // We have retried too many times and we have given up on this pipeline.
+  // We have retried too many times and we have given up on this pipeline (or
+  // the pipeline image doesn't exist)
   PIPELINE_FAILURE = 3;
-  // The pipeline has been explicitly paused by the user.
+  // The pipeline has been explicitly paused by the user (the pipeline spec's
+  // Stopped field should be true if the pipeline is in this state)
   PIPELINE_PAUSED = 4;
   // The pipeline is fully functional, but there are no commits to process.
   PIPELINE_STANDBY = 5;

--- a/src/server/admin/server/admin_test.go
+++ b/src/server/admin/server/admin_test.go
@@ -122,6 +122,28 @@ func testExtractRestore(t *testing.T, testObjects bool) {
 	commitInfos := collectCommitInfos(t, commitIter)
 	require.Equal(t, numPipelines, len(commitInfos))
 
+	// confirm that all the jobs passed (there may be a short delay between the
+	// job's output commit closing and the job being marked successful, thus retry
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		jobInfos, err := c.ListJob("", nil, nil, -1, false)
+		if err != nil {
+			return err
+		}
+		// Pipelines were created after commits, so only the HEAD commits of the
+		// input repo should be processed by each pipeline
+		if len(jobInfos) != numPipelines {
+			return fmt.Errorf("expected %d commits, but only encountered %d",
+				nCommits*numPipelines, len(jobInfos))
+		}
+		for _, ji := range jobInfos {
+			if ji.State != pps.JobState_JOB_SUCCESS {
+				return fmt.Errorf("expected job %q to be in state SUCCESS but was %q",
+					ji.Job.ID, ji.State.String())
+			}
+		}
+		return nil
+	})
+
 	// Extract existing cluster state
 	ops, err := c.ExtractAll(testObjects)
 	require.NoError(t, err)
@@ -137,6 +159,19 @@ func testExtractRestore(t *testing.T, testObjects bool) {
 	// Restore metadata and possibly objects
 	require.NoError(t, c.Restore(ops))
 
+	// Make sure all commits got re-created
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		commitInfos, err := c.ListCommit(dataRepo, "", "", 0)
+		if err != nil {
+			return err
+		}
+		if len(commitInfos) != nCommits {
+			return fmt.Errorf("expected %d commits, but only encountered %d in %q",
+				nCommits, len(commitInfos), dataRepo)
+		}
+		return nil
+	})
+
 	// Wait for re-created pipelines to process recreated input data
 	commitIter, err = c.FlushCommit([]*pfs.Commit{client.NewCommit(dataRepo, "master")}, nil)
 	require.NoError(t, err)
@@ -145,7 +180,7 @@ func testExtractRestore(t *testing.T, testObjects bool) {
 
 	// Confirm all the recreated jobs passed
 	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
-		jobInfos, err := c.ListJob("", nil, nil, -1, true) // make sure jobs all succeeded
+		jobInfos, err := c.ListJob("", nil, nil, -1, false) // make sure jobs all succeeded
 		if err != nil {
 			return err
 		}
@@ -162,11 +197,9 @@ func testExtractRestore(t *testing.T, testObjects bool) {
 				return fmt.Errorf("expected job %q to be in state JOB_SUCCESS but was %q",
 					ji.Job.ID, ji.State.String())
 			}
-			// Job must ultimately succeed
-			require.Equal(t, "JOB_SUCCESS", ji.State.String())
 		}
 		return nil
-	}, backoff.NewTestingBackOff())
+	})
 
 	// Make sure all branches were recreated
 	bis, err := c.ListBranch(dataRepo)

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -958,7 +958,7 @@ func (a *apiServer) GetOneTimePassword(ctx context.Context, req *authclient.GetO
 		return nil, authclient.ErrPartiallyActivated
 	}
 	if req.Subject == magicUser {
-		return nil, fmt.Errorf("GetAuthTokenRequest.Subject is invalid")
+		return nil, fmt.Errorf("GetOneTimePassword.Subject is invalid")
 	}
 
 	// Get current caller and check if they're authorized if req.Subject is set
@@ -1714,7 +1714,7 @@ func (a *apiServer) GetAuthToken(ctx context.Context, req *authclient.GetAuthTok
 		if !isAdmin && req.Subject != callerInfo.Subject {
 			return nil, &authclient.ErrNotAuthorized{
 				Subject: callerInfo.Subject,
-				AdminOp: "GetOneTimePassword on behalf of another user",
+				AdminOp: "GetAuthToken on behalf of another user",
 			}
 		}
 	}

--- a/src/server/auth/server/auth_test.go
+++ b/src/server/auth/server/auth_test.go
@@ -333,7 +333,7 @@ func TestGetSetBasic(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
-	dataRepo := tu.UniqueString("TestGetSetBasic")
+	dataRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, dataRepo))
@@ -481,7 +481,7 @@ func TestGetSetReverse(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
-	dataRepo := tu.UniqueString("TestGetSetReverse")
+	dataRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, dataRepo))
@@ -660,7 +660,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
-	dataRepo := tu.UniqueString("TestCreateAndUpdatePipeline")
+	dataRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, dataRepo))
@@ -856,8 +856,8 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// create two repos, and check that alice is the owner of the new repos
-	dataRepo1 := tu.UniqueString("TestPipelineMultipleInputs")
-	dataRepo2 := tu.UniqueString("TestPipelineMultipleInputs")
+	dataRepo1 := tu.UniqueString(t.Name())
+	dataRepo2 := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(dataRepo1))
 	require.NoError(t, aliceClient.CreateRepo(dataRepo2))
 	require.ElementsEqual(t,
@@ -1042,7 +1042,7 @@ func TestPipelineRevoke(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo, and adds bob as a reader
-	repo := tu.UniqueString("TestPipelineRevoke")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	_, err := aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repo,
@@ -1207,7 +1207,7 @@ func TestStopAndDeletePipeline(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestDeletePipeline")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 
@@ -1247,7 +1247,7 @@ func TestStopAndDeletePipeline(t *testing.T) {
 	require.ElementsEqual(t, entries(), getACL(t, aliceClient, repo))
 
 	// alice creates another repo
-	repo = tu.UniqueString("TestDeletePipeline")
+	repo = tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 
@@ -1371,7 +1371,7 @@ func TestListAndInspectRepo(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo and makes Bob a writer
-	repoWriter := tu.UniqueString("TestListRepo")
+	repoWriter := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoWriter))
 	_, err := aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repoWriter,
@@ -1383,7 +1383,7 @@ func TestListAndInspectRepo(t *testing.T) {
 		entries(alice, "owner", bob, "writer"), getACL(t, aliceClient, repoWriter))
 
 	// alice creates a repo and makes Bob a reader
-	repoReader := tu.UniqueString("TestListRepo")
+	repoReader := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoReader))
 	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repoReader,
@@ -1395,13 +1395,13 @@ func TestListAndInspectRepo(t *testing.T) {
 		entries(alice, "owner", bob, "reader"), getACL(t, aliceClient, repoReader))
 
 	// alice creates a repo and gives Bob no access privileges
-	repoNone := tu.UniqueString("TestListRepo")
+	repoNone := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoNone))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, repoNone))
 
 	// bob creates a repo
-	repoOwner := tu.UniqueString("TestListRepo")
+	repoOwner := tu.UniqueString(t.Name())
 	require.NoError(t, bobClient.CreateRepo(repoOwner))
 	require.ElementsEqual(t, entries(bob, "owner"), getACL(t, bobClient, repoOwner))
 
@@ -1439,7 +1439,7 @@ func TestUnprivilegedUserCannotMakeSelfOwner(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestUnprivilegedUserCannotMakeSelfOwner")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, repo))
@@ -1464,7 +1464,7 @@ func TestGetScopeRequiresReader(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestGetScopeRequiresReader")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 
@@ -1497,7 +1497,7 @@ func TestListRepoNotLoggedInError(t *testing.T) {
 	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestListRepo")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t,
 		entries(alice, "owner"), getACL(t, aliceClient, repo))
@@ -1523,7 +1523,7 @@ func TestListRepoNoAuthInfoIfDeactivated(t *testing.T) {
 	adminClient := getPachClient(t, "admin")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestListRepo")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// bob calls ListRepo, but has NONE access to all repos
@@ -1566,7 +1566,7 @@ func TestCreateRepoAlreadyExistsError(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestCreateRepoAlreadyExistsError")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// bob creates the same repo, and should get an error to the effect that the
@@ -1586,7 +1586,7 @@ func TestCreateRepoNotLoggedInError(t *testing.T) {
 	anonClient := getPachClient(t, "")
 
 	// anonClient tries and fails to create a repo
-	repo := tu.UniqueString("TestCreateRepo")
+	repo := tu.UniqueString(t.Name())
 	err := anonClient.CreateRepo(repo)
 	require.YesError(t, err)
 	require.Matches(t, "no authentication token", err.Error())
@@ -1604,7 +1604,7 @@ func TestCreatePipelineRepoAlreadyExistsError(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	inputRepo := tu.UniqueString("TestCreatePipelineRepoAlreadyExistsError")
+	inputRepo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(inputRepo))
 	aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Username: bob,
@@ -1653,7 +1653,7 @@ func TestAuthorizedNoneRole(t *testing.T) {
 	}, backoff.NewTestingBackOff()))
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestAuthorizedNoneRole")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, adminClient.CreateRepo(repo))
 
 	// Get new pach clients, re-activating auth
@@ -1682,7 +1682,7 @@ func TestDeleteAll(t *testing.T) {
 	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, "admin")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestAuthorizedNoneRole")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, adminClient.CreateRepo(repo))
 
 	// alice calls DeleteAll, but it fails
@@ -1705,9 +1705,9 @@ func TestListDatum(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repoA := tu.UniqueString("TestListDatum")
+	repoA := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoA))
-	repoB := tu.UniqueString("TestListDatum")
+	repoB := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repoB))
 
 	// alice creates a pipeline
@@ -1825,7 +1825,7 @@ func TestListJob(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestListJob")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline
@@ -1917,7 +1917,7 @@ func TestInspectDatum(t *testing.T) {
 	aliceClient := getPachClient(t, alice)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestInspectDatum")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline (we must enable stats for InspectDatum, which
@@ -1980,7 +1980,7 @@ func TestGetLogs(t *testing.T) {
 	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestGetLogs")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline
@@ -2076,7 +2076,7 @@ func TestGetLogsFromStats(t *testing.T) {
 	aliceClient := getPachClient(t, alice)
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestGetLogsFromStats")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 
 	// alice creates a pipeline (we must enable stats for InspectDatum, which
@@ -2467,7 +2467,7 @@ func TestGetJobsBugFix(t *testing.T) {
 	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
 
 	// alice creates a repo
-	repo := tu.UniqueString("TestDeletePipeline")
+	repo := tu.UniqueString(t.Name())
 	require.NoError(t, aliceClient.CreateRepo(repo))
 	require.ElementsEqual(t, entries(alice, "owner"), getACL(t, aliceClient, repo))
 	_, err := aliceClient.PutFile(repo, "master", "/file", strings.NewReader("lorem ipsum"))
@@ -2568,4 +2568,97 @@ func TestOneTimePasswordExpires(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Nil(t, authResp)
+}
+
+// TestDeleteFailedPipeline creates a pipeline with an invalid image and then
+// tries to delete it (which shouldn't be blocked by the auth system)
+func TestDeleteFailedPipeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	deleteAll(t)
+	alice := tu.UniqueString("alice")
+	aliceClient := getPachClient(t, alice)
+
+	// Create input repo w/ initial commit
+	repo := tu.UniqueString(t.Name())
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	_, err := aliceClient.PutFile(repo, "master", "/file", strings.NewReader("1"))
+	require.NoError(t, err)
+
+	// Create pipeline
+	pipeline := tu.UniqueString("pipeline")
+	require.NoError(t, aliceClient.CreatePipeline(
+		pipeline,
+		"does-not-exist", // nonexistant image
+		[]string{"true"}, nil,
+		&pps.ParallelismSpec{Constant: 1},
+		client.NewPFSInput(repo, "/*"),
+		"", // default output branch: master
+		false,
+	))
+	require.NoError(t, aliceClient.DeletePipeline(pipeline, true))
+
+	// make sure FlushCommit eventually returns (i.e. pipeline failure doesn't
+	// block flushCommit indefinitely)
+	iter, err := aliceClient.FlushCommit(
+		[]*pfs.Commit{client.NewCommit(repo, "master")},
+		[]*pfs.Repo{client.NewRepo(pipeline)})
+	require.NoError(t, err)
+	require.NoErrorWithinT(t, 30*time.Second, func() error {
+		_, err := iter.Next()
+		if err != io.EOF {
+			return err
+		}
+		return nil
+	})
+}
+
+// TestDeletePipelineMissingRepos creates a pipeline, force-deletes its input
+// and output repos, and then confirms that DeletePipeline still works (i.e.
+// the missing repos/ACLs don't cause an auth error).
+func TestDeletePipelineMissingRepos(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	deleteAll(t)
+	alice := tu.UniqueString("alice")
+	aliceClient := getPachClient(t, alice)
+
+	// Create input repo w/ initial commit
+	repo := tu.UniqueString(t.Name())
+	require.NoError(t, aliceClient.CreateRepo(repo))
+	_, err := aliceClient.PutFile(repo, "master", "/file", strings.NewReader("1"))
+	require.NoError(t, err)
+
+	// Create pipeline
+	pipeline := tu.UniqueString("pipeline")
+	require.NoError(t, aliceClient.CreatePipeline(
+		pipeline,
+		"does-not-exist", // nonexistant image
+		[]string{"true"}, nil,
+		&pps.ParallelismSpec{Constant: 1},
+		client.NewPFSInput(repo, "/*"),
+		"", // default output branch: master
+		false,
+	))
+
+	// force-delete input and output repos
+	require.NoError(t, aliceClient.DeleteRepo(repo, true))
+	require.NoError(t, aliceClient.DeleteRepo(pipeline, true))
+
+	// Attempt to delete the pipeline--must succeed
+	require.NoError(t, aliceClient.DeletePipeline(pipeline, true))
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		pis, err := aliceClient.ListPipeline()
+		if err != nil {
+			return err
+		}
+		for _, pi := range pis {
+			if pi.Pipeline.Name == pipeline {
+				return fmt.Errorf("Expected %q to be deleted, but still present", pipeline)
+			}
+		}
+		return nil
+	})
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -5299,7 +5299,7 @@ func TestGarbageCollection(t *testing.T) {
 	//   - Note that the hashtree for the output commit is the same object as the
 	//     datum hashtree. It contains the same metadata, and b/c hashtrees are
 	//     stored as objects, it's deduped with the datum hashtree
-	//   - The "datums" object attached to 'pipeline's output commit
+	// - The "datums" object attached to 'pipeline's output commit
 	// Note that deleting a pipeline doesn't delete the spec commits
 	objectsAfter = getAllObjects(t, c)
 	require.Equal(t, 2, len(objectsBefore)-len(objectsAfter))

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4321,7 +4321,7 @@ func TestSystemResourceRequests(t *testing.T) {
 	// Expected resource requests for pachyderm system pods:
 	defaultLocalMem := map[string]string{
 		"pachd": "512M",
-		"etcd":  "256M",
+		"etcd":  "512M",
 	}
 	defaultLocalCPU := map[string]string{
 		"pachd": "250m",

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9140,7 +9140,7 @@ func TestSpout(t *testing.T) {
 					Stdin: []string{
 						"while [ : ]",
 						"do",
-						"sleep 2",
+						"sleep 5",
 						"date > date",
 						"tar -cvf /pfs/out ./date*",
 						"done"},
@@ -9179,7 +9179,7 @@ func TestSpout(t *testing.T) {
 					Stdin: []string{
 						"while [ : ]",
 						"do",
-						"sleep 3",
+						"sleep 5",
 						"date > date",
 						"tar -cvf /pfs/out ./date*",
 						"done"},

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1947,6 +1947,8 @@ func (d *driver) flushCommit(pachClient *client.APIClient, fromCommits []*pfs.Co
 		if err != nil {
 			if _, ok := err.(pfsserver.ErrCommitNotFound); ok {
 				continue // just skip this
+			} else if auth.IsErrNotAuthorized(err) {
+				continue // again, just skip (we can't wait on commits we can't access)
 			}
 			return err
 		}

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -252,7 +252,7 @@ func fillDefaultResourceRequests(opts *AssetOpts, persistentDiskBackend backend)
 		}
 
 		if opts.EtcdMemRequest == "" {
-			opts.EtcdMemRequest = "256M"
+			opts.EtcdMemRequest = "512M"
 		}
 		if opts.EtcdCPURequest == "" {
 			opts.EtcdCPURequest = "0.25"

--- a/src/server/pkg/watch/op.go
+++ b/src/server/pkg/watch/op.go
@@ -5,12 +5,6 @@ import etcd "github.com/coreos/etcd/clientv3"
 // OpOption is a simple typedef for etcd.OpOption.
 type OpOption etcd.OpOption
 
-// WithPrevKV gets the previous key-value pair before the event happens. If the previous KV is already compacted,
-// nothing will be returned.
-func WithPrevKV() OpOption {
-	return OpOption(etcd.WithPrevKV())
-}
-
 // WithFilterPut discards PUT events from the watcher.
 func WithFilterPut() OpOption {
 	return OpOption(etcd.WithFilterPut())

--- a/src/server/pkg/watch/watch.go
+++ b/src/server/pkg/watch/watch.go
@@ -27,15 +27,13 @@ const (
 
 // Event is an event that occurred to an item in etcd.
 type Event struct {
-	Key       []byte
-	Value     []byte
-	PrevKey   []byte
-	PrevValue []byte
-	Type      EventType
-	Rev       int64
-	Ver       int64
-	Err       error
-	Template  proto.Message
+	Key      []byte
+	Value    []byte
+	Type     EventType
+	Rev      int64
+	Ver      int64
+	Err      error
+	Template proto.Message
 }
 
 // Unmarshal unmarshals the item in an event into a protobuf message.
@@ -45,16 +43,6 @@ func (e *Event) Unmarshal(key *string, val proto.Message) error {
 	}
 	*key = string(e.Key)
 	return proto.Unmarshal(e.Value, val)
-}
-
-// UnmarshalPrev unmarshals the prev item in an event into a protobuf
-// message.
-func (e *Event) UnmarshalPrev(key *string, val proto.Message) error {
-	if err := CheckType(e.Template, val); err != nil {
-		return err
-	}
-	*key = string(e.PrevKey)
-	return proto.Unmarshal(e.PrevValue, val)
 }
 
 // Watcher ...
@@ -172,10 +160,6 @@ func NewWatcher(ctx context.Context, client *etcd.Client, trimPrefix, prefix str
 					Rev:      etcdEv.Kv.ModRevision,
 					Ver:      etcdEv.Kv.Version,
 					Template: template,
-				}
-				if etcdEv.PrevKv != nil {
-					ev.PrevKey = bytes.TrimPrefix(etcdEv.PrevKv.Key, []byte(trimPrefix))
-					ev.PrevValue = etcdEv.PrevKv.Value
 				}
 				if etcdEv.Type == etcd.EventTypePut {
 					ev.Type = EventPut

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2476,6 +2476,8 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 		return nil, err
 	}
 
+	// TODO(msteffen): can I get rid of this and have the PPS master make the
+	// change?
 	pipelineInfo.Stopped = false
 	commit, err := a.makePipelineInfoCommit(pachClient, pipelineInfo)
 	if err != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1837,7 +1837,7 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	// propagate trace info (doesn't affect intra-RPC trace)
 	ctx = extended.TraceIn2Out(ctx)
 	pachClient := a.env.GetPachClient(ctx)
-	ctx = pachClient.Ctx() // GetPachClient propagates auth info
+	ctx = pachClient.Ctx() // GetPachClient propagates auth info to inner ctx
 	pfsClient := pachClient.PfsAPIClient
 	if request.Salt == "" {
 		request.Salt = uuid.NewWithoutDashes()

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -614,6 +614,7 @@ func (a *apiServer) scaleDownWorkersForPipeline(ctx context.Context, pipelineInf
 }
 
 func (a *apiServer) scaleUpWorkersForPipeline(ctx context.Context, pipelineInfo *pps.PipelineInfo) (retErr error) {
+	log.Infof("scaling up workers for %q", pipelineInfo.Pipeline.Name)
 	span, ctx := tracing.AddSpanToAnyExisting(ctx, "/pps.Master/ScaleUpWorkersForPipeline", "pipeline", pipelineInfo.Pipeline.Name)
 	defer func() {
 		tracing.TagAnySpan(span, "err", retErr)

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -102,7 +102,7 @@ func (a *apiServer) master() {
 					pipeline := string(event.Key)
 					// Create/Modify/Delete pipeline resources as needed per new state
 					if err := a.step(pachClient, pipeline, event.Ver, event.Rev); err != nil {
-						log.Errorf("PPS master: error stepping %q: %v", pipeline, err)
+						log.Errorf("PPS master: %v", err)
 					}
 				}
 			case event := <-watchChan:

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -1,0 +1,576 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/pachyderm/pachyderm/src/client"
+	"strings"
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/client/pkg/tracing"
+	"github.com/pachyderm/pachyderm/src/client/pkg/tracing/extended"
+	"github.com/pachyderm/pachyderm/src/client/pps"
+	"github.com/pachyderm/pachyderm/src/client/version"
+	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
+)
+
+const maxErrCount = 3 // gives all retried operations ~4.5s total to finish
+
+// pipelineOp contains all of the relevent current state for a pipeline. It's
+// used by step() to take any necessary actions
+type pipelineOp struct {
+	apiServer    *apiServer
+	pachClient   *client.APIClient
+	ptr          *pps.EtcdPipelineInfo
+	name         string // also in pipelineInfo, but that may not be set initially
+	pipelineInfo *pps.PipelineInfo
+	rc           *v1.ReplicationController
+}
+
+var (
+	errRCNotFound = errors.New("RC not found")
+	errTooManyRCs = errors.New("multiple RCs found for pipeline")
+	errStaleRC    = errors.New("RC is doesn't match pipeline version")
+)
+
+// step takes 'ptr', a newly-changed pipeline pointer in etcd, and
+// 1. retrieves its full pipeline spec and RC
+// 2. makes whatever changes are needed to bring the RC in line with the (new) spec
+// 3. updates 'ptr', if needed, to reflect the action it just took
+func (a *apiServer) step(pachClient *client.APIClient, pipeline string, keyVer, keyRev int64) error {
+	log.Infof("PPS master: processing event for %q", pipeline)
+
+	// Retrieve pipelineInfo from the spec repo
+	op, err := a.newPipelineOp(pachClient, pipeline)
+	if err != nil {
+		return a.setPipelineFailure(pachClient.Ctx(), pipeline,
+			fmt.Sprintf("couldn't initialize pipeline op: %v", err))
+	}
+	// set op.rc
+	if err := op.getRC(); err != nil && err != errRCNotFound {
+		return err
+	}
+
+	// Handle tracing
+	span, ctx := extended.AddPipelineSpanToAnyTrace(pachClient.Ctx(),
+		a.env.GetEtcdClient(), pipeline, "/pps.Master/ProcessPipelineUpdate",
+		"key-version", keyVer,
+		"mod-revision", keyRev,
+		"state", op.ptr.State.String(),
+		"spec-commit", op.ptr.SpecCommit)
+	defer tracing.FinishAnySpan(span)
+	if span != nil {
+		pachClient = pachClient.WithCtx(ctx)
+	}
+
+	// Bring 'pipeline' into the correct state by taking appropriate action
+	switch op.ptr.State {
+	case pps.PipelineState_PIPELINE_STARTING, pps.PipelineState_PIPELINE_RESTARTING:
+		if op.rc != nil && !op.rcIsFresh() {
+			// old RC is not down yet
+			log.Errorf("PPS master: restarting %q as it has an out-of-date RC", op.name)
+			op.restartPipeline()
+			return nil // step() will be called again after etcd write
+		} else if op.rc == nil {
+			// default: old RC (if any) is down but new RC is not up yet
+			if err := op.createPipelineResources(); err != nil {
+				return err
+			}
+		}
+		// trigger another event--once pipeline is RUNNING, step() will scale it up
+		if op.pipelineInfo.Stopped {
+			if err := op.setPipelineState(pps.PipelineState_PIPELINE_PAUSED); err != nil {
+				return err
+			}
+		} else {
+			if err := op.setPipelineState(pps.PipelineState_PIPELINE_RUNNING); err != nil {
+				return err
+			}
+		}
+	case pps.PipelineState_PIPELINE_RUNNING:
+		if !op.rcIsFresh() {
+			op.restartPipeline()
+			return nil // step() will be called again after etcd write
+		}
+		op.startPipelineMonitor()
+
+		if op.pipelineInfo.Stopped {
+			// StopPipeline has been called, but pipeline hasn't been paused yet
+			if err := op.scaleDownPipeline(); err != nil {
+				return err
+			}
+			return op.setPipelineState(pps.PipelineState_PIPELINE_PAUSED)
+		}
+		// default: scale up if pipeline start hasn't propagated to etcd yet
+		// Note: mostly this should do nothing, as this runs several times per job
+		return op.scaleUpPipeline()
+	case pps.PipelineState_PIPELINE_STANDBY, pps.PipelineState_PIPELINE_PAUSED:
+		if !op.rcIsFresh() {
+			log.Errorf("PPS master: restarting %q as its RC is missing or stale", op.name)
+			op.restartPipeline()
+			return nil // step() will be called again after etcd write
+		}
+		op.startPipelineMonitor()
+
+		if op.ptr.State == pps.PipelineState_PIPELINE_PAUSED && !op.pipelineInfo.Stopped {
+			// StartPipeline has been called, but pipeline hasn't been started yet
+			if err := op.scaleUpPipeline(); err != nil {
+				return err
+			}
+			return op.setPipelineState(pps.PipelineState_PIPELINE_RUNNING)
+		}
+		// default: scale down if pause/standby hasn't propagated to etcd yet
+		return op.scaleDownPipeline()
+	case pps.PipelineState_PIPELINE_FAILURE:
+		// pipeline fails if docker image isn't found
+		if err := op.finishPipelineOutputCommits(); err != nil {
+			return err
+		}
+		return op.deletePipelineResources()
+	}
+	return nil
+}
+
+func (a *apiServer) newPipelineOp(pachClient *client.APIClient, pipeline string) (*pipelineOp, error) {
+	op := &pipelineOp{
+		apiServer:  a,
+		pachClient: pachClient,
+		ptr:        &pps.EtcdPipelineInfo{},
+		name:       pipeline,
+	}
+	// get latest EtcdPipelineInfo (events can pile up, so that the current state
+	// doesn't match the event being processed)
+	if err := a.pipelines.ReadOnly(pachClient.Ctx()).Get(pipeline, op.ptr); err != nil {
+		return nil, fmt.Errorf("could not retrieve etcd pipeline info for %q: %v", pipeline, err)
+	}
+	// set op.pipelineInfo
+	if err := op.getPipelineInfo(); err != nil {
+		return nil, err
+	}
+	return op, nil
+}
+
+// getPipelineInfo reads the pipelineInfo associated with 'op's pipeline. This
+// should be one of the first calls made on 'op', as most other methods (e.g.
+// getRC, though not setPipelineFailure) assume that op.pipelineInfo is set.
+//
+// Like other functions in this file, it takes responsibility for failing op's
+// pipeline if it can't read the pipeline's info, and then returns an error to
+// the caller to indicate that the caller shouldn't continue.
+func (op *pipelineOp) getPipelineInfo() error {
+	var errCount int
+	if err := backoff.RetryNotify(func() error {
+		return op.apiServer.sudo(op.pachClient, func(superUserClient *client.APIClient) error {
+			var err error
+			op.pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, op.ptr)
+			return err
+		})
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if errCount++; errCount >= maxErrCount {
+			return fmt.Errorf("error retrieving spec for %q after %d attempts: %v",
+				op.name, maxErrCount, err)
+		}
+		log.Errorf("PPS master: error retrieving spec for %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	}); err != nil {
+		// don't restart PPS master, which might not fix the problem (crashloop)
+		op.setPipelineFailure(fmt.Sprintf("pipeline spec commit could not be read: %v", err))
+	}
+	return nil
+}
+
+// getRC reads the RC associated with 'op's pipeline. op.pipelineInfo must be
+// set already.
+//
+// Like other functions in this file, it takes responsibility for restarting
+// op's pipeline if it can't read the pipeline's RC (or if the RC is stale or
+// redundant), and then returns an error to the caller to indicate that the
+// caller shouldn't continue with other operations
+func (op *pipelineOp) getRC() (retErr error) {
+	defer func() {
+		if retErr != nil {
+			log.Infof("PPS master: could not retrieve RC for %q: %v", op.name, retErr)
+		}
+	}()
+	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/GetRC", "pipeline", op.name)
+	defer func(span opentracing.Span) {
+		tracing.TagAnySpan(span, "err", fmt.Sprintf("%v", retErr))
+		tracing.FinishAnySpan(span)
+	}(span)
+
+	selector := fmt.Sprintf("%s=%s", pipelineNameLabel, op.name)
+	rcName := ppsutil.PipelineRcName(op.name, op.pipelineInfo.Version)
+	kubeClient := op.apiServer.env.GetKubeClient()
+	namespace := op.apiServer.namespace
+
+	// count error types separately, so that this only errors if the pipeline is
+	// stuck and not changing
+	var notFoundErrCount, staleErrCount, tooManyErrCount int
+	backoff.RetryNotify(func() error {
+		// List all RCs, so stale RCs from old pipelines are noticed and deleted
+		rcs, err := kubeClient.CoreV1().ReplicationControllers(namespace).List(metav1.ListOptions{LabelSelector: selector})
+		if err != nil && !isNotFoundErr(err) {
+			return err
+		}
+		switch {
+		case len(rcs.Items) == 0:
+			return errRCNotFound
+		case len(rcs.Items) > 1:
+			return errTooManyRCs
+		case rcs.Items[0].ObjectMeta.Name != rcName:
+			return errStaleRC
+		default:
+			op.rc = &rcs.Items[0]
+			return nil
+		}
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		errCount := notFoundErrCount + staleErrCount + tooManyErrCount
+		switch err {
+		case errRCNotFound:
+			if notFoundErrCount++; notFoundErrCount < maxErrCount {
+				err = nil
+			}
+		case errTooManyRCs:
+			if tooManyErrCount++; tooManyErrCount < maxErrCount {
+				err = nil
+			}
+		case errStaleRC:
+			if staleErrCount++; staleErrCount < maxErrCount {
+				err = nil
+			}
+		default:
+			err = nil
+		}
+		if err != nil {
+			log.Errorf("PPS master: restarting %q after %d attempts to retrieve an RC: %v",
+				op.name, errCount+1, err)
+			op.restartPipeline()
+			return err
+		}
+		log.Errorf("PPS master: error retrieving RC for %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	})
+	return nil
+}
+
+// rcIsFresh returns a boolean indicating whether op.rc has the right labels
+// corresponding to op.ptr. If this returns false, it likely means the current
+// RC is using e.g. an old spec commit or something.
+func (op *pipelineOp) rcIsFresh() bool {
+	if op.rc == nil {
+		log.Errorf("PPS master: RC for %q is nil", op.name)
+		return false
+	}
+	rcPachVersion := op.rc.ObjectMeta.Annotations[pachVersionAnnotation]
+	rcAuthTokenHash := op.rc.ObjectMeta.Annotations[hashedAuthTokenAnnotation]
+	rcSpecCommit := op.rc.ObjectMeta.Annotations[specCommitAnnotation]
+	switch {
+	case rcAuthTokenHash != hashAuthToken(op.ptr.AuthToken):
+		log.Errorf("PPS master: auth token in %q is stale %s != %s",
+			op.name, rcAuthTokenHash, hashAuthToken(op.ptr.AuthToken))
+		return false
+	case rcSpecCommit != op.ptr.SpecCommit.ID:
+		log.Errorf("PPS master: spec commit in %q looks stale %s != %s",
+			op.name, rcSpecCommit, op.ptr.SpecCommit.ID)
+		return false
+	case rcPachVersion != version.PrettyVersion():
+		log.Errorf("PPS master: %q is using stale pachd v%s != current v%s",
+			op.name, rcPachVersion, version.PrettyVersion())
+		return false
+	}
+	return true
+}
+
+// setPipelineState set's op's state in etcd to 'state'. This will trigger an
+// etcd watch event and cause step() to eventually run again.
+//
+// Like other functions in this file, setPipelineState handles its own retries,
+// though if it can't eventually update the pipeline state, it just returns an
+// error (to indicate to the caller that it shouldn't continue with other
+// operations) but doesn't fail the pipeline as the pipeline state is already
+// unsettable.
+func (op *pipelineOp) setPipelineState(state pps.PipelineState) error {
+	var errCount int
+	return backoff.RetryNotify(func() error {
+		return op.apiServer.setPipelineState(op.pachClient, op.pipelineInfo, state, "")
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if errCount++; errCount >= maxErrCount {
+			log.Errorf("PPS master: could not set pipeline state for %q to %v: %v "+
+				"(you may need to restart pachd to un-stick the pipeline)", op.name, state, err)
+			return err
+		}
+		return nil
+	})
+}
+
+// restartPipeline deletes the RC/service associated with op's pipeline, and
+// then sets its state to RESTARTING so they can be recreated (e.g. if they're
+// out of date or missing).
+//
+// Like other functions in this file, restartPipeline takes responsibility for
+// retrying and eventually failing op's pipeline if restartPipeline can't
+// restart it. Other functions return an error to the caller to indicate that
+// the caller shouldn't proceed with further operations, but restartPipeline
+// should always be the last call in a codepath and logs its own errors, so it
+// returns nothing.
+func (op *pipelineOp) restartPipeline() {
+	log.Infof("PPS master: restarting pipeline %q", op.name)
+	var errCount int
+	if err := backoff.RetryNotify(func() error {
+		if err := op.deletePipelineResources(); err != nil {
+			return err
+		}
+		return op.setPipelineState(pps.PipelineState_PIPELINE_RESTARTING)
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		if errCount++; errCount >= maxErrCount {
+			return err
+		}
+		log.Errorf("PPS master: error restarting pipeline %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	}); err != nil {
+		op.setPipelineFailure(fmt.Sprintf("could not restart after %d attempts: %v", errCount, err))
+		log.Errorf("PPS master: failing pipeline %q after %d attempts to restart: %v",
+			op.name, errCount, err)
+	}
+}
+
+// setPipelineFailure fails op's pipeline. Don't return an error, as the caller
+// is likely in the middle of failing due to some other error, so there's no
+// sane handling to be done here but log. Also, this must not use
+// op.pipelineInfo, as getPipelineInfo may call setPipelineFailure in its error
+// case.
+func (op *pipelineOp) setPipelineFailure(reason string) {
+	if err := op.apiServer.setPipelineFailure(op.pachClient.Ctx(), op.name, reason); err != nil {
+		log.Errorf("PPS master: error failing pipeline %q: %v", op.name, err)
+	}
+}
+
+// createPipelineResources creates the RC and any services for op's pipeline.
+//
+// Like other functions in this file, it takes responsibility for failing op's
+// pipeline if it can't create the resources, and then returns an error to the
+// caller to indicate that the caller shouldn't continue.
+func (op *pipelineOp) createPipelineResources() error {
+	log.Infof("PPS master: creating resources for pipeline %q", op.name)
+	var errCount int
+	return backoff.RetryNotify(func() error {
+		return op.apiServer.createWorkerSvcAndRc(op.pachClient.Ctx(), op.ptr, op.pipelineInfo)
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		_, invalidOpts := err.(noValidOptionsErr)
+		errCount++
+		switch {
+		case invalidOpts:
+			// these errors indicate invalid pipelineInfo
+			op.setPipelineFailure(fmt.Sprintf("could not generate RC options: %v", err))
+			return fmt.Errorf("could not generate RC options from pipeline info for %q: %v", op.name, err)
+		case errCount >= maxErrCount:
+			op.setPipelineFailure(fmt.Sprintf(
+				"failed to create RC & services after %d attempts: %v", errCount, err))
+			return fmt.Errorf("could not create resources for pipeline %q after %d attempts: %v",
+				op.name, errCount, err)
+		default:
+			log.Errorf("PPS master: error creating resources for pipeline %q: %v; retrying in %v",
+				op.name, err, d)
+			return nil
+		}
+	})
+}
+
+// startPipelineMonitor spawns a monitorPipeline() goro for this pipeline (if
+// one doesn't exist already), which manages standby and cron inputs, and
+// updates the the pipeline state.
+// Note: this is called by every run through step(), so must be idempotent
+func (op *pipelineOp) startPipelineMonitor() {
+	op.apiServer.monitorCancelsMu.Lock()
+	defer op.apiServer.monitorCancelsMu.Unlock()
+	if _, ok := op.apiServer.monitorCancels[op.name]; !ok {
+		// use context.Background because we expect this goro to run for the rest of
+		// pachd's lifetime
+		ctx, cancel := context.WithCancel(context.Background())
+		op.apiServer.monitorCancels[op.name] = cancel
+		go op.apiServer.sudo(op.apiServer.env.GetPachClient(ctx),
+			func(superUserClient *client.APIClient) error {
+				op.apiServer.monitorPipeline(superUserClient, op.pipelineInfo)
+				return nil
+			})
+	}
+}
+
+// finishPipelineOutputCommits finishes any output commits of
+// 'pipelineInfo.Pipeline' with an empty tree.
+// TODO(msteffen) Note that if the pipeline has any jobs (which can happen if
+// the user manually deletes the pipeline's RC, failing the pipeline, after it
+// has created jobs) those will not be updated, but they should be FAILED
+//
+// Unlike other functions in this file, finishPipelineOutputCommits doesn't
+// retry if it encounters an error. Currently. it's only called by step() in the
+// case where op's pipeline is already in FAILURE. If it returns an error in
+// that case, the pps master will log the error and move on to the next pipeline
+// event. This pipeline's output commits will stay open until another watch
+// event arrives for the pipeline and finishPipelineOutputCommits is retried.
+func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
+	log.Infof("PPS master: finishing output commits for pipeline %q", op.name)
+
+	var pachClient *client.APIClient
+	if span, _ctx := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/FinishPipelineOutputCommits", "pipeline", op.name); span != nil {
+		pachClient = op.pachClient.WithCtx(_ctx) // copy span back into pachClient
+		defer func() {
+			tracing.TagAnySpan(span, "err", fmt.Sprintf("%v", retErr))
+			tracing.FinishAnySpan(span)
+		}()
+	} else {
+		pachClient = op.pachClient
+	}
+
+	return op.apiServer.sudo(pachClient, func(superUserClient *client.APIClient) error {
+		commitInfos, err := superUserClient.ListCommit(op.name, op.pipelineInfo.OutputBranch, "", 0)
+		if err != nil {
+			return fmt.Errorf("could not list output commits of %q to finish them: %v", op.name, err)
+		}
+
+		var finishCommitErr error
+		for _, ci := range commitInfos {
+			if ci.Finished != nil {
+				continue // nothing needs to be done
+			}
+			if _, err := superUserClient.PfsAPIClient.FinishCommit(superUserClient.Ctx(),
+				&pfs.FinishCommitRequest{
+					Commit: client.NewCommit(op.name, ci.Commit.ID),
+					Empty:  true,
+				}); err != nil && finishCommitErr == nil {
+				finishCommitErr = err
+			}
+		}
+		return finishCommitErr
+	})
+}
+
+// deletePipelineResources deletes the RC and services associated with op's
+// pipeline.
+//
+// Unlike other functions in this file, deletePipelineResources doesn't retry.
+// It's called in two places:
+// - step(), if the pipeline is in FAILURE(). In this case, the error will be
+//   logged and the pipeline's resources will be left around until a new etcd
+//   event arrives for the pipeline.
+// - op.restartPipeline(). Because restartPipeline does retry,
+//   deletePipelineResources will be retried a limited number of times and then
+//   the pipeline will be failed. If the pipeline's resources still can't be
+//   deleted, then (per step() above) the error will be logged and the PPS
+//   master will move on
+func (op *pipelineOp) deletePipelineResources() (retErr error) {
+	return op.apiServer.deletePipelineResources(op.pachClient.Ctx(), op.name)
+}
+
+// updateRC is a helper for {scaleUp,scaleDown}Pipeline. It includes all of the
+// logic for writing an updated RC spec to kubernetes, and updating/retrying if
+// k8s rejects the write. It presents a strange API, since the the RC being
+// updated is already available to the caller in op.rc, but update() may be
+// called muliple times if the k8s write fails. It may be helpful to think of
+// the rc passed to update() as mutable, while op.rc is immutable.
+//
+// Like other functions in this file, it takes responsibility for
+// failing/restarting op's pipeline if it can't update its RC. If this happens,
+// it will return an error to the caller to indicate that the caller shouldn't
+// continue with further operations
+func (op *pipelineOp) updateRC(update func(rc *v1.ReplicationController)) error {
+	kubeClient := op.apiServer.env.GetKubeClient()
+	namespace := op.apiServer.namespace
+	rc := kubeClient.CoreV1().ReplicationControllers(namespace)
+
+	var errCount int
+	return backoff.RetryNotify(func() error {
+		newRC := *op.rc
+		// Apply op's update to rc
+		update(&newRC)
+		// write updated RC to k8s
+		_, err := rc.Update(&newRC)
+		return err
+	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+		errCount++
+		if strings.Contains(err.Error(), "try again") {
+			// refresh RC--sometimes kubernetes complains that the RC is stale
+			if err := op.getRC(); err != nil {
+				return err // getRC will log & restart pipeline--just don't proceed
+			}
+		} else if errCount >= maxErrCount {
+			op.setPipelineFailure(fmt.Sprintf("failed to update RC after %d attempts: %v",
+				errCount, err))
+			log.Errorf("PPS master: failing pipeline %q after %d failed attempts to update RC: %v",
+				op.name, errCount, err)
+			return fmt.Errorf("failed to update RC for %q after %d attempts: %v", op.name, errCount, err)
+		}
+		log.Errorf("PPS master: error updating RC for pipeline %q: %v; retrying in %v", op.name, err, d)
+		return nil
+	})
+}
+
+// scaleUpPipeline edits the RC associated with op's pipeline & spins up the
+// configured number of workers.
+//
+// Like other functions in this file, it takes responsibility for
+// failing/restarting op's pipeline if it can't update its RC (via updateRC)
+func (op *pipelineOp) scaleUpPipeline() (retErr error) {
+	log.Infof("PPS master: scaling up workers for %q", op.name)
+	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/ScaleUpPipeline", "pipeline", op.name)
+	defer func() {
+		if retErr != nil {
+			log.Errorf("PPS master: error scaling up: %v", retErr)
+		}
+		tracing.TagAnySpan(span, "err", retErr)
+		tracing.FinishAnySpan(span)
+	}()
+
+	// compute target pipeline parallelism
+	kubeClient := op.apiServer.env.GetKubeClient()
+	parallelism, err := ppsutil.GetExpectedNumWorkers(kubeClient, op.pipelineInfo.ParallelismSpec)
+	if err != nil {
+		log.Errorf("PPS master: error getting number of workers (defaulting to 1 worker): %v", err)
+		parallelism = 1
+	}
+
+	// update pipeline RC
+	return op.updateRC(func(rc *v1.ReplicationController) {
+		if rc.Spec.Replicas != nil && *op.rc.Spec.Replicas == int32(parallelism) {
+			return // prior attempt succeeded
+		}
+		rc.Spec.Replicas = new(int32)
+		*rc.Spec.Replicas = int32(parallelism)
+	})
+}
+
+// scaleDownPipeline edits the RC associated with op's pipeline & spins down the
+// configured number of workers.
+//
+// Like other functions in this file, it takes responsibility for
+// failing/restarting op's pipeline if it can't update its RC (via updateRC)
+func (op *pipelineOp) scaleDownPipeline() (retErr error) {
+	log.Infof("PPS master: scaling down workers for %q", op.name)
+	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+		"/pps.Master/ScaleDownPipeline", "pipeline", op.name)
+	defer func() {
+		if retErr != nil {
+			log.Errorf("PPS master: error scaling down: %v", retErr)
+		}
+		tracing.TagAnySpan(span, "err", retErr)
+		tracing.FinishAnySpan(span)
+	}()
+
+	return op.updateRC(func(rc *v1.ReplicationController) {
+		if rc.Spec.Replicas != nil && *op.rc.Spec.Replicas == 0 {
+			return // prior attempt succeeded
+		}
+		rc.Spec.Replicas = &zero
+	})
+}

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -389,6 +389,9 @@ func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
 
 	return op.apiServer.sudo(pachClient, func(superUserClient *client.APIClient) error {
 		commitInfos, err := superUserClient.ListCommit(op.name, op.pipelineInfo.OutputBranch, "", 0)
+		if isNotFoundErr(err) {
+			return nil // already deleted
+		}
 		if err != nil {
 			return fmt.Errorf("could not list output commits of %q to finish them: %v", op.name, err)
 		}

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -54,7 +54,7 @@ type pipelineOp struct {
 var (
 	errRCNotFound = errors.New("RC not found")
 	errTooManyRCs = errors.New("multiple RCs found for pipeline")
-	errStaleRC    = errors.New("RC is doesn't match pipeline version")
+	errStaleRC    = errors.New("RC doesn't match pipeline version (likely stale)")
 )
 
 // step takes 'ptr', a newly-changed pipeline pointer in etcd, and

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -201,7 +201,7 @@ func (op *pipelineOp) getPipelineInfo() error {
 // getRC reads the RC associated with 'op's pipeline. op.pipelineInfo must be
 // set already. 'expected' indicates whether the PPS master expects an RC to
 // exist--if set to 'true', getRC will retry until a fresh RC is found (and if
-// false, getRC will return after the first RPC)
+// false, getRC will return after the first "not found" error)
 //
 // Like other functions in this file, it takes responsibility for restarting
 // op's pipeline if it can't read the pipeline's RC (or if the RC is stale or
@@ -241,7 +241,7 @@ func (op *pipelineOp) getRC(expected bool) (retErr error) {
 			return nil
 		}
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		if !expected {
+		if !expected && err == errRCNotFound {
 			return err
 		}
 		switch err {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -2,7 +2,11 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strconv"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -20,10 +24,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	kube "k8s.io/client-go/kubernetes"
 )
 
 const (
-	pipelineNameLabel = "pipelineName"
+	pipelineNameLabel         = "pipelineName"
+	pachVersionAnnotation     = "version"
+	specCommitAnnotation      = "specCommit"
+	hashedAuthTokenAnnotation = "authTokenHash"
 )
 
 // Parameters used when creating the kubernetes replication controller in charge
@@ -258,13 +266,40 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 	return podSpec, nil
 }
 
-func (a *apiServer) getWorkerOptions(pipelineName string, pipelineVersion uint64,
-	parallelism int32, resourceRequests *v1.ResourceList, resourceLimits *v1.ResourceList,
-	transform *pps.Transform, cacheSize string, service *pps.Service,
-	specCommitID string, schedulingSpec *pps.SchedulingSpec, podSpec string, podPatch string) *workerOptions {
+// We don't want to expose pipeline auth tokens, so we hash it. This will be
+// visible to any user with k8s cluster access
+// Note: This hash shouldn't be used for authentication in any way. We just use
+// this to detect if an auth token has been added/changed
+// Note: ptr.AuthToken is a pachyderm-generated UUID, and wouldn't appear in any
+// rainbow tables
+func hashAuthToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+func (a *apiServer) getWorkerOptions(ptr *pps.EtcdPipelineInfo, pipelineInfo *pps.PipelineInfo) (*workerOptions, error) {
+	pipelineName := pipelineInfo.Pipeline.Name
+	pipelineVersion := pipelineInfo.Version
+	var resourceRequests *v1.ResourceList
+	var resourceLimits *v1.ResourceList
+	if pipelineInfo.ResourceRequests != nil {
+		var err error
+		resourceRequests, err = ppsutil.GetRequestsResourceListFromPipeline(pipelineInfo)
+		if err != nil {
+			return nil, fmt.Errorf("could not determine resource request: %v", err)
+		}
+	}
+	if pipelineInfo.ResourceLimits != nil {
+		var err error
+		resourceLimits, err = ppsutil.GetLimitsResourceListFromPipeline(pipelineInfo)
+		if err != nil {
+			return nil, fmt.Errorf("could not determine resource limit: %v", err)
+		}
+	}
+
+	transform := pipelineInfo.Transform
 	rcName := ppsutil.PipelineRcName(pipelineName, pipelineVersion)
 	labels := labels(rcName)
-	labels["version"] = version.PrettyVersion()
 	labels[pipelineNameLabel] = pipelineName
 	userImage := transform.Image
 	if userImage == "" {
@@ -314,7 +349,11 @@ func (a *apiServer) getWorkerOptions(pipelineName string, pipelineVersion uint64
 	})
 	workerEnv = append(workerEnv, v1.EnvVar{
 		Name:  client.PPSSpecCommitEnv,
-		Value: specCommitID,
+		Value: ptr.SpecCommit.ID,
+	})
+	workerEnv = append(workerEnv, v1.EnvVar{
+		Name:  client.PPSPipelineNameEnv,
+		Value: pipelineInfo.Pipeline.Name,
 	})
 	// Set the worker gRPC port
 	workerEnv = append(workerEnv, v1.EnvVar{
@@ -391,9 +430,24 @@ func (a *apiServer) getWorkerOptions(pipelineName string, pipelineVersion uint64
 		imagePullSecrets = append(imagePullSecrets, v1.LocalObjectReference{Name: a.imagePullSecret})
 	}
 
-	annotations := map[string]string{"pipelineName": pipelineName}
+	annotations := map[string]string{
+		pipelineNameLabel:         pipelineName,
+		pachVersionAnnotation:     version.PrettyVersion(),
+		specCommitAnnotation:      ptr.SpecCommit.ID,
+		hashedAuthTokenAnnotation: hashAuthToken(ptr.AuthToken),
+	}
 	if a.iamRole != "" {
 		annotations["iam.amazonaws.com/role"] = a.iamRole
+	}
+	// A service can be present either directly on the pipeline spec
+	// or on the spout field of the spec.
+	var service *pps.Service
+	if pipelineInfo.Spout != nil && pipelineInfo.Service != nil {
+		return nil, errors.New("only one of pipeline.service or pipeline.spout can be set")
+	} else if pipelineInfo.Spout != nil && pipelineInfo.Spout.Service != nil {
+		service = pipelineInfo.Spout.Service
+	} else {
+		service = pipelineInfo.Service
 	}
 	if service != nil {
 		for k, v := range service.Annotations {
@@ -403,11 +457,12 @@ func (a *apiServer) getWorkerOptions(pipelineName string, pipelineVersion uint64
 		}
 	}
 
+	// Generate options for new RC
 	return &workerOptions{
 		rcName:           rcName,
 		labels:           labels,
 		annotations:      annotations,
-		parallelism:      int32(parallelism),
+		parallelism:      int32(0), // pipelines start w/ 0 workers & are scaled up
 		resourceRequests: resourceRequests,
 		resourceLimits:   resourceLimits,
 		userImage:        userImage,
@@ -415,23 +470,35 @@ func (a *apiServer) getWorkerOptions(pipelineName string, pipelineVersion uint64
 		volumes:          volumes,
 		volumeMounts:     volumeMounts,
 		imagePullSecrets: imagePullSecrets,
-		cacheSize:        cacheSize,
+		cacheSize:        pipelineInfo.CacheSize,
 		service:          service,
-		schedulingSpec:   schedulingSpec,
-		podSpec:          podSpec,
-		podPatch:         podPatch,
-	}
+		schedulingSpec:   pipelineInfo.SchedulingSpec,
+		podSpec:          pipelineInfo.PodSpec,
+		podPatch:         pipelineInfo.PodPatch,
+	}, nil
 }
 
-func (a *apiServer) createWorkerRc(ctx context.Context, options *workerOptions) (retErr error) {
-	log.Infof("PPS master: upserting workers for %q", options.labels[pipelineNameLabel])
+// noValidOptions error may be returned by createWorkerSvcAndRc to indicate that
+// getWorkerOptions returned an error to it (getWorkerOptions does not return
+// noValidOptions). This is a mechanism for createWorkerSvcAndRc to signal to
+// its caller not to retry
+type noValidOptionsErr struct {
+	error
+}
+
+func (a *apiServer) createWorkerSvcAndRc(ctx context.Context, ptr *pps.EtcdPipelineInfo, pipelineInfo *pps.PipelineInfo) (retErr error) {
+	log.Infof("PPS master: upserting workers for %q", pipelineInfo.Pipeline.Name)
 	span, ctx := tracing.AddSpanToAnyExisting(ctx, "/pps.Master/CreateWorkerRC",
-		"pipeline", options.labels[pipelineNameLabel])
+		"pipeline", pipelineInfo.Pipeline.Name)
 	defer func() {
 		tracing.TagAnySpan(span, "err", retErr)
 		tracing.FinishAnySpan(span)
 	}()
 
+	options, err := a.getWorkerOptions(ptr, pipelineInfo)
+	if err != nil {
+		return noValidOptionsErr{err}
+	}
 	podSpec, err := a.workerPodSpec(options)
 	if err != nil {
 		return err
@@ -533,5 +600,56 @@ func (a *apiServer) createWorkerRc(ctx context.Context, options *workerOptions) 
 			}
 		}
 	}
+
+	// True if the pipeline has a git input
+	var hasGitInput bool
+	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {
+		if input.Git != nil {
+			hasGitInput = true
+		}
+	})
+	if hasGitInput {
+		if err := a.checkOrDeployGithookService(); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func (a *apiServer) checkOrDeployGithookService() error {
+	kubeClient := a.env.GetKubeClient()
+	_, err := getGithookService(kubeClient, a.namespace)
+	if err != nil {
+		if _, ok := err.(*errGithookServiceNotFound); ok {
+			svc := assets.GithookService(a.namespace)
+			_, err = kubeClient.CoreV1().Services(a.namespace).Create(svc)
+			return err
+		}
+		return err
+	}
+	// service already exists
+	return nil
+}
+
+func getGithookService(kubeClient *kube.Clientset, namespace string) (*v1.Service, error) {
+	labels := map[string]string{
+		"app":   "githook",
+		"suite": suite,
+	}
+	serviceList, err := kubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ListOptions",
+			APIVersion: "v1",
+		},
+		LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(labels)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(serviceList.Items) != 1 {
+		return nil, &errGithookServiceNotFound{
+			fmt.Errorf("expected 1 githook service but found %v", len(serviceList.Items)),
+		}
+	}
+	return &serviceList.Items[0], nil
 }


### PR DESCRIPTION
The prior PPS master was written in such a way where there essentially three sources of pipeline state information: the previous value from the etcd key, the current value from the etcd key, and data from the pipeline RC. Inconsistencies between these three meant that the prior PPS master might have to deal with a lot of error states.

This structure only relies on two sources of pipeline state: the current state of the pipeline in etcd and the pipeline's current RC. This avoids bugs where the PPS master is responding to old PPS changes and makes unexpected changes to pipelines, and also means that there are fewer error states to handle and the code can be made simpler and more robust.