### PR TITLE
Treat EDITOR env var as a command with options.

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -675,6 +675,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	commands = append(commands, cmdutil.CreateAlias(extractPipeline, "extract pipeline"))
 
 	var editor string
+	var editorArgs []string
 	editPipeline := &cobra.Command{
 		Use:   "{{alias}} <pipeline>",
 		Short: "Edit the manifest for a pipeline in your text editor.",
@@ -707,11 +708,13 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			if editor == "" {
 				editor = "vim"
 			}
+			editorArgs = strings.Split(editor, " ")
+			editorArgs = append(editorArgs, f.Name())
 			if err := cmdutil.RunIO(cmdutil.IO{
 				Stdin:  os.Stdin,
 				Stdout: os.Stdout,
 				Stderr: os.Stderr,
-			}, editor, f.Name()); err != nil {
+			}, editorArgs...); err != nil {
 				return err
 			}
 			pipelineReader, err := ppsutil.NewPipelineManifestReader(f.Name())

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -475,7 +475,7 @@ func TestEditPipeline(t *testing.T) {
 		EOF
 		`).Run())
 	require.NoError(t, tu.BashCmd(`
-		EDITOR=cat pachctl edit pipeline my-pipeline -o yaml \
+		EDITOR="cat -u" pachctl edit pipeline my-pipeline -o yaml \
 		| match 'name: my-pipeline' \
 		| match 'repo: data' \
 		| match 'cmd:' \


### PR DESCRIPTION
Treat EDITOR env variable as a command with options. Eg. EDITOR="vi -v" should be passed to exec as "vi" with "-v" argument.

Addresses issue #3657 

Tested with go test and also with EDITOR="vim -v --" pachctl edit pipeline my-pipeline.

Without fix: 
EDITOR="vim -v --" pachctl edit pipeline my-pipeline
vim -v -- /var/folders/9k/d94jkft56s144mhbmd1vyww00000gp/T/my-pipeline987101247: exec: "vim -v --": executable file not found in $PATH

With fix:
EDITOR="vim -v --" ./pachctl edit pipeline my-pipeline
Pipeline unchanged, no update will be performed.

Fixes #3657 