### PR TITLE
Limit fan-In during compaction.

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -156,6 +156,7 @@ func newDriver(
 		memoryLimiter:    semaphore.NewWeighted(memoryRequest / 3),
 		putObjectLimiter: limit.New(env.StorageUploadConcurrencyLimit),
 		putFileLimiter:   limit.New(env.StoragePutFileConcurrencyLimit),
+		// TODO: set maxFanIn based on downward API.
 	}
 
 	// Create spec repo (default repo)

--- a/src/server/pkg/serviceenv/config.go
+++ b/src/server/pkg/serviceenv/config.go
@@ -75,6 +75,7 @@ type StorageConfiguration struct {
 	StoragePutFileConcurrencyLimit int    `env:"STORAGE_PUT_FILE_CONCURRENCY_LIMIT,default=100"`
 	StorageGCPolling               string `env:"STORAGE_GC_POLLING"`
 	StorageGCTimeout               string `env:"STORAGE_GC_TIMEOUT"`
+	StorageCompactionMaxFanIn      int    `env:"STORAGE_COMPACTION_MAX_FANIN"`
 }
 
 // WorkerFullConfiguration contains the full worker configuration.


### PR DESCRIPTION
Limits the number of objects that are open at a time during compact.  Adds a configurable `StorageCompactFanIn` parameter.

The workers will never have to open more than the fan-in value.  The master may need to compact more than fan-in filesets at once, but they will be well clustered because of a previous sharded compaction, and they can be concatenated while maintaining a correct ordering of keys in the final output. During concatenation only one fileset needs to be read from at a time.

Closes #4857