### PR TITLE
Push the image that was built

### DIFF
--- a/etc/pipeline-build/Makefile
+++ b/etc/pipeline-build/Makefile
@@ -4,7 +4,7 @@ docker-build:
 	ls | grep -v Makefile | xargs -I {} docker build -t pachyderm/{}-build:$(shell $(GOPATH)/bin/pachctl version --client-only) {}
 
 push-to-minikube: docker-build
-	ls | grep -v Makefile | xargs -I {} ../kube/push-to-minikube.sh {}
+	ls | grep -v Makefile | xargs -I {} ../kube/push-to-minikube.sh pachyderm/{}-build:$(shell $(GOPATH)/bin/pachctl version --client-only)
 
 docker-push: docker-build
 	ls | grep -v Makefile | xargs -I {} docker push pachyderm/{}-build:$(shell $(GOPATH)/bin/pachctl version --client-only)


### PR DESCRIPTION
This change fixes `(cd etc/pipeline-build; make push-to-minikube)` for me, by making it try to push the image it just built, rather than one named e.g. 'go' or 'python'.