### PR TITLE
Increase default value for local etcd memory

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4523,7 +4523,7 @@ func TestSystemResourceRequests(t *testing.T) {
 	// Expected resource requests for pachyderm system pods:
 	defaultLocalMem := map[string]string{
 		"pachd": "512M",
-		"etcd":  "512M",
+		"etcd":  "1G",
 	}
 	defaultLocalCPU := map[string]string{
 		"pachd": "250m",

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -287,7 +287,7 @@ func fillDefaultResourceRequests(opts *AssetOpts, persistentDiskBackend backend)
 		}
 
 		if opts.EtcdMemRequest == "" {
-			opts.EtcdMemRequest = "512M"
+			opts.EtcdMemRequest = "1G"
 		}
 		if opts.EtcdCPURequest == "" {
 			opts.EtcdCPURequest = "0.25"


### PR DESCRIPTION
Fixes #4549

The downside of this is that it increases memory utilization in local clusters. However, I think it makes sense to merge because [even simplistic spouts](https://github.com/pachyderm/python-pachyderm/pull/173) appear to fall over with the current 512mb limit due to etcdserver getting OOM killed.
