### PR TITLE
Make worker service account configurable

### DIFF
--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -571,6 +571,10 @@
                 "value": "IfNotPresent"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACHD_VERSION",
                 "value": "1.11.0"
               },
@@ -596,10 +600,6 @@
               {
                 "name": "PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING",
                 "value": "false"
-              },
-              {
-                "name": "WORKER_SERVICE_ACCOUNT",
-                "value": "pachyderm-worker"
               },
               {
                 "name": "PACH_NAMESPACE",

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -598,6 +598,10 @@
                 "value": "false"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -360,6 +360,8 @@ spec:
           value: pachyderm/pachd:1.11.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACHD_VERSION
           value: 1.11.0
         - name: METRICS
@@ -373,8 +375,6 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: WORKER_SERVICE_ACCOUNT
-          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -373,6 +373,8 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -581,6 +581,10 @@
                 "value": "false"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -554,6 +554,10 @@
                 "value": "IfNotPresent"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACHD_VERSION",
                 "value": "1.11.0"
               },
@@ -579,10 +583,6 @@
               {
                 "name": "PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING",
                 "value": "false"
-              },
-              {
-                "name": "WORKER_SERVICE_ACCOUNT",
-                "value": "pachyderm-worker"
               },
               {
                 "name": "PACH_NAMESPACE",

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -347,6 +347,8 @@ spec:
           value: pachyderm/pachd:1.11.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACHD_VERSION
           value: 1.11.0
         - name: METRICS
@@ -360,8 +362,6 @@ spec:
           value: "true"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: WORKER_SERVICE_ACCOUNT
-          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -360,6 +360,8 @@ spec:
           value: "true"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -571,6 +571,10 @@
                 "value": "IfNotPresent"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACHD_VERSION",
                 "value": "1.11.0"
               },
@@ -596,10 +600,6 @@
               {
                 "name": "PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING",
                 "value": "false"
-              },
-              {
-                "name": "WORKER_SERVICE_ACCOUNT",
-                "value": "pachyderm-worker"
               },
               {
                 "name": "PACH_NAMESPACE",

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -598,6 +598,10 @@
                 "value": "false"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -360,6 +360,8 @@ spec:
           value: pachyderm/pachd:1.11.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACHD_VERSION
           value: 1.11.0
         - name: METRICS
@@ -373,8 +375,6 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: WORKER_SERVICE_ACCOUNT
-          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -373,6 +373,8 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -578,6 +578,10 @@
                 "value": "false"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACH_NAMESPACE",
                 "valueFrom": {
                   "fieldRef": {

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -551,6 +551,10 @@
                 "value": "IfNotPresent"
               },
               {
+                "name": "WORKER_SERVICE_ACCOUNT",
+                "value": "pachyderm-worker"
+              },
+              {
                 "name": "PACHD_VERSION",
                 "value": "1.11.0"
               },
@@ -576,10 +580,6 @@
               {
                 "name": "PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING",
                 "value": "false"
-              },
-              {
-                "name": "WORKER_SERVICE_ACCOUNT",
-                "value": "pachyderm-worker"
               },
               {
                 "name": "PACH_NAMESPACE",

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -358,6 +358,8 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -345,6 +345,8 @@ spec:
           value: pachyderm/pachd:1.11.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
+        - name: WORKER_SERVICE_ACCOUNT
+          value: pachyderm-worker
         - name: PACHD_VERSION
           value: 1.11.0
         - name: METRICS
@@ -358,8 +360,6 @@ spec:
           value: "false"
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: "false"
-        - name: WORKER_SERVICE_ACCOUNT
-          value: pachyderm-worker
         - name: PACH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -27,11 +27,15 @@ import (
 )
 
 const (
-	// WorkerSAName is the name of the service account that pachyderm
-	// pipelines use to create an s3 gateway service for each job
-	WorkerSAName          = "pachyderm-worker"
-	workerRoleName        = "pachyderm-worker" // Role given to worker SA
-	workerRoleBindingName = "pachyderm-worker" // Binding worker role to SA
+	// WorkerServiceAccountEnvVar is the name of the environment variable used to tell pachd
+	// what service account to assign to new worker RCs, for the purpose of
+	// creating S3 gateway services.
+	WorkerServiceAccountEnvVar = "WORKER_SERVICE_ACCOUNT"
+	// DefaultWorkerServiceAccountName is the default value to use if WorkerServiceAccountEnvVar is
+	// undefined (for compatibility purposes)
+	DefaultWorkerServiceAccountName = "pachyderm-worker"
+	workerRoleName                  = "pachyderm-worker" // Role given to worker Service Account
+	workerRoleBindingName           = "pachyderm-worker" // Binding worker role to Service Account
 )
 
 var (
@@ -288,6 +292,10 @@ type AssetOpts struct {
 	// RequireCriticalServersOnly is true when only the critical Pachd servers
 	// are required to startup and run without error.
 	RequireCriticalServersOnly bool
+
+	// WorkerServiceAccountName is the name of the service account that will be
+	// used in the worker pods for creating S3 gateways.
+	WorkerServiceAccountName string
 }
 
 // replicas lets us create a pointer to a non-zero int32 in-line. This is
@@ -379,7 +387,7 @@ func ServiceAccounts(opts *AssetOpts) []*v1.ServiceAccount {
 				Kind:       "ServiceAccount",
 				APIVersion: "v1",
 			},
-			ObjectMeta: objectMeta(WorkerSAName, labels(""), nil, opts.Namespace),
+			ObjectMeta: objectMeta(opts.WorkerServiceAccountName, labels(""), nil, opts.Namespace),
 		},
 	}
 }
@@ -468,7 +476,7 @@ func RoleBinding(opts *AssetOpts) *rbacv1.RoleBinding {
 }
 
 // RoleBinding returns a RoleBinding that binds Pachyderm's workerRole to its
-// worker service account (WorkerSAName)
+// worker service account (assets.WorkerServiceAccountName)
 func workerRoleBinding(opts *AssetOpts) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -478,7 +486,7 @@ func workerRoleBinding(opts *AssetOpts) *rbacv1.RoleBinding {
 		ObjectMeta: objectMeta(workerRoleBindingName, labels(""), nil, opts.Namespace),
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
-			Name:      WorkerSAName,
+			Name:      opts.WorkerServiceAccountName,
 			Namespace: opts.Namespace,
 		}},
 		RoleRef: rbacv1.RoleRef{
@@ -655,6 +663,7 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend backend, hostPath strin
 		{Name: "IMAGE_PULL_SECRET", Value: opts.ImagePullSecret},
 		{Name: "WORKER_SIDECAR_IMAGE", Value: image},
 		{Name: "WORKER_IMAGE_PULL_POLICY", Value: "IfNotPresent"},
+		{Name: WorkerServiceAccountEnvVar, Value: opts.WorkerServiceAccountName},
 		{Name: "PACHD_VERSION", Value: opts.Version},
 		{Name: "METRICS", Value: strconv.FormatBool(opts.Metrics)},
 		{Name: "LOG_LEVEL", Value: opts.LogLevel},

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -287,6 +287,7 @@ func standardDeployCmds() []*cobra.Command {
 	var putFileConcurrencyLimit int
 	var clusterDeploymentID string
 	var requireCriticalServersOnly bool
+	var workerServiceAccountName string
 	appendGlobalFlags := func(cmd *cobra.Command) {
 		cmd.Flags().IntVar(&pachdShards, "shards", 16, "(rarely set) The maximum number of pachd nodes allowed in the cluster; increasing this number blindly can result in degraded performance.")
 		cmd.Flags().IntVar(&etcdNodes, "dynamic-etcd-nodes", 0, "Deploy etcd as a StatefulSet with the given number of pods.  The persistent volumes used by these pods are provisioned dynamically.  Note that StatefulSet is currently a beta kubernetes feature, which might be unavailable in older versions of kubernetes.")
@@ -312,6 +313,7 @@ func standardDeployCmds() []*cobra.Command {
 		cmd.Flags().IntVar(&putFileConcurrencyLimit, "put-file-concurrency-limit", assets.DefaultPutFileConcurrencyLimit, "The maximum number of files to upload or fetch from remote sources (HTTP, blob storage) using PutFile concurrently.")
 		cmd.Flags().StringVar(&clusterDeploymentID, "cluster-deployment-id", "", "Set an ID for the cluster deployment. Defaults to a random value.")
 		cmd.Flags().BoolVar(&requireCriticalServersOnly, "require-critical-servers-only", assets.DefaultRequireCriticalServersOnly, "Only require the critical Pachd servers to startup and run without errors.")
+		cmd.Flags().StringVar(&workerServiceAccountName, "worker-service-account", assets.DefaultWorkerServiceAccountName, "The Kubernetes service account for workers to use when creating S3 gateways.")
 
 		// Flags for setting pachd resource requests. These should rarely be set --
 		// only if we get the defaults wrong, or users have an unusual access pattern
@@ -418,6 +420,7 @@ func standardDeployCmds() []*cobra.Command {
 			ExposeObjectAPI:            exposeObjectAPI,
 			ClusterDeploymentID:        clusterDeploymentID,
 			RequireCriticalServersOnly: requireCriticalServersOnly,
+			WorkerServiceAccountName:   workerServiceAccountName,
 		}
 		if tlsCertKey != "" {
 			// TODO(msteffen): If either the cert path or the key path contains a

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -229,6 +229,12 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 	memDefaultQuantity := resource.MustParse("64M")
 	memSidecarQuantity := resource.MustParse(options.cacheSize)
 
+	// Get service account name for worker from env or use default
+	workerServiceAccountName, ok := os.LookupEnv(assets.WorkerServiceAccountEnvVar)
+	if !ok {
+		workerServiceAccountName = assets.DefaultWorkerServiceAccountName
+	}
+
 	// possibly expose s3 gateway port in the sidecar container
 	var sidecarPorts []v1.ContainerPort
 	if options.s3GatewayPort != 0 {
@@ -310,7 +316,7 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 				Ports: sidecarPorts,
 			},
 		},
-		ServiceAccountName:            assets.WorkerSAName,
+		ServiceAccountName:            workerServiceAccountName,
 		RestartPolicy:                 "Always",
 		Volumes:                       options.volumes,
 		ImagePullSecrets:              options.imagePullSecrets,


### PR DESCRIPTION
Adds a new flag to `pachctl deploy` for specifying the worker service account name: `--worker-service-account`, defaults to `pachyderm-worker`.  This must be exposed to `pachd` instances for `worker_rc.go` to assign the service account to new worker RCs, so an environment variable is used: `WORKER_SERVICE_ACCOUNT`.

Going forward, new deployments will always have this environment variable set, but we use the default `pachyderm-worker` value if the environment variable is not found for compatibility with old deployments.

Fixes #5047 