### PR TITLE
s3 gateway API docs updates

### DIFF
--- a/doc/docs/master/reference/s3gateway_api.md
+++ b/doc/docs/master/reference/s3gateway_api.md
@@ -23,8 +23,8 @@ and libraries already, so you do not need to configure these methods manually.
 
 ### Buckets
 
-Buckets are represented via `branch.repo`, e.g. the `master.images` bucket
-corresponds to the `master` branch of the `images` repo.
+Buckets are represented via `branch.repo`. For example, the `master.images`
+bucket corresponds to the `master` branch of the `images` repo.
 
 ### Operations
 
@@ -106,11 +106,10 @@ Deletes the PFS file `filepath` in an atomic commit on the HEAD of `branch`.
 
 Route: `GET /<branch>.<repo>/<filepath>`.
 
-By default, this gets the latest version of the given file (i.e. the file at
-`HEAD` of the given repo/branch.) You can use s3's versioning API (i.e. with
-the `versionId` subresource) to get the object at a non-HEAD commit by
-specifying either a specific commit ID, or via the caret syntax (e.g.
-`HEAD^`.)
+By default, this request gets the `HEAD` version of the file. You can use s3's
+versioning API (that is, with the `versionId` subresource) to get the object
+at a non-HEAD commit by specifying either a specific commit ID, or via the
+caret syntax (for example, `HEAD^`.)
 
 There is support for range queries and conditional requests, however error
 response bodies for bad requests using these headers are not standard S3 XML.

--- a/doc/docs/master/reference/s3gateway_api.md
+++ b/doc/docs/master/reference/s3gateway_api.md
@@ -107,9 +107,8 @@ Deletes the PFS file `filepath` in an atomic commit on the HEAD of `branch`.
 Route: `GET /<branch>.<repo>/<filepath>`.
 
 By default, this request gets the `HEAD` version of the file. You can use s3's
-versioning API (that is, with the `versionId` subresource) to get the object
-at a non-HEAD commit by specifying either a specific commit ID, or via the
-caret syntax (for example, `HEAD^`.)
+versioning API to get the object at a non-HEAD commit by specifying either a
+specific commit ID, or by using the caret syntax -- for example, `HEAD^`.
 
 There is support for range queries and conditional requests, however error
 response bodies for bad requests using these headers are not standard S3 XML.

--- a/doc/docs/master/reference/s3gateway_api.md
+++ b/doc/docs/master/reference/s3gateway_api.md
@@ -2,7 +2,7 @@
 
 This section outlines the HTTP API exposed by the s3 gateway and any peculiarities
 relative to S3. The operations largely mirror those documented in S3's
-[official docs](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html).
+[official docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html).
 
 Generally, you would not call these endpoints directly, but rather use a
 tool or library designed to work with S3-like APIs. Because of that, some
@@ -21,26 +21,27 @@ same value. Both values are the Pachyderm auth token that is used to issue the
 relevant PFS calls. One or both signature methods are built into most s3 tools
 and libraries already, so you do not need to configure these methods manually.
 
-### Operations on the Service
-
-#### GET Service
-
-Route: `GET /`.
-Lists all of the branches across all of the repos as S3 buckets.
-
-### Operations on Buckets
+### Buckets
 
 Buckets are represented via `branch.repo`, e.g. the `master.images` bucket
 corresponds to the `master` branch of the `images` repo.
 
-#### DELETE Bucket
+### Operations
+
+#### `ListBuckets`
+
+Route: `GET /`.
+
+Lists all of the branches across all of the repos as S3 buckets.
+
+#### `DeleteBucket`
 
 Route: `DELETE /<branch>.<repo>/`.
 
 Deletes the branch. If it is the last branch in the repo, the repo is also
 deleted. Unlike S3, you can delete non-empty branches.
 
-#### GET Bucket (List Objects) Version 1
+#### `ListObjects`
 
 Route: `GET /<branch>.<repo>/`
 
@@ -61,20 +62,26 @@ specific object listed.
 hash of the file contents.
 * The S3 `StorageClass` and `Owner` fields always have the same filler value.
 
-#### GET Bucket location
+#### `GetBucketLocation`
 
 Route: `GET /<branch>.<repo>/?location`
 
 This will always serve the same location for every bucket, but the endpoint
 is implemented to provide better compatibility with S3 clients.
 
-#### List Multipart Uploads
+#### `GetBucketVersioning`
+
+Route: `GET /<branch>.<repo>/?versioning`
+
+This will get whether versioning is enabled, which is always true.
+
+#### `ListMultipartUploads`
 
 Route: `GET /<branch>.<repo>/?uploads`
 
 Lists the in-progress multipart uploads in the given branch. The `delimiter` query parameter is not supported.
 
-#### PUT Bucket
+#### `CreateBucket`
 
 Route: `PUT /<branch>.<repo>/`.
 
@@ -83,26 +90,27 @@ is likewise created. As per S3's behavior in some regions (but not all),
 trying to create the same bucket twice will return a `BucketAlreadyOwnedByYou`
 error.
 
-### Operations on Objects
-
-Object operations act upon the HEAD commit of branches. Authorization-gated
-PFS branches are not supported.
-
-#### Delete Multiple Objects
+#### `DeleteObjects`
 
 Route: `POST /<branch>.<repo>/?delete`.
 
 Deletes multiple files specified in the request payload.
 
-#### DELETE Object
+#### `DeleteObject`
 
 Route: `DELETE /<branch>.<repo>/<filepath>`.
 
 Deletes the PFS file `filepath` in an atomic commit on the HEAD of `branch`.
 
-#### GET Object
+#### `GetObject`
 
 Route: `GET /<branch>.<repo>/<filepath>`.
+
+By default, this gets the latest version of the given file (i.e. the file at
+`HEAD` of the given repo/branch.) You can use s3's versioning API (i.e. with
+the `versionId` subresource) to get the object at a non-HEAD commit by
+specifying either a specific commit ID, or via the caret syntax (e.g.
+`HEAD^`.)
 
 There is support for range queries and conditional requests, however error
 response bodies for bad requests using these headers are not standard S3 XML.
@@ -115,7 +123,7 @@ modified this specific object.
 * The HTTP `ETag` does not use MD5, but is a cryptographically secure hash of
 the file contents.
 
-#### PUT Object
+#### `PutObject`
 
 Route: `PUT /<branch>.<repo>/<filepath>`.
 
@@ -128,13 +136,13 @@ Unlike s3, a 64mb max size is not enforced on this endpoint. Especially,
 as the file upload size gets larger, we recommend setting the `Content-MD5`
 request header to ensure data integrity.
 
-#### Abort Multipart Upload
+#### `AbortMultipartUpload`
 
 Route: `DELETE /<branch>.<repo>?uploadId=<uploadId>`
 
 Aborts an in-progress multipart upload.
 
-#### Complete Multipart Upload
+#### `CompleteMultipartUpload`
 
 Route: `POST /<branch>.<repo>?uploadId=<uploadId>`
 
@@ -143,19 +151,19 @@ payload, they must be of the same format as returned by the S3
 gateway when the multipart chunks are included. If they are `md5`
 hashes or any other hash algorithm, they are ignored.
 
-#### Initiate Multipart Upload
+#### `CreateMultipartUpload`
 
 Route: `POST /<branch>.<repo>?uploads`
 
 Initiates a multipart upload.
 
-#### List Parts
+#### `ListParts`
 
 Route: `GET /<branch>.<repo>?uploadId=<uploadId>`
 
 Lists the parts of an in-progress multipart upload.
 
-#### Upload Part
+#### `UploadPart`
 
 Route: `PUT /<branch>.<repo>?uploadId=<uploadId>&partNumber=<partNumber>`
 


### PR DESCRIPTION
A few changes to the s3 gateway API docs:

* Rewrote docs to align back with the AWS docs, which underwent [some recent changes](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html).
* Added a missing endpoint (`GetBucketVersioning`.)
* Added a note about getting an object version.

Closes #4413