### PR TITLE
Adds compactResult type to return information about compaction

### DIFF
--- a/src/server/pfs/server/driver_v2.go
+++ b/src/server/pfs/server/driver_v2.go
@@ -510,7 +510,8 @@ func (d *driverV2) compactionWorker() {
 				Lower: shard.Range.Lower,
 				Upper: shard.Range.Upper,
 			}
-			return d.storage.Compact(ctx, shard.OutputPath, shard.Compaction.InputPrefixes, index.WithRange(pathRange))
+			_, err = d.storage.Compact(ctx, shard.OutputPath, shard.Compaction.InputPrefixes, index.WithRange(pathRange))
+			return err
 		})
 	}, backoff.NewInfiniteBackOff(), func(err error, _ time.Duration) error {
 		log.Printf("error in compaction worker: %v", err)

--- a/src/server/pkg/storage/fileset/fileset_test.go
+++ b/src/server/pkg/storage/fileset/fileset_test.go
@@ -235,7 +235,8 @@ func TestCompaction(t *testing.T) {
 		// Get the file hashes.
 		getHashes(t, fileSets, files, msg)
 		// Compact the files.
-		require.NoError(t, fileSets.Compact(context.Background(), path.Join(testPath, Compacted), []string{testPath}), msg)
+		_, err := fileSets.Compact(context.Background(), path.Join(testPath, Compacted), []string{testPath})
+		require.NoError(t, err, msg)
 		// Check the files.
 		r := fileSets.newReader(context.Background(), path.Join(testPath, Compacted))
 		require.NoError(t, r.Iterate(func(fr *FileReader) error {

--- a/src/server/pkg/storage/fileset/option.go
+++ b/src/server/pkg/storage/fileset/option.go
@@ -65,7 +65,14 @@ type WriterOption func(w *Writer)
 // WithNoUpload sets the writer to no upload (will not upload chunks).
 func WithNoUpload(f func(*index.Index) error) WriterOption {
 	return func(w *Writer) {
+		w.noUpload = true
 		w.indexFunc = f
+	}
+}
+
+func WithIndexCallback(cb func(*index.Index) error) WriterOption {
+	return func(w *Writer) {
+		w.indexFunc = cb
 	}
 }
 

--- a/src/server/pkg/storage/fileset/option.go
+++ b/src/server/pkg/storage/fileset/option.go
@@ -69,6 +69,8 @@ func WithNoUpload() WriterOption {
 	}
 }
 
+// WithIndexCallback sets a function to be called after each index is written.
+// If WithNoUpload is set, the function is called after the index would have been written.
 func WithIndexCallback(cb func(*index.Index) error) WriterOption {
 	return func(w *Writer) {
 		w.indexFunc = cb

--- a/src/server/pkg/storage/fileset/option.go
+++ b/src/server/pkg/storage/fileset/option.go
@@ -63,10 +63,9 @@ func WithRoot(root string) Option {
 type WriterOption func(w *Writer)
 
 // WithNoUpload sets the writer to no upload (will not upload chunks).
-func WithNoUpload(f func(*index.Index) error) WriterOption {
+func WithNoUpload() WriterOption {
 	return func(w *Writer) {
 		w.noUpload = true
-		w.indexFunc = f
 	}
 }
 

--- a/src/server/pkg/storage/fileset/storage.go
+++ b/src/server/pkg/storage/fileset/storage.go
@@ -105,10 +105,14 @@ func (s *Storage) newReader(ctx context.Context, fileSet string, opts ...index.O
 // NewMergeReader returns a merge reader for a set for filesets.
 func (s *Storage) NewMergeReader(ctx context.Context, fileSets []string, opts ...index.Option) (*MergeReader, error) {
 	fileSets = applyPrefixes(fileSets)
+	return s.newMergeReader(ctx, fileSets, opts...)
+}
+
+func (s *Storage) newMergeReader(ctx context.Context, fileSets []string, opts ...index.Option) (*MergeReader, error) {
 	var rs []*Reader
 	for _, fileSet := range fileSets {
 		if err := s.objC.Walk(ctx, fileSet, func(name string) error {
-			rs = append(rs, s.NewReader(ctx, name, opts...))
+			rs = append(rs, s.newReader(ctx, name, opts...))
 			return nil
 		}); err != nil {
 			return nil, err
@@ -135,7 +139,7 @@ func (s *Storage) ResolveIndexes(ctx context.Context, fileSets []string, f func(
 // for creating shards).
 func (s *Storage) Shard(ctx context.Context, fileSets []string, shardFunc ShardFunc) error {
 	fileSets = applyPrefixes(fileSets)
-	mr, err := s.NewMergeReader(ctx, fileSets)
+	mr, err := s.newMergeReader(ctx, fileSets)
 	if err != nil {
 		return err
 	}
@@ -156,7 +160,7 @@ func (s *Storage) Compact(ctx context.Context, outputFileSet string, inputFileSe
 		size += idx.SizeBytes
 		return nil
 	}))
-	mr, err := s.NewMergeReader(ctx, inputFileSets, opts...)
+	mr, err := s.newMergeReader(ctx, inputFileSets, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pkg/storage/fileset/storage.go
+++ b/src/server/pkg/storage/fileset/storage.go
@@ -122,12 +122,12 @@ func (s *Storage) newMergeReader(ctx context.Context, fileSets []string, opts ..
 }
 
 // ResolveIndexes resolves index entries that are spread across multiple filesets.
-func (s *Storage) ResolveIndexes(ctx context.Context, fileSets []string, f func(*index.Index) error, opts ...index.Option) error {
+func (s *Storage) ResolveIndexes(ctx context.Context, fileSets []string, cb func(*index.Index) error, opts ...index.Option) error {
 	mr, err := s.NewMergeReader(ctx, fileSets, opts...)
 	if err != nil {
 		return err
 	}
-	w := s.newWriter(ctx, "", WithNoUpload(f))
+	w := s.newWriter(ctx, "", WithNoUpload(), WithIndexCallback(cb))
 	if err := mr.WriteTo(w); err != nil {
 		return err
 	}
@@ -146,13 +146,13 @@ func (s *Storage) Shard(ctx context.Context, fileSets []string, shardFunc ShardF
 	return shard(mr, s.shardThreshold, shardFunc)
 }
 
-// CompactResult contains information about what was compacted.
-type CompactResult struct {
-	OutputSize uint64
+// CompactStats contains information about what was compacted.
+type CompactStats struct {
+	OutputSize int64
 }
 
 // Compact compacts a set of filesets into an output fileset.
-func (s *Storage) Compact(ctx context.Context, outputFileSet string, inputFileSets []string, opts ...index.Option) (*CompactResult, error) {
+func (s *Storage) Compact(ctx context.Context, outputFileSet string, inputFileSets []string, opts ...index.Option) (*CompactStats, error) {
 	outputFileSet = applyPrefix(outputFileSet)
 	inputFileSets = applyPrefixes(inputFileSets)
 	var size int64
@@ -170,7 +170,7 @@ func (s *Storage) Compact(ctx context.Context, outputFileSet string, inputFileSe
 	if err := w.Close(); err != nil {
 		return nil, err
 	}
-	return &CompactResult{OutputSize: uint64(size)}, nil
+	return &CompactStats{OutputSize: size}, nil
 }
 
 // CompactSpec specifies the input and output for a compaction operation.

--- a/src/server/pkg/storage/fileset/writer.go
+++ b/src/server/pkg/storage/fileset/writer.go
@@ -115,6 +115,11 @@ func (w *Writer) callback() chunk.WriterFunc {
 		}
 		// Don't write out the last file index (it may have more content in the next chunk).
 		idxs = idxs[:len(idxs)-1]
+		if !w.noUpload {
+			if err := w.iw.WriteIndexes(idxs); err != nil {
+				return err
+			}
+		}
 		if w.indexFunc != nil {
 			for _, idx := range idxs {
 				if err := w.indexFunc(idx); err != nil {
@@ -122,10 +127,7 @@ func (w *Writer) callback() chunk.WriterFunc {
 				}
 			}
 		}
-		if w.noUpload {
-			return nil
-		}
-		return w.iw.WriteIndexes(idxs)
+		return nil
 	}
 }
 

--- a/src/server/pkg/storage/fileset/writer.go
+++ b/src/server/pkg/storage/fileset/writer.go
@@ -37,7 +37,7 @@ func newWriter(ctx context.Context, objC obj.Client, chunks *chunk.Storage, path
 		opt(w)
 	}
 	var chunkWriterOpts []chunk.WriterOption
-	if w.indexFunc != nil {
+	if w.noUpload {
 		chunkWriterOpts = append(chunkWriterOpts, chunk.WithNoUpload())
 	}
 	w.iw = index.NewWriter(ctx, objC, chunks, path, tmpID)


### PR DESCRIPTION
This adds a `compactResult` type to the `./src/server/pfs/server` package with a field `OutputSize` for returning the size of the compacted data after compaction.
Also has changes to `fileset.Writer` which allow a callback to be called with index data without disabling chunk uploading.