### PR TITLE
Added missing step to create storage container in Azure docs

### DIFF
--- a/doc/docs/1.9.x/deploy-manage/deploy/azure.md
+++ b/doc/docs/1.9.x/deploy-manage/deploy/azure.md
@@ -295,6 +295,14 @@ To create these resources, follow these steps:
    ]
    ```
 
+1. Create a new storage container within your storage account:
+
+   ```bash
+   $ az storage container create --name ${CONTAINER_NAME} \
+             --account-name ${STORAGE_ACCOUNT} \
+             --account-key "${STORAGE_KEY}"
+   ```
+
 **See Also**
 
 - [Azure Storage](https://azure.microsoft.com/documentation/articles/storage-introduction/)

--- a/doc/docs/master/deploy-manage/deploy/azure.md
+++ b/doc/docs/master/deploy-manage/deploy/azure.md
@@ -324,6 +324,14 @@ To create these resources, follow these steps:
    ]
    ```
 
+1. Create a new storage container within your storage account:
+
+   ```bash
+   az storage container create --name ${CONTAINER_NAME} \
+             --account-name ${STORAGE_ACCOUNT} \
+             --account-key "${STORAGE_KEY}"
+   ```
+
 !!! note "See also:"
     - [Azure Storage](https://azure.microsoft.com/documentation/articles/storage-introduction/)
 


### PR DESCRIPTION
The documentation for deploying to Azure is missing a step, once a Storage Account is created, a storage container is required before the deployment of Pachyderm to the AKS cluster.

This PR adds in the necessary step to the documentation to make things easier for users.

This links to resolve #4619 