### PR TITLE
gRPC server refactor

### DIFF
--- a/etc/compile/wait.sh
+++ b/etc/compile/wait.sh
@@ -2,8 +2,7 @@
 
 CONTAINER="${1}"
 
-docker wait "$CONTAINER" 2>/dev/null 1>/dev/null
-RET=$?
+RET=`docker wait "$CONTAINER"`
 
 if [ "$RET" -ne 0 ]
 then

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	golang.org/x/tools v0.0.0-20191120204900-17847a8424c1 // indirect
+	golang.org/x/tools v0.0.0-20191121165004-82924fac8e73 // indirect
 	google.golang.org/api v0.6.0
 	google.golang.org/grpc v1.24.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -77,8 +77,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/montanaflynn/stats v0.5.0
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
@@ -118,7 +116,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	golang.org/x/tools v0.0.0-20191108175616-46f5a7f28bf0 // indirect
+	golang.org/x/tools v0.0.0-20191120204900-17847a8424c1 // indirect
 	google.golang.org/api v0.6.0
 	google.golang.org/grpc v1.24.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ golang.org/x/tools v0.0.0-20191108175616-46f5a7f28bf0 h1:crJFnQNts8HmLQ4G+0O/30e
 golang.org/x/tools v0.0.0-20191108175616-46f5a7f28bf0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191120204900-17847a8424c1 h1:M9ExPAWDsCXaIb3bhIHNvBmjTMvKzRiSQ4Wh1jcG+gI=
 golang.org/x/tools v0.0.0-20191120204900-17847a8424c1/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191121165004-82924fac8e73 h1:5IfgtoPDYSGqmEywIeVGFsFsuCNPAJVc4GrsQF9V4b8=
+golang.org/x/tools v0.0.0-20191121165004-82924fac8e73/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.0 h1:2tJEkRfnZL5g1GeBUlITh/rqT5HG3sFcoVCUUxmgJ2g=

--- a/go.sum
+++ b/go.sum
@@ -63,10 +63,10 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
@@ -599,6 +599,8 @@ golang.org/x/tools v0.0.0-20191107235519-f7ea15e60b12 h1:Em35dEjqsNULK9Md61nyJCw
 golang.org/x/tools v0.0.0-20191107235519-f7ea15e60b12/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108175616-46f5a7f28bf0 h1:crJFnQNts8HmLQ4G+0O/30eU/J8peLNNKhX1jnzV58s=
 golang.org/x/tools v0.0.0-20191108175616-46f5a7f28bf0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191120204900-17847a8424c1 h1:M9ExPAWDsCXaIb3bhIHNvBmjTMvKzRiSQ4Wh1jcG+gI=
+golang.org/x/tools v0.0.0-20191120204900-17847a8424c1/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.0 h1:2tJEkRfnZL5g1GeBUlITh/rqT5HG3sFcoVCUUxmgJ2g=

--- a/src/client/pkg/grpcutil/server.go
+++ b/src/client/pkg/grpcutil/server.go
@@ -89,21 +89,6 @@ func (s *Server) ListenTCP(host string, port uint16) (net.Listener, error) {
 	return listener, nil
 }
 
-// ListenUDS causes the gRPC server to listen on a given Unix domain socket
-// path
-func (s *Server) ListenUDS(name string) (net.Listener, error) {
-	listener, err := net.Listen("unix", name)
-	if err != nil {
-		return nil, err
-	}
-
-	s.eg.Go(func() error {
-		return s.Server.Serve(listener)
-	})
-
-	return listener, nil
-}
-
 // Wait causes the gRPC server to wait until it finishes, returning any errors
 // that happened
 func (s *Server) Wait() error {

--- a/src/client/pkg/grpcutil/server.go
+++ b/src/client/pkg/grpcutil/server.go
@@ -17,6 +17,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Server is a convenience wrapper to gRPC servers that simplifies their
+// setup and execution
 type Server struct {
 	Server *grpc.Server
 	eg     *errgroup.Group
@@ -73,6 +75,7 @@ func NewServer(ctx context.Context, publicPortTLSAllowed bool) (*Server, error) 
 	}, nil
 }
 
+// ListenTCP causes the gRPC server to listen on a given TCP host and port
 func (s *Server) ListenTCP(host string, port uint16) (net.Listener, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
@@ -86,6 +89,8 @@ func (s *Server) ListenTCP(host string, port uint16) (net.Listener, error) {
 	return listener, nil
 }
 
+// ListenUDS causes the gRPC server to listen on a given Unix domain socket
+// path
 func (s *Server) ListenUDS(name string) (net.Listener, error) {
 	listener, err := net.Listen("unix", name)
 	if err != nil {
@@ -99,6 +104,8 @@ func (s *Server) ListenUDS(name string) (net.Listener, error) {
 	return listener, nil
 }
 
+// Wait causes the gRPC server to wait until it finishes, returning any errors
+// that happened
 func (s *Server) Wait() error {
 	return s.eg.Wait()
 }

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -369,6 +369,7 @@ func doFullMode(config interface{}) (retErr error) {
 		return fmt.Errorf("ListenAndServe: %v", err)
 	})
 	eg.Go(func() error {
+		// start public pachd server
 		server, err := grpcutil.NewServer(context.Background(), true)
 		if err != nil {
 			return err
@@ -467,7 +468,8 @@ func doFullMode(config interface{}) (retErr error) {
 		return server.Wait()
 	})
 	eg.Go(func() error {
-		server, err := grpcutil.NewServer(context.Background(), true)
+		// start internal pachd server
+		server, err := grpcutil.NewServer(context.Background(), false)
 		if err != nil {
 			return err
 		}

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -154,7 +154,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 		Host: "",
 		Port: env.PeerPort,
 	}
-	server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 	))
 	txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
 
-	return server.StartAndWait()
+	return server.StartAndWait(context.Background())
 }
 
 func doFullMode(config interface{}) (retErr error) {
@@ -373,7 +373,7 @@ func doFullMode(config interface{}) (retErr error) {
 		tcpConfig := grpcutil.TCPConfig{
 			Port: env.Port,
 		}
-		server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, true)
+		server, err := grpcutil.NewServer(&tcpConfig, nil, grpcutil.MaxMsgSize, true)
 		if err != nil {
 			return err
 		}
@@ -465,13 +465,13 @@ func doFullMode(config interface{}) (retErr error) {
 		))
 		txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
 
-		return server.StartAndWait()
+		return server.StartAndWait(context.Background())
 	})
 	eg.Go(func() error {
 		tcpConfig := grpcutil.TCPConfig{
 			Port: env.PeerPort,
 		}
-		server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, true)
+		server, err := grpcutil.NewServer(&tcpConfig, nil, grpcutil.MaxMsgSize, true)
 		if err != nil {
 			return err
 		}
@@ -577,7 +577,7 @@ func doFullMode(config interface{}) (retErr error) {
 		versionpb.RegisterAPIServer(server.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
 		adminclient.RegisterAPIServer(server.Server, adminserver.NewAPIServer(address, env.StorageRoot, &adminclient.ClusterInfo{ID: clusterID}))
 		txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
-		return server.StartAndWait()
+		return server.StartAndWait(context.Background())
 	})
 
 	// TODO(msteffen): Is it really necessary to indicate that the peer service is

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -150,97 +150,96 @@ func doSidecarMode(config interface{}) (retErr error) {
 	// The sidecar only needs to serve traffic on the peer port, as it only serves
 	// traffic from the user container (the worker binary and occasionally user
 	// pipelines)
-	_, eg := grpcutil.Serve(
-		context.Background(),
-		grpcutil.ServerOptions{
-			Port:       env.PeerPort,
-			MaxMsgSize: grpcutil.MaxMsgSize,
-			RegisterFunc: func(s *grpc.Server) error {
-				txnEnv := &txnenv.TransactionEnv{}
-				blockCacheBytes, err := units.RAMInBytes(env.BlockCacheBytes)
-				if err != nil {
-					return fmt.Errorf("units.RAMInBytes: %v", err)
-				}
-				blockAPIServer, err := pfs_server.NewBlockAPIServer(env.StorageRoot, blockCacheBytes, env.StorageBackend, net.JoinHostPort(env.EtcdHost, env.EtcdPort), false)
-				if err != nil {
-					return fmt.Errorf("pfs.NewBlockAPIServer: %v", err)
-				}
-				pfsclient.RegisterObjectAPIServer(s, blockAPIServer)
+	tcpConfig := grpcserver.TCPConfig{
+		Host: "",
+		Port: env.PeerPort,
+	}
+	server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	if err != nil {
+		return err
+	}
 
-				memoryRequestBytes, err := units.RAMInBytes(env.MemoryRequest)
-				if err != nil {
-					return err
-				}
-				pfsAPIServer, err := pfs_server.NewAPIServer(
-					env,
-					txnEnv,
-					path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
-					treeCache,
-					env.StorageRoot,
-					memoryRequestBytes,
-				)
-				if err != nil {
-					return fmt.Errorf("pfs.NewAPIServer: %v", err)
-				}
-				pfsclient.RegisterAPIServer(s, pfsAPIServer)
+	txnEnv := &txnenv.TransactionEnv{}
+	blockCacheBytes, err := units.RAMInBytes(env.BlockCacheBytes)
+	if err != nil {
+		return fmt.Errorf("units.RAMInBytes: %v", err)
+	}
+	blockAPIServer, err := pfs_server.NewBlockAPIServer(env.StorageRoot, blockCacheBytes, env.StorageBackend, net.JoinHostPort(env.EtcdHost, env.EtcdPort), false)
+	if err != nil {
+		return fmt.Errorf("pfs.NewBlockAPIServer: %v", err)
+	}
+	pfsclient.RegisterObjectAPIServer(server.Server, blockAPIServer)
 
-				ppsAPIServer, err := pps_server.NewSidecarAPIServer(
-					env,
-					path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
-					env.IAMRole,
-					reporter,
-					env.PPSWorkerPort,
-					env.PProfPort,
-					env.HTTPPort,
-					env.PeerPort,
-				)
-				if err != nil {
-					return fmt.Errorf("pps.NewSidecarAPIServer: %v", err)
-				}
-				ppsclient.RegisterAPIServer(s, ppsAPIServer)
-
-				authAPIServer, err := authserver.NewAuthServer(
-					env,
-					txnEnv,
-					path.Join(env.EtcdPrefix, env.AuthEtcdPrefix),
-					false,
-				)
-				if err != nil {
-					return fmt.Errorf("NewAuthServer: %v", err)
-				}
-				authclient.RegisterAPIServer(s, authAPIServer)
-
-				transactionAPIServer, err := txnserver.NewAPIServer(
-					env,
-					txnEnv,
-					path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
-				)
-				if err != nil {
-					return fmt.Errorf("transaction.NewAPIServer: %v", err)
-				}
-				transactionclient.RegisterAPIServer(s, transactionAPIServer)
-
-				enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
-					env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
-				if err != nil {
-					return fmt.Errorf("NewEnterpriseServer: %v", err)
-				}
-				eprsclient.RegisterAPIServer(s, enterpriseAPIServer)
-
-				healthclient.RegisterHealthServer(s, health.NewHealthServer())
-				debugclient.RegisterDebugServer(s, debugserver.NewDebugServer(
-					"", // no name for pachd servers
-					env.GetEtcdClient(),
-					path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
-					env.PPSWorkerPort,
-				))
-				txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
-				return nil
-			},
-		},
+	memoryRequestBytes, err := units.RAMInBytes(env.MemoryRequest)
+	if err != nil {
+		return err
+	}
+	pfsAPIServer, err := pfs_server.NewAPIServer(
+		env,
+		txnEnv,
+		path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+		treeCache,
+		env.StorageRoot,
+		memoryRequestBytes,
 	)
+	if err != nil {
+		return fmt.Errorf("pfs.NewAPIServer: %v", err)
+	}
+	pfsclient.RegisterAPIServer(server.Server, pfsAPIServer)
 
-	return eg.Wait()
+	ppsAPIServer, err := pps_server.NewSidecarAPIServer(
+		env,
+		path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+		env.IAMRole,
+		reporter,
+		env.PPSWorkerPort,
+		env.PProfPort,
+		env.HTTPPort,
+		env.PeerPort,
+	)
+	if err != nil {
+		return fmt.Errorf("pps.NewSidecarAPIServer: %v", err)
+	}
+	ppsclient.RegisterAPIServer(server.Server, ppsAPIServer)
+
+	authAPIServer, err := authserver.NewAuthServer(
+		env,
+		txnEnv,
+		path.Join(env.EtcdPrefix, env.AuthEtcdPrefix),
+		false,
+	)
+	if err != nil {
+		return fmt.Errorf("NewAuthServer: %v", err)
+	}
+	authclient.RegisterAPIServer(server.Server, authAPIServer)
+
+	transactionAPIServer, err := txnserver.NewAPIServer(
+		env,
+		txnEnv,
+		path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+	)
+	if err != nil {
+		return fmt.Errorf("transaction.NewAPIServer: %v", err)
+	}
+	transactionclient.RegisterAPIServer(server.Server, transactionAPIServer)
+
+	enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
+		env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
+	if err != nil {
+		return fmt.Errorf("NewEnterpriseServer: %v", err)
+	}
+	eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
+
+	healthclient.RegisterHealthServer(server.Server, health.NewHealthServer())
+	debugclient.RegisterDebugServer(server.Server, debugserver.NewDebugServer(
+		"", // no name for pachd servers
+		env.GetEtcdClient(),
+		path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+		env.PPSWorkerPort,
+	))
+	txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
+
+	return server.StartAndWait()
 }
 
 func doFullMode(config interface{}) (retErr error) {
@@ -371,234 +370,216 @@ func doFullMode(config interface{}) (retErr error) {
 		return fmt.Errorf("ListenAndServe: %v", err)
 	})
 	eg.Go(func() error {
-		_, grpcEg := grpcutil.Serve(
-			context.Background(),
-			grpcutil.ServerOptions{
-				Port:                 env.Port,
-				MaxMsgSize:           grpcutil.MaxMsgSize,
-				PublicPortTLSAllowed: true,
-				RegisterFunc: func(s *grpc.Server) error {
-					txnEnv := &txnenv.TransactionEnv{}
-					memoryRequestBytes, err := units.RAMInBytes(env.MemoryRequest)
-					if err != nil {
-						return err
-					}
-					pfsAPIServer, err := pfs_server.NewAPIServer(env, txnEnv, path.Join(env.EtcdPrefix, env.PFSEtcdPrefix), treeCache, env.StorageRoot, memoryRequestBytes)
-					if err != nil {
-						return fmt.Errorf("pfs.NewAPIServer: %v", err)
-					}
-					pfsclient.RegisterAPIServer(s, pfsAPIServer)
-
-					ppsAPIServer, err := pps_server.NewAPIServer(
-						env,
-						txnEnv,
-						path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
-						kubeNamespace,
-						env.WorkerImage,
-						env.WorkerSidecarImage,
-						env.WorkerImagePullPolicy,
-						env.StorageRoot,
-						env.StorageBackend,
-						env.StorageHostPath,
-						env.IAMRole,
-						env.ImagePullSecret,
-						env.NoExposeDockerSocket,
-						reporter,
-						env.WorkerUsesRoot,
-						env.PPSWorkerPort,
-						env.Port,
-						env.PProfPort,
-						env.HTTPPort,
-						env.PeerPort,
-					)
-					if err != nil {
-						return fmt.Errorf("pps.NewAPIServer: %v", err)
-					}
-					ppsclient.RegisterAPIServer(s, ppsAPIServer)
-
-					if env.ExposeObjectAPI {
-						// Generally the object API should not be exposed publicly, but
-						// TestGarbageCollection uses it and it may help with debugging
-						blockAPIServer, err := pfs_server.NewBlockAPIServer(
-							env.StorageRoot,
-							0 /* = blockCacheBytes (disable cache) */, env.StorageBackend,
-							etcdAddress,
-							true /* duplicate */)
-						if err != nil {
-							return fmt.Errorf("pfs.NewBlockAPIServer: %v", err)
-						}
-						pfsclient.RegisterObjectAPIServer(s, blockAPIServer)
-					}
-
-					authAPIServer, err := authserver.NewAuthServer(
-						env, txnEnv, path.Join(env.EtcdPrefix, env.AuthEtcdPrefix), true)
-					if err != nil {
-						return fmt.Errorf("NewAuthServer: %v", err)
-					}
-					authclient.RegisterAPIServer(s, authAPIServer)
-
-					transactionAPIServer, err := txnserver.NewAPIServer(
-						env,
-						txnEnv,
-						path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
-					)
-					if err != nil {
-						return fmt.Errorf("transaction.NewAPIServer: %v", err)
-					}
-					transactionclient.RegisterAPIServer(s, transactionAPIServer)
-
-					enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
-						env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
-					if err != nil {
-						return fmt.Errorf("NewEnterpriseServer: %v", err)
-					}
-					eprsclient.RegisterAPIServer(s, enterpriseAPIServer)
-
-					adminclient.RegisterAPIServer(s, adminserver.NewAPIServer(address, env.StorageRoot, &adminclient.ClusterInfo{ID: clusterID}))
-					healthclient.RegisterHealthServer(s, publicHealthServer)
-					versionpb.RegisterAPIServer(s, version.NewAPIServer(version.Version, version.APIServerOptions{}))
-					debugclient.RegisterDebugServer(s, debugserver.NewDebugServer(
-						"", // no name for pachd servers
-						env.GetEtcdClient(),
-						path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
-						env.PPSWorkerPort,
-					))
-					txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
-					return nil
-				},
-			},
-		)
-
-		err := grpcEg.Wait()
-		if err != nil {
-			log.Printf("error starting grpc server %v\n", err)
+		tcpConfig := grpcutil.TCPConfig{
+			Port: env.Port,
 		}
-		return err
+		server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, true)
+		if err != nil {
+			return err
+		}
+
+		txnEnv := &txnenv.TransactionEnv{}
+		memoryRequestBytes, err := units.RAMInBytes(env.MemoryRequest)
+		if err != nil {
+			return err
+		}
+		pfsAPIServer, err := pfs_server.NewAPIServer(env, txnEnv, path.Join(env.EtcdPrefix, env.PFSEtcdPrefix), treeCache, env.StorageRoot, memoryRequestBytes)
+		if err != nil {
+			return fmt.Errorf("pfs.NewAPIServer: %v", err)
+		}
+		pfsclient.RegisterAPIServer(server.Server, pfsAPIServer)
+
+		ppsAPIServer, err := pps_server.NewAPIServer(
+			env,
+			txnEnv,
+			path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+			kubeNamespace,
+			env.WorkerImage,
+			env.WorkerSidecarImage,
+			env.WorkerImagePullPolicy,
+			env.StorageRoot,
+			env.StorageBackend,
+			env.StorageHostPath,
+			env.IAMRole,
+			env.ImagePullSecret,
+			env.NoExposeDockerSocket,
+			reporter,
+			env.WorkerUsesRoot,
+			env.PPSWorkerPort,
+			env.Port,
+			env.PProfPort,
+			env.HTTPPort,
+			env.PeerPort,
+		)
+		if err != nil {
+			return fmt.Errorf("pps.NewAPIServer: %v", err)
+		}
+		ppsclient.RegisterAPIServer(server.Server, ppsAPIServer)
+
+		if env.ExposeObjectAPI {
+			// Generally the object API should not be exposed publicly, but
+			// TestGarbageCollection uses it and it may help with debugging
+			blockAPIServer, err := pfs_server.NewBlockAPIServer(
+				env.StorageRoot,
+				0 /* = blockCacheBytes (disable cache) */, env.StorageBackend,
+				etcdAddress,
+				true /* duplicate */)
+			if err != nil {
+				return fmt.Errorf("pfs.NewBlockAPIServer: %v", err)
+			}
+			pfsclient.RegisterObjectAPIServer(server.Server, blockAPIServer)
+		}
+
+		authAPIServer, err := authserver.NewAuthServer(
+			env, txnEnv, path.Join(env.EtcdPrefix, env.AuthEtcdPrefix), true)
+		if err != nil {
+			return fmt.Errorf("NewAuthServer: %v", err)
+		}
+		authclient.RegisterAPIServer(server.Server, authAPIServer)
+
+		transactionAPIServer, err := txnserver.NewAPIServer(
+			env,
+			txnEnv,
+			path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+		)
+		if err != nil {
+			return fmt.Errorf("transaction.NewAPIServer: %v", err)
+		}
+		transactionclient.RegisterAPIServer(server.Server, transactionAPIServer)
+
+		enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
+			env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
+		if err != nil {
+			return fmt.Errorf("NewEnterpriseServer: %v", err)
+		}
+		eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
+
+		adminclient.RegisterAPIServer(server.Server, adminserver.NewAPIServer(address, env.StorageRoot, &adminclient.ClusterInfo{ID: clusterID}))
+		healthclient.RegisterHealthServer(server.Server, publicHealthServer)
+		versionpb.RegisterAPIServer(server.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
+		debugclient.RegisterDebugServer(server.Server, debugserver.NewDebugServer(
+			"", // no name for pachd servers
+			env.GetEtcdClient(),
+			path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+			env.PPSWorkerPort,
+		))
+		txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
+
+		return server.StartAndWait()
 	})
-	// Unfortunately, calling Register___Server(x) twice on the same
-	// struct x doesn't work--x will only serve requests from the first
-	// grpc.Server it was registered with. So we create a second set of
-	// APIServer structs here so we can serve the Pachyderm API on the
-	// peer port
 	eg.Go(func() error {
-		_, grpcEg := grpcutil.Serve(
-			context.Background(),
-			grpcutil.ServerOptions{
-				Port:       env.PeerPort,
-				MaxMsgSize: grpcutil.MaxMsgSize,
-				RegisterFunc: func(s *grpc.Server) error {
-					txnEnv := &txnenv.TransactionEnv{}
-					cacheServer := cache_server.NewCacheServer(router, env.NumShards)
-					go func() {
-						if err := sharder.RegisterFrontends(address, []shard.Frontend{cacheServer}); err != nil {
-							log.Printf("error from sharder.RegisterFrontend %s", grpcutil.ScrubGRPC(err))
-						}
-					}()
-					go func() {
-						if err := sharder.Register(address, []shard.Server{cacheServer}); err != nil {
-							log.Printf("error from sharder.Register %s", grpcutil.ScrubGRPC(err))
-						}
-					}()
-					cache_pb.RegisterGroupCacheServer(s, cacheServer)
-
-					blockCacheBytes, err := units.RAMInBytes(env.BlockCacheBytes)
-					if err != nil {
-						return fmt.Errorf("units.RAMInBytes: %v", err)
-					}
-					blockAPIServer, err := pfs_server.NewBlockAPIServer(
-						env.StorageRoot, blockCacheBytes, env.StorageBackend, etcdAddress, false)
-					if err != nil {
-						return fmt.Errorf("pfs.NewBlockAPIServer: %v", err)
-					}
-					pfsclient.RegisterObjectAPIServer(s, blockAPIServer)
-
-					memoryRequestBytes, err := units.RAMInBytes(env.MemoryRequest)
-					if err != nil {
-						return err
-					}
-					pfsAPIServer, err := pfs_server.NewAPIServer(
-						env,
-						txnEnv,
-						path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
-						treeCache,
-						env.StorageRoot,
-						memoryRequestBytes,
-					)
-					if err != nil {
-						return fmt.Errorf("pfs.NewAPIServer: %v", err)
-					}
-					pfsclient.RegisterAPIServer(s, pfsAPIServer)
-
-					ppsAPIServer, err := pps_server.NewAPIServer(
-						env,
-						txnEnv,
-						path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
-						kubeNamespace,
-						env.WorkerImage,
-						env.WorkerSidecarImage,
-						env.WorkerImagePullPolicy,
-						env.StorageRoot,
-						env.StorageBackend,
-						env.StorageHostPath,
-						env.IAMRole,
-						env.ImagePullSecret,
-						env.NoExposeDockerSocket,
-						reporter,
-						env.WorkerUsesRoot,
-						env.PPSWorkerPort,
-						env.Port,
-						env.PProfPort,
-						env.HTTPPort,
-						env.PeerPort,
-					)
-					if err != nil {
-						return fmt.Errorf("pps.NewAPIServer: %v", err)
-					}
-					ppsclient.RegisterAPIServer(s, ppsAPIServer)
-
-					authAPIServer, err := authserver.NewAuthServer(
-						env,
-						txnEnv,
-						path.Join(env.EtcdPrefix, env.AuthEtcdPrefix),
-						false,
-					)
-					if err != nil {
-						return fmt.Errorf("NewAuthServer: %v", err)
-					}
-					authclient.RegisterAPIServer(s, authAPIServer)
-
-					transactionAPIServer, err := txnserver.NewAPIServer(
-						env,
-						txnEnv,
-						path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
-					)
-					if err != nil {
-						return fmt.Errorf("transaction.NewAPIServer: %v", err)
-					}
-					transactionclient.RegisterAPIServer(s, transactionAPIServer)
-
-					enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
-						env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
-					if err != nil {
-						return fmt.Errorf("NewEnterpriseServer: %v", err)
-					}
-					eprsclient.RegisterAPIServer(s, enterpriseAPIServer)
-
-					healthclient.RegisterHealthServer(s, peerHealthServer)
-					versionpb.RegisterAPIServer(s, version.NewAPIServer(version.Version, version.APIServerOptions{}))
-					adminclient.RegisterAPIServer(s, adminserver.NewAPIServer(address, env.StorageRoot, &adminclient.ClusterInfo{ID: clusterID}))
-					txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
-					return nil
-				},
-			},
-		)
-
-		err = grpcEg.Wait()
-		if err != nil {
-			log.Printf("error starting grpc server %v\n", err)
+		tcpConfig := grpcutil.TCPConfig{
+			Port: env.PeerPort,
 		}
-		return err
+		server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, true)
+		if err != nil {
+			return err
+		}
+
+		txnEnv := &txnenv.TransactionEnv{}
+		cacheServer := cache_server.NewCacheServer(router, env.NumShards)
+		go func() {
+			if err := sharder.RegisterFrontends(address, []shard.Frontend{cacheServer}); err != nil {
+				log.Printf("error from sharder.RegisterFrontend %s", grpcutil.ScrubGRPC(err))
+			}
+		}()
+		go func() {
+			if err := sharder.Register(address, []shard.Server{cacheServer}); err != nil {
+				log.Printf("error from sharder.Register %s", grpcutil.ScrubGRPC(err))
+			}
+		}()
+		cache_pb.RegisterGroupCacheServer(server.Server, cacheServer)
+
+		blockCacheBytes, err := units.RAMInBytes(env.BlockCacheBytes)
+		if err != nil {
+			return fmt.Errorf("units.RAMInBytes: %v", err)
+		}
+		blockAPIServer, err := pfs_server.NewBlockAPIServer(
+			env.StorageRoot, blockCacheBytes, env.StorageBackend, etcdAddress, false)
+		if err != nil {
+			return fmt.Errorf("pfs.NewBlockAPIServer: %v", err)
+		}
+		pfsclient.RegisterObjectAPIServer(server.Server, blockAPIServer)
+
+		memoryRequestBytes, err := units.RAMInBytes(env.MemoryRequest)
+		if err != nil {
+			return err
+		}
+		pfsAPIServer, err := pfs_server.NewAPIServer(
+			env,
+			txnEnv,
+			path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+			treeCache,
+			env.StorageRoot,
+			memoryRequestBytes,
+		)
+		if err != nil {
+			return fmt.Errorf("pfs.NewAPIServer: %v", err)
+		}
+		pfsclient.RegisterAPIServer(server.Server, pfsAPIServer)
+
+		ppsAPIServer, err := pps_server.NewAPIServer(
+			env,
+			txnEnv,
+			path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+			kubeNamespace,
+			env.WorkerImage,
+			env.WorkerSidecarImage,
+			env.WorkerImagePullPolicy,
+			env.StorageRoot,
+			env.StorageBackend,
+			env.StorageHostPath,
+			env.IAMRole,
+			env.ImagePullSecret,
+			env.NoExposeDockerSocket,
+			reporter,
+			env.WorkerUsesRoot,
+			env.PPSWorkerPort,
+			env.Port,
+			env.PProfPort,
+			env.HTTPPort,
+			env.PeerPort,
+		)
+		if err != nil {
+			return fmt.Errorf("pps.NewAPIServer: %v", err)
+		}
+		ppsclient.RegisterAPIServer(server.Server, ppsAPIServer)
+
+		authAPIServer, err := authserver.NewAuthServer(
+			env,
+			txnEnv,
+			path.Join(env.EtcdPrefix, env.AuthEtcdPrefix),
+			false,
+		)
+		if err != nil {
+			return fmt.Errorf("NewAuthServer: %v", err)
+		}
+		authclient.RegisterAPIServer(server.Server, authAPIServer)
+
+		transactionAPIServer, err := txnserver.NewAPIServer(
+			env,
+			txnEnv,
+			path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+		)
+		if err != nil {
+			return fmt.Errorf("transaction.NewAPIServer: %v", err)
+		}
+		transactionclient.RegisterAPIServer(server.Server, transactionAPIServer)
+
+		enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
+			env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
+		if err != nil {
+			return fmt.Errorf("NewEnterpriseServer: %v", err)
+		}
+		eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
+
+		healthclient.RegisterHealthServer(server.Server, peerHealthServer)
+		versionpb.RegisterAPIServer(server.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
+		adminclient.RegisterAPIServer(server.Server, adminserver.NewAPIServer(address, env.StorageRoot, &adminclient.ClusterInfo{ID: clusterID}))
+		txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer)
+		return server.StartAndWait()
 	})
+
 	// TODO(msteffen): Is it really necessary to indicate that the peer service is
 	// healthy? Presumably migrate() will call the peer service no matter what.
 	publicHealthServer.Ready()

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -155,7 +155,7 @@ func do(config interface{}) error {
 	tcpConfig := grpcutil.TCPConfig{
 		Port: env.PPSWorkerPort,
 	}
-	server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
 	if err != nil {
 		return err
 	}
@@ -189,5 +189,5 @@ func do(config interface{}) error {
 	}
 
 	// If server ever exits, return error
-	return server.Wait()
+	return server.StartAndWait(context.Background())
 }

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	"github.com/pachyderm/pachyderm/src/server/worker"
-	"google.golang.org/grpc"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -152,10 +151,7 @@ func do(config interface{}) error {
 	}
 
 	// Start worker api server
-	tcpConfig := grpcutil.TCPConfig{
-		Port: env.PPSWorkerPort,
-	}
-	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
+	server, err := grpcutil.NewServer(context.Background(), false)
 	if err != nil {
 		return err
 	}
@@ -189,5 +185,8 @@ func do(config interface{}) error {
 	}
 
 	// If server ever exits, return error
-	return server.StartAndWait(context.Background())
+	if _, err := server.ListenTCP("", env.PPSWorkerPort); err != nil {
+		return err
+	}
+	return server.Wait()
 }

--- a/src/server/pfs/server/testing.go
+++ b/src/server/pfs/server/testing.go
@@ -60,7 +60,7 @@ func runServers(
 	tcpConfig := grpcutil.TCPConfig{
 		Port: uint16(port),
 	}
-	server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
 	require.NoError(t, err)
 
 	pfs.RegisterAPIServer(server.Server, apiServer)
@@ -69,7 +69,7 @@ func runServers(
 	versionpb.RegisterAPIServer(server.Server,
 		version.NewAPIServer(version.Version, version.APIServerOptions{}))
 	go func() {
-		require.NoError(t, server.StartAndWait())
+		require.NoError(t, server.StartAndWait(context.Background()))
 	}()
 }
 

--- a/src/server/pfs/server/testing.go
+++ b/src/server/pfs/server/testing.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	tu "github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
-	"google.golang.org/grpc"
 
 	"golang.org/x/net/context"
 )
@@ -58,25 +57,19 @@ func runServers(
 	apiServer APIServer,
 	blockAPIServer BlockAPIServer,
 ) {
-	_, eg := grpcutil.Serve(
-		context.Background(),
-		grpcutil.ServerOptions{
-			Port:       uint16(port),
-			MaxMsgSize: grpcutil.MaxMsgSize,
-			RegisterFunc: func(s *grpc.Server) error {
-				pfs.RegisterAPIServer(s, apiServer)
-				pfs.RegisterObjectAPIServer(s, blockAPIServer)
-				auth.RegisterAPIServer(s, &authtesting.InactiveAPIServer{}) // PFS server uses auth API
-				versionpb.RegisterAPIServer(s,
-					version.NewAPIServer(version.Version, version.APIServerOptions{}))
-				return nil
-			}},
-	)
+	tcpConfig := grpcutil.TCPConfig{
+		Port: uint16(port),
+	}
+	server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	require.NoError(t, err)
 
-	// TODO: pretty sure `require` in a goroutine doesn't work very well, consider
-	// returning a structure that will be closed at the end of a test.
+	pfs.RegisterAPIServer(server.Server, apiServer)
+	pfs.RegisterObjectAPIServer(server.Server, blockAPIServer)
+	auth.RegisterAPIServer(server.Server, &authtesting.InactiveAPIServer{}) // PFS server uses auth API
+	versionpb.RegisterAPIServer(server.Server,
+		version.NewAPIServer(version.Version, version.APIServerOptions{}))
 	go func() {
-		require.NoError(t, eg.Wait())
+		require.NoError(t, server.StartAndWait())
 	}()
 }
 

--- a/src/server/pkg/testutil/env.go
+++ b/src/server/pkg/testutil/env.go
@@ -111,7 +111,10 @@ func WithEnv(cb func(*Env) error) (err error) {
 		return err
 	}
 
-	env.MockPachd = NewMockPachd()
+	env.MockPachd, err = NewMockPachd()
+	if err != nil {
+		return err
+	}
 
 	env.PachClient, err = client.NewFromAddress(env.MockPachd.Addr.String())
 	if err != nil {

--- a/src/server/pkg/testutil/mock_pachd.go
+++ b/src/server/pkg/testutil/mock_pachd.go
@@ -1238,8 +1238,7 @@ func NewMockPachd() (*MockPachd, error) {
 	mock.Version.api.mock = &mock.Version
 	mock.Admin.api.mock = &mock.Admin
 
-	tcpConfig := grpcutil.TCPConfig{}
-	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
+	server, err := grpcutil.NewServer(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,11 +1252,12 @@ func NewMockPachd() (*MockPachd, error) {
 	transaction.RegisterAPIServer(server.Server, &mock.Transaction.api)
 	version.RegisterAPIServer(server.Server, &mock.Version.api)
 
-	if err := server.Start(ctx); err != nil {
+	listener, err := server.ListenTCP("", 0)
+	if err != nil {
 		return nil, err
 	}
 
-	mock.Addr = server.TCPListener.Addr()
+	mock.Addr = listener.Addr()
 	return mock, nil
 }
 

--- a/src/server/pkg/testutil/mock_pachd.go
+++ b/src/server/pkg/testutil/mock_pachd.go
@@ -1239,7 +1239,7 @@ func NewMockPachd() (*MockPachd, error) {
 	mock.Admin.api.mock = &mock.Admin
 
 	tcpConfig := grpcutil.TCPConfig{}
-	server, err := grpcutil.NewServer(ctx, &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,7 +1253,7 @@ func NewMockPachd() (*MockPachd, error) {
 	transaction.RegisterAPIServer(server.Server, &mock.Transaction.api)
 	version.RegisterAPIServer(server.Server, &mock.Version.api)
 
-	if err := server.Start(); err != nil {
+	if err := server.Start(ctx); err != nil {
 		return nil, err
 	}
 

--- a/src/server/pkg/testutil/mock_pachd.go
+++ b/src/server/pkg/testutil/mock_pachd.go
@@ -17,7 +17,6 @@ import (
 	version "github.com/pachyderm/pachyderm/src/client/version/versionpb"
 
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
 )
 
 /* Admin Server Mocks */
@@ -1224,7 +1223,7 @@ type MockPachd struct {
 // NewMockPachd constructs a mock Pachd API server whose behavior can be
 // controlled through the MockPachd instance. By default, all API calls will
 // error, unless a handler is specified.
-func NewMockPachd() *MockPachd {
+func NewMockPachd() (*MockPachd, error) {
 	mock := &MockPachd{}
 
 	ctx := context.Background()
@@ -1239,29 +1238,27 @@ func NewMockPachd() *MockPachd {
 	mock.Version.api.mock = &mock.Version
 	mock.Admin.api.mock = &mock.Admin
 
-	var servers []*grpcutil.ServerRun
-	servers, mock.eg = grpcutil.Serve(
-		ctx,
-		grpcutil.ServerOptions{
-			Host:       "localhost",
-			AnyPort:    true,
-			MaxMsgSize: grpcutil.MaxMsgSize,
-			RegisterFunc: func(s *grpc.Server) error {
-				admin.RegisterAPIServer(s, &mock.Admin.api)
-				auth.RegisterAPIServer(s, &mock.Auth.api)
-				enterprise.RegisterAPIServer(s, &mock.Enterprise.api)
-				pfs.RegisterObjectAPIServer(s, &mock.Object.api)
-				pfs.RegisterAPIServer(s, &mock.PFS.api)
-				pps.RegisterAPIServer(s, &mock.PPS.api)
-				transaction.RegisterAPIServer(s, &mock.Transaction.api)
-				version.RegisterAPIServer(s, &mock.Version.api)
-				return nil
-			},
-		},
-	)
+	tcpConfig := grpcutil.TCPConfig{}
+	server, err := grpcutil.NewServer(ctx, &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	if err != nil {
+		return nil, err
+	}
 
-	mock.Addr = servers[0].Listener.Addr()
-	return mock
+	admin.RegisterAPIServer(server.Server, &mock.Admin.api)
+	auth.RegisterAPIServer(server.Server, &mock.Auth.api)
+	enterprise.RegisterAPIServer(server.Server, &mock.Enterprise.api)
+	pfs.RegisterObjectAPIServer(server.Server, &mock.Object.api)
+	pfs.RegisterAPIServer(server.Server, &mock.PFS.api)
+	pps.RegisterAPIServer(server.Server, &mock.PPS.api)
+	transaction.RegisterAPIServer(server.Server, &mock.Transaction.api)
+	version.RegisterAPIServer(server.Server, &mock.Version.api)
+
+	if err := server.Start(); err != nil {
+		return nil, err
+	}
+
+	mock.Addr = server.TCPListener.Addr()
+	return mock, nil
 }
 
 // Close will cancel the mock Pachd API server goroutine and return its result

--- a/src/server/transaction/server/server_test.go
+++ b/src/server/transaction/server/server_test.go
@@ -25,7 +25,6 @@ import (
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const (

--- a/src/server/transaction/server/server_test.go
+++ b/src/server/transaction/server/server_test.go
@@ -61,7 +61,7 @@ func runServers(
 	tcpConfig := grpcutil.TCPConfig{
 		Port: uint16(port),
 	}
-	server, err := grpcutil.NewServer(context.Background(), &tcpConfig, nil, grpcutil.MaxMsgSize, false)
+	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func runServers(
 	auth.RegisterAPIServer(server.Server, authServer)
 	transaction.RegisterAPIServer(server.Server, txnServer)
 	go func() {
-		require.NoError(t, server.StartAndWait())
+		require.NoError(t, server.StartAndWait(context.Background()))
 	}()
 }
 

--- a/src/server/transaction/server/server_test.go
+++ b/src/server/transaction/server/server_test.go
@@ -58,19 +58,19 @@ func runServers(
 	authServer auth.APIServer,
 	txnServer APIServer,
 ) {
-	tcpConfig := grpcutil.TCPConfig{
-		Port: uint16(port),
-	}
-	server, err := grpcutil.NewServer(&tcpConfig, nil, false)
-	if err != nil {
-		return err
-	}
+	server, err := grpcutil.NewServer(context.Background(), false)
+	require.NoError(t, err)
+
 	pfs.RegisterAPIServer(server.Server, pfsServer)
 	pfs.RegisterObjectAPIServer(server.Server, pfsBlockServer)
 	auth.RegisterAPIServer(server.Server, authServer)
 	transaction.RegisterAPIServer(server.Server, txnServer)
+
+	_, err = server.ListenTCP("", uint16(port))
+	require.NoError(t, err)
+
 	go func() {
-		require.NoError(t, server.StartAndWait(context.Background()))
+		require.NoError(t, server.Wait())
 	}()
 }
 


### PR DESCRIPTION
This was originally planned to be the introduction of support for Unix domain sockets in our gRPC services (#4347), however I first refactored some of the gRPC server utility functionality to make it easier to add. Continued work on Unix domain sockets has been pulled into a separate branch because it's an open experiment, and not clear whether it'll ever get merged.

The meat of the changes are in `grpcutil/server.go` -- all other changes are consumers of that package. Primarily, the new `Server` struct has been designed to leak fewer internal implementation details. Semantically, it should be the same, with one notable exception: TCP listeners are not constructed asynchronously. It wasn't clear to me whether making them asynchronous was a performance net benefit, and removing it made the things less convoluted.