### PR TITLE
Bump required golang version to v1.12+

### DIFF
--- a/doc/contributing/setup.md
+++ b/doc/contributing/setup.md
@@ -5,7 +5,7 @@
 First, go through the general local installation instructions [here](http://docs.pachyderm.io/en/latest/getting_started/local_installation.html). Additionally, make sure you have the following installed:
 
 - etcd
-- golang 1.11+
+- golang 1.12+
 - docker
 - [jq](https://stedolan.github.io/jq/)
 - [pv](http://ivarch.com/programs/pv.shtml)


### PR DESCRIPTION
go v1.11 no longer compiles pachyderm successfully