### PR TITLE
Fix crash when deleting a transaction and there is no active transaction

### DIFF
--- a/src/server/transaction/cmds/cmds.go
+++ b/src/server/transaction/cmds/cmds.go
@@ -182,14 +182,16 @@ transaction' or cancelled with 'delete transaction'.`,
 			// TODO: use advisory locks on config so we don't have a race condition if
 			// two commands are run simultaneously
 			var txn *transaction.Transaction
-			var isActive bool
+			isActive := false
 			if len(args) > 0 {
 				txn = &transaction.Transaction{ID: args[0]}
 
 				// Don't check err here, this is just a quality-of-life check to clean
 				// up the config after a successful delete
 				activeTxn, _ := requireActiveTransaction()
-				isActive = (txn.ID == activeTxn.ID)
+				if activeTxn != nil {
+					isActive = txn.ID == activeTxn.ID
+				}
 			} else {
 				txn, err = requireActiveTransaction()
 				if err != nil {


### PR DESCRIPTION
Fixes #3919 - the code was not checking if there was no active transaction before attempting to compare  the ID to the specified transaction to delete (which is done to make sure we clear the active transaction at the end).  Added a few tests that cover the `pachctl delete transaction` command, since there was only a basic test for CLI behavior.