### PR TITLE
Add tests for malformed pipeline creation requests and fix some bugs

### DIFF
--- a/src/client/pkg/errors/errors.go
+++ b/src/client/pkg/errors/errors.go
@@ -33,6 +33,7 @@ var (
 	WithStack = errors.WithStack
 )
 
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace = errors.StackTrace
 
 // EnsureStack will add a stack onto the given error only if it does not already

--- a/src/client/pkg/errors/errors.go
+++ b/src/client/pkg/errors/errors.go
@@ -33,6 +33,8 @@ var (
 	WithStack = errors.WithStack
 )
 
+type StackTrace = errors.StackTrace
+
 // EnsureStack will add a stack onto the given error only if it does not already
 // have a stack. If err is nil, EnsureStack returns nil.
 func EnsureStack(err error) error {
@@ -48,7 +50,7 @@ func EnsureStack(err error) error {
 }
 
 // Frame is the type of a StackFrame, it is an alias for errors.Frame.
-type Frame errors.Frame
+type Frame struct{ errors.Frame }
 
 // Callers returns an errors.StackTrace for the place at which it's called.
 func Callers() errors.StackTrace {
@@ -83,7 +85,7 @@ func ForEachStackFrame(err error, f func(Frame)) {
 	}
 	if len(st) > 0 {
 		for _, frame := range st {
-			f(Frame(frame))
+			f(Frame{frame})
 		}
 	}
 }

--- a/src/client/pps/util.go
+++ b/src/client/pps/util.go
@@ -117,15 +117,14 @@ func ValidateGitCloneURL(url string) error {
 	//     ssh_url: "git@github.com:sjezewski/testgithook.git",
 	//     clone_url: "https://github.com/sjezewski/testgithook.git",
 	//     svn_url: "https://github.com/sjezewski/testgithook",
-	invalidErr := errors.Errorf("clone URL is missing .git suffix (example clone URL %v)", exampleURL)
 
 	if !strings.HasSuffix(url, ".git") {
 		// svn_url case
-		return invalidErr
+		return errors.Errorf("clone URL is missing .git suffix (example clone URL %v)", exampleURL)
 	}
 	if !strings.HasPrefix(url, "https://") {
 		// git_url or ssh_url cases
-		return invalidErr
+		return errors.Errorf("clone URL must use https protocol (example clone URL %v)", exampleURL)
 	}
 
 	return nil

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -11551,6 +11551,178 @@ func TestKeepRepo(t *testing.T) {
 	require.NoError(t, c.DeletePipeline(pipeline, false))
 }
 
+// Regression test to make sure that pipeline creation doesn't crash pachd due to missing fields
+func TestMalformedPipeline(t *testing.T) {
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
+
+	pipelineName := tu.UniqueString("MalformedPipeline")
+
+	_, err := c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{})
+	require.YesError(t, err)
+	require.Matches(t, "invalid pipeline spec", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline: client.NewPipeline(pipelineName)},
+	)
+	require.YesError(t, err)
+	require.Matches(t, "must specify a transform", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "no input set", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:        client.NewPipeline(pipelineName),
+		Transform:       &pps.Transform{},
+		Service:         &pps.Service{},
+		ParallelismSpec: &pps.ParallelismSpec{},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "services can only be run with a constant parallelism of 1", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:     client.NewPipeline(pipelineName),
+		Transform:    &pps.Transform{},
+		HashtreeSpec: &pps.HashtreeSpec{},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "HashtreeSpec.Constant must be > 0", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:   client.NewPipeline(pipelineName),
+		Transform:  &pps.Transform{},
+		SpecCommit: &pfs.Commit{},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "cannot resolve commit with no repo", err.Error())
+
+	dataRepo := tu.UniqueString("TestMalformedPipeline_data")
+	require.NoError(t, c.CreateRepo(dataRepo))
+
+	_, err = c.PutFile(dataRepo, "master", "file", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Pfs: &pps.PFSInput{}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "input must specify a name", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Pfs: &pps.PFSInput{Name: "data"}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "input must specify a repo", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Pfs: &pps.PFSInput{Repo: dataRepo}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "input must specify a glob", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     client.NewPFSInput("out", "/*"),
+	})
+	require.YesError(t, err)
+	require.Matches(t, "input cannot be named \"out\"", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Pfs: &pps.PFSInput{Name: "out", Repo: dataRepo, Glob: "/*"}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "input cannot be named \"out\"", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Pfs: &pps.PFSInput{Name: "data", Repo: "dne", Glob: "/*"}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "dne not found", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input: client.NewCrossInput(
+			client.NewPFSInput("foo", "/*"),
+			client.NewPFSInput("foo", "/*"),
+		),
+	})
+	require.YesError(t, err)
+	require.Matches(t, "name \"foo\" was used more than once", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Cron: &pps.CronInput{}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "Empty spec string", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Git: &pps.GitInput{}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "clone URL is missing", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Cross: []*pps.Input{}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "no input set", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Union: []*pps.Input{}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "no input set", err.Error())
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{},
+		Input:     &pps.Input{Join: []*pps.Input{}},
+	})
+	require.YesError(t, err)
+	require.Matches(t, "no input set", err.Error())
+}
+
+func TestSimpleCron(t *testing.T) {
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
+
+	pipelineName := tu.UniqueString("MalformedPipeline")
+
+	_, err := c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
+		Pipeline:  client.NewPipeline(pipelineName),
+		Transform: &pps.Transform{Cmd: []string{"bash"}, Stdin: []string{"echo foo > /pfs/out/file"}},
+		Input:     &pps.Input{Cron: &pps.CronInput{Spec: "@every 10s"}},
+	})
+	require.NoError(t, err)
+
+	// TODO: the worker fails to symlink active data directory - because there is no name?
+}
+
 func getObjectCountForRepo(t testing.TB, c *client.APIClient, repo string) int {
 	pipelineInfos, err := c.ListPipeline()
 	require.NoError(t, err)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1851,6 +1851,9 @@ func (d *driver) resolveCommit(stm col.STM, userCommit *pfs.Commit) (*pfs.Commit
 	if userCommit == nil {
 		return nil, errors.Errorf("cannot resolve nil commit")
 	}
+	if userCommit.Repo == nil {
+		return nil, errors.Errorf("cannot resolve commit with no repo")
+	}
 	if userCommit.ID == "" {
 		return nil, errors.Errorf("cannot resolve commit with no ID or branch")
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -261,6 +261,9 @@ func (a *apiServer) validateInput(pachClient *client.APIClient, pipelineName str
 					return errors.Errorf("multiple input types set")
 				}
 				set = true
+				if len(input.Cron.Name) == 0 {
+					return errors.Errorf("input must specify a name")
+				}
 				if _, err := cron.ParseStandard(input.Cron.Spec); err != nil {
 					return errors.Wrapf(err, "error parsing cron-spec")
 				}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2229,9 +2229,9 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 		var commit *pfs.Commit
 		if request.SpecCommit != nil {
 			// Make sure that the spec commit actually exists
-			commitInfo, err := pachClient.InspectCommit(request.SpecCommit.Repo.Name, request.SpecCommit.ID)
+			commitInfo, err := pachClient.PfsAPIClient.InspectCommit(pachClient.Ctx(), &pfs.InspectCommitRequest{Commit: request.SpecCommit})
 			if err != nil {
-				return nil, errors.Wrapf(err, "error inspecting commit: \"%s@%s\"", request.SpecCommit.Repo.Name, request.SpecCommit.ID)
+				return nil, errors.Wrap(err, "error inspecting spec commit")
 			}
 			// It does, so we use that as the spec commit, rather than making a new one
 			commit = commitInfo.Commit

--- a/src/server/worker/driver/driver_unix.go
+++ b/src/server/worker/driver/driver_unix.go
@@ -111,6 +111,9 @@ func (d *driver) linkData(inputs []*common.Input, dir string) error {
 		if input.S3 {
 			continue // S3 data is not downloaded
 		}
+		if input.Name == "" {
+			return errors.New("input does not have a name")
+		}
 		src := filepath.Join(dir, input.Name)
 		dst := filepath.Join(d.InputDir(), input.Name)
 		if err := os.Symlink(src, dst); err != nil {


### PR DESCRIPTION
Fixes #2650 and also:

* `nil` dereference in `pfs.driver.resolveCommit` when the given `commit.Repo` is not set
* `nil` dereference in `pps.APIServer.CreatePipeline` when given a non-nil but empty `SpecCommit` field
* prevent pipelines from being created with unnamed cron inputs
* better error message when an unnamed input is encountered in the worker
  * before: `failed to process datum with error: symlink /pfs/.scratch/42b7dd25535c4b4aa503f7ce53dd3405 /pfs: file exists - error when linking active data directory`
  * after: `failed to process datum with error: input does not have a name`
* better logging of stack traces - the `Frame.String()` method was not working correctly because of type aliasing, I guess, resulting in it printing an array of integers rather than an array of stack frames
* better error message when a git input URL field does not use the `https` protocol