### PR TITLE
Fix run pipeline stats commit issue

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1099,6 +1099,58 @@ func TestRunPipeline(t *testing.T) {
 		require.NoError(t, c.DeletePipeline(pipeline, false))
 		require.NoError(t, c.DeletePipeline(pipeline, false))
 	})
+	// Test with stats enabled pipeline
+	t.Run("RunPipelineStats", func(t *testing.T) {
+		dataRepo := tu.UniqueString("TestRunPipeline_data")
+		require.NoError(t, c.CreateRepo(dataRepo))
+
+		branchA := "branchA"
+
+		pipeline := tu.UniqueString("stats-pipeline")
+		_, err := c.PpsAPIClient.CreatePipeline(
+			context.Background(),
+			&pps.CreatePipelineRequest{
+				Pipeline: client.NewPipeline(pipeline),
+				Transform: &pps.Transform{
+					Cmd: []string{"bash"},
+					Stdin: []string{
+						"cat /pfs/branch-a/file >> /pfs/out/file",
+
+						"echo ran-pipeline",
+					},
+				},
+				EnableStats: true,
+				Input:       client.NewPFSInputOpts("branch-a", dataRepo, branchA, "/*", "", false),
+			})
+		require.NoError(t, err)
+
+		commitA, err := c.StartCommit(dataRepo, branchA)
+		require.NoError(t, err)
+		c.PutFile(dataRepo, commitA.ID, "/file", strings.NewReader("data A\n"))
+		c.FinishCommit(dataRepo, commitA.ID)
+
+		// wait for the commit to finish before calling RunPipeline
+		_, err = c.FlushCommitAll([]*pfs.Commit{client.NewCommit(dataRepo, commitA.ID)}, nil)
+		require.NoError(t, err)
+
+		// now run the pipeline
+		require.NoError(t, backoff.Retry(func() error {
+			return c.RunPipeline(pipeline, []*pfs.CommitProvenance{
+				client.NewCommitProvenance(dataRepo, branchA, commitA.ID),
+			}, "")
+		}, backoff.NewTestingBackOff()))
+
+		// make sure the pipeline didn't crash
+		commitIter, err := c.FlushCommit([]*pfs.Commit{client.NewCommit(dataRepo, commitA.ID)}, nil)
+		require.NoError(t, err)
+
+		// we'll know it crashed if this causes it to hang
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			collectCommitInfos(t, commitIter)
+			return nil
+		})
+
+	})
 
 }
 func TestPipelineFailure(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1145,7 +1145,7 @@ func TestRunPipeline(t *testing.T) {
 		require.NoError(t, err)
 
 		// we'll know it crashed if this causes it to hang
-		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+		require.NoErrorWithinTRetry(t, 80*time.Second, func() error {
 			collectCommitInfos(t, commitIter)
 			return nil
 		})

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1336,6 +1336,7 @@ func (d *driver) makeCommit(
 
 		// ensure the commit provenance is consistent with the branch provenance
 		if len(branchProvMap) != 0 {
+			// the check for empty branch names is for the run pipeline case in which a commit with no branch are expected in the stats commit provenance
 			if prov.Branch.Repo.Name != ppsconsts.SpecRepo && prov.Branch.Name != "" && !branchProvMap[key(prov.Branch.Repo.Name, prov.Branch.Name)] {
 				return nil, fmt.Errorf("the commit provenance contains a branch which the branch is not provenant on")
 			}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1336,7 +1336,7 @@ func (d *driver) makeCommit(
 
 		// ensure the commit provenance is consistent with the branch provenance
 		if len(branchProvMap) != 0 {
-			if prov.Branch.Repo.Name != ppsconsts.SpecRepo && !branchProvMap[key(prov.Branch.Repo.Name, prov.Branch.Name)] {
+			if prov.Branch.Repo.Name != ppsconsts.SpecRepo && prov.Branch.Name != "" && !branchProvMap[key(prov.Branch.Repo.Name, prov.Branch.Name)] {
 				return nil, fmt.Errorf("the commit provenance contains a branch which the branch is not provenant on")
 			}
 		}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2835,7 +2835,7 @@ func (a *apiServer) RunPipeline(ctx context.Context, request *pps.RunPipelineReq
 	specProvenance := client.NewCommitProvenance(ppsconsts.SpecRepo, request.Pipeline.Name, specCommit.Commit.ID)
 	provenance = append(provenance, specProvenance)
 
-	_, err = pfsClient.StartCommit(ctx, &pfs.StartCommitRequest{
+	newCommit, err := pfsClient.StartCommit(ctx, &pfs.StartCommitRequest{
 		Parent: &pfs.Commit{
 			Repo: &pfs.Repo{
 				Name: request.Pipeline.Name,
@@ -2845,6 +2845,24 @@ func (a *apiServer) RunPipeline(ctx context.Context, request *pps.RunPipelineReq
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// if stats are enabled, then create a stats commit for the job as well
+	if pipelineInfo.EnableStats {
+		// it needs to additionally be provenant on the commit we just created
+		newCommitProv := client.NewCommitProvenance(newCommit.Repo.Name, "", newCommit.ID)
+		_, err = pfsClient.StartCommit(ctx, &pfs.StartCommitRequest{
+			Parent: &pfs.Commit{
+				Repo: &pfs.Repo{
+					Name: request.Pipeline.Name,
+				},
+			},
+			Branch:     "stats",
+			Provenance: append(provenance, newCommitProv),
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &types.Empty{}, nil
 }

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -714,9 +714,8 @@ func (a *APIServer) waitJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, 
 		}
 		if jobInfo.EnableStats {
 			if jobInfo.StatsCommit == nil {
-				return fmt.Errorf("stats are enabled, but the job has a nil stats commit")
-			}
-			if _, err = pachClient.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
+				logger.Logf("stats are enabled, but the job has a nil stats commit")
+			} else if _, err = pachClient.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
 				Commit:    jobInfo.StatsCommit,
 				Trees:     statsTrees,
 				SizeBytes: statsSize,

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -714,7 +714,7 @@ func (a *APIServer) waitJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, 
 		}
 		if jobInfo.EnableStats {
 			if jobInfo.StatsCommit == nil {
-				panic("on onoetenoentosuhaonteuhoaidu")
+				return fmt.Errorf("stats are enabled, but the job has a nil stats commit")
 			}
 			if _, err = pachClient.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
 				Commit:    jobInfo.StatsCommit,

--- a/src/server/worker/master.go
+++ b/src/server/worker/master.go
@@ -713,6 +713,9 @@ func (a *APIServer) waitJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, 
 			}
 		}
 		if jobInfo.EnableStats {
+			if jobInfo.StatsCommit == nil {
+				panic("on onoetenoentosuhaonteuhoaidu")
+			}
 			if _, err = pachClient.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
 				Commit:    jobInfo.StatsCommit,
 				Trees:     statsTrees,


### PR DESCRIPTION
Fix for the issue mentioned in Yusuf's comment on https://github.com/pachyderm/pachyderm/issues/4294

This allows the run pipeline feature to work correctly with stats enabled by creating a stats commit for the new job it creates.

This one was tricky because there is also an unrelated bug in StartCommit which causes strange behavior with RunPipeline, which I will fix in a separate PR.
