### PR TITLE
Add long description for exit command

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -448,6 +448,7 @@ Environment variables:
 	subcommands = append(subcommands, cmdutil.CreateAlias(versionCmd, "version"))
 	exitCmd := &cobra.Command{
 		Short: "Exit the pachctl shell.",
+		Long:  "Exit the pachctl shell.",
 		Run:   cmdutil.RunFixedArgs(0, func(args []string) error { return nil }),
 	}
 	subcommands = append(subcommands, cmdutil.CreateAlias(exitCmd, "exit"))


### PR DESCRIPTION
Fix CI on master by adding a long description for the exit command.