### PR TITLE
printing commits added to transactions to stdout

### DIFF
--- a/src/server/transaction/cmds/util.go
+++ b/src/server/transaction/cmds/util.go
@@ -78,7 +78,7 @@ func WithActiveTransaction(c *client.APIClient, callback func(*client.APIClient)
 	}
 	err = callback(c)
 	if err == nil && txn != nil {
-		fmt.Fprintf(os.Stderr, "Added to transaction: %s\n", txn.ID)
+		fmt.Fprintf(os.Stdout, "Added to transaction: %s\n", txn.ID)
 	}
 	return err
 }


### PR DESCRIPTION
This isn't an error, it's a status message.  Seems like it should go to stdout rather than stderr.

For example, for [creating a pipeline from stdin](https://github.com/pachyderm/pachyderm/blob/7eeb016f02c72036e17ba27ac778e699f695f9b8/src/server/pkg/ppsutil/decoder.go#L28), pachctl simply prints "Reading from stdin" to stdout. Seems like this is that kind of message.

I only propose this change because I had to jump through minor hoops when setting up testing scripts to make sure spurious output doesn't clog the logs...