### PR TITLE
Warn users when they use the `latest` tag

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -1169,6 +1169,22 @@ func pipelineHelper(reprocess bool, build bool, pushImages bool, registry, usern
 			}
 		}
 
+		// Don't warn if transform.build is set because latest is almost always
+		// legit for build-enabled pipelines.
+		if request.Transform != nil && request.Transform.Build == nil && request.Transform.Image != "" {
+			if !strings.Contains(request.Transform.Image, ":") {
+				fmt.Fprintf(os.Stderr,
+					"WARNING: please specify a tag for the docker image in your transform.image spec.\n"+
+						"For example, change 'python' to 'python:3' or 'bash' to 'bash:5'. This improves\n"+
+						"reproducibility of your pipelines.\n")
+			} else if strings.HasSuffix(request.Transform.Image, ":latest") {
+				fmt.Fprintf(os.Stderr,
+					"WARNING: please do not specify the ':latest' tag for the docker image in your\n"+
+						"transform.image spec. For example, change 'python:latest' to 'python:3' or\n"+
+						"'bash:latest' to 'bash:5'. This improves reproducibility of your pipelines.\n")
+			}
+		}
+
 		if _, err := pc.PpsAPIClient.CreatePipeline(
 			pc.Ctx(),
 			request,

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -835,7 +835,7 @@ func TestPipelineBuildMissingPath(t *testing.T) {
 // 	require.NoError(t, rootCmd().Execute())
 // }
 
-func runPipelineWithImageGetStderr(t *testing.T, image string) string {
+func runPipelineWithImageGetStderr(t *testing.T, image string) (string, error) {
 	// reset and create some test input
 	require.NoError(t, tu.BashCmd(`
 		yes | pachctl delete all
@@ -865,9 +865,9 @@ EOF
 	cmd.Stderr = buf
 	// cmd.Stdout = os.Stdout // uncomment for debugging
 	cmd.Env = os.Environ()
-	cmd.Run()
+	err := cmd.Run()
 	stderr := buf.String()
-	return stderr
+	return stderr, err
 }
 
 func TestWarningLatestTag(t *testing.T) {
@@ -875,7 +875,11 @@ func TestWarningLatestTag(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	// should emit a warning because user specified latest tag on docker image
-	stderr := runPipelineWithImageGetStderr(t, "ubuntu:latest")
+	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu:latest")
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	if !strings.Contains(stderr, "WARNING") {
 		t.Logf(
 			"pachctl create pipeline failed to emit a WARNING to stderr, got %s",
@@ -891,7 +895,11 @@ func TestWarningEmptyTag(t *testing.T) {
 	}
 	// should emit a warning because user specified empty tag, equivalent to
 	// :latest
-	stderr := runPipelineWithImageGetStderr(t, "ubuntu")
+	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu")
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	if !strings.Contains(stderr, "WARNING") {
 		t.Logf(
 			"pachctl create pipeline failed to emit a WARNING to stderr, got %s",
@@ -907,7 +915,11 @@ func TestNoWarningTagSpecified(t *testing.T) {
 	}
 	// should not emit a warning (note _lack_ of ! on strings.Contains) because
 	// user specified non-empty, non-latest tag
-	stderr := runPipelineWithImageGetStderr(t, "ubuntu:xenial")
+	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu:xenial")
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	if strings.Contains(stderr, "WARNING") {
 		t.Logf(
 			"pachctl create pipeline failed to emit a WARNING to stderr, got %s",

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -876,17 +876,8 @@ func TestWarningLatestTag(t *testing.T) {
 	}
 	// should emit a warning because user specified latest tag on docker image
 	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu:latest")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if !strings.Contains(stderr, "WARNING") {
-		t.Logf(
-			"pachctl create pipeline failed to emit a WARNING to stderr, got %s",
-			stderr,
-		)
-		t.Fail()
-	}
+	require.NoError(t, err)
+	require.Matches(t, "WARNING", stderr)
 }
 
 func TestWarningEmptyTag(t *testing.T) {
@@ -896,35 +887,17 @@ func TestWarningEmptyTag(t *testing.T) {
 	// should emit a warning because user specified empty tag, equivalent to
 	// :latest
 	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if !strings.Contains(stderr, "WARNING") {
-		t.Logf(
-			"pachctl create pipeline failed to emit a WARNING to stderr, got %s",
-			stderr,
-		)
-		t.Fail()
-	}
+	require.NoError(t, err)
+	require.Matches(t, "WARNING", stderr)
 }
 
 func TestNoWarningTagSpecified(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	// should not emit a warning (note _lack_ of ! on strings.Contains) because
-	// user specified non-empty, non-latest tag
+	// should not emit a warning (stderr should be empty) because user
+	// specified non-empty, non-latest tag
 	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu:xenial")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if strings.Contains(stderr, "WARNING") {
-		t.Logf(
-			"pachctl create pipeline failed to emit a WARNING to stderr, got %s",
-			stderr,
-		)
-		t.Fail()
-	}
+	require.NoError(t, err)
+	require.Equal(t, "", stderr)
 }


### PR DESCRIPTION
Attempts to solve https://github.com/pachyderm/pachyderm/issues/5114

Demo:

## latest tag case
```
luke@light:~/Projects/Pachyderm/pachyderm$ pachctl create pipeline <<EOF
            {
              "pipeline": {
                "name": "first"
              },
              "transform": {
                "image": "ubuntu:latest"
              },
              "input": {
                "pfs": {
                  "repo": "in",
                  "glob": "/*"
                }
              }
            }
EOF
Reading from stdin.
WARNING: please do not specify the ':latest' tag for the docker image in your
transform.image spec. For example, change 'python:latest' to 'python:3' or
'bash:latest' to 'bash:5'. This improves reproducibility of your pipelines.
```

## no tag case
```
luke@light:~/Projects/Pachyderm/pachyderm$ pachctl create pipeline <<EOF
            {
              "pipeline": {
                "name": "first"
              },
              "transform": {
                "image": "ubuntu"
              },
              "input": {
                "pfs": {
                  "repo": "in",
                  "glob": "/*"
                }
              }
            }
EOF
Reading from stdin.
WARNING: please specify a tag for the docker image in your transform.image spec.
For example, change 'python' to 'python:3' or 'bash' to 'bash:5'. This improves
reproducibility of your pipelines.
```