### PR TITLE
client: allow the client to use interceptors

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -146,6 +146,8 @@ type clientSettings struct {
 	dialTimeout          time.Duration
 	caCerts              *x509.CertPool
 	storageV2            bool
+	unaryInterceptors    []grpc.UnaryClientInterceptor
+	streamInterceptors   []grpc.StreamClientInterceptor
 }
 
 // NewFromAddress constructs a new APIClient for the server at addr.
@@ -155,7 +157,7 @@ func NewFromAddress(addr string, options ...Option) (*APIClient, error) {
 		return nil, errors.Errorf("address shouldn't contain protocol (\"://\"), but is: %q", addr)
 	}
 	// Apply creation options
-	settings := clientSettings{
+	settings := &clientSettings{
 		maxConcurrentStreams: DefaultMaxConcurrentStreams,
 		dialTimeout:          DefaultDialTimeout,
 	}
@@ -170,9 +172,13 @@ func NewFromAddress(addr string, options ...Option) (*APIClient, error) {
 		}
 	}
 	for _, option := range options {
-		if err := option(&settings); err != nil {
+		if err := option(settings); err != nil {
 			return nil, err
 		}
+	}
+	if tracing.IsActive() {
+		settings.unaryInterceptors = append(settings.unaryInterceptors, tracing.UnaryClientInterceptor())
+		settings.streamInterceptors = append(settings.streamInterceptors, tracing.StreamClientInterceptor())
 	}
 	c := &APIClient{
 		addr:         addr,
@@ -181,7 +187,7 @@ func NewFromAddress(addr string, options ...Option) (*APIClient, error) {
 		gzipCompress: settings.gzipCompress,
 		storageV2:    settings.storageV2,
 	}
-	if err := c.connect(settings.dialTimeout); err != nil {
+	if err := c.connect(settings.dialTimeout, settings.unaryInterceptors, settings.streamInterceptors); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -276,6 +282,34 @@ func WithAdditionalPachdCert() Option {
 			}
 			return addCertFromFile(settings.caCerts, path.Join(tls.VolumePath, tls.CertFile))
 		}
+		return nil
+	}
+}
+
+// WithAdditionalUnaryClientInterceptors instructs the New* functions to add the provided
+// UnaryClientInterceptors to the gRPC dial options when opening a client connection.  Internally,
+// all of the provided options are coalesced into one chain, so it is safe to provide this option
+// more than once.
+//
+// This client creates both Unary and Stream client connections, so you will probably want to supply
+// a corresponding WithAdditionalStreamClientInterceptors call.
+func WithAdditionalUnaryClientInterceptors(interceptors ...grpc.UnaryClientInterceptor) Option {
+	return func(settings *clientSettings) error {
+		settings.unaryInterceptors = append(settings.unaryInterceptors, interceptors...)
+		return nil
+	}
+}
+
+// WithAdditionalStreamClientInterceptors instructs the New* functions to add the provided
+// StreamClientInterceptors to the gRPC dial options when opening a client connection.  Internally,
+// all of the provided options are coalesced into one chain, so it is safe to provide this option
+// more than once.
+//
+// This client creates both Unary and Stream client connections, so you will probably want to supply
+// a corresponding WithAdditionalUnaryClientInterceptors option.
+func WithAdditionalStreamClientInterceptors(interceptors ...grpc.StreamClientInterceptor) Option {
+	return func(settings *clientSettings) error {
+		settings.streamInterceptors = append(settings.streamInterceptors, interceptors...)
 		return nil
 	}
 }
@@ -604,7 +638,8 @@ func DefaultDialOptions() []grpc.DialOption {
 	}
 }
 
-func (c *APIClient) connect(timeout time.Duration) error {
+func (c *APIClient) connect(timeout time.Duration, unaryInterceptors []grpc.UnaryClientInterceptor, streamInterceptors []grpc.StreamClientInterceptor) error {
+
 	dialOptions := DefaultDialOptions()
 	if c.caCerts == nil {
 		dialOptions = append(dialOptions, grpc.WithInsecure())
@@ -612,14 +647,14 @@ func (c *APIClient) connect(timeout time.Duration) error {
 		tlsCreds := credentials.NewClientTLSFromCert(c.caCerts, "")
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(tlsCreds))
 	}
-	if tracing.IsActive() {
-		dialOptions = append(dialOptions,
-			grpc.WithUnaryInterceptor(tracing.UnaryClientInterceptor()),
-			grpc.WithStreamInterceptor(tracing.StreamClientInterceptor()),
-		)
-	}
 	if c.gzipCompress {
 		dialOptions = append(dialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))
+	}
+	if len(unaryInterceptors) > 0 {
+		dialOptions = append(dialOptions, grpc.WithChainUnaryInterceptor(unaryInterceptors...))
+	}
+	if len(streamInterceptors) > 0 {
+		dialOptions = append(dialOptions, grpc.WithChainStreamInterceptor(streamInterceptors...))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -157,7 +157,7 @@ func NewFromAddress(addr string, options ...Option) (*APIClient, error) {
 		return nil, errors.Errorf("address shouldn't contain protocol (\"://\"), but is: %q", addr)
 	}
 	// Apply creation options
-	settings := &clientSettings{
+	settings := clientSettings{
 		maxConcurrentStreams: DefaultMaxConcurrentStreams,
 		dialTimeout:          DefaultDialTimeout,
 	}
@@ -172,7 +172,7 @@ func NewFromAddress(addr string, options ...Option) (*APIClient, error) {
 		}
 	}
 	for _, option := range options {
-		if err := option(settings); err != nil {
+		if err := option(&settings); err != nil {
 			return nil, err
 		}
 	}

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
+	"google.golang.org/grpc"
+)
+
+type countingInterceptor struct {
+	s int
+	u int
+}
+
+func (i *countingInterceptor) unary() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, call grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		i.u++
+		return call(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func (i *countingInterceptor) stream() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		i.s++
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+func TestInterceptors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	server, err := grpcutil.NewServer(ctx, false)
+	if err != nil {
+		t.Fatalf("server: %v", err)
+	}
+	defer server.Wait()
+
+	listener, err := server.ListenTCP("localhost", 0)
+	if err != nil {
+		t.Fatalf("listener: %v", err)
+	}
+	defer listener.Close()
+	pfs.RegisterAPIServer(server.Server, new(pfs.UnimplementedAPIServer))
+
+	interceptor := new(countingInterceptor)
+	c, err := NewFromAddress(listener.Addr().String(), WithAdditionalUnaryClientInterceptors(interceptor.unary()), WithAdditionalStreamClientInterceptors(interceptor.stream()))
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	defer c.Close()
+
+	// Unary call.
+	if err := c.CreateRepo("foo"); err == nil {
+		t.Fatal("create repo: expected error")
+	}
+	if got, want := interceptor.u, 1; got != want {
+		t.Errorf("unary call count:\n  got: %v\n want: %v", got, want)
+	}
+	if got, want := interceptor.s, 0; got != want {
+		t.Errorf("stream call count:\n  got: %v\n want: %v", got, want)
+	}
+
+	// Stream call.
+	if err := c.Fsck(true, func(*pfs.FsckResponse) error { return nil }); err == nil {
+		t.Fatal("fsck: expected error")
+	}
+	if got, want := interceptor.u, 1; got != want {
+		t.Errorf("unary call count:\n  got: %v\n want: %v", got, want)
+	}
+	if got, want := interceptor.s, 1; got != want {
+		t.Errorf("stream call count:\n  got: %v\n want: %v", got, want)
+	}
+}


### PR DESCRIPTION
This adds two new client options; `WithAdditionalUnaryClientInterceptor` and `WithAdditionalStreamClientInterceptor`.  gRPC client interceptors can be cleanly chained, so users of the library can add their own interceptors, and everything we do involving Jaeger tracing still works.

I considered letting callers add any arbitrary dial option, but that removes our ability to chain Jaeger on to any interceptor-related options that they explicitly pass in.  (Once they add an interceptor-related dial option, we lose the ability to see the interceptor they're adding and chain it onto interceptors that we want to add.)  And, arbitrary dial options can make problems with the client harder to debug -- they can override behaviors that we add with our own dial options.  So because of that, and because I don't need it, I decided to just stick with interceptors.  It's the minimum change required, at the cost of it being confusing in the future when people can do `WithAdditionalUnaryClientInterceptor(i)` or `WithAdditionalDialOptions(grpc.UnaryClientInterceptor(i))`.  But because of the issues I mentioned, that future seems unlikely :)
