### PR TITLE
Fix error printing in list pipeline

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -836,7 +836,8 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			}
 			for _, pi := range pipelineInfos {
 				if ppsutil.ErrorState(pi.State) {
-					fmt.Println("One or more pipelines have encountered errors, use inspect pipeline to get more info.")
+					fmt.Fprintln(os.Stderr, "One or more pipelines have encountered errors, use inspect pipeline to get more info.")
+					break
 				}
 			}
 			writer := tabwriter.NewWriter(os.Stdout, pretty.PipelineHeader)


### PR DESCRIPTION
This error statement was printed multiple times if multiple pipelines had errors, which seems unintended.  Also, it was printed to stdout, which can hurt things like parsing of a json-formatted output, so I moved it to stderr.