### PR TITLE
Fix RunPipeline creating an output commit on certain errors

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2845,35 +2845,41 @@ func (a *apiServer) RunPipeline(ctx context.Context, request *pps.RunPipelineReq
 	specProvenance := client.NewCommitProvenance(ppsconsts.SpecRepo, request.Pipeline.Name, specCommit.Commit.ID)
 	provenance = append(provenance, specProvenance)
 
-	newCommit, err := pfsClient.StartCommit(ctx, &pfs.StartCommitRequest{
-		Parent: &pfs.Commit{
-			Repo: &pfs.Repo{
-				Name: request.Pipeline.Name,
-			},
-		},
-		Provenance: provenance,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// if stats are enabled, then create a stats commit for the job as well
-	if pipelineInfo.EnableStats {
-		// it needs to additionally be provenant on the commit we just created
-		newCommitProv := client.NewCommitProvenance(newCommit.Repo.Name, "", newCommit.ID)
-		_, err = pfsClient.StartCommit(ctx, &pfs.StartCommitRequest{
+	if _, err := pachClient.ExecuteInTransaction(func(txnClient *client.APIClient) error {
+		newCommit, err := txnClient.PfsAPIClient.StartCommit(txnClient.Ctx(), &pfs.StartCommitRequest{
 			Parent: &pfs.Commit{
 				Repo: &pfs.Repo{
 					Name: request.Pipeline.Name,
 				},
 			},
-			Branch:     "stats",
-			Provenance: append(provenance, newCommitProv),
+			Provenance: provenance,
 		})
 		if err != nil {
-			return nil, err
+			return err
 		}
+
+		// if stats are enabled, then create a stats commit for the job as well
+		if pipelineInfo.EnableStats {
+			// it needs to additionally be provenant on the commit we just created
+			newCommitProv := client.NewCommitProvenance(newCommit.Repo.Name, "", newCommit.ID)
+			_, err = txnClient.PfsAPIClient.StartCommit(txnClient.Ctx(), &pfs.StartCommitRequest{
+				Parent: &pfs.Commit{
+					Repo: &pfs.Repo{
+						Name: request.Pipeline.Name,
+					},
+				},
+				Branch:     "stats",
+				Provenance: append(provenance, newCommitProv),
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
+
 	return &types.Empty{}, nil
 }
 


### PR DESCRIPTION
Before, `RunPipeline` would create a commit for the output, then a commit in the stats branch.  If the stats branch `StartCommit` failed for some reason, the pipeline would be left with an open commit (not on any branch).  This changes `RunPipeline` to use a transaction to avoid this situation.