### PR TITLE
Add OIDC integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,15 @@ launch-loki:
 clean-launch-loki:
 	helm uninstall loki
 
+launch-dex:
+	helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+	helm repo update
+	helm upgrade --install dex stable/dex -f etc/testing/auth/dex.yaml
+	until timeout 1s ./etc/kube/check_ready.sh release=dex; do sleep 1; done
+
+clean-launch-dex:
+	helm uninstall dex
+
 logs: check-kubectl
 	kubectl $(KUBECTLFLAGS) get pod -l app=pachd | sed '1d' | cut -f1 -d ' ' | xargs -n 1 -I pod sh -c 'echo pod && kubectl $(KUBECTLFLAGS) logs pod'
 

--- a/Makefile
+++ b/Makefile
@@ -395,8 +395,8 @@ clean-launch-loki:
 launch-dex:
 	helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 	helm repo update
-	helm upgrade --install dex stable/dex -f etc/testing/auth/dex.yaml
-	until timeout 1s ./etc/kube/check_ready.sh 'app.kubernetes.io/name=dex'; do sleep 1; done
+	helm upgrade --install --force dex stable/dex -f etc/testing/auth/dex.yaml
+	until timeout 1s bash -x ./etc/kube/check_ready.sh 'app.kubernetes.io/name=dex'; do sleep 1; done
 
 clean-launch-dex:
 	helm uninstall dex

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ launch-dex:
 	helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 	helm repo update
 	helm upgrade --install dex stable/dex -f etc/testing/auth/dex.yaml
-	until timeout 1s ./etc/kube/check_ready.sh release=dex; do sleep 1; done
+	until timeout 1s ./etc/kube/check_ready.sh 'app.kubernetes.io/name=dex'; do sleep 1; done
 
 clean-launch-dex:
 	helm uninstall dex

--- a/etc/testing/auth/dex.yaml
+++ b/etc/testing/auth/dex.yaml
@@ -1,0 +1,35 @@
+grpc: false
+service:
+  type: NodePort
+config:
+  issuer: http://dex:32000
+  storage:
+    type: etcd
+    config:
+      endpoints: 
+        - http://etcd:2379
+      namespace: dex      
+  logger:
+    level: debug
+  web:
+    # port is taken from ports section above
+    address: 0.0.0.0
+    tlsCert: /etc/dex/tls/https/server/tls.crt
+    tlsKey: /etc/dex/tls/https/server/tls.key
+    allowedOrigins: []
+  staticClients:
+  - id: pachyderm
+    name: "Pachyderm"
+    redirectURIs:
+    - 'http://pachd:657/authorization-code/callback'
+    secret: blahblahblah
+  enablePasswordDB: true
+  staticPasswords:
+  - email: "admin@example.com"
+  # bcrypt hash of the string "password"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466" 
+  oauth2:
+    alwaysShowLoginScreen: false
+    skipApprovalScreen: true

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -157,6 +157,7 @@ case "${BUCKET}" in
     fi
     ;;
  AUTH?)
+    make launch-dex
     bucket_num="${BUCKET#AUTH}"
     test_bucket "./src/server/auth/server/testing" test-auth "${bucket_num}" "${AUTH_BUCKETS}"
     set +x

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/auth"
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+)
+
+const (
+	k8sHost = "192.168.64.35"
+)
+
+// TestOIDCAuthCodeFlow tests that we can configure an OIDC provider and do the
+// auth code flow
+func TestOIDCAuthCodeFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	deleteAll(t)
+	adminClient := getPachClient(t, admin)
+
+	conf := &auth.AuthConfig{
+		LiveConfigVersion: 0,
+		IDProviders: []*auth.IDProvider{&auth.IDProvider{
+			Name:        "idp",
+			Description: "fake IdP for testing",
+			OIDC: &auth.IDProvider_OIDCOptions{
+				Issuer:       "http://dex:32000",
+				ClientID:     "pachyderm",
+				ClientSecret: "notsecret",
+				RedirectURI:  "http://pachd:657/authorization-code/callback",
+			},
+		}},
+	}
+	_, err := adminClient.SetConfiguration(adminClient.Ctx(),
+		&auth.SetConfigurationRequest{Configuration: conf})
+	require.NoError(t, err)
+
+	loginInfo, err := adminClient.GetOIDCLogin(adminClient.Ctx(), &auth.GetOIDCLoginRequest{})
+	require.NoError(t, err)
+
+	// Do a GET to Dex and get the redirect to the login page.
+	// This gets us the `req` param, which ties together the session.
+	loginUrl, err := url.Parse(loginInfo.LoginURL)
+	require.NoError(t, err)
+	loginUrl.Host = k8sHost + ":32000"
+
+	resp, err := http.Get(loginUrl.String())
+	require.NoError(t, err)
+
+	// POST our hard-coded credentials to the login page with the
+	// appropriate req params.
+	c := &http.Client{}
+	vals := make(url.Values)
+	vals.Add("login", "admin@example.com")
+	vals.Add("password", "password")
+
+	redirectUrl, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	redirectUrl.Scheme = "http"
+	redirectUrl.Host = k8sHost + ":32000"
+
+	resp, err = c.PostForm(redirectUrl.String(), vals)
+	require.NoError(t, err)
+
+	// Follow the resulting redirect back to pachd to complete the flow
+	callbackUrl, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	callbackUrl.
+		callbackUrl.Host = k8sHost + ":30657"
+
+	_, err = http.Get(callbackUrl.String())
+	require.NoError(t, err)
+
+	// Check that pachd recorded the response from the redirect
+	adminClient.Authenticate(adminClient.Ctx(), &auth.AuthenticateRequest{OIDCState: loginInfo.State})
+	require.NoError(t, err)
+
+	deleteAll(t)
+}


### PR DESCRIPTION
Stand up a Dex server with user/password authentication to test our OIDC support.

Open Q: do we need to do more to make this easy to use locally? Right now to run `make test-auth` locally you need to have run `make launch-dex` first.