### PR TITLE
Deferred provenance bugfix

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10692,6 +10692,89 @@ func TestSpout(t *testing.T) {
 	})
 }
 
+func TestDeferredCross(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
+
+	// make repo for our dataset
+	dataSet := "dataset"
+	require.NoError(t, c.CreateRepo(dataSet))
+
+	downstreamPipeline := "downstream"
+	_, err := c.PpsAPIClient.CreatePipeline(
+		context.Background(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(downstreamPipeline),
+			Transform: &pps.Transform{
+				Cmd: []string{"bash"},
+				Stdin: []string{
+					fmt.Sprintf("cp /pfs/%v/* /pfs/out", dataSet),
+				},
+			},
+			Input: client.NewPFSInput(dataSet, "master"),
+
+			OutputBranch: "master",
+		})
+	require.NoError(t, err)
+
+	_, err = c.PutFile(dataSet, "master", "file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+	_, err = c.PutFile(dataSet, "master", "file2", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	_, err = c.FlushCommitAll([]*pfs.Commit{client.NewCommit(dataSet, "master")}, nil)
+	require.NoError(t, err)
+
+	err = c.CreateBranch(downstreamPipeline, "other", "master^", nil)
+	require.NoError(t, err)
+
+	// next, create an imputation pipeline which is a cross of the dataset with the union of two different freeze branches
+	impPipeline := "imputed"
+	_, err = c.PpsAPIClient.CreatePipeline(
+		context.Background(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(impPipeline),
+			Transform: &pps.Transform{
+				Cmd: []string{"bash"},
+				Stdin: []string{
+					"true",
+				},
+			},
+			Input: client.NewCrossInput(
+				client.NewUnionInput(
+					client.NewPFSInputOpts("a", downstreamPipeline, "master", "/", "", false),
+					client.NewPFSInputOpts("b", downstreamPipeline, "other", "/", "", false),
+				),
+				client.NewPFSInput(dataSet, "/"),
+			),
+			OutputBranch: "master",
+		})
+	require.NoError(t, err)
+
+	// after all this, the imputation job should be using the master commit of the dataset repo
+	_, err = c.FlushJobAll([]*pfs.Commit{client.NewCommit(dataSet, "master")}, nil)
+	require.NoError(t, err)
+
+	jobs, err := c.ListJob(impPipeline, nil, nil, 0, true)
+	require.NoError(t, err)
+	require.Equal(t, len(jobs), 1)
+
+	jobInfo, err := c.InspectJob(jobs[0].Job.ID, false)
+
+	headCommit, err := c.InspectCommit(dataSet, "master")
+	require.NoError(t, err)
+
+	pps.VisitInput(jobInfo.Input, func(i *pps.Input) {
+		if i.Pfs != nil && i.Pfs.Repo == dataSet {
+			require.Equal(t, i.Pfs.Commit, headCommit.Commit.ID)
+		}
+	})
+}
+
 func TestDeferredProcessing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -10752,6 +10835,42 @@ func TestDeferredProcessing(t *testing.T) {
 	commitInfos, err = c.FlushCommitAll([]*pfs.Commit{commit}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(commitInfos))
+
+	pipeline3 := tu.UniqueString("TestDeferredProcessing3")
+	require.NoError(t, c.CreatePipeline(
+		pipeline3,
+		"",
+		[]string{"bash"},
+		[]string{
+			fmt.Sprintf("for a in /pfs/%s/*", pipeline1),
+			"do",
+			fmt.Sprintf("for b in /pfs/%s/*", pipeline2),
+			"do",
+			"touch /pfs/out/$(basename $a)_$(basename $b)",
+			"done",
+			"done",
+		},
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewCrossInput(
+			client.NewPFSInput(pipeline1, "/*"),
+			client.NewPFSInput(pipeline2, "/*"),
+		),
+		"",
+		false,
+	))
+
+	_, err = c.PutFile(dataRepo, "master", "a", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	_, err = c.PutFile(dataRepo, "master", "b", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	commit = client.NewCommit(dataRepo, "staging")
+	commitInfos, err = c.FlushCommitAll([]*pfs.Commit{commit}, nil)
+	require.NoError(t, err)
+
 }
 
 func TestPipelineHistory(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10702,10 +10702,10 @@ func TestDeferredCross(t *testing.T) {
 	require.NoError(t, c.DeleteAll())
 
 	// make repo for our dataset
-	dataSet := "dataset"
+	dataSet := tu.UniqueString("dataset")
 	require.NoError(t, c.CreateRepo(dataSet))
 
-	downstreamPipeline := "downstream"
+	downstreamPipeline := tu.UniqueString("downstream")
 	_, err := c.PpsAPIClient.CreatePipeline(
 		context.Background(),
 		&pps.CreatePipelineRequest{
@@ -10736,7 +10736,7 @@ func TestDeferredCross(t *testing.T) {
 	require.NoError(t, err)
 
 	// next, create an imputation pipeline which is a cross of the dataset with the union of two different freeze branches
-	impPipeline := "imputed"
+	impPipeline := tu.UniqueString("imputed")
 	_, err = c.PpsAPIClient.CreatePipeline(
 		context.Background(),
 		&pps.CreatePipelineRequest{

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1406,6 +1406,31 @@ func (d *driver) makeCommit(
 		}
 	}
 
+	// this isn't necessary here, but is done for consistency with commits created by propagateCommits
+	// it ensures that the last commit to appear from a specific branch is the latest one on that branch
+	sort.SliceStable(newCommitInfo.Provenance, func(i, j int) bool {
+		// to make sure the parent relationship is respected during sort, we need to make sure that we organize
+		// the provenance by repo name and branch name
+		if newCommitInfo.Provenance[i].Commit.Repo.Name != newCommitInfo.Provenance[j].Commit.Repo.Name {
+			return newCommitInfo.Provenance[i].Commit.Repo.Name < newCommitInfo.Provenance[j].Commit.Repo.Name
+		} else if newCommitInfo.Provenance[i].Branch.Name != newCommitInfo.Provenance[j].Branch.Name {
+			return newCommitInfo.Provenance[i].Branch.Name < newCommitInfo.Provenance[j].Branch.Name
+		}
+
+		// we need to check the commit info of the 'j' provenance commit to get the parent
+		provCommitInfo, err := d.resolveCommit(txnCtx.Stm, newCommitInfo.Provenance[j].Commit)
+		if err != nil {
+			// not really anything to do at this point
+			return true
+		}
+		// the parent commit of 'j' should precede it
+		if provCommitInfo.ParentCommit != nil &&
+			newCommitInfo.Provenance[i].Commit.ID == provCommitInfo.ParentCommit.ID {
+			return true
+		}
+		return false
+	})
+
 	// Finally, create the commit
 	if err := commits.Create(newCommit.ID, newCommitInfo); err != nil {
 		return nil, err
@@ -1777,6 +1802,31 @@ nextSubvBI:
 				return err
 			}
 		}
+
+		// this ensures that the job's output commit uses the latest commit on the branch, by ensuring it is the
+		// last commit to appear in the provenance slice
+		sort.SliceStable(newCommitInfo.Provenance, func(i, j int) bool {
+			// to make sure the parent relationship is respected during sort, we need to make sure that we organize
+			// the provenance by repo name and branch name
+			if newCommitInfo.Provenance[i].Commit.Repo.Name != newCommitInfo.Provenance[j].Commit.Repo.Name {
+				return newCommitInfo.Provenance[i].Commit.Repo.Name < newCommitInfo.Provenance[j].Commit.Repo.Name
+			} else if newCommitInfo.Provenance[i].Branch.Name != newCommitInfo.Provenance[j].Branch.Name {
+				return newCommitInfo.Provenance[i].Branch.Name < newCommitInfo.Provenance[j].Branch.Name
+			}
+
+			// we need to check the commit info of the 'j' provenance commit to get the parent
+			provCommitInfo, err := d.resolveCommit(stm, newCommitInfo.Provenance[j].Commit)
+			if err != nil {
+				// not really anything to do at this point
+				return true
+			}
+			// the parent commit of 'j' should precede it
+			if provCommitInfo.ParentCommit != nil &&
+				newCommitInfo.Provenance[i].Commit.ID == provCommitInfo.ParentCommit.ID {
+				return true
+			}
+			return false
+		})
 
 		// finally create open 'commit'
 		if err := stmCommits.Create(newCommit.ID, newCommitInfo); err != nil {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1418,9 +1418,10 @@ func (d *driver) makeCommit(
 		}
 
 		// we need to check the commit info of the 'j' provenance commit to get the parent
-		provCommitInfo, err := d.resolveCommit(txnCtx.Stm, newCommitInfo.Provenance[j].Commit)
+		var provCommitInfo *pfs.CommitInfo
+		provCommitInfo, err = d.resolveCommit(txnCtx.Stm, newCommitInfo.Provenance[j].Commit)
 		if err != nil {
-			// not really anything to do at this point
+			// not really anything to do at this point, error will be captured after
 			return true
 		}
 		// the parent commit of 'j' should precede it
@@ -1430,6 +1431,10 @@ func (d *driver) makeCommit(
 		}
 		return false
 	})
+	// capture any errors during sorting
+	if err != nil {
+		return nil, err
+	}
 
 	// Finally, create the commit
 	if err := commits.Create(newCommit.ID, newCommitInfo); err != nil {
@@ -1805,6 +1810,7 @@ nextSubvBI:
 
 		// this ensures that the job's output commit uses the latest commit on the branch, by ensuring it is the
 		// last commit to appear in the provenance slice
+		var err error
 		sort.SliceStable(newCommitInfo.Provenance, func(i, j int) bool {
 			// to make sure the parent relationship is respected during sort, we need to make sure that we organize
 			// the provenance by repo name and branch name
@@ -1815,9 +1821,10 @@ nextSubvBI:
 			}
 
 			// we need to check the commit info of the 'j' provenance commit to get the parent
-			provCommitInfo, err := d.resolveCommit(stm, newCommitInfo.Provenance[j].Commit)
+			var provCommitInfo *pfs.CommitInfo
+			provCommitInfo, err = d.resolveCommit(stm, newCommitInfo.Provenance[j].Commit)
 			if err != nil {
-				// not really anything to do at this point
+				// not really anything to do at this point, error will be captured after
 				return true
 			}
 			// the parent commit of 'j' should precede it
@@ -1827,6 +1834,10 @@ nextSubvBI:
 			}
 			return false
 		})
+		// capture any errors during sorting
+		if err != nil {
+			return err
+		}
 
 		// finally create open 'commit'
 		if err := stmCommits.Create(newCommit.ID, newCommitInfo); err != nil {

--- a/src/server/pkg/ppsutil/util.go
+++ b/src/server/pkg/ppsutil/util.go
@@ -220,6 +220,8 @@ func JobInput(pipelineInfo *pps.PipelineInfo, outputCommitInfo *pfs.CommitInfo) 
 	// branchToCommit maps strings of the form "<repo>/<branch>" to PFS commits
 	branchToCommit := make(map[string]*pfs.Commit)
 	key := path.Join
+	// for a given branch, the commit assigned to it will be the latest commit on that branch
+	// this is ensured by the way we sort the commit provenance when creating the outputCommit
 	for _, prov := range outputCommitInfo.Provenance {
 		branchToCommit[key(prov.Commit.Repo.Name, prov.Branch.Name)] = prov.Commit
 	}


### PR DESCRIPTION
Fixes https://github.com/pachyderm/pachyderm/issues/5172 by doing a topological sort on the provenance of commits, so that the job will naturally use the correct commit when multiple commits from the same branch appear in the output commit provenance.