### PR TITLE
Fix bug that crashed put file -o from stdin.

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1331,6 +1331,10 @@ func putFileHelper(c *client.APIClient, pfc client.PutFileClient,
 			if overwrite && !pipe {
 				return sync.PushFile(c, pfc, client.NewFile(repo, commit, path), reader)
 			}
+			if overwrite {
+				_, err = pfc.PutFileOverwrite(repo, commit, path, reader, 0)
+				return err
+			}
 			_, err = pfc.PutFile(repo, commit, path, reader)
 			return err
 		}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1324,7 +1324,7 @@ func putFileHelper(c *client.APIClient, pfc client.PutFileClient,
 	}
 	putFile := func(reader io.ReadSeeker) error {
 		if split == "" {
-			if overwrite {
+			if overwrite && reader != os.Stdin {
 				return sync.PushFile(c, pfc, client.NewFile(repo, commit, path), reader)
 			}
 			_, err := pfc.PutFile(repo, commit, path, reader)


### PR DESCRIPTION
This fixes the pesky issue that would come up when you do: `echo foo | pachctl put file foo@master:/file -o`

I couldn't find a github issue for this, although I feel like I remember seeing one.