### PR TITLE
mount empty dir for user containers in openshift environment

### DIFF
--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -119,10 +119,12 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 				EmptyDir: &v1.EmptyDirVolumeSource{},
 			},
 		})
-		sidecarVolumeMounts = append(sidecarVolumeMounts, v1.VolumeMount{
+		emptyDirVolumeMount := v1.VolumeMount{
 			Name:      "pach-dir-volume",
 			MountPath: a.storageRoot,
-		})
+		}
+		sidecarVolumeMounts = append(sidecarVolumeMounts, emptyDirVolumeMount)
+		userVolumeMounts = append(userVolumeMounts, emptyDirVolumeMount)
 	}
 	secretVolume, secretMount := assets.GetBackendSecretVolumeAndMount(a.storageBackend)
 	options.volumes = append(options.volumes, secretVolume)


### PR DESCRIPTION
Why:
fix #3738 

This change addresses the need by:

pod in openshift runs in unprivilege mode, for every pps worker, it
would create directory recursively in container, which leading to wrong
state.

@JoeyZwicker @gabrielgrant please review, thanks. 