### PR TITLE
Fix python setup process

### DIFF
--- a/etc/testing/travis_install.sh
+++ b/etc/testing/travis_install.sh
@@ -22,7 +22,6 @@ sudo cp etc/build/fuse.conf /etc/fuse.conf
 sudo chown root:root /etc/fuse.conf
 
 # Install aws CLI (for TLS test)
-pip3 install --upgrade --user pip
 pip3 install --upgrade --user wheel
 pip3 install --upgrade --user awscli
 


### PR DESCRIPTION
The python-pachyderm library calls into the travis setup script in its pachyderm submodule. With the deprecation of python 2, pachyderm's travis setup script appears to fail in some environments. This PR is tracking the fixes that'll ensure the setup script works both here and in python-pachyderm.