### PR TITLE
Fix ListDatum when called on a running job

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1041,8 +1041,17 @@ func (a *apiServer) listDatum(pachClient *client.APIClient, job *pps.Job, page, 
 	if err != nil {
 		return nil, err
 	}
-	// If there's no stats commit (job not finished), compute datums using jobInfo
-	if jobInfo.StatsCommit == nil {
+
+	var statsCommitInfo *pfs.CommitInfo
+	if jobInfo.StatsCommit != nil {
+		statsCommitInfo, err = pachClient.InspectCommit(jobInfo.StatsCommit.Repo.Name, jobInfo.StatsCommit.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// If the stats commit is not closed, compute datums using jobInfo
+	if statsCommitInfo == nil || statsCommitInfo.Finished == nil {
 		start := 0
 		end := df.Len()
 		if pageSize > 0 {
@@ -1074,7 +1083,7 @@ func (a *apiServer) listDatum(pachClient *client.APIClient, job *pps.Job, page, 
 		return response, nil
 	}
 
-	// There is a stats commit -- job is finished
+	// The stats commit is closed -- job is finished
 	// List the files under / in the stats branch to get all the datums
 	file := &pfs.File{
 		Commit: jobInfo.StatsCommit,


### PR DESCRIPTION
`ListDatum` currently checks if a stats commit is set on the job to tell if it is currently running.  This is not a thing.  This PR changes the call to check if the stats commit has been closed to see if that data can be used, otherwise it falls back on the existing code which is to construct a list of datums from the job's datum iterator.