### PR TITLE
Increased etcd's default max transaction operations and max request bytes

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -78,8 +78,6 @@ var (
 	// tlsVolumeName)
 	tlsSecretName = "pachd-tls-cert"
 
-	// 8 GiB, the max for etcd backend bytes.
-	etcdBackendBytes = 8 * 1024 * 1024 * 1024
 	// Cmd used to launch etcd
 	etcdCmd = []string{
 		"/usr/local/bin/etcd",
@@ -87,8 +85,9 @@ var (
 		"--advertise-client-urls=http://0.0.0.0:2379",
 		"--data-dir=/var/data/etcd",
 		"--auto-compaction-retention=1",
-		"--max-txn-ops=5000",
-		fmt.Sprintf("--quota-backend-bytes=%d", etcdBackendBytes),
+		"--max-txn-ops=10000",
+		"--max-request-bytes=52428800",     //50mb
+		"--quota-backend-bytes=8589934592", //8gb
 	}
 
 	// IAMAnnotation is the annotation used for the IAM role, this can work


### PR DESCRIPTION
Closes #4043.

1) I doubled the max txn ops to 10,000 and increased max request bytes to 50mb. Are these reasonable for most use cases? The comment from @mrene [makes me unsure](https://github.com/pachyderm/pachyderm/issues/4043#issuecomment-533726679).
2) This is setting the values via etcd flags, since it seems like we use that for similar configuration values (versus environment variables.) I'm not sure how these would interact with their respective environment variables; my guess is that it overrides them, and nullifies values that users may have manually set on their manifest. Do we want that?