### PR TITLE
Symlink old pachd location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go-bindata -o src/server/cmd/worker/assets/assets.go -pkg assets /etc/ssl/certs/... && \
     CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o pachd "src/server/cmd/pachd/main.go" && \
     CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o worker "src/server/cmd/worker/main.go"
+# symlink for systems (e.g. hub) that expect pachd to be in the old location
+RUN ln -s /app/pachd /pachd

--- a/etc/pachd/Dockerfile
+++ b/etc/pachd/Dockerfile
@@ -2,5 +2,5 @@ FROM scratch
 WORKDIR /app
 COPY --from=pachyderm_build /app/pachd .
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-RUN ln -s /app/pachd /pachd
+COPY --from=pachyderm_build /pachd /pachd
 ENTRYPOINT ["/app/pachd"]

--- a/etc/pachd/Dockerfile
+++ b/etc/pachd/Dockerfile
@@ -2,4 +2,5 @@ FROM scratch
 WORKDIR /app
 COPY --from=pachyderm_build /app/pachd .
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN ln -s /app/pachd /pachd
 ENTRYPOINT ["/app/pachd"]


### PR DESCRIPTION
Symlink the old pachd location, so that places relying on the old path (e.g. hub) have better compatibility with 1.11.