### PR TITLE
Makefile enhancements

### DIFF
--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -132,7 +132,7 @@ from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes n
 
 You can learn what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
 Some of the flags are marked as to be used with caution.
-Please consult with your Kubernetes administrator and your Pachyderm support team when unsure of the effect of a flag.
+When you are unsure of the effect of a flag, consult with your Kubernetes administrator and your Pachyderm support team.
 Some flags, like `--image-pull-secret`, will require the creation and loading of Kubernetes manifests outside of `pachctl`.
 
 ## Creating a Pachyderm manifest

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -91,7 +91,7 @@ A good example to check against is [OpenShift](./openshift.html).
 
 A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) declares the desired state of application pods to Kubernetes.
 
-For a static deployment, 
+If you configure a static deployment,
 Pahyderm deploys `Deployment` manifests for `etcd`, `pachd`, and `dash`.
 If you specify `--dynamic-etd-nodes`, Pachyderm deploys the `pachd` and `dash` as `Deployment`
 and `etcd` as a`StatefulSet`.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -12,7 +12,7 @@ Typically, you customize a deployment by running the command with the `--dry-run
 The command's standard output is directed into a series of customization scripts or a file for editing.
 
 This section describes how to use `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.
-We won't directly address automating your deployment by means of customization scripts,
+Although deployment automation is out of scope of this section, Pachyderm strongly encourages you to configure your [infrastructure as code](./on-premises.html#infrastructure-as-code).
 but we do encourage you to treat your [infrastructure as code](./on-premises.html#infrastructure-as-code).
 
 ## Anatomy of a Pachyderm deployment manifest

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -122,7 +122,7 @@ or the `pachctl deploy storage` command.
 
 ### Preparing your environment
 
-Please see the [introduction to on-premises deployment](./on_premises.html) for steps you need to take prior to creating a custom Pachyderm deployment manifest.
+See the [introduction to on-premises deployment](./on_premises.html) for steps that you need to take before to creating a custom Pachyderm deployment manifest.
 
 ### Customizing `pachctl` flags
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -175,7 +175,7 @@ You may either deploy manifests you created above or edit them to customize them
 
 ### Editing your manifest to customize it further
 
-This should only be approached if you are an experienced Kubernetes administrator.
+This functionality requires an experienced Kubernetes administrator.
 If you are attempting a highly customized deployment, 
 please engage with your Pachyderm support team. 
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -74,7 +74,7 @@ Services are how Kubernetes exposes Pods to the network.
 If you  use StatefulSets to deploy Pachyderm,
 that is, you use `--dynamic-etcd-nodes` flag,
 Pachyderm deploys one `Service` for `etcd-headless`, one for `pachd`, and one for `dash`.
-A static deployment will have `Services` for `etcd`, `pachd`, and `dash`.
+A static deployment has `Services` for `etcd`, `pachd`, and `dash`.
 
 The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.
 Likewise, if `--dashboard-only` is specified,

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -94,7 +94,6 @@ A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deplo
 For a static deployment, 
 there will three [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) manifests, for `etcd`, `pachd`, and `dash`.
 If you specify `--dynamic-etd-nodes` when doing your deploy, you'll only see two `Deployment`s, 
-`pachd` and `dash`,
 and `etcd` as a`StatefulSet`.
 
 If you run the deploy command with the `--no-dashboard` flag, Pachyderm omits the deployment of the `dash` `Service` and `Deployment`.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -107,7 +107,7 @@ For a `--dynamic-etcd-nodes` deployment, the `etcd` `Deployment` manifest will b
 ### Secret
 
 The final manifest is a Kubernetes [`Secret`](https://kubernetes.io/docs/concepts/configuration/secret/).
-It's used by Pachyderm to store the credentials necessary access object storage.
+Pachyderm uses the `Secret` to store the credentials that are necessary to access object storage.
 The final manifest uses the command-line arguments that you submit to the `pachctl deploy` command to store the parameters, 
 like region, secret, token, and endpoint that are used to access an object store. 
 The exact values in the secret depend on the kind of object store you configure for your deployment.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -1,6 +1,118 @@
 # Custom Deployments
 
-This document  details the various options of the `pachctl deploy custom ...` command for an on-premises deployment. 
+If you're deploying to a cloud infrastructure, 
+such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/deployment/amazon_web_services.html),
+[Google Cloud Platform (GCP)](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), or 
+[Microsoft Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html), 
+Pachyderm's `pachctl deploy` includes commands for those providers (`amazon`, `google`, and `microsoft`, respectively).
+You should use those commands when deploying to those cloud infrastructures.
+You can customize cloud provider deployments extensively through flags available for each provider.
+
+Pachyderm also includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
+It's usually invoked with the `--dry-run` flag, 
+with the command's standard output directed into a series of customization scripts or a file for editing.
+
+This document covers using `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.
+We won't directly address automating your deployment by means of customization scripts,
+but we do encourage you to treat your [infrastructure as code](./on-premises.html#infrastructure-as-code).
+
+## Anatomy of a Pachyderm deployment manifest
+
+When you run the `pachctl deploy ...` command with the `--dry-run` flag,
+you're generating a JSON-encoded Kubernetes manifest in one stream to standard output. 
+That manifest itself consists of a number of smaller manifests,
+corresponding to a particular aspect of a Pachyderm deployment.
+
+Pachyderm has three sets of application components usually deployed:
+- `pachd`, the main Pachyderm pod
+- `etcd`, the administrative datastore for `pachd`
+- `dash`, the web-based enterprise ui for Pachyderm
+We'll explore all of these within this document.
+
+In general, there are two categories of manifests in the file,
+roles-and-permissions-related and application-related.
+
+## Roles-and-permissions-related manifests
+
+### ServiceAccount
+
+Usually at the top of the file, this manifest has the `kind` key set to `ServiceAccount`. 
+[ServiceAccounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) are a way Kubernetes can assign namespace-specific privileges to applications in a lightweight way.
+Pachyderm's service account is called, appropriately enough, `pachyderm`.
+
+### Role or ClusterRole
+
+The next manifest will usually be of `kind` `Role` or `ClusterRole`, 
+depending on whether you  used the `--local-roles` flag `pachctl deploy` command.
+
+### RoleBinding or ClusterRoleBinding
+
+This manifest binds the `Rule` or `ClusterRole` to the `ServiceAccount` created above.
+
+## Application-related
+
+### PersistentVolume
+
+If you don't use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
+(that is, you don't specify `--dynamic-etcd-nodes` flag), 
+the value you specify for `--persistent-disk` will cause `pachctl` to write a manifest for creating a [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for Pachyderm's `etcd` to use in its [`PersistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
+
+### PersistentVolumeClaim
+
+This is the `PersistentVolumeClaim` that Pachyderm's `etcd` will use if you don't deploy using [StatefulSets](./on_premises.html#statefulsets).
+You'll see this manifest's name in the `etcd` Deployment manifest, below.
+
+### StorageClass
+
+If you *do* use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
+(that is, you use `--dynamic-etcd-nodes` flag), 
+this manifest, if needed, will specify the kind of storage and provisioner that's appropriate for what you've specified in the `--persistent-disk` flag. 
+
+### Service
+
+You'll see three [`Service`](https://kubernetes.io/docs/concepts/services-networking/service/) manifests in a Pachyderm deployment. 
+Services are how Kubernetes exposes Pods to the network.
+If you  use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
+(that is, you use `--dynamic-etcd-nodes` flag), 
+you'll see one for `etcd-headless`, one for `pachd`, and one for `dash`.
+A static deployment will have `Services` for `etcd`, `pachd`, and `dash`.
+
+The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.
+Likewise, if `--dashboard-only` is specified,
+manifests for the Pachyderm enterprise UI only will be generated. 
+
+The most common items to edit in `Service` manifests are the `NodePort` values for various services, 
+and the `containerPort` values for `Deployment` manifests.
+It will be necessary to add environment variables to a `Deployment` or `StatefulSet` object to make your `containerPort` values work properly.
+A good example to check against is [OpenShift](./openshift.html).
+
+### The Pachyderm pods
+
+#### Deployment 
+
+A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) is how it's declared to Kubernetes what the final state of an application's pods should be.
+
+For a static deployment, 
+there will three [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) manifests, for `etcd`, `pachd`, and `dash`.
+If you specify `--dynamic-etd-nodes` when doing your deploy, you'll only see two `Deployment`s, 
+`pachd` and `dash`,
+and  `etcd` will be deployed using a `StatefulSet`.
+
+The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.
+
+
+#### StatefulSet
+
+For a `--dynamic-etcd-nodes` deployment, the `etcd` `Deployment` manifest will be replaced with a `StatefulSet`.
+
+### Secret
+
+The final manifest is a Kubernetes [`Secret`](https://kubernetes.io/docs/concepts/configuration/secret/).
+It's used by Pachyderm to store the credentials necessary access object storage.
+It uses the command-line arguments to the `pachctl deploy` command to store the parameters, like region, secret, token and endpoint, used to access an object store. 
+The exact values in the secret depend on the kind of object store you configure for your deployment.
+You can update the values after deployment either using `kubectl` to deploy a new `Secret`
+or the `pachctl deploy storage` command.
 
 ## Prerequisites
 
@@ -11,7 +123,17 @@ This document  details the various options of the `pachctl deploy custom ...` co
 
 ### Preparing your environment
 
-Please see the [introduction to on-premises deployment](./on_premises.html) for steps you need to take prior to creating a Pachydemerm deployment manifest.
+Please see the [introduction to on-premises deployment](./on_premises.html) for steps you need to take prior to creating a custom Pachyderm deployment manifest.
+
+### Customizing through pachctl flags
+
+`pachctl` includes flags for customizing aspects of your deployment,
+from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes namespace.
+
+Please check what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
+Flag that should be used with caution are marked as such.
+Please consult with your Kubernetes administrator and your Pachyderm support team when unsure of the effect of a flag.
+Some flags, like `--image-pull-secret`, will require the creation and loading of Kubernetes manifests outside of `pachctl`.
 
 ## Creating a Pachyderm manifest
 
@@ -53,7 +175,9 @@ You may either deploy manifests you created above or edit them to customize them
 
 ### Editing your manifest to customize it further
 
-This should only be approached if you are an experienced Kubernetes administrator. 
+This should only be approached if you are an experienced Kubernetes administrator.
+If you are attempting a highly customized deployment, 
+please engage with your Pachyderm support team. 
 
 ### Deploying
 The command you'll want to run depends on the command you ran, above.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -4,7 +4,7 @@ If you are deploying Pachyderm to a cloud infrastructure,
 such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/deployment/amazon_web_services.html),
 [Google Cloud Platform (GCP)](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), or 
 [Microsoft Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html), 
-Pachyderm's `pachctl deploy` includes commands for those providers (`amazon`, `google`, and `microsoft`, respectively).
+use a related `pachctl deploy` subcommand, such as `amazon`, `google`, or `microsoft`, respectively.
 You should use those commands when deploying to those cloud infrastructures.
 You can customize cloud provider deployments extensively through flags available for each provider.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -97,7 +97,7 @@ If you specify `--dynamic-etd-nodes` when doing your deploy, you'll only see two
 `pachd` and `dash`,
 and  `etcd` will be deployed using a `StatefulSet`.
 
-The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.
+If you run the deploy command with the `--no-dashboard` flag, Pachyderm omits the deployment of the `dash` `Service` and `Deployment`.
 
 
 #### StatefulSet

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -89,7 +89,7 @@ A good example to check against is [OpenShift](./openshift.html).
 
 #### Deployment 
 
-A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) is how it's declared to Kubernetes what the final state of an application's pods should be.
+A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) declares the desired state of application pods to Kubernetes.
 
 For a static deployment, 
 there will three [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) manifests, for `etcd`, `pachd`, and `dash`.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -35,7 +35,7 @@ roles-and-permissions-related and application-related.
 
 ### ServiceAccount
 
-Usually at the top of the file, this manifest has the `kind` key set to `ServiceAccount`. 
+Typically at the top of the file, a roles and permissions manifest has the `kind` key set to `ServiceAccount`. 
 [ServiceAccounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) are a way Kubernetes can assign namespace-specific privileges to applications in a lightweight way.
 Pachyderm's service account is called, appropriately enough, `pachyderm`.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -92,7 +92,7 @@ A good example to check against is [OpenShift](./openshift.html).
 A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) declares the desired state of application pods to Kubernetes.
 
 For a static deployment, 
-there will three [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) manifests, for `etcd`, `pachd`, and `dash`.
+Pahyderm deploys `Deployment` manifests for `etcd`, `pachd`, and `dash`.
 If you specify `--dynamic-etd-nodes`, Pachyderm deploys the `pachd` and `dash` as `Deployment`
 and `etcd` as a`StatefulSet`.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -5,7 +5,6 @@ such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/d
 [Google Cloud Platform (GCP)](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), or 
 [Microsoft Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html), 
 use a related `pachctl deploy` subcommand, such as `amazon`, `google`, or `microsoft`, respectively.
-You should use those commands when deploying to those cloud infrastructures.
 You can customize cloud provider deployments extensively through flags available for each provider.
 
 Pachyderm also includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -52,7 +52,7 @@ This manifest binds the `Rule` or `ClusterRole` to the `ServiceAccount` created 
 ### PersistentVolume
 
 If you did not use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm,
-(that is, you don't specify `--dynamic-etcd-nodes` flag), 
+that is, you do not specify `--dynamic-etcd-nodes` flag, 
 the value you specify for `--persistent-disk` will cause `pachctl` to write a manifest for creating a [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for Pachyderm's `etcd` to use in its [`PersistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 
 ### PersistentVolumeClaim

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -18,7 +18,7 @@ but we do encourage you to treat your [infrastructure as code](./on-premises.htm
 ## Anatomy of a Pachyderm deployment manifest
 
 When you run the `pachctl deploy ...` command with the `--dry-run` flag,
-you're generating a JSON-encoded Kubernetes manifest in one stream to standard output. 
+you are generating a JSON-encoded Kubernetes manifest in one stream to standard output. 
 That manifest itself consists of a number of smaller manifests,
 corresponding to a particular aspect of a Pachyderm deployment.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -1,6 +1,6 @@
 # Custom Deployments
 
-If you're deploying to a cloud infrastructure, 
+If you are deploying Pachyderm to a cloud infrastructure, 
 such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/deployment/amazon_web_services.html),
 [Google Cloud Platform (GCP)](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), or 
 [Microsoft Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html), 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -133,7 +133,7 @@ from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes n
 You can learn what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
 Some of the flags are marked as to be used with caution.
 When you are unsure of the effect of a flag, consult with your Kubernetes administrator and your Pachyderm support team.
-Some flags, like `--image-pull-secret`, will require the creation and loading of Kubernetes manifests outside of `pachctl`.
+Some flags, such as `--image-pull-secret`, require the creation and loading of Kubernetes manifests outside of `pachctl`.
 
 ## Creating a Pachyderm manifest
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -8,7 +8,7 @@ use a related `pachctl deploy` subcommand, such as `amazon`, `google`, or `micro
 Also, you can customize cloud provider deployments extensively through flags available for each provider.
 
 Pachyderm includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
-It's usually invoked with the `--dry-run` flag, 
+Typically, you customize a deployment by running the command with the `--dry-run` flag.
 with the command's standard output directed into a series of customization scripts or a file for editing.
 
 This document covers using `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -51,7 +51,7 @@ This manifest binds the `Rule` or `ClusterRole` to the `ServiceAccount` created 
 
 ### PersistentVolume
 
-If you don't use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
+If you did not use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm,
 (that is, you don't specify `--dynamic-etcd-nodes` flag), 
 the value you specify for `--persistent-disk` will cause `pachctl` to write a manifest for creating a [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for Pachyderm's `etcd` to use in its [`PersistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -19,7 +19,7 @@ but we do encourage you to treat your [infrastructure as code](./on-premises.htm
 
 When you run the `pachctl deploy ...` command with the `--dry-run` flag,
 you are generating a JSON-encoded Kubernetes manifest in one stream to standard output. 
-That manifest itself consists of a number of smaller manifests,
+That manifest consists of a number of smaller manifests,
 corresponding to a particular aspect of a Pachyderm deployment.
 
 Pachyderm has three sets of application components usually deployed:

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -93,7 +93,7 @@ A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deplo
 
 For a static deployment, 
 there will three [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) manifests, for `etcd`, `pachd`, and `dash`.
-If you specify `--dynamic-etd-nodes` when doing your deploy, you'll only see two `Deployment`s, 
+If you specify `--dynamic-etd-nodes`, Pachyderm deploys the `pachd` and `dash` as `Deployment`
 and `etcd` as a`StatefulSet`.
 
 If you run the deploy command with the `--no-dashboard` flag, Pachyderm omits the deployment of the `dash` `Service` and `Deployment`.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -11,7 +11,7 @@ Pachyderm includes `pachctl deploy custom` for creating customized deployments f
 Typically, you customize a deployment by running the command with the `--dry-run` flag.
 The command's standard output is directed into a series of customization scripts or a file for editing.
 
-This document covers using `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.
+This section describes how to use `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.
 We won't directly address automating your deployment by means of customization scripts,
 but we do encourage you to treat your [infrastructure as code](./on-premises.html#infrastructure-as-code).
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -9,7 +9,7 @@ Also, you can customize cloud provider deployments extensively through flags ava
 
 Pachyderm includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
 Typically, you customize a deployment by running the command with the `--dry-run` flag.
-with the command's standard output directed into a series of customization scripts or a file for editing.
+The command's standard output is directed into a series of customization scripts or a file for editing.
 
 This document covers using `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.
 We won't directly address automating your deployment by means of customization scripts,

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -176,7 +176,6 @@ You may either deploy manifests you created above or edit them to customize them
 
 This functionality requires an experienced Kubernetes administrator.
 If you are attempting a highly customized deployment, 
-please engage with your Pachyderm support team. 
 
 ### Deploying
 The command you'll want to run depends on the command you ran, above.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -124,7 +124,7 @@ or the `pachctl deploy storage` command.
 
 Please see the [introduction to on-premises deployment](./on_premises.html) for steps you need to take prior to creating a custom Pachyderm deployment manifest.
 
-### Customizing through pachctl flags
+### Customizing `pachctl` flags
 
 `pachctl` includes flags for customizing aspects of your deployment,
 from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes namespace.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -37,7 +37,7 @@ roles-and-permissions-related and application-related.
 
 Typically at the top of the file, a roles and permissions manifest has the `kind` key set to `ServiceAccount`. 
 [ServiceAccounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) are a way Kubernetes can assign namespace-specific privileges to applications in a lightweight way.
-Pachyderm's service account is called, appropriately enough, `pachyderm`.
+The Pachyderm's service account is called  `pachyderm`.
 
 ### Role or ClusterRole
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -30,7 +30,7 @@ Pachyderm deploys the following sets of application components:
 In general, there are two categories of manifests in the file,
 roles-and-permissions-related and application-related.
 
-## Roles-and-permissions-related manifests
+## Roles and permissions manifests
 
 ### ServiceAccount
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -102,7 +102,7 @@ The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is
 
 #### StatefulSet
 
-For a `--dynamic-etcd-nodes` deployment, the `etcd` `Deployment` manifest will be replaced with a `StatefulSet`.
+For a `--dynamic-etcd-nodes` deployment, Pachyderm replaces the `etcd` `Deployment` manifest with a `StatefulSet`.
 
 ### Secret
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -1,117 +1,6 @@
 # Custom Deployments
 
-If you are deploying Pachyderm to a cloud infrastructure, 
-such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/deployment/amazon_web_services.html),
-[Google Cloud Platform (GCP)](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), or 
-[Microsoft Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html), 
-use a related `pachctl deploy` subcommand, such as `amazon`, `google`, or `microsoft`, respectively.
-Also, you can customize cloud provider deployments extensively through flags available for each provider.
-
-Pachyderm includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
-Typically, you customize a deployment by running the command with the `--dry-run` flag.
-The command's standard output is directed into a series of customization scripts or a file for editing.
-
-This section describes how to use `pachctl deploy custom ... --dry-run` to create a manifest for a custom, on-premises deployment.
-Although deployment automation is out of scope of this section, Pachyderm strongly encourages you to configure your [infrastructure as code](./on-premises.html#infrastructure-as-code).
-but we do encourage you to treat your [infrastructure as code](./on-premises.html#infrastructure-as-code).
-
-## Anatomy of a Pachyderm deployment manifest
-
-When you run the `pachctl deploy ...` command with the `--dry-run` flag,
-you are generating a JSON-encoded Kubernetes manifest in one stream to standard output. 
-That manifest consists of a number of smaller manifests,
-that correspond to a particular aspect of a Pachyderm deployment.
-
-Pachyderm deploys the following sets of application components:
-- `pachd`, the main Pachyderm pod
-- `etcd`, the administrative datastore for `pachd`
-- `dash`, the web-based enterprise ui for Pachyderm
-
-In general, there are two categories of manifests in the file,
-roles-and-permissions-related and application-related.
-
-## Roles and permissions manifests
-
-### ServiceAccount
-
-Typically at the top of the file, a roles and permissions manifest has the `kind` key set to `ServiceAccount`. 
-[ServiceAccounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) are a way Kubernetes can assign namespace-specific privileges to applications in a lightweight way.
-The Pachyderm's service account is called  `pachyderm`.
-
-### Role or ClusterRole
-
-Depending on whether you used the `--local-roles` flag or not, the next manifest will be of `kind` `Role` or `ClusterRole`.
-depending on whether you  used the `--local-roles` flag `pachctl deploy` command.
-
-### RoleBinding or ClusterRoleBinding
-
-This manifest binds the `Rule` or `ClusterRole` to the `ServiceAccount` created above.
-
-## Application-related
-
-### PersistentVolume
-
-If you did not use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm,
-that is, you do not specify `--dynamic-etcd-nodes` flag, 
-the value that you specify for `--persistent-disk` causes `pachctl` to write a manifest for creating a [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that Pachyderm's `etcd` uses in its [`PersistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
-
-### PersistentVolumeClaim
-
-Pachyderm's `etcd` uses this `PersistentVolumeClaim` unless you deploy using [StatefulSets](./on_premises.html#statefulsets).
-See this manifest's name in the `etcd` Deployment manifest, below.
-
-### StorageClass
-
-If you *do* use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
-that is, you use `--dynamic-etcd-nodes` flag, 
-this manifest specifies the kind of storage and provisioner that is appropriate for what you have specified in the `--persistent-disk` flag. 
-You won't see this manifest if you specified `azure` as the argument to `--persistent-disk`.
-
-### Service
-
-In a typical Pachyderm deployment, you see three [`Service`](https://kubernetes.io/docs/concepts/services-networking/service/) manifests. 
-Services are how Kubernetes exposes Pods to the network.
-If you  use StatefulSets to deploy Pachyderm,
-that is, you use `--dynamic-etcd-nodes` flag,
-Pachyderm deploys one `Service` for `etcd-headless`, one for `pachd`, and one for `dash`.
-A static deployment has `Services` for `etcd`, `pachd`, and `dash`.
-
-If you use the `--no-dashboard` flag, Pachyderm does not create the `dash` `Service` and `Deployment`.
-Likewise, if `--dashboard-only` is specified,
-Pachyderm generates the manifests for the Pachyderm enterprise UI only. 
-
-The most common items that you can edit in `Service` manifests are the `NodePort` values for various services, 
-and the `containerPort` values for `Deployment` manifests.
-To make your `containerPort` values work properly, add environment variables to a `Deployment` or `StatefulSet` object.
-You can verify this functionality in the [OpenShift](./openshift.html) example.
-
-### The Pachyderm pods
-
-#### Deployment 
-
-A [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) declares the desired state of application pods to Kubernetes.
-
-If you configure a static deployment,
-Pahyderm deploys `Deployment` manifests for `etcd`, `pachd`, and `dash`.
-If you specify `--dynamic-etd-nodes`, Pachyderm deploys the `pachd` and `dash` as `Deployment`
-and `etcd` as a`StatefulSet`.
-
-If you run the deploy command with the `--no-dashboard` flag, Pachyderm omits the deployment of the `dash` `Service` and `Deployment`.
-
-
-#### StatefulSet
-
-For a `--dynamic-etcd-nodes` deployment, Pachyderm replaces the `etcd` `Deployment` manifest with a `StatefulSet`.
-
-### Secret
-
-The final manifest is a Kubernetes [`Secret`](https://kubernetes.io/docs/concepts/configuration/secret/).
-Pachyderm uses the `Secret` to store the credentials that are necessary to access object storage.
-The final manifest uses the command-line arguments that you submit to the `pachctl deploy` command to store the parameters, 
-like region, secret, token, and endpoint that are used to access an object store. 
-The exact values in the secret depend on the kind of object store you configure for your deployment.
-You can update the values after the deployment either by using `kubectl` to deploy a new `Secret`
-or the `pachctl deploy storage` command.
+This document  details the various options of the `pachctl deploy custom ...` command for an on-premises deployment. 
 
 ## Prerequisites
 
@@ -122,17 +11,7 @@ or the `pachctl deploy storage` command.
 
 ### Preparing your environment
 
-See the [introduction to on-premises deployment](./on_premises.html) for steps that you need to take before to creating a custom Pachyderm deployment manifest.
-
-### Customizing `pachctl` flags
-
-`pachctl` includes flags for customizing aspects of your deployment,
-from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes namespace.
-
-You can learn what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
-Some of the flags are marked as to be used with caution.
-When you are unsure of the effect of a flag, consult with your Kubernetes administrator and your Pachyderm support team.
-Some flags, such as `--image-pull-secret`, require the creation and loading of Kubernetes manifests outside of `pachctl`.
+Please see the [introduction to on-premises deployment](./on_premises.html) for steps you need to take prior to creating a Pachydemerm deployment manifest.
 
 ## Creating a Pachyderm manifest
 
@@ -174,8 +53,7 @@ You may either deploy manifests you created above or edit them to customize them
 
 ### Editing your manifest to customize it further
 
-This functionality requires an experienced Kubernetes administrator.
-If you are attempting a highly customized deployment, 
+This should only be approached if you are an experienced Kubernetes administrator. 
 
 ### Deploying
 The command you'll want to run depends on the command you ran, above.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -26,7 +26,6 @@ Pachyderm deploys the following sets of application components:
 - `pachd`, the main Pachyderm pod
 - `etcd`, the administrative datastore for `pachd`
 - `dash`, the web-based enterprise ui for Pachyderm
-We'll explore all of these within this document.
 
 In general, there are two categories of manifests in the file,
 roles-and-permissions-related and application-related.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -69,7 +69,7 @@ You won't see this manifest if you specified `azure` as the argument to `--persi
 
 ### Service
 
-You'll see three [`Service`](https://kubernetes.io/docs/concepts/services-networking/service/) manifests in a Pachyderm deployment. 
+In a typical Pachyderm deployment, you see three [`Service`](https://kubernetes.io/docs/concepts/services-networking/service/) manifests. 
 Services are how Kubernetes exposes Pods to the network.
 If you  use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
 (that is, you use `--dynamic-etcd-nodes` flag), 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -64,7 +64,8 @@ You'll see this manifest's name in the `etcd` Deployment manifest, below.
 
 If you *do* use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
 that is, you use `--dynamic-etcd-nodes` flag, 
-this manifest, if needed, will specify the kind of storage and provisioner that's appropriate for what you've specified in the `--persistent-disk` flag. 
+this manifest specifies the kind of storage and provisioner that is appropriate for what you have specified in the `--persistent-disk` flag. 
+You won't see this manifest if you specified `azure` as the argument to `--persistent-disk`.
 
 ### Service
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -71,7 +71,7 @@ You won't see this manifest if you specified `azure` as the argument to `--persi
 
 In a typical Pachyderm deployment, you see three [`Service`](https://kubernetes.io/docs/concepts/services-networking/service/) manifests. 
 Services are how Kubernetes exposes Pods to the network.
-If you  use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
+If you  use StatefulSets to deploy Pachyderm,
 that is, you use `--dynamic-etcd-nodes` flag,
 Pachyderm deploys one `Service` for `etcd-headless`, one for `pachd`, and one for `dash`.
 A static deployment will have `Services` for `etcd`, `pachd`, and `dash`.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -82,7 +82,7 @@ manifests for the Pachyderm enterprise UI only will be generated.
 
 The most common items to edit in `Service` manifests are the `NodePort` values for various services, 
 and the `containerPort` values for `Deployment` manifests.
-It will be necessary to add environment variables to a `Deployment` or `StatefulSet` object to make your `containerPort` values work properly.
+To make your `containerPort` values work properly, add environment variables to a `Deployment` or `StatefulSet` object.
 You can verify this functionality in the [OpenShift](./openshift.html) example.
 
 ### The Pachyderm pods

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -78,7 +78,7 @@ A static deployment has `Services` for `etcd`, `pachd`, and `dash`.
 
 The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.
 Likewise, if `--dashboard-only` is specified,
-manifests for the Pachyderm enterprise UI only will be generated. 
+Pachyderm generates the manifests for the Pachyderm enterprise UI only. 
 
 The most common items that you can edit in `Service` manifests are the `NodePort` values for various services, 
 and the `containerPort` values for `Deployment` manifests.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -72,7 +72,7 @@ You won't see this manifest if you specified `azure` as the argument to `--persi
 In a typical Pachyderm deployment, you see three [`Service`](https://kubernetes.io/docs/concepts/services-networking/service/) manifests. 
 Services are how Kubernetes exposes Pods to the network.
 If you  use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
-(that is, you use `--dynamic-etcd-nodes` flag), 
+that is, you use `--dynamic-etcd-nodes` flag,
 you'll see one for `etcd-headless`, one for `pachd`, and one for `dash`.
 A static deployment will have `Services` for `etcd`, `pachd`, and `dash`.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -76,7 +76,7 @@ that is, you use `--dynamic-etcd-nodes` flag,
 Pachyderm deploys one `Service` for `etcd-headless`, one for `pachd`, and one for `dash`.
 A static deployment has `Services` for `etcd`, `pachd`, and `dash`.
 
-The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.
+If you use the `--no-dashboard` flag, Pachyderm does not create the `dash` `Service` and `Deployment`.
 Likewise, if `--dashboard-only` is specified,
 Pachyderm generates the manifests for the Pachyderm enterprise UI only. 
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -108,7 +108,8 @@ For a `--dynamic-etcd-nodes` deployment, the `etcd` `Deployment` manifest will b
 
 The final manifest is a Kubernetes [`Secret`](https://kubernetes.io/docs/concepts/configuration/secret/).
 It's used by Pachyderm to store the credentials necessary access object storage.
-It uses the command-line arguments to the `pachctl deploy` command to store the parameters, like region, secret, token and endpoint, used to access an object store. 
+The final manifest uses the command-line arguments that you submit to the `pachctl deploy` command to store the parameters, 
+like region, secret, token, and endpoint that are used to access an object store. 
 The exact values in the secret depend on the kind of object store you configure for your deployment.
 You can update the values after the deployment either by using `kubectl` to deploy a new `Secret`
 or the `pachctl deploy storage` command.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -131,7 +131,7 @@ Please see the [introduction to on-premises deployment](./on_premises.html) for 
 from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes namespace.
 
 Please check what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
-Flag that should be used with caution are marked as such.
+Some of the flags are marked as to be used with caution.
 Please consult with your Kubernetes administrator and your Pachyderm support team when unsure of the effect of a flag.
 Some flags, like `--image-pull-secret`, will require the creation and loading of Kubernetes manifests outside of `pachctl`.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -95,7 +95,7 @@ For a static deployment,
 there will three [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) manifests, for `etcd`, `pachd`, and `dash`.
 If you specify `--dynamic-etd-nodes` when doing your deploy, you'll only see two `Deployment`s, 
 `pachd` and `dash`,
-and  `etcd` will be deployed using a `StatefulSet`.
+and `etcd` as a`StatefulSet`.
 
 If you run the deploy command with the `--no-dashboard` flag, Pachyderm omits the deployment of the `dash` `Service` and `Deployment`.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -7,7 +7,7 @@ such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/d
 use a related `pachctl deploy` subcommand, such as `amazon`, `google`, or `microsoft`, respectively.
 Also, you can customize cloud provider deployments extensively through flags available for each provider.
 
-Pachyderm also includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
+Pachyderm includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
 It's usually invoked with the `--dry-run` flag, 
 with the command's standard output directed into a series of customization scripts or a file for editing.
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -130,7 +130,7 @@ Please see the [introduction to on-premises deployment](./on_premises.html) for 
 `pachctl` includes flags for customizing aspects of your deployment,
 from memory and cpu requests for `etcd` and `pachd` to specifying a Kubernetes namespace.
 
-Please check what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
+You can learn what flags are available in your version of Pachyderm by running `pachctl deploy custom --help`.
 Some of the flags are marked as to be used with caution.
 Please consult with your Kubernetes administrator and your Pachyderm support team when unsure of the effect of a flag.
 Some flags, like `--image-pull-secret`, will require the creation and loading of Kubernetes manifests outside of `pachctl`.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -73,7 +73,7 @@ In a typical Pachyderm deployment, you see three [`Service`](https://kubernetes.
 Services are how Kubernetes exposes Pods to the network.
 If you  use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
 that is, you use `--dynamic-etcd-nodes` flag,
-you'll see one for `etcd-headless`, one for `pachd`, and one for `dash`.
+Pachyderm deploys one `Service` for `etcd-headless`, one for `pachd`, and one for `dash`.
 A static deployment will have `Services` for `etcd`, `pachd`, and `dash`.
 
 The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is used.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -53,7 +53,7 @@ This manifest binds the `Rule` or `ClusterRole` to the `ServiceAccount` created 
 
 If you did not use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm,
 that is, you do not specify `--dynamic-etcd-nodes` flag, 
-the value you specify for `--persistent-disk` will cause `pachctl` to write a manifest for creating a [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for Pachyderm's `etcd` to use in its [`PersistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
+the value that you specify for `--persistent-disk` causes `pachctl` to write a manifest for creating a [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that Pachyderm's `etcd` uses in its [`PersistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 
 ### PersistentVolumeClaim
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -58,7 +58,7 @@ the value that you specify for `--persistent-disk` causes `pachctl` to write a m
 ### PersistentVolumeClaim
 
 Pachyderm's `etcd` uses this `PersistentVolumeClaim` unless you deploy using [StatefulSets](./on_premises.html#statefulsets).
-You'll see this manifest's name in the `etcd` Deployment manifest, below.
+See this manifest's name in the `etcd` Deployment manifest, below.
 
 ### StorageClass
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -57,7 +57,7 @@ the value that you specify for `--persistent-disk` causes `pachctl` to write a m
 
 ### PersistentVolumeClaim
 
-This is the `PersistentVolumeClaim` that Pachyderm's `etcd` will use if you don't deploy using [StatefulSets](./on_premises.html#statefulsets).
+Pachyderm's `etcd` uses this `PersistentVolumeClaim` unless you deploy using [StatefulSets](./on_premises.html#statefulsets).
 You'll see this manifest's name in the `etcd` Deployment manifest, below.
 
 ### StorageClass

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -40,7 +40,7 @@ The Pachyderm's service account is called  `pachyderm`.
 
 ### Role or ClusterRole
 
-The next manifest will usually be of `kind` `Role` or `ClusterRole`, 
+Depending on whether you used the `--local-roles` flag or not, the next manifest will be of `kind` `Role` or `ClusterRole`.
 depending on whether you  used the `--local-roles` flag `pachctl deploy` command.
 
 ### RoleBinding or ClusterRoleBinding

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -5,7 +5,7 @@ such as [Amazon Web Services (AWS)](https://pachyderm.readthedocs.io/en/latest/d
 [Google Cloud Platform (GCP)](https://pachyderm.readthedocs.io/en/latest/deployment/google_cloud_platform.html), or 
 [Microsoft Azure](https://pachyderm.readthedocs.io/en/latest/deployment/azure.html), 
 use a related `pachctl deploy` subcommand, such as `amazon`, `google`, or `microsoft`, respectively.
-You can customize cloud provider deployments extensively through flags available for each provider.
+Also, you can customize cloud provider deployments extensively through flags available for each provider.
 
 Pachyderm also includes `pachctl deploy custom` for creating customized deployments for cloud providers or on-premises use.
 It's usually invoked with the `--dry-run` flag, 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -20,7 +20,7 @@ but we do encourage you to treat your [infrastructure as code](./on-premises.htm
 When you run the `pachctl deploy ...` command with the `--dry-run` flag,
 you are generating a JSON-encoded Kubernetes manifest in one stream to standard output. 
 That manifest consists of a number of smaller manifests,
-corresponding to a particular aspect of a Pachyderm deployment.
+that correspond to a particular aspect of a Pachyderm deployment.
 
 Pachyderm has three sets of application components usually deployed:
 - `pachd`, the main Pachyderm pod

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -63,7 +63,7 @@ You'll see this manifest's name in the `etcd` Deployment manifest, below.
 ### StorageClass
 
 If you *do* use [StatefulSets](./on_premises.html#statefulsets) to deploy Pachyderm
-(that is, you use `--dynamic-etcd-nodes` flag), 
+that is, you use `--dynamic-etcd-nodes` flag, 
 this manifest, if needed, will specify the kind of storage and provisioner that's appropriate for what you've specified in the `--persistent-disk` flag. 
 
 ### Service

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -80,7 +80,7 @@ The `dash` `Service` and `Deployment` will be omitted if the `--no-dashboard` is
 Likewise, if `--dashboard-only` is specified,
 manifests for the Pachyderm enterprise UI only will be generated. 
 
-The most common items to edit in `Service` manifests are the `NodePort` values for various services, 
+The most common items that you can edit in `Service` manifests are the `NodePort` values for various services, 
 and the `containerPort` values for `Deployment` manifests.
 To make your `containerPort` values work properly, add environment variables to a `Deployment` or `StatefulSet` object.
 You can verify this functionality in the [OpenShift](./openshift.html) example.

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -83,7 +83,7 @@ manifests for the Pachyderm enterprise UI only will be generated.
 The most common items to edit in `Service` manifests are the `NodePort` values for various services, 
 and the `containerPort` values for `Deployment` manifests.
 It will be necessary to add environment variables to a `Deployment` or `StatefulSet` object to make your `containerPort` values work properly.
-A good example to check against is [OpenShift](./openshift.html).
+You can verify this functionality in the [OpenShift](./openshift.html) example.
 
 ### The Pachyderm pods
 

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -110,7 +110,7 @@ The final manifest is a Kubernetes [`Secret`](https://kubernetes.io/docs/concept
 It's used by Pachyderm to store the credentials necessary access object storage.
 It uses the command-line arguments to the `pachctl deploy` command to store the parameters, like region, secret, token and endpoint, used to access an object store. 
 The exact values in the secret depend on the kind of object store you configure for your deployment.
-You can update the values after deployment either using `kubectl` to deploy a new `Secret`
+You can update the values after the deployment either by using `kubectl` to deploy a new `Secret`
 or the `pachctl deploy storage` command.
 
 ## Prerequisites

--- a/doc/deployment/deploy_custom.md
+++ b/doc/deployment/deploy_custom.md
@@ -22,7 +22,7 @@ you are generating a JSON-encoded Kubernetes manifest in one stream to standard 
 That manifest consists of a number of smaller manifests,
 that correspond to a particular aspect of a Pachyderm deployment.
 
-Pachyderm has three sets of application components usually deployed:
+Pachyderm deploys the following sets of application components:
 - `pachd`, the main Pachyderm pod
 - `etcd`, the administrative datastore for `pachd`
 - `dash`, the web-based enterprise ui for Pachyderm

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-.PHONY: opencv object_detection delete minikube
+.PHONY: opencv object_detection delete minikube gatk hyperparameter
 
 GATK_GERMLINE_FILES	=	gatk/GATK_Germline/data/ref/ref.dict \
 				gatk/GATK_Germline/data/ref/ref.fasta \
@@ -40,13 +40,13 @@ ml/object-detection/frozen_inference_graph.pb:
 	wget -p http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz --directory-prefix /tmp
 	tar -C ml/object-detection --strip-components 1 -xvf /tmp/download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz ssd_mobilenet_v1_coco_11_06_2017/frozen_inference_graph.pb
 
-object_detection: ml/object-detection/frozen_inference_graph.pb
+object-detection: ml/object-detection/frozen_inference_graph.pb
 	pachctl create repo images
 	pachctl create repo training
-	pachctl create pipeline -f ml/object-detection/model.json
-	pachctl create pipeline -f ml/object-detection/detect.json
 	pachctl put file training@master:frozen_inference_graph.pb -f ml/object-detection/frozen_inference_graph.pb
 	pachctl put file images@master:dogs.jpg -f ml/object-detection/images/dogs.jpg
+	pachctl create pipeline -f ml/object-detection/model.json
+	pachctl create pipeline -f ml/object-detection/detect.json
 	pachctl put file images@master:kites.jpg -f ml/object-detection/images/kites.jpg
 
 hyperparameter:
@@ -65,7 +65,7 @@ $(GATK_GERMLINE_FILES):
 	wget -p https://s3-us-west-1.amazonaws.com/pachyderm.io/Examples_Data_Repo/GATK_Germline.zip --directory-prefix=/tmp
 	unzip -o /tmp/s3-us-west-1.amazonaws.com/pachyderm.io/Examples_Data_Repo/GATK_Germline.zip  data/ref/ref.dict data/ref/ref.fasta data/ref/ref.fasta.fai data/ref/refSDF/* data/bams/*  -d gatk/GATK_Germline
 
-gatk_demo: $(GATK_GERMLINE_FILES)
+gatk: $(GATK_GERMLINE_FILES)
 	pachctl create repo reference
 	pachctl put file reference@master:ref.dict  -f gatk/GATK_Germline/data/ref/ref.dict
 	pachctl put file reference@master:ref.fasta -f gatk/GATK_Germline/data/ref/ref.fasta

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,34 @@
 .PHONY: opencv object_detection delete minikube
 
+GATK_GERMLINE_FILES	=	gatk/GATK_Germline/data/ref/ref.dict \
+				gatk/GATK_Germline/data/ref/ref.fasta \
+				gatk/GATK_Germline/data/ref/ref.fasta.fai \
+				gatk/GATK_Germline/data/ref/refSDF/done \
+				gatk/GATK_Germline/data/ref/refSDF/format.log \
+				gatk/GATK_Germline/data/ref/refSDF/mainIndex \
+				gatk/GATK_Germline/data/ref/refSDF/namedata0 \
+				gatk/GATK_Germline/data/ref/refSDF/nameIndex0 \
+				gatk/GATK_Germline/data/ref/refSDF/namepointer0 \
+				gatk/GATK_Germline/data/ref/refSDF/progress \
+				gatk/GATK_Germline/data/ref/refSDF/seqdata0 \
+				gatk/GATK_Germline/data/ref/refSDF/seqpointer0 \
+				gatk/GATK_Germline/data/ref/refSDF/sequenceIndex0 \
+				gatk/GATK_Germline/data/ref/refSDF/summary.txt \
+				gatk/GATK_Germline/data/bams/father.bai \
+				gatk/GATK_Germline/data/bams/father.bam \
+				gatk/GATK_Germline/data/bams/mother.bai \
+				gatk/GATK_Germline/data/bams/mother.bam \
+				gatk/GATK_Germline/data/bams/motherICE.bai \
+				gatk/GATK_Germline/data/bams/motherICE.bam \
+				gatk/GATK_Germline/data/bams/motherNEX.bai \
+				gatk/GATK_Germline/data/bams/motherNEX.bam \
+				gatk/GATK_Germline/data/bams/motherRnaseq.bai \
+				gatk/GATK_Germline/data/bams/motherRnaseq.bam \
+				gatk/GATK_Germline/data/bams/motherRnaseqPP.bai \
+				gatk/GATK_Germline/data/bams/motherRnaseqPP.bam \
+				gatk/GATK_Germline/data/bams/son.bai \
+				gatk/GATK_Germline/data/bams/son.bam
+
 opencv:
 	pachctl create repo images
 	pachctl create pipeline -f opencv/edges.json
@@ -7,18 +36,59 @@ opencv:
 	pachctl put file images@master -i opencv/images.txt
 	pachctl put file images@master -i opencv/images2.txt
 
-object_detection:
+ml/object-detection/frozen_inference_graph.pb:
+	wget -p http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz --directory-prefix /tmp
+	tar -C ml/object-detection --strip-components 1 -xvf /tmp/download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz ssd_mobilenet_v1_coco_11_06_2017/frozen_inference_graph.pb
+
+object_detection: ml/object-detection/frozen_inference_graph.pb
 	pachctl create repo images
 	pachctl create repo training
 	pachctl create pipeline -f ml/object-detection/model.json
 	pachctl create pipeline -f ml/object-detection/detect.json
-	pachctl put file training@master:frozen_inference_graph.pb -f ~/ssd_mobilenet_v1_coco_11_06_2017/frozen_inference_graph.pb
+	pachctl put file training@master:frozen_inference_graph.pb -f ml/object-detection/frozen_inference_graph.pb
 	pachctl put file images@master:dogs.jpg -f ml/object-detection/images/dogs.jpg
 	pachctl put file images@master:kites.jpg -f ml/object-detection/images/kites.jpg
 
+hyperparameter:
+	pachctl create repo raw_data
+	pachctl create repo parameters
+	pachctl put file raw_data@master:iris.csv -f ml/hyperparameter/data/noisy_iris.csv
+	pachctl put file parameters@master:c_parameters.txt -f ml/hyperparameter/data/parameters/c_parameters.txt --split line --target-file-datums 1
+	pachctl put file parameters@master:gamma_parameters.txt -f ml/hyperparameter/data/parameters/gamma_parameters.txt --split line --target-file-datums 1
+	pachctl create pipeline -f ml/hyperparameter/split.json
+	pachctl create pipeline -f ml/hyperparameter/model.json
+	pachctl create pipeline -f ml/hyperparameter/test.json
+	pachctl create pipeline -f ml/hyperparameter/select.json
+
+$(GATK_GERMLINE_FILES): 
+	mkdir -p gatk/GATK_Germline
+	wget -p https://s3-us-west-1.amazonaws.com/pachyderm.io/Examples_Data_Repo/GATK_Germline.zip --directory-prefix=/tmp
+	unzip -o /tmp/s3-us-west-1.amazonaws.com/pachyderm.io/Examples_Data_Repo/GATK_Germline.zip  data/ref/ref.dict data/ref/ref.fasta data/ref/ref.fasta.fai data/ref/refSDF/* data/bams/*  -d gatk/GATK_Germline
+
+gatk_demo: $(GATK_GERMLINE_FILES)
+	pachctl create repo reference
+	pachctl put file reference@master:ref.dict  -f gatk/GATK_Germline/data/ref/ref.dict
+	pachctl put file reference@master:ref.fasta -f gatk/GATK_Germline/data/ref/ref.fasta
+	pachctl put file reference@master:ref.fasta.fai -f gatk/GATK_Germline/data/ref/ref.fasta.fai
+	pachctl put file reference@master:refSDF -r -f gatk/GATK_Germline/data/ref/refSDF
+	pachctl create repo samples
+	pachctl start commit samples@master
+	pachctl put file samples@master:mother/mother.bam -f gatk/GATK_Germline/data/bams/mother.bam
+	pachctl put file samples@master:mother/mother.bai -f gatk/GATK_Germline/data/bams/mother.bai
+	pachctl finish commit samples@master
+	pachctl start commit samples@master
+	pachctl put file samples@master:father/father.bam -f gatk/GATK_Germline/data/bams/father.bam
+	pachctl put file samples@master:father/father.bai -f gatk/GATK_Germline/data/bams/father.bai	
+	pachctl finish commit samples@master
+	pachctl create pipeline -f gatk/likelihoods.json
+	pachctl create pipeline -f gatk/joint-call.json
 
 delete:
 	yes | pachctl delete all
+
+clean: delete
+	rm -fr gatk/GATK_Germline
+	rm -f  ml/object-detection/frozen_inference_graph.pb
 
 minikube:echo hi
 	minikube start

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -35,6 +35,7 @@ opencv:
 	pachctl create pipeline -f opencv/montage.json
 	pachctl put file images@master -i opencv/images.txt
 	pachctl put file images@master -i opencv/images2.txt
+#	pachctl put file images@master -i opencv/images3.txt
 
 ml/object-detection/frozen_inference_graph.pb:
 	wget -p http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz --directory-prefix /tmp
@@ -48,6 +49,8 @@ object-detection: ml/object-detection/frozen_inference_graph.pb
 	pachctl create pipeline -f ml/object-detection/model.json
 	pachctl create pipeline -f ml/object-detection/detect.json
 	pachctl put file images@master:kites.jpg -f ml/object-detection/images/kites.jpg
+#	pachctl put file images@master:kites.jpg -f ml/object-detection/images/airplane.jpg
+
 
 hyperparameter:
 	pachctl create repo raw_data


### PR DESCRIPTION
I added data download targets for gatk & object detection so they're built with one command.
Added a clean target so that you can redownload the data if needed.
Updated gatk so it creates the reference repo and adds the reference data.

Now you can just type "make hyperparameter" or "make gatk" and they'll build with that one command.