### PR TITLE
Fix delete repo bug

### DIFF
--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -343,7 +343,7 @@ func (a *apiServer) DeleteCommitInTransaction(
 	txnCtx *txnenv.TransactionContext,
 	request *pfs.DeleteCommitRequest,
 ) error {
-	return a.driver.deleteCommit(txnCtx, request.Commit, false)
+	return a.driver.deleteCommit(txnCtx, request.Commit)
 }
 
 // DeleteCommit implements the protobuf pfs.DeleteCommit RPC

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -343,7 +343,7 @@ func (a *apiServer) DeleteCommitInTransaction(
 	txnCtx *txnenv.TransactionContext,
 	request *pfs.DeleteCommitRequest,
 ) error {
-	return a.driver.deleteCommit(txnCtx, request.Commit)
+	return a.driver.deleteCommit(txnCtx, request.Commit, false)
 }
 
 // DeleteCommit implements the protobuf pfs.DeleteCommit RPC

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -835,6 +835,9 @@ func (d *driver) deleteRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, f
 	for _, ci := range commitList {
 		err = d.deleteCommit(txnCtx, ci, true)
 		if err != nil && force == false {
+			if strings.Contains(err.Error(), "not found") {
+				continue
+			}
 			return err
 		}
 	}

--- a/src/server/pfs/server/server_test.go
+++ b/src/server/pfs/server/server_test.go
@@ -516,7 +516,7 @@ func TestDeleteRepo(t *testing.T) {
 	require.Equal(t, len(repoInfos), numRepos-reposToRemove)
 }
 
-func TestDeleteProvenanceRepo(t *testing.T) {
+func TestDeleteRepoProvenance(t *testing.T) {
 	client := GetPachClient(t)
 
 	// Create two repos, one as another's provenance
@@ -524,11 +524,20 @@ func TestDeleteProvenanceRepo(t *testing.T) {
 	require.NoError(t, client.CreateRepo("B"))
 	require.NoError(t, client.CreateBranch("B", "master", "", []*pfs.Branch{pclient.NewBranch("A", "master")}))
 
+	commit, err := client.StartCommit("A", "master")
+	require.NoError(t, err)
+	require.NoError(t, client.FinishCommit("A", commit.ID))
+
 	// Delete the provenance repo; that should fail.
 	require.YesError(t, client.DeleteRepo("A", false))
 
 	// Delete the leaf repo, then the provenance repo; that should succeed
 	require.NoError(t, client.DeleteRepo("B", false))
+
+	// Should be in a consistent state after B is deleted
+	_, err = client.Fsck(client.Ctx(), &types.Empty{})
+	require.NoError(t, err)
+
 	require.NoError(t, client.DeleteRepo("A", false))
 
 	repoInfos, err := client.ListRepo()
@@ -546,6 +555,11 @@ func TestDeleteProvenanceRepo(t *testing.T) {
 	repoInfos, err = client.ListRepo()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(repoInfos))
+
+	// Everything should be consistent
+	_, err = client.Fsck(client.Ctx(), &types.Empty{})
+	require.NoError(t, err)
+
 }
 
 func TestInspectCommit(t *testing.T) {
@@ -2032,11 +2046,10 @@ func TestBranch2(t *testing.T) {
 	require.Equal(t, "branch1", branches[1].Name)
 	require.Equal(t, commit2, branches[1].Head)
 }
-
-func TestDeleteNonexistantBranch(t *testing.T) {
+func TestDeleteNonexistentBranch(t *testing.T) {
 	client := GetPachClient(t)
 
-	repo := "TestDeleteNonexistantBranch"
+	repo := "TestDeleteNonexistentBranch"
 	require.NoError(t, client.CreateRepo(repo))
 	require.NoError(t, client.DeleteBranch(repo, "doesnt_exist", false))
 }


### PR DESCRIPTION
Previously, deleteRepo would simply delete all the commits of that repo, without doing any processing to fix the subvenance of upstream branches. This led to a bug where if a user deleted a pipeline, it might lead to a corrupted state.

This fixes that issue by ensuring that every deleted commit goes through `deleteCommit`, which does the necessary processing. The only problem is that it normally does not allow you to delete a commit which has provenance. So I added a force flag to be used by deleteRepo which overrides this restriction.

I also fixed a minor bug in `fsck`.