### PR TITLE
Fix run cron overwrite issue

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -138,12 +138,27 @@ func NewUnionInput(input ...*pps.Input) *pps.Input {
 // NewCronInput returns an input which will trigger based on a timed schedule.
 // It uses cron syntax to specify the schedule. The input will be exposed to
 // jobs as `/pfs/<name>/<timestamp>`. The timestamp uses the RFC 3339 format,
-// e.g. `2006-01-02T15:04:05Z07:00`.
+// e.g. `2006-01-02T15:04:05Z07:00`. It only takes required options.
 func NewCronInput(name string, spec string) *pps.Input {
 	return &pps.Input{
 		Cron: &pps.CronInput{
 			Name: name,
 			Spec: spec,
+		},
+	}
+}
+
+// NewCronInputOpts returns an input which will trigger based on a timed schedule.
+// It uses cron syntax to specify the schedule. The input will be exposed to
+// jobs as `/pfs/<name>/<timestamp>`. The timestamp uses the RFC 3339 format,
+// e.g. `2006-01-02T15:04:05Z07:00`. It includes all the options.
+func NewCronInputOpts(name string, repo string, spec string, overwrite bool) *pps.Input {
+	return &pps.Input{
+		Cron: &pps.CronInput{
+			Name:      name,
+			Repo:      repo,
+			Spec:      spec,
+			Overwrite: overwrite,
 		},
 	}
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2845,36 +2845,33 @@ func (a *apiServer) RunCron(ctx context.Context, request *pps.RunCronRequest) (r
 
 	cron := pipelineInfo.Input.Cron
 
-	var latestTime time.Time
-	files, err := pachClient.ListFile(cron.Repo, "master", "")
-	if err != nil && !pfsServer.IsNoHeadErr(err) {
-		return nil, err
-	} else if err != nil || len(files) == 0 {
-		// File not found, this happens the first time the pipeline is run
-		latestTime, err = types.TimestampFromProto(cron.Start)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// Take the name of the most recent file as the latest timestamp
-		// ListFile returns the files in lexicographical order, and the RFC3339 format goes
-		// from largest unit of time to smallest, so the most recent file will be the last one
-		latestTime, err = time.Parse(time.RFC3339, path.Base(files[len(files)-1].File.Path))
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// We need the DeleteFile and the PutFile to happen in the same commit
 	_, err = pachClient.StartCommit(cron.Repo, "master")
 	if err != nil {
 		return nil, err
 	}
 	if cron.Overwrite {
-		// If we want to "overwrite" the file, we need to delete the file with the previous time
-		err := pachClient.DeleteFile(cron.Repo, "master", latestTime.Format(time.RFC3339))
-		if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
-			return nil, fmt.Errorf("delete error %v", err)
+		// in an overwrite, we only want there to be one file, and bc of scheduled cron and run cron coexisting, we can potentially get multiple files here
+		for {
+			latestTime, err := a.getLatestCronTime(pachClient, pipelineInfo.Input)
+			if err != nil {
+				return nil, err
+			}
+
+			// If we want to "overwrite" the file, we need to delete the file with the previous time
+			err = pachClient.DeleteFile(cron.Repo, "master", latestTime.Format(time.RFC3339))
+			if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
+				return nil, fmt.Errorf("delete error %v", err)
+			}
+
+			files, err := pachClient.ListFile(cron.Repo, "master", "")
+			if len(files) == 0 || pfsServer.IsNoHeadErr(err) {
+				// so we're only done if there aren't any files
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2851,27 +2851,10 @@ func (a *apiServer) RunCron(ctx context.Context, request *pps.RunCronRequest) (r
 		return nil, err
 	}
 	if cron.Overwrite {
-		// in an overwrite, we only want there to be one file, and bc of scheduled cron and run cron coexisting, we can potentially get multiple files here
-		for {
-			latestTime, err := a.getLatestCronTime(pachClient, pipelineInfo.Input)
-			if err != nil {
-				return nil, err
-			}
-
-			// If we want to "overwrite" the file, we need to delete the file with the previous time
-			err = pachClient.DeleteFile(cron.Repo, "master", latestTime.Format(time.RFC3339))
-			if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
-				return nil, fmt.Errorf("delete error %v", err)
-			}
-
-			files, err := pachClient.ListFile(cron.Repo, "master", "")
-			if len(files) == 0 || pfsServer.IsNoHeadErr(err) {
-				// so we're only done if there aren't any files
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
+		// get rid of any files, so the new file "overwrites" previous runs
+		err = pachClient.DeleteFile(cron.Repo, "master", "")
+		if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
+			return nil, fmt.Errorf("delete error %v", err)
 		}
 	}
 

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -383,6 +383,29 @@ func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 	}
 }
 
+func (a *apiServer) getLatestCronTime(pachClient *client.APIClient, in *pps.Input) (time.Time, error) {
+	var latestTime time.Time
+	files, err := pachClient.ListFile(in.Cron.Repo, "master", "")
+	if err != nil && !pfsServer.IsNoHeadErr(err) {
+		return latestTime, err
+	} else if err != nil || len(files) == 0 {
+		// File not found, this happens the first time the pipeline is run
+		latestTime, err = types.TimestampFromProto(in.Cron.Start)
+		if err != nil {
+			return latestTime, err
+		}
+	} else {
+		// Take the name of the most recent file as the latest timestamp
+		// ListFile returns the files in lexicographical order, and the RFC3339 format goes
+		// from largest unit of time to smallest, so the most recent file will be the last one
+		latestTime, err = time.Parse(time.RFC3339, path.Base(files[len(files)-1].File.Path))
+		if err != nil {
+			return latestTime, err
+		}
+	}
+	return latestTime, nil
+}
+
 // makeCronCommits makes commits to a single cron input's repo. It's
 // a helper function called by monitorPipeline.
 func (a *apiServer) makeCronCommits(pachClient *client.APIClient, in *pps.Input) error {
@@ -401,24 +424,9 @@ func (a *apiServer) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 		}
 	}
 
-	var latestTime time.Time
-	files, err := pachClient.ListFile(in.Cron.Repo, "master", "")
-	if err != nil && !pfsServer.IsNoHeadErr(err) {
+	latestTime, err := a.getLatestCronTime(pachClient, in)
+	if err != nil {
 		return err
-	} else if err != nil || len(files) == 0 {
-		// File not found, this happens the first time the pipeline is run
-		latestTime, err = types.TimestampFromProto(in.Cron.Start)
-		if err != nil {
-			return err
-		}
-	} else {
-		// Take the name of the most recent file as the latest timestamp
-		// ListFile returns the files in lexicographical order, and the RFC3339 format goes
-		// from largest unit of time to smallest, so the most recent file will be the last one
-		latestTime, err = time.Parse(time.RFC3339, path.Base(files[len(files)-1].File.Path))
-		if err != nil {
-			return err
-		}
 	}
 
 	for {
@@ -440,10 +448,27 @@ func (a *apiServer) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 			return err
 		}
 		if in.Cron.Overwrite {
-			// If we want to "overwrite" the file, we need to delete the file with the previous time
-			err := pachClient.DeleteFile(in.Cron.Repo, "master", latestTime.Format(time.RFC3339))
-			if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
-				return fmt.Errorf("delete error %v", err)
+			for {
+				// in an overwrite, we only want there to be one file, and bc of scheduled cron and run cron coexisting, we can potentially get multiple files here
+				latestTime, err := a.getLatestCronTime(pachClient, in)
+				if err != nil {
+					return err
+				}
+
+				// If we want to "overwrite" the file, we need to delete the file with the previous time
+				err = pachClient.DeleteFile(in.Cron.Repo, "master", latestTime.Format(time.RFC3339))
+				if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
+					return fmt.Errorf("delete error %v", err)
+				}
+
+				files, err := pachClient.ListFile(in.Cron.Repo, "master", "")
+				if len(files) == 0 || pfsServer.IsNoHeadErr(err) {
+					// so we're only done if there aren't any files
+					break
+				}
+				if err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/pachyderm/pachyderm/issues/4511

This bug was found to occur on the scheduled cron following the latest run cron. In this case, there were two files, which led to the overwrite behavior being violated. I added a test which triggers this case, revealing the bug.

So I added a loop in the overwrite sections of the code to make sure that we deleted all the files, and not just the one with the latest time stamp. I also refactored some of the code to make this a bit more concise. 