### PR TITLE
Rewrite configs on reset

### DIFF
--- a/etc/reset.py
+++ b/etc/reset.py
@@ -194,11 +194,8 @@ def rewrite_config():
     contexts = v2["contexts"]
 
     for k, v in contexts.items():
-        if not LOCAL_CONFIG_PATTERN.fullmatch(k):
-            continue
-        if len(v) == 0:
-            continue
-        keys.add(k)
+        if LOCAL_CONFIG_PATTERN.fullmatch(k) and len(v) > 0:
+            keys.add(k)
 
     for k in keys:
         del contexts[k]

--- a/etc/reset.py
+++ b/etc/reset.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import sys
+import json
 import time
 import select
 import logging
@@ -24,6 +26,8 @@ LOG_COLORS = {
     "error": "\x1b[31;1m",
     "warning": "\x1b[33;1m",
 }
+
+LOCAL_CONFIG_PATTERN = re.compile(r"^local(-\d+)?$")
 
 log = logging.getLogger(__name__)
 handler = logging.StreamHandler()
@@ -172,9 +176,40 @@ def get_pachyderm(deploy_version):
     run("docker", "pull", "pachyderm/pachd:{}".format(deploy_version))
     run("docker", "pull", "pachyderm/worker:{}".format(deploy_version))
 
+def rewrite_config():
+    log.info("Rewriting config")
+
+    keys = set([])
+
+    try:
+        with open(os.path.expanduser("~/.pachyderm/config.json"), "r") as f:
+            j = json.load(f)
+    except:
+        return
+        
+    v2 = j.get("v2")
+    if not v2:
+        return
+
+    contexts = v2["contexts"]
+
+    for k, v in contexts.items():
+        if not LOCAL_CONFIG_PATTERN.fullmatch(k):
+            continue
+        if len(v) == 0:
+            continue
+        keys.add(k)
+
+    for k in keys:
+        del contexts[k]
+
+    with open(os.path.expanduser("~/.pachyderm/config.json"), "w") as f:
+        json.dump(j, f, indent=2)
+
 def main():
     parser = argparse.ArgumentParser(description="Recompiles pachyderm tooling and restarts the cluster with a clean slate.")
     parser.add_argument("--no-deploy", default=False, action="store_true", help="Disables deployment")
+    parser.add_argument("--no-config-rewrite", default=False, action="store_true", help="Disables config rewriting")
     parser.add_argument("--deploy-args", default="", help="Arguments to be passed into `pachctl deploy`")
     parser.add_argument("--deploy-version", default="local", help="Sets the deployment version")
     parser.add_argument("--log-level", default="info", type=parse_log_level, help="Sets the log level; defaults to 'info', other options include 'critical', 'error', 'warning', and 'debug'")
@@ -207,11 +242,16 @@ def main():
         except:
             pass
 
-        join(
+        procs = [
             driver.start,
             lambda: run("make", "install"),
             lambda: run("make", "docker-build"),
-        )
+        ]
+
+        if not args.no_config_rewrite:
+            procs.append(rewrite_config)
+
+        join(*procs)
     else:
         join(
             driver.start,

--- a/go.mod
+++ b/go.mod
@@ -75,8 +75,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/montanaflynn/stats v0.5.0
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect


### PR DESCRIPTION
This is just to address a small annoyance with the reset script. Presently, we create a new context on every reset (even though `pachctl` has logic to prevent this.) This fixes the issue.