### PR TITLE
Minor typo and wording changing

### DIFF
--- a/doc/docs/1.10.x/getting_started/local_installation.md
+++ b/doc/docs/1.10.x/getting_started/local_installation.md
@@ -155,7 +155,7 @@ deploy Pachyderm by following these steps:
   1. From the same directory, run:
 
      ```bash
-     kubectl create -f .\pachyderm.json
+     kubectl create -f ./pachyderm.json
      ```
 
   Because Pachyderm needs to pull the Pachyderm Docker image

--- a/doc/docs/1.10.x/getting_started/local_installation.md
+++ b/doc/docs/1.10.x/getting_started/local_installation.md
@@ -151,7 +151,7 @@ deploy Pachyderm by following these steps:
      pachctl deploy local --dry-run > pachyderm.json
      ```
 
-  1. Copy the `pachyderm.json` file into your Pachyderm directory.
+  1. Copy the `pachyderm.json` file into your working directory.
   1. From the same directory, run:
 
      ```bash

--- a/doc/docs/1.11.x/getting_started/local_installation.md
+++ b/doc/docs/1.11.x/getting_started/local_installation.md
@@ -155,7 +155,7 @@ deploy Pachyderm by following these steps:
   1. From the same directory, run:
 
      ```bash
-     kubectl create -f .\pachyderm.json
+     kubectl create -f ./pachyderm.json
      ```
 
   Because Pachyderm needs to pull the Pachyderm Docker image

--- a/doc/docs/1.11.x/getting_started/local_installation.md
+++ b/doc/docs/1.11.x/getting_started/local_installation.md
@@ -151,7 +151,7 @@ deploy Pachyderm by following these steps:
      pachctl deploy local --dry-run > pachyderm.json
      ```
 
-  1. Copy the `pachyderm.json` file into your Pachyderm directory.
+  1. Copy the `pachyderm.json` file into your working directory.
   1. From the same directory, run:
 
      ```bash

--- a/doc/docs/master/getting_started/local_installation.md
+++ b/doc/docs/master/getting_started/local_installation.md
@@ -155,7 +155,7 @@ deploy Pachyderm by following these steps:
   1. From the same directory, run:
 
      ```bash
-     kubectl create -f .\pachyderm.json
+     kubectl create -f ./pachyderm.json
      ```
 
   Because Pachyderm needs to pull the Pachyderm Docker image

--- a/doc/docs/master/getting_started/local_installation.md
+++ b/doc/docs/master/getting_started/local_installation.md
@@ -151,7 +151,7 @@ deploy Pachyderm by following these steps:
      pachctl deploy local --dry-run > pachyderm.json
      ```
 
-  1. Copy the `pachyderm.json` file into your Pachyderm directory.
+  1. Copy the `pachyderm.json` file into your working directory.
   1. From the same directory, run:
 
      ```bash


### PR DESCRIPTION
I understand that changing this phrase is debatable, so I won't be offended if you don't accept this change. I'm proposing this change because I misunderstood the wording. All throughout this tutorial, I am getting started, so my mental state is one where I am installing the Pachyderm code. So to me, the phrase "your Pachyderm directory" was very easily misunderstood to mean the folder where Pachyderm resides. I think this can be easily avoided by using the term _your working directory_. Some other options are _your project directory_ and _your working directory/project directory_.