### PR TITLE
Add cooperative lockfile as port-forward mutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
 	github.com/jinzhu/gorm v1.9.12
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.3.0
 	github.com/lunixbochs/vtclean v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -742,6 +742,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b h1:FQ7+9fxhyp82ks9vAuyPzG0/vVbWwMwLJ+P6yJI5FN8=
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b/go.mod h1:HMcgvsgd0Fjj4XXDkbjdmlbI505rUPBs6WBMYg2pXks=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -552,7 +552,7 @@ This resets the cluster to its initial state.`,
 			if err != nil {
 				return errors.New("could not determine user config directory")
 			}
-			lockfilePath := filepath.Join(configDir, fmt.Sprintf("port-forward.%s.lock", context.ClusterDeploymentID))
+			lockfilePath := filepath.Join(configDir, ".pachyderm", fmt.Sprintf("port-forward.%s.lock", context.ClusterDeploymentID))
 			lockfile := fslock.New(lockfilePath)
 
 			if err := lockfile.TryLock(); err != nil {

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -552,7 +552,7 @@ This resets the cluster to its initial state.`,
 			if err != nil {
 				return errors.New("could not determine user config directory")
 			}
-			lockfilePath := filepath.Join(configDir, ".pachyderm", fmt.Sprintf("port-forward.%s.lock", context.ClusterDeploymentID))
+			lockfilePath := filepath.Join(configDir, ".pachyderm", "lockfiles", fmt.Sprintf("port-forward.%s.lock", context.ClusterDeploymentID))
 			lockfile := fslock.New(lockfilePath)
 
 			if err := lockfile.TryLock(); err != nil {


### PR DESCRIPTION
Puts a lockfile in the config directory that prevents multiple `pachctl port-forward`s from running for the same context concurrently.  This is more reliable than keeping track of `port-forward` in the config file, as we can maintain a file-lock that is scoped to the lifetime of the locking process rather than relying on an orderly shutdown to clean up the config file.  There is a separate lockfile per-context.

This fixes #5182 and #4713.