### PR TITLE
Expose advanced configuration for amazon client

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -1231,52 +1231,56 @@ func LocalSecret() map[string][]byte {
 }
 
 // AmazonSecret creates an amazon secret with the following parameters:
-//   region       - AWS region
-//   bucket       - S3 bucket name
-//   id           - AWS access key id
-//   secret       - AWS secret access key
-//   token        - AWS access token
-//   distribution - cloudfront distribution
-//   endpoint     - Custom endpoint (generally used for S3 compatible object stores)
-func AmazonSecret(region, bucket, id, secret, token, distribution, endpoint string) map[string][]byte {
-	return map[string][]byte{
-		"amazon-region":       []byte(region),
-		"amazon-bucket":       []byte(bucket),
-		"amazon-id":           []byte(id),
-		"amazon-secret":       []byte(secret),
-		"amazon-token":        []byte(token),
-		"amazon-distribution": []byte(distribution),
-		"custom-endpoint":     []byte(endpoint),
-	}
+//   region         - AWS region
+//   bucket         - S3 bucket name
+//   id             - AWS access key id
+//   secret         - AWS secret access key
+//   token          - AWS access token
+//   distribution   - cloudfront distribution
+//   endpoint       - Custom endpoint (generally used for S3 compatible object stores)
+//   advancedConfig - advanced configuration
+func AmazonSecret(region, bucket, id, secret, token, distribution, endpoint string, advancedConfig *obj.AmazonAdvancedConfiguration) map[string][]byte {
+	s := amazonBasicSecret(region, bucket, distribution, advancedConfig)
+	s["amazon-id"] = []byte(id)
+	s["amazon-secret"] = []byte(secret)
+	s["amazon-token"] = []byte(token)
+	s["custom-endpoint"] = []byte(endpoint)
+	return s
 }
 
 // AmazonVaultSecret creates an amazon secret with the following parameters:
-//   region       - AWS region
-//   bucket       - S3 bucket name
-//   vaultAddress - address/hostport of vault
-//   vaultRole    - pachd's role in vault
-//   vaultToken   - pachd's vault token
-//   distribution - cloudfront distribution
-func AmazonVaultSecret(region, bucket, vaultAddress, vaultRole, vaultToken, distribution string) map[string][]byte {
-	return map[string][]byte{
-		"amazon-region":       []byte(region),
-		"amazon-bucket":       []byte(bucket),
-		"amazon-vault-addr":   []byte(vaultAddress),
-		"amazon-vault-role":   []byte(vaultRole),
-		"amazon-vault-token":  []byte(vaultToken),
-		"amazon-distribution": []byte(distribution),
-	}
+//   region         - AWS region
+//   bucket         - S3 bucket name
+//   vaultAddress   - address/hostport of vault
+//   vaultRole      - pachd's role in vault
+//   vaultToken     - pachd's vault token
+//   distribution   - cloudfront distribution
+//   advancedConfig - advanced configuration
+func AmazonVaultSecret(region, bucket, vaultAddress, vaultRole, vaultToken, distribution string, advancedConfig *obj.AmazonAdvancedConfiguration) map[string][]byte {
+	s := amazonBasicSecret(region, bucket, distribution, advancedConfig)
+	s["amazon-vault-addr"] = []byte(vaultAddress)
+	s["amazon-vault-role"] = []byte(vaultRole)
+	s["amazon-vault-token"] = []byte(vaultToken)
+	return s
 }
 
 // AmazonIAMRoleSecret creates an amazon secret with the following parameters:
-//   region       - AWS region
-//   bucket       - S3 bucket name
-//   distribution - cloudfront distribution
-func AmazonIAMRoleSecret(region, bucket, distribution string) map[string][]byte {
+//   region         - AWS region
+//   bucket         - S3 bucket name
+//   distribution   - cloudfront distribution
+//   advancedConfig - advanced configuration
+func AmazonIAMRoleSecret(region, bucket, distribution string, advancedConfig *obj.AmazonAdvancedConfiguration) map[string][]byte {
+	return amazonBasicSecret(region, bucket, distribution, advancedConfig)
+}
+
+func amazonBasicSecret(region, bucket, distribution string, advancedConfig *obj.AmazonAdvancedConfiguration) map[string][]byte {
 	return map[string][]byte{
 		"amazon-region":       []byte(region),
 		"amazon-bucket":       []byte(bucket),
 		"amazon-distribution": []byte(distribution),
+		"retries":             []byte(strconv.Itoa(advancedConfig.Retries)),
+		"timeout":             []byte(advancedConfig.Timeout),
+		"upload-acl":          []byte(advancedConfig.UploadACL),
 	}
 }
 
@@ -1476,7 +1480,7 @@ func WriteLocalAssets(encoder Encoder, opts *AssetOpts, hostPath string) error {
 
 // WriteCustomAssets writes assets to a custom combination of object-store and persistent disk.
 func WriteCustomAssets(encoder Encoder, opts *AssetOpts, args []string, objectStoreBackend string,
-	persistentDiskBackend string, secure, isS3V2 bool) error {
+	persistentDiskBackend string, secure, isS3V2 bool, advancedConfig *obj.AmazonAdvancedConfiguration) error {
 	switch objectStoreBackend {
 	case "s3":
 		if len(args) != s3CustomArgs {
@@ -1515,7 +1519,7 @@ func WriteCustomAssets(encoder Encoder, opts *AssetOpts, args []string, objectSt
 			return WriteSecret(encoder, MinioSecret(bucket, id, secret, endpoint, secure, isS3V2), opts)
 		}
 		// (bryce) hardcode region?
-		return WriteSecret(encoder, AmazonSecret("us-east-1", bucket, id, secret, "", "", endpoint), opts)
+		return WriteSecret(encoder, AmazonSecret("us-east-1", bucket, id, secret, "", "", endpoint, advancedConfig), opts)
 	default:
 		return fmt.Errorf("Did not recognize the choice of object-store")
 	}
@@ -1537,17 +1541,17 @@ type AmazonCreds struct {
 }
 
 // WriteAmazonAssets writes assets to an amazon backend.
-func WriteAmazonAssets(encoder Encoder, opts *AssetOpts, region string, bucket string, volumeSize int, creds *AmazonCreds, cloudfrontDistro string) error {
+func WriteAmazonAssets(encoder Encoder, opts *AssetOpts, region string, bucket string, volumeSize int, creds *AmazonCreds, cloudfrontDistro string, advancedConfig *obj.AmazonAdvancedConfiguration) error {
 	if err := WriteAssets(encoder, opts, amazonBackend, amazonBackend, volumeSize, ""); err != nil {
 		return err
 	}
 	var secret map[string][]byte
 	if creds == nil {
-		secret = AmazonIAMRoleSecret(region, bucket, cloudfrontDistro)
+		secret = AmazonIAMRoleSecret(region, bucket, cloudfrontDistro, advancedConfig)
 	} else if creds.ID != "" {
-		secret = AmazonSecret(region, bucket, creds.ID, creds.Secret, creds.Token, cloudfrontDistro, "")
+		secret = AmazonSecret(region, bucket, creds.ID, creds.Secret, creds.Token, cloudfrontDistro, "", advancedConfig)
 	} else if creds.VaultAddress != "" {
-		secret = AmazonVaultSecret(region, bucket, creds.VaultAddress, creds.VaultRole, creds.VaultToken, cloudfrontDistro)
+		secret = AmazonVaultSecret(region, bucket, creds.VaultAddress, creds.VaultRole, creds.VaultToken, cloudfrontDistro, advancedConfig)
 	}
 	return WriteSecret(encoder, secret, opts)
 }

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -1282,6 +1282,8 @@ func amazonBasicSecret(region, bucket, distribution string, advancedConfig *obj.
 		"timeout":             []byte(advancedConfig.Timeout),
 		"upload-acl":          []byte(advancedConfig.UploadACL),
 		"reverse":             []byte(strconv.FormatBool(advancedConfig.Reverse)),
+		"part-size":           []byte(strconv.FormatInt(advancedConfig.PartSize, 10)),
+		"max-upload-parts":    []byte(strconv.Itoa(advancedConfig.MaxUploadParts)),
 	}
 }
 

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -1281,6 +1281,7 @@ func amazonBasicSecret(region, bucket, distribution string, advancedConfig *obj.
 		"retries":             []byte(strconv.Itoa(advancedConfig.Retries)),
 		"timeout":             []byte(advancedConfig.Timeout),
 		"upload-acl":          []byte(advancedConfig.UploadACL),
+		"reverse":             []byte(strconv.FormatBool(advancedConfig.Reverse)),
 	}
 }
 

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -309,6 +309,7 @@ func deployCmds() []*cobra.Command {
 	var retries int
 	var timeout string
 	var uploadACL string
+	var reverse bool
 	deployCustom := &cobra.Command{
 		Use:   "{{alias}} --persistent-disk <persistent disk backend> --object-store <object store backend> <persistent disk args> <object store args>",
 		Short: "Deploy a custom Pachyderm cluster configuration",
@@ -328,6 +329,7 @@ If <object store backend> is \"s3\", then the arguments are:
 				Retries:   retries,
 				Timeout:   timeout,
 				UploadACL: uploadACL,
+				Reverse:   reverse,
 			}
 			// Generate manifest and write assets.
 			manifest := getEncoder(outputFormat)
@@ -360,6 +362,7 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployCustom.Flags().IntVar(&retries, "retries", obj.DefaultRetries, "(rarely set / S3V2 incompatible) Set a custom number of retries for object storage requests.")
 	deployCustom.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set / S3V2 incompatible) Set a custom timeout for object storage requests.")
 	deployCustom.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set / S3V2 incompatible) Set a custom upload ACL for object storage uploads.")
+	deployCustom.Flags().BoolVar(&reverse, "reverse", obj.DefaultReverse, "(rarely set) Reverse object storage paths.")
 	commands = append(commands, cmdutil.CreateAlias(deployCustom, "deploy custom"))
 
 	var cloudfrontDistribution string
@@ -451,6 +454,7 @@ If <object store backend> is \"s3\", then the arguments are:
 				Retries:   retries,
 				Timeout:   timeout,
 				UploadACL: uploadACL,
+				Reverse:   reverse,
 			}
 			// Generate manifest and write assets.
 			manifest := getEncoder(outputFormat)
@@ -481,6 +485,7 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployAmazon.Flags().IntVar(&retries, "retries", obj.DefaultRetries, "(rarely set) Set a custom number of retries for object storage requests.")
 	deployAmazon.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set) Set a custom timeout for object storage requests.")
 	deployAmazon.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set) Set a custom upload ACL for object storage uploads.")
+	deployAmazon.Flags().BoolVar(&reverse, "reverse", obj.DefaultReverse, "(rarely set) Reverse object storage paths.")
 	commands = append(commands, cmdutil.CreateAlias(deployAmazon, "deploy amazon"))
 
 	deployMicrosoft := &cobra.Command{
@@ -582,6 +587,7 @@ If <object store backend> is \"s3\", then the arguments are:
 				Retries:   retries,
 				Timeout:   timeout,
 				UploadACL: uploadACL,
+				Reverse:   reverse,
 			}
 			return deployStorageSecrets(assets.AmazonSecret(args[0], "", args[1], args[2], token, "", "", advancedConfig))
 		}),
@@ -589,6 +595,7 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployStorageAmazon.Flags().IntVar(&retries, "retries", obj.DefaultRetries, "(rarely set) Set a custom number of retries for object storage requests.")
 	deployStorageAmazon.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set) Set a custom timeout for object storage requests.")
 	deployStorageAmazon.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set) Set a custom upload ACL for object storage uploads.")
+	deployStorageAmazon.Flags().BoolVar(&reverse, "reverse", obj.DefaultReverse, "(rarely set) Reverse object storage paths.")
 	commands = append(commands, cmdutil.CreateAlias(deployStorageAmazon, "deploy storage amazon"))
 
 	deployStorageGoogle := &cobra.Command{

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/deploy/assets"
 	"github.com/pachyderm/pachyderm/src/server/pkg/deploy/images"
 	_metrics "github.com/pachyderm/pachyderm/src/server/pkg/metrics"
+	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/proto"
@@ -305,6 +306,9 @@ func deployCmds() []*cobra.Command {
 	var persistentDiskBackend string
 	var secure bool
 	var isS3V2 bool
+	var retries int
+	var timeout string
+	var uploadACL string
 	deployCustom := &cobra.Command{
 		Use:   "{{alias}} --persistent-disk <persistent disk backend> --object-store <object store backend> <persistent disk args> <object store args>",
 		Short: "Deploy a custom Pachyderm cluster configuration",
@@ -319,8 +323,15 @@ If <object store backend> is \"s3\", then the arguments are:
 				finishMetricsWait := _metrics.FinishReportAndFlushUserAction("Deploy", retErr, start)
 				finishMetricsWait()
 			}()
+			// Setup advanced configuration.
+			advancedConfig := &obj.AmazonAdvancedConfiguration{
+				Retries:   retries,
+				Timeout:   timeout,
+				UploadACL: uploadACL,
+			}
+			// Generate manifest and write assets.
 			manifest := getEncoder(outputFormat)
-			err := assets.WriteCustomAssets(manifest, opts, args, objectStoreBackend, persistentDiskBackend, secure, isS3V2)
+			err := assets.WriteCustomAssets(manifest, opts, args, objectStoreBackend, persistentDiskBackend, secure, isS3V2, advancedConfig)
 			if err != nil {
 				return err
 			}
@@ -346,6 +357,9 @@ If <object store backend> is \"s3\", then the arguments are:
 		"(required) Backend providing an object-storage API to pachyderm. One of: "+
 			"s3, gcs, or azure-blob.")
 	deployCustom.Flags().BoolVar(&isS3V2, "isS3V2", false, "Enable S3V2 client")
+	deployCustom.Flags().IntVar(&retries, "retries", obj.DefaultRetries, "(rarely set / S3V2 incompatible) Set a custom number of retries for object storage requests.")
+	deployCustom.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set / S3V2 incompatible) Set a custom timeout for object storage requests.")
+	deployCustom.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set / S3V2 incompatible) Set a custom upload ACL for object storage uploads.")
 	commands = append(commands, cmdutil.CreateAlias(deployCustom, "deploy custom"))
 
 	var cloudfrontDistribution string
@@ -432,10 +446,15 @@ If <object store backend> is \"s3\", then the arguments are:
 					os.Exit(1)
 				}
 			}
-
-			// generate manifest and write assets
+			// Setup advanced configuration.
+			advancedConfig := &obj.AmazonAdvancedConfiguration{
+				Retries:   retries,
+				Timeout:   timeout,
+				UploadACL: uploadACL,
+			}
+			// Generate manifest and write assets.
 			manifest := getEncoder(outputFormat)
-			if err = assets.WriteAmazonAssets(manifest, opts, region, bucket, volumeSize, amazonCreds, cloudfrontDistribution); err != nil {
+			if err = assets.WriteAmazonAssets(manifest, opts, region, bucket, volumeSize, amazonCreds, cloudfrontDistribution, advancedConfig); err != nil {
 				return err
 			}
 			if err := kubectlCreate(dryRun, manifest, opts); err != nil {
@@ -459,6 +478,9 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployAmazon.Flags().StringVar(&creds, "credentials", "", "Use the format \"<id>,<secret>[,<token>]\". You can get a token by running \"aws sts get-session-token\".")
 	deployAmazon.Flags().StringVar(&vault, "vault", "", "Use the format \"<address/hostport>,<role>,<token>\".")
 	deployAmazon.Flags().StringVar(&iamRole, "iam-role", "", fmt.Sprintf("Use the given IAM role for authorization, as opposed to using static credentials. The given role will be applied as the annotation %s, this used with a Kubernetes IAM role management system such as kube2iam allows you to give pachd credentials in a more secure way.", assets.IAMAnnotation))
+	deployAmazon.Flags().IntVar(&retries, "retries", obj.DefaultRetries, "(rarely set) Set a custom number of retries for object storage requests.")
+	deployAmazon.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set) Set a custom timeout for object storage requests.")
+	deployAmazon.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set) Set a custom upload ACL for object storage uploads.")
 	commands = append(commands, cmdutil.CreateAlias(deployAmazon, "deploy amazon"))
 
 	deployMicrosoft := &cobra.Command{
@@ -555,9 +577,18 @@ If <object store backend> is \"s3\", then the arguments are:
 			if len(args) == 4 {
 				token = args[3]
 			}
-			return deployStorageSecrets(assets.AmazonSecret(args[0], "", args[1], args[2], token, "", ""))
+			// Setup advanced configuration.
+			advancedConfig := &obj.AmazonAdvancedConfiguration{
+				Retries:   retries,
+				Timeout:   timeout,
+				UploadACL: uploadACL,
+			}
+			return deployStorageSecrets(assets.AmazonSecret(args[0], "", args[1], args[2], token, "", "", advancedConfig))
 		}),
 	}
+	deployStorageAmazon.Flags().IntVar(&retries, "retries", obj.DefaultRetries, "(rarely set) Set a custom number of retries for object storage requests.")
+	deployStorageAmazon.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set) Set a custom timeout for object storage requests.")
+	deployStorageAmazon.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set) Set a custom upload ACL for object storage uploads.")
 	commands = append(commands, cmdutil.CreateAlias(deployStorageAmazon, "deploy storage amazon"))
 
 	deployStorageGoogle := &cobra.Command{

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -310,6 +310,8 @@ func deployCmds() []*cobra.Command {
 	var timeout string
 	var uploadACL string
 	var reverse bool
+	var partSize int64
+	var maxUploadParts int
 	deployCustom := &cobra.Command{
 		Use:   "{{alias}} --persistent-disk <persistent disk backend> --object-store <object store backend> <persistent disk args> <object store args>",
 		Short: "Deploy a custom Pachyderm cluster configuration",
@@ -326,10 +328,12 @@ If <object store backend> is \"s3\", then the arguments are:
 			}()
 			// Setup advanced configuration.
 			advancedConfig := &obj.AmazonAdvancedConfiguration{
-				Retries:   retries,
-				Timeout:   timeout,
-				UploadACL: uploadACL,
-				Reverse:   reverse,
+				Retries:        retries,
+				Timeout:        timeout,
+				UploadACL:      uploadACL,
+				Reverse:        reverse,
+				PartSize:       partSize,
+				MaxUploadParts: maxUploadParts,
 			}
 			// Generate manifest and write assets.
 			manifest := getEncoder(outputFormat)
@@ -363,6 +367,8 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployCustom.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set / S3V2 incompatible) Set a custom timeout for object storage requests.")
 	deployCustom.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set / S3V2 incompatible) Set a custom upload ACL for object storage uploads.")
 	deployCustom.Flags().BoolVar(&reverse, "reverse", obj.DefaultReverse, "(rarely set) Reverse object storage paths.")
+	deployCustom.Flags().Int64Var(&partSize, "part-size", obj.DefaultPartSize, "(rarely set / S3V2 incompatible) Set a custom part size for object storage uploads.")
+	deployCustom.Flags().IntVar(&maxUploadParts, "max-upload-parts", obj.DefaultMaxUploadParts, "(rarely set / S3V2 incompatible) Set a custom maximum number of upload parts.")
 	commands = append(commands, cmdutil.CreateAlias(deployCustom, "deploy custom"))
 
 	var cloudfrontDistribution string
@@ -451,10 +457,12 @@ If <object store backend> is \"s3\", then the arguments are:
 			}
 			// Setup advanced configuration.
 			advancedConfig := &obj.AmazonAdvancedConfiguration{
-				Retries:   retries,
-				Timeout:   timeout,
-				UploadACL: uploadACL,
-				Reverse:   reverse,
+				Retries:        retries,
+				Timeout:        timeout,
+				UploadACL:      uploadACL,
+				Reverse:        reverse,
+				PartSize:       partSize,
+				MaxUploadParts: maxUploadParts,
 			}
 			// Generate manifest and write assets.
 			manifest := getEncoder(outputFormat)
@@ -486,6 +494,8 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployAmazon.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set) Set a custom timeout for object storage requests.")
 	deployAmazon.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set) Set a custom upload ACL for object storage uploads.")
 	deployAmazon.Flags().BoolVar(&reverse, "reverse", obj.DefaultReverse, "(rarely set) Reverse object storage paths.")
+	deployAmazon.Flags().Int64Var(&partSize, "part-size", obj.DefaultPartSize, "(rarely set) Set a custom part size for object storage uploads.")
+	deployAmazon.Flags().IntVar(&maxUploadParts, "max-upload-parts", obj.DefaultMaxUploadParts, "(rarely set) Set a custom maximum number of upload parts.")
 	commands = append(commands, cmdutil.CreateAlias(deployAmazon, "deploy amazon"))
 
 	deployMicrosoft := &cobra.Command{
@@ -584,10 +594,12 @@ If <object store backend> is \"s3\", then the arguments are:
 			}
 			// Setup advanced configuration.
 			advancedConfig := &obj.AmazonAdvancedConfiguration{
-				Retries:   retries,
-				Timeout:   timeout,
-				UploadACL: uploadACL,
-				Reverse:   reverse,
+				Retries:        retries,
+				Timeout:        timeout,
+				UploadACL:      uploadACL,
+				Reverse:        reverse,
+				PartSize:       partSize,
+				MaxUploadParts: maxUploadParts,
 			}
 			return deployStorageSecrets(assets.AmazonSecret(args[0], "", args[1], args[2], token, "", "", advancedConfig))
 		}),
@@ -596,6 +608,8 @@ If <object store backend> is \"s3\", then the arguments are:
 	deployStorageAmazon.Flags().StringVar(&timeout, "timeout", obj.DefaultTimeout, "(rarely set) Set a custom timeout for object storage requests.")
 	deployStorageAmazon.Flags().StringVar(&uploadACL, "upload-acl", obj.DefaultUploadACL, "(rarely set) Set a custom upload ACL for object storage uploads.")
 	deployStorageAmazon.Flags().BoolVar(&reverse, "reverse", obj.DefaultReverse, "(rarely set) Reverse object storage paths.")
+	deployStorageAmazon.Flags().Int64Var(&partSize, "part-size", obj.DefaultPartSize, "(rarely set) Set a custom part size for object storage uploads.")
+	deployStorageAmazon.Flags().IntVar(&maxUploadParts, "max-upload-parts", obj.DefaultMaxUploadParts, "(rarely set) Set a custom maximum number of upload parts.")
 	commands = append(commands, cmdutil.CreateAlias(deployStorageAmazon, "deploy storage amazon"))
 
 	deployStorageGoogle := &cobra.Command{

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -30,14 +30,6 @@ import (
 
 const oneDayInSeconds = 60 * 60 * 24
 const twoDaysInSeconds = 60 * 60 * 48
-const maxRetries = 10
-
-var (
-	// By default, objects uploaded to a bucket are only accessible to the
-	// uploader, and not the owner of the bucket.  We want to ensure that
-	// the owner of the bucket can access the buckets as well.
-	uploadACL = "bucket-owner-full-control"
-)
 
 type amazonClient struct {
 	bucket                 string
@@ -53,7 +45,8 @@ type amazonClient struct {
 	// be written around the same time, and overloading S3. Reversing the
 	// order of keys gives an easy way to spread out S3 assets and
 	// substantially speed up block writing.
-	reversed bool
+	reversed       bool
+	advancedConfig *AmazonAdvancedConfiguration
 }
 
 type vaultCredentialsProvider struct {
@@ -166,12 +159,17 @@ type AmazonCreds struct {
 	VaultToken   string
 }
 
-func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistribution string, endpoint string, reversed ...bool) (*amazonClient, error) {
+func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistribution string, endpoint string, advancedConfig *AmazonAdvancedConfiguration, reversed ...bool) (*amazonClient, error) {
 	// set up aws config, including credentials (if neither creds.ID nor
 	// creds.VaultAddress are set, then this will use the EC2 metadata service
+	timeout, err := time.ParseDuration(advancedConfig.Timeout)
+	if err != nil {
+		return nil, err
+	}
 	awsConfig := &aws.Config{
 		Region:     aws.String(region),
-		MaxRetries: aws.Int(maxRetries),
+		MaxRetries: aws.Int(advancedConfig.Retries),
+		HTTPClient: &http.Client{Timeout: timeout},
 	}
 	if creds.ID != "" {
 		awsConfig.Credentials = credentials.NewStaticCredentials(creds.ID, creds.Secret, creds.Token)
@@ -203,10 +201,11 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 		r = true
 	}
 	awsClient := &amazonClient{
-		bucket:   bucket,
-		s3:       s3.New(session),
-		uploader: s3manager.NewUploader(session),
-		reversed: r,
+		bucket:         bucket,
+		s3:             s3.New(session),
+		uploader:       s3manager.NewUploader(session),
+		reversed:       r,
+		advancedConfig: advancedConfig,
 	}
 
 	// Set awsClient.cloudfrontURLSigner and cloudfrontDistribution (if Pachd is
@@ -424,7 +423,7 @@ func newWriter(ctx context.Context, client *amazonClient, name string) *amazonWr
 	}
 	go func() {
 		_, err := client.uploader.Upload(&s3manager.UploadInput{
-			ACL:             &uploadACL,
+			ACL:             aws.String(client.advancedConfig.UploadACL),
 			Body:            reader,
 			Bucket:          aws.String(client.bucket),
 			Key:             aws.String(name),

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -37,16 +37,7 @@ type amazonClient struct {
 	cloudfrontURLSigner    *sign.URLSigner
 	s3                     *s3.S3
 	uploader               *s3manager.Uploader
-	// When true, keys are stored in reversed order; e.g. the key "ABCD" is
-	// rewritten to "DCBA". This is because, as of 12/2018, if a lot of assets
-	// have the same prefix, the same S3 servers will be hit. This comes into
-	// conflict with Pachyderm, which prefixes the keys of blocks with where
-	// the blocks came from, causing a lot of blocks with the same prefix to
-	// be written around the same time, and overloading S3. Reversing the
-	// order of keys gives an easy way to spread out S3 assets and
-	// substantially speed up block writing.
-	reversed       bool
-	advancedConfig *AmazonAdvancedConfiguration
+	advancedConfig         *AmazonAdvancedConfiguration
 }
 
 type vaultCredentialsProvider struct {
@@ -159,7 +150,7 @@ type AmazonCreds struct {
 	VaultToken   string
 }
 
-func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistribution string, endpoint string, advancedConfig *AmazonAdvancedConfiguration, reversed ...bool) (*amazonClient, error) {
+func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistribution string, endpoint string, advancedConfig *AmazonAdvancedConfiguration) (*amazonClient, error) {
 	// set up aws config, including credentials (if neither creds.ID nor
 	// creds.VaultAddress are set, then this will use the EC2 metadata service
 	timeout, err := time.ParseDuration(advancedConfig.Timeout)
@@ -194,17 +185,10 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 
 	// Create new session using awsConfig
 	session := session.New(awsConfig)
-	var r bool
-	if len(reversed) > 0 {
-		r = reversed[0]
-	} else {
-		r = true
-	}
 	awsClient := &amazonClient{
 		bucket:         bucket,
 		s3:             s3.New(session),
 		uploader:       s3manager.NewUploader(session),
-		reversed:       r,
 		advancedConfig: advancedConfig,
 	}
 
@@ -235,7 +219,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 }
 
 func (c *amazonClient) Writer(ctx context.Context, name string) (io.WriteCloser, error) {
-	if c.reversed {
+	if c.advancedConfig.Reverse {
 		name = reverse(name)
 	}
 	return newBackoffWriteCloser(ctx, c, newWriter(ctx, c, name)), nil
@@ -245,7 +229,7 @@ func (c *amazonClient) Walk(_ context.Context, name string, fn func(name string)
 	var fnErr error
 	var prefix *string
 
-	if c.reversed {
+	if c.advancedConfig.Reverse {
 		prefix = nil
 	} else {
 		prefix = &name
@@ -259,7 +243,7 @@ func (c *amazonClient) Walk(_ context.Context, name string, fn func(name string)
 		func(listObjectsOutput *s3.ListObjectsOutput, lastPage bool) bool {
 			for _, object := range listObjectsOutput.Contents {
 				key := *object.Key
-				if c.reversed {
+				if c.advancedConfig.Reverse {
 					key = reverse(key)
 				}
 				if strings.HasPrefix(key, name) {
@@ -278,7 +262,7 @@ func (c *amazonClient) Walk(_ context.Context, name string, fn func(name string)
 }
 
 func (c *amazonClient) Reader(ctx context.Context, name string, offset uint64, size uint64) (io.ReadCloser, error) {
-	if c.reversed {
+	if c.advancedConfig.Reverse {
 		name = reverse(name)
 	}
 	byteRange := byteRange(offset, size)
@@ -342,7 +326,7 @@ func (c *amazonClient) Reader(ctx context.Context, name string, offset uint64, s
 }
 
 func (c *amazonClient) Delete(_ context.Context, name string) error {
-	if c.reversed {
+	if c.advancedConfig.Reverse {
 		name = reverse(name)
 	}
 	_, err := c.s3.DeleteObject(&s3.DeleteObjectInput{
@@ -353,7 +337,7 @@ func (c *amazonClient) Delete(_ context.Context, name string) error {
 }
 
 func (c *amazonClient) Exists(_ context.Context, name string) bool {
-	if c.reversed {
+	if c.advancedConfig.Reverse {
 		name = reverse(name)
 	}
 	_, err := c.s3.HeadObject(&s3.HeadObjectInput{

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -186,9 +186,12 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 	// Create new session using awsConfig
 	session := session.New(awsConfig)
 	awsClient := &amazonClient{
-		bucket:         bucket,
-		s3:             s3.New(session),
-		uploader:       s3manager.NewUploader(session),
+		bucket: bucket,
+		s3:     s3.New(session),
+		uploader: s3manager.NewUploader(session, func(u *s3manager.Uploader) {
+			u.PartSize = advancedConfig.PartSize
+			u.MaxUploadParts = advancedConfig.MaxUploadParts
+		}),
 		advancedConfig: advancedConfig,
 	}
 

--- a/src/server/pkg/obj/obj.go
+++ b/src/server/pkg/obj/obj.go
@@ -78,9 +78,12 @@ const (
 
 // Advanced configuration environment variables
 const (
-	RetriesEnvVar   = "RETRIES"
-	TimeoutEnvVar   = "TIMEOUT"
-	UploadACLEnvVar = "UPLOAD_ACL"
+	RetriesEnvVar        = "RETRIES"
+	TimeoutEnvVar        = "TIMEOUT"
+	UploadACLEnvVar      = "UPLOAD_ACL"
+	ReverseEnvVar        = "REVERSE"
+	PartSizeEnvVar       = "PART_SIZE"
+	MaxUploadPartsEnvVar = "MAX_UPLOAD_PARTS"
 )
 
 const (
@@ -92,6 +95,10 @@ const (
 	DefaultUploadACL = "bucket-owner-full-control"
 	// DefaultReverse is the default for whether to reverse object storage paths or not.
 	DefaultReverse = true
+	// DefaultPartSize is the default part size for object storage uploads.
+	DefaultPartSize = 5242880
+	// DefaultMaxUploadParts is the default maximum number of upload parts.
+	DefaultMaxUploadParts = 10000
 )
 
 // AmazonAdvancedConfiguration contains the advanced configuration for the amazon client.
@@ -101,8 +108,10 @@ type AmazonAdvancedConfiguration struct {
 	// By default, objects uploaded to a bucket are only accessible to the
 	// uploader, and not the owner of the bucket. Using the default ensures that
 	// the owner of the bucket can access the objects as well.
-	UploadACL string `env:"UPLOAD_ACL, default=bucket-owner-full-control"`
-	Reverse   bool   `env:"REVERSE, default=true"`
+	UploadACL      string `env:"UPLOAD_ACL, default=bucket-owner-full-control"`
+	Reverse        bool   `env:"REVERSE, default=true"`
+	PartSize       int64  `env:"PART_SIZE, default=5242880"`
+	MaxUploadParts int    `env:"MAX_UPLOAD_PARTS, default=10000"`
 }
 
 // EnvVarToSecretKey is an environment variable name to secret key mapping
@@ -135,6 +144,9 @@ var EnvVarToSecretKey = map[string]string{
 	RetriesEnvVar:            "retries",
 	TimeoutEnvVar:            "timeout",
 	UploadACLEnvVar:          "upload-acl",
+	ReverseEnvVar:            "reverse",
+	PartSizeEnvVar:           "part-size",
+	MaxUploadPartsEnvVar:     "max-upload-parts",
 }
 
 // StorageRootFromEnv gets the storage root based on environment variables.

--- a/src/server/pkg/obj/obj.go
+++ b/src/server/pkg/obj/obj.go
@@ -84,8 +84,11 @@ const (
 )
 
 const (
-	DefaultRetries   = 10
-	DefaultTimeout   = "5m"
+	// DefaultRetries is the default number of retries for object storage requests.
+	DefaultRetries = 10
+	// DefaultTimeout is the default timeout for object storage requests.
+	DefaultTimeout = "5m"
+	// DefaultUploadACL is the default upload ACL for object storage uploads.
 	DefaultUploadACL = "bucket-owner-full-control"
 )
 


### PR DESCRIPTION
This PR exposes some advanced configuration (retries, timeout, upload acl) for the amazon client. This advanced configuration is exposed as additional flags during the deployment process.