### PR TITLE
Use vendor go mod flag on all calls to `go install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ env:
     - PATH=${HOME}/cached-deps:${PATH}
     - PPS_BUCKETS=6
     - AUTH_BUCKETS=2
-    # Disable Go modules: we use go mod to track deps but keep everything in
-    # the top-level 'vendor' directory rather than 'go-get'ing all modules
-    # every time
-    - GO111MODULE=off
   matrix:
     - BUCKET=MISC
     # If you want to update the number of PPS or auth buckets, you'll neet to

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     # etc/testing/travis_cache.sh
     - ${HOME}/.cache
     - ${HOME}/cached-deps
+    - ${HOME}/gopath/pkg/mod
 language: go
 go:
   - "1.13.1"

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ worker:
 
 install:
 	# GOPATH/bin must be on your PATH to access these binaries:
-	go install -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
+	go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
 
 install-mac:
 	# Result will be in $GOPATH/bin/darwin_amd64/pachctl (if building on linux)
-	GOOS=darwin GOARCH=amd64 go install -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
+	GOOS=darwin GOARCH=amd64 go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
 
 install-clean:
 	@# Need to blow away pachctl binary if its already there
@@ -79,7 +79,7 @@ install-clean:
 	@make install
 
 install-doc:
-	go install -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl-doc
+	go install -mod=vendor -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl-doc
 
 check-docker-version:
 	# The latest docker client requires server api version >= 1.24.
@@ -449,7 +449,7 @@ test-pps: launch-stats launch-kafka docker-build-test-entrypoint
 	  go test -v -count=1 ./src/server -parallel 1 -timeout $(TIMEOUT) $(RUN)
 
 test-cmds:
-	go install -v ./src/testing/match
+	go install -mod=vendor -v ./src/testing/match
 	CGOENABLED=0 go test -v -count=1 ./src/server/cmd/pachctl/cmd
 	go test -v -count=1 ./src/server/pkg/deploy/cmds -timeout $(TIMEOUT)
 	go test -v -count=1 ./src/server/pfs/cmds -timeout $(TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ worker:
 
 install:
 	# GOPATH/bin must be on your PATH to access these binaries:
-	go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
+	GO111MODULE=on go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
 
 install-mac:
 	# Result will be in $GOPATH/bin/darwin_amd64/pachctl (if building on linux)
-	GOOS=darwin GOARCH=amd64 go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
+	GO111MODULE=on GOOS=darwin GOARCH=amd64 go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
 
 install-clean:
 	@# Need to blow away pachctl binary if its already there
@@ -79,7 +79,7 @@ install-clean:
 	@make install
 
 install-doc:
-	go install -mod=vendor -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl-doc
+	GO111MODULE=on go install -mod=vendor -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl-doc
 
 check-docker-version:
 	# The latest docker client requires server api version >= 1.24.
@@ -449,7 +449,7 @@ test-pps: launch-stats launch-kafka docker-build-test-entrypoint
 	  go test -v -count=1 ./src/server -parallel 1 -timeout $(TIMEOUT) $(RUN)
 
 test-cmds:
-	go install -mod=vendor -v ./src/testing/match
+	GO111MODULE=on go install -mod=vendor -v ./src/testing/match
 	CGOENABLED=0 go test -v -count=1 ./src/server/cmd/pachctl/cmd
 	go test -v -count=1 ./src/server/pkg/deploy/cmds -timeout $(TIMEOUT)
 	go test -v -count=1 ./src/server/pfs/cmds -timeout $(TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,13 @@ update-deps:
 	go get -d -v -u ./src/... ./.
 
 build:
-	go build $$(go list ./src/client/... | grep -v '/src/client$$')
+	go build -mod=vendor $$(go list ./src/client/... | grep -v '/src/client$$')
 
 pachd:
-	go build ./src/server/cmd/pachd
+	go build -mod=vendor ./src/server/cmd/pachd
 
 worker:
-	go build ./src/server/cmd/worker
+	go build -mod=vendor ./src/server/cmd/worker
 
 install:
 	# GOPATH/bin must be on your PATH to access these binaries:

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ worker:
 
 install:
 	# GOPATH/bin must be on your PATH to access these binaries:
-	GO111MODULE=on go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
+	go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
 
 install-mac:
 	# Result will be in $GOPATH/bin/darwin_amd64/pachctl (if building on linux)
-	GO111MODULE=on GOOS=darwin GOARCH=amd64 go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
+	GOOS=darwin GOARCH=amd64 go install -mod=vendor -ldflags "$(LD_FLAGS)" -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl
 
 install-clean:
 	@# Need to blow away pachctl binary if its already there
@@ -79,7 +79,7 @@ install-clean:
 	@make install
 
 install-doc:
-	GO111MODULE=on go install -mod=vendor -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl-doc
+	go install -mod=vendor -gcflags "$(GC_FLAGS)" ./src/server/cmd/pachctl-doc
 
 check-docker-version:
 	# The latest docker client requires server api version >= 1.24.
@@ -449,7 +449,7 @@ test-pps: launch-stats launch-kafka docker-build-test-entrypoint
 	  go test -v -count=1 ./src/server -parallel 1 -timeout $(TIMEOUT) $(RUN)
 
 test-cmds:
-	GO111MODULE=on go install -mod=vendor -v ./src/testing/match
+	go install -mod=vendor -v ./src/testing/match
 	CGOENABLED=0 go test -v -count=1 ./src/server/cmd/pachctl/cmd
 	go test -v -count=1 ./src/server/pkg/deploy/cmds -timeout $(TIMEOUT)
 	go test -v -count=1 ./src/server/pfs/cmds -timeout $(TIMEOUT)

--- a/etc/build/vscode_install_task.sh
+++ b/etc/build/vscode_install_task.sh
@@ -7,4 +7,4 @@ VERSION_ADDITIONAL=-$(git log --pretty=format:%H | head -n 1)
 LD_FLAGS="-X github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion=${VERSION_ADDITIONAL}"
 GC_FLAGS="all=-trimpath=${PWD}"
 
-GO111MODULE=on go install -ldflags "${LD_FLAGS}" -gcflags "${GC_FLAGS}" ./src/server/cmd/pachctl
+GO111MODULE=on go install -mod=vendor -ldflags "${LD_FLAGS}" -gcflags "${GC_FLAGS}" ./src/server/cmd/pachctl

--- a/etc/build/vscode_install_task.sh
+++ b/etc/build/vscode_install_task.sh
@@ -7,4 +7,4 @@ VERSION_ADDITIONAL=-$(git log --pretty=format:%H | head -n 1)
 LD_FLAGS="-X github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion=${VERSION_ADDITIONAL}"
 GC_FLAGS="all=-trimpath=${PWD}"
 
-GO111MODULE=on go install -mod=vendor -ldflags "${LD_FLAGS}" -gcflags "${GC_FLAGS}" ./src/server/cmd/pachctl
+go install -mod=vendor -ldflags "${LD_FLAGS}" -gcflags "${GC_FLAGS}" ./src/server/cmd/pachctl

--- a/etc/compile/compile.sh
+++ b/etc/compile/compile.sh
@@ -20,6 +20,7 @@ mkdir -p _tmp
 TMP=docker_build_${BINARY}.tmpdir
 mkdir -p "${TMP}"
 CGO_ENABLED=0 GOOS=linux go build \
+  -mod=vendor \
   -installsuffix netgo \
   -tags netgo \
   -o ${TMP}/${BINARY} \

--- a/etc/compile/wait.sh
+++ b/etc/compile/wait.sh
@@ -2,8 +2,7 @@
 
 CONTAINER="${1}"
 
-docker wait "$CONTAINER" 2>/dev/null 1>/dev/null
-RET=$?
+RET=`docker wait "$CONTAINER"`
 
 if [ "$RET" -ne 0 ]
 then

--- a/etc/testing/test_tls.sh
+++ b/etc/testing/test_tls.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 which match || {
   here="$(dirname "${0}")"
-  go install -v "${here}/../../src/testing/match"
+  go install -mod=vendor -v "${here}/../../src/testing/match"
 }
 
 address=$(pachctl config get context `pachctl config get active-context` | jq -r .pachd_address)

--- a/etc/testing/test_tls.sh
+++ b/etc/testing/test_tls.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 which match || {
   here="$(dirname "${0}")"
-  go install -mod=vendor -v "${here}/../../src/testing/match"
+  GO111MODULE=on go install -mod=vendor -v "${here}/../../src/testing/match"
 }
 
 address=$(pachctl config get context `pachctl config get active-context` | jq -r .pachd_address)

--- a/etc/testing/test_tls.sh
+++ b/etc/testing/test_tls.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 which match || {
   here="$(dirname "${0}")"
-  GO111MODULE=on go install -mod=vendor -v "${here}/../../src/testing/match"
+  go install -mod=vendor -v "${here}/../../src/testing/match"
 }
 
 address=$(pachctl config get context `pachctl config get active-context` | jq -r .pachd_address)

--- a/etc/testing/travis_cache.sh
+++ b/etc/testing/travis_cache.sh
@@ -11,6 +11,7 @@ set -ex
 dirs=(
   "${HOME}/.cache"
   "${HOME}/cached-deps"
+  "${HOME}/gopath/pkg/mod"
 )
 
 for dir in "${dirs[@]}"; do

--- a/src/plugin/vault/Makefile
+++ b/src/plugin/vault/Makefile
@@ -2,7 +2,7 @@ VERSION_ADDITIONAL = -$(shell git log --pretty=format:%H | head -n 1)
 LD_FLAGS = -X github.com/pachyderm/pachyderm/src/plugin/vault/vendor/github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion=$(VERSION_ADDITIONAL)
 
 plugin:
-	go install -ldflags "$(LD_FLAGS)" ./pachyderm-plugin
+	go install -mod=vendor -ldflags "$(LD_FLAGS)" ./pachyderm-plugin
 
 test:
 	./etc/start-vault.sh

--- a/src/plugin/vault/Makefile
+++ b/src/plugin/vault/Makefile
@@ -2,7 +2,7 @@ VERSION_ADDITIONAL = -$(shell git log --pretty=format:%H | head -n 1)
 LD_FLAGS = -X github.com/pachyderm/pachyderm/src/plugin/vault/vendor/github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion=$(VERSION_ADDITIONAL)
 
 plugin:
-	GO111MODULE=on go install -mod=vendor -ldflags "$(LD_FLAGS)" ./pachyderm-plugin
+	go install -mod=vendor -ldflags "$(LD_FLAGS)" ./pachyderm-plugin
 
 test:
 	./etc/start-vault.sh

--- a/src/plugin/vault/Makefile
+++ b/src/plugin/vault/Makefile
@@ -2,7 +2,7 @@ VERSION_ADDITIONAL = -$(shell git log --pretty=format:%H | head -n 1)
 LD_FLAGS = -X github.com/pachyderm/pachyderm/src/plugin/vault/vendor/github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion=$(VERSION_ADDITIONAL)
 
 plugin:
-	go install -mod=vendor -ldflags "$(LD_FLAGS)" ./pachyderm-plugin
+	GO111MODULE=on go install -mod=vendor -ldflags "$(LD_FLAGS)" ./pachyderm-plugin
 
 test:
 	./etc/start-vault.sh

--- a/src/plugin/vault/etc/test-cookbook.sh
+++ b/src/plugin/vault/etc/test-cookbook.sh
@@ -16,7 +16,7 @@ vault secrets disable pachyderm
 
 # Build plugin
 mkdir /tmp/vault-plugins || true
-go build -o /tmp/vault-plugins/pachyderm "$(dirname ${0})/.."
+go build -mod=vendor -o /tmp/vault-plugins/pachyderm "$(dirname ${0})/.."
 
 ### Start the written instructions ###
 

--- a/src/plugin/vault/etc/test-vault.sh
+++ b/src/plugin/vault/etc/test-vault.sh
@@ -33,7 +33,7 @@ echo $ADMIN_TOKEN
 vault write $PLUGIN_PATH/config \
     admin_token="${ADMIN_TOKEN}" \
 	pachd_address="${PACHD_ADDRESS:-127.0.0.1}:30650"
-go build -o /tmp/vault-plugins/$PLUGIN_NAME src/plugin/vault/main.go
+go build -mod=vendor -o /tmp/vault-plugins/$PLUGIN_NAME src/plugin/vault/main.go
 
 # Test login (failure/success):
 vault write -f $PLUGIN_PATH/login/github:jdoliner

--- a/src/server/pkg/testutil/cmds.go
+++ b/src/server/pkg/testutil/cmds.go
@@ -105,7 +105,7 @@ export -f yes # use in subshells too
 
 which match >/dev/null || {
 	echo "You must have 'match' installed to run these tests. Please run:" >&2
-	echo "  GO111MODULE=on cd ${GOPATH}/src/github.com/pachyderm/pachyderm/ && go install -mod=vendor ./src/testing/match" >&2
+	echo "  cd ${GOPATH}/src/github.com/pachyderm/pachyderm/ && go install -mod=vendor ./src/testing/match" >&2
 	exit 1
 }`)
 	buf.WriteRune('\n')

--- a/src/server/pkg/testutil/cmds.go
+++ b/src/server/pkg/testutil/cmds.go
@@ -105,7 +105,7 @@ export -f yes # use in subshells too
 
 which match >/dev/null || {
 	echo "You must have 'match' installed to run these tests. Please run:" >&2
-	echo "  cd ${GOPATH}/src/github.com/pachyderm/pachyderm/ && go install -mod=vendor ./src/testing/match" >&2
+	echo "  GO111MODULE=on cd ${GOPATH}/src/github.com/pachyderm/pachyderm/ && go install -mod=vendor ./src/testing/match" >&2
 	exit 1
 }`)
 	buf.WriteRune('\n')

--- a/src/server/pkg/testutil/cmds.go
+++ b/src/server/pkg/testutil/cmds.go
@@ -105,7 +105,7 @@ export -f yes # use in subshells too
 
 which match >/dev/null || {
 	echo "You must have 'match' installed to run these tests. Please run:" >&2
-	echo "  cd ${GOPATH}/src/github.com/pachyderm/pachyderm/ && go install ./src/testing/match" >&2
+	echo "  cd ${GOPATH}/src/github.com/pachyderm/pachyderm/ && go install -mod=vendor ./src/testing/match" >&2
 	exit 1
 }`)
 	buf.WriteRune('\n')

--- a/src/testing/loadtest/obj/build/docker-build.sh
+++ b/src/testing/loadtest/obj/build/docker-build.sh
@@ -15,7 +15,7 @@ mkdir _out
 LD_FLAGS="-extldflags -static"
 BUILD_PATH=github.com/pachyderm/pachyderm/src/testing/loadtest/obj
 BUILD_CMD="
-GO111MODULE=on go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
+go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
 mv ../bin/* /out/"
 
 # Run compilation inside golang container, with pachyderm mounted

--- a/src/testing/loadtest/obj/build/docker-build.sh
+++ b/src/testing/loadtest/obj/build/docker-build.sh
@@ -15,7 +15,7 @@ mkdir _out
 LD_FLAGS="-extldflags -static"
 BUILD_PATH=github.com/pachyderm/pachyderm/src/testing/loadtest/obj
 BUILD_CMD="
-go install -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
+go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
 mv ../bin/* /out/"
 
 # Run compilation inside golang container, with pachyderm mounted

--- a/src/testing/loadtest/obj/build/docker-build.sh
+++ b/src/testing/loadtest/obj/build/docker-build.sh
@@ -15,7 +15,7 @@ mkdir _out
 LD_FLAGS="-extldflags -static"
 BUILD_PATH=github.com/pachyderm/pachyderm/src/testing/loadtest/obj
 BUILD_CMD="
-go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
+GO111MODULE=on go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
 mv ../bin/* /out/"
 
 # Run compilation inside golang container, with pachyderm mounted

--- a/src/testing/loadtest/split/build/docker-build.sh
+++ b/src/testing/loadtest/split/build/docker-build.sh
@@ -16,8 +16,8 @@ mkdir _out
 LD_FLAGS="-extldflags -static"
 BUILD_PATH=github.com/pachyderm/pachyderm/src/testing/loadtest/split
 BUILD_CMD="
-go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/pipeline && \
-go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
+GO111MODULE=on go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/pipeline && \
+GO111MODULE=on go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
 mv ../bin/* /out/"
 
 # Run compilation inside golang container, with pachyderm mounted

--- a/src/testing/loadtest/split/build/docker-build.sh
+++ b/src/testing/loadtest/split/build/docker-build.sh
@@ -16,8 +16,8 @@ mkdir _out
 LD_FLAGS="-extldflags -static"
 BUILD_PATH=github.com/pachyderm/pachyderm/src/testing/loadtest/split
 BUILD_CMD="
-go install -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/pipeline && \
-go install -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
+go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/pipeline && \
+go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
 mv ../bin/* /out/"
 
 # Run compilation inside golang container, with pachyderm mounted

--- a/src/testing/loadtest/split/build/docker-build.sh
+++ b/src/testing/loadtest/split/build/docker-build.sh
@@ -16,8 +16,8 @@ mkdir _out
 LD_FLAGS="-extldflags -static"
 BUILD_PATH=github.com/pachyderm/pachyderm/src/testing/loadtest/split
 BUILD_CMD="
-GO111MODULE=on go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/pipeline && \
-GO111MODULE=on go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
+go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/pipeline && \
+go install -mod=vendor -a -ldflags \"${LD_FLAGS}\" ./${BUILD_PATH}/cmd/supervisor && \
 mv ../bin/* /out/"
 
 # Run compilation inside golang container, with pachyderm mounted

--- a/src/testing/saml-idp/Dockerfile.build
+++ b/src/testing/saml-idp/Dockerfile.build
@@ -23,6 +23,6 @@ RUN mkdir -p /go/src/saml-idp
 ADD ./*.go /go/src/saml-idp
 
 # Build saml-id (quote -ldflags arguments)
-CMD go install -ldflags "-linkmode external -extldflags -static" -a saml-idp \
+CMD go install -mod=vendor -ldflags "-linkmode external -extldflags -static" -a saml-idp \
   && chmod 755 /go/bin/saml-idp \
   && cp /go/bin/saml-idp /out

--- a/src/testing/saml-idp/Dockerfile.build
+++ b/src/testing/saml-idp/Dockerfile.build
@@ -23,6 +23,6 @@ RUN mkdir -p /go/src/saml-idp
 ADD ./*.go /go/src/saml-idp
 
 # Build saml-id (quote -ldflags arguments)
-CMD go install -mod=vendor -ldflags "-linkmode external -extldflags -static" -a saml-idp \
+CMD GO111MODULE=on go install -mod=vendor -ldflags "-linkmode external -extldflags -static" -a saml-idp \
   && chmod 755 /go/bin/saml-idp \
   && cp /go/bin/saml-idp /out

--- a/src/testing/saml-idp/Dockerfile.build
+++ b/src/testing/saml-idp/Dockerfile.build
@@ -23,6 +23,6 @@ RUN mkdir -p /go/src/saml-idp
 ADD ./*.go /go/src/saml-idp
 
 # Build saml-id (quote -ldflags arguments)
-CMD GO111MODULE=on go install -mod=vendor -ldflags "-linkmode external -extldflags -static" -a saml-idp \
+CMD go install -mod=vendor -ldflags "-linkmode external -extldflags -static" -a saml-idp \
   && chmod 755 /go/bin/saml-idp \
   && cp /go/bin/saml-idp /out


### PR DESCRIPTION
Otherwise pachyderm will build from the normal go mod directory, rather than our vendored directory.