### PR TITLE
Shell completion caching

### DIFF
--- a/src/server/cmd/pachctl/shell/completions.go
+++ b/src/server/cmd/pachctl/shell/completions.go
@@ -74,7 +74,7 @@ func RepoCompletion(_, text string, maxCompletions int64) ([]prompt.Suggest, Cac
 	c := getPachClient()
 	ris, err := c.ListRepo()
 	if err != nil {
-		log.Fatal(err)
+		return nil, CacheNone
 	}
 	var result []prompt.Suggest
 	for _, ri := range ris {
@@ -98,7 +98,7 @@ func BranchCompletion(flag, text string, maxCompletions int64) ([]prompt.Suggest
 	case commitOrBranchPart:
 		bis, err := c.ListBranch(partialFile.Commit.Repo.Name)
 		if err != nil {
-			log.Fatal(err)
+			return nil, CacheNone
 		}
 		for _, bi := range bis {
 			head := "-"
@@ -108,6 +108,13 @@ func BranchCompletion(flag, text string, maxCompletions int64) ([]prompt.Suggest
 			result = append(result, prompt.Suggest{
 				Text:        fmt.Sprintf("%s@%s:", partialFile.Commit.Repo.Name, bi.Branch.Name),
 				Description: fmt.Sprintf("(%s)", head),
+			})
+		}
+		if len(result) == 0 {
+			// Master should show up even if it doesn't exist yet
+			result = append(result, prompt.Suggest{
+				Text:        fmt.Sprintf("%s@master", partialFile.Commit.Repo.Name),
+				Description: fmt.Sprintf("(nil)"),
 			})
 		}
 	}
@@ -150,7 +157,7 @@ func FileCompletion(flag, text string, maxCompletions int64) ([]prompt.Suggest, 
 			})
 			return nil
 		}); err != nil {
-			log.Fatal(err)
+			return nil, CacheNone
 		}
 	}
 	return result, AndCacheFunc(samePart(part), func(_, text string) (result bool) {
@@ -166,7 +173,7 @@ func FilesystemCompletion(_, text string, maxCompletions int64) ([]prompt.Sugges
 	dir := filepath.Dir(text)
 	fis, err := ioutil.ReadDir(dir)
 	if err != nil {
-		log.Fatal(err)
+		return nil, CacheNone
 	}
 	var result []prompt.Suggest
 	for _, fi := range fis {
@@ -184,7 +191,7 @@ func PipelineCompletion(_, _ string, maxCompletions int64) ([]prompt.Suggest, Ca
 	c := getPachClient()
 	pis, err := c.ListPipeline()
 	if err != nil {
-		log.Fatal(err)
+		return nil, CacheNone
 	}
 	var result []prompt.Suggest
 	for _, pi := range pis {
@@ -222,7 +229,7 @@ func JobCompletion(_, text string, maxCompletions int64) ([]prompt.Suggest, Cach
 		})
 		return nil
 	}); err != nil {
-		log.Fatal(err)
+		return nil, CacheNone
 	}
 	return result, CacheAll
 }

--- a/src/server/cmd/pachctl/shell/completions.go
+++ b/src/server/cmd/pachctl/shell/completions.go
@@ -21,15 +21,15 @@ import (
 	units "github.com/docker/go-units"
 )
 
-type part int
+type partEnum int
 
 const (
-	repoPart part = iota
+	repoPart partEnum = iota
 	commitOrBranchPart
 	filePart
 )
 
-func parsePart(text string) part {
+func parsePart(text string) partEnum {
 	switch {
 	case !strings.ContainsRune(text, '@'):
 		return repoPart
@@ -40,7 +40,7 @@ func parsePart(text string) part {
 	}
 }
 
-func samePart(p part) CacheFunc {
+func samePart(p partEnum) CacheFunc {
 	return func(_, text string) bool {
 		return parsePart(text) == p
 	}

--- a/src/server/cmd/pachctl/shell/completions.go
+++ b/src/server/cmd/pachctl/shell/completions.go
@@ -62,6 +62,13 @@ func getPachClient() *client.APIClient {
 	return pachClient
 }
 
+func closePachClient() error {
+	if pachClient == nil {
+		return nil
+	}
+	return pachClient.Close()
+}
+
 // RepoCompletion completes repo parameters of the form <repo>
 func RepoCompletion(_, text string, maxCompletions int64) ([]prompt.Suggest, CacheFunc) {
 	c := getPachClient()
@@ -175,7 +182,6 @@ func FilesystemCompletion(_, text string, maxCompletions int64) ([]prompt.Sugges
 // PipelineCompletion completes pipeline parameters of the form <pipeline>
 func PipelineCompletion(_, _ string, maxCompletions int64) ([]prompt.Suggest, CacheFunc) {
 	c := getPachClient()
-	defer c.Close()
 	pis, err := c.ListPipeline()
 	if err != nil {
 		log.Fatal(err)

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -40,11 +40,12 @@ func SameFlag(flag string) CacheFunc {
 // AndCacheFunc ands 0 or more cache funcs together.
 func AndCacheFunc(fs ...CacheFunc) CacheFunc {
 	return func(flag, text string) bool {
-		result := true
 		for _, f := range fs {
-			result = result && f(flag, text)
+			if !f(flag, text) {
+				return false
+			}
 		}
-		return result
+		return true
 	}
 }
 

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -160,6 +160,12 @@ func (s *shell) suggestor(in prompt.Document) []prompt.Suggest {
 	return nil
 }
 
+func (s *shell) clearCache() {
+	s.completionID = ""
+	s.suggests = nil
+	s.cacheF = nil
+}
+
 func (s *shell) run() {
 	color.NoColor = true // color doesn't work in terminal
 	prompt.New(
@@ -167,6 +173,10 @@ func (s *shell) run() {
 		s.suggestor,
 		prompt.OptionPrefix(">>> "),
 		prompt.OptionTitle("Pachyderm Shell"),
+		prompt.OptionAddKeyBind(prompt.KeyBind{
+			Key: prompt.F5,
+			Fn:  func(*prompt.Buffer) { s.clearCache() },
+		}),
 		prompt.OptionLivePrefix(func() (string, bool) {
 			cfg, err := config.Read(true)
 			if err != nil {

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -181,6 +181,9 @@ func (s *shell) run() {
 			return fmt.Sprintf("context:(%s) >>> ", activeContext), true
 		}),
 	).Run()
+	if err := closePachClient(); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // Run runs a prompt, it does not return.

--- a/src/server/config/cmds.go
+++ b/src/server/config/cmds.go
@@ -371,7 +371,7 @@ func Cmds() []*cobra.Command {
 	return commands
 }
 
-func contextCompletion(_, text string, maxCompletions int64) []prompt.Suggest {
+func contextCompletion(_, text string, maxCompletions int64) ([]prompt.Suggest, shell.CacheFunc) {
 	cfg, err := config.Read(false)
 	if err != nil {
 		log.Fatal(err)
@@ -401,5 +401,5 @@ func contextCompletion(_, text string, maxCompletions int64) []prompt.Suggest {
 			return result[i].Text < result[j].Text
 		}
 	})
-	return result
+	return result, shell.CacheAll
 }

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -882,14 +882,17 @@ $ {{alias}} repo@branch -i http://host/path`,
 	putFile.Flags().UintVar(&headerRecords, "header-records", 0, "the number of records that will be converted to a PFS 'header', and prepended to future retrievals of any subset of data from PFS; needs to be used with --split=(json|line|csv)")
 	putFile.Flags().BoolVarP(&putFileCommit, "commit", "c", false, "DEPRECATED: Put file(s) in a new commit.")
 	putFile.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "Overwrite the existing content of the file, either from previous commits or previous calls to 'put file' within this commit.")
-	shell.RegisterCompletionFunc(putFile, func(flag, text string, maxCompletions int64) []prompt.Suggest {
-		if flag == "-f" || flag == "--file" || flag == "-i" || flag == "input-file" {
-			return shell.FilesystemCompletion(flag, text, maxCompletions)
-		} else if flag == "" || flag == "-c" || flag == "--commit" || flag == "-o" || flag == "--overwrite" {
-			return shell.FileCompletion(flag, text, maxCompletions)
-		}
-		return nil
-	})
+	shell.RegisterCompletionFunc(putFile,
+		func(flag, text string, maxCompletions int64) ([]prompt.Suggest, shell.CacheFunc) {
+			if flag == "-f" || flag == "--file" || flag == "-i" || flag == "input-file" {
+				cs, cf := shell.FilesystemCompletion(flag, text, maxCompletions)
+				return cs, shell.AndCacheFunc(cf, shell.SameFlag(flag))
+			} else if flag == "" || flag == "-c" || flag == "--commit" || flag == "-o" || flag == "--overwrite" {
+				cs, cf := shell.FileCompletion(flag, text, maxCompletions)
+				return cs, shell.AndCacheFunc(cf, shell.SameFlag(flag))
+			}
+			return nil, shell.SameFlag(flag)
+		})
 	commands = append(commands, cmdutil.CreateAlias(putFile, "put file"))
 
 	copyFile := &cobra.Command{


### PR DESCRIPTION
This makes it so that completion results are cached between calls for psh, it should increase the responsiveness of the shell, and put less load on the server.