### PR TITLE
Periodically reload TLS certificate from disk

### DIFF
--- a/src/client/pkg/grpcutil/cert_loader.go
+++ b/src/client/pkg/grpcutil/cert_loader.go
@@ -1,0 +1,79 @@
+package grpcutil
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// certLoader provides simple hot TLS certificate reloading by checking for a renewed certificate at a configurable interval
+type certLoader struct {
+	certPath        string
+	keyPath         string
+	refreshInterval time.Duration
+
+	// cert is the current cached *tls.Certificate. It should only be accessed with atomic methods because it may be updated by the cert reloading routine.
+	cert     unsafe.Pointer
+	stopChan chan interface{}
+}
+
+func newCertLoader(certPath, keyPath string, refreshInterval time.Duration) *certLoader {
+	return &certLoader{
+		certPath:        certPath,
+		keyPath:         keyPath,
+		refreshInterval: refreshInterval,
+	}
+}
+
+// loadAndStart ensures the current TLS certificate is loaded and starts the reload routine to poll for renewed certificates
+func (l *certLoader) loadAndStart() error {
+	if err := l.loadCertificate(); err != nil {
+		return err
+	}
+	go l.reloadRoutine()
+	return nil
+}
+
+// stop signals the reloading routine to stop
+func (l *certLoader) stop() {
+	close(l.stopChan)
+}
+
+// getCertificate gets the currently cached certificate and fulfills
+func (l *certLoader) getCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	certPtr := atomic.LoadPointer(&l.cert)
+	cert := (*tls.Certificate)(certPtr)
+	if cert == nil {
+		return nil, fmt.Errorf("No cached TLS certificate available")
+	}
+	return cert, nil
+}
+
+func (l *certLoader) reloadRoutine() {
+	t := time.NewTicker(l.refreshInterval)
+	select {
+	case <-t.C:
+		err := l.loadCertificate()
+		if err != nil {
+			log.Error("Unable to load TLS certificate", err)
+		}
+	case <-l.stopChan:
+		return
+	}
+}
+
+func (l *certLoader) loadCertificate() error {
+	log.Debugf("Reloading TLS keypair - %q %q", l.certPath, l.keyPath)
+	cert, err := tls.LoadX509KeyPair(l.certPath, l.keyPath)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to load keypair")
+	}
+	atomic.StorePointer(&l.cert, unsafe.Pointer(&cert))
+	return nil
+}

--- a/src/client/pkg/tls/cert_loader.go
+++ b/src/client/pkg/tls/cert_loader.go
@@ -63,14 +63,16 @@ func (l *CertLoader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, e
 
 func (l *CertLoader) reloadRoutine() {
 	t := time.NewTicker(l.refreshInterval)
-	select {
-	case <-t.C:
-		err := l.loadCertificate()
-		if err != nil {
-			log.Error("Unable to load TLS certificate", err)
+	for {
+		select {
+		case <-t.C:
+			err := l.loadCertificate()
+			if err != nil {
+				log.Error("Unable to load TLS certificate", err)
+			}
+		case <-l.stopChan:
+			return
 		}
-	case <-l.stopChan:
-		return
 	}
 }
 

--- a/src/client/pkg/tls/cert_loader.go
+++ b/src/client/pkg/tls/cert_loader.go
@@ -24,6 +24,7 @@ type CertLoader struct {
 	stopped  bool
 }
 
+// NewCertLoader creates a new CertLoader to refresh the specified TLS key at a fixed interval
 func NewCertLoader(certPath, keyPath string, refreshInterval time.Duration) *CertLoader {
 	return &CertLoader{
 		certPath:        certPath,

--- a/src/client/pkg/tls/cert_loader.go
+++ b/src/client/pkg/tls/cert_loader.go
@@ -56,7 +56,7 @@ func (l *CertLoader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, e
 	certPtr := atomic.LoadPointer(&l.cert)
 	cert := (*tls.Certificate)(certPtr)
 	if cert == nil {
-		return nil, fmt.Errorf("No cached TLS certificate available")
+		return nil, fmt.Errorf("no cached TLS certificate available")
 	}
 	return cert, nil
 }
@@ -80,7 +80,7 @@ func (l *CertLoader) loadCertificate() error {
 	log.Debugf("Reloading TLS keypair - %q %q", l.certPath, l.keyPath)
 	cert, err := tls.LoadX509KeyPair(l.certPath, l.keyPath)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to load keypair")
+		return errors.Wrapf(err, "unable to load keypair")
 	}
 	atomic.StorePointer(&l.cert, unsafe.Pointer(&cert))
 	return nil

--- a/src/client/pkg/tls/tls.go
+++ b/src/client/pkg/tls/tls.go
@@ -3,6 +3,7 @@ package tls
 import (
 	"os"
 	"path"
+	"time"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 )
@@ -19,6 +20,9 @@ const (
 	// KeyFile is the name of the mounted file containing a private key
 	// corresponding to the public certificate in TLSCertFile
 	KeyFile = "tls.key"
+
+	// CertCheckFrequency is how often we check for a renewed TLS certificate
+	CertCheckFrequency = time.Hour
 )
 
 // GetCertPaths gets the paths to the cert and key files within a cluster

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -694,6 +694,13 @@ func doFullMode(config interface{}) (retErr error) {
 			log.Warnf("s3gateway TLS disabled: %v", err)
 			return server.ListenAndServe()
 		}
+		// Read TLS cert and key
+		err := cLoader.LoadAndStart()
+		if err != nil {
+			return errors.Wrapf(err, "couldn't load TLS cert for s3gateway: %v", err)
+		}
+		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
+		server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
 		return server.ListenAndServeTLS(certPath, keyPath)
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gotls "crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -694,12 +695,12 @@ func doFullMode(config interface{}) (retErr error) {
 			log.Warnf("s3gateway TLS disabled: %v", err)
 			return server.ListenAndServe()
 		}
+		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
 		// Read TLS cert and key
-		err := cLoader.LoadAndStart()
+		err = cLoader.LoadAndStart()
 		if err != nil {
 			return errors.Wrapf(err, "couldn't load TLS cert for s3gateway: %v", err)
 		}
-		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
 		server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
 		return server.ListenAndServeTLS(certPath, keyPath)
 	})


### PR DESCRIPTION
When we're terminating TLS directly at the pachd pod, we want to load new TLS certificates without bouncing every pod. This PR adds a simple routine to reload the TLS cert every hour. Incoming connections will handshake with whatever version of the cert is currently cached, and won't be dropped when a new cert is loaded.

A likely case would be to use cert-manager to do the DNS challenge and put the certificate in a secret. This secret would be mounted as a volume in the pachd container and the updated secret will propagate to all pods over time without restarting.

Alternatives considered:
- inotify to detect new certificates
- fancier logic for polling based on certificate expiration time

Overall this design is simple and meets our needs, it seems like a premature optimization to try and reduce how often we reload the cert since it already happens very infrequently.
