### PR TITLE
Fix fetching cached chunks in recycled workers

### DIFF
--- a/src/server/pkg/hashtree/cache.go
+++ b/src/server/pkg/hashtree/cache.go
@@ -141,6 +141,11 @@ func (c *MergeCache) Put(id int64, tree io.Reader) (retErr error) {
 	return c.Cache.Put(fmt.Sprint(id), tree)
 }
 
+// Has returns true if the key is present in the cache, false otherwise.
+func (c *MergeCache) Has(id int64) bool {
+	return c.Cache.Has(fmt.Sprint(id))
+}
+
 // Get does a filtered write of id's hashtree to the passed in io.Writer.
 func (c *MergeCache) Get(id int64, w io.Writer, filter Filter) (retErr error) {
 	r, err := c.Cache.Get(fmt.Sprint(id))

--- a/src/server/pkg/localcache/cache.go
+++ b/src/server/pkg/localcache/cache.go
@@ -26,6 +26,13 @@ func NewCache(root string) *Cache {
 	}
 }
 
+// Has returns true if the key is present in the cache, false otherwise.
+func (c *Cache) Has(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.keys[key]
+}
+
 // Put puts a key/value pair in the cache and reads the value from an io.Reader.
 func (c *Cache) Put(key string, value io.Reader) (retErr error) {
 	c.mu.Lock()

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -1379,7 +1379,9 @@ func (a *APIServer) mergeDatums(jobCtx context.Context, pachClient *client.APICl
 }
 
 func (a *APIServer) getChunk(ctx context.Context, id int64, address string, failed bool) error {
-	// If this worker processed the chunk, make sure it is already in the chunk cache
+	// If we think this worker processed the chunk, make sure it is already in the
+	// chunk cache, otherwise we may have cleared the cache since datum
+	// processing, or the IP was recycled.
 	if address == os.Getenv(client.PPSWorkerIPEnv) {
 		if !a.chunkCache.Has(id) {
 			return fmt.Errorf("chunk (%d) missing from local chunk cache", id)

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -1374,8 +1374,11 @@ func (a *APIServer) mergeDatums(jobCtx context.Context, pachClient *client.APICl
 }
 
 func (a *APIServer) getChunk(ctx context.Context, id int64, address string, failed bool) error {
-	// If this worker processed the chunk, then it is already in the chunk cache
+	// If this worker processed the chunk, make sure it is already in the chunk cache
 	if address == os.Getenv(client.PPSWorkerIPEnv) {
+		if !a.chunkCache.Has(id) {
+			return fmt.Errorf("chunk (%d) missing from local chunk cache", id)
+		}
 		return nil
 	}
 	if _, ok := a.clients[address]; !ok {


### PR DESCRIPTION
If a pipeline picks up a job in the MERGING state, it fetches chunks from other workers by the address of the worker which originally processed the datums in that chunk.  There is the possibility for collisions in addresses, which can result in an empty hashtree for that chunk (because none of the workers have the chunks cached in this scenario).  This PR checks that the chunks are present rather than assuming they are and will fall back to fetching datum hashtrees from object storage when this fails.