### PR TITLE
Update s3 gateway docs with recent changes

### DIFF
--- a/doc/enterprise/s3gateway.md
+++ b/doc/enterprise/s3gateway.md
@@ -45,11 +45,11 @@ commits by using the commit ID as the version.
 
 ## Port Forwarding
 
-If you do not have direct access to the kubernetes cluster, you can use port
+If you do not have direct access to the Kubernetes cluster, you can use port
 forwarding instead. Simply run `pachctl port-forward`, which will allow you
 to access the s3 gateway through `localhost:30600`.
 
-However, note that kubernetes' port forwarder incurs substantial overhead and
+However, the Kubernetes port forwarder incurs substantial overhead and
 does not recover well from broken connections. Connecting to the cluster
 directly is therefore faster and more reliable.
 

--- a/doc/enterprise/s3gateway.md
+++ b/doc/enterprise/s3gateway.md
@@ -4,7 +4,7 @@ Pachyderm Enterprise includes an S3 gateway that enables you to interact
 with PFS storage through an HTTP application programming interface (API)
 that imitates the Amazon S3 Storage API. Therefore, with Pachyderm S3
 gateway, you can interact with Pachyderm through tools and libraries designed
-to work with object stores; to name a few that we've tested against:
+to work with object stores. For example, you can use these tools:
 
 * [MinIO](https://docs.min.io/docs/minio-client-complete-guide)
 * [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html)
@@ -14,17 +14,17 @@ When you deploy `pachd`, the S3 gateway starts automatically. However, the
 S3 gateway is an enterprise feature that is only available to paid customers or
 during the free trial evaluation.
 
-The S3 gateway does have some limitations outlined below. If you need richer
-access, use the PFS gRPC interface instead, or one of our
+The S3 gateway has some limitations that are outlined below. If you need richer
+access, use the PFS gRPC interface instead, or one of the
 [client drivers](https://github.com/pachyderm/python-pachyderm).
 
 ## Authentication
 
 If auth is enabled on the Pachyderm cluster, credentials must be passed with
 each s3 gateway endpoint using AWS' signature v2 or v4 methods. Object store
-tools and libraries will have built-in support for these methods, but they do
-not work in the browser. When using authentication, the access and secret key
-should be set to the same value; they are both the Pachyderm auth token used
+tools and libraries provide built-in support for these methods, but they do
+not work in the browser. When you use authentication, set the access and secret key
+to the same value; they are both the Pachyderm auth token used
 to issue the relevant PFS calls.
 
 If auth is not enabled on the Pachyderm cluster, no credentials need to be
@@ -99,7 +99,7 @@ the following command:
            },
      ```
 
-     Note that both the access key and secret key should be set to your
+     Set both the access key and secret key to your
      Pachyderm auth token. If auth is not enabled on the cluster, both should
      be empty strings.
 
@@ -183,7 +183,7 @@ For example, in macOS, run:
      HTTP Proxy server port: 0
    ```
 
-   Note that both the access key and secret key should be set to your
+   Set both the access key and secret key to your
    Pachyderm auth token. If auth is not enabled on the cluster, both should
    be empty strings.
 

--- a/doc/enterprise/s3gateway.md
+++ b/doc/enterprise/s3gateway.md
@@ -67,7 +67,7 @@ To install and configure MinIO, complete the following steps:
 
 1. Install the MinIO client on your platform as
 described on the [MinIO download page](https://min.io/download#/macos).
-2. Verify that MinIO components are successfully installed by running
+1. Verify that MinIO components are successfully installed by running
 the following command:
 
    ```bash
@@ -78,7 +78,7 @@ the following command:
    Commit-id: 31e5ac02bdbdbaf20a87683925041f406307cfb9
    ```
 
-3. Set up the MinIO configuration file to use the `30600` port for your host:
+1. Set up the MinIO configuration file to use the `30600` port for your host:
 
    ```bash
    vi ~/.mc/config.json
@@ -114,13 +114,13 @@ complete the following steps:
 1. Install the AWS CLI for your operating system as described
 in the [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
 
-2. Verify that the AWS CLI is installed:
+1. Verify that the AWS CLI is installed:
 
    ```bash
    $ aws --version aws-cli/1.16.204 Python/2.7.16 Darwin/17.7.0 botocore/1.12.194
    ```
 
-3. Configure AWS CLI:
+1. Configure AWS CLI:
 
    ```bash
    $ aws configure
@@ -150,21 +150,21 @@ For example, in macOS, run:
    $ brew install s3cmd
    ```
 
-2. Verify that S3cmd is installed:
+1. Verify that S3cmd is installed:
 
    ```bash
    $ s3cmd --version
    s3cmd version 2.0.2
    ```
 
-3. Configure S3cmd to use Pachyderm:
+1. Configure S3cmd to use Pachyderm:
 
    ```bash
    $ s3cmd --configure
      ...
    ```
 
-4. Fill all fields and specify the following settings for Pachyderm.
+1. Fill all fields and specify the following settings for Pachyderm.
 
    **Example:**
 
@@ -242,7 +242,7 @@ To list filesystem objects, complete the following steps:
      2019-07-12 14:36 master.raw_data
      ```
 
-2. List the contents of a repository:
+1. List the contents of a repository:
 
    * If you are using MinIO, type:
 
@@ -298,7 +298,7 @@ S3 bucket, which is a repository with a branch in Pachyderm.
 
    This command creates the `test` repository with the `master` branch.
 
-2. Verify that the S3 bucket has been successfully created:
+1. Verify that the S3 bucket has been successfully created:
 
    * If you are using MinIO, type:
 
@@ -416,7 +416,7 @@ To add a file to a repository, complete the following steps:
    These commands add the `test.csv` file to the `master` branch in
    the `raw_data` repository. `raw_data` is an input repository.
 
-2. Check that the file was added:
+1. Check that the file was added:
 
    * If you are using MinIO, type:
 
@@ -442,7 +442,7 @@ To add a file to a repository, complete the following steps:
      2019-07-19 12:11       62 test.csv
      ```
 
-3. Download a file from MinIO to the
+1. Download a file from MinIO to the
 current directory by running the following commands:
 
    * If you are using MinIO, type:
@@ -496,7 +496,7 @@ MinIO command-line interface:
       2019-07-19 12:11         62 test.csv
       ```
 
-2. Delete a file from a repository. Example:
+1. Delete a file from a repository. Example:
 
    * If you are using MinIO, type:
 

--- a/doc/reference/s3gateway_api.md
+++ b/doc/reference/s3gateway_api.md
@@ -10,9 +10,9 @@ working knowledge of S3 and HTTP is assumed.
 
 ### Authentication
 
-If authentication is not enabled on the Pachyderm cluster, s3 gateway endpoints can be hit without passing auth credentials.
+If authentication is not enabled on the Pachyderm cluster, S3 gateway endpoints can be hit without passing auth credentials.
 
-If authentication is enabled, credentials must be passed using AWS' [signature v2](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html) or [signature v4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) methods. For both methods, the AWS access key and secret key should be set to the same value; they are both the Pachyderm auth token used to issue the relevant PFS calls. Note that one or both signature methods are built into all s3 tools and libraries already, so you don't need to hand-roll these methods.
+If authentication is enabled, credentials must be passed using AWS' [signature v2](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html) or [signature v4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) methods. For both methods, set the AWS access key and secret key to the same value. Both values are the Pachyderm auth token that is used to issue the relevant PFS calls. One or both signature methods are built into most s3 tools and libraries already, so you do not need to configure these methods manually.
 
 ### Operations on the Service
 
@@ -126,7 +126,7 @@ Aborts an in-progress multipart upload.
 
 Route: `POST /<branch>.<repo>?uploadId=<uploadId>`
 
-Completes a multipart upload. Note that if ETags are included in the request payload, they must be of the same format as returned by s3 gateway when the multipart chunks are included. If they are md5 hashes (or any other hash algorithm), they will be ignored.
+Completes a multipart upload. If ETags are included in the request payload, they must be of the same format as returned by the s3 gateway when the multipart chunks are included. If they are `md5` hashes or any other hash algorithm, they are ignored.
 
 #### Initiate Multipart Upload
 

--- a/doc/reference/s3gateway_api.md
+++ b/doc/reference/s3gateway_api.md
@@ -1,12 +1,18 @@
-# S3Gateway API
+# S3 Gateway API
 
-This outlines the HTTP API exposed by the s3gateway and any peculiarities
+This outlines the HTTP API exposed by the s3 gateway and any peculiarities
 relative to S3. The operations largely mirror those documented in S3's
 [official docs](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html).
 
 Generally, you would not call these endpoints directly, but rather use a
 tool or library designed to work with S3-like APIs. Because of that, some
 working knowledge of S3 and HTTP is assumed.
+
+### Authentication
+
+If authentication is not enabled on the Pachyderm cluster, s3 gateway endpoints can be hit without passing auth credentials.
+
+If authentication is enabled, credentials must be passed using AWS' [signature v2](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html) or [signature v4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) methods. For both methods, the AWS access key and secret key should be set to the same value; they are both the Pachyderm auth token used to issue the relevant PFS calls. Note that one or both signature methods are built into all s3 tools and libraries already, so you don't need to hand-roll these methods.
 
 ### Operations on the Service
 
@@ -120,7 +126,7 @@ Aborts an in-progress multipart upload.
 
 Route: `POST /<branch>.<repo>?uploadId=<uploadId>`
 
-Completes a multipart upload. Note that if ETags are included in the request payload, they must be of the same format as returned by s3gateway when the multipart chunks are included. If they are md5 hashes (or any other hash algorithm), they will be ignored.
+Completes a multipart upload. Note that if ETags are included in the request payload, they must be of the same format as returned by s3 gateway when the multipart chunks are included. If they are md5 hashes (or any other hash algorithm), they will be ignored.
 
 #### Initiate Multipart Upload
 


### PR DESCRIPTION
Closes #4064 

I also cut out the browser and curl example of bucket listing because it no longer works with auth mode, as well as some other minor touch-ups. The parts about authentication probably need the most vetting, as AWS' idiosyncratic authentication methodologies are not the most straight-forward to explain.