### PR TITLE
Fix dash compatibility file read to be from a branch not a tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ point-release:
 
 # Run via 'make VERSION_ADDITIONAL=-rc2 release-candidate' to specify a version string
 release-candidate:
+	@if [ $${VERSION_ADDITIONAL:0:1} != - ]; then \
+	  echo "VERSION_ADDITIONAL must start with a '-'"; \
+	  exit 1; \
+	fi
 	@make release-helper
 	@make release-pachctl-custom
 	@echo "Release completed"

--- a/doc/release_instructions.md
+++ b/doc/release_instructions.md
@@ -55,17 +55,15 @@ If you're doing a custom release (off a branch that isn't master), [skip to the 
 4) Update dash compatibility version. Commit these changes locally. You will push to GitHub in a later step.
 ```
 > make dash-compatibility
-> git add src/server/pkg/deploy/cmds/cmds.go
+> git add etc/compatibility/<VERSION>
 > git commit -m"Update dash compatibility for $(pachctl version --client-only) release"
 ```
 
-5) Run `make doc` or `make VERSION_ADDITIONAL=<rc/version suffix> doc-custom` with the new version values.
-
-  Note in particular:
-
-  * You can also run just `make release-custom` to use the commit hash as the version suffix.
-
-  * Make sure you add any newly created (untracked) doc files, in addition to docs that have been updated (`git commit -a` might not get everything)
+5) Run `make doc` or `make VERSION_ADDITIONAL=-<rc/version suffix> doc-custom` with the new version values.
+    - This is only done for Major or Minor releases. We don't publish docs for alpha/beta/rc or custom releases
+    - Note in particular:
+        - You can also run just `make release-custom` to use the commit hash as the version suffix.
+        - Make sure you add any newly created (untracked) doc files, in addition to docs that have been updated (`git commit -a` might not get everything)
 
 6) At this point, all of our auto-generated documentation should be updated. You will push to GitHub in a later step.
 ```
@@ -92,6 +90,10 @@ If you're doing a custom release (off a branch that isn't master), [skip to the 
 ```
 
 10) Run `make point-release` or `make VERSION_ADDITIONAL=-rc1 release-candidate`
+    - To make alpha/beta/rc releases use...
+        - `make VERSION_ADDITIONAL=-alpha1 release-candidate` or
+        - `make VERSION_ADDITIONAL=-beta1 release-candidate` or
+        - `make VERSION_ADDITIONAL=-rc1 release-candidate`
 
 11) Update the
 [release's notes](https://github.com/pachyderm/pachyderm/releases)

--- a/etc/build/dash_compatibility.sh
+++ b/etc/build/dash_compatibility.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-VERSION=$("$GOPATH/bin/pachctl" version --client-only)
+if [ ! -f "$GOPATH/bin/pachctl" ]
+then
+    echo "$GOPATH/bin/pachctl not found."
+    exit 1
+fi
+
+RELVERSION=$("$GOPATH/bin/pachctl" version --client-only)
+VERSION=$(echo "$RELVERSION" | cut -f -1 -d "-")
+
 touch "etc/compatibility/$VERSION"
 go run etc/build/get_dash_version.go >> "etc/compatibility/$VERSION"
 

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
+	golang.org/x/tools v0.0.0-20200706180831-95bc2bdf7e31 // indirect
 	google.golang.org/api v0.6.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/grpc v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -984,6 +984,8 @@ golang.org/x/tools v0.0.0-20200617042924-7f3f4b10a808 h1:t4rDo0JMqBOEHVnboBBPY/e
 golang.org/x/tools v0.0.0-20200617042924-7f3f4b10a808/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f h1:JcoF/bowzCDI+MXu1yLqQGNO3ibqWsWq+Sk7pOT218w=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200706180831-95bc2bdf7e31 h1:wNo56hdB7qh+ACt0fjErJ+RKPLPHJeFQhvSyiJdOThM=
+golang.org/x/tools v0.0.0-20200706180831-95bc2bdf7e31/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/src/client/version/client.go
+++ b/src/client/version/client.go
@@ -67,11 +67,11 @@ func IsCustomRelease(version *pb.Version) bool {
 	return false
 }
 
-// Get branch from version string
+// BranchFromVersion returns version string for the release branch
 // patch release of .0 is always from the master. Others are from the M.m.x branch
 func BranchFromVersion(version *pb.Version) string {
 	if version.Micro == 0 {
-		return fmt.Sprintf("master")
+		return "master"
 	}
 	return fmt.Sprintf("%d.%d.x", version.Major, version.Minor)
 }

--- a/src/client/version/client.go
+++ b/src/client/version/client.go
@@ -67,6 +67,15 @@ func IsCustomRelease(version *pb.Version) bool {
 	return false
 }
 
+// Get branch from version string
+// patch release of .0 is always from the master. Others are from the M.m.x branch
+func BranchFromVersion(version *pb.Version) string {
+	if version.Micro == 0 {
+		return fmt.Sprintf("master")
+	}
+	return fmt.Sprintf("%d.%d.x", version.Major, version.Minor)
+}
+
 // PrettyVersion calls PrettyPrintVersion on Version and returns the result.
 func PrettyVersion() string {
 	return PrettyPrintVersion(Version)

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -1317,9 +1317,9 @@ func getDefaultOrLatestDashImage(dashImage string, dryRun bool) string {
 	var relVersion string
 
 	// This is the branch where to look.
-	// If a new dash version need to be pushed we can just update the compatibility file
-	// in github repo. All version of pachd will pick it upon restart. To make this work
-	// we have to point to the right branch (not tag) in the repo
+	// When a new dash version needs to be pushed we can just update the compatibility file
+	// in pachyderm repo branch. A (re)deploy will pick it up. To make this work we have to
+	// point the URL to the branch (not tag) in the repo.
 	branch := version.BranchFromVersion(version.Version)
 	if version.IsCustomRelease(version.Version) {
 		relVersion = version.PrettyPrintVersionNoAdditional(version.Version)

--- a/src/server/pkg/deploy/cmds/cmds.go
+++ b/src/server/pkg/deploy/cmds/cmds.go
@@ -1307,23 +1307,31 @@ underlying volume will not be removed.`)
 }
 
 func getDefaultOrLatestDashImage(dashImage string, dryRun bool) string {
-	var err error
-	tagVersion := version.PrettyPrintVersion(version.Version)
-	defer func() {
-		if err != nil && !dryRun {
-			fmt.Printf("No updated dash image found for pachctl %v: %v Falling back to dash image %v\n", tagVersion, err, defaultDashImage)
-		}
-	}()
 	if dashImage != "" {
 		// It has been supplied explicitly by version on the command line
 		return dashImage
 	}
 	dashImage = defaultDashImage
-	verCustom := tagVersion
+
+	var err error
+	var relVersion string
+
+	// This is the branch where to look.
+	// If a new dash version need to be pushed we can just update the compatibility file
+	// in github repo. All version of pachd will pick it upon restart. To make this work
+	// we have to point to the right branch (not tag) in the repo
+	branch := version.BranchFromVersion(version.Version)
 	if version.IsCustomRelease(version.Version) {
-		verCustom = version.PrettyPrintVersionNoAdditional(version.Version)
+		relVersion = version.PrettyPrintVersionNoAdditional(version.Version)
+	} else {
+		relVersion = version.PrettyPrintVersion(version.Version)
 	}
-	compatibleDashVersionsURL := fmt.Sprintf("https://raw.githubusercontent.com/pachyderm/pachyderm/v%v/etc/compatibility/%v", tagVersion, verCustom)
+	defer func() {
+		if err != nil && !dryRun {
+			fmt.Printf("No updated dash image found for pachctl in branch %v in release %v: %v Falling back to dash image %v\n", branch, relVersion, err, defaultDashImage)
+		}
+	}()
+	compatibleDashVersionsURL := fmt.Sprintf("https://raw.githubusercontent.com/pachyderm/pachyderm/%v/etc/compatibility/%v", branch, relVersion)
 	resp, err := http.Get(compatibleDashVersionsURL)
 	if err != nil {
 		return dashImage


### PR DESCRIPTION
The problem with the previous fix was that we read from the tag. This meant that if the dash version was every updated, it would only be usable by the next patch release. The big benefit of reading the compatibility file from github is that we can deploy a new hub without releasing a new pach.

This change fixes the issue by reading from the branch. There are a few other changes to note...
1. For any custom/alpha/beta/rc build the compatibility file will remain the main version eg. for 1.11.0-rc1 the dash compatibility file will be in 1.11.0
2. All the VERSION_ADDITIONAL strings need to start with a "-". We recommend passing the variable is in the release-candidate target. We could also pass it in custom-release, but generally, it picks up the head commit hash of the branch.

I have updated the release instructions for alpha/beta/rc candidates.