### PR TITLE
Confirm deploy for unstable builds

### DIFF
--- a/src/client/version/client.go
+++ b/src/client/version/client.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"strings"
 
 	pb "github.com/pachyderm/pachyderm/src/client/version/versionpb"
 )
@@ -31,6 +32,11 @@ var (
 		Additional: AdditionalVersion,
 	}
 )
+
+// IsUnstable will return true for alpha or beta builds, and false otherwise.
+func IsUnstable() bool {
+	return strings.Contains(Version.Additional, "beta") || strings.Contains(Version.Additional, "alpha")
+}
 
 // PrettyPrintVersion returns a version string optionally tagged with metadata.
 // For example: "1.2.3", or "1.2.3rc1" if version.Additional is "rc1".

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -505,20 +504,16 @@ This resets the cluster to its initial state.`,
 			if len(pipelines) > 0 {
 				fmt.Printf("Pipelines to delete: %s\n", strings.Join(pipelines, ", "))
 			}
-			fmt.Println("Are you sure you want to do this? (y/n):")
-			r := bufio.NewReader(os.Stdin)
-			bytes, err := r.ReadBytes('\n')
-			if err != nil {
+			if ok, err := cmdutil.InteractiveConfirm(); err != nil {
+				return err
+			} else if !ok {
+				return nil
+			}
+
+			if err := client.DeleteAll(); err != nil {
 				return err
 			}
-			if bytes[0] == 'y' || bytes[0] == 'Y' {
-				err = client.DeleteAll()
-				if err != nil {
-					return err
-				}
-				return txncmds.ClearActiveTransaction()
-			}
-			return nil
+			return txncmds.ClearActiveTransaction()
 		}),
 	}
 	subcommands = append(subcommands, cmdutil.CreateAlias(deleteAll, "delete all"))

--- a/src/server/pkg/cmdutil/util.go
+++ b/src/server/pkg/cmdutil/util.go
@@ -1,0 +1,21 @@
+package cmdutil
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// InteractiveConfirm will ask the user to confirm an action on the command-line with a y/n response.
+func InteractiveConfirm() (bool, error) {
+	fmt.Printf("Are you sure you want to do this? (y/n): ")
+	r := bufio.NewReader(os.Stdin)
+	bytes, err := r.ReadBytes('\n')
+	if err != nil {
+		return false, err
+	}
+	if bytes[0] == 'y' || bytes[0] == 'Y' {
+		return true, nil
+	}
+	return false, nil
+}

--- a/src/server/pkg/deploy/cmds/cmds_test.go
+++ b/src/server/pkg/deploy/cmds/cmds_test.go
@@ -88,5 +88,4 @@ func TestStripS3Prefix(t *testing.T) {
 			return // done--success
 		}
 	}
-	t.Fatalf("could not find storage secret in kubernetes manifest")
 }


### PR DESCRIPTION
Adds a `y/n` confirmation to `pachctl` deploy commands when the version is an alpha or beta build, alongside a scary warning.  Also moved the `y/n` confirmation code into a common package because this is the third place to use it.