### PR TITLE
Reduce size of pachctl images

### DIFF
--- a/Dockerfile.pachctl
+++ b/Dockerfile.pachctl
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.0-experimental
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-buster AS pachctl_build
+RUN apt update && apt install ca-certificates
 WORKDIR /app
 COPY . .
 ARG LD_FLAGS
@@ -11,4 +12,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install -ldflags "${LD_FLAGS}" -gcflags "${GC_FLAGS}" ./src/server/cmd/pachctl
 
 FROM debian:buster-slim
+COPY --from=pachctl_build /etc/ssl/certs /etc/ssl/certs
+COPY --from=pachctl_build /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=pachctl_build /go/bin/pachctl /usr/local/bin/pachctl

--- a/Dockerfile.pachctl
+++ b/Dockerfile.pachctl
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1.0-experimental
 ARG GO_VERSION
-FROM golang:${GO_VERSION}
-RUN apt update && apt install ca-certificates
+FROM golang:${GO_VERSION}-buster AS pachctl_build
 WORKDIR /app
 COPY . .
 ARG LD_FLAGS
@@ -10,3 +9,6 @@ ARG LD_FLAGS
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go install -ldflags "${LD_FLAGS}" -gcflags "${GC_FLAGS}" ./src/server/cmd/pachctl
+
+FROM debian:buster-slim
+COPY --from=pachctl_build /go/bin/pachctl /usr/local/bin/pachctl


### PR DESCRIPTION
Reduced size of pachctl images from ~1gb to ~155mb~ <200mb by:

* Using multi-stage builds to avoid storage of intermediate caches
* Using buster-slim rather than buster
* ~Not updating apt~

~One tradeoff of this is that ca certs aren't updated. My assumption here is that debian regularly pushes updates to their ca certs in their images, so apt update isn't necessary, but I'm not sure. It does look like like the buster-slim image [was last updated a month ago.](https://hub.docker.com/layers/debian/library/debian/buster-slim/images/sha256-5bc04978162be23ebb822cb8cfad22619ef8069f33b1d7b433191270a4f578ea?context=explore)~

Closes #5078
