### PR TITLE
Fix issue where bad datums didn't always fail jobs

### DIFF
--- a/src/server/pkg/ppsutil/util.go
+++ b/src/server/pkg/ppsutil/util.go
@@ -391,7 +391,7 @@ func IsTerminal(state pps.JobState) bool {
 // UpdateJobState performs the operations involved with a job state transition.
 func UpdateJobState(pipelines col.ReadWriteCollection, jobs col.ReadWriteCollection, jobPtr *pps.EtcdJobInfo, state pps.JobState, reason string) error {
 	if jobPtr.State == pps.JobState_JOB_FAILURE {
-		return nil
+		return fmt.Errorf("cannot put %q in state %s as it's already in state JOB_FAILURE", jobPtr.Job.ID, state.String())
 	}
 
 	// Update pipeline

--- a/src/server/pkg/ppsutil/util.go
+++ b/src/server/pkg/ppsutil/util.go
@@ -390,6 +390,10 @@ func IsTerminal(state pps.JobState) bool {
 
 // UpdateJobState performs the operations involved with a job state transition.
 func UpdateJobState(pipelines col.ReadWriteCollection, jobs col.ReadWriteCollection, jobPtr *pps.EtcdJobInfo, state pps.JobState, reason string) error {
+	if jobPtr.State == pps.JobState_JOB_FAILURE {
+		return nil
+	}
+
 	// Update pipeline
 	pipelinePtr := &pps.EtcdPipelineInfo{}
 	if err := pipelines.Get(jobPtr.Pipeline.Name, pipelinePtr); err != nil {

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -692,6 +692,7 @@ func (a *APIServer) waitJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, 
 			}); err != nil && !pfsserver.IsCommitFinishedErr(err) {
 				return err
 			}
+			return nil
 		}
 		// Write out the datums processed/skipped and merged for this job
 		buf := &bytes.Buffer{}


### PR DESCRIPTION
The fix is the new return statement in `worker/master.go`. The change in `ppsutil` is explained at the bottom.

The reason that this bug occurred so rarely is that is the goro (spawned [here](https://github.com/pachyderm/pachyderm/blob/master/src/server/worker/master.go#L441 )) calls `cancel()` as soon as the job's output commit is finished with no tree. Then one of the operations in `waitJob` after line 695 (e.g. [PutObject](https://github.com/pachyderm/pachyderm/blob/master/src/server/worker/master.go#L706)) typically fails with `context cancelled` and the backoff handler exits at [ctx.Done()](https://github.com/pachyderm/pachyderm/blob/master/src/server/worker/master.go#L736). However, rarely, the goro might be too slow to call `cancel()` and then `waitJob` makes it all the way to [updateJobState(SUCCESS)](https://github.com/pachyderm/pachyderm/blob/master/src/server/worker/master.go#L732) at the end, overwriting the `FAILURE` state the the job was previously in.

This bug can be exposed by adding a sleep [right before cancel() is called](https://github.com/pachyderm/pachyderm/blob/master/src/server/worker/master.go#L479) (inside a defer). This is how I tested the fix manually.

Finally, I also changed `UpdateJobState` so that jobs can't be taken out of `FAILURE` once they've been put into failure, a rule we already enforce [with pipelines](https://github.com/pachyderm/pachyderm/blob/master/src/server/pps/server/master.go#L255)

Fixes #4151 