### PR TITLE
Fix duplicate datums in stats commit when retries occurred

### DIFF
--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -396,10 +396,10 @@ func processDatum(
 		return stats, recoveredDatumTags, nil
 	}
 
+	statsRoot := path.Join("/", datumID)
 	var inputTree, outputTree *hashtree.Ordered
 	var statsTree *hashtree.Unordered
 	if driver.PipelineInfo().EnableStats {
-		statsRoot := path.Join("/", datumID)
 		inputTree = hashtree.NewOrdered(path.Join(statsRoot, "pfs"))
 		outputTree = hashtree.NewOrdered(path.Join(statsRoot, "pfs", "out"))
 		statsTree = hashtree.NewUnordered(statsRoot)
@@ -492,6 +492,11 @@ func processDatum(
 				}
 			}
 			return err
+		}
+		// If stats is enabled, reset input and output tree on retry.
+		if statsTree != nil {
+			inputTree = hashtree.NewOrdered(path.Join(statsRoot, "pfs"))
+			outputTree = hashtree.NewOrdered(path.Join(statsRoot, "pfs", "out"))
 		}
 		logger.Logf("failed processing datum: %v, retrying in %v", err, d)
 		return nil


### PR DESCRIPTION
This should fix an issue that causes datums to appear more than once in the stats commit. If a datum gets retried, then we need to clear the state of the stats commit subtrees (input and output) because they will be repopulated during the retry.