### PR TITLE
Fix update pipeline with reprocess and stats

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1833,6 +1833,16 @@ func (a *apiServer) hardStopPipeline(pachClient *client.APIClient, pipelineInfo 
 	); err != nil && !isNotFoundErr(err) {
 		return errors.Wrapf(err, "could not recreate original output branch")
 	}
+	if pipelineInfo.EnableStats {
+		if err := pachClient.CreateBranch(
+			pipelineInfo.Pipeline.Name,
+			"stats",
+			"stats",
+			nil,
+		); err != nil && !isNotFoundErr(err) {
+			return errors.Wrapf(err, "could not recreate original stats branch")
+		}
+	}
 
 	// Now that new commits won't be created on the master branch, enumerate
 	// existing commits and close any open ones.


### PR DESCRIPTION
Update pipeline removes the branch provenance from the output branch when a pipeline is being updated. This prevents new commits from getting created during the update (and therefore jobs). After the update, the branch provenance is re-enabled which will create a new commit that corresponds with the new provenant spec commit. Based on the code, it looks like this same pattern was intended to apply to the stats branch, but the part where the provenance is removed before the update is missing. So, this ended up working fine when doing an update without a reprocess because we would set the head commit for each branch to the current head when re-enabling provenance. When the output branch provenance was re-enabled, it would generate a new commit which would then result with a new stats commit due the stats branch provenance still being enabled. Then "re-enabling" the stats branch would result with no new commits because the head commit would have the correct provenance. This is not the case with reprocess because the commit chain gets broken in both branches. So, re-enabling the output branch provenance would still create an output commit with no parent and a stats commit with a parent in the same chain. Then, we would set the stats branch head to nil (to break the stats commit chain), which would result with propagate commit creating another stats commit. This is why we would see two stats commits after an update pipeline with reprocess and stats enabled. So, the fix is just to disable the stats branch provenance and re-enable after the output branch provenance is restored. This should guarantee that our stats commits are setup correctly after update pipeline.