### PR TITLE
Fix Docs commands usage strings

### DIFF
--- a/src/server/config/cmds.go
+++ b/src/server/config/cmds.go
@@ -249,8 +249,7 @@ func Cmds() []*cobra.Command {
 		Short: "Manages the pachyderm config.",
 		Long:  "Gets/sets pachyderm config values.",
 	}
-	cmdutil.SetDocsUsage(configDocs, "^pachctl config ")
-	commands = append(commands, cmdutil.CreateAlias(configDocs, "config"))
+	commands = append(commands, cmdutil.CreateDocsAlias(configDocs, "config", "^pachctl config "))
 
 	return commands
 }

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -67,8 +67,7 @@ func Cmds() []*cobra.Command {
 Repos contain version-controlled directories and files. Files can be of any size
 or type (e.g. csv, binary, images, etc).`,
 	}
-	cmdutil.SetDocsUsage(repoDocs, " repo$")
-	commands = append(commands, cmdutil.CreateAlias(repoDocs, "repo"))
+	commands = append(commands, cmdutil.CreateDocsAlias(repoDocs, "repo", " repo$"))
 
 	var description string
 	createRepo := &cobra.Command{
@@ -245,8 +244,7 @@ Commits become reliable (and immutable) when they are finished.
 
 Commits can be created with another commit as a parent.`,
 	}
-	cmdutil.SetDocsUsage(commitDocs, " commit$")
-	commands = append(commands, cmdutil.CreateAlias(commitDocs, "commit"))
+	commands = append(commands, cmdutil.CreateDocsAlias(commitDocs, "commit", " commit$"))
 
 	var parent string
 	startCommit := &cobra.Command{
@@ -571,8 +569,7 @@ multiple branches can refer to the same commit.
 
 Any pachctl command that can take a Commit ID, can take a branch name instead.`,
 	}
-	cmdutil.SetDocsUsage(branchDocs, " branch$")
-	commands = append(commands, cmdutil.CreateAlias(branchDocs, "branch"))
+	commands = append(commands, cmdutil.CreateDocsAlias(branchDocs, "branch", " branch$"))
 
 	var branchProvenance cmdutil.RepeatedStringArg
 	var head string
@@ -669,8 +666,7 @@ Files can be of any type (e.g. csv, binary, images, etc) or size and can be
 written to started (but not finished) commits with 'put file'. Files can be read
 from commits with 'get file'.`,
 	}
-	cmdutil.SetDocsUsage(fileDocs, " file$")
-	commands = append(commands, cmdutil.CreateAlias(fileDocs, "file"))
+	commands = append(commands, cmdutil.CreateDocsAlias(fileDocs, "file", " file$"))
 
 	var filePaths []string
 	var recursive bool
@@ -1183,8 +1179,7 @@ $ {{alias}} foo@master:path1 bar@master:path2`,
 
 Objects are a low-level resource and should not be accessed directly by most users.`,
 	}
-	cmdutil.SetDocsUsage(objectDocs, " object$")
-	commands = append(commands, cmdutil.CreateAlias(objectDocs, "object"))
+	commands = append(commands, cmdutil.CreateDocsAlias(objectDocs, "object", " object$"))
 
 	getObject := &cobra.Command{
 		Use:   "{{alias}} <hash>",
@@ -1207,8 +1202,7 @@ Objects are a low-level resource and should not be accessed directly by most use
 
 Tags are a low-level resource and should not be accessed directly by most users.`,
 	}
-	cmdutil.SetDocsUsage(tagDocs, " tag$")
-	commands = append(commands, cmdutil.CreateAlias(tagDocs, "tag"))
+	commands = append(commands, cmdutil.CreateDocsAlias(tagDocs, "tag", " tag$"))
 
 	getTag := &cobra.Command{
 		Use:   "{{alias}} <tag>",

--- a/src/server/pkg/cmdutil/cobra.go
+++ b/src/server/pkg/cmdutil/cobra.go
@@ -315,9 +315,9 @@ func MergeCommands(root *cobra.Command, children []*cobra.Command) {
 	}
 }
 
-// SetDocsUsage sets the usage string for a docs-style command.  Docs commands
-// have no functionality except to output some docs and related commands, and
-// should not specify a 'Run' attribute.
+// CreateDocsAlias sets the usage string for a docs-style command.  Docs
+// commands have no functionality except to output some docs and related
+// commands, and should not specify a 'Run' attribute.
 func CreateDocsAlias(command *cobra.Command, invocation string, pattern string) *cobra.Command {
 	// This should create a linked-list-shaped tree, follow it to the one leaf
 	root := CreateAlias(command, invocation)

--- a/src/server/pkg/cmdutil/cobra.go
+++ b/src/server/pkg/cmdutil/cobra.go
@@ -318,15 +318,25 @@ func MergeCommands(root *cobra.Command, children []*cobra.Command) {
 // SetDocsUsage sets the usage string for a docs-style command.  Docs commands
 // have no functionality except to output some docs and related commands, and
 // should not specify a 'Run' attribute.
-func SetDocsUsage(command *cobra.Command, pattern string) {
-	command.SetHelpTemplate(`{{or .Long .Short}}
+func CreateDocsAlias(command *cobra.Command, invocation string, pattern string) *cobra.Command {
+	// This should create a linked-list-shaped tree, follow it to the one leaf
+	root := CreateAlias(command, invocation)
+	command = root
+	for len(command.Commands()) != 0 {
+		command = command.Commands()[0]
+	}
 
-{{.UsageString}}
-`)
+	// Normally cobra will not render usage if the command is not runnable or has
+	// no subcommands, specify our own help template to override that.
+	command.SetHelpTemplate(`{{with (or .Long .Short)}}{{. | trimRightSpace}}
+
+{{end}}{{.UsageString}}`)
 
 	originalUsageFunc := command.UsageFunc()
 	command.SetUsageFunc(func(cmd *cobra.Command) error {
-		if cmd != command {
+		// commands inherit their parents' usage function, so we'll want to pass-
+		// through anything but usage for this specific command
+		if cmd.CommandPath() != command.CommandPath() {
 			return originalUsageFunc(cmd)
 		}
 		rootCmd := cmd.Root()
@@ -364,11 +374,13 @@ func SetDocsUsage(command *cobra.Command, pattern string) {
 		}
 
 		text := `Associated Commands:{{range associated}}{{if .IsAvailableCommand}}
-  {{pad .CommandPath}} {{.Short}}{{end}}{{end}}`
+  {{pad .CommandPath}} {{.Short}}{{end}}{{end}}
+`
 
 		t := template.New("top")
 		t.Funcs(templateFuncs)
 		template.Must(t.Parse(text))
 		return t.Execute(cmd.Out(), cmd)
 	})
+	return root
 }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -67,8 +67,7 @@ results will be merged together at the end.
 
 If the job fails, the output commit will not be populated with data.`,
 	}
-	cmdutil.SetDocsUsage(jobDocs, " job$")
-	commands = append(commands, cmdutil.CreateAlias(jobDocs, "job"))
+	commands = append(commands, cmdutil.CreateDocsAlias(jobDocs, "job", " job$"))
 
 	var block bool
 	inspectJob := &cobra.Command{
@@ -273,8 +272,7 @@ Datums within a job will be processed independently, sometimes distributed
 across separate workers.  A separate execution of user code will be run for
 each datum.`,
 	}
-	cmdutil.SetDocsUsage(datumDocs, " datum$")
-	commands = append(commands, cmdutil.CreateAlias(datumDocs, "datum"))
+	commands = append(commands, cmdutil.CreateDocsAlias(datumDocs, "datum", " datum$"))
 
 	restartDatum := &cobra.Command{
 		Use:   "{{alias}} <job> <datum-path1>,<datum-path2>,...",
@@ -453,8 +451,7 @@ and launch a job to process each incoming commit.
 
 All jobs created by a pipeline will create commits in the pipeline's output repo.`,
 	}
-	cmdutil.SetDocsUsage(pipelineDocs, " pipeline$")
-	commands = append(commands, cmdutil.CreateAlias(pipelineDocs, "pipeline"))
+	commands = append(commands, cmdutil.CreateDocsAlias(pipelineDocs, "pipeline", " pipeline$"))
 
 	var build bool
 	var pushImages bool

--- a/src/server/transaction/cmds/cmds.go
+++ b/src/server/transaction/cmds/cmds.go
@@ -48,8 +48,7 @@ commands will be stored in the transaction rather than immediately executed.
 The stored commands can be executed as a single operation with 'finish
 transaction' or cancelled with 'delete transaction'.`,
 	}
-	cmdutil.SetDocsUsage(transactionDocs, " transaction$")
-	commands = append(commands, cmdutil.CreateAlias(transactionDocs, "transaction"))
+	commands = append(commands, cmdutil.CreateDocsAlias(transactionDocs, "transaction", " transaction$"))
 
 	listTransaction := &cobra.Command{
 		Short: "List transactions.",


### PR DESCRIPTION
I noticed the docs commands bitrotted some and were no longer displaying their list of associated commands (because `CreateAlias` generates a new `cobra.Command`, so we could no longer rely on comparing pointers when applying the docs usage function).  Since `SetDocsUsage` should always be used in conjunction with `CreateAlias` anyway, I combined the two into `CreateDocsAlias`, which works around this problem.  It makes the calling code slightly simpler, but slightly less explicit.