### PR TITLE
CLI pretty printer improvements.

### DIFF
--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -14,11 +14,11 @@ import (
 
 const (
 	// RepoHeader is the header for repos.
-	RepoHeader = "NAME\tCREATED\tSIZE (MASTER)\t\n"
+	RepoHeader = "NAME\tCREATED\tSIZE (MASTER)\tDESCRIPTION\t\n"
 	// RepoAuthHeader is the header for repos with auth information attached.
 	RepoAuthHeader = "NAME\tCREATED\tSIZE (MASTER)\tACCESS LEVEL\t\n"
 	// CommitHeader is the header for commits.
-	CommitHeader = "REPO\tBRANCH\tCOMMIT\tPARENT\tSTARTED\tDURATION\tSIZE\tPROGRESS\t\n"
+	CommitHeader = "REPO\tBRANCH\tCOMMIT\tSTARTED\tSIZE\tPROGRESS\tDESCRIPTION\n"
 	// BranchHeader is the header for branches.
 	BranchHeader = "BRANCH\tHEAD\t\n"
 	// FileHeader is the header for files.
@@ -41,6 +41,7 @@ func PrintRepoInfo(w io.Writer, repoInfo *pfs.RepoInfo, fullTimestamps bool) {
 	if repoInfo.AuthInfo != nil {
 		fmt.Fprintf(w, "%s\t", repoInfo.AuthInfo.AccessLevel.String())
 	}
+	fmt.Fprintf(w, "%s\t", repoInfo.Description)
 	fmt.Fprintln(w)
 }
 
@@ -114,29 +115,26 @@ func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps boo
 		fmt.Fprintf(w, "<none>\t")
 	}
 	fmt.Fprintf(w, "%s\t", commitInfo.Commit.ID)
-	if commitInfo.ParentCommit != nil {
-		fmt.Fprintf(w, "%s\t", commitInfo.ParentCommit.ID)
-	} else {
-		fmt.Fprint(w, "<none>\t")
-	}
 	if fullTimestamps {
 		fmt.Fprintf(w, "%s\t", commitInfo.Started.String())
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(commitInfo.Started))
 	}
-	if commitInfo.Finished != nil {
-		fmt.Fprintf(w, fmt.Sprintf("%s\t", pretty.TimeDifference(commitInfo.Started, commitInfo.Finished)))
-		fmt.Fprintf(w, "%s\t", units.BytesSize(float64(commitInfo.SizeBytes)))
+	if commitInfo.Finished == nil {
+		fmt.Fprintf(w, "-\t")
 	} else {
-		fmt.Fprintf(w, "-\t")
-		// Open commits don't have meaningful size information
-		fmt.Fprintf(w, "-\t")
+		fmt.Fprintf(w, "%s\t", units.BytesSize(float64(commitInfo.SizeBytes)))
 	}
-	fmt.Fprintf(w, "%s\t\n", pretty.ProgressBar(
-		8,
-		int(commitInfo.SubvenantCommitsSuccess),
-		int(commitInfo.SubvenantCommitsTotal-commitInfo.SubvenantCommitsSuccess-commitInfo.SubvenantCommitsFailure),
-		int(commitInfo.SubvenantCommitsFailure)))
+	if commitInfo.SubvenantCommitsTotal == 0 {
+		fmt.Fprintf(w, "-\t")
+	} else {
+		fmt.Fprintf(w, "%s\t", pretty.ProgressBar(
+			8,
+			int(commitInfo.SubvenantCommitsSuccess),
+			int(commitInfo.SubvenantCommitsTotal-commitInfo.SubvenantCommitsSuccess-commitInfo.SubvenantCommitsFailure),
+			int(commitInfo.SubvenantCommitsFailure)))
+	}
+	fmt.Fprintf(w, "%s\t\n", commitInfo.Description)
 }
 
 // PrintableCommitInfo is a wrapper around CommitInfo containing any formatting options

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -18,7 +18,7 @@ const (
 	// RepoAuthHeader is the header for repos with auth information attached.
 	RepoAuthHeader = "NAME\tCREATED\tSIZE (MASTER)\tACCESS LEVEL\t\n"
 	// CommitHeader is the header for commits.
-	CommitHeader = "REPO\tBRANCH\tCOMMIT\tSTARTED\tSIZE\tPROGRESS\tDESCRIPTION\n"
+	CommitHeader = "REPO\tBRANCH\tCOMMIT\tFINISHED\tSIZE\tPROGRESS\tDESCRIPTION\n"
 	// BranchHeader is the header for branches.
 	BranchHeader = "BRANCH\tHEAD\t\n"
 	// FileHeader is the header for files.
@@ -83,10 +83,11 @@ Access level: {{ .AuthInfo.AccessLevel.String }}{{end}}
 func PrintBranch(w io.Writer, branchInfo *pfs.BranchInfo) {
 	fmt.Fprintf(w, "%s\t", branchInfo.Branch.Name)
 	if branchInfo.Head != nil {
-		fmt.Fprintf(w, "%s\t\n", branchInfo.Head.ID)
+		fmt.Fprintf(w, "%s\t", branchInfo.Head.ID)
 	} else {
-		fmt.Fprintf(w, "-\t\n")
+		fmt.Fprintf(w, "-\t")
 	}
+	fmt.Fprintln(w)
 }
 
 // PrintDetailedBranchInfo pretty-prints detailed branch info.
@@ -116,9 +117,9 @@ func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps boo
 	}
 	fmt.Fprintf(w, "%s\t", commitInfo.Commit.ID)
 	if fullTimestamps {
-		fmt.Fprintf(w, "%s\t", commitInfo.Started.String())
+		fmt.Fprintf(w, "%s\t", commitInfo.Finished.String())
 	} else {
-		fmt.Fprintf(w, "%s\t", pretty.Ago(commitInfo.Started))
+		fmt.Fprintf(w, "%s\t", pretty.Ago(commitInfo.Finished))
 	}
 	if commitInfo.Finished == nil {
 		fmt.Fprintf(w, "-\t")
@@ -134,7 +135,8 @@ func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps boo
 			int(commitInfo.SubvenantCommitsTotal-commitInfo.SubvenantCommitsSuccess-commitInfo.SubvenantCommitsFailure),
 			int(commitInfo.SubvenantCommitsFailure)))
 	}
-	fmt.Fprintf(w, "%s\t\n", commitInfo.Description)
+	fmt.Fprintf(w, "%s\t", commitInfo.Description)
+	fmt.Fprintln(w)
 }
 
 // PrintableCommitInfo is a wrapper around CommitInfo containing any formatting options
@@ -197,7 +199,8 @@ func PrintFileInfo(w io.Writer, fileInfo *pfs.FileInfo, fullTimestamps, withComm
 			fmt.Fprintf(w, "%s\t", pretty.Ago(fileInfo.Committed))
 		}
 	}
-	fmt.Fprintf(w, "%s\t\n", units.BytesSize(float64(fileInfo.SizeBytes)))
+	fmt.Fprintf(w, "%s\t", units.BytesSize(float64(fileInfo.SizeBytes)))
+	fmt.Fprintln(w)
 }
 
 // PrintDiffFileInfo pretty-prints a file info from diff file.

--- a/src/server/pkg/pretty/pretty.go
+++ b/src/server/pkg/pretty/pretty.go
@@ -64,8 +64,10 @@ func ProgressBar(width, green, yellow, red int) string {
 			sb.WriteString(color.GreenString("▇"))
 		case i*total < (green+yellow)*width:
 			sb.WriteString(color.YellowString("▇"))
-		default:
+		case i*total < (green+yellow+red)*width:
 			sb.WriteString(color.RedString("▇"))
+		default:
+			sb.WriteString(" ")
 		}
 	}
 	return sb.String()

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -60,10 +60,11 @@ func PrintJobInfo(w io.Writer, jobInfo *ppsclient.JobInfo, fullTimestamps bool) 
 	fmt.Fprintf(w, "%s\t", pretty.Size(jobInfo.Stats.DownloadBytes))
 	fmt.Fprintf(w, "%s\t", pretty.Size(jobInfo.Stats.UploadBytes))
 	if jobInfo.State == ppsclient.JobState_JOB_FAILURE {
-		fmt.Fprintf(w, "%s: %s\t\n", jobState(jobInfo.State), safeTrim(jobInfo.Reason, jobReasonLen))
+		fmt.Fprintf(w, "%s: %s\t", jobState(jobInfo.State), safeTrim(jobInfo.Reason, jobReasonLen))
 	} else {
-		fmt.Fprintf(w, "%s\t\n", jobState(jobInfo.State))
+		fmt.Fprintf(w, "%s\t", jobState(jobInfo.State))
 	}
+	fmt.Fprintln(w)
 }
 
 // PrintPipelineInfo pretty-prints pipeline info.
@@ -77,7 +78,8 @@ func PrintPipelineInfo(w io.Writer, pipelineInfo *ppsclient.PipelineInfo, fullTi
 		fmt.Fprintf(w, "%s\t", pretty.Ago(pipelineInfo.CreatedAt))
 	}
 	fmt.Fprintf(w, "%s / %s\t", pipelineState(pipelineInfo.State), jobState(pipelineInfo.LastJobState))
-	fmt.Fprintf(w, "%s\t\n", pipelineInfo.Description)
+	fmt.Fprintf(w, "%s\t", pipelineInfo.Description)
+	fmt.Fprintln(w)
 }
 
 // PrintWorkerStatusHeader pretty prints a worker status header.
@@ -98,7 +100,8 @@ func PrintWorkerStatus(w io.Writer, workerStatus *ppsclient.WorkerStatus, fullTi
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(workerStatus.Started))
 	}
-	fmt.Fprintf(w, "%d\t\n", workerStatus.QueueSize)
+	fmt.Fprintf(w, "%d\t", workerStatus.QueueSize)
+	fmt.Fprintln(w)
 }
 
 // PrintableJobInfo is a wrapper around JobInfo containing any formatting options
@@ -235,7 +238,8 @@ func PrintDatumInfo(w io.Writer, datumInfo *ppsclient.DatumInfo) {
 	if datumInfo.Stats != nil {
 		totalTime = units.HumanDuration(client.GetDatumTotalTime(datumInfo.Stats))
 	}
-	fmt.Fprintf(w, "%s\t%s\t%s\n", datumInfo.Datum.ID, datumState(datumInfo.State), totalTime)
+	fmt.Fprintf(w, "%s\t%s\t%s\t", datumInfo.Datum.ID, datumState(datumInfo.State), totalTime)
+	fmt.Fprintln(w)
 }
 
 // PrintDetailedDatumInfo pretty-prints detailed info about a datum

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// PipelineHeader is the header for pipelines.
-	PipelineHeader = "NAME\tVERSION\tINPUT\tCREATED\tSTATE / LAST JOB\t\n"
+	PipelineHeader = "NAME\tVERSION\tINPUT\tCREATED\tSTATE / LAST JOB\tDESCRIPTION\t\n"
 	// JobHeader is the header for jobs
 	JobHeader = "ID\tPIPELINE\tSTARTED\tDURATION\tRESTART\tPROGRESS\tDL\tUL\tSTATE\t\n"
 	// DatumHeader is the header for datums
@@ -76,7 +76,8 @@ func PrintPipelineInfo(w io.Writer, pipelineInfo *ppsclient.PipelineInfo, fullTi
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(pipelineInfo.CreatedAt))
 	}
-	fmt.Fprintf(w, "%s / %s\t\n", pipelineState(pipelineInfo.State), jobState(pipelineInfo.LastJobState))
+	fmt.Fprintf(w, "%s / %s\t", pipelineState(pipelineInfo.State), jobState(pipelineInfo.LastJobState))
+	fmt.Fprintf(w, "%s\t\n", pipelineInfo.Description)
 }
 
 // PrintWorkerStatusHeader pretty prints a worker status header.

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1973,12 +1973,20 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	var visitErr error
 	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {
 		if input.Cron != nil {
-			if err := pachClient.CreateRepo(input.Cron.Repo); err != nil && !isAlreadyExistsErr(err) {
+			if _, err := pachClient.PfsAPIClient.CreateRepo(pachClient.Ctx(),
+				&pfs.CreateRepoRequest{
+					Repo:        client.NewRepo(input.Cron.Repo),
+					Description: fmt.Sprintf("Cron tick repo for pipeline %s.", request.Pipeline.Name),
+				}); err != nil && !isAlreadyExistsErr(err) {
 				visitErr = err
 			}
 		}
 		if input.Git != nil {
-			if err := pachClient.CreateRepo(input.Git.Name); err != nil && !isAlreadyExistsErr(err) {
+			if _, err := pachClient.PfsAPIClient.CreateRepo(pachClient.Ctx(),
+				&pfs.CreateRepoRequest{
+					Repo:        client.NewRepo(input.Git.Name),
+					Description: fmt.Sprintf("Git input repo for pipeline %s.", request.Pipeline.Name),
+				}); err != nil && !isAlreadyExistsErr(err) {
 				visitErr = err
 			}
 		}
@@ -2106,7 +2114,11 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 		}
 	} else {
 		// Create output repo, pipeline output, and stats
-		if err := pachClient.CreateRepo(pipelineName); err != nil && !isAlreadyExistsErr(err) {
+		if _, err := pachClient.PfsAPIClient.CreateRepo(pachClient.Ctx(),
+			&pfs.CreateRepoRequest{
+				Repo:        client.NewRepo(pipelineName),
+				Description: fmt.Sprintf("Output repo for pipeline %s.", request.Pipeline.Name),
+			}); err != nil && !isAlreadyExistsErr(err) {
 			return nil, err
 		}
 


### PR DESCRIPTION
This PR makes a few changes that users have been asking for to our CLI printing. Here's an example of what it looks like:

```
➜ pachctl list repo
NAME    CREATED            SIZE (MASTER) DESCRIPTION                       
montage About a minute ago 1.283MiB      Output repo for pipeline montage. 
edges   About a minute ago 133.6KiB      Output repo for pipeline edges.   
images  About a minute ago 238.3KiB      A repo for images.                
➜ pachctl list commit images 
REPO   BRANCH COMMIT                           STARTED        SIZE     PROGRESS DESCRIPTION
images master 0f04136baae042c799109c05f98845a7 24 seconds ago 238.3KiB ▇▇▇▇▇▇▇▇ Commit some more images. 
images master 6212d23dbcf14c569835307a9d171863 44 seconds ago 57.27KiB ▇▇▇▇▇▇▇▇ Commit some images.      
➜ pachctl list pipeline
NAME    VERSION INPUT                CREATED            STATE / LAST JOB  DESCRIPTION                                                           
montage 1       (edges:/ ⨯ images:/) About a minute ago running / success A pipeline that makes a montage of edge detected and original images. 
edges   1       images:/*            About a minute ago running / success A pipeline that runs edge detection on images. 
```

Changes include:
- all objects that have description fields (repos, commits and pipelines) now print the descriptions in the list view.
- removed parent and duration fields from `list commit`, parent field made the results into a wall of random characters which was hard to read and generally not useful, since the parent commit is normally the one right before. Even when it's not, it's generally not that useful, since the parent of a commit can simply be referenced as `<commit-id>^` which is more understandable. Duration was removed because it's not that interesting. Removing these allowed us to make space for the description field.
- repos created by pipelines (output repos, cron input repos, and git input repos) now have descriptions attached to them automatically.

Fixes #4108.