### PR TITLE
Fix spout provenance issue

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9438,6 +9438,13 @@ func TestSpout(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, buf.String(), "foo")
 	})
+
+	require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
+		if resp.Error != "" {
+			return fmt.Errorf("%v", resp.Error)
+		}
+		return nil
+	}))
 }
 
 func TestKafka(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9290,7 +9290,7 @@ func TestSpout(t *testing.T) {
 		pipelineInfo, err := c.InspectPipeline(pipeline)
 		require.NoError(t, err)
 		iter, err := c.SubscribeCommit(pipeline, "",
-			client.NewCommitProvenance(ppsconsts.SpecRepo, "master", pipelineInfo.SpecCommit.ID),
+			client.NewCommitProvenance(ppsconsts.SpecRepo, pipeline, pipelineInfo.SpecCommit.ID),
 			"", pfs.CommitState_FINISHED)
 		require.NoError(t, err)
 		// and we want to make sure that these commits all have the same provenance
@@ -9332,7 +9332,7 @@ func TestSpout(t *testing.T) {
 		pipelineInfo, err = c.InspectPipeline(pipeline)
 		require.NoError(t, err)
 		iter, err = c.SubscribeCommit(pipeline, "",
-			client.NewCommitProvenance(ppsconsts.SpecRepo, "master", pipelineInfo.SpecCommit.ID),
+			client.NewCommitProvenance(ppsconsts.SpecRepo, pipeline, pipelineInfo.SpecCommit.ID),
 			"", pfs.CommitState_FINISHED)
 		require.NoError(t, err)
 

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -849,7 +849,7 @@ func (a *APIServer) receiveSpout(ctx context.Context, logger *taggedLogger) erro
 				commit, err := a.pachClient.PfsAPIClient.StartCommit(a.pachClient.Ctx(), &pfs.StartCommitRequest{
 					Parent:     client.NewCommit(repo, ""),
 					Branch:     a.pipelineInfo.OutputBranch,
-					Provenance: []*pfs.CommitProvenance{client.NewCommitProvenance(ppsconsts.SpecRepo, a.pipelineInfo.OutputBranch, a.pipelineInfo.SpecCommit.ID)},
+					Provenance: []*pfs.CommitProvenance{client.NewCommitProvenance(ppsconsts.SpecRepo, repo, a.pipelineInfo.SpecCommit.ID)},
 				})
 				if err != nil {
 					return err


### PR DESCRIPTION
The provenance was incorrect, in the spec repo, the branch name needs to be the name of the repo for the pipeline it is referencing. I tested to make sure that this did in fact fix the issue.