### PR TITLE
Break up byte slices when writing a stream of bytes to gRPC

### DIFF
--- a/src/client/pkg/grpcutil/stream.go
+++ b/src/client/pkg/grpcutil/stream.go
@@ -107,8 +107,17 @@ func (s *streamingBytesWriter) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if err := s.streamingBytesServer.Send(&types.BytesValue{Value: p}); err != nil {
-		return 0, err
+	for i := 0; i < len(p); i += MaxMsgSize {
+		var sp []byte
+		if i+MaxMsgSize < len(p) {
+			sp = p[i : i+MaxMsgSize]
+		} else {
+			sp = p[i:]
+		}
+
+		if err := s.streamingBytesServer.Send(&types.BytesValue{Value: sp}); err != nil {
+			return 0, err
+		}
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
Fixes #3879 
