### PR TITLE
force unix style paths on put file

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1290,6 +1290,13 @@ func putFileHelper(c *client.APIClient, pfc client.PutFileClient,
 		path = strings.TrimPrefix(path, "../")
 	}
 
+	//force windows style paths to unix style
+	path = strings.ReplaceAll(path, `\`, `/`)
+	//remove leading forward slash
+	if path[0] == '/' {
+		path = strings.Replace(path, "/", "", 1)
+	}
+
 	if _, ok := filesPut.LoadOrStore(path, nil); ok {
 		return fmt.Errorf("multiple files put with the path %s, aborting, "+
 			"some files may already have been put and should be cleaned up with "+


### PR DESCRIPTION
force unix style paths for pachctl put so that functionality is same when used on native windows.