### PR TITLE
kustomize 

### DIFF
--- a/kustomize/base/dash/deployment.yaml
+++ b/kustomize/base/dash/deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dash
+spec:
+  template:
+    metadata:
+      name: dash
+    spec:
+      containers:
+      - image: pachyderm/dash:1.9.0
+        imagePullPolicy: IfNotPresent
+        name: dash
+        ports:
+        - containerPort: 8080
+          name: dash-http
+      - image: pachyderm/grpc-proxy:0.4.10
+        imagePullPolicy: IfNotPresent
+        name: grpc-proxy
+        ports:
+        - containerPort: 8081
+          name: grpc-proxy-http

--- a/kustomize/base/dash/kustomization.yaml
+++ b/kustomize/base/dash/kustomization.yaml
@@ -1,0 +1,7 @@
+commonLabels:
+  app: dash
+  suite: pachyderm
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kustomize/base/dash/service.yaml
+++ b/kustomize/base/dash/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dash
+spec:
+  ports:
+  - name: dash-http
+    nodePort: 30080
+    port: 8080
+    targetPort: 0
+  - name: grpc-proxy-http
+    nodePort: 30081
+    port: 8081
+    targetPort: 0
+#  selector:
+#    app: dash
+#    suite: pachyderm
+  type: NodePort

--- a/kustomize/base/etcd/headless.service.yaml
+++ b/kustomize/base/etcd/headless.service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  #labels:
+  #  app: etcd
+  #  suite: pachyderm
+  name: etcd-headless
+spec:
+  clusterIP: None
+  ports:
+  - name: peer-port
+    port: 2380
+    targetPort: 0
+  #selector:
+  #  app: etcd

--- a/kustomize/base/etcd/kustomization.yaml
+++ b/kustomize/base/etcd/kustomization.yaml
@@ -1,0 +1,8 @@
+commonLabels:
+  app: etcd
+  suite: pachyderm
+
+resources:
+  - statefulset.yaml
+  - headless.service.yaml
+  - service.yaml

--- a/kustomize/base/etcd/service.yaml
+++ b/kustomize/base/etcd/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+spec:
+  ports:
+  - name: client-port
+    port: 2379
+    targetPort: 0
+  #selector:
+  #  app: etcd
+  type: NodePort

--- a/kustomize/base/etcd/statefulset.yaml
+++ b/kustomize/base/etcd/statefulset.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: etcd
+spec:
+  replicas: 1
+  #selector:
+  #  matchLabels:
+  #    app: etcd
+  #    suite: pachyderm
+  serviceName: etcd-headless
+  template:
+    metadata:
+      #labels:
+      #  app: etcd
+      #  suite: pachyderm
+      name: etcd
+      # namespace: default
+    spec:
+      containers:
+      - args:
+        - '"/usr/local/bin/etcd" "--listen-client-urls=http://0.0.0.0:2379" "--advertise-client-urls=http://0.0.0.0:2379"
+          "--data-dir=/var/data/etcd" "--auto-compaction-retention=1" "--max-txn-ops=10000"
+          "--max-request-bytes=52428800" "--quota-backend-bytes=8589934592" "--listen-peer-urls=http://0.0.0.0:2380"
+          "--initial-cluster-token=pach-cluster" "--initial-advertise-peer-urls=http://${ETCD_NAME}.etcd-headless.${NAMESPACE}.svc.cluster.local:2380"
+          "--initial-cluster=etcd-0=http://etcd-0.etcd-headless.${NAMESPACE}.svc.cluster.local:2380"'
+        command:
+        - /bin/sh
+        - -c
+        env:
+        - name: ETCD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/coreos/etcd:v3.3.5
+        imagePullPolicy: IfNotPresent
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client-port
+        - containerPort: 2380
+          name: peer-port
+        resources:
+          requests:
+            cpu: "1"
+            memory: 2G
+        volumeMounts:
+        - mountPath: /var/data/etcd
+          name: etcd-storage
+      imagePullSecrets: null
+  volumeClaimTemplates:
+  - metadata:
+      annotations:
+        volume.beta.kubernetes.io/storage-class: etcd-storage-class
+      #labels:
+      #  app: etcd
+      #  suite: pachyderm
+      name: etcd-storage
+      #namespace: default
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+namespace: blah
+
+images:
+  - name: pachyderm/pachd
+    newTag: "1.11"
+
+resources:
+  - pach
+  - etcd
+  - dash

--- a/kustomize/base/pach/clusterrole.yaml
+++ b/kustomize/base/pach/clusterrole.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: ""
+    suite: pachyderm
+  name: pachyderm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - pods/log
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - deletecollection

--- a/kustomize/base/pach/clusterrolebinding.yaml
+++ b/kustomize/base/pach/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: ""
+    suite: pachyderm
+  name: pachyderm
+roleRef:
+  apiGroup: ""
+  kind: ClusterRole
+  name: pachyderm
+subjects:
+- kind: ServiceAccount
+  name: pachyderm

--- a/kustomize/base/pach/deployment.yaml
+++ b/kustomize/base/pach/deployment.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+#  labels:
+#    app: pachd
+#    suite: pachyderm
+  name: pachd
+spec:
+  replicas: 1
+  #selector:
+  #  matchLabels:
+  #    app: pachd
+  #    suite: pachyderm
+  template:
+  #  labels:
+  #    app: pachd
+  #    suite: pachyderm
+    name: pachd
+  #  namespace: default
+    spec:
+      containers:
+      - name: pachd
+        image: pachyderm/pachd:1.10.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: PACH_ROOT
+            value: /pach
+          - name: ETCD_PREFIX
+          - name: NUM_SHARDS
+            value: "16"
+          - name: WORKER_IMAGE
+            value: pachyderm/worker:1.10.0
+          - name: IMAGE_PULL_SECRET
+          - name: WORKER_SIDECAR_IMAGE
+            value: pachyderm/pachd:1.10.0
+          - name: WORKER_IMAGE_PULL_POLICY
+            value: IfNotPresent
+          - name: PACHD_VERSION
+            value: 1.10.0
+          - name: METRICS
+            value: "true"
+          - name: LOG_LEVEL
+            value: info
+          - name: BLOCK_CACHE_BYTES
+            value: 0G
+          - name: IAM_ROLE
+          - name: NO_EXPOSE_DOCKER_SOCKET
+            value: "false"
+          - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
+            value: "false"
+          - name: PACHD_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PACHD_MEMORY_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: pachd
+                divisor: "0"
+                resource: requests.memory
+          - name: EXPOSE_OBJECT_API
+            value: "false"
+          - name: CLUSTER_DEPLOYMENT_ID
+            value: 6690ec503e1344f5b58bdeef87f29c78
+          - name: REQUIRE_CRITICAL_SERVERS_ONLY
+            value: "false"
+          - name: DISABLE_SSL
+            valueFrom:
+              secretKeyRef:
+                key: disable-ssl
+                name: pachyderm-storage-secret
+                optional: true
+          - name: NO_VERIFY_SSL
+            valueFrom:
+              secretKeyRef:
+                key: no-verify-ssl
+                name: pachyderm-storage-secret
+                optional: true
+          - name: STORAGE_UPLOAD_CONCURRENCY_LIMIT
+            value: "100"
+        ports:
+          - containerPort: 650
+            name: api-grpc-port
+            protocol: TCP
+          - containerPort: 651
+            name: trace-port
+          - containerPort: 652
+            name: api-http-port
+            protocol: TCP
+          - containerPort: 653
+            name: peer-port
+            protocol: TCP
+          - containerPort: 655
+            name: api-git-port
+            protocol: TCP
+          - containerPort: 654
+            name: saml-port
+            protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /pachd
+            - --readiness
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2G
+          requests:
+            cpu: "1"
+            memory: 2G
+        volumeMounts:
+          - mountPath: /pach
+            name: pach-disk
+          - mountPath: /pachyderm-storage-secret
+            name: pachyderm-storage-secret
+      serviceAccountName: pachyderm
+      volumes:
+        - name: pach-disk
+        - name: pachyderm-storage-secret
+          secret:
+            secretName: pachyderm-storage-secret

--- a/kustomize/base/pach/kustomization.yaml
+++ b/kustomize/base/pach/kustomization.yaml
@@ -1,0 +1,14 @@
+commonLabels:
+  app: pachd
+  suite: pachyderm
+
+resources:
+  - clusterrolebinding.yaml
+  - clusterrole.yaml
+  - deployment.yaml
+  - peer.service.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - worker.role.yaml
+  - worker.rolebinding.yaml
+  - worker.serviceaccount.yaml

--- a/kustomize/base/pach/peer.service.yaml
+++ b/kustomize/base/pach/peer.service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  #labels:
+  #  app: pachd
+  #  suite: pachyderm
+  name: pachd-peer
+spec:
+  ports:
+  - name: api-grpc-peer-port
+    port: 30653
+    targetPort: 653
+  #selector:
+  #  app: pachd
+  type: ClusterIP

--- a/kustomize/base/pach/service.yaml
+++ b/kustomize/base/pach/service.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "656"
+    prometheus.io/scrape: "true"
+#  labels:
+#    app: pachd
+#    suite: pachyderm
+  name: pachd
+spec:
+  ports:
+  - name: api-grpc-port
+    nodePort: 30650
+    port: 650
+    targetPort: 0
+  - name: trace-port
+    nodePort: 30651
+    port: 651
+    targetPort: 0
+  - name: api-http-port
+    nodePort: 30652
+    port: 652
+    targetPort: 0
+  - name: saml-port
+    nodePort: 30654
+    port: 654
+    targetPort: 0
+  - name: api-git-port
+    nodePort: 30655
+    port: 655
+    targetPort: 0
+  - name: s3gateway-port
+    nodePort: 30600
+    port: 600
+    targetPort: 0
+#  selector:
+#    app: pachd
+  type: NodePort

--- a/kustomize/base/pach/serviceaccount.yaml
+++ b/kustomize/base/pach/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: ""
+    suite: pachyderm
+  name: pachyderm

--- a/kustomize/base/pach/worker.role.yaml
+++ b/kustomize/base/pach/worker.role.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: ""
+    suite: pachyderm
+  name: pachyderm-worker
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - update
+  - create
+  - delete

--- a/kustomize/base/pach/worker.rolebinding.yaml
+++ b/kustomize/base/pach/worker.rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: ""
+    suite: pachyderm
+  name: pachyderm-worker
+roleRef:
+  apiGroup: ""
+  kind: Role
+  name: pachyderm-worker
+subjects:
+- kind: ServiceAccount
+  name: pachyderm-worker

--- a/kustomize/base/pach/worker.serviceaccount.yaml
+++ b/kustomize/base/pach/worker.serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: ""
+    suite: pachyderm
+  name: pachyderm-worker

--- a/kustomize/overlays/aws/kustomization.yaml
+++ b/kustomize/overlays/aws/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- pach/deployment.yaml

--- a/kustomize/overlays/aws/pach/deployment.yaml
+++ b/kustomize/overlays/aws/pach/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pachd
+spec:
+  template:
+    metadata:
+      annotations:
+        iam.amazonaws.com/role: ""
+    spec:
+      containers:
+        - name: pachd
+          env:
+            - name: STORAGE_BACKEND
+              value: AMAZON
+            - name: AMAZON_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-region
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-bucket
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_ID
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-id
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-secret
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-token
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_VAULT_ADDR
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-vault-addr
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_VAULT_ROLE
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-vault-role
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-vault-token
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: AMAZON_DISTRIBUTION
+              valueFrom:
+                secretKeyRef:
+                  key: amazon-distribution
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: UPLOAD_ACL
+              valueFrom:
+                secretKeyRef:
+                  key: upload-acl
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: REVERSE
+              valueFrom:
+                secretKeyRef:
+                  key: reverse
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: RETRIES
+              valueFrom:
+                secretKeyRef:
+                  key: retries
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  key: timeout
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: PART_SIZE
+              valueFrom:
+                secretKeyRef:
+                  key: part-size
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MAX_UPLOAD_PARTS
+              valueFrom:
+                secretKeyRef:
+                  key: max-upload-parts
+                  name: pachyderm-storage-secret
+                  optional: true

--- a/kustomize/overlays/gcp/dash/kustomization.yaml
+++ b/kustomize/overlays/gcp/dash/kustomization.yaml
@@ -1,0 +1,2 @@
+patchesStrategicMerge:
+  - service.yaml

--- a/kustomize/overlays/gcp/dash/service.yaml
+++ b/kustomize/overlays/gcp/dash/service.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dash
+spec:
+  type: ClusterIP

--- a/kustomize/overlays/gcp/etcd/kustomization.yaml
+++ b/kustomize/overlays/gcp/etcd/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - storageclass.yaml

--- a/kustomize/overlays/gcp/etcd/storageclass.yaml
+++ b/kustomize/overlays/gcp/etcd/storageclass.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  labels:
+    app: etcd
+    suite: pachyderm
+  name: etcd-storage-class
+  namespace: default
+parameters:
+  type: pd-ssd
+provisioner: kubernetes.io/gce-pd

--- a/kustomize/overlays/gcp/kustomization.yaml
+++ b/kustomize/overlays/gcp/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- pach
+- etcd

--- a/kustomize/overlays/gcp/pach/deployment.yaml
+++ b/kustomize/overlays/gcp/pach/deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pachd
+spec:
+  template:
+    spec:
+      containers:
+        - name: pachd
+          env:
+            - name: STORAGE_BACKEND
+              value: GOOGLE
+            - name: GOOGLE_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: google-bucket
+                  name: pachyderm-storage-secret
+            - name: GOOGLE_CRED
+              valueFrom:
+                secretKeyRef:
+                  key: google-cred
+                  name: pachyderm-storage-secret

--- a/kustomize/overlays/gcp/pach/kustomization.yaml
+++ b/kustomize/overlays/gcp/pach/kustomization.yaml
@@ -1,0 +1,8 @@
+patchesStrategicMerge:
+  - deployment.yaml
+
+bases:
+  - ../../../base
+
+resources:
+  - storage.secret.yaml

--- a/kustomize/overlays/gcp/pach/storage.secret.yaml
+++ b/kustomize/overlays/gcp/pach/storage.secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+data:
+  google-bucket: YnVja2V0
+  google-cred: ""
+kind: Secret
+metadata:
+  labels:
+    app: pachyderm-storage-secret
+    suite: pachyderm
+  name: pachyderm-storage-secret

--- a/kustomize/overlays/local/pach/deployment.yaml
+++ b/kustomize/overlays/local/pach/deployment.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pachd
+spec:
+  template:
+    spec:
+      containers:
+        - name: pachd
+          env:
+            - name: STORAGE_BACKEND
+              value: LOCAL
+            - name: STORAGE_HOST_PATH

--- a/kustomize/overlays/microsoft/pach/deployment.yaml
+++ b/kustomize/overlays/microsoft/pach/deployment.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pachd
+spec:
+  template:
+    spec:
+      containers:
+        - name: pachd
+          env:
+            - name: STORAGE_BACKEND
+              value: MICROSOFT
+            - name: MICROSOFT_CONTAINER
+              valueFrom:
+                secretKeyRef:
+                  key: microsoft-container
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MICROSOFT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: microsoft-id
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MICROSOFT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: microsoft-secret
+                  name: pachyderm-storage-secret
+                  optional: true

--- a/kustomize/overlays/minio/pach/deployment.yaml
+++ b/kustomize/overlays/minio/pach/deployment.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pachd
+spec:
+  template:
+    spec:
+      containers:
+        - name: pachd
+          env:
+            - name: STORAGE_BACKEND
+              value: MINIO #Confirm
+            - name: MINIO_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: minio-bucket
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MINIO_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  key: minio-endpoint
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MINIO_ID
+              valueFrom:
+                secretKeyRef:
+                  key: minio-id
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MINIO_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: minio-secret
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MINIO_SECURE
+              valueFrom:
+                secretKeyRef:
+                  key: minio-secure
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: MINIO_SIGNATURE
+              valueFrom:
+                secretKeyRef:
+                  key: minio-signature
+                  name: pachyderm-storage-secret
+                  optional: true
+            - name: CUSTOM_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  key: custom-endpoint
+                  name: pachyderm-storage-secret
+                  optional: true


### PR DESCRIPTION
TODO
- [ ] Figure out how to handle `WORKER_SIDECAR_IMAGE` and `WORKER_IMAGE` (Should match pach version set in kustomize images section
- [ ] How to handle `CLUSTER_DEPLOYMENT_ID`
- [ ] Use secrets handlers to generate storage secret per env?
- [ ] Use kustomize vars to match port names?
- [ ] Set `ClusterIP` as base and set to `NodePort` only for local deployment

- Finish and test
  - [ ] GCP
  - [ ] AWS 
  - [ ] Microsoft
  - [ ] Local
  - [ ] Minio
