### PR TITLE
[WIP] Use slashes in tags for worker artifacts

### DIFF
--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -83,7 +83,7 @@ func do(config interface{}) error {
 
 	// Construct worker API server.
 	workerRcName := ppsutil.PipelineRcName(pipelineInfo.Pipeline.Name, pipelineInfo.Version)
-	workerInstance, err := worker.NewWorker(pachClient, env.GetEtcdClient(), env.PPSEtcdPrefix, pipelineInfo, env.PodName, env.Namespace, env.StorageRoot, "/")
+	workerInstance, err := worker.NewWorker(env, pachClient, pipelineInfo, "/")
 	if err != nil {
 		return err
 	}

--- a/src/server/pkg/serviceenv/config.go
+++ b/src/server/pkg/serviceenv/config.go
@@ -111,6 +111,7 @@ type FeatureFlags struct {
 	StorageV2                    bool `env:"STORAGE_V2,default=false"`
 	DisableCommitProgressCounter bool `env:"DISABLE_COMMIT_PROGRESS_COUNTER,default=false"`
 	LokiLogging                  bool `env:"LOKI_LOGGING,default=false"`
+	WorkerArtifactTagHierarchy   bool `env:"WORKER_ARTIFACT_TAG_HIERARCHY,default=false"`
 }
 
 // NewConfiguration creates a generic configuration from a specific type of configuration.

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -14,6 +14,7 @@ import (
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/hashtree"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsconsts"
+	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	"github.com/pachyderm/pachyderm/src/server/pkg/testpachd"
 	"github.com/pachyderm/pachyderm/src/server/pkg/work"
 	"github.com/pachyderm/pachyderm/src/server/worker/cache"
@@ -63,6 +64,9 @@ type testDriver struct {
 }
 
 // Fuck golang
+func (td *testDriver) Env() *serviceenv.ServiceEnv {
+	return td.inner.Env()
+}
 func (td *testDriver) Jobs() col.Collection {
 	return td.inner.Jobs()
 }
@@ -147,13 +151,10 @@ func withTestEnv(pipelineInfo *pps.PipelineInfo, cb func(*testEnv) error) error 
 		logger := logs.NewMockLogger()
 		workerDir := filepath.Join(realEnv.Directory, "worker")
 		driver, err := driver.NewDriver(
+			realEnv.ServiceEnv,
 			pipelineInfo,
 			realEnv.PachClient,
-			realEnv.EtcdClient,
-			"/pachyderm_test",
-			filepath.Join(workerDir, "hashtrees"),
 			workerDir,
-			"namespace",
 		)
 		if err != nil {
 			return err

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -29,7 +29,7 @@ func defaultPipelineInfo() *pps.PipelineInfo {
 		Pipeline:     client.NewPipeline(name),
 		OutputBranch: "master",
 		Transform: &pps.Transform{
-			Cmd:        []string{"cp", "inputRepo/*", "out"},
+			Cmd:        []string{"bash", "-c", "cp inputRepo/* out"},
 			WorkingDir: client.PPSInputPrefix,
 		},
 		ParallelismSpec: &pps.ParallelismSpec{

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -35,12 +35,16 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/worker/pipeline/transform/chain"
 )
 
+const (
+	jobTagArtifactPrefix = "job-artifacts"
+)
+
 // All tags that begin with this prefix (and their associated objects) will be
 // cleaned up when the job ends. If any of these objects are leaked due to a
 // crash between finishing the job and removing the artifacts, they can be
 // removed using the `garbage-collect` command.
 func jobTagPrefix(pipelineName string, jobID string) string {
-	return filepath.Join(fmt.Sprintf("pipeline-%s", pipelineName), fmt.Sprintf("job-%s", jobID))
+	return filepath.Join(jobTagArtifactPrefix, fmt.Sprintf("pipeline-%s", pipelineName), fmt.Sprintf("job-%s", jobID))
 }
 
 // This generates a unique ID each time, as the datums present in a given chunk

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -46,11 +46,11 @@ func withWorkerSpawnerPair(pipelineInfo *pps.PipelineInfo, cb func(env *testEnv)
 			return err
 		}
 
-		if err := os.MkdirAll(env.LocalStorageDirectory, 0777); err != nil {
+		if err := os.MkdirAll(env.ServiceEnv.StorageRoot, 0777); err != nil {
 			return err
 		}
 		// TODO: this is global and complicates running tests in parallel
-		if err := os.Setenv(obj.PachRootEnvVar, env.LocalStorageDirectory); err != nil {
+		if err := os.Setenv(obj.PachRootEnvVar, env.ServiceEnv.StorageRoot); err != nil {
 			return err
 		}
 

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -227,9 +227,9 @@ func uploadChunk(
 
 func checkS3Gateway(driver driver.Driver, logger logs.TaggedLogger) error {
 	return backoff.RetryNotify(func() error {
-		endpoint := fmt.Sprintf("http://%s:%s/",
+		endpoint := fmt.Sprintf("http://%s:%d/",
 			ppsutil.SidecarS3GatewayService(logger.JobID()),
-			os.Getenv("S3GATEWAY_PORT"),
+			driver.Env().S3GatewayPort,
 		)
 
 		_, err := (&http.Client{Timeout: 5 * time.Second}).Get(endpoint)

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"time"
 
-	etcd "github.com/coreos/etcd/clientv3"
 	docker "github.com/fsouza/go-dockerclient"
 	"golang.org/x/sync/errgroup"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	"github.com/pachyderm/pachyderm/src/server/pkg/dlock"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
+	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	"github.com/pachyderm/pachyderm/src/server/pkg/watch"
 	"github.com/pachyderm/pachyderm/src/server/pkg/work"
 	"github.com/pachyderm/pachyderm/src/server/worker/driver"
@@ -46,13 +46,9 @@ type Worker struct {
 //  3. an api server that serves requests for status or cross-worker communication
 //  4. a driver that provides common functionality between the above components
 func NewWorker(
+	env *serviceenv.ServiceEnv,
 	pachClient *client.APIClient,
-	etcdClient *etcd.Client,
-	etcdPrefix string,
 	pipelineInfo *pps.PipelineInfo,
-	workerName string,
-	namespace string,
-	hashtreePath string,
 	rootPath string,
 ) (*Worker, error) {
 	stats.InitPrometheus()
@@ -62,15 +58,7 @@ func NewWorker(
 		hasDocker = false
 	}
 
-	driver, err := driver.NewDriver(
-		pipelineInfo,
-		pachClient,
-		etcdClient,
-		etcdPrefix,
-		hashtreePath,
-		rootPath,
-		namespace,
-	)
+	driver, err := driver.NewDriver(env, pipelineInfo, pachClient, rootPath)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +80,7 @@ func NewWorker(
 		}
 		if pipelineInfo.Transform.Cmd == nil {
 			if len(image.Config.Entrypoint) == 0 {
-				ppsutil.FailPipeline(pachClient.Ctx(), etcdClient, driver.Pipelines(),
+				ppsutil.FailPipeline(pachClient.Ctx(), env.GetEtcdClient(), driver.Pipelines(),
 					pipelineInfo.Pipeline.Name,
 					"nothing to run: no transform.cmd and no entrypoint")
 			}
@@ -105,9 +93,9 @@ func NewWorker(
 		status: &transform.Status{},
 	}
 
-	worker.APIServer = server.NewAPIServer(driver, worker.status, workerName)
+	worker.APIServer = server.NewAPIServer(driver, worker.status, env.PodName)
 
-	go worker.master(etcdClient, etcdPrefix)
+	go worker.master(env)
 	go worker.worker()
 	return worker, nil
 }
@@ -157,11 +145,11 @@ func (w *Worker) worker() {
 	})
 }
 
-func (w *Worker) master(etcdClient *etcd.Client, etcdPrefix string) {
+func (w *Worker) master(env *serviceenv.ServiceEnv) {
 	pipelineInfo := w.driver.PipelineInfo()
 	logger := logs.NewMasterLogger(pipelineInfo)
-	lockPath := path.Join(etcdPrefix, masterLockPath, pipelineInfo.Pipeline.Name, pipelineInfo.Salt)
-	masterLock := dlock.NewDLock(etcdClient, lockPath)
+	lockPath := path.Join(env.EtcdPrefix, masterLockPath, pipelineInfo.Pipeline.Name, pipelineInfo.Salt)
+	masterLock := dlock.NewDLock(env.GetEtcdClient(), lockPath)
 
 	b := backoff.NewInfiniteBackOff()
 	// Setting a high backoff so that when this master fails, the other
@@ -190,7 +178,7 @@ func (w *Worker) master(etcdClient *etcd.Client, etcdPrefix string) {
 			logger.Logf("failing %q due to auth rejection", pipelineInfo.Pipeline.Name)
 			return ppsutil.FailPipeline(
 				w.driver.PachClient().Ctx(),
-				etcdClient,
+				env.GetEtcdClient(),
 				w.driver.Pipelines(),
 				pipelineInfo.Pipeline.Name,
 				"worker master could not access output repo to watch for new commits",


### PR DESCRIPTION
Slow `ListTags` performance can cause jobs to block in the worker while cleaning up job artifacts.  Some object stores may have better performance when the tag prefix contains slashes, so this PR changes the prefix for worker job artifacts, and also moves the cleanup to happen after succeeding the job in the job chain to avoid blocking parallel jobs.

In local testing, using tags with slashes only caused issues in the `localcache` package, which uses the tag name as a filename (and there was no logic to provision directory trees).  Avoided this problem by url-encoding the tag name.

This should not be merged as-is, as the impacts on all object stores is not well-understood.  Therefore, this should be behind a feature-flag that must be added, and enabling or disabling this flag may cause spurious failures in any currently-in-progress jobs due to the tag naming scheme changing.