### PR TITLE
Add PodSpec and PodPatch to util function converting PipelineInfo to CreatePipeLineRequest

### DIFF
--- a/src/server/admin/server/api_server.go
+++ b/src/server/admin/server/api_server.go
@@ -319,6 +319,8 @@ func pipelineInfoToRequest(pi *pps.PipelineInfo) *pps.CreatePipelineRequest {
 		ChunkSpec:          pi.ChunkSpec,
 		DatumTimeout:       pi.DatumTimeout,
 		JobTimeout:         pi.JobTimeout,
+		PodPatch:           pi.PodPatch,
+		PodSpec:            pi.PodSpec,
 	}
 }
 

--- a/src/server/pkg/ppsutil/util.go
+++ b/src/server/pkg/ppsutil/util.go
@@ -254,6 +254,8 @@ func PipelineReqFromInfo(pipelineInfo *ppsclient.PipelineInfo) *ppsclient.Create
 		DatumTimeout:       pipelineInfo.DatumTimeout,
 		JobTimeout:         pipelineInfo.JobTimeout,
 		Salt:               pipelineInfo.Salt,
+		PodSpec:            pipelineInfo.PodSpec,
+		PodPatch:           pipelineInfo.PodPatch,
 	}
 }
 


### PR DESCRIPTION
`pod_spec` and `pod_patch` and missing from both `ExtractPipeline` and `pachctl list pipeline --raw` - this adds them to the helper function converting between types.