### PR TITLE
[Docs] [Getting-started] fixed some minor issues on getting-started

### DIFF
--- a/doc/docs/master/deploy-manage/manage/migrations.md
+++ b/doc/docs/master/deploy-manage/manage/migrations.md
@@ -228,7 +228,6 @@ cluster by using a `pachctl deploy` command for your cloud provider with the
     pachctl deploy amazon <bucket-name> <region> <storage-size> --dynamic-etcd-nodes=<number> --iam-role <iam-role> --namespace=<namespace-name>
     ```
 
-<<<<<<< HEAD
 === "GKE"
     ```shell
     pachctl deploy google <bucket-name> <storage-size> --dynamic-etcd-nodes=1  --namespace=<namespace-name>

--- a/doc/docs/master/getting_started/beginner_tutorial.md
+++ b/doc/docs/master/getting_started/beginner_tutorial.md
@@ -133,54 +133,48 @@ We can check to make sure the data we just added is in Pachyderm.
   **System response:**
 
   ```
-  COMMIT                           NAME         TYPE COMMITTED          SIZE 
+  COMMIT                           NAME         TYPE COMMITTED          SIZE
   d89758a7496a4c56920b0eaa7d7d3255 /liberty.png file About a minute ago 57.27KiB
   ```
 
-Also, you can view the file you have just added to Pachyderm. Because this is an
+Now you can view the file by retrieving it from Pachyderm. Because this is an
 image, you cannot just print it out in the terminal, but the following
-commands will let you view it easily:
+command will let you view it:
 
+* On macOS, run:
 
-* On macOS prior to Catalina, run:
-    ```
-    pachctl get file images@master:liberty.png | open -f -a /Applications/Preview.app
-    ```
+```shell
+pachctl get file images@master:liberty.png | open -f -a Preview.app
+```
 
-* On macOS Catalina, run:
-    ```
-    pachctl get file images@master:liberty.png | open -f -a /System/Applications/Preview.app
-    ```
-    
 * On Linux 64-bit, run:
-    ```
-    pachctl get file images@master:liberty.png | display
-    ```
+
+```shell
+pachctl get file images@master:liberty.png | display
+```
 
 ### Create a Pipeline
 
 Now that you have some data in your repo, it is time to do something
-with it. Pipelines are the core processing primitive in Pachyderm and
-you can define them with a JSON encoding. For this example, we have
-already created the pipeline for you and you can find the [code on
-GitHub](https://github.com/pachyderm/pachyderm/blob/master/examples/opencv).
+with it. Pipelines are the core processing primitive in Pachyderm.
+Pipelines are defined with a simple JSON file called a pipeline
+specification or pipeline spec for short. For this example, we already
+[created the pipeline spec for you](https://github.com/pachyderm/pachyderm/blob/master/examples/opencv).
 
-When you want to create your own pipelines later, you can refer to the
+When you want to create your own pipeline specs later, you can refer to the
 full [Pipeline Specification](../../reference/pipeline_spec) to use
 more advanced options. Options include building your own code into a
-container instead of the pre-built Docker image that we are
-using in this tutorial.
+container. In this tutorial, we are using a pre-built Docker image.
 
-For now, we are going to create a single pipeline that takes in images
+For now, we are going to create a single pipeline spec that takes in images
 and does some simple edge detection.
 
 ![image](../assets/images/opencv-liberty.png)
 
-Below is the pipeline spec and python code that we are using. Let's walk
+Below is the `edges.json` pipeline spec. Let's walk
 through the details.
 
-```shell
-# edges.json
+```json
 {
   "pipeline": {
     "name": "edges"
@@ -199,22 +193,24 @@ through the details.
 }
 ```
 
-Our pipeline spec contains a few simple sections. First, it is the pipeline
-`name`, edges. Then we have the `transform` which specifies the docker
-image we want to use, `pachyderm/opencv` (defaults to DockerHub as the
-registry), and the entry point `edges.py`. Lastly, we specify the input.
-Here we only have one PFS input, our images repo with a particular glob
-pattern.
+The pipeline spec contains a few simple sections. The pipeline section contains
+a `name`, which is how you will identify your pipeline. Your pipeline will also
+automatically create an output repo with the same name. The `transform` section
+allows you to specify the docker image you want to use. In this case,
+`pachyderm/opencv` is the docker image (defaults to DockerHub as the registry),
+and the entry point is `edges.py`. The input section specifies repos visible
+to the running pipeline, and how to process the data from the repos. Commits to
+these repos will automatically trigger the pipeline to create new jobs to
+process them. In this case, `images` is the repo, and `/*` is the glob pattern.
 
-The glob pattern defines how the input data can be broken up if we want
-to distribute our computation. `/*` means that each file can be
+The glob pattern defines how the input data can be broken up if you want
+to distribute computation. `/*` means that each file can be
 processed individually, which makes sense for images. Glob patterns are
-one of the most powerful features in  Pachyderm.
+one of the most powerful features in Pachyderm.
 
-The following text is the Python code that we run in this pipeline:
+The following text is the Python code run in this pipeline:
 
-``` python
-# edges.py
+```python
 import cv2
 import numpy as np
 from matplotlib import pyplot as plt
@@ -266,7 +262,7 @@ connection. Subsequent runs will be much faster.
 
 You can view the job with:
 
-``` bash
+```shell
 pachctl list job
 ```
 
@@ -283,7 +279,7 @@ pipeline, and all the results of that pipeline will be versioned in this
 output repo. In our example, the `edges` pipeline created a repo
 called `edges` to store the results.
 
-``` bash
+```
 pachctl list repo
 ```
 
@@ -300,21 +296,15 @@ images 5 minutes ago 57.27KiB
 We can view the output data from the `edges` repo in the same fashion
 that we viewed the input data.
 
-* On macOS prior to Catalina, run:
+* On macOS, run:
 
-```
-pachctl get file edges@master:liberty.png | open -f -a /Applications/Preview.app
-```
-
-* On macOS Catalina, run:
-
-```
-pachctl get file edges@master:liberty.png | open -f -a /System/Applications/Preview.app
+```shell
+pachctl get file edges@master:liberty.png | open -f -a Preview.app
 ```
 
 * On Linux 64-bit, run:
 
-```
+```shell
 pachctl get file edges@master:liberty.png | display
 ```
 
@@ -347,7 +337,7 @@ new outputs.
 
 View the list of jobs that have started:
 
-``` bash
+```shell
 pachctl list job
 ```
 
@@ -388,8 +378,7 @@ montage of images:
 
 Below is the pipeline spec for this new pipeline:
 
-```shell
-# montage.json
+```json
 {
   "pipeline": {
     "name": "montage"
@@ -461,25 +450,19 @@ ce448c12d0dd4410b3a5ae0c0f07e1f9    2 minutes ago  Less than a second 0       1 
 View the generated montage image by running one of
 the following commands:
 
-* On macOS prior to Catalina, run:
+* On macOS, run:
 
-```
-pachctl get file montage@master:montage.png | open -f -a /Applications/Preview.app
-```
-
-* On macOS Catalina, run:
-
-```
-pachctl get file montage@master:montage.png | open -f -a /System/Applications/Preview.app
+```shell
+pachctl get file montage@master:montage.png | open -f -a Preview.app
 ```
 
 * On Linux 64-bit, run:
 
-```
+```shell
 pachctl get file montage@master:montage.png | display
 ```
 
-  ![image](../assets/images/montage-screenshot.png)
+![image](../assets/images/montage-screenshot.png)
 
 Exploring your DAG in the Pachyderm dashboard
 ---------------------------------------------

--- a/doc/docs/master/getting_started/install-pachctl-completion.md
+++ b/doc/docs/master/getting_started/install-pachctl-completion.md
@@ -85,7 +85,7 @@ steps:
 1. Install `pachctl` autocompletion for `zsh`:
 
    ```zsh
-   pachctl completion zsh --install --path <path/to/zfs-completions>
+   pachctl completion zsh --install --path <path/to/zsh-completions>
    ```
 
    **Example:**


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

I think this document needs quite a bit of work, but it's a little too early (for me) to do a more thorough overhaul. For now, I've stuck with a few changes while keeping to the current format.

Improvements:

1. macOS does not need to specify the full path to an application to launch it with `open`. We can avoid a potentially confusing situation by modifying this command. This also avoids supporting N number of specific operating systems on a go-forward basis (macOS Big Sur is likely to have some large changes as well...). Overall: cleaner, more simple, and more likely to work and avoid bad copypasta.

2. Removed any references to PFS. Get this out of the way and don't bog down the user with too many details before getting to the next action. Stay focused on the pipeline specification instead.

3. JSON does not support comments, so remove the comments from JSON to avoid copy-pasta errors in other people's editors.

4. ` ```bash ` is not typically a supported grammar in markdown code fences. If it is, it is an alias for ` ```shell `, which references  https://github.com/atom/language-shellscript -- See also: https://github.com/github/linguist/blob/master/vendor/README.md

5. Some minor spelling errors and grammar cleanup.