### PR TITLE
Bring back `--namespace` to `pachctl port-forward`

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -314,7 +314,7 @@ func portForwarder() *PortForwarder {
 	// NOTE: this will always use the default namespace; if a custom
 	// namespace is required with port forwarding,
 	// `pachctl port-forward` should be explicitly called.
-	fw, err := NewPortForwarder()
+	fw, err := NewPortForwarder("")
 	if err != nil {
 		log.Infof("Implicit port forwarding was not enabled because the kubernetes config could not be read: %v", err)
 		return nil

--- a/src/client/pkg/config/kube_config.go
+++ b/src/client/pkg/config/kube_config.go
@@ -8,7 +8,6 @@ import (
 // KubeConfig gets the kubernetes config
 func KubeConfig(context *Context) clientcmd.ClientConfig {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-
 	overrides := &clientcmd.ConfigOverrides{}
 	if context != nil {
 		overrides.Context = api.Context{

--- a/src/client/portforwarder.go
+++ b/src/client/portforwarder.go
@@ -46,7 +46,7 @@ type PortForwarder struct {
 }
 
 // NewPortForwarder creates a new port forwarder
-func NewPortForwarder() (*PortForwarder, error) {
+func NewPortForwarder(namespace string) (*PortForwarder, error) {
 	cfg, err := config.Read()
 	if err != nil {
 		return nil, fmt.Errorf("could not read config: %v", err)
@@ -54,6 +54,10 @@ func NewPortForwarder() (*PortForwarder, error) {
 	_, context, err := cfg.ActiveContext()
 	if err != nil {
 		return nil, fmt.Errorf("could not get active context: %v", err)
+	}
+
+	if namespace == "" {
+		namespace = context.Namespace
 	}
 
 	kubeConfig := config.KubeConfig(context)
@@ -74,7 +78,7 @@ func NewPortForwarder() (*PortForwarder, error) {
 		core:          core,
 		client:        core.RESTClient(),
 		config:        kubeClientConfig,
-		namespace:     context.Namespace,
+		namespace:     namespace,
 		logger:        log.StandardLogger().Writer(),
 		stopChansLock: &sync.Mutex{},
 		stopChans:     []chan struct{}{},

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -504,11 +504,16 @@ This resets the cluster to its initial state.`,
 	var uiWebsocketPort uint16
 	var pfsPort uint16
 	var s3gatewayPort uint16
+	var namespace string
 	portForward := &cobra.Command{
 		Short: "Forward a port on the local machine to pachd. This command blocks.",
 		Long:  "Forward a port on the local machine to pachd. This command blocks.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			fw, err := client.NewPortForwarder()
+			if namespace != "" {
+				fmt.Printf("WARNING: The `--namespace` flag is deprecated and will be removed in a future version. Please set the namespace in the pachyderm context instead: pachctl config update context `pachctl config get active-context` --namespace '%s'\n", namespace)
+			}
+
+			fw, err := client.NewPortForwarder(namespace)
 			if err != nil {
 				return err
 			}
@@ -574,6 +579,7 @@ This resets the cluster to its initial state.`,
 	portForward.Flags().Uint16VarP(&uiWebsocketPort, "proxy-port", "x", 30081, "The local port to bind Pachyderm's dash proxy service to.")
 	portForward.Flags().Uint16VarP(&pfsPort, "pfs-port", "f", 30652, "The local port to bind PFS over HTTP to.")
 	portForward.Flags().Uint16VarP(&s3gatewayPort, "s3gateway-port", "s", 30600, "The local port to bind the s3gateway to.")
+	portForward.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace Pachyderm is deployed in.")
 	subcommands = append(subcommands, cmdutil.CreateAlias(portForward, "port-forward"))
 
 	var install bool


### PR DESCRIPTION
This brings the namespace flag back so fewer users are affected by the embedded contexts transition, and prints a warning that it'll be removed in a future version