### PR TITLE
[Build] [Dev Env] fix eating command input in build environment

### DIFF
--- a/etc/kube/start-minikube-vm.sh
+++ b/etc/kube/start-minikube-vm.sh
@@ -24,6 +24,11 @@ function get_images {
 }
 export -f get_images
 
+function start_minikube {
+    minikube start ${MINIKUBE_FLAGS[@]}
+}
+export -f start_minikube
+
 ## If the caller provided a tag, build and use that
 export PACH_VERSION=local
 KUBE_VERSION=v1.13.0
@@ -59,7 +64,7 @@ Running:
 EOF
 cat <<EOF | tail -c+1 | xargs -I{} -n1 -P3 -- /bin/bash -c {}
 get_images
-minikube start ${MINIKUBE_FLAGS[@]}
+start_minikube
 EOF
 
 # Print a spinning wheel while waiting for minikube to come up


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This is my first PR!

In order to build Pachyderm locally, one must do `make launch-dev-vm`. It appears that the command is getting eaten (unsure *precisely* why). Putting this in a function fixes the issue, and it's a good idea to put shellout commands in functions in any case. There's opportunities to clean up this shell script further but in the interest of keeping bite-sized-PRs and doing my first PR, I've decided to keep the churn/blast radius small on this one.

If this PR is unnecessary, needs additional work, etc, please let me know. I'd be happy to work to get this one over the finish line, as a way of learning how contributions to the project work.

Dev setup instructions: https://github.com/pachyderm/pachyderm/blob/master/doc/docs/master/contributing/setup.md

Before:

```
make launch-dev-vm
...
Running:
  get_images
  minikube start --kubernetes-version=v1.13.0
/bin/bash: start: command not found
/bin/bash: --: invalid option
Usage:	/bin/bash [GNU long option] [option] ...
	/bin/bash [GNU long option] [option] script-file ...
```

After:

```
make launch-dev-vm

etc/kube/start-minikube-vm.sh --cpus=4  --memory=8192
Running:
  get_images
  minikube start --kubernetes-version=v1.13.0
😄  minikube v1.14.2 on Darwin 10.15.7
```

Local environment:

macOS Catalina 10.15
Minikube
zsh