### PR TITLE
Delete all should be paginated

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3726,7 +3726,25 @@ func (d *driver) deleteAll(txnCtx *txnenv.TransactionContext) error {
 		return err
 	}
 	for _, repoInfo := range repoInfos.RepoInfo {
-		if err := d.deleteRepo(txnCtx, repoInfo.Repo, true); err != nil && !auth.IsErrNotAuthorized(err) {
+		// split this between transactions because we're likely to run into etcd limits otherwise
+		if err := d.txnEnv.WithWriteContext(context.Background(), func(tc *txnenv.TransactionContext) error {
+			// try to delete without breaking pachyderm first, in case something goes wrong
+			if err := d.deleteRepo(tc, repoInfo.Repo, true); err != nil && !auth.IsErrNotAuthorized(err) {
+				logrus.Warnf("could not delete repo while preserving pachyderm invarians: ", err)
+			}
+			// regardless of whether that worked, we now delete everything directly, to make sure it's actually all gone
+			// check if the caller is authorized to delete this repo
+			if err := d.checkIsAuthorizedInTransaction(tc, repoInfo.Repo, auth.Scope_OWNER); err != nil {
+				return err
+			}
+
+			branches := d.branches(repoInfo.Repo.Name).ReadWrite(tc.Stm)
+			branches.DeleteAll()
+			commits := d.commits(repoInfo.Repo.Name).ReadWrite(tc.Stm)
+			commits.DeleteAll()
+			return nil
+
+		}); err != nil {
 			return err
 		}
 	}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3735,7 +3735,8 @@ func (d *driver) deleteAll(txnCtx *txnenv.TransactionContext) error {
 			// regardless of whether that worked, we now delete everything directly, to make sure it's actually all gone
 			// check if the caller is authorized to delete this repo
 			if err := d.checkIsAuthorizedInTransaction(tc, repoInfo.Repo, auth.Scope_OWNER); err != nil {
-				return err
+				logrus.Warnf("not authorized to delete repo %v: %v", repoInfo.Repo.Name, err)
+				return nil
 			}
 
 			branches := d.branches(repoInfo.Repo.Name).ReadWrite(tc.Stm)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3730,19 +3730,8 @@ func (d *driver) deleteAll(txnCtx *txnenv.TransactionContext) error {
 		if err := d.txnEnv.WithWriteContext(context.Background(), func(tc *txnenv.TransactionContext) error {
 			// try to delete without breaking pachyderm first, in case something goes wrong
 			if err := d.deleteRepo(tc, repoInfo.Repo, true); err != nil && !auth.IsErrNotAuthorized(err) {
-				logrus.Warnf("could not delete repo while preserving pachyderm invarians: ", err)
+				logrus.Warn("could not delete repo while preserving pachyderm invariants: ", err)
 			}
-			// regardless of whether that worked, we now delete everything directly, to make sure it's actually all gone
-			// check if the caller is authorized to delete this repo
-			if err := d.checkIsAuthorizedInTransaction(tc, repoInfo.Repo, auth.Scope_OWNER); err != nil {
-				logrus.Warnf("not authorized to delete repo %v: %v", repoInfo.Repo.Name, err)
-				return nil
-			}
-
-			branches := d.branches(repoInfo.Repo.Name).ReadWrite(tc.Stm)
-			branches.DeleteAll()
-			commits := d.commits(repoInfo.Repo.Name).ReadWrite(tc.Stm)
-			commits.DeleteAll()
 			return nil
 
 		}); err != nil {


### PR DESCRIPTION
DeleteAll done in a single transaction will often have a transactions size exceeding etcd's limit. Since we're trying to delete everything, we're not as concerned about possible data races, and instead find it worth it to split it into separate transactions.