### PR TITLE
Fixes CI for outside contributors

### DIFF
--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -38,12 +38,19 @@ kubectl version
 
 echo "Running test suite based on BUCKET=$BUCKET"
 
-make install
-version=$(pachctl version --client-only)
-docker pull "pachyderm/pachd:${version}"
-docker tag "pachyderm/pachd:${version}" "pachyderm/pachd:local"
-docker pull "pachyderm/worker:${version}"
-docker tag "pachyderm/worker:${version}" "pachyderm/worker:local"
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+    # Pull the pre-built images. This is only done if we have access to the
+    # secret env vars, because otherwise the build step would've had to be
+    # skipped.
+    make install
+    version=$(pachctl version --client-only)
+    docker pull "pachyderm/pachd:${version}"
+    docker tag "pachyderm/pachd:${version}" "pachyderm/pachd:local"
+    docker pull "pachyderm/worker:${version}"
+    docker tag "pachyderm/worker:${version}" "pachyderm/worker:local"
+else
+    make docker-build
+fi
 
 for i in $(seq 3); do
     make clean-launch-dev || true # may be nothing to delete

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -95,27 +95,25 @@ case "${BUCKET}" in
  MISC)
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
         echo "Running the full misc test suite because secret env vars exist"
-        make lint
-        make enterprise-code-checkin-test
-        make test-cmds
-        make test-libs
-        make test-tls
-        make test-vault
-        make test-enterprise
-        make test-worker
-        make test-s3gateway-unit
-        make test-proto-static
-        make test-transaction
-        make test-deploy-manifests
     else
         echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
-        make lint
-        make enterprise-code-checkin-test
-        make test-cmds
-        make test-libs
-        make test-proto-static
-        make test-transaction
-        make test-deploy-manifests
+    fi
+
+    make lint
+    make enterprise-code-checkin-test
+    make test-cmds
+    make test-libs
+    make test-proto-static
+    make test-transaction
+    make test-deploy-manifests
+
+    make test-s3gateway-unit
+    make test-enterprise
+    make test-worker
+
+    if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+        make test-tls
+        make test-vault
     fi
     ;;
  ADMIN)

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -93,12 +93,6 @@ go clean -testcache
 
 case "${BUCKET}" in
  MISC)
-    if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc test suite because secret env vars exist"
-    else
-        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
-    fi
-
     make lint
     make enterprise-code-checkin-test
     make test-cmds
@@ -106,12 +100,13 @@ case "${BUCKET}" in
     make test-proto-static
     make test-transaction
     make test-deploy-manifests
-
     make test-s3gateway-unit
     make test-enterprise
     make test-worker
-
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+        # these tests require secure env vars to run, which aren't available
+        # when the PR is coming from an outside contributor - so we just
+        # disable them
         make test-tls
         make test-vault
     fi

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -113,7 +113,6 @@ case "${BUCKET}" in
         make enterprise-code-checkin-test
         make test-cmds
         make test-libs
-        make test-tls
         make test-proto-static
         make test-transaction
         make test-deploy-manifests

--- a/etc/testing/travis_build.sh
+++ b/etc/testing/travis_build.sh
@@ -2,11 +2,13 @@
 
 set -ex
 
-docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
-
-make install docker-build
-version=$(pachctl version --client-only)
-docker tag "pachyderm/pachd:local" "pachyderm/pachd:${version}"
-docker push "pachyderm/pachd:${version}"
-docker tag "pachyderm/worker:local" "pachyderm/worker:${version}"
-docker push "pachyderm/worker:${version}"
+# We can't run the build step if there's no access to the secret env vars
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+    docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
+    make install docker-build
+    version=$(pachctl version --client-only)
+    docker tag "pachyderm/pachd:local" "pachyderm/pachd:${version}"
+    docker push "pachyderm/pachd:${version}"
+    docker tag "pachyderm/worker:local" "pachyderm/worker:${version}"
+    docker push "pachyderm/worker:${version}"
+fi

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -31,7 +31,7 @@ func activateEnterprise(t *testing.T) {
 	if string(out) != "ACTIVE" {
 		// Enterprise not active in the cluster. Activate it
 		require.NoError(t,
-			tu.Cmd("pachctl", "enterprise", "activate", tu.GetTestEnterpriseCode()).Run())
+			tu.Cmd("pachctl", "enterprise", "activate", tu.GetTestEnterpriseCode(t)).Run())
 	}
 }
 

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -550,7 +550,7 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -623,7 +623,7 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	year := 365 * 24 * time.Hour
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			// This will stop working some time in 2026
 			Expires: TSProtoOrDie(t, time.Now().Add(year)),
 		})
@@ -722,7 +722,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -776,7 +776,7 @@ func TestGetSetScopeAndAclWithExpiredToken(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -1438,21 +1438,7 @@ func TestActivateAsRobotUser(t *testing.T) {
 	defer deleteAll(t)
 
 	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(t, backoff.Retry(func() error {
-		resp, err := seedClient.Enterprise.GetState(context.Background(),
-			&enterprise.GetStateRequest{})
-		if err != nil {
-			return err
-		}
-		if resp.State == enterprise.State_ACTIVE {
-			return nil
-		}
-		_, err = seedClient.Enterprise.Activate(context.Background(),
-			&enterprise.ActivateRequest{
-				ActivationCode: tu.GetTestEnterpriseCode(t),
-			})
-		return err
-	}, backoff.NewTestingBackOff()))
+	require.NoError(t, tu.ActivateEnterprise(t, seedClient))
 
 	client := seedClient.WithCtx(context.Background())
 	resp, err := client.Activate(client.Ctx(), &auth.ActivateRequest{
@@ -1484,21 +1470,7 @@ func TestActivateMismatchedUsernames(t *testing.T) {
 	defer deleteAll(t)
 
 	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(t, backoff.Retry(func() error {
-		resp, err := seedClient.Enterprise.GetState(context.Background(),
-			&enterprise.GetStateRequest{})
-		if err != nil {
-			return err
-		}
-		if resp.State == enterprise.State_ACTIVE {
-			return nil
-		}
-		_, err = seedClient.Enterprise.Activate(context.Background(),
-			&enterprise.ActivateRequest{
-				ActivationCode: tu.GetTestEnterpriseCode(t),
-			})
-		return err
-	}, backoff.NewTestingBackOff()))
+	require.NoError(t, tu.ActivateEnterprise(t, seedClient))
 
 	client := seedClient.WithCtx(context.Background())
 	_, err := client.Activate(client.Ctx(), &auth.ActivateRequest{

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -1437,6 +1437,23 @@ func TestActivateAsRobotUser(t *testing.T) {
 	deleteAll(t)
 	defer deleteAll(t)
 
+	// Activate Pachyderm Enterprise (if it's not already active)
+	require.NoError(t, backoff.Retry(func() error {
+		resp, err := seedClient.Enterprise.GetState(context.Background(),
+			&enterprise.GetStateRequest{})
+		if err != nil {
+			return err
+		}
+		if resp.State == enterprise.State_ACTIVE {
+			return nil
+		}
+		_, err = seedClient.Enterprise.Activate(context.Background(),
+			&enterprise.ActivateRequest{
+				ActivationCode: tu.GetTestEnterpriseCode(t),
+			})
+		return err
+	}, backoff.NewTestingBackOff()))
+
 	client := seedClient.WithCtx(context.Background())
 	resp, err := client.Activate(client.Ctx(), &auth.ActivateRequest{
 		Subject: robot("deckard"),
@@ -1465,6 +1482,23 @@ func TestActivateMismatchedUsernames(t *testing.T) {
 	}
 	deleteAll(t)
 	defer deleteAll(t)
+
+	// Activate Pachyderm Enterprise (if it's not already active)
+	require.NoError(t, backoff.Retry(func() error {
+		resp, err := seedClient.Enterprise.GetState(context.Background(),
+			&enterprise.GetStateRequest{})
+		if err != nil {
+			return err
+		}
+		if resp.State == enterprise.State_ACTIVE {
+			return nil
+		}
+		_, err = seedClient.Enterprise.Activate(context.Background(),
+			&enterprise.ActivateRequest{
+				ActivationCode: tu.GetTestEnterpriseCode(t),
+			})
+		return err
+	}, backoff.NewTestingBackOff()))
 
 	client := seedClient.WithCtx(context.Background())
 	_, err := client.Activate(client.Ctx(), &auth.ActivateRequest{

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -16,7 +16,6 @@ import (
 	minio "github.com/minio/minio-go"
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/auth"
-	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -201,21 +200,7 @@ func getPachClientP(tb testing.TB, subject string, checkConfig bool) *client.API
 	}
 
 	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(tb, backoff.Retry(func() error {
-		resp, err := seedClient.Enterprise.GetState(context.Background(),
-			&enterprise.GetStateRequest{})
-		if err != nil {
-			return err
-		}
-		if resp.State == enterprise.State_ACTIVE {
-			return nil
-		}
-		_, err = seedClient.Enterprise.Activate(context.Background(),
-			&enterprise.ActivateRequest{
-				ActivationCode: tu.GetTestEnterpriseCode(tb),
-			})
-		return err
-	}, backoff.NewTestingBackOff()))
+	require.NoError(tb, tu.ActivateEnterprise(tb, seedClient))
 
 	// Cluster may be in one of four states:
 	// 1) Auth is off (=> Activate auth)

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -212,7 +212,7 @@ func getPachClientP(tb testing.TB, subject string, checkConfig bool) *client.API
 		}
 		_, err = seedClient.Enterprise.Activate(context.Background(),
 			&enterprise.ActivateRequest{
-				ActivationCode: tu.GetTestEnterpriseCode(),
+				ActivationCode: tu.GetTestEnterpriseCode(tb),
 			})
 		return err
 	}, backoff.NewTestingBackOff()))

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -17,7 +17,7 @@ import (
 const year = 365 * 24 * time.Hour
 
 func TestValidateActivationCode(t *testing.T) {
-	_, err := validateActivationCode(testutil.GetTestEnterpriseCode())
+	_, err := validateActivationCode(testutil.GetTestEnterpriseCode(t))
 	require.NoError(t, err)
 }
 
@@ -29,7 +29,7 @@ func TestGetState(t *testing.T) {
 
 	// Activate Pachyderm Enterprise and make sure the state is ACTIVE
 	_, err := client.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode()})
+		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode(t)})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err := client.Enterprise.GetState(context.Background(),
@@ -47,8 +47,8 @@ func TestGetState(t *testing.T) {
 		if time.Until(expires) <= year {
 			return errors.Errorf("expected test token to expire >1yr in the future, but expires at %v (congratulations on making it to 2026!)", expires)
 		}
-		if resp.ActivationCode != testutil.GetTestEnterpriseCode() {
-			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode())
+		if resp.ActivationCode != testutil.GetTestEnterpriseCode(t) {
+			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode(t))
 		}
 		return nil
 	}, backoff.NewTestingBackOff()))
@@ -59,7 +59,7 @@ func TestGetState(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.Enterprise.Activate(context.Background(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testutil.GetTestEnterpriseCode(),
+			ActivationCode: testutil.GetTestEnterpriseCode(t),
 			Expires:        expiresProto,
 		})
 	require.NoError(t, err)
@@ -79,8 +79,8 @@ func TestGetState(t *testing.T) {
 		if expires.Unix() != respExpires.Unix() {
 			return errors.Errorf("expected enterprise expiration to be %v, but was %v", expires, respExpires)
 		}
-		if resp.ActivationCode != testutil.GetTestEnterpriseCode() {
-			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode())
+		if resp.ActivationCode != testutil.GetTestEnterpriseCode(t) {
+			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode(t))
 		}
 		return nil
 	}, backoff.NewTestingBackOff()))
@@ -94,7 +94,7 @@ func TestDeactivate(t *testing.T) {
 
 	// Activate Pachyderm Enterprise and make sure the state is ACTIVE
 	_, err := client.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode()})
+		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode(t)})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err := client.Enterprise.GetState(context.Background(),

--- a/src/server/pkg/testutil/enterprise.go
+++ b/src/server/pkg/testutil/enterprise.go
@@ -2,11 +2,14 @@ package testutil
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/src/client"
+	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,4 +63,25 @@ func GetTestEnterpriseCode(t testing.TB) string {
 		t.Skip("skipping test since credentials aren't available.")
 	}
 	return cachedEnterpriseCode
+}
+
+// ActivateEnterprise activates enterprise in Pachyderm (if it's not on already.)
+func ActivateEnterprise(t testing.TB, c *client.APIClient) error {
+	code := GetTestEnterpriseCode(t)
+
+	return backoff.Retry(func() error {
+		resp, err := c.Enterprise.GetState(context.Background(),
+			&enterprise.GetStateRequest{})
+		if err != nil {
+			return err
+		}
+		if resp.State == enterprise.State_ACTIVE {
+			return nil
+		}
+		_, err = c.Enterprise.Activate(context.Background(),
+			&enterprise.ActivateRequest{
+				ActivationCode: code,
+			})
+		return err
+	}, backoff.NewTestingBackOff())
 }

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/auth"
-	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -76,12 +75,10 @@ func initPachClient(t testing.TB) (*client.APIClient, string) {
 	if _, ok := os.LookupEnv("PACH_TEST_WITH_AUTH"); !ok {
 		return c, ""
 	}
+
 	// Activate Pachyderm Enterprise (if it's not already active)
-	_, err := c.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(t),
-		})
-	require.NoError(t, err)
+	require.NoError(t, tu.ActivateEnterprise(t, c))
+
 	activateResp, err := c.AuthAPIClient.Activate(context.Background(),
 		&auth.ActivateRequest{Subject: "robot:admin"},
 	)

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -79,7 +79,7 @@ func initPachClient(t testing.TB) (*client.APIClient, string) {
 	// Activate Pachyderm Enterprise (if it's not already active)
 	_, err := c.Enterprise.Activate(context.Background(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 		})
 	require.NoError(t, err)
 	activateResp, err := c.AuthAPIClient.Activate(context.Background(),

--- a/src/server/worker/stats/stats_test.go
+++ b/src/server/worker/stats/stats_test.go
@@ -24,9 +24,9 @@ import (
 	prom_model "github.com/prometheus/common/model"
 )
 
-func activateEnterprise(c *client.APIClient) error {
+func activateEnterprise(t testing.TB, c *client.APIClient) error {
 	_, err := c.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: tu.GetTestEnterpriseCode()})
+		&enterprise.ActivateRequest{ActivationCode: tu.GetTestEnterpriseCode(t)})
 
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func activateEnterprise(c *client.APIClient) error {
 func TestPrometheusStats(t *testing.T) {
 	c := tu.GetPachClient(t)
 	defer require.NoError(t, c.DeleteAll())
-	require.NoError(t, activateEnterprise(c))
+	require.NoError(t, activateEnterprise(t, c))
 
 	dataRepo := tu.UniqueString("TestSimplePipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -261,7 +261,7 @@ func TestPrometheusStats(t *testing.T) {
 func TestCloseStatsCommitWithNoInputDatums(t *testing.T) {
 	c := tu.GetPachClient(t)
 	defer require.NoError(t, c.DeleteAll())
-	require.NoError(t, activateEnterprise(c))
+	require.NoError(t, activateEnterprise(t, c))
 
 	dataRepo := tu.UniqueString("TestSimplePipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))

--- a/src/server/worker/stats/stats_test.go
+++ b/src/server/worker/stats/stats_test.go
@@ -11,11 +11,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/src/client"
-	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
 	"github.com/pachyderm/pachyderm/src/client/pps"
-	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	tu "github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
@@ -24,31 +22,10 @@ import (
 	prom_model "github.com/prometheus/common/model"
 )
 
-func activateEnterprise(t testing.TB, c *client.APIClient) error {
-	_, err := c.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: tu.GetTestEnterpriseCode(t)})
-
-	if err != nil {
-		return err
-	}
-
-	return backoff.Retry(func() error {
-		resp, err := c.Enterprise.GetState(context.Background(),
-			&enterprise.GetStateRequest{})
-		if err != nil {
-			return err
-		}
-		if resp.State != enterprise.State_ACTIVE {
-			return errors.Errorf("expected enterprise state to be ACTIVE but was %v", resp.State)
-		}
-		return nil
-	}, backoff.NewTestingBackOff())
-}
-
 func TestPrometheusStats(t *testing.T) {
 	c := tu.GetPachClient(t)
 	defer require.NoError(t, c.DeleteAll())
-	require.NoError(t, activateEnterprise(t, c))
+	require.NoError(t, tu.ActivateEnterprise(t, c))
 
 	dataRepo := tu.UniqueString("TestSimplePipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -261,7 +238,7 @@ func TestPrometheusStats(t *testing.T) {
 func TestCloseStatsCommitWithNoInputDatums(t *testing.T) {
 	c := tu.GetPachClient(t)
 	defer require.NoError(t, c.DeleteAll())
-	require.NoError(t, activateEnterprise(t, c))
+	require.NoError(t, tu.ActivateEnterprise(t, c))
 
 	dataRepo := tu.UniqueString("TestSimplePipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))


### PR DESCRIPTION
Changes:

* Disable the build step from outside PRs, as we won't be able to push the docker images anyway. Instead, we build in each step, like the way we did it before #5007.
* Added a check in go test code to skip tests that require enterprise mode when secrets aren't available. This allows us to selectively skip tests rather than skip entire buckets.
* Disable `test-tls` on outside PRs since it needs secrets.
* Explicitly enable enterprise mode in `TestActivateAsRobotUser` and `TestActivateMismatchedUsernames`, as before they implicitly assumed that other tests that were run before had already enabled enterprise.

As a test, this PR is opened from my fork of pachyderm, which should reproduce any issues that exist.

Closes #5037 