### PR TITLE
Restrict mock pachd instance to only listen on localhost

### DIFF
--- a/src/server/pkg/testutil/mock_pachd.go
+++ b/src/server/pkg/testutil/mock_pachd.go
@@ -1252,7 +1252,7 @@ func NewMockPachd() (*MockPachd, error) {
 	transaction.RegisterAPIServer(server.Server, &mock.Transaction.api)
 	version.RegisterAPIServer(server.Server, &mock.Version.api)
 
-	listener, err := server.ListenTCP("", 0)
+	listener, err := server.ListenTCP("localhost", 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is test code that may run directly on a dev's machine rather than in a container - this should not be listening on public network interfaces.