### PR TITLE
Remove shell syntax highlighting on doc examples as this breaks stuff

### DIFF
--- a/src/server/cmd/pachctl-doc/main.go
+++ b/src/server/cmd/pachctl-doc/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/pachyderm/pachyderm/src/server/cmd/pachctl/cmd"
 	"github.com/pachyderm/pachyderm/src/server/pkg/cmdutil"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
 
@@ -17,23 +15,11 @@ func main() {
 	cmdutil.Main(do, &appEnv{})
 }
 
-// Walk the command tree, wrap any examples in a block-quote with shell highlighting
-func recursiveBlockQuoteExamples(parent *cobra.Command) {
-	if parent.Example != "" {
-		parent.Example = fmt.Sprintf("```sh\n%s\n```", parent.Example)
-	}
-
-	for _, cmd := range parent.Commands() {
-		recursiveBlockQuoteExamples(cmd)
-	}
-}
-
 func do(appEnvObj interface{}) error {
 	// Set 'os.Args[0]' so that examples use the expected command name
 	os.Args[0] = "pachctl"
 
 	rootCmd := cmd.PachctlCmd()
 
-	recursiveBlockQuoteExamples(rootCmd)
 	return doc.GenMarkdownTree(rootCmd, "./doc/pachctl/")
 }


### PR DESCRIPTION
`cobra`'s `GenMarkdownTree` already wraps examples in \`\`\`s, so adding our own broke the rendering.  See #3880.