### PR TITLE
Support exit command in pachctl shell

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -446,6 +446,11 @@ Environment variables:
 		"default timeout; if set to 0s, the call will never time out.")
 	versionCmd.Flags().AddFlagSet(rawFlags)
 	subcommands = append(subcommands, cmdutil.CreateAlias(versionCmd, "version"))
+	exitCmd := &cobra.Command{
+		Short: "Exit the pachctl shell",
+		Run:   cmdutil.RunFixedArgs(0, func(args []string) error { return nil }),
+	}
+	subcommands = append(subcommands, cmdutil.CreateAlias(exitCmd, "exit"))
 
 	var maxCompletions int64
 	shellCmd := &cobra.Command{

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -447,7 +447,7 @@ Environment variables:
 	versionCmd.Flags().AddFlagSet(rawFlags)
 	subcommands = append(subcommands, cmdutil.CreateAlias(versionCmd, "version"))
 	exitCmd := &cobra.Command{
-		Short: "Exit the pachctl shell",
+		Short: "Exit the pachctl shell.",
 		Run:   cmdutil.RunFixedArgs(0, func(args []string) error { return nil }),
 	}
 	subcommands = append(subcommands, cmdutil.CreateAlias(exitCmd, "exit"))

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -93,6 +93,10 @@ func newShell(rootCmd *cobra.Command, maxCompletions int64) *shell {
 }
 
 func (s *shell) executor(in string) {
+	if in == "exit" {
+		os.Exit(1)
+	}
+
 	cmd := exec.Command("bash")
 	cmd.Stdin = strings.NewReader("pachctl " + in)
 	cmd.Stdout = os.Stdout
@@ -167,6 +171,7 @@ func (s *shell) clearCache() {
 }
 
 func (s *shell) run() {
+	fmt.Printf("Type 'exit' or press Ctrl-D to exit\n")
 	color.NoColor = true // color doesn't work in terminal
 	prompt.New(
 		s.executor,

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -94,7 +94,7 @@ func newShell(rootCmd *cobra.Command, maxCompletions int64) *shell {
 
 func (s *shell) executor(in string) {
 	if in == "exit" {
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	cmd := exec.Command("bash")
@@ -171,7 +171,7 @@ func (s *shell) clearCache() {
 }
 
 func (s *shell) run() {
-	fmt.Printf("Type 'exit' or press Ctrl-D to exit\n")
+	fmt.Printf("Type 'exit' or press Ctrl-D to exit.\n")
 	color.NoColor = true // color doesn't work in terminal
 	prompt.New(
 		s.executor,


### PR DESCRIPTION
- Add a prompt to `pachctl shell` that informs users of how to exit
- Add a command, `exit`, which quits the shell

It would be nice if `exit` didn't show up in the normal CLI help output, but if we mark it `hidden` it also doesn't show up in auto-complete in the shell. I figured it's better to suggest it to users.