### PR TITLE
Disallow transition from standby to crashing

### DIFF
--- a/src/server/pkg/ppsutil/util.go
+++ b/src/server/pkg/ppsutil/util.go
@@ -194,6 +194,12 @@ func SetPipelineState(ctx context.Context, etcdClient *etcd.Client, pipelinesCol
 			}
 			return nil
 		}
+		// Don't allow a transition from STANDBY to CRASHING if we receive events out of order
+		if pipelinePtr.State == pps.PipelineState_PIPELINE_STANDBY && to == pps.PipelineState_PIPELINE_CRASHING {
+			log.Warningf("cannot move pipeline %q to CRASHING when it is in STANDBY", pipeline)
+			return nil
+		}
+
 		// transitionPipelineState case: error if pipeline is in an unexpected
 		// state.
 		//


### PR DESCRIPTION
Resolves #5272 

This issue was affecting @JimmyWhitaker developing GPU pipelines on Hub. When you submit a standby job that needs to auto-provision a GPU, it races to go into either standby or crashing. If it ends up in crashing it has no pods and it doesn't ever transition back to running.