### PR TITLE
Fix v1.8 extract dumps not restoring properly

### DIFF
--- a/src/server/admin/server/api_server.go
+++ b/src/server/admin/server/api_server.go
@@ -375,7 +375,7 @@ func (a *apiServer) Restore(restoreServer admin.API_RestoreServer) (retErr error
 				extractReader := &extractObjectReader{
 					adminAPIRestoreServer: restoreServer,
 					restoreURLReader:      r,
-					version:               v1_9,
+					version:               v1_8,
 				}
 				extractReader.buf.Write(op.Op1_8.Object.Value)
 				if _, _, err := pachClient.PutObject(extractReader); err != nil {


### PR DESCRIPTION
It looks like there was a copy-paste error in the code and the `extractObjectReader` is tagged as the wrong version when restoring a `v1.8` dump - it is configured to expect `v1.9` operations and will then error out with:

`cannot mix different versions of pachd operation within a metadata dumps (found both 1.8 and 1.9)`