### PR TITLE
Fix BREAK error when listing commits with a limit

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -130,7 +130,7 @@
     {
       "label": "deploy-dev",
       "type": "shell",
-      "command": "pachctl deploy local --no-guaranteed -d --dry-run --cluster-deployment-id=dev | kubectl apply -f - && kubectl rollout restart deployment.apps"
+      "command": "pachctl deploy local --no-guaranteed -d --dry-run --cluster-deployment-id=dev | kubectl apply -f -"
     },
     {
       "label": "wait-dev",

--- a/etc/compile/vscode_compile_task.sh
+++ b/etc/compile/vscode_compile_task.sh
@@ -10,6 +10,7 @@ LD_FLAGS="-X github.com/pachyderm/pachyderm/src/client/version.AdditionalVersion
 DOCKER_OPTS=()
 DOCKER_OPTS+=("--build-arg=GO_VERSION=${GO_VERSION}")
 DOCKER_OPTS+=("--build-arg=LD_FLAGS=${LD_FLAGS}")
+DOCKER_OPTS+=("--build-arg=GC_FLAGS=${GC_FLAGS}")
 DOCKER_OPTS+=("--memory=3gb")
 
 if [[ "${OS}" == "Windows_NT" ]]; then
@@ -17,7 +18,7 @@ if [[ "${OS}" == "Windows_NT" ]]; then
   eval "$(minikube docker-env --shell bash)"
 fi
 
-DOCKER_BUILDKIT=1 docker build "${DOCKER_OPTS[@]}" --progress plain -t pachyderm_build "${REPO_DIR}"
+DOCKER_BUILDKIT=1 docker build "${DOCKER_OPTS[@]}" --progress plain -f Dockerfile.pachd -t pachyderm_build "${REPO_DIR}"
 docker build "${DOCKER_OPTS[@]}" -t pachyderm/pachd "${REPO_DIR}/etc/pachd"
 docker tag pachyderm/pachd pachyderm/pachd:local
 docker build "${DOCKER_OPTS[@]}" -t pachyderm/worker "${REPO_DIR}/etc/worker"

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -2038,6 +2038,9 @@ func (d *driver) listCommitF(pachClient *client.APIClient, repo *pfs.Repo,
 		if err := commits.ListRev(ci, &opts, func(commitID string, createRev int64) error {
 			if createRev != lastRev {
 				if err := sendCis(); err != nil {
+					if errors.Is(err, errutil.ErrBreak) {
+						return nil
+					}
 					return err
 				}
 				lastRev = createRev
@@ -2048,7 +2051,7 @@ func (d *driver) listCommitF(pachClient *client.APIClient, repo *pfs.Repo,
 			return err
 		}
 		// Call sendCis one last time to send whatever's pending in 'cis'
-		if err := sendCis(); err != nil {
+		if err := sendCis(); err != nil && !errors.Is(err, errutil.ErrBreak) {
 			return err
 		}
 	} else {

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -388,6 +388,28 @@ func TestCreateDeletedRepo(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Make sure that commits of deleted repos do not resurface
+func TestListCommitLimit(t *testing.T) {
+	t.Parallel()
+	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
+		repo := "repo"
+		require.NoError(t, env.PachClient.CreateRepo(repo))
+
+		_, err := env.PachClient.PutFile(repo, "master", "foo", strings.NewReader("foo"))
+		require.NoError(t, err)
+
+		_, err = env.PachClient.PutFile(repo, "master", "bar", strings.NewReader("bar"))
+		require.NoError(t, err)
+
+		commitInfos, err := env.PachClient.ListCommit(repo, "", "", 1)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(commitInfos))
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 // The DAG looks like this before the update:
 // prov1 prov2
 //   \    /

--- a/src/server/pkg/cmdutil/password.go
+++ b/src/server/pkg/cmdutil/password.go
@@ -16,8 +16,8 @@ func ReadPassword(prompt string) (string, error) {
 
 	// If stdin is a attached to the TTY (rather than being piped in), use a
 	// terminal password prompt, which will hide the input
-	if terminal.IsTerminal(syscall.Stdin) {
-		pass, err := terminal.ReadPassword(syscall.Stdin)
+	if terminal.IsTerminal(int(syscall.Stdin)) {
+		pass, err := terminal.ReadPassword(int(syscall.Stdin))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
When `pfs.listCommitF` goes over the user-specified commit limit, it returns an `errutil.ErrBreak`, which is not handled by callers.  For the PFS `driver.listCommit`, this means it will return nothing except the error.  For the PFS `apiServer.ListCommitStream`, it will return each of the commits followed by an error.

Added a simple test for the list commit limit behavior which is fixed by this change.

Also includes a couple unrelated fixes for the windows build that have bitrotted.