### PR TITLE
Make default config have v1 & add test

### DIFF
--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -286,7 +286,7 @@ func TestConfig(t *testing.T) {
 		echo "admin" | pachctl auth login
 		pachctl auth set-config <<EOF
 		{
-		  "live_config_version": 0,
+		  "live_config_version": 1,
 		  "id_providers": [{
 		    "name": "idp",
 		    "description": "fake ID provider for testing",
@@ -301,7 +301,7 @@ func TestConfig(t *testing.T) {
 		}
 		EOF
 		pachctl auth get-config \
-		  | match '"live_config_version": 1,' \
+		  | match '"live_config_version": 2,' \
 		  | match '"saml_svc_options": {' \
 		  | match '"acs_url": "http://www.example.com",' \
 		  | match '"metadata_url": "http://www.example.com"' \

--- a/src/server/auth/server/saml_test.go
+++ b/src/server/auth/server/saml_test.go
@@ -78,7 +78,7 @@ func TestValidateConfigMultipleSAMLIdPs(t *testing.T) {
 	configResp, err := adminClient.GetConfiguration(adminClient.Ctx(),
 		&auth.GetConfigurationRequest{})
 	require.NoError(t, err)
-	requireConfigsEqual(t, &auth.AuthConfig{}, configResp.Configuration)
+	requireConfigsEqual(t, &defaultAuthConfig, configResp.Configuration)
 }
 
 // TestValidateConfigErrMissingSAMLConfig tests that SetConfig rejects configs
@@ -109,7 +109,7 @@ func TestValidateConfigErrMissingSAMLConfig(t *testing.T) {
 	configResp, err := adminClient.GetConfiguration(adminClient.Ctx(),
 		&auth.GetConfigurationRequest{})
 	require.NoError(t, err)
-	requireConfigsEqual(t, &auth.AuthConfig{}, configResp.Configuration)
+	requireConfigsEqual(t, &defaultAuthConfig, configResp.Configuration)
 }
 
 func TestSAMLBasic(t *testing.T) {


### PR DESCRIPTION
Fix one more issue that I realized I'd forgotten in the prior config PR: the default config should have `LiveConfigVersion: 1`. This PR makes that change, and adds a test confirming that an interrupted R+M+W operation on the initial config doesn't work