### PR TITLE
modified makefile to assist in release testing

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,19 @@
 .PHONY: opencv object_detection delete minikube gatk hyperparameter
 
+JQ := jq
+JQFLAGS :=
+DOCKER := docker
+ECHO := echo
+TOUCH := touch
+CP := cp
+RM := rm
+STATS := .enable_stats=true
+DETECTMODEL := .pipeline.name="object-detect"|.input.cross[1].pfs.repo="object-model"|.input.cross[1].pfs.name="model"
+HYPERPSPLIT := .input.cross[0].pfs.repo="hp-split"|.input.cross[0].pfs.name="split"
+HYPERPMODEL := .input.cross[1].pfs.repo="hp-model"|.input.cross[1].pfs.name="model"
+HYPERPTEST := .input.cross[0].pfs.repo="hp-test"|.input.cross[0].pfs.name="test"
+
+
 GATK_GERMLINE_FILES	=	gatk/GATK_Germline/data/ref/ref.dict \
 				gatk/GATK_Germline/data/ref/ref.fasta \
 				gatk/GATK_Germline/data/ref/ref.fasta.fai \
@@ -35,33 +49,97 @@ opencv:
 	pachctl create pipeline -f opencv/montage.json
 	pachctl put file images@master -i opencv/images.txt
 	pachctl put file images@master -i opencv/images2.txt
-#	pachctl put file images@master -i opencv/images3.txt
+
+opencv-testing: 
+	pachctl create repo images
+	$(JQ) "$(STATS)" opencv/edges.json | pachctl create pipeline -f -
+	$(JQ) "$(STATS)" opencv/montage.json | pachctl create pipeline -f -
+	pachctl start transaction
+	pachctl start commit images@master
+	pachctl finish transaction
+	pachctl put file images@master -i opencv/images.txt
+	pachctl put file images@master -i opencv/images2.txt
+	pachctl put file images@master -i opencv/images3.txt
+	pachctl put file images@master -i opencv/images4.txt
+	pachctl delete file images@master:/w7RVTsv.jpg
+	pachctl finish commit images@master
+
+opencv-testing-delete:
+	-pachctl delete pipeline montage
+	-pachctl delete pipeline edges
+
+opencv-delete: opencv-testing-delete
+	-pachctl delete repo images
 
 ml/object-detection/frozen_inference_graph.pb:
 	wget -p http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz --directory-prefix /tmp
 	tar -C ml/object-detection --strip-components 1 -xvf /tmp/download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_11_06_2017.tar.gz ssd_mobilenet_v1_coco_11_06_2017/frozen_inference_graph.pb
 
-object-detection: ml/object-detection/frozen_inference_graph.pb
+
+object-detection-images-repo: ml/object-detection/frozen_inference_graph.pb
 	pachctl create repo images
+
+object-detection-no-images-repo: ml/object-detection/frozen_inference_graph.pb
+
+object-detection-demo: object-detection-no-images-repo
 	pachctl create repo training
 	pachctl put file training@master:frozen_inference_graph.pb -f ml/object-detection/frozen_inference_graph.pb
 	pachctl put file images@master:dogs.jpg -f ml/object-detection/images/dogs.jpg
+
+object-detection:  object-detection-images-repo object-detection-demo
 	pachctl create pipeline -f ml/object-detection/model.json
 	pachctl create pipeline -f ml/object-detection/detect.json
-	pachctl put file images@master:kites.jpg -f ml/object-detection/images/kites.jpg
-#	pachctl put file images@master:airplane.jpg -f ml/object-detection/images/airplane.jpg
 
+object-detection-testing:  object-detection-demo
+	$(JQ) '$(STATS)|.pipeline.name="object-model"'  ml/object-detection/model.json | pachctl create pipeline -f -
+	$(JQ) '$(STATS)|$(DETECTMODEL)'  ml/object-detection/detect.json | pachctl create pipeline -f -
+	pachctl put file images@master:airplane.jpg -f ml/object-detection/images/airplane.jpg
 
-hyperparameter:
+object-detection-testing-delete:
+	-pachctl delete pipeline object-detect
+	-pachctl delete pipeline object-model
+	-pachctl delete repo training
+
+object-detection-delete: object-detection-delete
+	-pachctl delete pipeline detect
+	-pachctl delete pipeline model
+	-pachctl delete repo training
+	-pachctl delete repo images
+
+hyperparameter-common:
 	pachctl create repo raw_data
 	pachctl create repo parameters
 	pachctl put file raw_data@master:iris.csv -f ml/hyperparameter/data/noisy_iris.csv
 	pachctl put file parameters@master:c_parameters.txt -f ml/hyperparameter/data/parameters/c_parameters.txt --split line --target-file-datums 1
 	pachctl put file parameters@master:gamma_parameters.txt -f ml/hyperparameter/data/parameters/gamma_parameters.txt --split line --target-file-datums 1
+
+hyperparameter: hyperparameter-common
 	pachctl create pipeline -f ml/hyperparameter/split.json
 	pachctl create pipeline -f ml/hyperparameter/model.json
 	pachctl create pipeline -f ml/hyperparameter/test.json
 	pachctl create pipeline -f ml/hyperparameter/select.json
+
+hyperparameter-testing: hyperparameter-common
+	$(JQ) '$(STATS)|.pipeline.name="hp-split"' ml/hyperparameter/split.json | pachctl create pipeline -f -
+	$(JQ) '$(STATS)|.pipeline.name="hp-model"' ml/hyperparameter/model.json | pachctl create pipeline -f -
+	$(JQ) '$(STATS)|.pipeline.name="hp-test"|$(HYPERPSPLIT)|$(HYPERPMODEL)' ml/hyperparameter/test.json | pachctl create pipeline -f -
+	$(JQ) '$(STATS)|.pipeline.name="hp-select"|$(HYPERPTEST)|$(HYPERPMODEL)'  ml/hyperparameter/select.json | pachctl create pipeline -f -
+
+hyperparameter-testing-delete:
+	-pachctl delete pipeline hp-select
+	-pachctl delete pipeline hp-test
+	-pachctl delete pipeline hp-split
+	-pachctl delete pipeline hp-model
+	-pachctl delete repo parameters
+	-pachctl delete repo raw_data
+
+hyperparameter-delete:
+	-pachctl delete pipeline select
+	-pachctl delete pipeline test
+	-pachctl delete pipeline split
+	-pachctl delete pipeline model
+	-pachctl delete repo parameters
+	-pachctl delete repo raw_data
 
 $(GATK_GERMLINE_FILES): 
 	mkdir -p gatk/GATK_Germline
@@ -85,6 +163,25 @@ gatk: $(GATK_GERMLINE_FILES)
 	pachctl finish commit samples@master
 	pachctl create pipeline -f gatk/likelihoods.json
 	pachctl create pipeline -f gatk/joint-call.json
+
+gatk-testing: gatk
+	pachctl start commit samples@master
+	pachctl put file samples@master:son/son.bam -f gatk/GATK_Germline/data/bams/son.bam
+	pachctl put file samples@master:son/son.bai -f gatk/GATK_Germline/data/bams/son.bai	
+	pachctl finish commit samples@master
+
+gatk-delete:
+	-pachctl delete pipeline joint_call
+	-pachctl delete pipeline likelihoods
+	-pachctl delete repo reference
+	-pachctl delete repo samples
+
+gatk-testing-delete: gatk-delete
+
+testing-delete: gatk-testing-delete hyperparameter-testing-delete object-detection-testing-delete opencv-testing-delete
+	-pachctl delete repo images
+
+testing: opencv-testing object-detection-testing hyperparameter-testing gatk-testing
 
 delete:
 	yes | pachctl delete all

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -106,6 +106,9 @@ object-detection-delete: object-detection-delete
 	-pachctl delete repo training
 	-pachctl delete repo images
 
+opencv-object-detection-testing: opencv-testing object-detection-testing
+opencv-object-detection-testing-delete: object-detection-testing-delete opencv-delete
+
 hyperparameter-common:
 	pachctl create repo raw_data
 	pachctl create repo parameters


### PR DESCRIPTION
I've created a number of new Makefile targets based on 4 examples to assist in release testing.

The opencv and object-detection demos share the `images` repo.  All pipelines are built with stats enabled.

You’ll need to install `jq` to use the new targets.  `brew install jq` should install it on macOS with homebrew.

* `make opencv-testing` will create an opencv demo and pump 45 images into it. 
* `make object-detection-testing` will create the object-detection demo, using the images repo from opencv.  It will also load in some more test images.

There are also targets for 
* `make hyperparameter-testing` will make a version of hyperparameter that won't have repo and pipeline name collisions with object-detection.  It will also load in more demo data.
* `make gatk-testing` will load the gatk example and also the "son" data

and convenience targets for making opencv and object-detection together:
* `opencv-object-detection-testing`
* `opencv-object-detection-testing-delete`

To make all the demos at once, use `make testing`.

To delete all the demos, use `make testing-delete` or just `make-delete`. (The former works better on hub.)  There are also individual targets for deleting each demo. There is a dependency between opencv and object detection, as noted above.  You should `make object-detection-testing-delete` before running `make opencv-testing-delete`.

Every pipeline should successfully run with the data loaded, and the final jobs output should look like

```
pachctl list job
ID                               PIPELINE      STARTED        DURATION       RESTART PROGRESS    DL       UL       STATE   
3e3dedfaf6624c6e8f0b46ecbec0cb57 hp-select     42 seconds ago 17 seconds     0       1 + 0 / 1   235.6KiB 0B       success 
4789b11b53b849919bb63c8a3d307ae1 object-detect 53 seconds ago 17 seconds     0       1 + 44 / 45 27.92MiB 537.2KiB success 
62d72d3893bb4b718b80c24b0f82e42a hp-test       6 minutes ago  6 minutes      0       77 + 0 / 77 341.1KiB 231B     success 
ab7ea28282404e9db93247cd2fefd4ef joint_call    8 minutes ago  26 seconds     0       1 + 0 / 1   97.64MiB 188.6KiB success 
4e8c44e5375745768fe97acd156e8ac9 likelihoods   9 minutes ago  About a minute 0       1 + 2 / 3   93.26MiB 4.729MiB success 
98ac85152737496f98e17145ec8b0562 joint_call    9 minutes ago  37 seconds     0       1 + 0 / 1   92.91MiB 166.3KiB success 
75d2655006a24ecd9d0b3b727df5fe8e montage       10 minutes ago 52 seconds     0       1 + 0 / 1   13.86MiB 16.82MiB success 
2ca380b88415422e91c2f67f5cc5f839 montage       11 minutes ago 51 seconds     0       1 + 0 / 1   13.73MiB 16.27MiB success 
b70ceecd43e44cfabaf83dddd7cd4068 likelihoods   11 minutes ago 2 minutes      0       2 + 0 / 2   200.8MiB 9.231MiB success 
05ee34d65518431f92de5c50d2234b1b edges         12 minutes ago 7 seconds      0       1 + 44 / 45 90.03KiB 46.58KiB success 
a08dc16c82a0402fb5e0a98cf4aeb61c edges         12 minutes ago 7 seconds      0       1 + 43 / 44 126.8KiB 39.3KiB  success 
f73316c2336a415da19c04d8270294f7 montage       12 minutes ago 50 seconds     0       1 + 0 / 1   13.56MiB 15.88MiB success 
688431b2cdbd4cca8ae9064bc650ba0c hp-model      13 minutes ago 6 minutes      0       77 + 0 / 77 529.1KiB 235.4KiB success 
960641b40e054a7198ac321cf2d62dd6 hp-split      13 minutes ago 5 seconds      0       1 + 0 / 1   6.858KiB 6.858KiB success 
17a52de955984138a96d133eeaaa1d7d object-detect 14 minutes ago 13 minutes     0       44 + 0 / 44 1.207GiB 82.55MiB success 
71f05a4d93224e0f9f43707c39d6797e object-model  14 minutes ago 5 seconds      0       1 + 0 / 1   27.83MiB 0B       success 
421ea715a5724f00a7bf4ac3d5089425 edges         15 minutes ago 2 minutes      0       43 + 0 / 43 10.85MiB 2.717MiB success 

```
