### PR TITLE
Include namespace in S3_ENDPOINT in worker

### DIFF
--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -597,7 +597,7 @@
                 "value": "false"
               },
               {
-                "name": "PACHD_POD_NAMESPACE",
+                "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {
                     "apiVersion": "v1",

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -372,7 +372,7 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: PACHD_POD_NAMESPACE
+        - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -581,7 +581,7 @@
                 "value": "false"
               },
               {
-                "name": "PACHD_POD_NAMESPACE",
+                "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {
                     "apiVersion": "v1",

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -360,7 +360,7 @@ spec:
           value: "true"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: PACHD_POD_NAMESPACE
+        - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -597,7 +597,7 @@
                 "value": "false"
               },
               {
-                "name": "PACHD_POD_NAMESPACE",
+                "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {
                     "apiVersion": "v1",

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -372,7 +372,7 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: PACHD_POD_NAMESPACE
+        - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -578,7 +578,7 @@
                 "value": "false"
               },
               {
-                "name": "PACHD_POD_NAMESPACE",
+                "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {
                     "apiVersion": "v1",

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -358,7 +358,7 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: PACHD_POD_NAMESPACE
+        - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1

--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -29,8 +29,6 @@ const (
 	// PPSPipelineNameEnv is the env var that sets the name of the pipeline
 	// that the workers are running.
 	PPSPipelineNameEnv = "PPS_PIPELINE_NAME"
-	// PPSNamespaceEnv is the namespace in which pachyderm is deployed
-	PPSNamespaceEnv = "PPS_NAMESPACE"
 	// PPSJobIDEnv is the env var that sets the ID of the job that the
 	// workers are running (if the workers belong to an orphan job, rather than a
 	// pipeline).

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -619,7 +619,7 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend backend, hostPath strin
 		{Name: "NO_EXPOSE_DOCKER_SOCKET", Value: strconv.FormatBool(opts.NoExposeDockerSocket)},
 		{Name: auth.DisableAuthenticationEnvVar, Value: strconv.FormatBool(opts.DisableAuthentication)},
 		{
-			Name: "PACHD_POD_NAMESPACE",
+			Name: "PACH_NAMESPACE",
 			ValueFrom: &v1.EnvVarSource{
 				FieldRef: &v1.ObjectFieldSelector{
 					APIVersion: "v1",

--- a/src/server/pkg/serviceenv/config.go
+++ b/src/server/pkg/serviceenv/config.go
@@ -18,7 +18,7 @@ type GlobalConfiguration struct {
 	PeerPort      uint16 `env:"PEER_PORT,default=653"`
 	S3GatewayPort uint16 `env:"S3GATEWAY_PORT,default=600"`
 	PPSEtcdPrefix string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
-	Namespace     string `env:"PACHD_POD_NAMESPACE,default=default"`
+	Namespace     string `env:"PACH_NAMESPACE,default=default"`
 	StorageRoot   string `env:"PACH_ROOT,default=/pach"`
 
 	// PPSSpecCommitID is only set for workers and sidecar pachd instances.

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -263,6 +263,53 @@ func TestS3Input(t *testing.T) {
 	})
 }
 
+func TestNamespaceInEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c, _ := initPachClient(t)
+
+	repo := tu.UniqueString(t.Name() + "_data")
+	require.NoError(t, c.CreateRepo(repo))
+
+	_, err := c.PutFile(repo, "master", "foo", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	pipeline := tu.UniqueString("Pipeline")
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline: client.NewPipeline(pipeline),
+		Transform: &pps.Transform{
+			Cmd: []string{"bash", "-x"},
+			Stdin: []string{
+				"echo \"${S3_ENDPOINT}\" >/pfs/out/s3_endpoint",
+			},
+		},
+		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
+		Input: &pps.Input{
+			Pfs: &pps.PFSInput{
+				Name:   "input_repo",
+				Repo:   repo,
+				Branch: "master",
+				S3:     true,
+				Glob:   "/",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	jis, err := c.FlushJobAll([]*pfs.Commit{client.NewCommit(repo, "master")}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(jis))
+	jobInfo := jis[0]
+	require.Equal(t, "JOB_SUCCESS", jobInfo.State.String())
+
+	// check S3_ENDPOINT variable
+	var buf bytes.Buffer
+	c.GetFile(pipeline, "master", "s3_endpoint", 0, 0, &buf)
+	require.True(t, strings.Contains(buf.String(), ".default"))
+}
+
 func TestS3Output(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")

--- a/src/server/worker/api_server.go
+++ b/src/server/worker/api_server.go
@@ -1179,8 +1179,9 @@ func (a *APIServer) userCodeEnv(jobID string, outputCommitID string, data []*Inp
 		// mock a ServiceEnv. Once we can create mock ServiceEnvs, we should store
 		// a ServiceEnv in worker.APIServer, rewrite newTestAPIServer and
 		// NewAPIServer, and then change this code.
-		result = append(result, fmt.Sprintf("S3_ENDPOINT=http://%s:%s",
-			ppsutil.SidecarS3GatewayService(jobID), os.Getenv("S3GATEWAY_PORT")))
+		result = append(result, fmt.Sprintf("S3_ENDPOINT=http://%s.%s:%s",
+			ppsutil.SidecarS3GatewayService(jobID), a.namespace,
+			os.Getenv("S3GATEWAY_PORT")))
 	}
 	return result
 }


### PR DESCRIPTION
Also, remove the `PPS_NAMESPACE` and `PACHD_POD_NAMESPACE` environment variables, which conceptually contain the same information (the former isn't used by Pachyderm, AFAICT, and the latter is used in `serviceenv/config.go` to set `env.Namespace`).

Replace both of these with `PACH_NAMESPACE` and use that to set `env.Namespace`