### PR TITLE
Add additional logging to pachd setup

### DIFF
--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -102,7 +102,7 @@ func (env *ServiceEnv) initPachClient() error {
 			return fmt.Errorf("failed to initialize pach client: %v", err)
 		}
 		return nil
-	}, backoff.RetryEvery(time.Second).For(time.Minute))
+	}, backoff.RetryEvery(time.Second).For(5*time.Minute))
 }
 
 func (env *ServiceEnv) initEtcdClient() error {
@@ -125,7 +125,7 @@ func (env *ServiceEnv) initEtcdClient() error {
 			return fmt.Errorf("failed to initialize etcd client: %v", err)
 		}
 		return nil
-	}, backoff.RetryEvery(time.Second).For(time.Minute))
+	}, backoff.RetryEvery(time.Second).For(5*time.Minute))
 }
 
 func (env *ServiceEnv) initKubeClient() error {
@@ -153,7 +153,7 @@ func (env *ServiceEnv) initKubeClient() error {
 			return fmt.Errorf("could not initialize kube client: %v", err)
 		}
 		return nil
-	}, backoff.RetryEvery(time.Second).For(time.Minute))
+	}, backoff.RetryEvery(time.Second).For(5*time.Minute))
 }
 
 // GetPachClient returns a pachd client with the same authentication


### PR DESCRIPTION
Adds logging to each grpc server setup in pachd and bumps up the timeout for setting up pachd, etcd, and kube clients to 5 mins.