### PR TITLE
'pachctl debug pprof' and PPS_NAMESPACE bug fixes for 1.10.x

### DIFF
--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -607,6 +607,15 @@
                 }
               },
               {
+                "name": "PPS_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              },
+              {
                 "name": "PACHD_MEMORY_REQUEST",
                 "valueFrom": {
                   "resourceFieldRef": {

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -377,6 +377,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: PPS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: PACHD_MEMORY_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -591,6 +591,15 @@
                 }
               },
               {
+                "name": "PPS_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              },
+              {
                 "name": "PACHD_MEMORY_REQUEST",
                 "valueFrom": {
                   "resourceFieldRef": {

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -365,6 +365,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: PPS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: PACHD_MEMORY_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -607,6 +607,15 @@
                 }
               },
               {
+                "name": "PPS_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              },
+              {
                 "name": "PACHD_MEMORY_REQUEST",
                 "valueFrom": {
                   "resourceFieldRef": {

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -377,6 +377,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: PPS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: PACHD_MEMORY_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -588,6 +588,15 @@
                 }
               },
               {
+                "name": "PPS_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              },
+              {
                 "name": "PACHD_MEMORY_REQUEST",
                 "valueFrom": {
                   "resourceFieldRef": {

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -363,6 +363,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: PPS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: PACHD_MEMORY_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/src/server/debug/cmds/cmds.go
+++ b/src/server/debug/cmds/cmds.go
@@ -65,6 +65,7 @@ func Cmds() []*cobra.Command {
 
 	var profileFile string
 	var binaryFile string
+	var interactive bool
 	pprof := &cobra.Command{
 		Use:   "{{alias}} <profile>",
 		Short: "Analyze a profile of pachd in pprof.",
@@ -108,16 +109,22 @@ func Cmds() []*cobra.Command {
 			if err := eg.Wait(); err != nil {
 				return err
 			}
-			cmd := exec.Command("go", "tool", "pprof", binaryFile, profileFile)
-			cmd.Stdin = os.Stdin
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			return cmd.Run()
+			if interactive {
+				cmd := exec.Command("go", "tool", "pprof", binaryFile, profileFile)
+				cmd.Stdin = os.Stdin
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				return cmd.Run()
+			}
+			return nil
 		}),
 	}
 	pprof.Flags().StringVar(&profileFile, "profile-file", "profile", "File to write the profile to.")
 	pprof.Flags().StringVar(&binaryFile, "binary-file", "binary", "File to write the binary to.")
 	pprof.Flags().DurationVarP(&duration, "duration", "d", time.Minute, "Duration to run a CPU profile for.")
+	pprof.Flags().BoolVarP(&interactive, "interactive", "i", false, "If set, "+
+		"open an interactive session with 'go tool pprof' analyzing the collected "+
+		"profile.")
 	commands = append(commands, cmdutil.CreateAlias(pprof, "debug pprof"))
 
 	debug := &cobra.Command{

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -643,6 +643,15 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend backend, hostPath strin
 			},
 		},
 		{
+			Name: client.PPSNamespaceEnv,
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace",
+				},
+			},
+		},
+		{
 			Name: "PACHD_MEMORY_REQUEST",
 			ValueFrom: &v1.EnvVarSource{
 				ResourceFieldRef: &v1.ResourceFieldSelector{

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -100,6 +100,9 @@ func (a *apiServer) workerPodSpec(options *workerOptions) (v1.PodSpec, error) {
 	}, {
 		Name:  "PACHD_POD_NAMESPACE",
 		Value: a.namespace,
+	}, {
+		Name:  client.PPSNamespaceEnv,
+		Value: a.namespace,
 	}}
 	sidecarEnv = append(sidecarEnv, assets.GetSecretEnvVars(a.storageBackend)...)
 	storageEnvVars, err := getStorageEnvVars()


### PR DESCRIPTION
Two fixes:
1. Wrap 'go tool' cmd in'pachctl debug pprof' with -i (#5022 for 1.10.x)
2. Fix namespace bug in 1.10.x (PPS_NAMESPACE isn't set in the sidecar, which causes s3 gateway to create services in the wrong namespace)