### PR TITLE
Fixes for PutObjDirect and default values for amazon object client env vars

### DIFF
--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -1872,7 +1872,7 @@ func (w *putObjWriteCloser) Write(p []byte) (int, error) {
 }
 
 func (w *putObjWriteCloser) Close() error {
-	if w.request.Obj == "" {
+	if w.request.Obj != "" {
 		// This happens if the block is empty in which case Write was never
 		// called, so we need to send an empty request to identify the block.
 		if err := w.client.Send(w.request); err != nil {

--- a/src/server/pfs/server/testing/block_api_server_test.go
+++ b/src/server/pfs/server/testing/block_api_server_test.go
@@ -146,20 +146,42 @@ func TestReadObjects(t *testing.T) {
 func TestDirectObjects(t *testing.T) {
 	t.Parallel()
 	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
-		fmt.Printf("test path: %s\n", env.Directory)
 		path := "direct-foo"
 		data := []byte("foo")
 		fooWriter, err := env.PachClient.DirectObjWriter(path)
+		require.NoError(t, err)
 		_, err = fooWriter.Write(data)
 		require.NoError(t, err)
 		require.NoError(t, fooWriter.Close())
 
 		fooReader, err := env.PachClient.DirectObjReader(path)
+		require.NoError(t, err)
 		readData := &bytes.Buffer{}
 		_, err = readData.ReadFrom(fooReader)
 		require.NoError(t, err)
-		require.Equal(t, data, readData.Bytes())
 		require.NoError(t, fooReader.Close())
+		require.Equal(t, data, readData.Bytes())
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestEmptyDirectObjects(t *testing.T) {
+	t.Parallel()
+	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
+		path := "empty-foo"
+		fooWriter, err := env.PachClient.DirectObjWriter(path)
+		require.NoError(t, err)
+		require.NoError(t, fooWriter.Close())
+
+		fooReader, err := env.PachClient.DirectObjReader(path)
+		require.NoError(t, err)
+		readData := &bytes.Buffer{}
+		_, err = readData.ReadFrom(fooReader)
+		require.NoError(t, err)
+		require.NoError(t, fooReader.Close())
+		require.Equal(t, 0, len(readData.Bytes()))
 
 		return nil
 	})

--- a/src/server/pfs/server/testing/block_api_server_test.go
+++ b/src/server/pfs/server/testing/block_api_server_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -136,6 +137,29 @@ func TestReadObjects(t *testing.T) {
 		value, err = env.PachClient.ReadObjects([]string{fooObject.Hash, barObject.Hash}, 4, 0)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ar"), value)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestDirectObjects(t *testing.T) {
+	t.Parallel()
+	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
+		fmt.Printf("test path: %s\n", env.Directory)
+		path := "direct-foo"
+		data := []byte("foo")
+		fooWriter, err := env.PachClient.DirectObjWriter(path)
+		_, err = fooWriter.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, fooWriter.Close())
+
+		fooReader, err := env.PachClient.DirectObjReader(path)
+		readData := &bytes.Buffer{}
+		_, err = readData.ReadFrom(fooReader)
+		require.NoError(t, err)
+		require.Equal(t, data, readData.Bytes())
+		require.NoError(t, fooReader.Close())
 
 		return nil
 	})

--- a/src/server/pkg/cmdutil/env.go
+++ b/src/server/pkg/cmdutil/env.go
@@ -151,7 +151,7 @@ func getEnvTag(structField reflect.StructField) (*envTag, error) {
 	if len(split) == 1 {
 		return envTag, nil
 	}
-	split = strings.SplitN(split[1], "=", 2)
+	split = strings.SplitN(strings.TrimSpace(split[1]), "=", 2)
 	switch split[0] {
 	case "required":
 		envTag.required = true

--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -157,7 +157,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 	// creds.VaultAddress are set, then this will use the EC2 metadata service
 	timeout, err := time.ParseDuration(advancedConfig.Timeout)
 	if err != nil {
-		return nil, err
+		return nil, errors.EnsureStack(err)
 	}
 	httpClient := &http.Client{Timeout: timeout}
 	// If NoVerifySSL is true, then configure the transport to skip ssl verification (enables self-signed certificates).
@@ -196,7 +196,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 	// Create new session using awsConfig
 	session, err := session.NewSession(awsConfig)
 	if err != nil {
-		return nil, err
+		return nil, errors.EnsureStack(err)
 	}
 	awsClient := &amazonClient{
 		bucket: bucket,
@@ -226,7 +226,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 		}
 		cloudfrontPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
-			return nil, err
+			return nil, errors.EnsureStack(err)
 		}
 		awsClient.cloudfrontURLSigner = sign.NewURLSigner(cloudfrontKeyPairID, cloudfrontPrivateKey)
 		log.Infof("Using cloudfront security credentials - keypair ID (%v) - to sign cloudfront URLs", string(cloudfrontKeyPairID))

--- a/src/server/pkg/obj/obj.go
+++ b/src/server/pkg/obj/obj.go
@@ -132,7 +132,7 @@ type AmazonAdvancedConfiguration struct {
 	// uploader, and not the owner of the bucket. Using the default ensures that
 	// the owner of the bucket can access the objects as well.
 	UploadACL      string `env:"UPLOAD_ACL, default=bucket-owner-full-control"`
-	Reverse        bool   `env:"REVERSE, default=true"`
+	Reverse        bool   `env:"REVERSE, default=false"`
 	PartSize       int64  `env:"PART_SIZE, default=5242880"`
 	MaxUploadParts int    `env:"MAX_UPLOAD_PARTS, default=10000"`
 	DisableSSL     bool   `env:"DISABLE_SSL, default=false"`

--- a/src/server/pkg/obj/obj.go
+++ b/src/server/pkg/obj/obj.go
@@ -283,7 +283,7 @@ func secretFile(name string) string {
 func readSecretFile(name string) (string, error) {
 	bytes, err := ioutil.ReadFile(secretFile(name))
 	if err != nil {
-		return "", err
+		return "", errors.EnsureStack(err)
 	}
 	return strings.TrimSpace(string(bytes)), nil
 }
@@ -403,7 +403,7 @@ func NewAmazonClient(region, bucket string, creds *AmazonCreds, distribution str
 	defer func() { c = newCheckedClient(c) }()
 	advancedConfig := &AmazonAdvancedConfiguration{}
 	if err := cmdutil.Populate(advancedConfig); err != nil {
-		return nil, err
+		return nil, errors.EnsureStack(err)
 	}
 	if len(reverse) > 0 {
 		advancedConfig.Reverse = reverse[0]


### PR DESCRIPTION
Added a new test for putting and reading an object with `DirectObjWriter` and `DirectObjReader`, uncovered a bug where we would double-write data if there was only one chunk of data.  Also found out that we weren't actually getting default values for the `AmazonAdvancedConfiguration` fields because they included a space in their tag.  Rather than remove the space, I changed the tag parser to account for this because it's not obviously wrong and reads better with the space.  Could maybe use more generic tag parsing, but that's a bit out of scope.  Left in a few `errors.EnsureStack` calls for errors that obviously are missing stack traces.