### PR TITLE
Make TestUpdateStoppedPipeline more rigorous, and fix some related issues

### DIFF
--- a/src/server/auth/server/admin_test.go
+++ b/src/server/auth/server/admin_test.go
@@ -1503,7 +1503,7 @@ func TestDeleteRCInStandby(t *testing.T) {
 		[]*pfs.Commit{client.NewCommit(repo, "master")},
 		[]*pfs.Repo{client.NewRepo(pipeline)})
 	require.NoError(t, err)
-	require.NoErrorWithinT(t, 30*time.Second, func() error {
+	require.NoErrorWithinT(t, 60*time.Second, func() error {
 		_, err := iter.Next()
 		return err
 	})

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2504,8 +2504,6 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 	}
 
 	// Remove 'Stopped' from the pipeline spec
-	// TODO(msteffen): can I get rid of this and have the PPS master make the
-	// change?
 	pipelineInfo.Stopped = false
 	commit, err := a.makePipelineInfoCommit(pachClient, pipelineInfo)
 	if err != nil {

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -406,6 +406,11 @@ func NewAPIServer(pachClient *client.APIClient, etcdClient *etcd.Client, etcdPre
 			pipelineInfo.Transform.WorkingDir = image.Config.WorkingDir
 		}
 		if server.pipelineInfo.Transform.Cmd == nil {
+			if len(image.Config.Entrypoint) == 0 {
+				ppsutil.FailPipeline(ctx, etcdClient, server.pipelines,
+					pipelineInfo.Pipeline.Name,
+					"nothing to run: no transform.cmd and no entrypoint")
+			}
 			server.pipelineInfo.Transform.Cmd = image.Config.Entrypoint
 		}
 	}


### PR DESCRIPTION
Text fix for https://github.com/pachyderm/pachyderm/issues/3934. Also fixes a small bug where updating a stopped pipeline would create a spurious output commit, and starting a stopped pipeline would create a spurious output commit

Also fix https://github.com/pachyderm/pachyderm/issues/3932 and fix https://github.com/pachyderm/pachyderm/issues/3950