### PR TITLE
first cut at kafka spout example

### DIFF
--- a/examples/spouts/README.md
+++ b/examples/spouts/README.md
@@ -23,6 +23,16 @@ Sentiment Analysis of Social Media Text. Eighth International Conference on
 Weblogs and Social Media (ICWSM-14). Ann Arbor, MI, June 2014.
 ```
 
+## Ingress data from an S3 bucket using SQS
+
+[This example](https://github.com/pachyderm/pachyderm/tree/master/examples/spouts/SQS-S3) shows how to use spouts to ingress data from an S3 bucket using an SQS queue for notification of new items added to the bucket. 
+
+## Commit messages from a Kafka queue
+
+A [simple example](https://github.com/pachyderm/pachyderm/tree/master/examples/spouts/go-kafka-spout), of using spouts with Kafka to process messages and write them to files.
+
+
+
 
 
 

--- a/examples/spouts/README.md
+++ b/examples/spouts/README.md
@@ -29,7 +29,7 @@ Weblogs and Social Media (ICWSM-14). Ann Arbor, MI, June 2014.
 
 ## Commit messages from a Kafka queue
 
-A [simple example](https://github.com/pachyderm/pachyderm/tree/master/examples/spouts/go-kafka-spout), of using spouts with Kafka to process messages and write them to files.
+A [simple example](https://github.com/pachyderm/pachyderm/tree/master/examples/spouts/go-kafka-spout) of using spouts with Kafka to process messages and write them to files.
 
 
 

--- a/examples/spouts/go-kafka-spout/Dockerfile
+++ b/examples/spouts/go-kafka-spout/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.12.1
+RUN mkdir /app 
+ADD source/main.go /app/ 
+WORKDIR /app 
+ADD source/kafka-go /go/src/github.com/segmentio/kafka-go
+RUN go build -o main . 
+CMD ["/app/main"]

--- a/examples/spouts/go-kafka-spout/Makefile
+++ b/examples/spouts/go-kafka-spout/Makefile
@@ -1,0 +1,68 @@
+.PHONY: 
+PROJNAME := pachkafka
+
+# customize these to your kafka deployment and needs
+KAFKA_HOST := kafka.kafka
+KAFKA_TOPIC := test_topic
+KAFKA_GROUP_ID := test_group
+KAFKA_PORT := 9092
+KAFKA_TIMEOUT := 5
+NAMED_PIPE := /pfs/out
+VERBOSE_LOGGING := true
+
+PIPELINES_DIR := pipelines
+SOURCE_DIR := source
+ADDITIONAL_MANIFESTS_DIR := additional_manifests
+PROJ_DIRS := $(SOURCE_DIR) $(PIPELINES_DIR)
+CONTAINER_VERSION := 1.9.8
+DOCKER_ACCOUNT := pachyderm
+CONTAINER_NAME := kafka_spout
+CONTAINER_TAG := $(DOCKER_ACCOUNT)/$(CONTAINER_NAME):$(CONTAINER_VERSION)
+JQ := jq
+JQFLAGS :=
+DOCKER := docker
+ECHO := echo
+TOUCH := touch
+CP := cp
+RM := rm
+PIPELINE_TRANSFORM := .transform.image="$(CONTAINER_TAG)"|.transform.env.KAFKA_HOST="$(KAFKA_HOST)"|.transform.env.KAFKA_TOPIC="$(KAFKA_TOPIC)"|.transform.env.KAFKA_GROUP_ID="$(KAFKA_GROUP_ID)"|.transform.env.KAFKA_PORT="$(KAFKA_PORT)"|.transform.env.KAFKA_TIMEOUT="$(KAFKA_TIMEOUT)"|.transform.env.NAMED_PIPE="$(NAMED_PIPE)"|.transform.env.VERBOSE_LOGGING="$(VERBOSE_LOGGING)"
+PIPELINE_SOURCE_FILES = $(shell find $(PROJ_DIRS) -type f -name \*.go)
+PIPELINE_DEF_FILES = $(shell find $(PROJ_DIRS) -type f -name \*.pipeline)
+KAFKA_FILES = $(sort $(shell find $(ADDITIONAL_MANIFESTS_DIR) -type f -name [0-9][0-9][0-9]\*.yaml))
+PIPELINE_JSON_FILES := $(patsubst %.pipeline,%.json,$(PIPELINE_DEF_FILES))
+DAG := kafka_spout 
+PACHCTL := pachctl
+PACHCTL_FLAGS :=
+#this needs to be recursively expanded because it's used in a foreach loop
+PACHCTL_FILE = -f $(PIPELINES_DIR)/$(stage).json
+
+KUBECTL := kubectl
+KUBECTL_FLAGS :=
+
+pachctl-pipeline = @$(foreach stage,$(2), $(PACHCTL) $(1) pipeline $(PACHCTL_FILE) $(PACHCTL_FLAGS) ; )
+kubectl-apply = @$(foreach manifest,$(1), $(KUBECTL) apply -f $(manifest) $(KUBECTL_FLAGS) ; )
+
+%.json: %.pipeline Makefile 
+	@$(JQ) $(JQFLAGS) '$(PIPELINE_TRANSFORM)'  $< > $@
+
+kafka: $(KAFKA_FILES)
+	@$(TOUCH) $@
+	@$(call kubectl-apply,$(KAFKA_FILES))
+
+docker-image: Dockerfile $(PIPELINE_JSON_FILES) $(PIPELINE_SOURCE_FILES)
+	@$(TOUCH) $@
+	@$(CP) -R ../../../vendor/github.com/segmentio/kafka-go $(SOURCE_DIR)
+	@$(DOCKER) build -t $(CONTAINER_TAG) .|| { $(RM) -r docker-image $(SOURCE_DIR)/kafka-go; exit 1; }
+	@$(DOCKER) push $(CONTAINER_TAG)
+	@$(RM) -r $(SOURCE_DIR)/kafka-go	
+
+create-dag: kafka docker-image $(PIPELINE_JSON_FILES) $(PIPELINE_SOURCE_FILES)
+	@$(call pachctl-pipeline,create,$(DAG))
+
+update-dag: kafka docker-image $(PIPELINE_JSON_FILES) $(PIPELINE_SOURCE_FILES)
+	@$(call pachctl-pipeline,update,$(DAG))
+
+clean:
+	-@$(RM) $(wildcard $(PIPELINE_JSON_FILES) docker-image secrets kafka)
+
+

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -25,7 +25,7 @@ You should be able to easily adapt it to your needs.
 ## Setup
 
 This example includes a pre-configured Kafka cluster that you can deploy on Amazon EKS,
-adapted from [Craig Johnston's excellent blog post](https://imti.co/kafka-kubernetes/).
+adapted from [Craig Johnston's blog post](https://imti.co/kafka-kubernetes/).
 If you'd like to adapt it for your own cluster on GCP, Azure, or on-premises Kubernetes deployment,
 the file 001-storage-class.yaml is probably the only thing you'd need to change.
 You can replace the parameters and provisioner with the appropriate one for your environment.

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -5,7 +5,7 @@ This is a simple example of using spouts with [Kafka](https://kafka.apache.org) 
 
 This example spout connects to a Kafka queue and reads a topic.
 The spout then writes each message in the topic to a file named by the topic and offset. 
-It uses Kafka group ids to maintain a cursor into the offset in the topic, 
+It uses Kafka group IDs to maintain a cursor into the offset in the topic, 
 making it resilient to restarts.
 
 ## Introduction

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -2,7 +2,6 @@
 
 This is a simple example of using spouts with [Kafka](https://kafka.apache.org) to process messages and write them to files.
 
-## Background
 
 This example connects to a Kafka queue and reads a topic.
 It then writes each message in the topic to a file named by the topic and offset. 

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -27,7 +27,7 @@ You should be able to easily adapt it to your needs.
 This example includes a pre-configured Kafka cluster that you can deploy on Amazon EKS,
 adapted from [Craig Johnston's blog post](https://imti.co/kafka-kubernetes/).
 If you'd like to adapt it for your own cluster on GCP, Azure, or on-premises Kubernetes deployment,
-the file 001-storage-class.yaml is probably the only thing you'd need to change.
+the `001-storage-class.yaml` file is probably the only thing you'd need to change.
 You can replace the parameters and provisioner with the appropriate one for your environment.
 
 If you already have a Kafka cluster setup, you may skip step 1 of the Kafka setup.

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -10,7 +10,7 @@ making it resilient to restarts.
 
 ## Introduction
 
-Apache Kafka is a distributed streaming platform.  
+Apache® Kafka is a distributed streaming platform
 It's used in a variety of applications to provide communications between microservices.  
 Many Pachyderm users use Kafka to ingest data from legacy data sources using Pachyderm spouts.
 

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -11,7 +11,7 @@ making it resilient to restarts.
 ## Introduction
 
 Apache® Kafka is a distributed streaming platform
-It's used in a variety of applications to provide communications between microservices.  
+that is used in a variety of applications to provide communications between microservices.  
 Many Pachyderm users use Kafka to ingest data from legacy data sources using Pachyderm spouts.
 
 Pachyderm spouts are a way to ingest data into Pachyderm 

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -24,7 +24,7 @@ You should be able to easily adapt it to your needs.
 
 ## Setup
 
-This example includes a pre-configured Kafka cluster you can deploy on Amazon EKS,
+This example includes a pre-configured Kafka cluster that you can deploy on Amazon EKS,
 adapted from [Craig Johnston's excellent blog post](https://imti.co/kafka-kubernetes/).
 If you'd like to adapt it for your own cluster on GCP, Azure, or on-premises Kubernetes deployment,
 the file 001-storage-class.yaml is probably the only thing you'd need to change.

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -1,0 +1,231 @@
+# Commit messages from a Kafka queue
+
+A simple example using spouts with [Kafka](https://kafka.apache.org) to process messages and write them to files.
+
+## Background
+
+This example connects to a Kafka queue and reads a topic.
+It then writes each message in the topic to a file named by the topic and offset. 
+It uses Kafka group ids to maintain a cursor into the offset in the topic, 
+making it resilient to restarts.
+
+## Introduction
+
+Apache Kafka is a distributed streaming platform.  
+It's used in a variety of applications to provide communications between microservices.  
+Many Pachyderm users use Kafka to ingest data from legacy data sources using Pachyderm spouts.
+
+Pachyderm spouts are a way to ingest data into Pachyderm 
+by having your code get the data from inside a Pachyderm pipeline.
+
+This is the simplest possible implementation of a Pachyderm spout using Kafka to ingest data.
+The data ingested is simply the message posted to Kafka.
+The filename is derived from the Kafka topic name and the message's offset in the topic.
+You should be able to easily adapt it to your needs.
+
+## Setup
+
+This example includes a pre-configured Kafka cluster you can deploy on Amazon EKS,
+adapted from [Craig Johnston's excellent blog post](https://imti.co/kafka-kubernetes/).
+If you'd like to adapt it for your own cluster on GCP, Azure, or on-premises Kubernetes deployment,
+the file 001-storage-class.yaml is probably the only thing you'd need to change.
+You can replace the parameters and provisioner with the appropriate one for your environment.
+
+If you already have a Kafka cluster setup, you may skip step 1 of the Kafka setup.
+
+To correctly build the Docker container from source, 
+it will be necessary to have the Pachyderm source repo structure around this example.
+It depends on the directory `../../../vendor/github.com/segmentio/kafka-go`,
+relative to this one,
+containing the correct code.
+You can, of course, set up your Go development environment to achieve the same result.
+
+### Kafka setup
+
+1. In the directory `additional_manifests`, 
+you'll find a numbered sequence of Kubernetes manifests for creating a fully-functioning Kafka deployment.
+You can use the makefile target `make kafka`,
+which will deploy a kafka cluster a `kafka` namespace, created in the first step.
+If you'd like to see the order in which the manifests will be loaded into Kubernetes,
+run the command
+```sh
+make -n kafka
+```
+You can confirm that the kafka cluster is running properly by checking to see if all the pods are running.
+```sh
+$ kubectl get pods -n kafka
+NAME                READY   STATUS    RESTARTS   AGE
+kafka-0             1/1     Running   0          3d19h
+kafka-1             1/1     Running   0          3d19h
+kafka-2             1/1     Running   0          3d19h
+kafka-test-client   1/1     Running   0          3d19h
+kafka-zookeeper-0   1/1     Running   0          3d19h
+kafka-zookeeper-1   1/1     Running   0          3d19h
+kafka-zookeeper-2   1/1     Running   0          3d19h
+```
+2. Once the Kafka cluster is running, create the topic you'd like to consume messages from.
+The example is configured to look for a topic called `test-topic`.
+You may modify the Makefile to use another topic name, of course.
+To use the example's Kafka environment,
+you may use the following command to create the topic:
+```sh
+$ kubectl -n kafka exec kafka-test-client -- /usr/bin/kafka-topics --zookeeper \
+      kafka-zookeeper.kafka:2181 --topic test --create \
+      --partitions 1 --replication-factor 1
+Created topic "test".
+```
+Note that the command is using Kubernetes DNS names to specify the Kafka zookeeper service,
+`kafka-zookeeper.kafka`.
+3. You can start populating the topic with data using the `kafka-console-producer` command.
+It provides you with a `>` prompt for entering data,
+delimited by lines for each offset into the topic.
+In the example below, the messages at offset 0 is `yo`, 
+at offset 1, `man`,
+and so on.
+Data entry is completed with an end-of-file character,
+`Control-d` in most shells.
+```sh
+$ kubectl -n kafka exec -ti kafka-test-client --  /usr/bin/kafka-console-producer \
+   --broker-list kafka.kafka:9092 --topic test 
+>yo 
+>man
+>this 
+>is so
+>cool!!
+>
+```
+4. You can see if the data has been added to the topic with the `kafka-console-consumer` command.
+In the example below,
+the session was terminated with `Control-C` keystrokes.
+```sh
+$ kubectl -n kafka exec -ti kafka-test-client -- /usr/bin/kafka-console-consumer 
+   --bootstrap-server kafka:9092 --topic test --from-beginning
+yo
+man
+this
+is so
+cool!!
+^CProcessed a total of 5 messages
+command terminated with exit code 130
+```
+### Pachyderm setup
+
+This guide assumes that you already have a Pachyderm cluster running and have configured `pachctl` to talk to the cluster and `kubectl` to talk to Kubernetes.
+[Installation instructions can be found here](http://pachyderm.readthedocs.io/en/stable/getting_started/local_installation.html).
+
+1. If you would simply like to use the prebuilt spout image,
+you can simply create the spout with the pachctl command
+using the pipeline definition available in the `pipelines` directory
+```
+$ pachctl create pipeline -f pipelines/kafka_spout.json
+```
+
+2. To create your own version of the spout,
+you may modify the Makefile to use your own Dockerhub account, tag and version
+by changing these variables accordingly
+```
+CONTAINER_VERSION := 1.9.8
+DOCKER_ACCOUNT := pachyderm
+CONTAINER_NAME := kafka_spout
+```
+The Makefile has targets for `create-dag` and `update-dag`, 
+or you may simply make the image with `docker-image`.
+
+3. Once the spout is running, 
+if the `VERBOSE_LOGGING` variable is set to anything other than `false`,
+you will see verbose logging in the `kafka_spout` pipeline logs.
+```sh
+$ pachctl logs -p kafka_spout -f
+creating new kafka reader for kafka.kafka:9092 with topic 'test_topic' and group 'test_group'
+reading kafka queue.
+opening named pipe /pfs/out.
+opening tarstream
+processing header for topic test_topic @ offset 0
+processing data for topic  test_topic @ offset 0
+closing tarstream.
+closing named pipe /pfs/out.
+cleaning up context.
+reading kafka queue.
+opening named pipe /pfs/out.
+opening tarstream
+processing header for topic test_topic @ offset 1
+processing data for topic  test_topic @ offset 1
+closing tarstream.
+closing named pipe /pfs/out.
+cleaning up context.
+reading kafka queue.
+opening named pipe /pfs/out.
+opening tarstream
+processing header for topic test_topic @ offset 2
+processing data for topic  test_topic @ offset 2
+closing tarstream.
+closing named pipe /pfs/out.
+cleaning up context.
+reading kafka queue.
+opening named pipe /pfs/out.
+opening tarstream
+processing header for topic test_topic @ offset 3
+processing data for topic  test_topic @ offset 3
+closing tarstream.
+closing named pipe /pfs/out.
+cleaning up context.
+reading kafka queue.
+opening named pipe /pfs/out.
+opening tarstream
+processing header for topic test_topic @ offset 4
+processing data for topic  test_topic @ offset 4
+closing tarstream.
+closing named pipe /pfs/out.
+...
+```
+And you will see the message files in the `kafka_spout` repo
+```sh
+$ pachctl list file kafka_spout@master
+NAME          TYPE SIZE 
+/test_topic-0 file 2B   
+/test_topic-1 file 3B   
+/test_topic-2 file 4B   
+/test_topic-3 file 5B   
+/test_topic-4 file 6B   
+```
+## Pipelines
+
+### kafka_spout
+
+The file `source/main.go` contains a simple Pachyderm spout that processes messages from Kafka,
+saving them to files in a Pachyderm repo named for the topic and message offset.
+
+It is configurable via environment variables and command-line flags. 
+Flags override environment variable settings.
+If your Go development environment is set up correctly,
+you can see the settings by running the command:
+```
+$ go run source/main.go --help
+Usage of /var/folders/xl/xtvj4xtx0tv1llxcnbvlmwc40000gq/T/go-build997659573/b001/exe/main:
+  -kafka_group_id string
+    	the Kafka group for maintaining offset state (default "test")
+  -kafka_host string
+    	the hostname of the Kafka broker (default "kafka.kafka")
+  -kafka_port string
+    	the port of the Kafka broker (default "9092")
+  -kafka_timeout int
+    	the timeout in seconds for reading messages from the Kafka queue (default 5)
+  -kafka_topic string
+    	the Kafka topic for messages (default "test")
+  -named_pipe string
+    	the named pipe for the spout (default "/pfs/out")
+  -v	verbose logging
+exit status 2
+```
+The environment variables are as shown 
+in this excerpt from the `pipelines/kafka_spout.pipeline` file:
+```sh
+            "KAFKA_HOST": "kafka.kafka",
+            "KAFKA_PORT": "9092",
+            "KAFKA_TOPIC": "test_topic",
+            "KAFKA_GROUP_ID": "test_group",
+            "KAFKA_TIMEOUT": "5",
+            "NAMED_PIPE": "/pfs/out",
+            "VERBOSE_LOGGING": "false"
+```
+

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -50,7 +50,7 @@ run the command
 ```sh
 make -n kafka
 ```
-You can confirm that the kafka cluster is running properly by checking to see if all the pods are running.
+You can confirm that the Kafka cluster is running properly by verifying that the pods are running.
 ```sh
 $ kubectl get pods -n kafka
 NAME                READY   STATUS    RESTARTS   AGE

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -1,6 +1,6 @@
 # Commit messages from a Kafka queue
 
-A simple example using spouts with [Kafka](https://kafka.apache.org) to process messages and write them to files.
+This is a simple example of using spouts with [Kafka](https://kafka.apache.org) to process messages and write them to files.
 
 ## Background
 

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -4,7 +4,7 @@ This is a simple example of using spouts with [Kafka](https://kafka.apache.org) 
 
 
 This example spout connects to a Kafka queue and reads a topic.
-It then writes each message in the topic to a file named by the topic and offset. 
+The spout then writes each message in the topic to a file named by the topic and offset. 
 It uses Kafka group ids to maintain a cursor into the offset in the topic, 
 making it resilient to restarts.
 

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -47,10 +47,13 @@ You can use the makefile target `make kafka`,
 which will deploy a kafka cluster a `kafka` namespace, created in the first step.
 If you'd like to see the order in which the manifests will be loaded into Kubernetes,
 run the command
+
 ```sh
 make -n kafka
 ```
+
 You can confirm that the Kafka cluster is running properly by verifying that the pods are running.
+
 ```sh
 $ kubectl get pods -n kafka
 NAME                READY   STATUS    RESTARTS   AGE
@@ -62,19 +65,23 @@ kafka-zookeeper-0   1/1     Running   0          3d19h
 kafka-zookeeper-1   1/1     Running   0          3d19h
 kafka-zookeeper-2   1/1     Running   0          3d19h
 ```
+
 2. Once the Kafka cluster is running, create the topic you'd like to consume messages from.
 The example is configured to look for a topic called `test-topic`.
 You may modify the Makefile to use another topic name, of course.
 To use the example's Kafka environment,
 you may use the following command to create the topic:
+
 ```sh
 $ kubectl -n kafka exec kafka-test-client -- /usr/bin/kafka-topics --zookeeper \
       kafka-zookeeper.kafka:2181 --topic test --create \
       --partitions 1 --replication-factor 1
 Created topic "test".
 ```
+
 Note that the command is using Kubernetes DNS names to specify the Kafka zookeeper service,
 `kafka-zookeeper.kafka`.
+
 3. You can start populating the topic with data using the `kafka-console-producer` command.
 It provides you with a `>` prompt for entering data,
 delimited by lines for each offset into the topic.
@@ -83,6 +90,7 @@ at offset 1, `man`,
 and so on.
 Data entry is completed with an end-of-file character,
 `Control-d` in most shells.
+
 ```sh
 $ kubectl -n kafka exec -ti kafka-test-client --  /usr/bin/kafka-console-producer \
    --broker-list kafka.kafka:9092 --topic test 
@@ -93,9 +101,11 @@ $ kubectl -n kafka exec -ti kafka-test-client --  /usr/bin/kafka-console-produce
 >cool!!
 >
 ```
+
 4. You can see if the data has been added to the topic with the `kafka-console-consumer` command.
 In the example below,
 the session was terminated with `Control-C` keystrokes.
+
 ```sh
 $ kubectl -n kafka exec -ti kafka-test-client -- /usr/bin/kafka-console-consumer 
    --bootstrap-server kafka:9092 --topic test --from-beginning
@@ -107,6 +117,7 @@ cool!!
 ^CProcessed a total of 5 messages
 command terminated with exit code 130
 ```
+
 ### Pachyderm setup
 
 This guide assumes that you already have a Pachyderm cluster running and have configured `pachctl` to talk to the cluster and `kubectl` to talk to Kubernetes.
@@ -115,6 +126,7 @@ This guide assumes that you already have a Pachyderm cluster running and have co
 1. If you would simply like to use the prebuilt spout image,
 you can simply create the spout with the pachctl command
 using the pipeline definition available in the `pipelines` directory
+
 ```
 $ pachctl create pipeline -f pipelines/kafka_spout.json
 ```
@@ -122,17 +134,20 @@ $ pachctl create pipeline -f pipelines/kafka_spout.json
 2. To create your own version of the spout,
 you may modify the Makefile to use your own Dockerhub account, tag and version
 by changing these variables accordingly
+
 ```
 CONTAINER_VERSION := 1.9.8
 DOCKER_ACCOUNT := pachyderm
 CONTAINER_NAME := kafka_spout
 ```
+
 The Makefile has targets for `create-dag` and `update-dag`, 
 or you may simply make the image with `docker-image`.
 
 3. Once the spout is running, 
 if the `VERBOSE_LOGGING` variable is set to anything other than `false`,
 you will see verbose logging in the `kafka_spout` pipeline logs.
+
 ```sh
 $ pachctl logs -p kafka_spout -f
 creating new kafka reader for kafka.kafka:9092 with topic 'test_topic' and group 'test_group'
@@ -177,7 +192,9 @@ closing tarstream.
 closing named pipe /pfs/out.
 ...
 ```
+
 And you will see the message files in the `kafka_spout` repo
+
 ```sh
 $ pachctl list file kafka_spout@master
 NAME          TYPE SIZE 
@@ -187,7 +204,10 @@ NAME          TYPE SIZE
 /test_topic-3 file 5B   
 /test_topic-4 file 6B   
 ```
+
 ## Pipelines
+
+This section describes the pipelines that you use in this example.
 
 ### kafka_spout
 
@@ -198,6 +218,7 @@ It is configurable via environment variables and command-line flags.
 Flags override environment variable settings.
 If your Go development environment is set up correctly,
 you can see the settings by running the command:
+
 ```
 $ go run source/main.go --help
 Usage of /var/folders/xl/xtvj4xtx0tv1llxcnbvlmwc40000gq/T/go-build997659573/b001/exe/main:
@@ -216,8 +237,10 @@ Usage of /var/folders/xl/xtvj4xtx0tv1llxcnbvlmwc40000gq/T/go-build997659573/b001
   -v	verbose logging
 exit status 2
 ```
+
 The environment variables are as shown 
 in this excerpt from the `pipelines/kafka_spout.pipeline` file:
+
 ```sh
             "KAFKA_HOST": "kafka.kafka",
             "KAFKA_PORT": "9092",

--- a/examples/spouts/go-kafka-spout/README.md
+++ b/examples/spouts/go-kafka-spout/README.md
@@ -3,7 +3,7 @@
 This is a simple example of using spouts with [Kafka](https://kafka.apache.org) to process messages and write them to files.
 
 
-This example connects to a Kafka queue and reads a topic.
+This example spout connects to a Kafka queue and reads a topic.
 It then writes each message in the topic to a file named by the topic and offset. 
 It uses Kafka group ids to maintain a cursor into the offset in the topic, 
 making it resilient to restarts.

--- a/examples/spouts/go-kafka-spout/additional_manifests/000-namespace.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/000-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka
+  

--- a/examples/spouts/go-kafka-spout/additional_manifests/001-storage-class-gcp.yml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/001-storage-class-gcp.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  labels:
+    app: kafka
+    suite: kafka
+  name: kafka-storage-class
+  namespace: default
+parameters:
+  type: gp2
+provisioner: kubernetes.io/aws-ebs

--- a/examples/spouts/go-kafka-spout/additional_manifests/001-storage-class.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/001-storage-class.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  labels:
+    app: kafka
+    suite: kafka
+  name: kafka-storage-class
+  namespace: default
+parameters:
+  type: gp2
+provisioner: kubernetes.io/aws-ebs

--- a/examples/spouts/go-kafka-spout/additional_manifests/110-zookeeper-service-headless.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/110-zookeeper-service-headless.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-zookeeper-headless
+  namespace: kafka
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 21
+    protocol: TCP
+    targetPort: 2181
+  - name: election
+    port: 3888
+    protocol: TCP
+    targetPort: 3888
+  - name: server
+    port: 2888
+    protocol: TCP
+    targetPort: 2888
+  selector:
+    app: kafka-zookeeper
+  sessionAffinity: None
+  type: ClusterIP

--- a/examples/spouts/go-kafka-spout/additional_manifests/110-zookeeper-service.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/110-zookeeper-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-zookeeper
+  namespace: kafka
+spec:
+  ports:
+  - name: client
+    port: 2181
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kafka-zookeeper
+  sessionAffinity: None
+  type: ClusterIP

--- a/examples/spouts/go-kafka-spout/additional_manifests/140-zookeeper-statefulset.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/140-zookeeper-statefulset.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-zookeeper
+  namespace: kafka
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: kafka-zookeeper
+  serviceName: kafka-zookeeper-headless
+  template:
+    metadata:
+      labels:
+        app: kafka-zookeeper
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -xec
+        - zkGenConfig.sh && exec zkServer.sh start-foreground
+        env:
+        - name: ZK_REPLICAS
+          value: "3"
+        - name: JMXAUTH
+          value: "false"
+        - name: JMXDISABLE
+          value: "false"
+        - name: JMXPORT
+          value: "1099"
+        - name: JMXSSL
+          value: "false"
+        - name: ZK_CLIENT_PORT
+          value: "2181"
+        - name: ZK_ELECTION_PORT
+          value: "3888"
+        - name: ZK_HEAP_SIZE
+          value: 1G
+        - name: ZK_INIT_LIMIT
+          value: "5"
+        - name: ZK_LOG_LEVEL
+          value: INFO
+        - name: ZK_MAX_CLIENT_CNXNS
+          value: "60"
+        - name: ZK_MAX_SESSION_TIMEOUT
+          value: "40000"
+        - name: ZK_MIN_SESSION_TIMEOUT
+          value: "4000"
+        - name: ZK_PURGE_INTERVAL
+          value: "0"
+        - name: ZK_SERVER_PORT
+          value: "2888"
+        - name: ZK_SNAP_RETAIN_COUNT
+          value: "3"
+        - name: ZK_SYNC_LIMIT
+          value: "10"
+        - name: ZK_TICK_TIME
+          value: "2000"
+        image: gcr.io/google_samples/k8szk:v3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - zkOk.sh
+          failureThreshold: 3
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: zookeeper
+        ports:
+        - containerPort: 2181
+          name: client
+          protocol: TCP
+        - containerPort: 3888
+          name: election
+          protocol: TCP
+        - containerPort: 2888
+          name: server
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - zkOk.sh
+          failureThreshold: 3
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/zookeeper
+          name: data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: data
+  updateStrategy:
+    type: OnDelete

--- a/examples/spouts/go-kafka-spout/additional_manifests/150-zookeeper-disruptionbudget.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/150-zookeeper-disruptionbudget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: kafka-zookeeper
+  name: kafka-zookeeper
+  namespace: kafka
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: kafka-zookeeper

--- a/examples/spouts/go-kafka-spout/additional_manifests/210-kafka-service-headless.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/210-kafka-service-headless.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-headless
+  namespace: kafka
+spec:
+  clusterIP: None
+  ports:
+  - name: broker
+    port: 9092
+    protocol: TCP
+    targetPort: 9092
+  selector:
+    app: kafka
+  sessionAffinity: None
+  type: ClusterIP

--- a/examples/spouts/go-kafka-spout/additional_manifests/210-kafka-service.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/210-kafka-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  ports:
+  - name: broker
+    port: 9092
+    protocol: TCP
+    targetPort: kafka
+  selector:
+    app: kafka
+  sessionAffinity: None
+  type: ClusterIP

--- a/examples/spouts/go-kafka-spout/additional_manifests/240-kafka-statefulset.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/240-kafka-statefulset.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: kafka
+  name: kafka
+  namespace: kafka
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: kafka
+  serviceName: kafka-headless
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+      - command:
+        - sh
+        - -exc
+        - |
+          unset KAFKA_PORT && \
+          export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
+          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092 && \
+          exec /etc/confluent/docker/run
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx1G -Xms1G
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: kafka-zookeeper:2181
+        - name: KAFKA_LOG_DIRS
+          value: /opt/kafka/data/logs
+        - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+          value: "3"
+        - name: KAFKA_JMX_PORT
+          value: "5555"
+        image: confluentinc/cp-kafka:4.1.2-2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -ec
+            - /usr/bin/jps | /bin/grep -q SupportedKafka
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: kafka-broker
+        ports:
+        - containerPort: 9092
+          name: kafka
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: kafka
+          timeoutSeconds: 5
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /opt/kafka/data
+          name: datadir
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 60
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - metadata:
+      annotations:
+        volume.beta.kubernetes.io/storage-class: kafka-storage-class
+      labels:
+        app: kafka
+        suite: kafka
+      name: datadir
+      namespace: kafka
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi 

--- a/examples/spouts/go-kafka-spout/additional_manifests/400-pod-test.yaml
+++ b/examples/spouts/go-kafka-spout/additional_manifests/400-pod-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kafka-test-client
+  namespace: kafka
+spec:
+  containers:
+  - command:
+    - sh
+    - -c
+    - exec tail -f /dev/null
+    image: confluentinc/cp-kafka:4.1.2-2
+    imagePullPolicy: IfNotPresent
+    name: kafka
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File

--- a/examples/spouts/go-kafka-spout/pipelines/kafka_spout.json
+++ b/examples/spouts/go-kafka-spout/pipelines/kafka_spout.json
@@ -1,0 +1,25 @@
+{
+  "pipeline": {
+    "name": "kafka_spout"
+  },
+  "spout": {
+    "overwrite": true
+  },
+  "transform": {
+    "cmd": [
+      "go",
+      "run",
+      "./main.go"
+    ],
+    "image": "pachyderm/kafka_spout:1.9.8",
+    "env": {
+      "KAFKA_HOST": "kafka.kafka",
+      "KAFKA_PORT": "9092",
+      "KAFKA_TOPIC": "test_topic",
+      "KAFKA_GROUP_ID": "test_group",
+      "KAFKA_TIMEOUT": "5",
+      "NAMED_PIPE": "/pfs/out",
+      "VERBOSE_LOGGING": "true"
+    }
+  }
+}

--- a/examples/spouts/go-kafka-spout/pipelines/kafka_spout.pipeline
+++ b/examples/spouts/go-kafka-spout/pipelines/kafka_spout.pipeline
@@ -1,0 +1,22 @@
+{
+    "pipeline": {
+        "name": "kafka_spout"
+    },
+    "spout": {
+        "overwrite": true
+    },
+    "transform": {
+        "cmd": [ "go", "run", "./main.go"],
+        "image": "pachyderm/kafka_spout:1.9.8",
+        "env" : {
+            "KAFKA_HOST": "kafka.kafka",
+            "KAFKA_PORT": "9092",
+            "KAFKA_TOPIC": "test_topic",
+            "KAFKA_GROUP_ID": "test_group",
+            "KAFKA_TIMEOUT": "5",
+            "NAMED_PIPE": "/pfs/out",
+            "VERBOSE_LOGGING": "false"
+        }
+    }
+}
+

--- a/examples/spouts/go-kafka-spout/source/main.go
+++ b/examples/spouts/go-kafka-spout/source/main.go
@@ -1,0 +1,200 @@
+
+package main
+
+import (
+	"archive/tar"
+	"context"
+	"os"
+	"strings"
+	"time"
+	"fmt"
+	"strconv"
+	"flag"
+
+	kafka "github.com/segmentio/kafka-go"
+)
+
+const defaultHost = "kafka.kafka"
+const defaultPort = "9092"
+const defaultTopic = "test"
+const defaultGroupID = "test"
+const defaultTimeout = 5
+const defaultNamedPipe = "/pfs/out"
+
+
+func process_messages(pipe string, reader *kafka.Reader, timeout int, log bool) error {
+	// read a message
+	if (log) {
+		fmt.Printf("reading kafka queue.\n")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout) * time.Second)
+	defer func() {
+		if (log) {
+			fmt.Printf("cleaning up context.\n")
+		}
+		cancel()
+	}()
+	m, err := reader.ReadMessage(ctx)
+	if err != nil {
+		return err
+	}
+	if (log) {
+		fmt.Printf("opening named pipe %v.\n", pipe)
+	}
+	// Open the /pfs/out pipe with write only permissons (the pachyderm spout will be reading at the other end of this)
+	// Note: it won't work if you try to open this with read, or read/write permissions
+	out, err := os.OpenFile(pipe, os.O_WRONLY, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if (log) {
+			fmt.Printf("closing named pipe %v.\n", pipe)
+		}
+		out.Close()
+	}()
+
+	if (log) {
+		fmt.Printf("opening tarstream\n")
+	}
+	tw := tar.NewWriter(out)
+	defer func() {
+		if (log) {
+			fmt.Printf("closing tarstream.\n")
+		}
+		tw.Close()
+	}()
+
+	if (log) {
+		fmt.Printf("processing header for topic %v @ offset %v\n", m.Topic, m.Offset)
+	}
+	// give it a unique name
+	name := fmt.Sprintf("%v-%v", m.Topic,  m.Offset)
+	// write the header
+	for err = tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0600,
+		Size: int64(len(m.Value)),
+	}); err != nil; {
+		if !strings.Contains(err.Error(), "broken pipe") {
+			return err
+		}
+		// if there's a broken pipe, just give it some time to get ready for the next message
+		if (log) {
+			fmt.Printf("broken pipe\n")
+		}
+		time.Sleep(time.Duration(timeout) * time.Millisecond)
+	}
+	if (log) {
+		fmt.Printf("processing data for topic  %v @ offset %v\n", m.Topic, m.Offset)
+	}
+	// and the message
+	for _, err = tw.Write(m.Value); err != nil; {
+		if !strings.Contains(err.Error(), "broken pipe") {
+			return err
+		}
+		// if there's a broken pipe, just give it some time to get ready for the next message
+		if (log) {
+			fmt.Printf("broken pipe\n")
+		}
+		time.Sleep(time.Duration(timeout) * time.Millisecond)
+	}
+	return nil
+}
+
+func main() {
+
+	// Set the default values of the configurable variables
+	var (
+		host = defaultHost
+		port = defaultPort
+		topic = defaultTopic
+		group_id = defaultGroupID
+		timeout = defaultTimeout
+		named_pipe = defaultNamedPipe
+		log = false
+		ok = false
+		tmp = ""
+	)
+
+	// override with environment variables if they're set
+	host, ok = os.LookupEnv("KAFKA_HOST")
+	if !ok {
+		host = defaultHost
+	}
+	port, ok = os.LookupEnv("KAFKA_PORT")
+	if !ok {
+		port = defaultPort
+	}
+	topic, ok = os.LookupEnv("KAFKA_TOPIC")
+	if !ok {
+		topic = defaultTopic
+	}
+	group_id, ok = os.LookupEnv("KAFKA_GROUP_ID")
+	if !ok {
+		group_id = defaultGroupID
+	}
+	tmp, ok = os.LookupEnv("KAFKA_TIMEOUT")
+	if ok {
+		if myTimeout, err := strconv.Atoi(tmp); err != nil {
+			fmt.Sprintf("error parsing KAFKA_TIMEOUT env value %v, using default %v unless flagged\n", tmp, defaultTimeout)
+			timeout = defaultTimeout
+		} else {
+			timeout = myTimeout
+		}
+	} else {
+		timeout = defaultTimeout
+
+	}
+	named_pipe, ok = os.LookupEnv("NAMED_PIPE")
+	if !ok {
+		named_pipe = defaultNamedPipe
+	}
+	tmp, ok = os.LookupEnv("VERBOSE_LOGGING")
+	if !ok || strings.EqualFold("false", tmp) || tmp == "" {
+		log = false
+	} else {
+		log = true
+	}
+
+	// override with flags if they're set
+	flag.StringVar(&host, "kafka_host",  host, "the hostname of the Kafka broker")
+	flag.StringVar(&port, "kafka_port", port,  "the port of the Kafka broker")
+	flag.StringVar(&topic, "kafka_topic", topic, "the Kafka topic for messages")
+	flag.StringVar(&group_id, "kafka_group_id", group_id, "the Kafka group for maintaining offset state")
+	flag.IntVar(&timeout, "kafka_timeout",  timeout, "the timeout in seconds for reading messages from the Kafka queue")
+	flag.StringVar(&named_pipe, "named_pipe", named_pipe, "the named pipe for the spout")
+	flag.BoolVar(&log, "v", log, "verbose logging")
+
+	flag.Parse()
+
+	// And create a new kafka reader
+	if (log) {
+		fmt.Printf("creating new kafka reader for %v:%v with topic '%v' and group '%v'\n", host, port, topic, group_id)
+	}
+	
+	reader := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:  []string{host + ":" + port},
+		Topic:    topic,
+		GroupID:    group_id,
+		MinBytes: 10e1,
+		MaxBytes: 10e6,
+	})
+	defer reader.Close()
+
+	for {
+		err := process_messages(named_pipe, reader, timeout, log)
+		if err != nil {
+			if (log) {
+				if !strings.Contains(err.Error(), "context deadline exceeded") {
+					fmt.Printf("error processing kafka: %v\n", err)
+				} else {
+					fmt.Printf("timeout\n")
+				}
+			}
+		}
+		// fix for https://github.com/pachyderm/pachyderm/issues/4327
+		time.Sleep(time.Duration(200) * time.Millisecond)
+	}
+}
+


### PR DESCRIPTION
Rebased version.

Still todo: add GCP and Azure support for kafka cluster.

Sufficient as an example of writing a spout in Go, and as a copypasta resource for users.