### PR TITLE
Revert changes to error stacks in object clients

### DIFF
--- a/src/server/pkg/obj/amazon_client.go
+++ b/src/server/pkg/obj/amazon_client.go
@@ -193,7 +193,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 	// creds.VaultAddress are set, then this will use the EC2 metadata service
 	timeout, err := time.ParseDuration(advancedConfig.Timeout)
 	if err != nil {
-		return nil, errors.EnsureStack(err)
+		return nil, err
 	}
 	httpClient := &http.Client{Timeout: timeout}
 	// If NoVerifySSL is true, then configure the transport to skip ssl verification (enables self-signed certificates).
@@ -234,7 +234,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 	// Create new session using awsConfig
 	session, err := session.NewSession(awsConfig)
 	if err != nil {
-		return nil, errors.EnsureStack(err)
+		return nil, err
 	}
 	awsClient := &amazonClient{
 		bucket: bucket,
@@ -264,7 +264,7 @@ func newAmazonClient(region, bucket string, creds *AmazonCreds, cloudfrontDistri
 		}
 		cloudfrontPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
-			return nil, errors.EnsureStack(err)
+			return nil, err
 		}
 		awsClient.cloudfrontURLSigner = sign.NewURLSigner(cloudfrontKeyPairID, cloudfrontPrivateKey)
 		log.Infof("Using cloudfront security credentials - keypair ID (%v) - to sign cloudfront URLs", string(cloudfrontKeyPairID))

--- a/src/server/pkg/obj/obj.go
+++ b/src/server/pkg/obj/obj.go
@@ -288,7 +288,7 @@ func secretFile(name string) string {
 func readSecretFile(name string) (string, error) {
 	bytes, err := ioutil.ReadFile(secretFile(name))
 	if err != nil {
-		return "", errors.EnsureStack(err)
+		return "", err
 	}
 	return strings.TrimSpace(string(bytes)), nil
 }
@@ -408,7 +408,7 @@ func NewAmazonClient(region, bucket string, creds *AmazonCreds, distribution str
 	defer func() { c = newCheckedClient(c) }()
 	advancedConfig := &AmazonAdvancedConfiguration{}
 	if err := cmdutil.Populate(advancedConfig); err != nil {
-		return nil, errors.EnsureStack(err)
+		return nil, err
 	}
 	if len(reverse) > 0 {
 		advancedConfig.Reverse = reverse[0]


### PR DESCRIPTION
This is breaking amazon deployments in `v1.11.6` due to `os.IsNotExist` explicitly not using `errors.Is`.  I'm currently working on a more-complete fix with tests for our object client code in CI, but this should unblock `v1.11.7`.