### PR TITLE
Update Makefile with correct pachctl path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,22 +106,22 @@ release-candidate:
 
 custom-release: release-helper release-pachctl-custom
 	@echo 'For brew install, do:'
-	@echo "$$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$(shell pachctl version --client-only)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$(shell pachctl version --client-only | cut -f -2 -d\.).rb"
+	@echo "$$ brew install https://raw.githubusercontent.com/pachyderm/homebrew-tap/$(shell $(GOPATH)/bin/pachctl version --client-only)-$$(git log --pretty=format:%H | head -n 1)/pachctl@$(shell $(GOPATH)/bin/pachctl version --client-only | cut -f -2 -d\.).rb"
 	@echo 'For linux install, do:'
-	@echo "$$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$(shell pachctl version --client-only)/pachctl_$(shell pachctl version --client-only)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
+	@echo "$$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v$(shell $(GOPATH)/bin/pachctl version --client-only)/pachctl_$(shell $(GOPATH)/bin/pachctl version --client-only)_amd64.deb && sudo dpkg -i /tmp/pachctl.deb"
 	# Workaround for https://github.com/laher/goxc/issues/112
-	@git push origin :v$(shell pachctl version --client-only)
-	@git tag v$(shell pachctl version --client-only)
+	@git push origin :v$(shell $(GOPATH)/bin/pachctl version --client-only)
+	@git tag v$(shell $(GOPATH)/bin/pachctl version --client-only)
 	@git push origin --tags
 	@echo "Release completed"
 
 release-pachctl-custom:
 	@# Run pachctl release script w deploy branch name
-	@VERSION="$(shell pachctl version --client-only)" ./etc/build/release_pachctl $$(pachctl version --client-only)
+	@VERSION="$(shell $(GOPATH)/bin/pachctl version --client-only)" ./etc/build/release_pachctl $(shell $(GOPATH)/bin/pachctl version --client-only)
 
 release-pachctl:
 	@# Run pachctl release script w deploy branch name
-	@VERSION="$(shell pachctl version --client-only)" ./etc/build/release_pachctl
+	@VERSION="$(shell $(GOPATH)/bin/pachctl version --client-only)" ./etc/build/release_pachctl
 
 release-helper: check-docker-version release-version release-pachd release-worker
 
@@ -129,10 +129,10 @@ release-version: install-clean
 	@./etc/build/repo_ready_for_release.sh
 
 release-pachd:
-	@VERSION="$(shell pachctl version --client-only)" ./etc/build/release_pachd
+	@VERSION="$(shell $(GOPATH)/bin/pachctl version --client-only)" ./etc/build/release_pachd
 
 release-worker:
-	@VERSION="$(shell pachctl version --client-only)" ./etc/build/release_worker
+	@VERSION="$(shell $(GOPATH)/bin/pachctl version --client-only)" ./etc/build/release_worker
 
 docker-build-compile:
 	docker build $(DOCKER_BUILD_FLAGS) -t pachyderm_compile .

--- a/etc/build/doc
+++ b/etc/build/doc
@@ -2,7 +2,7 @@
 
 set -e
 
-version="$(pachctl version --client-only)"
+version="$($(GOPATH)/bin/pachctl version --client-only)"
 major_minor=`echo $version | cut -f -2 -d "."`
 echo "--- Updating docs for version: $version"
 


### PR DESCRIPTION
Fixing an issue that calls the correct pachctl to get client version. The change here restores the behavior of Makefile when VERSION file was used to set the VERSION env variable passed to various build scripts.

By explicitly refering to $(GOPATH)/bin the version become independent of developers PATH varaible.