### PR TITLE
Check for boundary condition when skipping blocks

### DIFF
--- a/src/server/pfs/server/obj_block_api_server.go
+++ b/src/server/pfs/server/obj_block_api_server.go
@@ -460,7 +460,7 @@ func (s *objBlockAPIServer) GetObjects(request *pfsclient.GetObjectsRequest, get
 		}
 
 		objectSize := objectInfo.BlockRef.Range.Upper - objectInfo.BlockRef.Range.Lower
-		if offset > objectSize {
+		if offset >= objectSize {
 			offset -= objectSize
 			continue
 		}

--- a/src/server/pfs/server/obj_block_api_server.go
+++ b/src/server/pfs/server/obj_block_api_server.go
@@ -712,7 +712,7 @@ func (s *objBlockAPIServer) GetBlocks(request *pfsclient.GetBlocksRequest, getBl
 	size := request.SizeBytes
 	for _, blockRef := range request.BlockRefs {
 		blockSize := blockRef.Range.Upper - blockRef.Range.Lower
-		if offset > blockSize {
+		if offset >= blockSize {
 			offset -= blockSize
 			continue
 		}


### PR DESCRIPTION
Address https://github.com/pachyderm/python-pachyderm/issues/226

Fairly certain that this is the underlying issue, though I need to find a way to test it with hub.

When a file is uploaded in BSIZE blocks and the same file is read at offsets that are a multiple of BSIZE, GetBlocks will fail. Due to the missing check, GetBlocks tries to read 0 bytes from the block that should be skipped.

The obj read returns an invalid range... "googleapi: got HTTP response code 416 with body: ... The requested range cannot be satisfied." Depending on how the object store handles reads of 0, the results could vary.

GetBlocks also gets called from getFile. It is possible that under certain perfect conditions this bug could explain failed downloads (unexpected EOF).