### PR TITLE
Disable cluster ID check for 1.9.x

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -456,22 +456,6 @@ func NewOnUserMachine(prefix string, options ...Option) (*APIClient, error) {
 		client.authenticationToken = context.SessionToken
 	}
 
-	// Verify cluster ID
-	clusterInfo, err := client.InspectCluster()
-	if err != nil {
-		return nil, fmt.Errorf("could not get cluster ID: %v", err)
-	}
-	if context.ClusterID != clusterInfo.ID {
-		if context.ClusterID == "" {
-			context.ClusterID = clusterInfo.ID
-			if err = cfg.Write(); err != nil {
-				return nil, fmt.Errorf("could not write config to save cluster ID: %v", err)
-			}
-		} else {
-			return nil, fmt.Errorf("connected to the wrong cluster (context cluster ID = %q vs reported cluster ID = %q)", context.ClusterID, clusterInfo.ID)
-		}
-	}
-
 	// Add port forwarding. This will set it to nil if port forwarding is
 	// disabled, or an address is explicitly set.
 	client.portForwarder = fw


### PR DESCRIPTION
Disable cluster ID check for now, as a workaround for #4504. The proper fix is in #4532, but that will land only in 1.10 since it includes new functionality.