### PR TITLE
Changes to GPT2 Dockerfile

### DIFF
--- a/examples/ml/gpt-2/Dockerfile
+++ b/examples/ml/gpt-2/Dockerfile
@@ -1,6 +1,10 @@
-FROM tensorflow/tensorflow:latest-gpu-py3
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
-RUN pip install twitterscraper tensorflow-gpu gpt_2_simple
+RUN apt-get update && \
+    apt-get install -y python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install twitterscraper gpt_2_simple tensorflow-gpu==1.14
 
 ADD tweets.py /
 ADD train.py /


### PR DESCRIPTION
- Version lock to cuda 10 with cudnn7 and ubuntu 18.04
- Version lock to tensorflow 1.14 from python (compatible with cuda 10, not cuda 10.1) (tensorflow latest was actually pulling TF v2?)
- Use nvidia/cuda image over tensorflow image (sets up LD_LIBRARY_PATH correctly for GCP)