### PR TITLE
Use Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 
 language: go
 go:
-  - "1.13.1"
+  - "1.15.2"
 env:
   global:
     - PATH="${HOME}/cached-deps:$(python3 -c 'import site; print(site.USER_BASE)')/bin:${PATH}"

--- a/src/server/pfs/server/testing/block_api_server_test.go
+++ b/src/server/pfs/server/testing/block_api_server_test.go
@@ -78,17 +78,17 @@ func TestManyObjects(t *testing.T) {
 	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
 		var objects []string
 		for i := 0; i < 25; i++ {
-			object, _, err := env.PachClient.PutObject(strings.NewReader(string(i)), fmt.Sprint(i))
+			object, _, err := env.PachClient.PutObject(strings.NewReader(string(rune(i))), fmt.Sprint(i))
 			require.NoError(t, err)
 			objects = append(objects, object.Hash)
 		}
 		for i, hash := range objects {
 			value, err := env.PachClient.ReadObject(hash)
 			require.NoError(t, err)
-			require.Equal(t, []byte(string(i)), value)
+			require.Equal(t, []byte(string(rune(i))), value)
 			value, err = env.PachClient.ReadTag(fmt.Sprint(i))
 			require.NoError(t, err)
-			require.Equal(t, []byte(string(i)), value)
+			require.Equal(t, []byte(string(rune(i))), value)
 		}
 
 		return nil


### PR DESCRIPTION
CI has been failing on master since last week with:
```
etc/testing/lint.sh
go: finding golang.org/x/lint latest
go: finding golang.org/x/tools latest
go: downloading golang.org/x/tools v0.0.0-20200915173823-2db8f0ff891c
go: extracting golang.org/x/tools v0.0.0-20200915173823-2db8f0ff891c
-: could not analyze dependency github.com/spf13/cobra/doc of github.com/pachyderm/pachyderm/src/server/cmd/pachctl-doc: 
	could not analyze dependency github.com/cpuguy83/go-md2man/v2/md2man of github.com/spf13/cobra/doc: 
	could not analyze dependency github.com/russross/blackfriday/v2 of github.com/cpuguy83/go-md2man/v2/md2man: 
	/home/travis/gopath/pkg/mod/github.com/russross/blackfriday/v2@v2.0.1/markdown.go:148:32: undeclared name: Node (compile)
```

It's not entirely clear to me what's broken in go-lint but 1.13.x is no longer a supported Go version. Upgrading to 1.15 resolves the issue. I had to fix one cast that broke as well.