### PR TITLE
Remove direct connect on docker for mac

### DIFF
--- a/etc/reset.py
+++ b/etc/reset.py
@@ -93,8 +93,7 @@ class BaseDriver:
         pass
 
 class DockerDesktopDriver(BaseDriver):
-    def update_config(self):
-        run("pachctl", "config", "update", "context", "--pachd-address=localhost:30650")
+    pass
 
 class MinikubeDriver(BaseDriver):
     def clear(self):


### PR DESCRIPTION
It looks like the latest docker for mac no longer sets up services to bind on localhost :(

This changes the reset script to use implicit port forwarding on docker for mac deployments