### PR TITLE
Chunk Storage Changes

### DIFF
--- a/src/server/pkg/storage/chunk/chunk.pb.go
+++ b/src/server/pkg/storage/chunk/chunk.pb.go
@@ -25,7 +25,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 // DataRef is a reference to data within a chunk.
 type DataRef struct {
 	// The chunk the referenced data is located in.
-	Chunk *Chunk `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
+	ChunkInfo *ChunkInfo `protobuf:"bytes,1,opt,name=chunk_info,json=chunkInfo,proto3" json:"chunk_info,omitempty"`
 	// The hash of the data being referenced.
 	// This field is empty when it is equal to the chunk hash (the ref is the whole chunk).
 	Hash string `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -71,9 +71,9 @@ func (m *DataRef) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DataRef proto.InternalMessageInfo
 
-func (m *DataRef) GetChunk() *Chunk {
+func (m *DataRef) GetChunkInfo() *ChunkInfo {
 	if m != nil {
-		return m.Chunk
+		return m.ChunkInfo
 	}
 	return nil
 }
@@ -108,8 +108,6 @@ func (m *DataRef) GetTags() []*Tag {
 
 type Chunk struct {
 	Hash                 string   `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
-	SizeBytes            int64    `protobuf:"varint,2,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
-	Edge                 bool     `protobuf:"varint,3,opt,name=edge,proto3" json:"edge,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -155,14 +153,63 @@ func (m *Chunk) GetHash() string {
 	return ""
 }
 
-func (m *Chunk) GetSizeBytes() int64 {
+type ChunkInfo struct {
+	Chunk                *Chunk   `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
+	SizeBytes            int64    `protobuf:"varint,2,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Edge                 bool     `protobuf:"varint,3,opt,name=edge,proto3" json:"edge,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ChunkInfo) Reset()         { *m = ChunkInfo{} }
+func (m *ChunkInfo) String() string { return proto.CompactTextString(m) }
+func (*ChunkInfo) ProtoMessage()    {}
+func (*ChunkInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_80b36f82a9f02ff9, []int{2}
+}
+func (m *ChunkInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ChunkInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ChunkInfo.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ChunkInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ChunkInfo.Merge(m, src)
+}
+func (m *ChunkInfo) XXX_Size() int {
+	return m.Size()
+}
+func (m *ChunkInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_ChunkInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ChunkInfo proto.InternalMessageInfo
+
+func (m *ChunkInfo) GetChunk() *Chunk {
+	if m != nil {
+		return m.Chunk
+	}
+	return nil
+}
+
+func (m *ChunkInfo) GetSizeBytes() int64 {
 	if m != nil {
 		return m.SizeBytes
 	}
 	return 0
 }
 
-func (m *Chunk) GetEdge() bool {
+func (m *ChunkInfo) GetEdge() bool {
 	if m != nil {
 		return m.Edge
 	}
@@ -181,7 +228,7 @@ func (m *Tag) Reset()         { *m = Tag{} }
 func (m *Tag) String() string { return proto.CompactTextString(m) }
 func (*Tag) ProtoMessage()    {}
 func (*Tag) Descriptor() ([]byte, []int) {
-	return fileDescriptor_80b36f82a9f02ff9, []int{2}
+	return fileDescriptor_80b36f82a9f02ff9, []int{3}
 }
 func (m *Tag) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -227,6 +274,7 @@ func (m *Tag) GetSizeBytes() int64 {
 func init() {
 	proto.RegisterType((*DataRef)(nil), "chunk.DataRef")
 	proto.RegisterType((*Chunk)(nil), "chunk.Chunk")
+	proto.RegisterType((*ChunkInfo)(nil), "chunk.ChunkInfo")
 	proto.RegisterType((*Tag)(nil), "chunk.Tag")
 }
 
@@ -235,25 +283,27 @@ func init() {
 }
 
 var fileDescriptor_80b36f82a9f02ff9 = []byte{
-	// 282 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x91, 0xbd, 0x4e, 0xc3, 0x30,
-	0x14, 0x85, 0x71, 0x7e, 0x80, 0xde, 0x54, 0x0c, 0x9e, 0xb2, 0x10, 0x85, 0x88, 0x21, 0x53, 0x22,
-	0x15, 0x36, 0xb6, 0x96, 0x15, 0x06, 0xab, 0x13, 0x0b, 0x72, 0x92, 0x1b, 0x27, 0xaa, 0x20, 0x91,
-	0xed, 0x22, 0x95, 0x27, 0x61, 0xe7, 0x65, 0x18, 0x79, 0x04, 0x14, 0x5e, 0x04, 0xc5, 0xce, 0xd0,
-	0x22, 0x21, 0x96, 0xab, 0xe3, 0xef, 0x1e, 0x9d, 0x63, 0xe9, 0xc2, 0xa5, 0x42, 0xf9, 0x82, 0x32,
-	0xef, 0x37, 0x22, 0x57, 0xba, 0x93, 0x5c, 0x60, 0x5e, 0x36, 0xdb, 0xe7, 0x8d, 0x9d, 0x59, 0x2f,
-	0x3b, 0xdd, 0x51, 0xdf, 0x3c, 0x92, 0x77, 0x02, 0x27, 0xb7, 0x5c, 0x73, 0x86, 0x35, 0x4d, 0xc0,
-	0xc2, 0x90, 0xc4, 0x24, 0x0d, 0x16, 0xf3, 0xcc, 0xfa, 0x57, 0xe3, 0x64, 0x76, 0x45, 0x29, 0x78,
-	0x0d, 0x57, 0x4d, 0xe8, 0xc4, 0x24, 0x9d, 0x31, 0xa3, 0xe9, 0x05, 0xcc, 0xbb, 0xba, 0x56, 0xa8,
-	0x1f, 0x8b, 0x9d, 0x46, 0x15, 0xba, 0x31, 0x49, 0x5d, 0x16, 0x58, 0xb6, 0x1c, 0x11, 0x3d, 0x07,
-	0x50, 0xed, 0x2b, 0x4e, 0x06, 0xcf, 0x18, 0x66, 0x23, 0xb1, 0xeb, 0x08, 0x3c, 0xcd, 0x85, 0x0a,
-	0xfd, 0xd8, 0x4d, 0x83, 0x05, 0x4c, 0xc5, 0x6b, 0x2e, 0x98, 0xe1, 0xc9, 0x3d, 0xf8, 0xab, 0x83,
-	0x7a, 0xb2, 0x57, 0x7f, 0x98, 0xed, 0xfc, 0xce, 0xa6, 0xe0, 0x61, 0x25, 0xd0, 0xfc, 0xea, 0x94,
-	0x19, 0x9d, 0x5c, 0x83, 0xbb, 0xe6, 0x82, 0x9e, 0x81, 0xd3, 0x56, 0x53, 0x96, 0xd3, 0x56, 0xff,
-	0x24, 0x2d, 0xef, 0x3e, 0x86, 0x88, 0x7c, 0x0e, 0x11, 0xf9, 0x1a, 0x22, 0xf2, 0xf6, 0x1d, 0x1d,
-	0x3d, 0xdc, 0x88, 0x56, 0x37, 0xdb, 0x22, 0x2b, 0xbb, 0xa7, 0xbc, 0xe7, 0x65, 0xb3, 0xab, 0x50,
-	0xee, 0x2b, 0x25, 0xcb, 0xfc, 0xaf, 0x6b, 0x14, 0xc7, 0xe6, 0x10, 0x57, 0x3f, 0x01, 0x00, 0x00,
-	0xff, 0xff, 0x93, 0x52, 0xd5, 0x4f, 0xb0, 0x01, 0x00, 0x00,
+	// 311 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x51, 0xb1, 0x4e, 0xc3, 0x30,
+	0x10, 0xc5, 0x49, 0x0a, 0xe4, 0x5a, 0x21, 0xe4, 0x29, 0x12, 0x22, 0x0a, 0x11, 0x43, 0xa6, 0x5a,
+	0x2a, 0x6c, 0x6c, 0x85, 0x85, 0x81, 0xc5, 0xea, 0xc4, 0x52, 0x39, 0x89, 0xe3, 0x44, 0x15, 0x75,
+	0x65, 0xbb, 0x48, 0xe5, 0x4b, 0xf8, 0x0c, 0x3e, 0x83, 0x91, 0x4f, 0x40, 0xe1, 0x47, 0x50, 0xec,
+	0x50, 0xaa, 0x4a, 0x88, 0xe5, 0xf4, 0xfc, 0xee, 0x7c, 0xef, 0x3d, 0x1d, 0x5c, 0x6a, 0xae, 0x9e,
+	0xb9, 0x22, 0xab, 0x85, 0x20, 0xda, 0x48, 0xc5, 0x04, 0x27, 0x45, 0xbd, 0x5e, 0x2e, 0x5c, 0x1d,
+	0xaf, 0x94, 0x34, 0x12, 0x0f, 0xec, 0x23, 0x7d, 0x43, 0x70, 0x74, 0xc7, 0x0c, 0xa3, 0xbc, 0xc2,
+	0x04, 0xc0, 0x92, 0xf3, 0x66, 0x59, 0xc9, 0x08, 0x25, 0x28, 0x1b, 0x4e, 0x4e, 0xc7, 0xee, 0xd3,
+	0x6d, 0x57, 0xef, 0x97, 0x95, 0xa4, 0x61, 0xf1, 0x03, 0x31, 0x86, 0xa0, 0x66, 0xba, 0x8e, 0xbc,
+	0x04, 0x65, 0x21, 0xb5, 0x18, 0x5f, 0xc0, 0x48, 0x56, 0x95, 0xe6, 0x66, 0x9e, 0x6f, 0x0c, 0xd7,
+	0x91, 0x9f, 0xa0, 0xcc, 0xa7, 0x43, 0xc7, 0x4d, 0x3b, 0x0a, 0x9f, 0x03, 0xe8, 0xe6, 0x85, 0xf7,
+	0x03, 0x81, 0x1d, 0x08, 0x3b, 0xc6, 0xb5, 0x63, 0x08, 0x0c, 0x13, 0x3a, 0x1a, 0x24, 0x7e, 0x36,
+	0x9c, 0x40, 0x6f, 0x60, 0xc6, 0x04, 0xb5, 0x7c, 0x7a, 0x06, 0x03, 0xeb, 0x66, 0x2b, 0x8f, 0x7e,
+	0xe5, 0xd3, 0x1c, 0xc2, 0xad, 0x55, 0x9c, 0x82, 0x4b, 0xd9, 0x67, 0x19, 0xed, 0x66, 0xa1, 0xae,
+	0xb5, 0x67, 0xc6, 0xdb, 0x37, 0x83, 0x21, 0xe0, 0xa5, 0xe0, 0x36, 0xc6, 0x31, 0xb5, 0x38, 0xbd,
+	0x06, 0x7f, 0xc6, 0x04, 0x3e, 0x01, 0xaf, 0x29, 0x7b, 0x71, 0xaf, 0x29, 0xff, 0xd9, 0x34, 0x7d,
+	0x78, 0x6f, 0x63, 0xf4, 0xd1, 0xc6, 0xe8, 0xb3, 0x8d, 0xd1, 0xeb, 0x57, 0x7c, 0xf0, 0x78, 0x23,
+	0x1a, 0x53, 0xaf, 0xf3, 0x71, 0x21, 0x9f, 0xc8, 0x8a, 0x15, 0xf5, 0xa6, 0xe4, 0x6a, 0x17, 0x69,
+	0x55, 0x90, 0xbf, 0x6e, 0x99, 0x1f, 0xda, 0x33, 0x5e, 0x7d, 0x07, 0x00, 0x00, 0xff, 0xff, 0x92,
+	0xaf, 0xbc, 0x6d, 0xee, 0x01, 0x00, 0x00,
 }
 
 func (m *DataRef) Marshal() (dAtA []byte, err error) {
@@ -311,9 +361,9 @@ func (m *DataRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x12
 	}
-	if m.Chunk != nil {
+	if m.ChunkInfo != nil {
 		{
-			size, err := m.Chunk.MarshalToSizedBuffer(dAtA[:i])
+			size, err := m.ChunkInfo.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
@@ -350,6 +400,40 @@ func (m *Chunk) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
+	if len(m.Hash) > 0 {
+		i -= len(m.Hash)
+		copy(dAtA[i:], m.Hash)
+		i = encodeVarintChunk(dAtA, i, uint64(len(m.Hash)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ChunkInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ChunkInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ChunkInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
 	if m.Edge {
 		i--
 		if m.Edge {
@@ -365,10 +449,15 @@ func (m *Chunk) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x10
 	}
-	if len(m.Hash) > 0 {
-		i -= len(m.Hash)
-		copy(dAtA[i:], m.Hash)
-		i = encodeVarintChunk(dAtA, i, uint64(len(m.Hash)))
+	if m.Chunk != nil {
+		{
+			size, err := m.Chunk.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintChunk(dAtA, i, uint64(size))
+		}
 		i--
 		dAtA[i] = 0xa
 	}
@@ -431,8 +520,8 @@ func (m *DataRef) Size() (n int) {
 	}
 	var l int
 	_ = l
-	if m.Chunk != nil {
-		l = m.Chunk.Size()
+	if m.ChunkInfo != nil {
+		l = m.ChunkInfo.Size()
 		n += 1 + l + sovChunk(uint64(l))
 	}
 	l = len(m.Hash)
@@ -465,6 +554,22 @@ func (m *Chunk) Size() (n int) {
 	_ = l
 	l = len(m.Hash)
 	if l > 0 {
+		n += 1 + l + sovChunk(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ChunkInfo) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Chunk != nil {
+		l = m.Chunk.Size()
 		n += 1 + l + sovChunk(uint64(l))
 	}
 	if m.SizeBytes != 0 {
@@ -535,7 +640,7 @@ func (m *DataRef) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Chunk", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ChunkInfo", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -562,10 +667,10 @@ func (m *DataRef) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Chunk == nil {
-				m.Chunk = &Chunk{}
+			if m.ChunkInfo == nil {
+				m.ChunkInfo = &ChunkInfo{}
 			}
-			if err := m.Chunk.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.ChunkInfo.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -758,6 +863,96 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Hash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipChunk(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ChunkInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowChunk
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ChunkInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ChunkInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Chunk", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthChunk
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Chunk == nil {
+				m.Chunk = &Chunk{}
+			}
+			if err := m.Chunk.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 0 {

--- a/src/server/pkg/storage/chunk/chunk.pb.go
+++ b/src/server/pkg/storage/chunk/chunk.pb.go
@@ -22,53 +22,6 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
-type Chunk struct {
-	Hash                 string   `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *Chunk) Reset()         { *m = Chunk{} }
-func (m *Chunk) String() string { return proto.CompactTextString(m) }
-func (*Chunk) ProtoMessage()    {}
-func (*Chunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_80b36f82a9f02ff9, []int{0}
-}
-func (m *Chunk) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *Chunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_Chunk.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *Chunk) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Chunk.Merge(m, src)
-}
-func (m *Chunk) XXX_Size() int {
-	return m.Size()
-}
-func (m *Chunk) XXX_DiscardUnknown() {
-	xxx_messageInfo_Chunk.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Chunk proto.InternalMessageInfo
-
-func (m *Chunk) GetHash() string {
-	if m != nil {
-		return m.Hash
-	}
-	return ""
-}
-
 // DataRef is a reference to data within a chunk.
 type DataRef struct {
 	// The chunk the referenced data is located in.
@@ -79,6 +32,7 @@ type DataRef struct {
 	// The offset and size used for accessing the data within the chunk.
 	OffsetBytes          int64    `protobuf:"varint,3,opt,name=offset_bytes,json=offsetBytes,proto3" json:"offset_bytes,omitempty"`
 	SizeBytes            int64    `protobuf:"varint,4,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Tags                 []*Tag   `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -88,7 +42,7 @@ func (m *DataRef) Reset()         { *m = DataRef{} }
 func (m *DataRef) String() string { return proto.CompactTextString(m) }
 func (*DataRef) ProtoMessage()    {}
 func (*DataRef) Descriptor() ([]byte, []int) {
-	return fileDescriptor_80b36f82a9f02ff9, []int{1}
+	return fileDescriptor_80b36f82a9f02ff9, []int{0}
 }
 func (m *DataRef) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -145,9 +99,135 @@ func (m *DataRef) GetSizeBytes() int64 {
 	return 0
 }
 
+func (m *DataRef) GetTags() []*Tag {
+	if m != nil {
+		return m.Tags
+	}
+	return nil
+}
+
+type Chunk struct {
+	Hash                 string   `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
+	SizeBytes            int64    `protobuf:"varint,2,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Edge                 bool     `protobuf:"varint,3,opt,name=edge,proto3" json:"edge,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Chunk) Reset()         { *m = Chunk{} }
+func (m *Chunk) String() string { return proto.CompactTextString(m) }
+func (*Chunk) ProtoMessage()    {}
+func (*Chunk) Descriptor() ([]byte, []int) {
+	return fileDescriptor_80b36f82a9f02ff9, []int{1}
+}
+func (m *Chunk) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Chunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Chunk.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Chunk) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Chunk.Merge(m, src)
+}
+func (m *Chunk) XXX_Size() int {
+	return m.Size()
+}
+func (m *Chunk) XXX_DiscardUnknown() {
+	xxx_messageInfo_Chunk.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Chunk proto.InternalMessageInfo
+
+func (m *Chunk) GetHash() string {
+	if m != nil {
+		return m.Hash
+	}
+	return ""
+}
+
+func (m *Chunk) GetSizeBytes() int64 {
+	if m != nil {
+		return m.SizeBytes
+	}
+	return 0
+}
+
+func (m *Chunk) GetEdge() bool {
+	if m != nil {
+		return m.Edge
+	}
+	return false
+}
+
+type Tag struct {
+	Id                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	SizeBytes            int64    `protobuf:"varint,2,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Tag) Reset()         { *m = Tag{} }
+func (m *Tag) String() string { return proto.CompactTextString(m) }
+func (*Tag) ProtoMessage()    {}
+func (*Tag) Descriptor() ([]byte, []int) {
+	return fileDescriptor_80b36f82a9f02ff9, []int{2}
+}
+func (m *Tag) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Tag) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Tag.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Tag) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Tag.Merge(m, src)
+}
+func (m *Tag) XXX_Size() int {
+	return m.Size()
+}
+func (m *Tag) XXX_DiscardUnknown() {
+	xxx_messageInfo_Tag.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Tag proto.InternalMessageInfo
+
+func (m *Tag) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+func (m *Tag) GetSizeBytes() int64 {
+	if m != nil {
+		return m.SizeBytes
+	}
+	return 0
+}
+
 func init() {
-	proto.RegisterType((*Chunk)(nil), "chunk.Chunk")
 	proto.RegisterType((*DataRef)(nil), "chunk.DataRef")
+	proto.RegisterType((*Chunk)(nil), "chunk.Chunk")
+	proto.RegisterType((*Tag)(nil), "chunk.Tag")
 }
 
 func init() {
@@ -155,55 +235,25 @@ func init() {
 }
 
 var fileDescriptor_80b36f82a9f02ff9 = []byte{
-	// 220 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x29, 0x4e, 0x2d, 0x2a,
-	0x4b, 0x2d, 0xd2, 0x2f, 0xc8, 0x4e, 0xd7, 0x2f, 0x2e, 0xc9, 0x2f, 0x4a, 0x4c, 0x4f, 0xd5, 0x4f,
-	0xce, 0x28, 0xcd, 0xcb, 0x86, 0x90, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0xac, 0x60, 0x8e,
-	0x92, 0x34, 0x17, 0xab, 0x33, 0x88, 0x21, 0x24, 0xc4, 0xc5, 0x92, 0x91, 0x58, 0x9c, 0x21, 0xc1,
-	0xa8, 0xc0, 0xa8, 0xc1, 0x19, 0x04, 0x66, 0x2b, 0x35, 0x33, 0x72, 0xb1, 0xbb, 0x24, 0x96, 0x24,
-	0x06, 0xa5, 0xa6, 0x09, 0x29, 0x71, 0x41, 0x74, 0x80, 0x15, 0x70, 0x1b, 0xf1, 0xe8, 0x41, 0x0c,
-	0x03, 0x6b, 0x0e, 0x82, 0x48, 0xc1, 0xcd, 0x60, 0x42, 0x98, 0x21, 0xa4, 0xc8, 0xc5, 0x93, 0x9f,
-	0x96, 0x56, 0x9c, 0x5a, 0x12, 0x9f, 0x54, 0x59, 0x92, 0x5a, 0x2c, 0xc1, 0xac, 0xc0, 0xa8, 0xc1,
-	0x1c, 0xc4, 0x0d, 0x11, 0x73, 0x02, 0x09, 0x09, 0xc9, 0x72, 0x71, 0x15, 0x67, 0x56, 0xa5, 0x42,
-	0x15, 0xb0, 0x80, 0x15, 0x70, 0x82, 0x44, 0xc0, 0xd2, 0x4e, 0xbe, 0x27, 0x1e, 0xc9, 0x31, 0x5e,
-	0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x8c, 0xc7, 0x72, 0x0c, 0x51, 0xd6, 0xe9, 0x99,
-	0x25, 0x19, 0xa5, 0x49, 0x7a, 0xc9, 0xf9, 0xb9, 0xfa, 0x05, 0x89, 0xc9, 0x19, 0x95, 0x29, 0xa9,
-	0x45, 0xc8, 0xac, 0xe2, 0xa2, 0x64, 0x7d, 0x5c, 0x81, 0x90, 0xc4, 0x06, 0xf6, 0xbf, 0x31, 0x20,
-	0x00, 0x00, 0xff, 0xff, 0x55, 0x0d, 0x1d, 0x07, 0x27, 0x01, 0x00, 0x00,
-}
-
-func (m *Chunk) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Chunk) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *Chunk) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if len(m.Hash) > 0 {
-		i -= len(m.Hash)
-		copy(dAtA[i:], m.Hash)
-		i = encodeVarintChunk(dAtA, i, uint64(len(m.Hash)))
-		i--
-		dAtA[i] = 0xa
-	}
-	return len(dAtA) - i, nil
+	// 282 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x91, 0xbd, 0x4e, 0xc3, 0x30,
+	0x14, 0x85, 0x71, 0x7e, 0x80, 0xde, 0x54, 0x0c, 0x9e, 0xb2, 0x10, 0x85, 0x88, 0x21, 0x53, 0x22,
+	0x15, 0x36, 0xb6, 0x96, 0x15, 0x06, 0xab, 0x13, 0x0b, 0x72, 0x92, 0x1b, 0x27, 0xaa, 0x20, 0x91,
+	0xed, 0x22, 0x95, 0x27, 0x61, 0xe7, 0x65, 0x18, 0x79, 0x04, 0x14, 0x5e, 0x04, 0xc5, 0xce, 0xd0,
+	0x22, 0x21, 0x96, 0xab, 0xe3, 0xef, 0x1e, 0x9d, 0x63, 0xe9, 0xc2, 0xa5, 0x42, 0xf9, 0x82, 0x32,
+	0xef, 0x37, 0x22, 0x57, 0xba, 0x93, 0x5c, 0x60, 0x5e, 0x36, 0xdb, 0xe7, 0x8d, 0x9d, 0x59, 0x2f,
+	0x3b, 0xdd, 0x51, 0xdf, 0x3c, 0x92, 0x77, 0x02, 0x27, 0xb7, 0x5c, 0x73, 0x86, 0x35, 0x4d, 0xc0,
+	0xc2, 0x90, 0xc4, 0x24, 0x0d, 0x16, 0xf3, 0xcc, 0xfa, 0x57, 0xe3, 0x64, 0x76, 0x45, 0x29, 0x78,
+	0x0d, 0x57, 0x4d, 0xe8, 0xc4, 0x24, 0x9d, 0x31, 0xa3, 0xe9, 0x05, 0xcc, 0xbb, 0xba, 0x56, 0xa8,
+	0x1f, 0x8b, 0x9d, 0x46, 0x15, 0xba, 0x31, 0x49, 0x5d, 0x16, 0x58, 0xb6, 0x1c, 0x11, 0x3d, 0x07,
+	0x50, 0xed, 0x2b, 0x4e, 0x06, 0xcf, 0x18, 0x66, 0x23, 0xb1, 0xeb, 0x08, 0x3c, 0xcd, 0x85, 0x0a,
+	0xfd, 0xd8, 0x4d, 0x83, 0x05, 0x4c, 0xc5, 0x6b, 0x2e, 0x98, 0xe1, 0xc9, 0x3d, 0xf8, 0xab, 0x83,
+	0x7a, 0xb2, 0x57, 0x7f, 0x98, 0xed, 0xfc, 0xce, 0xa6, 0xe0, 0x61, 0x25, 0xd0, 0xfc, 0xea, 0x94,
+	0x19, 0x9d, 0x5c, 0x83, 0xbb, 0xe6, 0x82, 0x9e, 0x81, 0xd3, 0x56, 0x53, 0x96, 0xd3, 0x56, 0xff,
+	0x24, 0x2d, 0xef, 0x3e, 0x86, 0x88, 0x7c, 0x0e, 0x11, 0xf9, 0x1a, 0x22, 0xf2, 0xf6, 0x1d, 0x1d,
+	0x3d, 0xdc, 0x88, 0x56, 0x37, 0xdb, 0x22, 0x2b, 0xbb, 0xa7, 0xbc, 0xe7, 0x65, 0xb3, 0xab, 0x50,
+	0xee, 0x2b, 0x25, 0xcb, 0xfc, 0xaf, 0x6b, 0x14, 0xc7, 0xe6, 0x10, 0x57, 0x3f, 0x01, 0x00, 0x00,
+	0xff, 0xff, 0x93, 0x52, 0xd5, 0x4f, 0xb0, 0x01, 0x00, 0x00,
 }
 
 func (m *DataRef) Marshal() (dAtA []byte, err error) {
@@ -229,6 +279,20 @@ func (m *DataRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	if m.XXX_unrecognized != nil {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Tags) > 0 {
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintChunk(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
 	}
 	if m.SizeBytes != 0 {
 		i = encodeVarintChunk(dAtA, i, uint64(m.SizeBytes))
@@ -262,6 +326,94 @@ func (m *DataRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Chunk) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Chunk) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Chunk) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Edge {
+		i--
+		if m.Edge {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.SizeBytes != 0 {
+		i = encodeVarintChunk(dAtA, i, uint64(m.SizeBytes))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Hash) > 0 {
+		i -= len(m.Hash)
+		copy(dAtA[i:], m.Hash)
+		i = encodeVarintChunk(dAtA, i, uint64(len(m.Hash)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Tag) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Tag) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Tag) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.SizeBytes != 0 {
+		i = encodeVarintChunk(dAtA, i, uint64(m.SizeBytes))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = encodeVarintChunk(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintChunk(dAtA []byte, offset int, v uint64) int {
 	offset -= sovChunk(v)
 	base := offset
@@ -273,22 +425,6 @@ func encodeVarintChunk(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *Chunk) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	l = len(m.Hash)
-	if l > 0 {
-		n += 1 + l + sovChunk(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
-	return n
-}
-
 func (m *DataRef) Size() (n int) {
 	if m == nil {
 		return 0
@@ -309,6 +445,53 @@ func (m *DataRef) Size() (n int) {
 	if m.SizeBytes != 0 {
 		n += 1 + sovChunk(uint64(m.SizeBytes))
 	}
+	if len(m.Tags) > 0 {
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 1 + l + sovChunk(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Chunk) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Hash)
+	if l > 0 {
+		n += 1 + l + sovChunk(uint64(l))
+	}
+	if m.SizeBytes != 0 {
+		n += 1 + sovChunk(uint64(m.SizeBytes))
+	}
+	if m.Edge {
+		n += 2
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Tag) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovChunk(uint64(l))
+	}
+	if m.SizeBytes != 0 {
+		n += 1 + sovChunk(uint64(m.SizeBytes))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -320,92 +503,6 @@ func sovChunk(x uint64) (n int) {
 }
 func sozChunk(x uint64) (n int) {
 	return sovChunk(uint64((x << 1) ^ uint64((int64(x) >> 63))))
-}
-func (m *Chunk) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowChunk
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Chunk: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Chunk: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Hash", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowChunk
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthChunk
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthChunk
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Hash = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipChunk(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthChunk
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthChunk
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
 }
 func (m *DataRef) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -524,6 +621,270 @@ func (m *DataRef) Unmarshal(dAtA []byte) error {
 				}
 			}
 		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SizeBytes", wireType)
+			}
+			m.SizeBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SizeBytes |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthChunk
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipChunk(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Chunk) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowChunk
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Chunk: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Chunk: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthChunk
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Hash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SizeBytes", wireType)
+			}
+			m.SizeBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SizeBytes |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Edge", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Edge = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipChunk(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Tag) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowChunk
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Tag: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Tag: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChunk
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthChunk
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthChunk
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SizeBytes", wireType)
 			}

--- a/src/server/pkg/storage/chunk/chunk.proto
+++ b/src/server/pkg/storage/chunk/chunk.proto
@@ -6,7 +6,7 @@ option go_package = "github.com/pachyderm/pachyderm/src/server/pkg/storage/chunk
 // DataRef is a reference to data within a chunk.
 message DataRef {
   // The chunk the referenced data is located in.
-  Chunk chunk = 1;
+  ChunkInfo chunk_info = 1;
   // The hash of the data being referenced.
   // This field is empty when it is equal to the chunk hash (the ref is the whole chunk).
   string hash = 2;
@@ -18,6 +18,10 @@ message DataRef {
 
 message Chunk {
   string hash = 1;
+}
+
+message ChunkInfo {
+  Chunk chunk = 1;
   int64 size_bytes = 2;
   bool edge = 3;
 }

--- a/src/server/pkg/storage/chunk/chunk.proto
+++ b/src/server/pkg/storage/chunk/chunk.proto
@@ -3,10 +3,6 @@ syntax = "proto3";
 package chunk;
 option go_package = "github.com/pachyderm/pachyderm/src/server/pkg/storage/chunk";
 
-message Chunk {
-  string hash = 1;
-}
-
 // DataRef is a reference to data within a chunk.
 message DataRef {
   // The chunk the referenced data is located in.
@@ -17,4 +13,16 @@ message DataRef {
   // The offset and size used for accessing the data within the chunk.
   int64 offset_bytes = 3;
   int64 size_bytes = 4;
+  repeated Tag tags = 5;
+}
+
+message Chunk {
+  string hash = 1;
+  int64 size_bytes = 2;
+  bool edge = 3;
+}
+
+message Tag {
+  string id = 1;
+  int64 size_bytes = 2;
 }

--- a/src/server/pkg/storage/chunk/chunk_test.go
+++ b/src/server/pkg/storage/chunk/chunk_test.go
@@ -71,7 +71,7 @@ func TestCopy(t *testing.T) {
 		as := append(as1, as2...)
 		f := func(annotations []*Annotation) error {
 			for _, a := range annotations {
-				testA := a.Meta.(*testAnnotation)
+				testA := a.Data.(*testAnnotation)
 				testA.dataRefs = append(testA.dataRefs, a.NextDataRef)
 			}
 			return nil
@@ -168,7 +168,7 @@ func writeAnnotations(t *testing.T, chunks *Storage, annotations []*testAnnotati
 	t.Run("Write", func(t *testing.T) {
 		f := func(annotations []*Annotation) error {
 			for _, a := range annotations {
-				testA := a.Meta.(*testAnnotation)
+				testA := a.Data.(*testAnnotation)
 				testA.dataRefs = append(testA.dataRefs, a.NextDataRef)
 			}
 			return nil
@@ -177,7 +177,7 @@ func writeAnnotations(t *testing.T, chunks *Storage, annotations []*testAnnotati
 		for _, a := range annotations {
 			w.Annotate(&Annotation{
 				NextDataRef: &DataRef{},
-				Meta:        a,
+				Data:        a,
 			})
 			var offset int
 			for _, tag := range a.tags {
@@ -199,7 +199,7 @@ func copyAnnotations(t *testing.T, chunks *Storage, w *Writer, annotations []*te
 			a.dataRefs = nil
 			w.Annotate(&Annotation{
 				NextDataRef: &DataRef{},
-				Meta:        a,
+				Data:        a,
 			})
 			require.NoError(t, r.Iterate(func(dr *DataReader) error {
 				return w.Copy(dr.LimitReader())

--- a/src/server/pkg/storage/chunk/chunk_test.go
+++ b/src/server/pkg/storage/chunk/chunk_test.go
@@ -3,66 +3,92 @@ package chunk
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/chmduquesne/rollinghash/buzhash64"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"modernc.org/mathutil"
 )
 
 const (
 	averageBits = 23
 )
 
-func Write(t *testing.T, chunks *Storage, n, annotationSize int) ([]*DataRef, []byte) {
-	var finalDataRefs []*DataRef
-	var seq []byte
-	t.Run("Write", func(t *testing.T) {
-		f := func(annotations []*Annotation) error {
-			for _, a := range annotations {
-				finalDataRefs = append(finalDataRefs, a.NextDataRef)
-			}
-			return nil
-		}
-		w := chunks.NewWriter(context.Background(), averageBits, f, 0)
-		seq = RandSeq(n * MB)
-		for i := 0; i < n/annotationSize; i++ {
-			w.Annotate(&Annotation{
-				NextDataRef: &DataRef{},
-				Meta:        i,
-			})
-			w.StartTag(strconv.Itoa(i))
-			_, err := w.Write(seq[i*MB*annotationSize : (i+1)*MB*annotationSize])
-			require.NoError(t, err)
-		}
-		require.NoError(t, w.Close())
-	})
-	return finalDataRefs, seq
+var tests = []struct {
+	maxAnnotationSize int
+	maxTagSize        int
+	n                 int
+}{
+	{1 * KB, 1 * KB, 1 * KB},
+	{1 * KB, 1 * KB, 1 * MB},
+	{1 * MB, 1 * KB, 100 * MB},
+	{1 * MB, 1 * MB, 100 * MB},
+	{10 * MB, 1 * MB, 100 * MB},
 }
 
 func TestWriteThenRead(t *testing.T) {
 	objC, chunks := LocalStorage(t)
 	defer Cleanup(objC, chunks)
-	finalDataRefs, seq := Write(t, chunks, 100, 1)
-	mid := len(finalDataRefs) / 2
-	initialRefs := finalDataRefs[:mid]
-	streamRefs := finalDataRefs[mid:]
-	r := chunks.NewReader(context.Background())
-	r.NextDataRefs(initialRefs)
-	buf := &bytes.Buffer{}
-	t.Run("ReadInitial", func(t *testing.T) {
-		require.NoError(t, r.Get(buf))
-		require.Equal(t, 0, bytes.Compare(buf.Bytes(), seq[:buf.Len()]))
-	})
-	seq = seq[buf.Len():]
-	buf.Reset()
-	t.Run("ReadStream", func(t *testing.T) {
-		for _, ref := range streamRefs {
-			r.NextDataRefs([]*DataRef{ref})
-			require.NoError(t, r.Get(buf))
+	// Setup seed.
+	seed := time.Now().UTC().UnixNano()
+	rand.Seed(seed)
+	msg := seedStr(seed)
+	for _, test := range tests {
+		// Generate set of annotations.
+		as := generateAnnotations(test.maxAnnotationSize, test.maxTagSize, test.n)
+		// Write then read the set of annotations.
+		writeAnnotations(t, chunks, as, msg)
+		readAnnotations(t, chunks, as, msg)
+	}
+}
+
+func TestCopy(t *testing.T) {
+	objC, chunks := LocalStorage(t)
+	defer Cleanup(objC, chunks)
+	// Setup seed.
+	seed := time.Now().UTC().UnixNano()
+	rand.Seed(seed)
+	msg := seedStr(seed)
+	for _, test := range tests {
+		// Generate two sets of annotations.
+		as1 := generateAnnotations(test.maxAnnotationSize, test.maxTagSize, test.n)
+		as2 := generateAnnotations(test.maxAnnotationSize, test.maxTagSize, test.n)
+		// Write the two sets of annotations.
+		writeAnnotations(t, chunks, as1, msg)
+		writeAnnotations(t, chunks, as2, msg)
+		// Initial chunk count.
+		var initialChunkCount int64
+		require.NoError(t, chunks.List(context.Background(), func(_ string) error {
+			initialChunkCount++
+			return nil
+		}), msg)
+		// Copy the annotations from the two sets of annotations.
+		as := append(as1, as2...)
+		f := func(annotations []*Annotation) error {
+			for _, a := range annotations {
+				testA := a.Meta.(*testAnnotation)
+				testA.dataRefs = append(testA.dataRefs, a.NextDataRef)
+			}
+			return nil
 		}
-		require.Equal(t, 0, bytes.Compare(buf.Bytes(), seq))
-	})
+		w := chunks.NewWriter(context.Background(), averageBits, f, 0)
+		copyAnnotations(t, chunks, w, as, msg)
+		require.NoError(t, w.Close(), msg)
+		// Check that the annotations were correctly copied.
+		readAnnotations(t, chunks, as, msg)
+		// Check that only one new chunk was created when connecting the two sets of annotations.
+		var finalChunkCount int64
+		require.NoError(t, chunks.List(context.Background(), func(_ string) error {
+			finalChunkCount++
+			return nil
+		}), msg)
+		require.Equal(t, initialChunkCount+1, finalChunkCount, msg)
+	}
 }
 
 func BenchmarkWriter(b *testing.B) {
@@ -78,6 +104,7 @@ func BenchmarkWriter(b *testing.B) {
 			w.Annotate(&Annotation{
 				NextDataRef: &DataRef{},
 			})
+			w.StartTag(strconv.Itoa(i))
 			_, err := w.Write(seq[i*MB : (i+1)*MB])
 			require.NoError(b, err)
 		}
@@ -102,51 +129,101 @@ func BenchmarkRollingHash(b *testing.B) {
 	}
 }
 
-func TestCopy(t *testing.T) {
-	objC, chunks := LocalStorage(t)
-	defer Cleanup(objC, chunks)
-	// Write the initial data and count the chunks.
-	dataRefs1, seq1 := Write(t, chunks, 60, 20)
-	dataRefs2, seq2 := Write(t, chunks, 60, 20)
-	var initialChunkCount int64
-	require.NoError(t, chunks.List(context.Background(), func(_ string) error {
-		initialChunkCount++
-		return nil
-	}))
-	// Copy data from readers into new writer.
-	var finalDataRefs []*DataRef
-	f := func(annotations []*Annotation) error {
-		for _, a := range annotations {
-			finalDataRefs = append(finalDataRefs, a.NextDataRef)
-		}
-		return nil
+func seedStr(seed int64) string {
+	return fmt.Sprint("seed: ", strconv.FormatInt(seed, 10))
+}
+
+type testAnnotation struct {
+	data     []byte
+	tags     []*Tag
+	dataRefs []*DataRef
+}
+
+func generateAnnotations(maxAnnotationSize, maxTagSize, n int) []*testAnnotation {
+	var as []*testAnnotation
+	for n > 0 {
+		a := &testAnnotation{}
+		a.data = RandSeq(mathutil.Min(rand.Intn(maxAnnotationSize)+1, n))
+		a.tags = generateTags(maxTagSize, len(a.data))
+		n -= len(a.data)
+		as = append(as, a)
 	}
-	w := chunks.NewWriter(context.Background(), averageBits, f, 0)
-	r1 := chunks.NewReader(context.Background())
-	r1.NextDataRefs(dataRefs1)
-	r2 := chunks.NewReader(context.Background())
-	r2.NextDataRefs(dataRefs2)
-	w.Annotate(&Annotation{
-		NextDataRef: &DataRef{},
+	return as
+}
+
+func generateTags(maxTagSize, n int) []*Tag {
+	var tags []*Tag
+	for n > 0 {
+		tagSize := mathutil.Min(rand.Intn(maxTagSize)+1, n)
+		n -= tagSize
+		tags = append(tags, &Tag{
+			Id:        strconv.Itoa(len(tags)),
+			SizeBytes: int64(tagSize),
+		})
+	}
+	return tags
+}
+
+func writeAnnotations(t *testing.T, chunks *Storage, annotations []*testAnnotation, msg string) {
+	t.Run("Write", func(t *testing.T) {
+		f := func(annotations []*Annotation) error {
+			for _, a := range annotations {
+				testA := a.Meta.(*testAnnotation)
+				testA.dataRefs = append(testA.dataRefs, a.NextDataRef)
+			}
+			return nil
+		}
+		w := chunks.NewWriter(context.Background(), averageBits, f, 0)
+		for _, a := range annotations {
+			w.Annotate(&Annotation{
+				NextDataRef: &DataRef{},
+				Meta:        a,
+			})
+			var offset int
+			for _, tag := range a.tags {
+				w.StartTag(tag.Id)
+				_, err := w.Write(a.data[offset : offset+int(tag.SizeBytes)])
+				require.NoError(t, err, msg)
+				offset += int(tag.SizeBytes)
+			}
+		}
+		require.NoError(t, w.Close(), msg)
 	})
-	require.NoError(t, r1.Iterate(func(dr *DataReader) error {
-		return w.Copy(dr.LimitReader())
-	}))
-	require.NoError(t, r2.Iterate(func(dr *DataReader) error {
-		return w.Copy(dr.LimitReader())
-	}))
-	require.NoError(t, w.Close())
-	// Check that the initial data equals the final data.
-	buf := &bytes.Buffer{}
-	finalR := chunks.NewReader(context.Background())
-	finalR.NextDataRefs(finalDataRefs)
-	require.NoError(t, finalR.Get(buf))
-	require.Equal(t, append(seq1, seq2...), buf.Bytes())
-	// Only one extra chunk should get created when connecting the two sets of data.
-	var finalChunkCount int64
-	require.NoError(t, chunks.List(context.Background(), func(_ string) error {
-		finalChunkCount++
-		return nil
-	}))
-	require.Equal(t, initialChunkCount+1, finalChunkCount)
+}
+
+func copyAnnotations(t *testing.T, chunks *Storage, w *Writer, annotations []*testAnnotation, msg string) {
+	t.Run("Copy", func(t *testing.T) {
+		r := chunks.NewReader(context.Background())
+		for _, a := range annotations {
+			r.NextDataRefs(a.dataRefs)
+			a.dataRefs = nil
+			w.Annotate(&Annotation{
+				NextDataRef: &DataRef{},
+				Meta:        a,
+			})
+			require.NoError(t, r.Iterate(func(dr *DataReader) error {
+				return w.Copy(dr.LimitReader())
+			}), msg)
+		}
+	})
+}
+
+func readAnnotations(t *testing.T, chunks *Storage, annotations []*testAnnotation, msg string) {
+	t.Run("Read", func(t *testing.T) {
+		r := chunks.NewReader(context.Background())
+		for _, a := range annotations {
+			r.NextDataRefs(a.dataRefs)
+			data := &bytes.Buffer{}
+			var tags []*Tag
+			require.NoError(t, r.Iterate(func(dr *DataReader) error {
+				return dr.Iterate(func(tag *Tag, r io.Reader) error {
+					tags = joinTags(tags, []*Tag{tag})
+					_, err := io.Copy(data, r)
+					return err
+				})
+			}), msg)
+			require.Equal(t, 0, bytes.Compare(a.data, data.Bytes()), msg)
+			require.Equal(t, a.tags, tags, msg)
+		}
+	})
 }

--- a/src/server/pkg/storage/chunk/chunk_test.go
+++ b/src/server/pkg/storage/chunk/chunk_test.go
@@ -18,7 +18,7 @@ func Write(t *testing.T, chunks *Storage, n, annotationSize int) ([]*DataRef, []
 	var finalDataRefs []*DataRef
 	var seq []byte
 	t.Run("Write", func(t *testing.T) {
-		f := func(_ *DataRef, annotations []*Annotation) error {
+		f := func(annotations []*Annotation) error {
 			for _, a := range annotations {
 				finalDataRefs = append(finalDataRefs, a.NextDataRef)
 			}
@@ -72,7 +72,7 @@ func BenchmarkWriter(b *testing.B) {
 	b.SetBytes(100 * MB)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		f := func(_ *DataRef, _ []*Annotation) error { return nil }
+		f := func(_ []*Annotation) error { return nil }
 		w := chunks.NewWriter(context.Background(), averageBits, f, 0)
 		for i := 0; i < 100; i++ {
 			w.Annotate(&Annotation{
@@ -115,7 +115,7 @@ func TestCopy(t *testing.T) {
 	}))
 	// Copy data from readers into new writer.
 	var finalDataRefs []*DataRef
-	f := func(_ *DataRef, annotations []*Annotation) error {
+	f := func(annotations []*Annotation) error {
 		for _, a := range annotations {
 			finalDataRefs = append(finalDataRefs, a.NextDataRef)
 		}

--- a/src/server/pkg/storage/chunk/reader.go
+++ b/src/server/pkg/storage/chunk/reader.go
@@ -4,109 +4,167 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"fmt"
 	"io"
-	"math"
 	"path"
+	"strings"
+	"sync"
 
-	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
-	"modernc.org/mathutil"
 )
 
-// ReaderFunc is a callback that returns the next set of data references
-// to a reader.
-type ReaderFunc func() ([]*DataRef, error)
-
-// Reader reads a set of DataRefs from chunk storage.
+// Reader reads data from chunk storage.
 type Reader struct {
-	ctx              context.Context
-	objC             obj.Client
-	dataRefs         []*DataRef
-	curr             *DataRef
-	buf              *bytes.Buffer
-	r                *bytes.Reader
-	len              int64
-	f                ReaderFunc
-	onSplit          func()
-	bytesBeforeSplit int64
+	ctx      context.Context
+	objC     obj.Client
+	dataRefs []*DataRef
+	peek     *DataReader
+	prev     *DataReader
 }
 
-func newReader(ctx context.Context, objC obj.Client, f ...ReaderFunc) *Reader {
-	r := &Reader{
-		ctx:  ctx,
-		objC: objC,
-		buf:  &bytes.Buffer{},
+func newReader(ctx context.Context, objC obj.Client, dataRefs ...*DataRef) *Reader {
+	return &Reader{
+		ctx:      ctx,
+		objC:     objC,
+		dataRefs: dataRefs,
 	}
-	if len(f) > 0 {
-		r.f = f[0]
-	}
-	return r
 }
 
-// NextRange sets the next range for the reader.
-func (r *Reader) NextRange(dataRefs []*DataRef) {
+// NextDataRefs sets the next data references for the reader.
+func (r *Reader) NextDataRefs(dataRefs []*DataRef) {
 	r.dataRefs = dataRefs
-	r.r = bytes.NewReader([]byte{})
-	r.len = 0
-	for _, dataRef := range dataRefs {
-		r.len += dataRef.SizeBytes
-	}
 }
 
-// Len returns the number of bytes left.
-func (r *Reader) Len() int64 {
-	return r.len
-}
-
-// Read reads from the byte stream produced by the set of DataRefs.
-func (r *Reader) Read(data []byte) (int, error) {
-	var totalRead int
-	defer func() {
-		r.len -= int64(totalRead)
-		r.bytesBeforeSplit += int64(totalRead)
-	}()
-	for len(data) > 0 {
-		n, err := r.r.Read(data)
-		data = data[n:]
-		totalRead += n
+func (r *Reader) Peek() (*DataReader, error) {
+	if r.peek == nil {
+		var err error
+		r.peek, err = r.Next()
 		if err != nil {
-			if err := r.nextDataRef(); err != nil {
-				return totalRead, err
-			}
+			return nil, err
 		}
 	}
-	return totalRead, nil
+	return r.peek, nil
 }
 
-func (r *Reader) nextDataRef() error {
-	// If all DataRefs have been read, then io.EOF.
-	if len(r.dataRefs) == 0 {
-		if r.f != nil {
-			dataRefs, err := r.f()
-			if err != nil {
-				return err
-			}
-			r.NextRange(dataRefs)
-		} else {
-			return io.EOF
-		}
+func (r *Reader) Next() (*DataReader, error) {
+	if r.peek != nil {
+		dr := r.peek
+		r.peek = nil
+		return dr, nil
 	}
-	// Get next chunk if necessary.
-	if r.curr == nil || r.curr.Chunk.Hash != r.dataRefs[0].Chunk.Hash {
-		r.executeOnSplitFunc()
-		if err := r.readChunk(r.dataRefs[0].Chunk); err != nil {
+	if len(r.dataRefs) == 0 {
+		return nil, io.EOF
+	}
+	dr := newDataReader(r.ctx, r.objC, r.dataRefs[0], r.prev)
+	r.dataRefs = r.dataRefs[1:]
+	r.prev = dr
+	return dr, nil
+}
+
+func (r *Reader) Iterate(f func(*DataReader) error) error {
+	for {
+		dr, err := r.Peek()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if err := f(dr); err != nil {
+			return err
+		}
+		if _, err := r.Next(); err != nil {
 			return err
 		}
 	}
-	r.curr = r.dataRefs[0]
-	r.dataRefs = r.dataRefs[1:]
-	r.r = bytes.NewReader(r.buf.Bytes()[r.curr.OffsetBytes : r.curr.OffsetBytes+r.curr.SizeBytes])
 	return nil
 }
 
-func (r *Reader) readChunk(chunk *Chunk) error {
-	objR, err := r.objC.Reader(r.ctx, path.Join(prefix, chunk.Hash), 0, 0)
+func (r *Reader) Get(w io.Writer) error {
+	return r.Iterate(func(dr *DataReader) error {
+		return dr.Get(w)
+	})
+}
+
+type DataReader struct {
+	ctx        context.Context
+	objC       obj.Client
+	dataRef    *DataRef
+	getChunkMu sync.Mutex
+	chunk      []byte
+	offset     int64
+	tags       []*Tag
+	seed       *DataReader
+}
+
+func newDataReader(ctx context.Context, objC obj.Client, dataRef *DataRef, seed *DataReader) *DataReader {
+	return &DataReader{
+		ctx:     ctx,
+		objC:    objC,
+		dataRef: dataRef,
+		offset:  dataRef.OffsetBytes,
+		tags:    dataRef.Tags,
+		seed:    seed,
+	}
+}
+
+func (dr *DataReader) DataRef() *DataRef {
+	return dr.dataRef
+}
+
+func (dr *DataReader) Len() int64 {
+	var size int64
+	for _, tag := range dr.tags {
+		size += tag.SizeBytes
+	}
+	return size
+}
+
+func (dr *DataReader) Peek() (*Tag, error) {
+	if len(dr.tags) == 0 {
+		return nil, io.EOF
+	}
+	return dr.tags[0], nil
+}
+
+func (dr *DataReader) Iterate(f func(*Tag, io.Reader) error, tagBound ...string) error {
+	if err := dr.getChunk(); err != nil {
+		return err
+	}
+	for {
+		tag, err := dr.Peek()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if !BeforeBound(tag.Id, tagBound...) {
+			return nil
+		}
+		if err := f(tag, bytes.NewReader(dr.chunk[dr.offset:dr.offset+tag.SizeBytes])); err != nil {
+			return err
+		}
+		dr.tags = dr.tags[1:]
+		dr.offset += tag.SizeBytes
+	}
+}
+
+func (dr *DataReader) getChunk() error {
+	dr.getChunkMu.Lock()
+	defer dr.getChunkMu.Unlock()
+	if dr.chunk != nil {
+		return nil
+	}
+	// Use seed chunk if possible.
+	if dr.seed != nil && dr.dataRef.Chunk.Hash == dr.seed.dataRef.Chunk.Hash {
+		if err := dr.seed.getChunk(); err != nil {
+			return err
+		}
+		dr.chunk = dr.seed.chunk
+		return nil
+	}
+	// Get chunk from object storage.
+	objR, err := dr.objC.Reader(dr.ctx, path.Join(prefix, dr.dataRef.Chunk.Hash), 0, 0)
 	if err != nil {
 		return err
 	}
@@ -116,90 +174,52 @@ func (r *Reader) readChunk(chunk *Chunk) error {
 		return err
 	}
 	defer gzipR.Close()
-	r.buf.Reset()
-	buf := grpcutil.GetBuffer()
-	defer grpcutil.PutBuffer(buf)
-	if _, err := io.CopyBuffer(r.buf, gzipR, buf); err != nil {
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, gzipR); err != nil {
+		return err
+	}
+	dr.chunk = buf.Bytes()
+	return nil
+}
+
+// BeforeBound checks if the passed in string is before the string bound (exclusive).
+// The string bound is optional, so if no string bound is passed then it returns true.
+func BeforeBound(str string, strBound ...string) bool {
+	return len(strBound) == 0 || strings.Compare(str, strBound[0]) < 0
+}
+
+func (dr *DataReader) Get(w io.Writer) error {
+	if err := dr.getChunk(); err != nil {
+		return err
+	}
+	data := dr.chunk[dr.dataRef.OffsetBytes : dr.dataRef.OffsetBytes+dr.dataRef.SizeBytes]
+	if _, err := w.Write(data); err != nil {
 		return err
 	}
 	return nil
 }
 
-// OnSplit registers a callback for when a chunk split point is encountered.
-// The callback is only executed at a split point found after reading WindowSize bytes.
-// The reason for this is to guarantee that the same split point will appear in the writer
-// the data is being written to.
-func (r *Reader) OnSplit(f func()) {
-	r.bytesBeforeSplit = 0
-	r.onSplit = f
-}
-
-func (r *Reader) executeOnSplitFunc() {
-	if r.onSplit != nil && r.bytesBeforeSplit > WindowSize {
-		r.onSplit()
-		r.onSplit = nil
-	}
-}
-
-// Copy is the basic data structure to represent a copy of data from
-// a reader to a writer.
-// before/after are the raw bytes that precede/follow full chunks
-// in the set of bytes represented by the copy.
-type Copy struct {
-	before, after *bytes.Buffer
-	chunkRefs     []*DataRef
-}
-
-// ReadCopy reads copy data from the reader.
-func (r *Reader) ReadCopy(n ...int64) (*Copy, error) {
-	totalLeft := int64(math.MaxInt64)
-	if len(n) > 0 {
-		totalLeft = n[0]
-		if r.Len() < totalLeft {
-			return nil, fmt.Errorf("reader length (%v) less than copy length (%v)", r.Len(), totalLeft)
+func (dr *DataReader) LimitReader(tagBound ...string) *DataReader {
+	offset := dr.offset
+	var tags []*Tag
+	for {
+		if len(dr.tags) == 0 {
+			break
 		}
-	}
-	rawCopy := func(w io.Writer, n int64) error {
-		if _, err := io.CopyN(w, r, n); err != nil {
-			return err
+		tag := dr.tags[0]
+		if !BeforeBound(tag.Id, tagBound...) {
+			break
 		}
-		totalLeft -= n
-		return nil
+		tags = append(tags, tag)
+		dr.offset += tag.SizeBytes
+		dr.tags = dr.tags[1:]
 	}
-	c := &Copy{
-		before: &bytes.Buffer{},
-		after:  &bytes.Buffer{},
+	return &DataReader{
+		ctx:     dr.ctx,
+		objC:    dr.objC,
+		dataRef: dr.dataRef,
+		offset:  offset,
+		tags:    tags,
+		seed:    dr,
 	}
-	// Copy the first WindowSize bytes raw to be sure that
-	// the chunks we will copy will exist in the writer that
-	// this data is being copied to.
-	if err := rawCopy(c.before, mathutil.MinInt64(WindowSize, totalLeft)); err != nil {
-		return nil, err
-	}
-	// Copy the bytes left in the current chunk (if any)
-	if r.r.Len() > 0 {
-		if err := rawCopy(c.before, mathutil.MinInt64(int64(r.r.Len()), totalLeft)); err != nil {
-			return nil, err
-		}
-	}
-	// Copy the in between chunk references.
-	// (bryce) is there an edge case with a size zero chunk?
-	for len(r.dataRefs) > 0 && r.dataRefs[0].Hash == "" && totalLeft >= r.dataRefs[0].SizeBytes {
-		r.executeOnSplitFunc()
-		c.chunkRefs = append(c.chunkRefs, r.dataRefs[0])
-		totalLeft -= r.dataRefs[0].SizeBytes
-		r.len -= r.dataRefs[0].SizeBytes
-		r.dataRefs = r.dataRefs[1:]
-	}
-	// Copy the rest of the bytes raw.
-	if err := rawCopy(c.after, totalLeft); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
-// Close closes the reader.
-// Currently a no-op, but will be used when streaming is implemented.
-func (r *Reader) Close() error {
-	return nil
 }

--- a/src/server/pkg/storage/chunk/reader.go
+++ b/src/server/pkg/storage/chunk/reader.go
@@ -172,7 +172,7 @@ func (dr *DataReader) getChunk() error {
 		return nil
 	}
 	// Use seed chunk if possible.
-	if dr.seed != nil && dr.dataRef.Chunk.Hash == dr.seed.dataRef.Chunk.Hash {
+	if dr.seed != nil && dr.dataRef.ChunkInfo.Chunk.Hash == dr.seed.dataRef.ChunkInfo.Chunk.Hash {
 		if err := dr.seed.getChunk(); err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func (dr *DataReader) getChunk() error {
 		return nil
 	}
 	// Get chunk from object storage.
-	objR, err := dr.objC.Reader(dr.ctx, path.Join(prefix, dr.dataRef.Chunk.Hash), 0, 0)
+	objR, err := dr.objC.Reader(dr.ctx, path.Join(prefix, dr.dataRef.ChunkInfo.Chunk.Hash), 0, 0)
 	if err != nil {
 		return err
 	}

--- a/src/server/pkg/storage/chunk/storage.go
+++ b/src/server/pkg/storage/chunk/storage.go
@@ -17,7 +17,7 @@ const (
 type Annotation struct {
 	RefDataRefs []*DataRef
 	NextDataRef *DataRef
-	Meta        interface{}
+	Data        interface{}
 	buf         *bytes.Buffer
 	tags        []*Tag
 	drs         []*DataReader

--- a/src/server/pkg/storage/chunk/storage.go
+++ b/src/server/pkg/storage/chunk/storage.go
@@ -1,6 +1,7 @@
 package chunk
 
 import (
+	"bytes"
 	"context"
 	"path"
 
@@ -11,13 +12,16 @@ const (
 	prefix = "chunks"
 )
 
-// Annotation is used to associate information with a set of bytes
+// Annotation is used to associate information with data
 // written into the chunk storage layer.
 type Annotation struct {
 	Offset      int64
 	RefDataRefs []*DataRef
 	NextDataRef *DataRef
 	Meta        interface{}
+	buf         *bytes.Buffer
+	tags        []*Tag
+	drs         []*DataReader
 }
 
 // Storage is the abstraction that manages chunk storage.
@@ -36,18 +40,15 @@ func NewStorage(objC obj.Client, opts ...StorageOption) *Storage {
 	return s
 }
 
-// NewReader creates an io.ReadCloser for a chunk.
-// (bryce) The whole chunk is in-memory right now. Could be a problem with
-// concurrency, particularly the merge process.
-// May want to handle concurrency here (pass in multiple data refs)
-func (s *Storage) NewReader(ctx context.Context, f ...ReaderFunc) *Reader {
-	return newReader(ctx, s.objC, f...)
+// NewReader creates a new Reader.
+func (s *Storage) NewReader(ctx context.Context, dataRefs ...*DataRef) *Reader {
+	return newReader(ctx, s.objC, dataRefs...)
 }
 
-// NewWriter creates an io.WriteCloser for a stream of bytes to be chunked.
+// NewWriter creates a new Writer for a stream of bytes to be chunked.
 // Chunks are created based on the content, then hashed and deduplicated/uploaded to
 // object storage.
-// The callback arguments are the chunk hash and content.
+// The callback arguments are the chunk hash and annotations.
 func (s *Storage) NewWriter(ctx context.Context, averageBits int, f WriterFunc, seed int64) *Writer {
 	return newWriter(ctx, s.objC, averageBits, f, seed)
 }

--- a/src/server/pkg/storage/chunk/storage.go
+++ b/src/server/pkg/storage/chunk/storage.go
@@ -15,7 +15,6 @@ const (
 // Annotation is used to associate information with data
 // written into the chunk storage layer.
 type Annotation struct {
-	Offset      int64
 	RefDataRefs []*DataRef
 	NextDataRef *DataRef
 	Meta        interface{}

--- a/src/server/pkg/storage/chunk/util.go
+++ b/src/server/pkg/storage/chunk/util.go
@@ -1,13 +1,22 @@
 package chunk
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"os"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
+)
+
+const (
+	// KB is Kilobyte.
+	KB = 1024
+	// MB is Megabyte.
+	MB = 1024 * KB
 )
 
 // LocalStorage creates a local chunk storage instance.
@@ -35,4 +44,75 @@ func RandSeq(n int) []byte {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return []byte(string(b))
+}
+
+func joinAnnotations(as []*Annotation, a *Annotation) []*Annotation {
+	// If the annotation being added is the same as the
+	// last, then they are merged.
+	if as != nil {
+		lastA := as[len(as)-1]
+		if lastA.Meta == a.Meta {
+			lastA.buf.Write(a.buf.Bytes())
+			if lastA.tags != nil {
+				lastA.tags = joinTags(lastA.tags, a.tags)
+			}
+			return as
+		}
+	}
+	return append(as, a)
+}
+
+func joinTags(ts1, ts2 []*Tag) []*Tag {
+	if ts1 != nil {
+		lastT := ts1[len(ts1)-1]
+		if lastT.Id == ts2[0].Id {
+			lastT.SizeBytes += ts2[0].SizeBytes
+			ts2 = ts2[1:]
+		}
+	}
+	return append(ts1, ts2...)
+}
+
+func splitAnnotation(a *Annotation, size int) (*Annotation, *Annotation) {
+	a1 := copyAnnotation(a)
+	a2 := copyAnnotation(a)
+	if a.buf != nil {
+		a1.buf = bytes.NewBuffer(a.buf.Bytes()[:size])
+		a2.buf = bytes.NewBuffer(a.buf.Bytes()[size:])
+	}
+	if a.tags != nil {
+		a1.tags, a2.tags = splitTags(a.tags, size)
+	}
+	return a1, a2
+}
+
+func copyAnnotation(a *Annotation) *Annotation {
+	copyA := &Annotation{Meta: a.Meta}
+	if a.NextDataRef != nil {
+		copyA.NextDataRef = &DataRef{}
+	}
+	if a.buf != nil {
+		copyA.buf = &bytes.Buffer{}
+	}
+	return copyA
+}
+
+func splitTags(ts []*Tag, size int) ([]*Tag, []*Tag) {
+	var ts1, ts2 []*Tag
+	for _, t := range ts {
+		ts2 = append(ts2, proto.Clone(t).(*Tag))
+	}
+	for {
+		if int(ts2[0].SizeBytes) >= size {
+			t := proto.Clone(ts2[0]).(*Tag)
+			t.SizeBytes = int64(size)
+			ts1 = append(ts1, t)
+			ts2[0].SizeBytes -= int64(size)
+			break
+		}
+		size -= int(ts2[0].SizeBytes)
+		ts1 = append(ts1, ts2[0])
+		ts2 = ts2[1:]
+	}
+	return ts1, ts2
 }

--- a/src/server/pkg/storage/chunk/util.go
+++ b/src/server/pkg/storage/chunk/util.go
@@ -51,7 +51,7 @@ func joinAnnotations(as []*Annotation, a *Annotation) []*Annotation {
 	// last, then they are merged.
 	if as != nil {
 		lastA := as[len(as)-1]
-		if lastA.Meta == a.Meta {
+		if lastA.Data == a.Data {
 			lastA.buf.Write(a.buf.Bytes())
 			if lastA.tags != nil {
 				lastA.tags = joinTags(lastA.tags, a.tags)
@@ -87,7 +87,7 @@ func splitAnnotation(a *Annotation, size int) (*Annotation, *Annotation) {
 }
 
 func copyAnnotation(a *Annotation) *Annotation {
-	copyA := &Annotation{Meta: a.Meta}
+	copyA := &Annotation{Data: a.Data}
 	if a.NextDataRef != nil {
 		copyA.NextDataRef = &DataRef{}
 	}

--- a/src/server/pkg/storage/chunk/writer.go
+++ b/src/server/pkg/storage/chunk/writer.go
@@ -216,7 +216,7 @@ func (w *worker) setupHash(a *Annotation) error {
 }
 
 func (w *worker) resetHash(a *Annotation) {
-	if w.lastAnnotation != nil && a.Meta != w.lastAnnotation.Meta {
+	if w.lastAnnotation != nil && a.Data != w.lastAnnotation.Data {
 		w.hash.Reset()
 		w.hash.Write(initialWindow)
 	}

--- a/src/server/pkg/storage/chunk/writer.go
+++ b/src/server/pkg/storage/chunk/writer.go
@@ -437,13 +437,18 @@ func (w *Writer) AnnotationCount() int64 {
 	return w.stats.annotationCount
 }
 
+// StartTag starts a tag in the current annotation with the passed in id.
 func (w *Writer) StartTag(id string) {
 	w.finishTag()
 	a := w.annotations[len(w.annotations)-1]
 	a.tags = append(a.tags, &Tag{Id: id})
 }
 
-func (w *Writer) FinishTag(t string) {
+// FinishTag finishes the current tag in the current annotation.
+// (bryce) this is here to explicitly bound the tag at the end of
+// file content before tar padding is added, might be easier to
+// just filter this out at a layer above.
+func (w *Writer) FinishTag() {
 	w.finishTag()
 }
 
@@ -463,6 +468,8 @@ func (w *Writer) ChunkCount() int64 {
 	return w.stats.chunkCount
 }
 
+// Write buffers data up to a certain threshold, then creates a worker
+// to process it (find chunk split points, hash data, and execute the callback).
 func (w *Writer) Write(data []byte) (int, error) {
 	a := w.annotations[len(w.annotations)-1]
 	var written int
@@ -500,6 +507,9 @@ func (w *Writer) writeDataSet() {
 	w.bufSize = 0
 }
 
+// Copy copies data from a data reader to the writer.
+// The copy will either be by reading the referenced data, or just
+// copying the data reference (cheap copy).
 func (w *Writer) Copy(dr *DataReader) error {
 	lastA := w.annotations[len(w.annotations)-1]
 	lastA.drs = append(lastA.drs, dr)

--- a/src/server/pkg/storage/chunk/writer.go
+++ b/src/server/pkg/storage/chunk/writer.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/chmduquesne/rollinghash/buzhash64"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 	"github.com/pachyderm/pachyderm/src/server/pkg/storage/hash"
 	"golang.org/x/sync/errgroup"
@@ -29,32 +30,31 @@ var initialWindow = make([]byte, WindowSize)
 // WriterFunc is a callback that returns a data reference to the next chunk and the annotations within the chunk.
 type WriterFunc func(*DataRef, []*Annotation) error
 
-// byteSet is a unit of work for the workers.
-// A worker will roll the rolling hash function across the bytes
+// dataSet is a unit of work for the workers.
+// A worker will roll the rolling hash function across the data set
 // while processing the associated annotations.
-type byteSet struct {
-	data        []byte
+type dataSet struct {
 	annotations []*Annotation
-	// nextBytes is used for the edge case where no split point is found in an assigned byte set.
-	// A worker that did not find a chunk in its assigned byte set will pass it to the prior
-	// worker in the chain with nextBytes set to the next worker's bytes channel. This allows shuffling
-	// of byte sets between workers until a split point is found.
-	nextBytes <-chan *byteSet
+	// nextDataSet is used for the edge case where no split point is found in the assigned data set.
+	// A worker that did not find a chunk in its assigned data set will pass it to the prior
+	// worker in the chain with nextDataSet set to the next worker's dataSet channel. This allows shuffling
+	// of data sets between workers until a split point is found.
+	nextDataSet <-chan *dataSet
 }
 
 // chanSet is a group of channels used to setup the daisy chain and shuffle data between the workers.
 // How these channels are used by a worker depends on whether they are associated with
 // the previous or next worker in the chain.
 type chanSet struct {
-	bytes chan *byteSet
-	done  chan struct{}
+	dataSet chan *dataSet
+	done    chan struct{}
 }
 
 // The following chanSet types enforce the directionality of the channels at compile time
 // to help prevent potentially tricky bugs now and in the future with the daisy chain.
 type prevChanSet struct {
-	bytes chan<- *byteSet
-	done  <-chan struct{}
+	dataSet chan<- *dataSet
+	done    <-chan struct{}
 }
 
 func newPrevChanSet(c *chanSet) *prevChanSet {
@@ -62,69 +62,74 @@ func newPrevChanSet(c *chanSet) *prevChanSet {
 		return nil
 	}
 	return &prevChanSet{
-		bytes: c.bytes,
-		done:  c.done,
+		dataSet: c.dataSet,
+		done:    c.done,
 	}
 }
 
 type nextChanSet struct {
-	bytes <-chan *byteSet
-	done  chan<- struct{}
+	dataSet <-chan *dataSet
+	done    chan<- struct{}
 }
 
 func newNextChanSet(c *chanSet) *nextChanSet {
 	return &nextChanSet{
-		bytes: c.bytes,
-		done:  c.done,
+		dataSet: c.dataSet,
+		done:    c.done,
 	}
 }
 
 type worker struct {
-	ctx         context.Context
-	objC        obj.Client
-	hash        *buzhash64.Buzhash64
-	splitMask   uint64
-	first       bool
-	buf         *bytes.Buffer
-	annotations []*Annotation
-	f           WriterFunc
-	fs          []func() error
-	prev        *prevChanSet
-	next        *nextChanSet
-	stats       *stats
+	ctx            context.Context
+	objC           obj.Client
+	hash           *buzhash64.Buzhash64
+	splitMask      uint64
+	first          bool
+	annotations    []*Annotation
+	bufAnnotations []*Annotation
+	bufSize        int64
+	f              WriterFunc
+	fs             []func() error
+	prev           *prevChanSet
+	next           *nextChanSet
+	stats          *stats
 }
 
-func (w *worker) run(byteSet *byteSet) error {
-	// Roll through the assigned byte set.
-	if err := w.rollByteSet(byteSet); err != nil {
+func (w *worker) run(dataSet *dataSet) error {
+	// Roll through the assigned data set.
+	if err := w.rollDataSet(dataSet); err != nil {
 		return err
 	}
 	// No split point found.
 	if w.prev != nil && w.first {
-		byteSet.nextBytes = w.next.bytes
+		dataSet.annotations = w.annotations
+		dataSet.nextDataSet = w.next.dataSet
 		select {
-		case w.prev.bytes <- byteSet:
+		case w.prev.dataSet <- dataSet:
 		case <-w.ctx.Done():
 			return w.ctx.Err()
 		}
 	} else {
-		// Wait for the next byte set to roll.
-		nextBytes := w.next.bytes
-		for nextBytes != nil {
+		// Wait for the next data set to roll.
+		nextDataSet := w.next.dataSet
+		for nextDataSet != nil {
 			select {
-			case byteSet, more := <-nextBytes:
-				// The next bytes channel is closed for the last worker,
+			case dataSet, more := <-nextDataSet:
+				// The next data set channel is closed for the last worker,
 				// so it uploads the last buffer as a chunk.
 				if !more {
-					if err := w.put(); err != nil {
-						return err
+					if w.annotations[len(w.annotations)-1].buf.Len() > 0 {
+						// Last chunk in byte stream is an edge chunk.
+						if err := w.put(true); err != nil {
+							return err
+						}
 					}
-					nextBytes = nil
+					nextDataSet = nil
 					break
-				} else if err := w.rollByteSet(byteSet); err != nil {
+				} else if err := w.rollDataSet(dataSet); err != nil {
 					return err
 				}
-				nextBytes = byteSet.nextBytes
+				nextDataSet = dataSet.nextDataSet
 			case <-w.ctx.Done():
 				return w.ctx.Err()
 			}
@@ -134,81 +139,90 @@ func (w *worker) run(byteSet *byteSet) error {
 	return w.executeFuncs()
 }
 
-func (w *worker) rollByteSet(byteSet *byteSet) error {
-	// Roll across the byte set.
-	for i, a := range byteSet.annotations {
-		var data []byte
-		if i == len(byteSet.annotations)-1 {
-			data = byteSet.data[a.Offset:len(byteSet.data)]
-		} else {
-			data = byteSet.data[a.Offset:byteSet.annotations[i+1].Offset]
-		}
-		// Convert from byte set offset to chunk offset.
-		a.Offset = int64(w.buf.Len())
-		w.annotations = joinAnnotations(w.annotations, a)
-		if err := w.roll(data); err != nil {
-			return err
-		}
-		// Reset hash between annotations.
-		w.resetHash()
-	}
-	return nil
-}
-
-func joinAnnotations(as []*Annotation, a *Annotation) []*Annotation {
-	// If the annotation being added is the same as the
-	// last, then they are merged.
-	if as != nil && as[len(as)-1].Meta == a.Meta {
-		return as
-	}
-	return append(as, a)
-}
-
-func (w *worker) roll(data []byte) error {
-	offset := 0
-	for i, b := range data {
-		w.hash.Roll(b)
-		if w.hash.Sum64()&w.splitMask == 0 {
-			w.buf.Write(data[offset : i+1])
-			offset = i + 1
-			if w.prev != nil && w.first {
-				// We do not consider chunk split points within WindowSize bytes
-				// of the start of the byte set.
-				if w.buf.Len() < WindowSize {
-					continue
-				}
-				byteSet := &byteSet{
-					data:        w.buf.Bytes(),
-					annotations: w.annotations,
-				}
-				w.prev.bytes <- byteSet
-				w.first = false
-			} else if err := w.put(); err != nil {
+func (w *worker) rollDataSet(dataSet *dataSet) error {
+	// Roll across the annotations in the data set.
+	for _, a := range dataSet.annotations {
+		if a.buf.Len() > 0 {
+			if err := w.roll(a); err != nil {
 				return err
 			}
-			w.buf = &bytes.Buffer{}
-			w.annotations = splitAnnotations(w.annotations)
+			// Reset hash between annotations.
+			w.resetHash()
+		} else {
+			if err := w.copyDataReaders(a); err != nil {
+				return err
+			}
 		}
 	}
-	w.buf.Write(data[offset:])
+	if err := w.flushDataReaders(); err != nil {
+		return err
+	}
 	return nil
 }
 
-func (w *worker) put() error {
-	chunk := &Chunk{Hash: hash.EncodeHash(hash.Sum(w.buf.Bytes()))}
+func (w *worker) roll(a *Annotation) error {
+	offset := 0
+	for i, b := range a.buf.Bytes() {
+		w.hash.Roll(b)
+		if w.hash.Sum64()&w.splitMask == 0 {
+			// Split annotation.
+			// The annotation before the split is handled at this chunk split point.
+			var beforeSplitA *Annotation
+			beforeSplitA, a = splitAnnotation(a, i+1-offset)
+			w.annotations = joinAnnotations(w.annotations, beforeSplitA)
+			offset = i + 1
+			// Send the annotations up to this point to the prior worker if this
+			// is the first split point encountered by this worker.
+			if w.prev != nil && w.first {
+				// We do not consider chunk split points within WindowSize bytes
+				// of the start of the data rolled in a worker.
+				if w.numBytesRolled() < WindowSize {
+					continue
+				}
+				dataSet := &dataSet{annotations: w.annotations}
+				w.prev.dataSet <- dataSet
+			} else if err := w.put(w.first); err != nil {
+				return err
+			}
+			w.annotations = nil
+			w.first = false
+		}
+	}
+	w.annotations = joinAnnotations(w.annotations, a)
+	return nil
+}
+
+func (w *worker) numBytesRolled() int {
+	var numBytes int
+	for _, a := range w.annotations {
+		numBytes += a.buf.Len()
+	}
+	return numBytes
+}
+
+func (w *worker) put(edge bool) error {
+	var chunkBytes []byte
+	for _, a := range w.annotations {
+		chunkBytes = append(chunkBytes, a.buf.Bytes()...)
+	}
+	chunk := &Chunk{
+		Hash:      hash.EncodeHash(hash.Sum(chunkBytes)),
+		SizeBytes: int64(len(chunkBytes)),
+		Edge:      edge,
+	}
 	path := path.Join(prefix, chunk.Hash)
 	// If the chunk does not exist, upload it.
 	if !w.objC.Exists(w.ctx, path) {
-		if err := w.upload(path); err != nil {
+		if err := w.upload(path, chunkBytes); err != nil {
 			return err
 		}
 	}
 	chunkRef := &DataRef{
 		Chunk:     chunk,
-		SizeBytes: int64(w.buf.Len()),
+		SizeBytes: int64(len(chunkBytes)),
 	}
 	// Update the annotations for the current chunk.
-	updateAnnotations(chunkRef, w.buf.Bytes(), w.annotations)
+	w.updateAnnotations(chunkRef)
 	annotations := w.annotations
 	w.fs = append(w.fs, func() error {
 		return w.f(chunkRef, annotations)
@@ -216,48 +230,25 @@ func (w *worker) put() error {
 	return nil
 }
 
-func updateAnnotations(chunkRef *DataRef, buf []byte, annotations []*Annotation) {
-	// (bryce) add check for no buf and greater than one annotation.
-	// Fast path for next data reference being full chunk.
-	if len(annotations) == 1 && annotations[0].NextDataRef != nil {
-		annotations[0].NextDataRef = chunkRef
-	}
-	for i, a := range annotations {
+func (w *worker) updateAnnotations(chunkRef *DataRef) {
+	var offset int64
+	for _, a := range w.annotations {
 		// (bryce) probably a better way to communicate whether to compute datarefs for an annotation.
+		a.Offset = offset
 		if a.NextDataRef != nil {
 			a.NextDataRef.Chunk = chunkRef.Chunk
-			var data []byte
-			if i == len(annotations)-1 {
-				data = buf[a.Offset:len(buf)]
-			} else {
-				data = buf[a.Offset:annotations[i+1].Offset]
+			if len(w.annotations) > 1 {
+				a.NextDataRef.Hash = hash.EncodeHash(hash.Sum(a.buf.Bytes()))
 			}
-			a.NextDataRef.Hash = hash.EncodeHash(hash.Sum(data))
-			a.NextDataRef.OffsetBytes = a.Offset
-			a.NextDataRef.SizeBytes = int64(len(data))
+			a.NextDataRef.OffsetBytes = offset
+			a.NextDataRef.SizeBytes = int64(a.buf.Len())
+			a.NextDataRef.Tags, a.tags = splitTags(a.tags, a.buf.Len())
 		}
+		offset += int64(a.buf.Len())
 	}
 }
 
-func splitAnnotations(as []*Annotation) []*Annotation {
-	if len(as) == 0 {
-		return nil
-	}
-	// Copy the last annotation.
-	lastA := as[len(as)-1]
-	copyA := &Annotation{Meta: lastA.Meta}
-	if lastA.NextDataRef != nil {
-		copyA.NextDataRef = &DataRef{}
-	}
-	return []*Annotation{copyA}
-}
-
-func (w *worker) resetHash() {
-	w.hash.Reset()
-	w.hash.Write(initialWindow)
-}
-
-func (w *worker) upload(path string) error {
+func (w *worker) upload(path string, chunk []byte) error {
 	objW, err := w.objC.Writer(w.ctx, path)
 	if err != nil {
 		return err
@@ -269,8 +260,101 @@ func (w *worker) upload(path string) error {
 	}
 	defer gzipW.Close()
 	// (bryce) Encrypt?
-	_, err = io.Copy(gzipW, bytes.NewReader(w.buf.Bytes()))
+	_, err = io.Copy(gzipW, bytes.NewReader(chunk))
 	return err
+}
+
+func (w *worker) resetHash() {
+	w.hash.Reset()
+	w.hash.Write(initialWindow)
+}
+
+func (w *worker) copyDataReaders(a *Annotation) error {
+	for _, dr := range a.drs {
+		// We can only consider a data reader for buffering / cheap copying
+		// when it does not reference an edge chunk and we are at a split point.
+		if dr.DataRef().Chunk.Edge || !w.atSplit() {
+			if err := w.flushDataReaders(); err != nil {
+				return err
+			}
+			if err := w.rollDataReader(copyAnnotation(a), dr); err != nil {
+				return err
+			}
+			continue
+		}
+		// Flush buffered annotations if the next data reader is from a different chunk.
+		if len(w.bufAnnotations) > 0 {
+			lastA := w.bufAnnotations[len(w.bufAnnotations)-1]
+			if lastA.drs[0].DataRef().Chunk.Hash != dr.DataRef().Chunk.Hash {
+				if err := w.flushDataReaders(); err != nil {
+					return err
+				}
+			}
+		}
+		// Join annotation with current buffered annotations, then buffer the current data reader.
+		w.bufAnnotations = joinAnnotations(w.bufAnnotations, copyAnnotation(a))
+		lastA := w.bufAnnotations[len(w.bufAnnotations)-1]
+		lastA.drs = append(lastA.drs, dr)
+		w.bufSize += dr.Len()
+		// Cheap copy if full chunk is buffered.
+		if w.bufSize == dr.DataRef().Chunk.SizeBytes {
+			// (bryce) I think passing the chunk ref into the callback is no longer necessary
+			// in the indexing and can be removed.
+			chunkRef := proto.Clone(dr.DataRef()).(*DataRef)
+			chunkRef.Hash = ""
+			chunkRef.OffsetBytes = 0
+			chunkRef.SizeBytes = chunkRef.Chunk.SizeBytes
+			for _, a := range w.bufAnnotations {
+				// (bryce) need to handle tags.
+				var size int64
+				for _, dr := range a.drs {
+					size += dr.DataRef().SizeBytes
+				}
+				a.NextDataRef = a.drs[0].DataRef()
+				a.NextDataRef.SizeBytes = size
+			}
+			annotations := w.bufAnnotations
+			w.fs = append(w.fs, func() error {
+				return w.f(chunkRef, annotations)
+			})
+			w.bufAnnotations = nil
+			w.bufSize = 0
+		}
+	}
+	return nil
+}
+
+func (w *worker) atSplit() bool {
+	return w.prev != nil && (!w.first && w.numBytesRolled() == 0)
+}
+
+func (w *worker) rollDataReader(a *Annotation, dr *DataReader) error {
+	if err := dr.Iterate(func(tag *Tag, r io.Reader) error {
+		_, err := io.Copy(a.buf, r)
+		if err != nil {
+			return err
+		}
+		a.tags = append(a.tags, tag)
+		return nil
+	}); err != nil {
+		return err
+	}
+	return w.roll(a)
+}
+
+func (w *worker) flushDataReaders() error {
+	for _, a := range w.bufAnnotations {
+		for _, dr := range a.drs {
+			if err := w.rollDataReader(copyAnnotation(a), dr); err != nil {
+				return err
+			}
+		}
+		// Reset hash between annotations.
+		w.resetHash()
+	}
+	w.bufAnnotations = nil
+	w.bufSize = 0
+	return nil
 }
 
 func (w *worker) executeFuncs() error {
@@ -296,9 +380,9 @@ func (w *worker) executeFuncs() error {
 }
 
 type stats struct {
-	chunkCount         int64
-	annotationCount    int64
-	annotatedBytesSize int64
+	chunkCount      int64
+	annotationCount int64
+	taggedBytesSize int64
 }
 
 // Writer splits a byte stream into content defined chunks that are hashed and deduplicated/uploaded to object storage.
@@ -308,8 +392,8 @@ type stats struct {
 // bytes between workers in the chain and the writer function is executed on the sequential ordering of the chunks in the byte stream.
 type Writer struct {
 	ctx, cancelCtx context.Context
-	buf            *bytes.Buffer
 	annotations    []*Annotation
+	bufSize        int
 	eg             *errgroup.Group
 	newWorkerFunc  func(context.Context, *prevChanSet, *nextChanSet) *worker
 	prev           *chanSet
@@ -326,7 +410,6 @@ func newWriter(ctx context.Context, objC obj.Client, averageBits int, f WriterFu
 			hash:      buzhash64.NewFromUint64Array(buzhash64.GenerateHashes(seed)),
 			splitMask: (1 << uint64(averageBits)) - 1,
 			first:     true,
-			buf:       &bytes.Buffer{},
 			prev:      prev,
 			next:      next,
 			f:         f,
@@ -339,7 +422,6 @@ func newWriter(ctx context.Context, objC obj.Client, averageBits int, f WriterFu
 	w := &Writer{
 		ctx:           ctx,
 		cancelCtx:     cancelCtx,
-		buf:           &bytes.Buffer{},
 		eg:            eg,
 		newWorkerFunc: newWorkerFunc,
 		f:             f,
@@ -348,15 +430,12 @@ func newWriter(ctx context.Context, objC obj.Client, averageBits int, f WriterFu
 	return w
 }
 
-// Annotate associates an annotation with the current byte set.
+// Annotate associates an annotation with the current data.
 func (w *Writer) Annotate(a *Annotation) {
-	a.Offset = int64(w.buf.Len())
-	if a.Offset == 0 {
-		w.annotations = nil
-	}
+	w.finishTag()
+	a.buf = &bytes.Buffer{}
 	w.annotations = append(w.annotations, a)
 	w.stats.annotationCount++
-	w.stats.annotatedBytesSize = 0
 }
 
 // AnnotationCount returns a count of the number of annotations created/referenced by
@@ -365,36 +444,24 @@ func (w *Writer) AnnotationCount() int64 {
 	return w.stats.annotationCount
 }
 
-// AnnotatedBytesSize returns the size of the bytes for the current annotation.
-func (w *Writer) AnnotatedBytesSize() int64 {
-	return w.stats.annotatedBytesSize
+func (w *Writer) StartTag(id string) {
+	w.finishTag()
+	a := w.annotations[len(w.annotations)-1]
+	a.tags = append(a.tags, &Tag{Id: id})
 }
 
-// Flush flushes the buffered data.
-func (w *Writer) Flush() error {
-	// Write out the last buffer.
-	if w.buf.Len() > 0 {
-		w.writeByteSet()
-	}
-	// Signal to the last worker that it is last.
-	if w.prev != nil {
-		close(w.prev.bytes)
-		w.prev = nil
-	}
-	// Wait for the workers to finish.
-	if err := w.eg.Wait(); err != nil {
-		return err
-	}
-	w.eg, w.cancelCtx = errgroup.WithContext(w.ctx)
-	return nil
+func (w *Writer) FinishTag(t string) {
+	w.finishTag()
 }
 
-// Reset resets the buffer and annotations.
-func (w *Writer) Reset() {
-	// (bryce) should cancel all workers.
-	w.buf = &bytes.Buffer{}
-	w.annotations = nil
-	w.stats.annotatedBytesSize = 0
+func (w *Writer) finishTag() {
+	if len(w.annotations) > 0 {
+		a := w.annotations[len(w.annotations)-1]
+		if a.tags != nil {
+			a.tags[len(a.tags)-1].SizeBytes = w.stats.taggedBytesSize
+			w.stats.taggedBytesSize = 0
+		}
+	}
 }
 
 // ChunkCount returns a count of the number of chunks created/referenced by
@@ -403,70 +470,133 @@ func (w *Writer) ChunkCount() int64 {
 	return w.stats.chunkCount
 }
 
-// Write rolls through the data written, calling c.f when a chunk is found.
-// Note: If making changes to this function, be wary of the performance
-// implications (check before and after performance with chunker benchmarks).
 func (w *Writer) Write(data []byte) (int, error) {
+	a := w.annotations[len(w.annotations)-1]
 	var written int
-	for w.buf.Len()+len(data) >= bufSize {
-		i := bufSize - w.buf.Len()
-		w.buf.Write(data[:i])
-		w.writeByteSet()
+	for w.bufSize+len(data) >= bufSize {
+		i := bufSize - w.bufSize
+		a.buf.Write(data[:i])
+		w.stats.taggedBytesSize += int64(i)
+		w.writeDataSet()
+		a = w.annotations[len(w.annotations)-1]
 		written += i
 		data = data[i:]
 	}
-	w.buf.Write(data)
+	a.buf.Write(data)
+	w.bufSize += len(data)
+	w.stats.taggedBytesSize += int64(len(data))
 	written += len(data)
-	w.stats.annotatedBytesSize += int64(written)
 	return written, nil
 }
 
-func (w *Writer) writeByteSet() {
+func (w *Writer) writeDataSet() {
+	w.finishTag()
 	prev := w.prev
 	next := &chanSet{
-		bytes: make(chan *byteSet, 1),
-		done:  make(chan struct{}),
+		dataSet: make(chan *dataSet, 1),
+		done:    make(chan struct{}),
 	}
-	byteSet := &byteSet{
-		data:        w.buf.Bytes(),
-		annotations: w.annotations,
-	}
+	dataSet := &dataSet{annotations: w.annotations}
 	w.eg.Go(func() error {
-		return w.newWorkerFunc(w.cancelCtx, newPrevChanSet(prev), newNextChanSet(next)).run(byteSet)
+		return w.newWorkerFunc(w.cancelCtx, newPrevChanSet(prev), newNextChanSet(next)).run(dataSet)
 	})
 	w.prev = next
-	w.buf = &bytes.Buffer{}
-	w.annotations = splitAnnotations(w.annotations)
+	lastA := w.annotations[len(w.annotations)-1]
+	_, a := splitAnnotation(lastA, lastA.buf.Len())
+	w.annotations = []*Annotation{a}
+	w.bufSize = 0
 }
 
-// Copy does a cheap copy from a reader to a writer.
-func (w *Writer) Copy(r *Reader, n ...int64) error {
-	c, err := r.ReadCopy(n...)
-	if err != nil {
-		return err
+func (w *Writer) Copy(dr *DataReader) error {
+	lastA := w.annotations[len(w.annotations)-1]
+	lastA.drs = append(lastA.drs, dr)
+	w.bufSize += int(dr.Len())
+	if w.bufSize > bufSize {
+		w.writeDataSet()
 	}
-	return w.WriteCopy(c)
-}
-
-// WriteCopy writes copy data to the writer.
-func (w *Writer) WriteCopy(c *Copy) error {
-	if _, err := io.Copy(w, c.before); err != nil {
-		return err
-	}
-	for _, chunkRef := range c.chunkRefs {
-		w.stats.chunkCount++
-		// (bryce) might want to double check if this is correct.
-		w.stats.annotatedBytesSize += chunkRef.SizeBytes
-		updateAnnotations(chunkRef, nil, w.annotations)
-		if err := w.f(chunkRef, w.annotations); err != nil {
-			return err
-		}
-	}
-	_, err := io.Copy(w, c.after)
-	return err
+	return nil
 }
 
 // Close closes the writer.
 func (w *Writer) Close() error {
-	return w.Flush()
+	// Write out the last data set.
+	if w.bufSize > 0 {
+		w.writeDataSet()
+	}
+	// Signal to the last worker that it is last.
+	if w.prev != nil {
+		close(w.prev.dataSet)
+		w.prev = nil
+	}
+	// Wait for the workers to finish.
+	return w.eg.Wait()
+}
+
+func joinAnnotations(as []*Annotation, a *Annotation) []*Annotation {
+	// If the annotation being added is the same as the
+	// last, then they are merged.
+	if as != nil {
+		lastA := as[len(as)-1]
+		if lastA.Meta == a.Meta {
+			lastA.buf.Write(a.buf.Bytes())
+			if lastA.tags != nil {
+				lastA.tags = joinTags(lastA.tags, a.tags)
+			}
+			return as
+		}
+	}
+	return append(as, a)
+}
+
+func joinTags(ts1, ts2 []*Tag) []*Tag {
+	lastT := ts1[len(ts1)-1]
+	if lastT.Id == ts2[0].Id {
+		lastT.SizeBytes += ts2[0].SizeBytes
+		ts2 = ts2[1:]
+	}
+	return append(ts1, ts2...)
+}
+
+func splitAnnotation(a *Annotation, size int) (*Annotation, *Annotation) {
+	a1 := copyAnnotation(a)
+	a2 := copyAnnotation(a)
+	if a.buf != nil {
+		a1.buf = bytes.NewBuffer(a.buf.Bytes()[:size])
+		a2.buf = bytes.NewBuffer(a.buf.Bytes()[size:])
+	}
+	if a.tags != nil {
+		a1.tags, a2.tags = splitTags(a.tags, size)
+	}
+	return a1, a2
+}
+
+func copyAnnotation(a *Annotation) *Annotation {
+	copyA := &Annotation{Meta: a.Meta}
+	if a.NextDataRef != nil {
+		copyA.NextDataRef = &DataRef{}
+	}
+	if a.buf != nil {
+		copyA.buf = &bytes.Buffer{}
+	}
+	return copyA
+}
+
+func splitTags(ts []*Tag, size int) ([]*Tag, []*Tag) {
+	var ts1, ts2 []*Tag
+	for _, t := range ts {
+		ts2 = append(ts2, proto.Clone(t).(*Tag))
+	}
+	for {
+		if int(ts2[0].SizeBytes) >= size {
+			t := proto.Clone(ts2[0]).(*Tag)
+			t.SizeBytes = int64(size)
+			ts1 = append(ts1, t)
+			ts2[0].SizeBytes -= int64(size)
+			break
+		}
+		size -= int(ts2[0].SizeBytes)
+		ts1 = append(ts1, ts2[0])
+		ts2 = ts2[1:]
+	}
+	return ts1, ts2
 }


### PR DESCRIPTION
This PR makes a few changes to the chunk storage layer:

- Adds a new abstraction and API endpoints for callback based iteration over data references (`Iterate`) and full writes of data (`Get`).
- Moves the tagging logic into the chunk storage layer (data references now store a list of
  tags that are created within an annotated range through `StartTag`).
- Moves the cheap copy logic into the chunk storage layer. Copying can now be thought of as buffering lazy readers (`DataReader`) to be copied into a writer until a full chunk is buffered, which is when a cheap copy will be performed, or a reader that references a different chunk is copied, which will copy the buffered readers.