### PR TITLE
Separate build and deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,14 @@ env:
 stages:
   - build
   - test
+  - deploy
 
 jobs:
   include:
     - stage: build
       script: etc/testing/travis_build.sh
+    - stage: deploy
+      script: etc/testing/travis_deploy.sh
 
 before_install:
   # Make sure cache dirs exist and are writable

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -38,19 +38,8 @@ kubectl version
 
 echo "Running test suite based on BUCKET=$BUCKET"
 
-if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-    # Pull the pre-built images. This is only done if we have access to the
-    # secret env vars, because otherwise the build step would've had to be
-    # skipped.
-    make install
-    version=$(pachctl version --client-only)
-    docker pull "pachyderm/pachd:${version}"
-    docker tag "pachyderm/pachd:${version}" "pachyderm/pachd:local"
-    docker pull "pachyderm/worker:${version}"
-    docker tag "pachyderm/worker:${version}" "pachyderm/worker:local"
-else
-    make docker-build
-fi
+docker load < ~/cached-deps/pachd.tar.gz
+docker load < ~/cached-deps/worker.tar.gz
 
 for i in $(seq 3); do
     make clean-launch-dev || true # may be nothing to delete

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -38,12 +38,19 @@ kubectl version
 
 echo "Running test suite based on BUCKET=$BUCKET"
 
-make install
-version=$(pachctl version --client-only)
-docker pull "pachyderm/pachd:${version}"
-docker tag "pachyderm/pachd:${version}" "pachyderm/pachd:local"
-docker pull "pachyderm/worker:${version}"
-docker tag "pachyderm/worker:${version}" "pachyderm/worker:local"
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+    # Pull the pre-built images. This is only done if we have access to the
+    # secret env vars, because otherwise the build step would've had to be
+    # skipped.
+    make install
+    version=$(pachctl version --client-only)
+    docker pull "pachyderm/pachd:${version}"
+    docker tag "pachyderm/pachd:${version}" "pachyderm/pachd:local"
+    docker pull "pachyderm/worker:${version}"
+    docker tag "pachyderm/worker:${version}" "pachyderm/worker:local"
+else
+    make docker-build
+fi
 
 for i in $(seq 3); do
     make clean-launch-dev || true # may be nothing to delete
@@ -86,30 +93,22 @@ go clean -testcache
 
 case "${BUCKET}" in
  MISC)
+    make lint
+    make enterprise-code-checkin-test
+    make test-cmds
+    make test-libs
+    make test-proto-static
+    make test-transaction
+    make test-deploy-manifests
+    make test-s3gateway-unit
+    make test-enterprise
+    make test-worker
     if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-        echo "Running the full misc test suite because secret env vars exist"
-        make lint
-        make enterprise-code-checkin-test
-        make test-cmds
-        make test-libs
+        # these tests require secure env vars to run, which aren't available
+        # when the PR is coming from an outside contributor - so we just
+        # disable them
         make test-tls
         make test-vault
-        make test-enterprise
-        make test-worker
-        make test-s3gateway-unit
-        make test-proto-static
-        make test-transaction
-        make test-deploy-manifests
-    else
-        echo "Running the misc test suite with some tests disabled because secret env vars have not been set"
-        make lint
-        make enterprise-code-checkin-test
-        make test-cmds
-        make test-libs
-        make test-tls
-        make test-proto-static
-        make test-transaction
-        make test-deploy-manifests
     fi
     ;;
  ADMIN)

--- a/etc/testing/travis_build.sh
+++ b/etc/testing/travis_build.sh
@@ -2,11 +2,13 @@
 
 set -ex
 
-docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
-
-make install docker-build
-version=$(pachctl version --client-only)
-docker tag "pachyderm/pachd:local" "pachyderm/pachd:${version}"
-docker push "pachyderm/pachd:${version}"
-docker tag "pachyderm/worker:local" "pachyderm/worker:${version}"
-docker push "pachyderm/worker:${version}"
+# We can't run the build step if there's no access to the secret env vars
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+    docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
+    make install docker-build
+    version=$(pachctl version --client-only)
+    docker tag "pachyderm/pachd:local" "pachyderm/pachd:${version}"
+    docker push "pachyderm/pachd:${version}"
+    docker tag "pachyderm/worker:local" "pachyderm/worker:${version}"
+    docker push "pachyderm/worker:${version}"
+fi

--- a/etc/testing/travis_build.sh
+++ b/etc/testing/travis_build.sh
@@ -2,13 +2,7 @@
 
 set -ex
 
-# We can't run the build step if there's no access to the secret env vars
-if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-    docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
-    make install docker-build
-    version=$(pachctl version --client-only)
-    docker tag "pachyderm/pachd:local" "pachyderm/pachd:${version}"
-    docker push "pachyderm/pachd:${version}"
-    docker tag "pachyderm/worker:local" "pachyderm/worker:${version}"
-    docker push "pachyderm/worker:${version}"
-fi
+make docker-build
+mkdir -p ~/cached-deps
+docker save pachyderm/pachd:local | gzip > ~/cached-deps/pachd.tar.gz
+docker save pachyderm/worker:local | gzip > ~/cached-deps/worker.tar.gz

--- a/etc/testing/travis_deploy.sh
+++ b/etc/testing/travis_deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+# We can't run the build step if there's no access to the secret env vars
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+    docker load < ~/cached-deps/pachd.tar.gz
+    docker load < ~/cached-deps/worker.tar.gz
+
+    make install
+    docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
+    version=$(pachctl version --client-only)
+    docker tag "pachyderm/pachd:local" "pachyderm/pachd:${version}"
+    docker push "pachyderm/pachd:${version}"
+    docker tag "pachyderm/worker:local" "pachyderm/worker:${version}"
+    docker push "pachyderm/worker:${version}"
+fi

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -31,7 +31,7 @@ func activateEnterprise(t *testing.T) {
 	if string(out) != "ACTIVE" {
 		// Enterprise not active in the cluster. Activate it
 		require.NoError(t,
-			tu.Cmd("pachctl", "enterprise", "activate", tu.GetTestEnterpriseCode()).Run())
+			tu.Cmd("pachctl", "enterprise", "activate", tu.GetTestEnterpriseCode(t)).Run())
 	}
 }
 

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -550,7 +550,7 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -623,7 +623,7 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	year := 365 * 24 * time.Hour
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			// This will stop working some time in 2026
 			Expires: TSProtoOrDie(t, time.Now().Add(year)),
 		})
@@ -722,7 +722,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -776,7 +776,7 @@ func TestGetSetScopeAndAclWithExpiredToken(t *testing.T) {
 	// Make current enterprise token expire
 	adminClient.Enterprise.Activate(adminClient.Ctx(),
 		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
+			ActivationCode: tu.GetTestEnterpriseCode(t),
 			Expires:        TSProtoOrDie(t, time.Now().Add(-30*time.Second)),
 		})
 	// wait for Enterprise token to expire
@@ -1437,6 +1437,9 @@ func TestActivateAsRobotUser(t *testing.T) {
 	deleteAll(t)
 	defer deleteAll(t)
 
+	// Activate Pachyderm Enterprise (if it's not already active)
+	require.NoError(t, tu.ActivateEnterprise(t, seedClient))
+
 	client := seedClient.WithCtx(context.Background())
 	resp, err := client.Activate(client.Ctx(), &auth.ActivateRequest{
 		Subject: robot("deckard"),
@@ -1465,6 +1468,9 @@ func TestActivateMismatchedUsernames(t *testing.T) {
 	}
 	deleteAll(t)
 	defer deleteAll(t)
+
+	// Activate Pachyderm Enterprise (if it's not already active)
+	require.NoError(t, tu.ActivateEnterprise(t, seedClient))
 
 	client := seedClient.WithCtx(context.Background())
 	_, err := client.Activate(client.Ctx(), &auth.ActivateRequest{

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -16,7 +16,6 @@ import (
 	minio "github.com/minio/minio-go"
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/auth"
-	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -201,21 +200,7 @@ func getPachClientP(tb testing.TB, subject string, checkConfig bool) *client.API
 	}
 
 	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(tb, backoff.Retry(func() error {
-		resp, err := seedClient.Enterprise.GetState(context.Background(),
-			&enterprise.GetStateRequest{})
-		if err != nil {
-			return err
-		}
-		if resp.State == enterprise.State_ACTIVE {
-			return nil
-		}
-		_, err = seedClient.Enterprise.Activate(context.Background(),
-			&enterprise.ActivateRequest{
-				ActivationCode: tu.GetTestEnterpriseCode(),
-			})
-		return err
-	}, backoff.NewTestingBackOff()))
+	require.NoError(tb, tu.ActivateEnterprise(tb, seedClient))
 
 	// Cluster may be in one of four states:
 	// 1) Auth is off (=> Activate auth)

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -17,7 +17,7 @@ import (
 const year = 365 * 24 * time.Hour
 
 func TestValidateActivationCode(t *testing.T) {
-	_, err := validateActivationCode(testutil.GetTestEnterpriseCode())
+	_, err := validateActivationCode(testutil.GetTestEnterpriseCode(t))
 	require.NoError(t, err)
 }
 
@@ -29,7 +29,7 @@ func TestGetState(t *testing.T) {
 
 	// Activate Pachyderm Enterprise and make sure the state is ACTIVE
 	_, err := client.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode()})
+		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode(t)})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err := client.Enterprise.GetState(context.Background(),
@@ -47,8 +47,8 @@ func TestGetState(t *testing.T) {
 		if time.Until(expires) <= year {
 			return errors.Errorf("expected test token to expire >1yr in the future, but expires at %v (congratulations on making it to 2026!)", expires)
 		}
-		if resp.ActivationCode != testutil.GetTestEnterpriseCode() {
-			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode())
+		if resp.ActivationCode != testutil.GetTestEnterpriseCode(t) {
+			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode(t))
 		}
 		return nil
 	}, backoff.NewTestingBackOff()))
@@ -59,7 +59,7 @@ func TestGetState(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.Enterprise.Activate(context.Background(),
 		&enterprise.ActivateRequest{
-			ActivationCode: testutil.GetTestEnterpriseCode(),
+			ActivationCode: testutil.GetTestEnterpriseCode(t),
 			Expires:        expiresProto,
 		})
 	require.NoError(t, err)
@@ -79,8 +79,8 @@ func TestGetState(t *testing.T) {
 		if expires.Unix() != respExpires.Unix() {
 			return errors.Errorf("expected enterprise expiration to be %v, but was %v", expires, respExpires)
 		}
-		if resp.ActivationCode != testutil.GetTestEnterpriseCode() {
-			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode())
+		if resp.ActivationCode != testutil.GetTestEnterpriseCode(t) {
+			return errors.Errorf("incorrect activation code, got: %s, expected: %s", resp.ActivationCode, testutil.GetTestEnterpriseCode(t))
 		}
 		return nil
 	}, backoff.NewTestingBackOff()))
@@ -94,7 +94,7 @@ func TestDeactivate(t *testing.T) {
 
 	// Activate Pachyderm Enterprise and make sure the state is ACTIVE
 	_, err := client.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode()})
+		&enterprise.ActivateRequest{ActivationCode: testutil.GetTestEnterpriseCode(t)})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err := client.Enterprise.GetState(context.Background(),

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/auth"
-	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -76,12 +75,10 @@ func initPachClient(t testing.TB) (*client.APIClient, string) {
 	if _, ok := os.LookupEnv("PACH_TEST_WITH_AUTH"); !ok {
 		return c, ""
 	}
+
 	// Activate Pachyderm Enterprise (if it's not already active)
-	_, err := c.Enterprise.Activate(context.Background(),
-		&enterprise.ActivateRequest{
-			ActivationCode: tu.GetTestEnterpriseCode(),
-		})
-	require.NoError(t, err)
+	require.NoError(t, tu.ActivateEnterprise(t, c))
+
 	activateResp, err := c.AuthAPIClient.Activate(context.Background(),
 		&auth.ActivateRequest{Subject: "robot:admin"},
 	)


### PR DESCRIPTION
Experimental PR to use TravisCI caching in order to clean up the docker build process a bit.

On master, we build the docker images, push them to docker hub, then pull them for each test bucket. With this experiment, we build the docker images, save them to TravisCI cache, then pull them for each test bucket. If all test buckets pass, we push the images to docker hub.

The advantages of this setup:
1) Fewer differences between PRs from pachyderm members and PRs from outside contributors.
2) Better performance and reliability since we're relying on TravisCI caching for tests rather than docker hub.

This is experimental, though, because it's not clear from [the docs](https://docs.travis-ci.com/user/build-stages) how caching interacts with the stages.