### PR TITLE
Use GOPROXY in CI for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - PATH="${HOME}/cached-deps:$(python3 -c 'import site; print(site.USER_BASE)')/bin:${PATH}"
     - PPS_BUCKETS=6
     - AUTH_BUCKETS=2
+    - GOPROXY=https://proxy.golang.org
   matrix:
     - BUCKET=MISC
     # If you want to update the number of PPS or auth buckets, you'll neet to

--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.11.2
 LABEL maintainer="msteffen@pachyderm.io"
 
+ENV GOPROXY https://proxy.golang.org
+
 RUN apt-get update -yq
 RUN apt-get install -yq unzip
 


### PR DESCRIPTION
This shaves a couple minutes off the build by using go proxy (which downloads via zip file, vs git clone from GH)