### PR TITLE
Add "everyone" subject to ACLs

### DIFF
--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -44,7 +44,7 @@ const (
 	// pachyderm token for any username in the AuthenticateRequest.GitHubToken field
 	DisableAuthenticationEnvVar = "PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING"
 
-	everyoneSubject = "everyone"
+	allClusterUsersSubject = "allClusterUsers"
 
 	tokensPrefix           = "/tokens"
 	oneTimePasswordsPrefix = "/auth-codes"
@@ -1572,8 +1572,8 @@ func (a *apiServer) SetScope(ctx context.Context, req *auth.SetScopeRequest) (re
 // Authorized() and other authorization checks (e.g. checking if a user is an
 // OWNER to determine if they can modify an ACL).
 func (a *apiServer) getScope(ctx context.Context, subject string, acl *auth.ACL) (auth.Scope, error) {
-	// Get the scope for the "everyone" ACL, if available
-	scope := acl.Entries[everyoneSubject]
+	// Get the scope for the "allClusterUsers" ACL, if available
+	scope := acl.Entries[allClusterUsersSubject]
 
 	// Get scope based on user's direct access
 	if subjectScope := acl.Entries[subject]; scope < subjectScope {
@@ -2554,7 +2554,7 @@ func (a *apiServer) canonicalizeSubjects(ctx context.Context, subjects []string)
 // TODO(msteffen): We'd like to require that subjects always have a prefix, but
 // this behavior hasn't been implemented in the dash yet.
 func (a *apiServer) canonicalizeSubject(ctx context.Context, subject string) (string, error) {
-	if subject == everyoneSubject {
+	if subject == allClusterUsersSubject {
 		return subject, nil
 	}
 

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -1948,7 +1948,7 @@ func TestAuthorizedNoneRole(t *testing.T) {
 }
 
 // TestAuthorizedEveryone tests that Authorized(user, repo, NONE) tests that the
-// `everyone` binding  for an ACL sets the minimum authorized scope
+// `allClusterUsers` binding  for an ACL sets the minimum authorized scope
 func TestAuthorizedEveryone(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -1983,7 +1983,7 @@ func TestAuthorizedEveryone(t *testing.T) {
 	_, err = aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Repo:     repo,
 		Scope:    auth.Scope_WRITER,
-		Username: "everyone",
+		Username: "allClusterUsers",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Similar to the `allAuthorizedUsers` IAM subject, this would allow a user to express an ACL like "everyone in the company can read this repo" without actively maintaining the set of users in the ACL, or group membership.

I think this + default ACLs for new repos would solve a significant pain point.