### PR TITLE
Fix incorrect error message during worker s3 gateway check

### DIFF
--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -1919,9 +1919,7 @@ func (a *APIServer) worker() {
 						endpoint := fmt.Sprintf("http://%s:%s/",
 							ppsutil.SidecarS3GatewayService(jobInfo.Job.ID),
 							os.Getenv("S3GATEWAY_PORT"))
-						if _, err := (&http.Client{Timeout: 5 * time.Second}).Get(endpoint); err != nil {
-							return err
-						}
+						_, err := (&http.Client{Timeout: 5 * time.Second}).Get(endpoint)
 						logger.Logf("checking s3 gateway service for job %q: %v", jobInfo.Job.ID, err)
 						return err
 					}, backoff.New60sBackOff(), func(err error, d time.Duration) error {


### PR DESCRIPTION
Came across this when merging the code into the parallel jobs branch.  Since `err` was scoped to the above if statement, the error printed by this function was from the outer scope.  Incidentally, `err` is likely always `nil` here, so the log statement and return value would be correct.  It seems like this log statement was intended to print out any errors from the check, though, so this PR fixes that.