### PR TITLE
start-minikube-vm script should work when GOPATH is not set.

### DIFF
--- a/etc/kube/start-minikube-vm.sh
+++ b/etc/kube/start-minikube-vm.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-cd "${GOPATH}/src/github.com/pachyderm/pachyderm"
+# only cd if go.mod is not found
+if [ ! -f "go.mod" ]; then
+  cd "${GOPATH}/src/github.com/pachyderm/pachyderm"
+fi
 
 function die {
   echo "error: $1" >&2


### PR DESCRIPTION
The `start-minikube-vm` script does not work unless a GOPATH is set.

If GOPATH is not set it defaults to $HOME/go.  Since Go modules allows building code outside GOPATH many developers do not set this.

It looks like this script just uses GOPATH to make sure it is at the root of the repository before running. Checking for the existence of `go.mod` seems like a reasonable heuristic.