### PR TITLE
Log half of OIDC state token

### DIFF
--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -204,7 +204,9 @@ func LoginCmd() *cobra.Command {
 				if authErr != nil && !auth.IsErrPartiallyActivated(authErr) {
 					return errors.Wrapf(grpcutil.ScrubGRPC(authErr),
 						"authorization failed (OIDC state token: %q; Pachyderm logs may "+
-							"contain more information)", state)
+							"contain more information)",
+						// Print state token as it's logged, for easy searching
+						fmt.Sprintf("%s.../%d", state[:len(state)/2], len(state)))
 				}
 			} else {
 				// Exchange GitHub token for Pachyderm token

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1887,7 +1887,8 @@ func (a *apiServer) GetAuthToken(ctx context.Context, req *auth.GetAuthTokenRequ
 // GetOIDCLogin implements the protobuf auth.GetOIDCLogin RPC
 func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequest) (resp *auth.GetOIDCLoginResponse, retErr error) {
 	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	// Don't log response to avoid logging OIDC state token
+	defer func(start time.Time) { a.LogResp(req, nil, retErr, time.Since(start)) }(time.Now())
 	var err error
 
 	sp := a.getOIDCSP()
@@ -2472,8 +2473,7 @@ func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigura
 	}
 
 	// Get calling user. The user must be logged in to get the cluster config
-	_, err := a.getAuthenticatedUser(ctx)
-	if err != nil {
+	if _, err := a.getAuthenticatedUser(ctx); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This allows k8s cluster admins to correlate login errors with pachd
logs, without giving them a full authenticator that they can exercise