### PR TITLE
fix metrics crash

### DIFF
--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -30,9 +30,9 @@ type Reporter struct {
 func NewReporter(clusterID string, env *serviceenv.ServiceEnv) *Reporter {
 	var r *router
 	if env.MetricsEndpoint != "" {
-		newRouter(env.MetricsEndpoint)
+		r = newRouter(env.MetricsEndpoint)
 	} else {
-		newRouter()
+		r = newRouter()
 	}
 	reporter := &Reporter{
 		router:    r,


### PR DESCRIPTION
I noticed my pipeline nodes were crash looping occasionally, looks like an uninitialized field.