### PR TITLE
Streamline worker pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.0-experimental
 ARG GO_VERSION
 FROM golang:${GO_VERSION}
+RUN go get github.com/go-bindata/go-bindata/...
 WORKDIR /app
 COPY . .
 ARG LD_FLAGS
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
+    go-bindata -o src/server/cmd/worker/assets/assets.go -pkg assets /etc/ssl/certs/... && \
     CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o pachd "src/server/cmd/pachd/main.go" && \
     CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o worker "src/server/cmd/worker/main.go"

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,11 @@ docker-build: enterprise-code-checkin-test
 		--progress plain -t pachyderm_build .
 	docker build $(DOCKER_BUILD_FLAGS) -t pachyderm/pachd etc/pachd
 	docker tag pachyderm/pachd pachyderm/pachd:local
-	docker build $(DOCKER_BUILD_FLAGS) -t pachyderm/worker etc/worker
+	docker build \
+		--build-arg GO_VERSION=`cat etc/compile/GO_VERSION` \
+		--build-arg LD_FLAGS="$(LD_FLAGS)" \
+		$(DOCKER_BUILD_FLAGS) \
+		-t pachyderm/worker etc/worker
 	docker tag pachyderm/worker pachyderm/worker:local
 
 docker-build-proto:

--- a/etc/pachd/Dockerfile
+++ b/etc/pachd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM scratch
 WORKDIR /app
 COPY --from=pachyderm_build /app/pachd .
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/etc/worker/Dockerfile
+++ b/etc/worker/Dockerfile
@@ -1,4 +1,11 @@
-FROM alpine:3
+ARG GO_VERSION
+FROM golang:${GO_VERSION} AS worker_build
+WORKDIR /app
+COPY init.go .
+ARG LD_FLAGS
+RUN CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o init "init.go"
+
+FROM scratch
 WORKDIR /app
 COPY --from=pachyderm_build /app/worker .
-COPY init.sh .
+COPY --from=worker_build /app/init .

--- a/etc/worker/Dockerfile
+++ b/etc/worker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3
-WORKDIR /pach
+WORKDIR /app
 COPY --from=pachyderm_build /app/worker .
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY worker.sh .

--- a/etc/worker/Dockerfile
+++ b/etc/worker/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3
 WORKDIR /app
 COPY --from=pachyderm_build /app/worker .
+COPY init.sh .

--- a/etc/worker/Dockerfile
+++ b/etc/worker/Dockerfile
@@ -1,5 +1,3 @@
 FROM alpine:3
 WORKDIR /app
 COPY --from=pachyderm_build /app/worker .
-COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY worker.sh .

--- a/etc/worker/init.go
+++ b/etc/worker/init.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"io"
+	"os"
+)
+
+func cp(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+
+	// make the file executable
+	if err = out.Chmod(os.ModePerm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := cp("/app/worker", "/pach-bin/worker"); err != nil {
+		panic(err)
+	}
+}

--- a/etc/worker/init.sh
+++ b/etc/worker/init.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-cp /app/* /pach-bin/

--- a/etc/worker/init.sh
+++ b/etc/worker/init.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cp /app/* /pach-bin/

--- a/etc/worker/worker.sh
+++ b/etc/worker/worker.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cp /app/* /pach-bin/
-cp -r /etc/ssl/certs /pach-bin/certs

--- a/etc/worker/worker.sh
+++ b/etc/worker/worker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-cp /pach/* /pach-bin/
+cp /app/* /pach-bin/
 cp -r /etc/ssl/certs /pach-bin/certs

--- a/go.mod
+++ b/go.mod
@@ -109,13 +109,13 @@ require (
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.12.0 // indirect
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
-	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
-	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	golang.org/x/tools v0.0.0-20200227184634-afe1c6fc1b2a // indirect
+	golang.org/x/tools v0.0.0-20200305140159-d7d444866696 // indirect
 	google.golang.org/api v0.6.0
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,11 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNT
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367 h1:0IiAsCRByjO2QjX7ZPkw5oU9x+n1YqRL802rjC0c3Aw=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -520,6 +523,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -577,6 +582,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115230748-a7dab0268b5f h1:NpM/3jXkRPegnt/me9EqO3YbnrKCSrbJKm+b71OLh34=
@@ -590,8 +596,11 @@ golang.org/x/tools v0.0.0-20200226224502-204d844ad48d h1:loGv/4fxITSrCD4t2P8ZF4o
 golang.org/x/tools v0.0.0-20200226224502-204d844ad48d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200227184634-afe1c6fc1b2a h1:BRx3NnKv+ZtrNTQvhzlzuelWnJgbB8HzJGy4KSFL6Ck=
 golang.org/x/tools v0.0.0-20200227184634-afe1c6fc1b2a/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200305140159-d7d444866696 h1:uuiLBSsR+ZDddgZ/2k23Y7FrUNl29gq4sEFcO170R5k=
+golang.org/x/tools v0.0.0-20200305140159-d7d444866696/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.0 h1:2tJEkRfnZL5g1GeBUlITh/rqT5HG3sFcoVCUUxmgJ2g=
 google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=

--- a/src/client/pkg/config/context.go
+++ b/src/client/pkg/config/context.go
@@ -15,5 +15,8 @@ func (c *Context) EqualClusterReference(other *Context) bool {
 	if c.Namespace != other.Namespace {
 		return false
 	}
+	if c.PachdAddress != other.PachdAddress {
+		return false
+	}
 	return true
 }

--- a/src/server/cmd/worker/assets/assets.go
+++ b/src/server/cmd/worker/assets/assets.go
@@ -1,0 +1,13 @@
+package assets
+
+import "errors"
+
+// This is an empty placeholder file. At build time, go-bindata will package
+// cert data from /etc/ssl/certs here.
+
+// RestoreAssets restores an asset under the given directory recursively
+func RestoreAssets(dir, name string) error {
+	// don't panic here because the linter is too damn smart, and figures out
+	// that downstream functions are unused when a panic occurs here
+	return errors.New("RestoreAssets is not implemented because it is only populated at build-time")
+}

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -3,10 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"path"
-	"path/filepath"
 	"time"
 
 	etcd "github.com/coreos/etcd/clientv3"
@@ -17,6 +14,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/client/version"
 	"github.com/pachyderm/pachyderm/src/client/version/versionpb"
+	"github.com/pachyderm/pachyderm/src/server/cmd/worker/assets"
 	debugserver "github.com/pachyderm/pachyderm/src/server/debug/server"
 	"github.com/pachyderm/pachyderm/src/server/pkg/cmdutil"
 	logutil "github.com/pachyderm/pachyderm/src/server/pkg/log"
@@ -30,70 +28,16 @@ import (
 func main() {
 	log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
 
-	// Copy the contents of /pach-bin/certs into /etc/ssl/certs. Don't return an
-	// error (which would cause 'Walk()' to exit early) but do record if any certs
-	// are known to be missing so we can inform the user
-	copyErr := false
-	if err := filepath.Walk("/pach-bin/certs", func(inPath string, info os.FileInfo, err error) error {
-		if err != nil {
-			log.Warnf("skipping \"%s\", could not stat path: %v", inPath, err)
-			copyErr = true
-			return nil // Don't try and fix any errors encountered by Walk() itself
-		}
-		if info.IsDir() {
-			return nil // We'll just copy the children of any directories when we traverse them
-		}
-
-		// Open input file (src)
-		in, err := os.OpenFile(inPath, os.O_RDONLY, 0)
-		if err != nil {
-			log.Warnf("could not read \"%s\": %v", inPath, err)
-			copyErr = true
-			return nil
-		}
-		defer in.Close()
-
-		// Create output file (dest) and open for writing
-		outRelPath, err := filepath.Rel("/pach-bin/certs", inPath)
-		if err != nil {
-			log.Warnf("skipping \"%s\", could not extract relative path: %v", inPath, err)
-			copyErr = true
-			return nil
-		}
-		outPath := filepath.Join("/etc/ssl/certs", outRelPath)
-		outDir := filepath.Dir(outPath)
-		if err := os.MkdirAll(outDir, 0755); err != nil {
-			log.Warnf("skipping \"%s\", could not create directory \"%s\": %v", inPath, outDir, err)
-			copyErr = true
-			return nil
-		}
-		out, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
-		if err != nil {
-			log.Warnf("skipping \"%s\", could not create output file \"%s\": %v", inPath, outPath, err)
-			copyErr = true
-			return nil
-		}
-		defer out.Close()
-
-		// Copy src -> dest
-		if _, err := io.Copy(out, in); err != nil {
-			log.Warnf("could not copy \"%s\" to \"%s\": %v", inPath, outPath, err)
-			copyErr = true
-			return nil
-		}
-		return nil
-	}); err != nil {
-		// Should never happen, but just log if it does
-		copyErr = true
-		log.Warnf("walk failed with: %v", err)
+	// Copy certs embedded via go-bindata to /etc/ssl/certs. Because the
+	// container running this app is user-specified, we don't otherwise have
+	// control over the certs that are available.
+	//
+	// If an error occurs, don't hard-fail, but do record if any certs are
+	// known to be missing so we can inform the user.
+	if err := assets.RestoreAssets("/etc/ssl/certs", "/etc/ssl/certs"); err != nil {
+		log.Warnf("failed to inject TLS certs: %v", err)
 	}
-	if copyErr {
-		log.Warnf(
-			"pachyderm's worker binary encountered errors while copying " +
-				"/pach-bin/certs to /etc/ssl/certs (see above). This might cause the " +
-				"worker binary to error while communicating with object storage for " +
-				"egress pipelines or for merging pipeline outputs")
-	}
+
 	cmdutil.Main(do, &serviceenv.WorkerFullConfiguration{})
 }
 

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -34,7 +34,7 @@ func main() {
 	//
 	// If an error occurs, don't hard-fail, but do record if any certs are
 	// known to be missing so we can inform the user.
-	if err := assets.RestoreAssets("/etc/ssl/certs", "/etc/ssl/certs"); err != nil {
+	if err := assets.RestoreAssets("/", "etc/ssl/certs"); err != nil {
 		log.Warnf("failed to inject TLS certs: %v", err)
 	}
 

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -163,34 +163,15 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 		})
 	}
 	zeroVal := int64(0)
-	workerImage := a.workerImage
 	var securityContext *v1.PodSecurityContext
 	if a.workerUsesRoot {
 		securityContext = &v1.PodSecurityContext{RunAsUser: &zeroVal}
 	}
-	resp, err := a.env.GetPachClient(context.Background()).Enterprise.GetState(context.Background(), &enterprise.GetStateRequest{})
+	_, err = a.env.GetPachClient(context.Background()).Enterprise.GetState(context.Background(), &enterprise.GetStateRequest{})
 	if err != nil {
 		return v1.PodSpec{}, err
 	}
-	if resp.State != enterprise.State_ACTIVE {
-		workerImage = assets.AddRegistry("", workerImage)
-	}
 	podSpec := v1.PodSpec{
-		InitContainers: []v1.Container{
-			{
-				Name:            "init",
-				Image:           workerImage,
-				Command:         []string{"/app/worker.sh"},
-				ImagePullPolicy: v1.PullPolicy(pullPolicy),
-				VolumeMounts:    options.volumeMounts,
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceCPU:    cpuZeroQuantity,
-						v1.ResourceMemory: memDefaultQuantity,
-					},
-				},
-			},
-		},
 		Containers: []v1.Container{
 			{
 				Name:            client.PPSWorkerUserContainerName,

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -180,7 +180,7 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 			{
 				Name:            "init",
 				Image:           workerImage,
-				Command:         []string{"/app/init.sh"},
+				Command:         []string{"/app/init"},
 				ImagePullPolicy: v1.PullPolicy(pullPolicy),
 				VolumeMounts:    options.volumeMounts,
 				Resources: v1.ResourceRequirements{

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -180,7 +180,7 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 			{
 				Name:            "init",
 				Image:           workerImage,
-				Command:         []string{"/pach/worker.sh"},
+				Command:         []string{"/app/worker.sh"},
 				ImagePullPolicy: v1.PullPolicy(pullPolicy),
 				VolumeMounts:    options.volumeMounts,
 				Resources: v1.ResourceRequirements{


### PR DESCRIPTION
Builds off of #4663 with a few more improvements:

* Inject certs into the worker binary via go-bindata rather than copying them `/etc/ssl/certs` (build container) -> `/etc/ssl/certs` (worker init container) -> `/pach-bin/certs` (worker user container) -> `/etc/ssl/certs` (worker user container.)
* Inject binaries in `/app` instead of `/pach`. This aligns with the changes to pachd in #4663 and should furthermore reduce confusion, as before, `/pach` meant either a mounted directory or the directory for binaries depending on the worker container.
* Switch back to scratch for pachd.
* Use scratch for the worker image (vs ubuntu on master, and alpine on #4663.) alpine is no longer necessary with the removal of the shell script, and using scratch seems safer since there's a smaller attack surface. I'm not sure if this is worthwhile, though, as alpine introduced the possibility of new ways to debug issues with pachd/worker images.

We still need an init container to copy the worker binary into the user container. As a result, I figured it didn't make sense to combine the pachd/worker images/binaries.

Closes #4679
Closes #3863