### PR TITLE
Add support for GZIP compression on the wire

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -15,6 +15,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	// Import registers the grpc GZIP encoder
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -240,9 +240,9 @@ func WithDialTimeout(t time.Duration) Option {
 }
 
 // WithGZIPCompression enabled GZIP compression for data on the wire
-func WithGZIPCompression(enabled bool) Option {
+func WithGZIPCompression() Option {
 	return func(settings *clientSettings) error {
-		settings.gzipCompress = enabled
+		settings.gzipCompress = true
 		return nil
 	}
 }

--- a/src/client/pkg/grpcutil/server.go
+++ b/src/client/pkg/grpcutil/server.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"

--- a/src/client/pkg/grpcutil/server.go
+++ b/src/client/pkg/grpcutil/server.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	// Import registers the grpc GZIP decoder
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -783,7 +783,11 @@ $ {{alias}} repo@branch -i http://host/path`,
 			if err != nil {
 				return err
 			}
-			c, err := client.NewOnUserMachine("user", client.WithMaxConcurrentStreams(parallelism), client.WithGZIPCompression(compress))
+			opts := []client.Option{client.WithMaxConcurrentStreams(parallelism)}
+			if compress {
+				opts = append(opts, client.WithGZIPCompression())
+			}
+			c, err := client.NewOnUserMachine("user", opts...)
 			if err != nil {
 				return err
 			}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -734,6 +734,7 @@ from commits with 'get file'.`,
 	var headerRecords uint
 	var putFileCommit bool
 	var overwrite bool
+	var compress bool
 	putFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>[:<path/to/file>]",
 		Short: "Put a file into the filesystem.",
@@ -782,7 +783,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 			if err != nil {
 				return err
 			}
-			c, err := client.NewOnUserMachine("user", client.WithMaxConcurrentStreams(parallelism))
+			c, err := client.NewOnUserMachine("user", client.WithMaxConcurrentStreams(parallelism), client.WithGZIPCompression(compress))
 			if err != nil {
 				return err
 			}
@@ -877,6 +878,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 	putFile.Flags().StringSliceVarP(&filePaths, "file", "f", []string{"-"}, "The file to be put, it can be a local file or a URL.")
 	putFile.Flags().StringVarP(&inputFile, "input-file", "i", "", "Read filepaths or URLs from a file.  If - is used, paths are read from the standard input.")
 	putFile.Flags().BoolVarP(&recursive, "recursive", "r", false, "Recursively put the files in a directory.")
+	putFile.Flags().BoolVarP(&compress, "compress", "", false, "Compress data during upload.")
 	putFile.Flags().IntVarP(&parallelism, "parallelism", "p", DefaultParallelism, "The maximum number of files that can be uploaded in parallel.")
 	putFile.Flags().StringVar(&split, "split", "", "Split the input file into smaller files, subject to the constraints of --target-file-datums and --target-file-bytes. Permissible values are `line`, `json`, `sql` and `csv`.")
 	putFile.Flags().UintVar(&targetFileDatums, "target-file-datums", 0, "The upper bound of the number of datums that each file contains, the last file will contain fewer if the datums don't divide evenly; needs to be used with --split.")


### PR DESCRIPTION
- Registers the GZIP decompressor in pachd, so it can handle GZIP-compressed GRPC requests
- Adds a flag for `pachctl put file` to enable compression in the client for all GRPC calls, default to false

This should let users trade CPU usage for throughput when their data is compressible and bandwidth to pachd is a limiting factor.

TODO:
- Do some testing on a simulated slow link with tc to confirm this improves upload performance with constrained bandwidth.
