### PR TITLE
Fix deadlock in monitorPipeline & refactor

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -2192,6 +2192,77 @@ func TestRecreatePipeline(t *testing.T) {
 	createPipeline()
 }
 
+// TestRecreateStandbyPipeline ensures that deleting and recreating a pipeline
+// with standby:true works. Because the PPS master now blocks after cancelling a
+// standby pipeline's 'monitorPipeline' goroutine, successfully recreating a
+// deleted pipeline proves that the old pipeline's `monitorPipeline` goroutine
+// successfully exited.
+//
+// This tests the fix for https://github.com/pachyderm/pachyderm/issues/5346
+func TestRecreateStandbyPipeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
+
+	for i := 0; i < 2; i++ {
+		// Create a new data repo for each iteration, as it prevents the second
+		// iteration from having to process the first iteration's commit, and it
+		// doesn't affect the fidelity of the test (If DeletePipeline orphans the
+		// monitorPipeline goro, this pipeline should never leave STARTING because
+		// the pipeline controller should be blocked/crash)
+		dataRepo := tu.UniqueString(fmt.Sprintf("%s-%d-data", t.Name(), i))
+		require.NoError(t, c.CreateRepo(dataRepo))
+
+		// Create a standby-enabled pipeline
+		pipeline := tu.UniqueString(t.Name())
+		_, err := c.PpsAPIClient.CreatePipeline(context.Background(),
+			&pps.CreatePipelineRequest{
+				Pipeline: client.NewPipeline(pipeline),
+				Transform: &pps.Transform{
+					Cmd: []string{"sh"},
+					Stdin: []string{
+						"echo $PPS_POD_NAME >/pfs/out/pod",
+					},
+				},
+				Input:           client.NewPFSInput(dataRepo, "/"),
+				Standby:         true,
+				ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
+				ResourceRequests: &pps.ResourceSpec{
+					Cpu: 0.5,
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NoErrorWithinTRetry(t, time.Second*30, func() error {
+			pi, err := c.InspectPipeline(pipeline)
+			require.NoError(t, err)
+			if pi.State != pps.PipelineState_PIPELINE_STANDBY {
+				return fmt.Errorf("expected %q to be in STANDBY but was in %s", pipeline, pi.State)
+			}
+			return nil
+		})
+
+		// Run a job, to prove that 'monitorPipeline' is running and works
+		_, err = c.PutFile(dataRepo, "master", "/foo", strings.NewReader("data"))
+		require.NoError(t, err)
+		commitIter, err := c.FlushCommit([]*pfs.Commit{client.NewCommit(dataRepo, "master")}, nil)
+		require.NoError(t, err)
+		_, err = commitIter.Next()
+		require.NoError(t, err)
+
+		// Delete the pipeline and wait for it to disappear from etcd
+		require.NoError(t, c.DeletePipeline(pipeline, false))
+		require.NoErrorWithinTRetry(t, time.Second*30, func() error {
+			_, err := c.InspectPipeline(pipeline)
+			require.YesError(t, err)
+			return nil
+		})
+	}
+}
+
 func TestDeletePipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")

--- a/src/server/pkg/backoff/retry.go
+++ b/src/server/pkg/backoff/retry.go
@@ -72,7 +72,7 @@ func NotifyContinue(inner interface{}) Notify {
 			case func(error, time.Duration) error:
 				return n(err, d)
 			default:
-				log.Errorf("error in %v: %v (retrying in: %v) (%T)", n, err, d, n)
+				log.Errorf("error in %v: %v (retrying in: %v)", n, err, d)
 				return nil
 			}
 		}

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -153,13 +153,7 @@ func (a *apiServer) master() {
 			}
 		}
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		// cancel all monitorPipeline goroutines
-		a.monitorCancelsMu.Lock()
-		defer a.monitorCancelsMu.Unlock()
-		for _, c := range a.monitorCancels {
-			c()
-		}
-		a.monitorCancels = make(map[string]func())
+		a.cancelAllMonitorsAndCrashingMonitors()
 		log.Errorf("PPS master: error running the master process: %v; retrying in %v", err, d)
 		return nil
 	})

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -7,10 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/gogo/protobuf/types"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/robfig/cron"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -18,15 +15,12 @@ import (
 	kube_watch "k8s.io/apimachinery/pkg/watch"
 
 	"github.com/pachyderm/pachyderm/src/client"
-	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/tracing"
-	"github.com/pachyderm/pachyderm/src/client/pkg/tracing/extended"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	pfsServer "github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	"github.com/pachyderm/pachyderm/src/server/pkg/dlock"
-	"github.com/pachyderm/pachyderm/src/server/pkg/ppsconsts"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
 	"github.com/pachyderm/pachyderm/src/server/pkg/watch"
 )
@@ -180,30 +174,6 @@ func (a *apiServer) setPipelineCrashing(ctx context.Context, pipelineName string
 	return a.setPipelineState(ctx, pipelineName, pps.PipelineState_PIPELINE_CRASHING, reason)
 }
 
-// Every running pipeline with standby == true has a corresponding goroutine
-// running monitorPipeline() that puts the pipeline in and out of standby in
-// response to new output commits appearing in that pipeline's output repo
-func (a *apiServer) cancelMonitor(pipeline string) {
-	a.monitorCancelsMu.Lock()
-	defer a.monitorCancelsMu.Unlock()
-	if cancel, ok := a.monitorCancels[pipeline]; ok {
-		cancel()
-		delete(a.monitorCancels, pipeline)
-	}
-}
-
-// Every crashing pipeline has a corresponding goro running
-// monitorCrashingPipeline that checks to see if the issues have resolved
-// themselves and moves the pipeline out of crashing if they have.
-func (a *apiServer) cancelCrashingMonitor(pipeline string) {
-	a.monitorCancelsMu.Lock()
-	defer a.monitorCancelsMu.Unlock()
-	if cancel, ok := a.crashingMonitorCancels[pipeline]; ok {
-		cancel()
-		delete(a.crashingMonitorCancels, pipeline)
-	}
-}
-
 func (a *apiServer) deletePipelineResources(ctx context.Context, pipelineName string) (retErr error) {
 	log.Infof("PPS master: deleting resources for pipeline %q", pipelineName)
 	span, ctx := tracing.AddSpanToAnyExisting(ctx, //lint:ignore SA4006 ctx is unused, but better to have the right ctx in scope so people don't use the wrong one
@@ -286,189 +256,6 @@ func (a *apiServer) transitionPipelineState(ctx context.Context, pipeline string
 	}()
 	return ppsutil.SetPipelineState(ctx, a.env.GetEtcdClient(), a.pipelines,
 		pipeline, &from, to, reason)
-}
-
-func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) {
-	log.Printf("PPS master: monitoring pipeline %q", pipelineInfo.Pipeline.Name)
-	// If this exits (e.g. b/c Standby is false, and pipeline has no cron inputs),
-	// remove this fn's cancel() call from a.monitorCancels (if it hasn't already
-	// been removed, e.g. by deletePipelineResources cancelling this call), so
-	// that it can be called again
-	defer a.cancelMonitor(pipelineInfo.Pipeline.Name)
-	var eg errgroup.Group
-	pps.VisitInput(pipelineInfo.Input, func(in *pps.Input) {
-		if in.Cron != nil {
-			eg.Go(func() error {
-				return backoff.RetryNotify(func() error {
-					return a.makeCronCommits(pachClient, in)
-				}, backoff.NewInfiniteBackOff(), notifyCtx(pachClient.Ctx(), "cron for "+in.Cron.Name))
-			})
-		}
-	})
-	if pipelineInfo.Standby {
-		// Capacity 1 gives us a bit of buffer so we don't needlessly go into
-		// standby when SubscribeCommit takes too long to return.
-		ciChan := make(chan *pfs.CommitInfo, 1)
-		eg.Go(func() error {
-			return backoff.RetryNotify(func() error {
-				return pachClient.SubscribeCommitF(pipelineInfo.Pipeline.Name, "",
-					client.NewCommitProvenance(ppsconsts.SpecRepo, pipelineInfo.Pipeline.Name, pipelineInfo.SpecCommit.ID),
-					"", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
-						ciChan <- ci
-						return nil
-					})
-			}, backoff.NewInfiniteBackOff(), notifyCtx(pachClient.Ctx(), "SubscribeCommit"))
-		})
-		eg.Go(func() error {
-			return backoff.RetryNotify(func() error {
-				span, ctx := extended.AddPipelineSpanToAnyTrace(pachClient.Ctx(),
-					a.env.GetEtcdClient(), pipelineInfo.Pipeline.Name, "/pps.Master/MonitorPipeline",
-					"standby", pipelineInfo.Standby)
-				if span != nil {
-					pachClient = pachClient.WithCtx(ctx)
-				}
-				defer tracing.FinishAnySpan(span)
-
-				if err := a.transitionPipelineState(pachClient.Ctx(),
-					pipelineInfo.Pipeline.Name,
-					pps.PipelineState_PIPELINE_RUNNING,
-					pps.PipelineState_PIPELINE_STANDBY, ""); err != nil {
-
-					pte := &ppsutil.PipelineTransitionError{}
-					if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_PAUSED {
-						// pipeline is stopped, exit monitorPipeline (which pausing the
-						// pipeline should also do). monitorPipeline will be called when
-						// it transitions back to running
-						// TODO(msteffen): this should happen in the pipeline
-						// controller
-						return nil
-					}
-					return err
-				}
-				var (
-					childSpan     opentracing.Span
-					oldCtx        = ctx
-					oldPachClient = pachClient
-				)
-				defer func() {
-					tracing.FinishAnySpan(childSpan) // Finish any dangling children of 'span'
-				}()
-				for {
-					// finish span from previous loops
-					tracing.FinishAnySpan(childSpan)
-					childSpan = nil
-
-					var ci *pfs.CommitInfo
-					select {
-					case ci = <-ciChan:
-						if ci.Finished != nil {
-							continue
-						}
-						childSpan, ctx = tracing.AddSpanToAnyExisting(
-							oldCtx, "/pps.Master/MonitorPipeline_SpinUp",
-							"pipeline", pipelineInfo.Pipeline.Name, "commit", ci.Commit.ID)
-						if childSpan != nil {
-							pachClient = oldPachClient.WithCtx(ctx)
-						}
-
-						if err := a.transitionPipelineState(pachClient.Ctx(),
-							pipelineInfo.Pipeline.Name,
-							pps.PipelineState_PIPELINE_STANDBY,
-							pps.PipelineState_PIPELINE_RUNNING, ""); err != nil {
-
-							pte := &ppsutil.PipelineTransitionError{}
-							if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_PAUSED {
-								// pipeline is stopped, exit monitorPipeline (see above)
-								return nil
-							}
-							return err
-						}
-
-						// Stay running while commits are available
-					running:
-						for {
-							// Wait for the commit to be finished before blocking on the
-							// job because the job may not exist yet.
-							if _, err := pachClient.BlockCommit(ci.Commit.Repo.Name, ci.Commit.ID); err != nil {
-								return err
-							}
-							if _, err := pachClient.InspectJobOutputCommit(ci.Commit.Repo.Name, ci.Commit.ID, true); err != nil {
-								return err
-							}
-
-							select {
-							case ci = <-ciChan:
-							default:
-								break running
-							}
-						}
-
-						if err := a.transitionPipelineState(pachClient.Ctx(),
-							pipelineInfo.Pipeline.Name,
-							pps.PipelineState_PIPELINE_RUNNING,
-							pps.PipelineState_PIPELINE_STANDBY, ""); err != nil {
-
-							pte := &ppsutil.PipelineTransitionError{}
-							if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_PAUSED {
-								// pipeline is stopped; monitorPipeline will be called when it
-								// transitions back to running
-								// TODO(msteffen): this should happen in the pipeline
-								// controller
-								return nil
-							}
-							return err
-						}
-					case <-pachClient.Ctx().Done():
-						return context.DeadlineExceeded
-					}
-				}
-			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-				select {
-				case <-pachClient.Ctx().Done():
-					return context.DeadlineExceeded
-				default:
-					log.Printf("error in monitorPipeline: %v: retrying in: %v", err, d)
-				}
-				return nil
-			})
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		log.Printf("error in monitorPipeline: %v", err)
-	}
-}
-
-func (a *apiServer) monitorCrashingPipeline(ctx context.Context, op *pipelineOp) {
-	defer a.cancelMonitor(op.name)
-For:
-	for {
-		select {
-		case <-time.After(crashingBackoff):
-		case <-ctx.Done():
-			break For
-		}
-		time.Sleep(crashingBackoff)
-		workersUp, err := op.allWorkersUp()
-		if err != nil {
-			log.Printf("error in monitorCrashingPipeline: %v", err)
-			continue
-		}
-		if workersUp {
-			if err := a.transitionPipelineState(ctx, op.name,
-				pps.PipelineState_PIPELINE_CRASHING,
-				pps.PipelineState_PIPELINE_RUNNING, ""); err != nil {
-
-				pte := &ppsutil.PipelineTransitionError{}
-				if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_CRASHING {
-					log.Print(err) // Pipeline has moved to STOPPED or been updated--give up
-					return
-				}
-				log.Printf("error in monitorCrashingPipeline: %v", err)
-				continue
-			}
-			break
-		}
-	}
 }
 
 func (a *apiServer) getLatestCronTime(pachClient *client.APIClient, in *pps.Input) (time.Time, error) {

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"context"
+	"path"
 	"strings"
 	"time"
 

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -173,6 +173,7 @@ func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 		// standby when SubscribeCommit takes too long to return.
 		ciChan := make(chan *pfs.CommitInfo, 1)
 		eg.Go(func() error {
+			defer close(ciChan)
 			return backoff.RetryNotify(func() error {
 				return pachClient.SubscribeCommitF(pipelineInfo.Pipeline.Name, "",
 					client.NewCommitProvenance(ppsconsts.SpecRepo, pipelineInfo.Pipeline.Name, pipelineInfo.SpecCommit.ID),

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -41,6 +41,8 @@ import (
 	workerserver "github.com/pachyderm/pachyderm/src/server/worker/server"
 )
 
+const crashingBackoff = time.Second * 15
+
 // startMonitorThread is a helper used by startMonitor, startCrashingMonitor,
 // and startPipelinePoller. It doesn't manipulate any of APIServer's fields,
 // just wrapps the passed function in a goroutine, and returns a cancel() fn to
@@ -344,7 +346,7 @@ func (a *apiServer) monitorCrashingPipeline(pachClient *client.APIClient, parall
 			}
 			return nil
 		},
-		&backoff.ZeroBackOff{},
+		backoff.NewConstantBackOff(crashingBackoff),
 		backoff.NotifyContinue("monitorCrashingPipeline for "+pipeline),
 	); err != nil && ctx.Err() == nil {
 		// retryUntilCancel should exit iff 'ctx' is cancelled, so this should be

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -1,3 +1,5 @@
+package server
+
 // monitor.go contains methods of s/s/pps/server/api_server.go:APIServer that
 // pertain to these fields of APIServer:
 //   - monitorCancels,
@@ -13,7 +15,6 @@
 // Likewise, to avoid reentrancy deadlocks (A -> B -> A), methods in this file
 // should avoid calling other methods of APIServer defined outside this file and
 // shouldn't call each other.
-package server
 
 import (
 	"context"

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -153,10 +153,13 @@ func (a *apiServer) cancelAllMonitorsAndCrashingMonitors() {
 //////////////////////////////////////////////////////////////////////////////
 //                     Monitor Functions                                    //
 // - These do not lock monitorCancelsMu, but they are called by the         //
-//   functions above, which do. They can in turn call each other but cannot //
-//   call any of the functions above or any functions outside this file (or //
-//   else they will trigger a reentrancy deadlock:                          //
-//                 A (lock succeeds) -> B -> A (lock fails)                 //
+// functions above, which do. They should not be called by functions        //
+// outside monitor.go (to avoid data races). They can in turn call each     //
+// other but also should not call any of the functions above or any         //
+// functions outside this file (or else they will trigger a reentrancy      //
+// deadlock):                                                               //
+// master.go -> monitor.go(lock succeeds) -> master -> monitor(lock fails,  //
+//                                                              deadlock)   //
 //////////////////////////////////////////////////////////////////////////////
 
 func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) {

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -1,0 +1,237 @@
+// monitor.go contains methods of s/s/pps/server/api_server.go:APIServer that
+// pertain to these fields of APIServer:
+//   - monitorCancels,
+//   - crashingMonitorCancels,
+//   - pollCancel, and
+//   - monitorCancelsMu (which protects all of the other fields).
+package server
+
+import (
+	"context"
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pachyderm/pachyderm/src/client"
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
+	"github.com/pachyderm/pachyderm/src/client/pkg/tracing"
+	"github.com/pachyderm/pachyderm/src/client/pkg/tracing/extended"
+	"github.com/pachyderm/pachyderm/src/client/pps"
+	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+	"github.com/pachyderm/pachyderm/src/server/pkg/ppsconsts"
+	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
+)
+
+// Every running pipeline with standby == true has a corresponding goroutine
+// running monitorPipeline() that puts the pipeline in and out of standby in
+// response to new output commits appearing in that pipeline's output repo
+func (a *apiServer) cancelMonitor(pipeline string) {
+	a.monitorCancelsMu.Lock()
+	defer a.monitorCancelsMu.Unlock()
+	if cancel, ok := a.monitorCancels[pipeline]; ok {
+		cancel()
+		delete(a.monitorCancels, pipeline)
+	}
+}
+
+// Every crashing pipeline has a corresponding goro running
+// monitorCrashingPipeline that checks to see if the issues have resolved
+// themselves and moves the pipeline out of crashing if they have.
+func (a *apiServer) cancelCrashingMonitor(pipeline string) {
+	a.monitorCancelsMu.Lock()
+	defer a.monitorCancelsMu.Unlock()
+	if cancel, ok := a.crashingMonitorCancels[pipeline]; ok {
+		cancel()
+		delete(a.crashingMonitorCancels, pipeline)
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                     Monitor Functions                                    //
+//////////////////////////////////////////////////////////////////////////////
+
+func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) {
+	log.Printf("PPS master: monitoring pipeline %q", pipelineInfo.Pipeline.Name)
+	// If this exits (e.g. b/c Standby is false, and pipeline has no cron inputs),
+	// remove this fn's cancel() call from a.monitorCancels (if it hasn't already
+	// been removed, e.g. by deletePipelineResources cancelling this call), so
+	// that it can be called again
+	defer a.cancelMonitor(pipelineInfo.Pipeline.Name)
+	var eg errgroup.Group
+	pps.VisitInput(pipelineInfo.Input, func(in *pps.Input) {
+		if in.Cron != nil {
+			eg.Go(func() error {
+				return backoff.RetryNotify(func() error {
+					return a.makeCronCommits(pachClient, in)
+				}, backoff.NewInfiniteBackOff(), notifyCtx(pachClient.Ctx(), "cron for "+in.Cron.Name))
+			})
+		}
+	})
+	if pipelineInfo.Standby {
+		// Capacity 1 gives us a bit of buffer so we don't needlessly go into
+		// standby when SubscribeCommit takes too long to return.
+		ciChan := make(chan *pfs.CommitInfo, 1)
+		eg.Go(func() error {
+			return backoff.RetryNotify(func() error {
+				return pachClient.SubscribeCommitF(pipelineInfo.Pipeline.Name, "",
+					client.NewCommitProvenance(ppsconsts.SpecRepo, pipelineInfo.Pipeline.Name, pipelineInfo.SpecCommit.ID),
+					"", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
+						ciChan <- ci
+						return nil
+					})
+			}, backoff.NewInfiniteBackOff(), notifyCtx(pachClient.Ctx(), "SubscribeCommit"))
+		})
+		eg.Go(func() error {
+			return backoff.RetryNotify(func() error {
+				span, ctx := extended.AddPipelineSpanToAnyTrace(pachClient.Ctx(),
+					a.env.GetEtcdClient(), pipelineInfo.Pipeline.Name, "/pps.Master/MonitorPipeline",
+					"standby", pipelineInfo.Standby)
+				if span != nil {
+					pachClient = pachClient.WithCtx(ctx)
+				}
+				defer tracing.FinishAnySpan(span)
+
+				if err := a.transitionPipelineState(pachClient.Ctx(),
+					pipelineInfo.Pipeline.Name,
+					pps.PipelineState_PIPELINE_RUNNING,
+					pps.PipelineState_PIPELINE_STANDBY, ""); err != nil {
+
+					pte := &ppsutil.PipelineTransitionError{}
+					if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_PAUSED {
+						// pipeline is stopped, exit monitorPipeline (which pausing the
+						// pipeline should also do). monitorPipeline will be called when
+						// it transitions back to running
+						// TODO(msteffen): this should happen in the pipeline
+						// controller
+						return nil
+					}
+					return err
+				}
+				var (
+					childSpan     opentracing.Span
+					oldCtx        = ctx
+					oldPachClient = pachClient
+				)
+				defer func() {
+					tracing.FinishAnySpan(childSpan) // Finish any dangling children of 'span'
+				}()
+				for {
+					// finish span from previous loops
+					tracing.FinishAnySpan(childSpan)
+					childSpan = nil
+
+					var ci *pfs.CommitInfo
+					select {
+					case ci = <-ciChan:
+						if ci.Finished != nil {
+							continue
+						}
+						childSpan, ctx = tracing.AddSpanToAnyExisting(
+							oldCtx, "/pps.Master/MonitorPipeline_SpinUp",
+							"pipeline", pipelineInfo.Pipeline.Name, "commit", ci.Commit.ID)
+						if childSpan != nil {
+							pachClient = oldPachClient.WithCtx(ctx)
+						}
+
+						if err := a.transitionPipelineState(pachClient.Ctx(),
+							pipelineInfo.Pipeline.Name,
+							pps.PipelineState_PIPELINE_STANDBY,
+							pps.PipelineState_PIPELINE_RUNNING, ""); err != nil {
+
+							pte := &ppsutil.PipelineTransitionError{}
+							if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_PAUSED {
+								// pipeline is stopped, exit monitorPipeline (see above)
+								return nil
+							}
+							return err
+						}
+
+						// Stay running while commits are available
+					running:
+						for {
+							// Wait for the commit to be finished before blocking on the
+							// job because the job may not exist yet.
+							if _, err := pachClient.BlockCommit(ci.Commit.Repo.Name, ci.Commit.ID); err != nil {
+								return err
+							}
+							if _, err := pachClient.InspectJobOutputCommit(ci.Commit.Repo.Name, ci.Commit.ID, true); err != nil {
+								return err
+							}
+
+							select {
+							case ci = <-ciChan:
+							default:
+								break running
+							}
+						}
+
+						if err := a.transitionPipelineState(pachClient.Ctx(),
+							pipelineInfo.Pipeline.Name,
+							pps.PipelineState_PIPELINE_RUNNING,
+							pps.PipelineState_PIPELINE_STANDBY, ""); err != nil {
+
+							pte := &ppsutil.PipelineTransitionError{}
+							if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_PAUSED {
+								// pipeline is stopped; monitorPipeline will be called when it
+								// transitions back to running
+								// TODO(msteffen): this should happen in the pipeline
+								// controller
+								return nil
+							}
+							return err
+						}
+					case <-pachClient.Ctx().Done():
+						return context.DeadlineExceeded
+					}
+				}
+			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+				select {
+				case <-pachClient.Ctx().Done():
+					return context.DeadlineExceeded
+				default:
+					log.Printf("error in monitorPipeline: %v: retrying in: %v", err, d)
+				}
+				return nil
+			})
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		log.Printf("error in monitorPipeline: %v", err)
+	}
+}
+
+func (a *apiServer) monitorCrashingPipeline(ctx context.Context, op *pipelineOp) {
+	defer a.cancelMonitor(op.name)
+For:
+	for {
+		select {
+		case <-time.After(crashingBackoff):
+		case <-ctx.Done():
+			break For
+		}
+		time.Sleep(crashingBackoff)
+		workersUp, err := op.allWorkersUp()
+		if err != nil {
+			log.Printf("error in monitorCrashingPipeline: %v", err)
+			continue
+		}
+		if workersUp {
+			if err := a.transitionPipelineState(ctx, op.name,
+				pps.PipelineState_PIPELINE_CRASHING,
+				pps.PipelineState_PIPELINE_RUNNING, ""); err != nil {
+
+				pte := &ppsutil.PipelineTransitionError{}
+				if errors.As(err, &pte) && pte.Current == pps.PipelineState_PIPELINE_CRASHING {
+					log.Print(err) // Pipeline has moved to STOPPED or been updated--give up
+					return
+				}
+				log.Printf("error in monitorCrashingPipeline: %v", err)
+				continue
+			}
+			break
+		}
+	}
+}

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -283,7 +283,7 @@ func (a *apiServer) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 							return err
 						}
 					case <-pachClient.Ctx().Done():
-						return context.DeadlineExceeded
+						return pachClient.Ctx().Err()
 					}
 				}
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -32,8 +32,6 @@ const (
 	rcExpected
 )
 
-const crashingBackoff = time.Second * 15
-
 func max(is ...int) int {
 	if len(is) == 0 {
 		return 0

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -49,8 +50,15 @@ func max(is ...int) int {
 // pipelineOp contains all of the relevent current state for a pipeline. It's
 // used by step() to take any necessary actions
 type pipelineOp struct {
-	apiServer    *apiServer
-	pachClient   *client.APIClient
+	apiServer *apiServer
+	// a pachyderm client wrapping the PPS Master's context. This should only be
+	// used in startPipelineMonitor and startCrashingPipelineMonitor
+	// TODO(msteffen): refactor master() into its own service and make those
+	// methods of that service
+	masterClient *client.APIClient
+	// a pachyderm client wrapping this operation's context (child of the PPS
+	// master's context, and cancelled at the end of step())
+	opClient     *client.APIClient
 	ptr          *pps.EtcdPipelineInfo
 	name         string // also in pipelineInfo, but that may not be set initially
 	pipelineInfo *pps.PipelineInfo
@@ -68,14 +76,30 @@ var (
 // 1. retrieves its full pipeline spec and RC
 // 2. makes whatever changes are needed to bring the RC in line with the (new) spec
 // 3. updates 'ptr', if needed, to reflect the action it just took
-func (a *apiServer) step(pachClient *client.APIClient, pipeline string, keyVer, keyRev int64) error {
+func (a *apiServer) step(masterClient *client.APIClient, pipeline string, keyVer, keyRev int64) error {
 	log.Infof("PPS master: processing event for %q", pipeline)
 
+	// Initialize op ctx (cancelled at the end of step(), to avoid leaking
+	// resources). op.opClient wraps opCtx, whereas masterClient is passed by the
+	// PPS master and used in case a monitor needs to be spawned for 'pipeline',
+	// whose lifetime is tied to the master rather than this op.
+	opCtx, cancel := context.WithCancel(masterClient.Ctx())
+	defer cancel()
+
+	// Handle tracing
+	span, opCtx := extended.AddPipelineSpanToAnyTrace(opCtx,
+		a.env.GetEtcdClient(), pipeline, "/pps.Master/ProcessPipelineUpdate",
+		"key-version", keyVer,
+		"mod-revision")
+	if span != nil {
+		defer tracing.FinishAnySpan(span)
+	}
+
 	// Retrieve pipelineInfo from the spec repo
-	op, err := a.newPipelineOp(pachClient, pipeline)
+	op, err := a.newPipelineOp(masterClient, masterClient.WithCtx(opCtx), pipeline)
 	if err != nil {
 		// op is nil, so can't use op.failPipeline
-		return a.setPipelineFailure(pachClient.Ctx(), pipeline,
+		return a.setPipelineFailure(opCtx, pipeline,
 			fmt.Sprintf("couldn't initialize pipeline op: %v", err))
 	}
 	// set op.rc
@@ -85,18 +109,34 @@ func (a *apiServer) step(pachClient *client.APIClient, pipeline string, keyVer, 
 		return err
 	}
 
-	// Handle tracing
-	span, ctx := extended.AddPipelineSpanToAnyTrace(pachClient.Ctx(),
-		a.env.GetEtcdClient(), pipeline, "/pps.Master/ProcessPipelineUpdate",
-		"key-version", keyVer,
-		"mod-revision", keyRev,
+	// Process the pipeline event
+	return op.run()
+}
+
+func (a *apiServer) newPipelineOp(masterClient *client.APIClient, opClient *client.APIClient, pipeline string) (*pipelineOp, error) {
+	op := &pipelineOp{
+		apiServer:    a,
+		masterClient: masterClient,
+		opClient:     opClient,
+		ptr:          &pps.EtcdPipelineInfo{},
+		name:         pipeline,
+	}
+	// get latest EtcdPipelineInfo (events can pile up, so that the current state
+	// doesn't match the event being processed)
+	if err := a.pipelines.ReadOnly(opClient.Ctx()).Get(pipeline, op.ptr); err != nil {
+		return nil, errors.Wrapf(err, "could not retrieve etcd pipeline info for %q", pipeline)
+	}
+	tracing.TagAnySpan(opClient.Ctx(),
 		"state", op.ptr.State.String(),
 		"spec-commit", op.ptr.SpecCommit)
-	if span != nil {
-		defer tracing.FinishAnySpan(span)
-		pachClient = pachClient.WithCtx(ctx) //lint:ignore SA4006 pachClient is unused but we want the right one in scope in case someone uses it below in the future
+	// set op.pipelineInfo
+	if err := op.getPipelineInfo(); err != nil {
+		return nil, err
 	}
+	return op, nil
+}
 
+func (op *pipelineOp) run() error {
 	// Bring 'pipeline' into the correct state by taking appropriate action
 	switch op.ptr.State {
 	case pps.PipelineState_PIPELINE_STARTING, pps.PipelineState_PIPELINE_RESTARTING:
@@ -173,25 +213,6 @@ func (a *apiServer) step(pachClient *client.APIClient, pipeline string, keyVer, 
 	return nil
 }
 
-func (a *apiServer) newPipelineOp(pachClient *client.APIClient, pipeline string) (*pipelineOp, error) {
-	op := &pipelineOp{
-		apiServer:  a,
-		pachClient: pachClient,
-		ptr:        &pps.EtcdPipelineInfo{},
-		name:       pipeline,
-	}
-	// get latest EtcdPipelineInfo (events can pile up, so that the current state
-	// doesn't match the event being processed)
-	if err := a.pipelines.ReadOnly(pachClient.Ctx()).Get(pipeline, op.ptr); err != nil {
-		return nil, errors.Wrapf(err, "could not retrieve etcd pipeline info for %q", pipeline)
-	}
-	// set op.pipelineInfo
-	if err := op.getPipelineInfo(); err != nil {
-		return nil, err
-	}
-	return op, nil
-}
-
 // getPipelineInfo reads the pipelineInfo associated with 'op's pipeline. This
 // should be one of the first calls made on 'op', as most other methods (e.g.
 // getRC, though not failPipeline) assume that op.pipelineInfo is set.
@@ -202,7 +223,7 @@ func (a *apiServer) newPipelineOp(pachClient *client.APIClient, pipeline string)
 func (op *pipelineOp) getPipelineInfo() error {
 	var errCount int
 	return backoff.RetryNotify(func() error {
-		return op.apiServer.sudo(op.pachClient, func(superUserClient *client.APIClient) error {
+		return op.apiServer.sudo(op.opClient, func(superUserClient *client.APIClient) error {
 			var err error
 			op.pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, op.name, op.ptr)
 			return err
@@ -231,7 +252,7 @@ func (op *pipelineOp) getPipelineInfo() error {
 // redundant), and then returns an error to the caller to indicate that the
 // caller shouldn't continue with other operations
 func (op *pipelineOp) getRC(expectation rcExpectation) (retErr error) {
-	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
 		"/pps.Master/GetRC", "pipeline", op.name)
 	defer func(span opentracing.Span) {
 		tracing.TagAnySpan(span, "err", fmt.Sprintf("%v", retErr))
@@ -356,7 +377,7 @@ func (op *pipelineOp) rcIsFresh() bool {
 func (op *pipelineOp) setPipelineState(state pps.PipelineState, reason string) error {
 	var errCount int
 	return backoff.RetryNotify(func() error {
-		return op.apiServer.setPipelineState(op.pachClient.Ctx(),
+		return op.apiServer.setPipelineState(op.opClient.Ctx(),
 			op.pipelineInfo.Pipeline.Name, state, reason)
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 		if errCount++; errCount >= maxErrCount {
@@ -376,7 +397,7 @@ func (op *pipelineOp) createPipelineResources() error {
 	log.Infof("PPS master: creating resources for pipeline %q", op.name)
 	var errCount int
 	return backoff.RetryNotify(func() error {
-		return op.apiServer.createWorkerSvcAndRc(op.pachClient.Ctx(), op.ptr, op.pipelineInfo)
+		return op.apiServer.createWorkerSvcAndRc(op.opClient.Ctx(), op.ptr, op.pipelineInfo)
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 		invalidOpts := errors.As(err, &noValidOptionsErr{})
 		errCount++
@@ -401,12 +422,12 @@ func (op *pipelineOp) createPipelineResources() error {
 // Note: this is called by every run through step(), so must be idempotent
 func (op *pipelineOp) startPipelineMonitor() {
 	op.stopCrashingPipelineMonitor()
-	op.apiServer.startMonitor(op.pachClient, op.pipelineInfo)
+	op.apiServer.startMonitor(op.masterClient, op.pipelineInfo)
 }
 
 func (op *pipelineOp) startCrashingPipelineMonitor() {
 	op.stopPipelineMonitor()
-	op.apiServer.startCrashingMonitor(op.pachClient, op.ptr.Parallelism, op.pipelineInfo)
+	op.apiServer.startCrashingMonitor(op.masterClient, op.ptr.Parallelism, op.pipelineInfo)
 }
 
 func (op *pipelineOp) stopPipelineMonitor() {
@@ -433,15 +454,15 @@ func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
 	log.Infof("PPS master: finishing output commits for pipeline %q", op.name)
 
 	var pachClient *client.APIClient
-	if span, _ctx := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+	if span, _ctx := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
 		"/pps.Master/FinishPipelineOutputCommits", "pipeline", op.name); span != nil {
-		pachClient = op.pachClient.WithCtx(_ctx) // copy span back into pachClient
+		pachClient = op.opClient.WithCtx(_ctx) // copy span back into pachClient
 		defer func() {
 			tracing.TagAnySpan(span, "err", fmt.Sprintf("%v", retErr))
 			tracing.FinishAnySpan(span)
 		}()
 	} else {
-		pachClient = op.pachClient
+		pachClient = op.opClient
 	}
 
 	return op.apiServer.sudo(pachClient, func(superUserClient *client.APIClient) error {
@@ -484,7 +505,7 @@ func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
 //   deleted, then (per step() above) the error will be logged and the PPS
 //   master will move on
 func (op *pipelineOp) deletePipelineResources() error {
-	return op.apiServer.deletePipelineResources(op.pachClient.Ctx(), op.name)
+	return op.apiServer.deletePipelineResources(op.opClient.Ctx(), op.name)
 }
 
 // updateRC is a helper for {scaleUp,scaleDown}Pipeline. It includes all of the
@@ -534,7 +555,7 @@ func (op *pipelineOp) updateRC(update func(rc *v1.ReplicationController)) error 
 // failing/restarting op's pipeline if it can't update its RC (via updateRC)
 func (op *pipelineOp) scaleUpPipeline() (retErr error) {
 	log.Infof("PPS master: scaling up workers for %q", op.name)
-	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
 		"/pps.Master/ScaleUpPipeline", "pipeline", op.name)
 	defer func() {
 		if retErr != nil {
@@ -568,7 +589,7 @@ func (op *pipelineOp) scaleUpPipeline() (retErr error) {
 // failing/restarting op's pipeline if it can't update its RC (via updateRC)
 func (op *pipelineOp) scaleDownPipeline() (retErr error) {
 	log.Infof("PPS master: scaling down workers for %q", op.name)
-	span, _ := tracing.AddSpanToAnyExisting(op.pachClient.Ctx(),
+	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
 		"/pps.Master/ScaleDownPipeline", "pipeline", op.name)
 	defer func() {
 		if retErr != nil {
@@ -642,7 +663,7 @@ func (op *pipelineOp) restartPipeline(reason string) error {
 // Like other functions in this file, failPipeline takes responsibility for
 // retrying.
 func (op *pipelineOp) failPipeline(reason string) error {
-	if err := op.apiServer.setPipelineFailure(op.pachClient.Ctx(), op.name, reason); err != nil {
+	if err := op.apiServer.setPipelineFailure(op.opClient.Ctx(), op.name, reason); err != nil {
 		return errors.Wrapf(err, "error failing pipeline %q", op.name)
 	}
 	return errors.Errorf("failing pipeline %q: %v", op.name, reason)

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -401,12 +401,12 @@ func (op *pipelineOp) createPipelineResources() error {
 // Note: this is called by every run through step(), so must be idempotent
 func (op *pipelineOp) startPipelineMonitor() {
 	op.stopCrashingPipelineMonitor()
-	op.apiServer.startMonitor(op.pipelineInfo)
+	op.apiServer.startMonitor(op.pachClient.Ctx(), op.pipelineInfo)
 }
 
 func (op *pipelineOp) startCrashingPipelineMonitor() {
 	op.stopPipelineMonitor()
-	op.apiServer.startCrashingMonitor(op.pachClient.Ctx(), op.pipelineInfo)
+	op.apiServer.startCrashingMonitor(op.pachClient.Ctx(), op.ptr.Parallelism, op.pipelineInfo)
 }
 
 func (op *pipelineOp) stopPipelineMonitor() {

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -401,12 +401,12 @@ func (op *pipelineOp) createPipelineResources() error {
 // Note: this is called by every run through step(), so must be idempotent
 func (op *pipelineOp) startPipelineMonitor() {
 	op.stopCrashingPipelineMonitor()
-	op.apiServer.startMonitor(op.pachClient.Ctx(), op.pipelineInfo)
+	op.apiServer.startMonitor(op.pachClient, op.pipelineInfo)
 }
 
 func (op *pipelineOp) startCrashingPipelineMonitor() {
 	op.stopPipelineMonitor()
-	op.apiServer.startCrashingMonitor(op.pachClient.Ctx(), op.ptr.Parallelism, op.pipelineInfo)
+	op.apiServer.startCrashingMonitor(op.pachClient, op.ptr.Parallelism, op.pipelineInfo)
 }
 
 func (op *pipelineOp) stopPipelineMonitor() {


### PR DESCRIPTION
The main change is the creation of `monitor.go`, and the convention that functions in `monitor.go` not call outside of monitor.go.

I think it might be possible to refactor the PPS master so that those functions are in their own package and can't call outside the package without introducing a circular dependency, but that seemed more complicated, and may make sense to persue separately.

The 1.11.x version of this PR #5364 

Fixes #4371