### PR TITLE
Spout markers

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10358,6 +10358,10 @@ func TestExtractPipeline(t *testing.T) {
 	// Update and reprocess don't get extracted back either so don't set it.
 	request.Update = false
 	request.Reprocess = false
+	// Spouts can't have stats, so disable stats in that case
+	if request.Spout != nil {
+		request.EnableStats = false
+	}
 
 	// Create the pipeline
 	_, err := c.PpsAPIClient.CreatePipeline(

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9224,7 +9224,7 @@ func TestSpout(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	c := getPachClient(t)
-	defer require.NoError(t, c.DeleteAll())
+	require.NoError(t, c.DeleteAll())
 	t.Run("SpoutBasic", func(t *testing.T) {
 		dataRepo := tu.UniqueString("TestSpoutBasic_data")
 		require.NoError(t, c.CreateRepo(dataRepo))

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -578,13 +578,10 @@ func (d *driver) fsck(pachClient *client.APIClient, fix bool, cb func(*pfs.FsckR
 		}
 		branches := d.branches(repoName).ReadOnly(ctx)
 		branchInfo := &pfs.BranchInfo{}
-		if err := branches.List(branchInfo, col.DefaultOptions, func(branchName string) error {
+		return branches.List(branchInfo, col.DefaultOptions, func(branchName string) error {
 			branchInfos[key(repoName, branchName)] = proto.Clone(branchInfo).(*pfs.BranchInfo)
 			return nil
-		}); err != nil {
-			return err
-		}
-		return nil
+		})
 	}); err != nil {
 		return err
 	}
@@ -2633,10 +2630,7 @@ func (d *driver) createBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Bra
 	// propagate the head commit to 'branch'. This may also modify 'branch', by
 	// creating a new HEAD commit if 'branch's provenance was changed and its
 	// current HEAD commit has old provenance
-	if err := txnCtx.PropagateCommit(branch, false); err != nil {
-		return err
-	}
-	return nil
+	return txnCtx.PropagateCommit(branch, false)
 }
 
 func (d *driver) inspectBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Branch) (*pfs.BranchInfo, error) {

--- a/src/server/pkg/sync/sync.go
+++ b/src/server/pkg/sync/sync.go
@@ -78,7 +78,7 @@ func (p *Puller) makeFile(path string, f func(io.Writer) error) (retErr error) {
 
 // Pull clones an entire repo at a certain commit.
 // root is the local path you want to clone to.
-// fileInfo is the file/dir we are puuling.
+// repo, commit, file specify the file/dir we are pulling.
 // pipes causes the function to create named pipes in place of files, thus
 // lazily downloading the data as it's needed.
 // emptyFiles causes the function to create empty files with no content, it's

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1637,6 +1637,11 @@ func (a *apiServer) validatePipeline(pachClient *client.APIClient, pipelineInfo 
 			return fmt.Errorf("the following service type %s is not allowed", pipelineInfo.Service.Type)
 		}
 	}
+	if pipelineInfo.Spout != nil {
+		if pipelineInfo.EnableStats == true {
+			return fmt.Errorf("spouts are not allowed to have a stats branch")
+		}
+	}
 	return nil
 }
 
@@ -2177,6 +2182,11 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 				return nil, err
 			}
 		}
+	}
+
+	// spouts don't need to keep track of branch provenance since they are essentially inputs
+	if request.Spout != nil {
+		provenance = nil
 	}
 
 	// Create/update output branch (creating new output commit for the pipeline

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -541,9 +541,9 @@ func (a *APIServer) downloadData(pachClient *client.APIClient, logger *taggedLog
 		if err := syscall.Mkfifo(outPath, 0666); err != nil {
 			return "", fmt.Errorf("mkfifo :%v", err)
 		}
-		_, err := pachClient.InspectFile(a.pipelineInfo.Pipeline.Name, "master", "marker")
+		_, err := pachClient.InspectFile(a.pipelineInfo.Pipeline.Name, a.pipelineInfo.OutputBranch, "marker")
 		if err == nil {
-			if err := puller.Pull(pachClient, filepath.Join(dir, "marker"), a.pipelineInfo.Pipeline.Name, "master", "/marker", false, false, concurrency, nil, ""); err != nil {
+			if err := puller.Pull(pachClient, filepath.Join(dir, "marker"), a.pipelineInfo.Pipeline.Name, a.pipelineInfo.OutputBranch, "/marker", false, false, concurrency, nil, ""); err != nil {
 				return "", err
 			}
 		}

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -542,7 +542,7 @@ func (a *APIServer) downloadData(pachClient *client.APIClient, logger *taggedLog
 			return "", fmt.Errorf("mkfifo :%v", err)
 		}
 		_, err := pachClient.InspectFile(a.pipelineInfo.Pipeline.Name, a.pipelineInfo.OutputBranch, "marker")
-		if err == nil {
+		if err != nil && strings.Contains(err.Error(), "not found") {
 			if err := puller.Pull(pachClient, filepath.Join(dir, "marker"), a.pipelineInfo.Pipeline.Name, a.pipelineInfo.OutputBranch, "/marker", false, false, concurrency, nil, ""); err != nil {
 				return "", err
 			}

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -965,6 +965,10 @@ func (a *APIServer) uploadOutput(pachClient *client.APIClient, dir string, tag s
 		// Open local file that is being uploaded
 		f, err := os.Open(filePath)
 		if err != nil {
+			// if the error is that the spout marker file is missing, that's fine, just skip to the next file
+			if strings.Contains(err.Error(), "out/marker") {
+				return nil
+			}
 			return fmt.Errorf("os.Open(%s): %v", filePath, err)
 		}
 		defer func() {

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -911,7 +911,7 @@ func (a *APIServer) receiveSpout(ctx context.Context, logger *taggedLogger) erro
 						return err
 					}
 					// put files into pachyderm
-					if a.pipelineInfo.Spout.Overwrite {
+					if a.pipelineInfo.Spout.Overwrite || strings.Contains(fileHeader.Name, "marker") {
 						_, err = a.pachClient.PutFileOverwrite(repo, commit.ID, fileHeader.Name, outTar, 0)
 						if err != nil {
 							return err


### PR DESCRIPTION
This adds support for creating a file (named `marker`) as part of a spout, which can be read when the spout starts up again, so that you can keep track of things such as the kafka offset through spout failures or updates.

