### PR TITLE
deploy/assets: Set allowVolumeExpansion on StorageClass

### DIFF
--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -990,6 +990,7 @@ func makeStorageClass(
 			"labels":    storageClassLabels,
 			"namespace": opts.Namespace,
 		},
+		"allowVolumeExpansion": true,
 	}
 	switch backend {
 	case googleBackend:


### PR DESCRIPTION
As far as I know, there's no negative consequence of doing this and this feature has been around since Kubernetes 1.11.

This just allows resizing a persistent disk without recreating.

More information: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims