### PR TITLE
Resolve branch names in PFS makeCommit provenance

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1307,11 +1307,11 @@ func (d *driver) makeCommit(
 	// commitInfo.Provenance
 	newCommitProv := make(map[string]*pfs.CommitProvenance)
 	for _, prov := range provenance {
-		newCommitProv[prov.Commit.ID] = prov
 		provCommitInfo, err := d.resolveCommit(txnCtx.Stm, prov.Commit)
 		if err != nil {
 			return nil, err
 		}
+		newCommitProv[prov.Commit.ID] = prov
 
 		for _, c := range provCommitInfo.Provenance {
 			newCommitProv[c.Commit.ID] = c


### PR DESCRIPTION
If a branch name is passed in the `provenance` field of `makeCommit`, it will use the branch name rather than the commit ID for the `newCommitProv` map.  This PR reorders operations so that the branch name is resolved to a commit ID in `resolveCommit` before adding to the map.  This is related to an adjacent problem in `RunPipeline` where it may pass multiple provenances for the same repo/branch pair, but this part is a simple fix to maintain assumptions.