### PR TITLE
Make PutFile parallelism configurable in pachd

### DIFF
--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -920,6 +920,10 @@
               {
                 "name": "STORAGE_UPLOAD_CONCURRENCY_LIMIT",
                 "value": "100"
+              },
+              {
+                "name": "STORAGE_PUT_FILE_CONCURRENCY_LIMIT",
+                "value": "100"
               }
             ],
             "resources": {

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -565,6 +565,8 @@ spec:
               optional: true
         - name: STORAGE_UPLOAD_CONCURRENCY_LIMIT
           value: "100"
+        - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
+          value: "100"
         image: pachyderm/pachd:1.10.0
         imagePullPolicy: IfNotPresent
         name: pachd

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -904,6 +904,10 @@
               {
                 "name": "STORAGE_UPLOAD_CONCURRENCY_LIMIT",
                 "value": "100"
+              },
+              {
+                "name": "STORAGE_PUT_FILE_CONCURRENCY_LIMIT",
+                "value": "100"
               }
             ],
             "resources": {

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -553,6 +553,8 @@ spec:
               optional: true
         - name: STORAGE_UPLOAD_CONCURRENCY_LIMIT
           value: "100"
+        - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
+          value: "100"
         image: pachyderm/pachd:1.10.0
         imagePullPolicy: IfNotPresent
         name: pachd

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -920,6 +920,10 @@
               {
                 "name": "STORAGE_UPLOAD_CONCURRENCY_LIMIT",
                 "value": "100"
+              },
+              {
+                "name": "STORAGE_PUT_FILE_CONCURRENCY_LIMIT",
+                "value": "100"
               }
             ],
             "resources": {

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -565,6 +565,8 @@ spec:
               optional: true
         - name: STORAGE_UPLOAD_CONCURRENCY_LIMIT
           value: "100"
+        - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
+          value: "100"
         image: pachyderm/pachd:1.10.0
         imagePullPolicy: IfNotPresent
         name: pachd

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -901,6 +901,10 @@
               {
                 "name": "STORAGE_UPLOAD_CONCURRENCY_LIMIT",
                 "value": "100"
+              },
+              {
+                "name": "STORAGE_PUT_FILE_CONCURRENCY_LIMIT",
+                "value": "100"
               }
             ],
             "resources": {

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -551,6 +551,8 @@ spec:
               optional: true
         - name: STORAGE_UPLOAD_CONCURRENCY_LIMIT
           value: "100"
+        - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
+          value: "100"
         image: pachyderm/pachd:1.10.0
         imagePullPolicy: IfNotPresent
         name: pachd

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -4501,7 +4501,7 @@ func (s *putFileServer) Peek() (*pfs.PutFileRequest, error) {
 }
 
 func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_PutFileServer, f func(*pfs.PutFileRequest, io.Reader) error) (oneOff bool, repo string, branch string, err error) {
-	limiter := limit.New(client.DefaultMaxConcurrentStreams)
+	limiter := limit.New(d.env.StorageUploadConcurrencyLimit)
 	var pr *io.PipeReader
 	var pw *io.PipeWriter
 	var req *pfs.PutFileRequest

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -112,6 +112,8 @@ type driver struct {
 	memoryLimiter *semaphore.Weighted
 	// put object limiter (useful for limiting put object requests)
 	putObjectLimiter limit.ConcurrencyLimiter
+	// download limiter (useful for limiting parallel downloads from blob stores)
+	downloadLimiter limit.ConcurrencyLimiter
 
 	// New storage layer.
 	storage         *fileset.Storage
@@ -154,6 +156,7 @@ func newDriver(
 		// Allow up to a third of the requested memory to be used for memory intensive operations
 		memoryLimiter:    semaphore.NewWeighted(memoryRequest / 3),
 		putObjectLimiter: limit.New(env.StorageUploadConcurrencyLimit),
+		downloadLimiter:  limit.New(env.StorageDownloadConcurrencyLimit),
 	}
 
 	// Create spec repo (default repo)
@@ -4501,7 +4504,6 @@ func (s *putFileServer) Peek() (*pfs.PutFileRequest, error) {
 }
 
 func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_PutFileServer, f func(*pfs.PutFileRequest, io.Reader) error) (oneOff bool, repo string, branch string, err error) {
-	limiter := limit.New(d.env.StorageUploadConcurrencyLimit)
 	var pr *io.PipeReader
 	var pw *io.PipeWriter
 	var req *pfs.PutFileRequest
@@ -4573,7 +4575,7 @@ func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_Put
 				case "http":
 					fallthrough
 				case "https":
-					limiter.Acquire()
+					d.downloadLimiter.Acquire()
 					resp, err := http.Get(req.Url)
 					if err != nil {
 						return false, "", "", err
@@ -4581,7 +4583,7 @@ func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_Put
 						return false, "", "", errors.Errorf("error retrieving content from %q: %s", req.Url, resp.Status)
 					}
 					eg.Go(func() (retErr error) {
-						defer limiter.Release()
+						defer d.downloadLimiter.Release()
 						defer func() {
 							if err := resp.Body.Close(); err != nil && retErr == nil {
 								retErr = err
@@ -4609,13 +4611,13 @@ func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_Put
 							}
 							req := *req // copy req so we can make changes
 							req.File = client.NewFile(req.File.Commit.Repo.Name, req.File.Commit.ID, filepath.Join(req.File.Path, strings.TrimPrefix(name, path)))
-							limiter.Acquire()
+							d.downloadLimiter.Acquire()
 							r, err := objClient.Reader(server.Context(), name, 0, 0)
 							if err != nil {
 								return err
 							}
 							eg.Go(func() (retErr error) {
-								defer limiter.Release()
+								defer d.downloadLimiter.Release()
 								defer func() {
 									if err := r.Close(); err != nil && retErr == nil {
 										retErr = err
@@ -4628,13 +4630,13 @@ func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_Put
 							return false, "", "", err
 						}
 					} else {
-						limiter.Acquire()
+						d.downloadLimiter.Acquire()
 						r, err := objClient.Reader(server.Context(), url.Object, 0, 0)
 						if err != nil {
 							return false, "", "", err
 						}
 						eg.Go(func() (retErr error) {
-							defer limiter.Release()
+							defer d.downloadLimiter.Release()
 							defer func() {
 								if err := r.Close(); err != nil && retErr == nil {
 									retErr = err
@@ -4652,9 +4654,9 @@ func (d *driver) forEachPutFile(pachClient *client.APIClient, server pfs.API_Put
 			}
 			pr, pw = io.Pipe()
 			pr := pr
-			limiter.Acquire()
+			d.downloadLimiter.Acquire()
 			eg.Go(func() error {
-				defer limiter.Release()
+				defer d.downloadLimiter.Release()
 				if err := f(req, pr); err != nil {
 					// needed so the parent goroutine doesn't block
 					pr.CloseWithError(err)

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -139,6 +139,9 @@ type FeatureFlags struct {
 const (
 	// UploadConcurrencyLimitEnvVar is the environment variable for the upload concurrency limit.
 	UploadConcurrencyLimitEnvVar = "STORAGE_UPLOAD_CONCURRENCY_LIMIT"
+
+	// DownloadConcurrencyLimitEnvVar is the environemnt variable for the download concurrency limit.
+	DownloadConcurrencyLimitEnvVar = "STORAGE_DOWNLOAD_CONCURRENCY_LIMIT"
 )
 
 const (
@@ -146,11 +149,15 @@ const (
 	// (bryce) this default is set here and in the service env config, need to figure out how to refactor
 	// this to be in one place.
 	DefaultUploadConcurrencyLimit = 100
+
+	// DefaultUploadConcurrencyLimit is the default maximum number of concurrent object downloads.
+	DefaultDownloadConcurrencyLimit = 100
 )
 
 // StorageOpts are options that are applicable to the storage layer.
 type StorageOpts struct {
-	UploadConcurrencyLimit int
+	UploadConcurrencyLimit   int
+	DownloadConcurrencyLimit int
 }
 
 const (
@@ -528,6 +535,7 @@ func GetSecretEnvVars(storageBackend string) []v1.EnvVar {
 func getStorageEnvVars(opts *AssetOpts) []v1.EnvVar {
 	return []v1.EnvVar{
 		{Name: UploadConcurrencyLimitEnvVar, Value: strconv.Itoa(opts.StorageOpts.UploadConcurrencyLimit)},
+		{Name: DownloadConcurrencyLimitEnvVar, Value: strconv.Itoa(opts.StorageOpts.DownloadConcurrencyLimit)},
 	}
 }
 

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -140,8 +140,8 @@ const (
 	// UploadConcurrencyLimitEnvVar is the environment variable for the upload concurrency limit.
 	UploadConcurrencyLimitEnvVar = "STORAGE_UPLOAD_CONCURRENCY_LIMIT"
 
-	// DownloadConcurrencyLimitEnvVar is the environemnt variable for the download concurrency limit.
-	DownloadConcurrencyLimitEnvVar = "STORAGE_DOWNLOAD_CONCURRENCY_LIMIT"
+	// PutFileConcurrencyLimitEnvVar is the environemnt variable for the PutFile concurrency limit.
+	PutFileConcurrencyLimitEnvVar = "STORAGE_PUT_FILE_CONCURRENCY_LIMIT"
 )
 
 const (
@@ -150,14 +150,14 @@ const (
 	// this to be in one place.
 	DefaultUploadConcurrencyLimit = 100
 
-	// DefaultUploadConcurrencyLimit is the default maximum number of concurrent object downloads.
-	DefaultDownloadConcurrencyLimit = 100
+	// DefaultPutFileConcurrencyLimit is the default maximum number of concurrent files that can be uploaded over GRPC or downloaded from external sources (ex. HTTP or blob storage).
+	DefaultPutFileConcurrencyLimit = 100
 )
 
 // StorageOpts are options that are applicable to the storage layer.
 type StorageOpts struct {
-	UploadConcurrencyLimit   int
-	DownloadConcurrencyLimit int
+	UploadConcurrencyLimit  int
+	PutFileConcurrencyLimit int
 }
 
 const (
@@ -535,7 +535,7 @@ func GetSecretEnvVars(storageBackend string) []v1.EnvVar {
 func getStorageEnvVars(opts *AssetOpts) []v1.EnvVar {
 	return []v1.EnvVar{
 		{Name: UploadConcurrencyLimitEnvVar, Value: strconv.Itoa(opts.StorageOpts.UploadConcurrencyLimit)},
-		{Name: DownloadConcurrencyLimitEnvVar, Value: strconv.Itoa(opts.StorageOpts.DownloadConcurrencyLimit)},
+		{Name: PutFileConcurrencyLimitEnvVar, Value: strconv.Itoa(opts.StorageOpts.PutFileConcurrencyLimit)},
 	}
 }
 

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -140,7 +140,7 @@ const (
 	// UploadConcurrencyLimitEnvVar is the environment variable for the upload concurrency limit.
 	UploadConcurrencyLimitEnvVar = "STORAGE_UPLOAD_CONCURRENCY_LIMIT"
 
-	// PutFileConcurrencyLimitEnvVar is the environemnt variable for the PutFile concurrency limit.
+	// PutFileConcurrencyLimitEnvVar is the environment variable for the PutFile concurrency limit.
 	PutFileConcurrencyLimitEnvVar = "STORAGE_PUT_FILE_CONCURRENCY_LIMIT"
 )
 

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -284,7 +284,7 @@ func standardDeployCmds() []*cobra.Command {
 	var registry string
 	var tlsCertKey string
 	var uploadConcurrencyLimit int
-	var downloadConcurrencyLimit int
+	var putFileConcurrencyLimit int
 	var clusterDeploymentID string
 	var requireCriticalServersOnly bool
 	appendGlobalFlags := func(cmd *cobra.Command) {
@@ -309,7 +309,7 @@ func standardDeployCmds() []*cobra.Command {
 		cmd.Flags().StringVar(&tlsCertKey, "tls", "", "string of the form \"<cert path>,<key path>\" of the signed TLS certificate and private key that Pachd should use for TLS authentication (enables TLS-encrypted communication with Pachd)")
 		cmd.Flags().BoolVar(&newStorageLayer, "new-storage-layer", false, "(feature flag) Do not set, used for testing.")
 		cmd.Flags().IntVar(&uploadConcurrencyLimit, "upload-concurrency-limit", assets.DefaultUploadConcurrencyLimit, "The maximum number of concurrent object storage uploads per Pachd instance.")
-		cmd.Flags().IntVar(&downloadConcurrencyLimit, "download-concurrency-limit", assets.DefaultDownloadConcurrencyLimit, "The maximum number of concurrent objects to fetch from remote sources (HTTP, blob storage) at a time.")
+		cmd.Flags().IntVar(&putFileConcurrencyLimit, "put-file-concurrency-limit", assets.DefaultPutFileConcurrencyLimit, "The maximum number of files to upload or fetch from remote sources (HTTP, blob storage) using PutFile concurrently.")
 		cmd.Flags().StringVar(&clusterDeploymentID, "cluster-deployment-id", "", "Set an ID for the cluster deployment. Defaults to a random value.")
 		cmd.Flags().BoolVar(&requireCriticalServersOnly, "require-critical-servers-only", assets.DefaultRequireCriticalServersOnly, "Only require the critical Pachd servers to startup and run without errors.")
 
@@ -390,8 +390,8 @@ func standardDeployCmds() []*cobra.Command {
 				NewStorageLayer: newStorageLayer,
 			},
 			StorageOpts: assets.StorageOpts{
-				UploadConcurrencyLimit:   uploadConcurrencyLimit,
-				DownloadConcurrencyLimit: downloadConcurrencyLimit,
+				UploadConcurrencyLimit:  uploadConcurrencyLimit,
+				PutFileConcurrencyLimit: putFileConcurrencyLimit,
 			},
 			PachdShards:                uint64(pachdShards),
 			Version:                    version.PrettyPrintVersion(version.Version),

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -284,6 +284,7 @@ func standardDeployCmds() []*cobra.Command {
 	var registry string
 	var tlsCertKey string
 	var uploadConcurrencyLimit int
+	var downloadConcurrencyLimit int
 	var clusterDeploymentID string
 	var requireCriticalServersOnly bool
 	appendGlobalFlags := func(cmd *cobra.Command) {
@@ -308,6 +309,7 @@ func standardDeployCmds() []*cobra.Command {
 		cmd.Flags().StringVar(&tlsCertKey, "tls", "", "string of the form \"<cert path>,<key path>\" of the signed TLS certificate and private key that Pachd should use for TLS authentication (enables TLS-encrypted communication with Pachd)")
 		cmd.Flags().BoolVar(&newStorageLayer, "new-storage-layer", false, "(feature flag) Do not set, used for testing.")
 		cmd.Flags().IntVar(&uploadConcurrencyLimit, "upload-concurrency-limit", assets.DefaultUploadConcurrencyLimit, "The maximum number of concurrent object storage uploads per Pachd instance.")
+		cmd.Flags().IntVar(&downloadConcurrencyLimit, "download-concurrency-limit", assets.DefaultDownloadConcurrencyLimit, "The maximum number of concurrent objects to fetch from remote sources (HTTP, blob storage) at a time.")
 		cmd.Flags().StringVar(&clusterDeploymentID, "cluster-deployment-id", "", "Set an ID for the cluster deployment. Defaults to a random value.")
 		cmd.Flags().BoolVar(&requireCriticalServersOnly, "require-critical-servers-only", assets.DefaultRequireCriticalServersOnly, "Only require the critical Pachd servers to startup and run without errors.")
 
@@ -388,7 +390,8 @@ func standardDeployCmds() []*cobra.Command {
 				NewStorageLayer: newStorageLayer,
 			},
 			StorageOpts: assets.StorageOpts{
-				UploadConcurrencyLimit: uploadConcurrencyLimit,
+				UploadConcurrencyLimit:   uploadConcurrencyLimit,
+				DownloadConcurrencyLimit: downloadConcurrencyLimit,
 			},
 			PachdShards:                uint64(pachdShards),
 			Version:                    version.PrettyPrintVersion(version.Version),

--- a/src/server/pkg/serviceenv/config.go
+++ b/src/server/pkg/serviceenv/config.go
@@ -67,13 +67,14 @@ type PachdSpecificConfiguration struct {
 
 // StorageConfiguration contains the storage configuration.
 type StorageConfiguration struct {
-	StorageMemoryThreshold        int64  `env:"STORAGE_MEMORY_THRESHOLD"`
-	StorageShardThreshold         int64  `env:"STORAGE_SHARD_THRESHOLD"`
-	StorageLevelZeroSize          int64  `env:"STORAGE_LEVEL_ZERO_SIZE"`
-	StorageLevelSizeBase          int    `env:"STORAGE_LEVEL_SIZE_BASE"`
-	StorageUploadConcurrencyLimit int    `env:"STORAGE_UPLOAD_CONCURRENCY_LIMIT,default=100"`
-	StorageGCPolling              string `env:"STORAGE_GC_POLLING"`
-	StorageGCTimeout              string `env:"STORAGE_GC_TIMEOUT"`
+	StorageMemoryThreshold          int64  `env:"STORAGE_MEMORY_THRESHOLD"`
+	StorageShardThreshold           int64  `env:"STORAGE_SHARD_THRESHOLD"`
+	StorageLevelZeroSize            int64  `env:"STORAGE_LEVEL_ZERO_SIZE"`
+	StorageLevelSizeBase            int    `env:"STORAGE_LEVEL_SIZE_BASE"`
+	StorageUploadConcurrencyLimit   int    `env:"STORAGE_UPLOAD_CONCURRENCY_LIMIT,default=100"`
+	StorageDownloadConcurrencyLimit int    `env:"STORAGE_DOWNLOAD_CONCURRENCY_LIMIT,default=100"`
+	StorageGCPolling                string `env:"STORAGE_GC_POLLING"`
+	StorageGCTimeout                string `env:"STORAGE_GC_TIMEOUT"`
 }
 
 // WorkerFullConfiguration contains the full worker configuration.

--- a/src/server/pkg/serviceenv/config.go
+++ b/src/server/pkg/serviceenv/config.go
@@ -67,14 +67,14 @@ type PachdSpecificConfiguration struct {
 
 // StorageConfiguration contains the storage configuration.
 type StorageConfiguration struct {
-	StorageMemoryThreshold          int64  `env:"STORAGE_MEMORY_THRESHOLD"`
-	StorageShardThreshold           int64  `env:"STORAGE_SHARD_THRESHOLD"`
-	StorageLevelZeroSize            int64  `env:"STORAGE_LEVEL_ZERO_SIZE"`
-	StorageLevelSizeBase            int    `env:"STORAGE_LEVEL_SIZE_BASE"`
-	StorageUploadConcurrencyLimit   int    `env:"STORAGE_UPLOAD_CONCURRENCY_LIMIT,default=100"`
-	StorageDownloadConcurrencyLimit int    `env:"STORAGE_DOWNLOAD_CONCURRENCY_LIMIT,default=100"`
-	StorageGCPolling                string `env:"STORAGE_GC_POLLING"`
-	StorageGCTimeout                string `env:"STORAGE_GC_TIMEOUT"`
+	StorageMemoryThreshold         int64  `env:"STORAGE_MEMORY_THRESHOLD"`
+	StorageShardThreshold          int64  `env:"STORAGE_SHARD_THRESHOLD"`
+	StorageLevelZeroSize           int64  `env:"STORAGE_LEVEL_ZERO_SIZE"`
+	StorageLevelSizeBase           int    `env:"STORAGE_LEVEL_SIZE_BASE"`
+	StorageUploadConcurrencyLimit  int    `env:"STORAGE_UPLOAD_CONCURRENCY_LIMIT,default=100"`
+	StoragePutFileConcurrencyLimit int    `env:"STORAGE_PUT_FILE_CONCURRENCY_LIMIT,default=100"`
+	StorageGCPolling               string `env:"STORAGE_GC_POLLING"`
+	StorageGCTimeout               string `env:"STORAGE_GC_TIMEOUT"`
 }
 
 // WorkerFullConfiguration contains the full worker configuration.


### PR DESCRIPTION
When a user does a recursive PutFile on a dataset in blob storage, we currently hard-code the parallelism to 100. For datasets with many large files this can cause pachd to OOM. We could expose this as an environment variable, but the desired parallelism is dependent on cluster config and on the shape of the dataset (many small files may benefit from more parallelism. This exposes an option in the PutFile RPC to tune the parallelism of each PutFile individually.

This may not be necessary because we can also tune the `STORAGE_UPLOAD_CONCURRENCY` to get a similar result.