### PR TITLE
Ignore output not finished errors when putting files via s3gateway

### DIFF
--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -56,6 +56,12 @@ type ErrParentCommitNotFound struct {
 	Commit *pfs.Commit
 }
 
+// ErrOutputCommitNotFinished represents an error where the commit has not
+// been finished
+type ErrOutputCommitNotFinished struct {
+	Commit *pfs.Commit
+}
+
 func (e ErrFileNotFound) Error() string {
 	return fmt.Sprintf("file %v not found in repo %v at commit %v", e.File.Path, e.File.Commit.Repo.Name, e.File.Commit.ID)
 }
@@ -93,19 +99,24 @@ func (e ErrParentCommitNotFound) Error() string {
 	return fmt.Sprintf("parent commit %v not found in repo %v", e.Commit.ID, e.Commit.Repo.Name)
 }
 
+func (e ErrOutputCommitNotFinished) Error() string {
+	return fmt.Sprintf("output commit %v not finished", e.Commit.ID)
+}
+
 // ByteRangeSize returns byteRange.Upper - byteRange.Lower.
 func ByteRangeSize(byteRange *pfs.ByteRange) uint64 {
 	return byteRange.Upper - byteRange.Lower
 }
 
 var (
-	commitNotFoundRe = regexp.MustCompile("commit [^ ]+ not found in repo [^ ]+")
-	commitDeletedRe  = regexp.MustCompile("commit [^ ]+/[^ ]+ was deleted")
-	commitFinishedRe = regexp.MustCompile("commit [^ ]+ in repo [^ ]+ has already finished")
-	repoNotFoundRe   = regexp.MustCompile(`repos/ ?[a-zA-Z0-9.\-_]{1,255} not found`)
-	branchNotFoundRe = regexp.MustCompile(`branches/[a-zA-Z0-9.\-_]{1,255}/ [^ ]+ not found`)
-	fileNotFoundRe   = regexp.MustCompile(`file .+ not found`)
-	hasNoHeadRe      = regexp.MustCompile(`the branch .+ has no head \(create one with 'start commit'\)`)
+	commitNotFoundRe          = regexp.MustCompile("commit [^ ]+ not found in repo [^ ]+")
+	commitDeletedRe           = regexp.MustCompile("commit [^ ]+/[^ ]+ was deleted")
+	commitFinishedRe          = regexp.MustCompile("commit [^ ]+ in repo [^ ]+ has already finished")
+	repoNotFoundRe            = regexp.MustCompile(`repos/ ?[a-zA-Z0-9.\-_]{1,255} not found`)
+	branchNotFoundRe          = regexp.MustCompile(`branches/[a-zA-Z0-9.\-_]{1,255}/ [^ ]+ not found`)
+	fileNotFoundRe            = regexp.MustCompile(`file .+ not found`)
+	hasNoHeadRe               = regexp.MustCompile(`the branch .+ has no head \(create one with 'start commit'\)`)
+	outputCommitNotFinishedRe = regexp.MustCompile("output commit .+ not finished")
 )
 
 // IsCommitNotFoundErr returns true if 'err' has an error message that matches
@@ -162,11 +173,20 @@ func IsFileNotFoundErr(err error) bool {
 	return fileNotFoundRe.MatchString(err.Error())
 }
 
-// IsNoHeadError returns true if the err is due to an operation that cannot be
+// IsNoHeadErr returns true if the err is due to an operation that cannot be
 // performed on a headless branch
-func IsNoHeadError(err error) bool {
+func IsNoHeadErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	return hasNoHeadRe.MatchString(err.Error())
+}
+
+// IsOutputCommitNotFinishedErr returns true if the err is due to an operation
+// that cannot be performed on an unfinished output commit
+func IsOutputCommitNotFinishedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return outputCommitNotFinishedRe.MatchString(err.Error())
 }

--- a/src/server/pfs/s3/multipart.go
+++ b/src/server/pfs/s3/multipart.go
@@ -233,7 +233,7 @@ func (c *controller) CompleteMultipart(r *http.Request, bucket, key, uploadID st
 
 	// check if the destination file already exists, and if so, delete it
 	_, err = pc.InspectFile(repo, branch, key)
-	if err != nil && !pfsServer.IsFileNotFoundErr(err) && !pfsServer.IsNoHeadError(err) {
+	if err != nil && !pfsServer.IsFileNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
 		return nil, err
 	} else if err == nil {
 		err = pc.DeleteFile(repo, branch, key)
@@ -285,15 +285,16 @@ func (c *controller) CompleteMultipart(r *http.Request, bucket, key, uploadID st
 	}
 
 	fileInfo, err := pc.InspectFile(repo, branch, key)
-	if err != nil {
+	if err != nil && !pfsServer.IsOutputCommitNotFinishedErr(err) {
 		return nil, err
 	}
 
-	result := s2.CompleteMultipartResult{
-		Location: globalLocation,
-		ETag:     fmt.Sprintf("%x", fileInfo.Hash),
-		Version:  fileInfo.File.Commit.ID,
+	result := s2.CompleteMultipartResult{Location: globalLocation}
+	if fileInfo != nil {
+		result.ETag = fmt.Sprintf("%x", fileInfo.Hash)
+		result.Version = fileInfo.File.Commit.ID
 	}
+
 	return &result, nil
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3360,7 +3360,7 @@ func (d *driver) getFile(pachClient *client.APIClient, file *pfs.File, offset in
 	}
 	// Handle commits that use the newer hashtree format.
 	if commitInfo.Finished == nil {
-		return nil, fmt.Errorf("output commit %v not finished", commitInfo.Commit.ID)
+		return nil, pfsserver.ErrOutputCommitNotFinished{commitInfo.Commit}
 	}
 	if commitInfo.Trees == nil {
 		return nil, pfsserver.ErrFileNotFound{file}
@@ -3517,7 +3517,7 @@ func (d *driver) inspectFile(pachClient *client.APIClient, file *pfs.File) (fi *
 	}
 	// Handle commits that use the newer hashtree format.
 	if commitInfo.Finished == nil {
-		return nil, fmt.Errorf("output commit %v not finished", commitInfo.Commit.ID)
+		return nil, pfsserver.ErrOutputCommitNotFinished{commitInfo.Commit}
 	}
 	if commitInfo.Trees == nil {
 		return nil, pfsserver.ErrFileNotFound{file}
@@ -3590,7 +3590,7 @@ func (d *driver) listFile(pachClient *client.APIClient, file *pfs.File, full boo
 	}
 	// Handle commits that use the newer hashtree format.
 	if commitInfo.Finished == nil {
-		return fmt.Errorf("output commit %v not finished", commitInfo.Commit.ID)
+		return pfsserver.ErrOutputCommitNotFinished{commitInfo.Commit}
 	}
 	if commitInfo.Trees == nil {
 		return nil
@@ -3673,7 +3673,7 @@ func (d *driver) walkFile(pachClient *client.APIClient, file *pfs.File, f func(*
 	}
 	// Handle commits that use the newer hashtree format.
 	if commitInfo.Finished == nil {
-		return fmt.Errorf("output commit %v not finished", commitInfo.Commit.ID)
+		return pfsserver.ErrOutputCommitNotFinished{commitInfo.Commit}
 	}
 	if commitInfo.Trees == nil {
 		return nil
@@ -3723,7 +3723,7 @@ func (d *driver) globFile(pachClient *client.APIClient, commit *pfs.Commit, patt
 	}
 	// Handle commits that use the newer hashtree format.
 	if commitInfo.Finished == nil {
-		return fmt.Errorf("output commit %v not finished", commitInfo.Commit.ID)
+		return pfsserver.ErrOutputCommitNotFinished{commitInfo.Commit}
 	}
 	if commitInfo.Trees == nil {
 		return nil

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -384,7 +384,7 @@ func (a *apiServer) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 	}
 	// make sure there isn't an unfinished commit on the branch
 	commitInfo, err := pachClient.InspectCommit(in.Cron.Repo, "master")
-	if err != nil && !pfsServer.IsNoHeadError(err) {
+	if err != nil && !pfsServer.IsNoHeadErr(err) {
 		return err
 	} else if commitInfo != nil && commitInfo.Finished == nil {
 		// and if there is, delete it
@@ -395,7 +395,7 @@ func (a *apiServer) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 
 	var latestTime time.Time
 	files, err := pachClient.ListFile(in.Cron.Repo, "master", "")
-	if err != nil && !pfsServer.IsNoHeadError(err) {
+	if err != nil && !pfsServer.IsNoHeadErr(err) {
 		return err
 	} else if err != nil || len(files) == 0 {
 		// File not found, this happens the first time the pipeline is run
@@ -435,7 +435,7 @@ func (a *apiServer) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 		if in.Cron.Overwrite {
 			// If we want to "overwrite" the file, we need to delete the file with the previous time
 			err := pachClient.DeleteFile(in.Cron.Repo, "master", latestTime.Format(time.RFC3339))
-			if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadError(err) {
+			if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
 				return fmt.Errorf("delete error %v", err)
 			}
 		}


### PR DESCRIPTION
Closes #4065. This should be the best of both worlds: file hashes and versions will continue to be served when there are no open commits, and open commits will now be supported.