### PR TITLE
Allow plural nouns when running 'pachctl list' commands

### DIFF
--- a/src/server/config/cmds.go
+++ b/src/server/config/cmds.go
@@ -217,7 +217,7 @@ func Cmds() []*cobra.Command {
 		Short: "Updates a context.",
 		Long: "Updates an existing context config from a given name (or the " +
 			"currently-active context, if no name is given).",
-		Use: "context [context]",
+		Use: "{{alias}} [<context>]",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) (retErr error) {
 			cfg, err := config.Read(false)
 			if err != nil {
@@ -340,6 +340,7 @@ func Cmds() []*cobra.Command {
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(listContext, "config list context"))
+	commands = append(commands, cmdutil.CreateAlias(listContext, "config list contexts"))
 
 	configDocs := &cobra.Command{
 		Short: "Manages the pachyderm config.",

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -938,6 +938,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 	copyFile.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "Overwrite the existing content of the file, either from previous commits or previous calls to 'put file' within this commit.")
 	shell.RegisterCompletionFunc(copyFile, shell.FileCompletion)
 	commands = append(commands, cmdutil.CreateAlias(copyFile, "copy file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(copyFile, "copy files")))
 
 	var outputPath string
 	getFile := &cobra.Command{

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -497,6 +497,7 @@ $ {{alias}} foo@XXX -r bar -r baz`,
 	flushCommit.Flags().AddFlagSet(fullTimestampsFlags)
 	shell.RegisterCompletionFunc(flushCommit, shell.BranchCompletion)
 	commands = append(commands, cmdutil.CreateAlias(flushCommit, "flush commit"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(flushCommit, "flush commits")))
 
 	var newCommits bool
 	var pipeline string
@@ -557,6 +558,7 @@ $ {{alias}} test@master --new`,
 	subscribeCommit.Flags().AddFlagSet(fullTimestampsFlags)
 	shell.RegisterCompletionFunc(subscribeCommit, shell.BranchCompletion)
 	commands = append(commands, cmdutil.CreateAlias(subscribeCommit, "subscribe commit"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(subscribeCommit, "subscribe commits")))
 
 	deleteCommit := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>",
@@ -905,6 +907,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 			return nil, shell.SameFlag(flag)
 		})
 	commands = append(commands, cmdutil.CreateAlias(putFile, "put file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(putFile, "put files")))
 
 	copyFile := &cobra.Command{
 		Use:   "{{alias}} <src-repo>@<src-branch-or-commit>:<src-path> <dst-repo>@<dst-branch-or-commit>:<dst-path>",
@@ -989,6 +992,7 @@ $ {{alias}} foo@master^2:XXX`,
 	getFile.Flags().IntVarP(&parallelism, "parallelism", "p", DefaultParallelism, "The maximum number of files that can be downloaded in parallel")
 	shell.RegisterCompletionFunc(getFile, shell.FileCompletion)
 	commands = append(commands, cmdutil.CreateAlias(getFile, "get file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(getFile, "get files")))
 
 	inspectFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>:<path/in/pfs>",
@@ -1131,6 +1135,7 @@ $ {{alias}} "foo@master:data/*"`,
 	globFile.Flags().AddFlagSet(fullTimestampsFlags)
 	shell.RegisterCompletionFunc(globFile, shell.FileCompletion)
 	commands = append(commands, cmdutil.CreateAlias(globFile, "glob file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(globFile, "glob files")))
 
 	var shallow bool
 	var nameOnly bool
@@ -1235,6 +1240,7 @@ $ {{alias}} foo@master:path1 bar@master:path2`,
 	diffFile.Flags().AddFlagSet(noPagerFlags)
 	shell.RegisterCompletionFunc(diffFile, shell.FileCompletion)
 	commands = append(commands, cmdutil.CreateAlias(diffFile, "diff file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(diffFile, "diff files")))
 
 	deleteFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>:<path/in/pfs>",
@@ -1256,6 +1262,7 @@ $ {{alias}} foo@master:path1 bar@master:path2`,
 	}
 	shell.RegisterCompletionFunc(deleteFile, shell.FileCompletion)
 	commands = append(commands, cmdutil.CreateAlias(deleteFile, "delete file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(deleteFile, "delete files")))
 
 	objectDocs := &cobra.Command{
 		Short: "Docs for objects.",

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -193,6 +193,7 @@ or type (e.g. csv, binary, images, etc).`,
 	listRepo.Flags().AddFlagSet(rawFlags)
 	listRepo.Flags().AddFlagSet(fullTimestampsFlags)
 	commands = append(commands, cmdutil.CreateAlias(listRepo, "list repo"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listRepo, "list repos")))
 
 	var force bool
 	var all bool
@@ -423,6 +424,7 @@ $ {{alias}} foo@master --from XXX`,
 	listCommit.Flags().AddFlagSet(fullTimestampsFlags)
 	shell.RegisterCompletionFunc(listCommit, shell.RepoCompletion)
 	commands = append(commands, cmdutil.CreateAlias(listCommit, "list commit"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listCommit, "list commits")))
 
 	printCommitIter := func(commitIter client.CommitInfoIterator) error {
 		if raw {
@@ -689,6 +691,7 @@ Any pachctl command that can take a Commit ID, can take a branch name instead.`,
 	listBranch.Flags().AddFlagSet(rawFlags)
 	shell.RegisterCompletionFunc(listBranch, shell.RepoCompletion)
 	commands = append(commands, cmdutil.CreateAlias(listBranch, "list branch"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listBranch, "list branches")))
 
 	deleteBranch := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>",
@@ -1081,6 +1084,7 @@ $ {{alias}} foo@master --history all`,
 	listFile.Flags().StringVar(&history, "history", "none", "Return revision history for files.")
 	shell.RegisterCompletionFunc(listFile, shell.FileCompletion)
 	commands = append(commands, cmdutil.CreateAlias(listFile, "list file"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listFile, "list files")))
 
 	globFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>:<pattern>",

--- a/src/server/pkg/cmdutil/cobra.go
+++ b/src/server/pkg/cmdutil/cobra.go
@@ -311,6 +311,18 @@ func (r *RepeatedStringArg) Type() string {
 	return "[]string"
 }
 
+// Hide marks all runnable subcommands as hidden and returns it
+// for method chaining.
+func Hide(cmd *cobra.Command) *cobra.Command {
+	if cmd.Run != nil {
+		cmd.Hidden = true
+	}
+	for _, subcmd := range cmd.Commands() {
+		Hide(subcmd)
+	}
+	return cmd
+}
+
 // CreateAlias generates a nested command tree for the invocation specified,
 // which should be space-delimited as on the command-line.  The 'Use' field of
 // 'cmd' should specify '{{alias}}' instead of the command name as that will be

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -587,6 +587,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	createPipeline.Flags().StringVarP(&registry, "registry", "r", "index.docker.io", "The registry to push images to.")
 	createPipeline.Flags().StringVarP(&username, "username", "u", "", "The username to push images as.")
 	commands = append(commands, cmdutil.CreateAlias(createPipeline, "create pipeline"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(createPipeline, "create pipelines")))
 
 	var reprocess bool
 	updatePipeline := &cobra.Command{
@@ -603,6 +604,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	updatePipeline.Flags().StringVarP(&username, "username", "u", "", "The username to push images as.")
 	updatePipeline.Flags().BoolVar(&reprocess, "reprocess", false, "If true, reprocess datums that were already processed by previous version of the pipeline.")
 	commands = append(commands, cmdutil.CreateAlias(updatePipeline, "update pipeline"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(updatePipeline, "update pipelines")))
 
 	runPipeline := &cobra.Command{
 		Use:   "{{alias}} <pipeline> [<repo>@<branch>[=<commit>]...]",

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -224,6 +224,7 @@ $ {{alias}} -p foo -i bar@YYY`,
 			return nil, shell.SameFlag(flag)
 		})
 	commands = append(commands, cmdutil.CreateAlias(listJob, "list job"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listJob, "list jobs")))
 
 	var pipelines cmdutil.RepeatedStringArg
 	flushJob := &cobra.Command{
@@ -406,6 +407,7 @@ each datum.`,
 	listDatum.Flags().AddFlagSet(outputFlags)
 	shell.RegisterCompletionFunc(listDatum, shell.JobCompletion)
 	commands = append(commands, cmdutil.CreateAlias(listDatum, "list datum"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listDatum, "list datums")))
 
 	inspectDatum := &cobra.Command{
 		Use:   "{{alias}} <job> <datum>",
@@ -844,6 +846,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	listPipeline.Flags().AddFlagSet(fullTimestampsFlags)
 	listPipeline.Flags().StringVar(&history, "history", "none", "Return revision history for pipelines.")
 	commands = append(commands, cmdutil.CreateAlias(listPipeline, "list pipeline"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listPipeline, "list pipelines")))
 
 	var (
 		all      bool
@@ -1031,6 +1034,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(listSecret, "list secret"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listSecret, "list secrets")))
 
 	var memory string
 	garbageCollect := &cobra.Command{

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -288,6 +288,7 @@ $ {{alias}} foo@XXX -p bar -p baz`,
 			return cs, shell.AndCacheFunc(cf, shell.SameFlag(flag))
 		})
 	commands = append(commands, cmdutil.CreateAlias(flushJob, "flush job"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(flushJob, "flush jobs")))
 
 	deleteJob := &cobra.Command{
 		Use:   "{{alias}} <job>",
@@ -365,6 +366,7 @@ each datum.`,
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(restartDatum, "restart datum"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(restartDatum, "restart datums")))
 
 	var pageSize int64
 	var page int64

--- a/src/server/transaction/cmds/cmds.go
+++ b/src/server/transaction/cmds/cmds.go
@@ -82,6 +82,7 @@ transaction' or cancelled with 'delete transaction'.`,
 	listTransaction.Flags().AddFlagSet(rawFlags)
 	listTransaction.Flags().AddFlagSet(fullTimestampsFlags)
 	commands = append(commands, cmdutil.CreateAlias(listTransaction, "list transaction"))
+	commands = append(commands, cmdutil.Hide(cmdutil.CreateAlias(listTransaction, "list transactions")))
 
 	startTransaction := &cobra.Command{
 		Short: "Start a new transaction.",


### PR DESCRIPTION
Fixes #5183.

I looked through the existing commands and pluralized the ones that made sense - mostly just `list` commands and `flush jobs` and `restart datums` - none of the other commands take multiple targets.  The pluralized nouns are hidden from help to avoid polluting it.