### PR TITLE
Fix TestPipelineBuildLifecycle & fix race in PutFile

### DIFF
--- a/etc/kube/start-minikube-vm.sh
+++ b/etc/kube/start-minikube-vm.sh
@@ -25,7 +25,7 @@ function get_images {
 export -f get_images
 
 function start_minikube {
-    minikube start ${MINIKUBE_FLAGS[@]}
+    minikube start "${MINIKUBE_FLAGS[@]}"
 }
 export -f start_minikube
 

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -5,24 +5,23 @@ set -e
 GIT_REPO_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" 2>&1 > /dev/null && git rev-parse --show-toplevel)
 cd "${GIT_REPO_DIR}"
 
-# Collect untracked args into '\( -path abc -o -path def -o ... \) -prune'
+# Collect untracked args into '\( -o -path abc -o -path def -o ... \) -prune'
 # argument to be passed to 'find'
 skip_paths=()
 for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
+  # Convert to relative path, as required by -path
   file="./$(realpath --relative-to="." "${file}")"
-  if [[ "${#skip_paths[@]}" -gt 0 ]]; then
-    skip_paths+=( -o )
-  fi
-  skip_paths+=( -path "${file%/}" ) # strip trailing slash as req'd by -path
+  # 1. Always prefix with -o (i.e. don't fencepost; find always has an argument
+  #    before skip_paths, so including the initial -o works whether skip_paths
+  #    is empty or not
+  # 2. strip trailing slash as required by -path
+  skip_paths+=( -o -path "${file%/}" )
 done
 
 go get -u golang.org/x/lint/golint
 find "./src" \
-  \( -path "*.pb.go" -o "${skip_paths[@]}" \) -prune -o -name '*.go' -print \
+  \( -path "*.pb.go" -o -path "*pkg/tar*" "${skip_paths[@]}" \) -prune -o -name '*.go' -print \
 | while read -r file; do
-    if [[ "${file}" == *pkg/tar* ]]; then
-        continue
-    fi
     golint -set_exit_status "$file";
 done;
 
@@ -38,7 +37,7 @@ staticcheck "${GIT_REPO_DIR}/..."
 
 # shellcheck disable=SC2046
 find . \
-  \( -path ./etc/plugin -o "${skip_paths[@]}" \) -prune -o -name "*.sh" -print \
+  \( -path ./etc/plugin "${skip_paths[@]}" \) -prune -o -name "*.sh" -print \
 | while read -r file; do
     shellcheck -e SC1091 -e SC2010 -e SC2181 -e SC2004 -e SC2219 "${file}"
 done

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3050,10 +3050,11 @@ func (d *driver) putFiles(pachClient *client.APIClient, s *putFileServer) error 
 		var records *pfs.PutFileRecords
 		logPutFileStart(req)
 		defer func() { logPutFileEnd(req, start, records, retErr) }() //late binding
-		records, retErr = d.putFile(pachClient, req.File, req.Delimiter, req.TargetFileDatums,
+		var err error
+		records, err = d.putFile(pachClient, req.File, req.Delimiter, req.TargetFileDatums,
 			req.TargetFileBytes, req.HeaderRecords, req.OverwriteIndex, req.Delete, r)
-		if retErr != nil {
-			return retErr
+		if err != nil {
+			return err
 		}
 		mu.Lock()
 		defer mu.Unlock()

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3034,7 +3034,7 @@ func logPutFileEnd(req *pfs.PutFileRequest, start time.Time, records *pfs.PutFil
 			bytes += float64(r.SizeBytes)
 		}
 	}
-	dur := time.Now().Sub(start).Truncate(time.Millisecond)
+	dur := time.Since(start).Truncate(time.Millisecond)
 	rate := float64(bytes) / dur.Seconds()
 	log.Debugf(`pfs.API.PutFile/%s {"to":%q,"sz":%q,"dur":"%s (%s/s)","err":"%v"`,
 		verb, pretty.CompactPrintFile(req.File), units.BytesSize(bytes), dur, units.BytesSize(rate), retErr)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3029,8 +3029,10 @@ func logPutFileEnd(req *pfs.PutFileRequest, start time.Time, records *pfs.PutFil
 		verb = "Deleted"
 	}
 	var bytes float64
-	for _, r := range records.Records {
-		bytes += float64(r.SizeBytes)
+	if records != nil {
+		for _, r := range records.Records {
+			bytes += float64(r.SizeBytes)
+		}
 	}
 	dur := time.Now().Sub(start).Truncate(time.Millisecond)
 	rate := float64(bytes) / dur.Seconds()

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
 	pfsserver "github.com/pachyderm/pachyderm/src/server/pfs"
+	"github.com/pachyderm/pachyderm/src/server/pfs/pretty"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ancestry"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/errutil"
@@ -43,6 +44,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/watch"
 
 	etcd "github.com/coreos/etcd/clientv3"
+	units "github.com/docker/go-units"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	log "github.com/sirupsen/logrus"
@@ -3013,17 +3015,43 @@ func (d *driver) scratchFilePrefix(file *pfs.File) (string, error) {
 	return path.Join(d.scratchCommitPrefix(file.Commit), cleanedPath), nil
 }
 
+func logPutFileStart(req *pfs.PutFileRequest) {
+	verb := "Writing"
+	if req.Delete {
+		verb = "Deleting"
+	}
+	log.Debugf(`pfs.API.PutFile/%s {"to":%q}`, verb, pretty.CompactPrintFile(req.File))
+}
+
+func logPutFileEnd(req *pfs.PutFileRequest, start time.Time, records *pfs.PutFileRecords, retErr error) {
+	verb := "Wrote"
+	if req.Delete {
+		verb = "Deleted"
+	}
+	var bytes float64
+	for _, r := range records.Records {
+		bytes += float64(r.SizeBytes)
+	}
+	dur := time.Now().Sub(start).Truncate(time.Millisecond)
+	rate := float64(bytes) / dur.Seconds()
+	log.Debugf(`pfs.API.PutFile/%s {"to":%q,"sz":%q,"dur":"%s (%s/s)","err":"%v"`,
+		verb, pretty.CompactPrintFile(req.File), units.BytesSize(bytes), dur, units.BytesSize(rate), retErr)
+}
+
 func (d *driver) putFiles(pachClient *client.APIClient, s *putFileServer) error {
 	var files []*pfs.File
 	var putFilePaths []string
 	var putFileRecords []*pfs.PutFileRecords
 	var mu sync.Mutex
-	oneOff, repo, branch, err := d.forEachPutFile(pachClient, s, func(req *pfs.PutFileRequest, r io.Reader) error {
-		log.Debugf("Writing to %v@%v:/%v", req.File.Commit.Repo.Name, req.File.Commit.ID, req.File.Path)
-		records, err := d.putFile(pachClient, req.File, req.Delimiter, req.TargetFileDatums,
+	oneOff, repo, branch, err := d.forEachPutFile(pachClient, s, func(req *pfs.PutFileRequest, r io.Reader) (retErr error) {
+		start := time.Now()
+		var records *pfs.PutFileRecords
+		logPutFileStart(req)
+		defer func() { logPutFileEnd(req, start, records, retErr) }() //late binding
+		records, retErr = d.putFile(pachClient, req.File, req.Delimiter, req.TargetFileDatums,
 			req.TargetFileBytes, req.HeaderRecords, req.OverwriteIndex, req.Delete, r)
-		if err != nil {
-			return err
+		if retErr != nil {
+			return retErr
 		}
 		mu.Lock()
 		defer mu.Unlock()

--- a/src/server/pfs/server/pathlock.go
+++ b/src/server/pfs/server/pathlock.go
@@ -54,9 +54,6 @@ func newPathLock(putFileLimiter limit.ConcurrencyLimiter) *pathlock {
 
 func (p *pathlock) start(path string) (retErr error) {
 	// add leading slash, so '/' collides w/ everything.
-	// TODO(msteffen): would paths.go (in this package) or s/s/pkg/paths be
-	// better? The latter doesn't exist in 1.11.x, and the former adds a leading
-	// slash but doesn't clean the path.
 	path = gopath.Clean("/" + path)
 	defer func() {
 		if retErr == nil && p.putFileLimiter != nil {

--- a/src/server/pfs/server/pathlock.go
+++ b/src/server/pfs/server/pathlock.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	gopath "path"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/pachyderm/pachyderm/src/client/limit"
+	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
+)
+
+// pathlock is used to prevent two PutFile calls that affect the same path (e.g.
+// Put("/foo") and Delete("/")) from racing. The rule is: before running any
+// PutFile operation B, make sure there is no running PutFile operation A such
+// that B.Path is a prefix of A.Path or vice-versa.
+//
+// Note that pathlock can only block one goro at a time. This works for PutFile
+// (where requests are arriving in a stream, and the whole stream stream can be
+// paused until conflicting paths are finished), but you could not use this to
+// schedule N goroutines and have each independently call start() (i.e. many
+// goros blocking at once). Not only would it be complicated to track which
+// goros are blocked on what, this use-case would introduce complicated
+// fairness/livelock issues that pathlock doesn't attempt to solve.
+type pathlock struct {
+	sync.Mutex
+	sync.Cond
+
+	// running contains the set of paths being written to by some in-progress
+	// PutFile operation (we use a set of sorted strings rather than a map so that
+	// we can quickly find prefix collisions)
+	running []string
+
+	// blocking is an in-progress PutFile operation that is blocking the next
+	// PutFile operation in the stream. Before exiting, each putFile goro checks
+	// if it's the blocking operation, and if so, signals to the blocked goro that
+	// it may proceed
+	blocking string
+
+	// This is used to limit the total concurrency of putFile request. It's
+	// included in pathlock as a convenience, as everywhere that putFile calls
+	// pathlock.start(), it would also call putFileLimiter.Acquire() (and likewise
+	// for pathlock.finish() and putFileLimiter.Release). This is unset for tests.
+	putFileLimiter limit.ConcurrencyLimiter
+}
+
+func newPathLock(putFileLimiter limit.ConcurrencyLimiter) *pathlock {
+	p := pathlock{
+		putFileLimiter: putFileLimiter,
+	}
+	p.Cond.L = &p.Mutex
+	return &p
+}
+
+func (p *pathlock) start(path string) (retErr error) {
+	// add leading slash, so '/' collides w/ everything.
+	// TODO(msteffen): would paths.go (in this package) or s/s/pkg/paths be
+	// better? The latter doesn't exist in 1.11.x, and the former adds a leading
+	// slash but doesn't clean the path.
+	path = gopath.Clean("/" + path)
+	defer func() {
+		if retErr == nil && p.putFileLimiter != nil {
+			p.putFileLimiter.Acquire()
+		}
+	}()
+	p.Lock()
+	defer p.Unlock()
+	for { // Check block condition in loop--see sync.Cond documentation
+		if blocking := func() string {
+			// Find if there's any path P in 'running' such that 'path' is a prefix of
+			// P
+			//
+			// minGe is the smallest entry in 'running' that is greater than or equal
+			// to 'path'. If there is a P in running such that 'path' is a prefix of
+			// P, then 'path' must be a prefix of 'running[minGe]'[1]
+			minGe := sort.SearchStrings(p.running, path)
+			if minGe < len(p.running) && strings.HasPrefix(p.running[minGe], path) {
+				return p.running[minGe]
+			}
+			// Find if there's any path P in 'running' such that P is a prefix of
+			// 'path'. Do this by checking if every prefix of 'path' is in 'running'.
+			for i := len(path) - 1; i > 0 && minGe > 0; i-- {
+				// Loop invariant: minGe is the smallest entry in running that is >=
+				//   path[:i+1] (note loop starts at len-1).
+				//   path[:i] < path[:i+1] --> path[:i] must be in [0,minGe)
+				// Loop invariant: path[:i] and [0, minGe) are non-empty
+				minGe = sort.SearchStrings(p.running[:minGe], path[:i])
+				if minGe < len(p.running) && p.running[minGe] == path[:i] {
+					return p.running[minGe]
+				}
+			}
+			return ""
+		}(); blocking != "" {
+			if p.blocking != "" {
+				return errors.Errorf("Internal error: PutFile operation on %q cannot block on %q as an operation is already waiting on %q",
+					path, blocking, p.blocking)
+			}
+			p.blocking = blocking
+			p.Wait() // yield p
+		} else {
+			break
+		}
+	}
+	minGe := sort.SearchStrings(p.running, path)
+	p.running = append(p.running, "")
+	copy(p.running[minGe+1:], p.running[minGe:]) // OK even if minGe == len(running)
+	p.running[minGe] = path
+	return nil
+}
+
+func (p *pathlock) finish(path string) (retErr error) {
+	// add leading slash, so '/' collides w/ everything (see start())
+	path = gopath.Clean("/" + path)
+	defer func() {
+		if p.putFileLimiter != nil {
+			// Call Release() even if finish() returns an error, as the semaphore is
+			// currently locked by the caller.
+			p.putFileLimiter.Release()
+		}
+	}()
+	p.Lock()
+	defer p.Unlock()
+	// remove 'path' from 'running
+	minGe := sort.SearchStrings(p.running, path)
+	if minGe == len(p.running) || p.running[minGe] != path {
+		return errors.Errorf("no path lock found for PutFile operation on %q", path)
+	}
+	copy(p.running[minGe:], p.running[minGe+1:]) // OK even if (minGe+1) == len(running)
+	p.running = p.running[:len(p.running)-1]
+
+	// Wake up any blocked threads
+	if p.blocking == path {
+		p.blocking = "" // reset block
+		// Both Signal() and Broadcast() *should* be safe, b/c there should only
+		// ever be one blocked goro, but I'm always a little worried about having
+		// introduced some subtle deadlock, and because and start() wraps p.Wait()
+		// in a loop anyway, Broadcast() seems like the safer option
+		p.Broadcast()
+	}
+	return nil
+}
+
+// [1] Proof:
+// By assumption, we know I = { i ∈ ℕ | path is a prefix of running[i] }
+// is nonempty. Let i be the smallest element of I (well-ordering).
+//
+// Because path is a prefix of running[i], we know path <= running[i], therefore
+// minGe <= i (by the definition of minGe). Then, because
+//                   path <= running[minGe] <= running[i]
+// path must be a prefix of running[minGe] as well.
+//
+// (if there were some j s.t.  j < len(path) && path[j] != running[minGe], then
+// let j be minimal (w.o.) and we have either 1) path[j] < running[minGe][j]
+// --> running[i][j] < running[minGe][j] --> running[i] < running[minGe], a
+// contradition. Or 2) path[j] > running[minGe][j] --> path > running[minGe], a
+// contradiction)

--- a/src/server/pfs/server/pathlock.go
+++ b/src/server/pfs/server/pathlock.go
@@ -67,12 +67,12 @@ func (p *pathlock) start(path string) (retErr error) {
 	defer p.Unlock()
 	for { // Check block condition in a loop--see sync.Cond documentation
 		if blocking := func() string {
-			// Find if there's any P in 'running' such that 'path' is a prefix of P[1]
+			// Find any P in 'running' such that 'path' is a prefix of P. [1]
 			lub := sort.SearchStrings(p.running, path)
 			if lub < len(p.running) && strings.HasPrefix(p.running[lub], path) {
 				return p.running[lub]
 			}
-			// Find if there's any P in 'running' such that P is a prefix of 'path'.
+			// Find any P in 'running' such that P is a prefix of 'path'.
 			for i := len(path) - 1; i > 0 && lub >= 0; i-- {
 				// Loop invariants:
 				// 1. lub is the smallest entry in running that is >= path[:i+1] (note
@@ -146,10 +146,11 @@ func (p *pathlock) finish(path string) (retErr error) {
 // well (if any letter was different, it would place running[lub] either before
 // 'path' or after 'running[i]').
 //
-// [2] To see that the loop invariant is maintained, we need to show that
-// SearchStrings(running[:lub], path[:i]) yields the least upper bound of
-// path[:i] in running. To see that, observe:
-//   path[:i] < path[:i+1] <= running[lub]
+// [2] To see that the loop invariant 'path[:i+1] <= running[lub]' is
+// maintained, we need to show that
+//   lub' = SearchStrings(running[:lub], path[:i]) = lub of path[:i] in running
+// yields the least upper bound of path[:i] in running. To see that, observe:
+//   path[:i] < path[:i+1] <= running[lub] <= running[lub+1:]...
 //   --> SearchStrings(running[:lub], path[:i])
 //         = 1. lub of path[:i] in running[:lub], if any values in running[:lub]
 //              are >= path[:i], or

--- a/src/server/pfs/server/pathlock_test.go
+++ b/src/server/pfs/server/pathlock_test.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+)
+
+// TestPathLockSomeCollisions starts a bunch of threads for paths, some of which
+// overlap and some of which don't. This is the main way that we expect PutFile
+// to work.
+func TestPathLockSomeCollisions(t *testing.T) {
+	var (
+		seed       = time.Now().UnixNano()
+		r          = rand.New(rand.NewSource(seed))
+		running    = make(map[string]bool) // paths held by currently running ops
+		runningMu  sync.Mutex              // guards 'running'
+		runningStr = func() []string {     // print 'running' as a list, not a map
+			strs := make([]string, 0, len(running))
+			for k := range running {
+				strs = append(strs, k)
+			}
+			return strs
+		}
+		start, end   = true, false                  // syntax sugar for checkRunning
+		maxRunning   = 0                            // count the max # of running ops
+		checkRunning = func(op bool, path string) { // check 'running' for prefix collisions
+			runningMu.Lock()
+			defer runningMu.Unlock()
+			if len(running) > maxRunning {
+				maxRunning = len(running)
+			}
+			for p := range running {
+				if op == end && path == p {
+					continue // we expect path itself to be in running if we're removing it
+				}
+				// no prefix of 'path' is running (as this isn't the main test goro, use
+				// Errorf instead of require.False so that execution isn't halted on
+				// failure, preventing deadlock)
+				if strings.HasPrefix(path, p) {
+					t.Errorf("(seed: %d) path %q has prefix %s ∈ %v", seed, path, p, runningStr())
+				}
+				// 'path' is not a prefix of any running op
+				if strings.HasPrefix(p, path) {
+					t.Errorf("(seed: %d) path %q is a prefix of %s ∈ %v", seed, path, p, runningStr())
+				}
+			}
+			if op == start {
+				running[path] = true
+			} else {
+				delete(running, path)
+			}
+		}
+		p  = newPathLock() // the data structure under test
+		eg errgroup.Group  // for running the subprocesses
+	)
+	// Iterate through [0,1000) in a random order, represented as binary strings.
+	// This induces regular collisions (these strings aren't fixed-width, so small
+	// numbers' representations are often prefixes of larger numbers), but also
+	// allows for some parallelism.
+	//
+	// This test uses 'maxRunning' to check that some parallelism occurs, and the
+	// prevention of collisions can be verified by removing 'p.start(path)' and
+	// 'p.finish(path)' below, which causes the collision checks in 'checkRunning'
+	// to fail.
+	for _, i := range r.Perm(1000) {
+		// small nums are prefixes of bigger nums. Iterate all nums but jump around
+		// to induce collisions
+		path := fmt.Sprintf("%b", i)
+		require.NoError(t, p.start(path))
+		eg.Go(func() error {
+			defer func() { require.NoError(t, p.finish(path)) }()
+			checkRunning(start, path)
+			// force later prefixes to run ~first
+			time.Sleep(time.Duration(100-i) * time.Millisecond)
+			checkRunning(end, path)
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
+	// want at least some concurrency in this test
+	require.True(t, maxRunning > 1, maxRunning)
+}
+
+// TestPathLockAllCollisions is the strictest test, and starts several
+// goroutines where every goroutine is given a path that extends the previous
+// goroutines' paths. There should be no overlap, and later goroutines should
+// wait on earlier goroutines
+func TestPathLockAllCollisions(t *testing.T) {
+	p := newPathLock()
+	// Lock every prefix of 'paths' and make sure that they're processed in order
+	paths := strings.Repeat("a", 100)
+	ch := make(chan string)
+	// write all paths in a separate goro so the main goro can read from 'ch'
+	go func() {
+		var eg errgroup.Group
+		for i := range paths {
+			path := paths[:i]
+			require.NoError(t, p.start(path))
+			eg.Go(func() error {
+				defer func() { require.NoError(t, p.finish(path)) }()
+				// force later prefixes to run first
+				time.Sleep(time.Duration(100-i) * time.Millisecond)
+				ch <- path
+				return nil
+			})
+		}
+		require.NoError(t, eg.Wait())
+		close(ch)
+	}()
+
+	var prev string
+	for p := range ch {
+		if prev != "" {
+			require.True(t, len(prev) < len(p), "expected %q to be shorter than %q", p, prev)
+		}
+		prev = p
+	}
+}
+
+// TestPathLockAllCollisionsRev is similar to TestPathLockAllCollisions, but it
+// iterates over the colliding paths from longest to shortest, to ensure that
+// pathlock handles that direction as well (blocking paths if they're a prefix
+// of a running operation's path)
+func TestPathLockAllCollisionsRev(t *testing.T) {
+	p := newPathLock()
+	// Lock every prefix of 'paths' and make sure that they're processed in order
+	paths := strings.Repeat("a", 100)
+	ch := make(chan string)
+	// write all paths in a separate goro so the main goro can read from 'ch'
+	go func() {
+		var eg errgroup.Group
+		for i := range paths {
+			path := paths[:len(paths)-1-i]
+			require.NoError(t, p.start(path))
+			eg.Go(func() error {
+				defer func() { require.NoError(t, p.finish(path)) }()
+				// force later prefixes to run first
+				time.Sleep(time.Duration(100-i) * time.Millisecond)
+				ch <- path
+				return nil
+			})
+		}
+		require.NoError(t, eg.Wait())
+		close(ch)
+	}()
+
+	var prev string
+	for p := range ch {
+		if prev != "" {
+			require.True(t, len(prev) > len(p), "expected %q to be shorter than %q", p, prev)
+		}
+		prev = p
+	}
+}

--- a/src/server/pfs/server/pathlock_test.go
+++ b/src/server/pfs/server/pathlock_test.go
@@ -58,8 +58,8 @@ func TestPathLockSomeCollisions(t *testing.T) {
 				delete(running, path)
 			}
 		}
-		p  = newPathLock() // the data structure under test
-		eg errgroup.Group  // for running the subprocesses
+		p  = newPathLock(nil) // the data structure under test
+		eg errgroup.Group     // for running the subprocesses
 	)
 	// Iterate through [0,1000) in a random order, represented as binary strings.
 	// This induces regular collisions (these strings aren't fixed-width, so small
@@ -94,7 +94,7 @@ func TestPathLockSomeCollisions(t *testing.T) {
 // goroutines' paths. There should be no overlap, and later goroutines should
 // wait on earlier goroutines
 func TestPathLockAllCollisions(t *testing.T) {
-	p := newPathLock()
+	p := newPathLock(nil)
 	// Lock every prefix of 'paths' and make sure that they're processed in order
 	paths := strings.Repeat("a", 100)
 	ch := make(chan string)
@@ -130,7 +130,7 @@ func TestPathLockAllCollisions(t *testing.T) {
 // pathlock handles that direction as well (blocking paths if they're a prefix
 // of a running operation's path)
 func TestPathLockAllCollisionsRev(t *testing.T) {
-	p := newPathLock()
+	p := newPathLock(nil)
 	// Lock every prefix of 'paths' and make sure that they're processed in order
 	paths := strings.Repeat("a", 100)
 	ch := make(chan string)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -578,6 +578,43 @@ func TestPutFileDirectoryTraversal(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestPutFileOverlappingPaths tests the fix for
+// https://github.com/pachyderm/pachyderm/issues/5345.
+// However, I can't get the test to fail without adding a sleep to
+// forEachPutFile in driver.go that induces the race. Setting GOMAXPROCS to 1
+// and 100 doesn't seem to help. In practice, that means we're still relying on
+// TestPipelineBuildLifecycle and pachyderm-in-Minikube to expose the race
+// (Minikube seems to induce more races), but maybe this test will be useful in
+// conjunction with e.g. some kind of race detector.
+// TODO(msteffen): Get this test to fail reliably in the presence of the race.
+func TestPutFileOverlappingPaths(t *testing.T) {
+	t.Parallel()
+	files := []string{"/a", "/b", "/c"}
+	contents := []string{"foo", "bar", "baz"}
+	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
+		c := env.PachClient
+		c.CreateRepo("test")
+		for i := 0; i < 100; i++ {
+			pfc, err := c.NewPutFileClient()
+			require.NoError(t, err)
+			require.NoError(t, pfc.DeleteFile("test", "master", "/"))
+			for i, f := range files {
+				_, err := pfc.PutFile("test", "master", f, strings.NewReader(contents[i]))
+				require.NoError(t, err)
+			}
+			require.NoError(t, pfc.Close())
+			var actualFiles []string
+			c.ListFileF("test", "master", "/", 0, func(f *pfs.FileInfo) error {
+				actualFiles = append(actualFiles, f.File.Path)
+				return nil
+			})
+			require.ElementsEqual(t, files, actualFiles)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestCreateInvalidBranchName(t *testing.T) {
 	t.Parallel()
 	err := testpachd.WithRealEnv(func(env *testpachd.RealEnv) error {
@@ -6422,11 +6459,16 @@ func TestAtomicHistory(t *testing.T) {
 
 type SlowReader struct {
 	underlying io.Reader
+	delay      time.Duration
 }
 
 func (r *SlowReader) Read(p []byte) (n int, err error) {
 	n, err = r.underlying.Read(p)
-	time.Sleep(1 * time.Millisecond)
+	if r.delay == 0 {
+		time.Sleep(1 * time.Millisecond)
+	} else {
+		time.Sleep(r.delay)
+	}
 	return
 }
 

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -581,8 +581,9 @@ func TestPutFileDirectoryTraversal(t *testing.T) {
 // TestPutFileOverlappingPaths tests the fix for
 // https://github.com/pachyderm/pachyderm/issues/5345.
 // However, I can't get the test to fail without adding a sleep to
-// forEachPutFile in driver.go that induces the race. Setting GOMAXPROCS to 1
-// and 100 doesn't seem to help. In practice, that means we're still relying on
+// forEachPutFile in driver.go that induces the race (at:
+// `if req.Delete {...eg.Go(/*here*/...)}`). Setting GOMAXPROCS to 1 and 100
+// doesn't seem to help. In practice, that means we're still relying on
 // TestPipelineBuildLifecycle and pachyderm-in-Minikube to expose the race
 // (Minikube seems to induce more races), but maybe this test will be useful in
 // conjunction with e.g. some kind of race detector.

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -28,7 +28,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
@@ -940,14 +939,14 @@ func runPipelineWithImageGetStderr(t *testing.T, image string) (string, error) {
 		pachctl put file -r in@master:/ -f ../../../../etc/testing/pipeline-build/input
 	`).Run())
 
-	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf(`
+	cmd := tu.BashCmd(`
 		pachctl create pipeline <<EOF
 		  {
 		    "pipeline": {
 		      "name": "first"
 		    },
 		    "transform": {
-		      "image": "%s"
+		      "image": "{{.image}}"
 		    },
 		    "input": {
 		      "pfs": {
@@ -957,7 +956,7 @@ func runPipelineWithImageGetStderr(t *testing.T, image string) (string, error) {
 		    }
 		  }
 		EOF
-	`, image))
+	`, "image", image)
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	// cmd.Stdout = os.Stdout // uncomment for debugging
@@ -1009,7 +1008,7 @@ func TestWarningLatestTag(t *testing.T) {
 	}
 	// should emit a warning because user specified latest tag on docker image
 	stderr, err := runPipelineWithImageGetStderr(t, "ubuntu:latest")
-	require.NoError(t, err)
+	require.NoError(t, err, "%v", err)
 	require.Matches(t, "WARNING", stderr)
 }
 

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -671,7 +671,7 @@ func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
 		pachctl create pipeline <<EOF
 			{{.spec}}
 		EOF
-		pachctl flush commit test-pipeline-build@master
+		pachctl flush commit in@master
 		`,
 		"dir", dir,
 		"spec", spec,
@@ -687,7 +687,7 @@ func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
 		pachctl update pipeline <<EOF
 			{{.spec}}
 		EOF
-		pachctl flush commit test-pipeline-build@master
+		pachctl flush commit in@master
 		`,
 		"dir", dir,
 		"spec", spec,
@@ -725,7 +725,7 @@ func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
 		pachctl update pipeline --reprocess <<EOF
 			{{.spec}}
 		EOF
-		pachctl flush commit test-pipeline-build@master
+		pachctl flush commit in@master
 		`,
 		"dir", dir,
 		"spec", spec,
@@ -738,7 +738,7 @@ func verifyPipelineBuildOutput(t *testing.T, pipeline, prefix string) {
 	t.Helper()
 
 	require.NoError(t, tu.BashCmd(`
-		pachctl flush commit test-pipeline-build@master
+		pachctl flush commit in@master
 		pachctl get file {{.pipeline}}@master:/1.txt | match {{.prefix}}{{.prefix}}{{.prefix}}1
 		pachctl get file {{.pipeline}}@master:/11.txt | match {{.prefix}}{{.prefix}}11
 		pachctl get file {{.pipeline}}@master:/111.txt | match {{.prefix}}111

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -99,19 +99,19 @@ func TestRawFullPipelineInfo(t *testing.T) {
 		pachctl create repo data
 		pachctl put file data@master:/file <<<"This is a test"
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {"name": "{{.pipeline}}"},
-			  "input": {
-			    "pfs": {
-			      "glob": "/*",
-			      "repo": "data"
-			    }
-			  },
-			  "transform": {
-			    "cmd": ["bash"],
-			    "stdin": ["cp /pfs/data/file /pfs/out"]
-			  }
-			}
+		  {
+		    "pipeline": {"name": "{{.pipeline}}"},
+		    "input": {
+		      "pfs": {
+		        "glob": "/*",
+		        "repo": "data"
+		      }
+		    },
+		    "transform": {
+		      "cmd": ["bash"],
+		      "stdin": ["cp /pfs/data/file /pfs/out"]
+		    }
+		  }
 		EOF
 		`,
 		"pipeline", tu.UniqueString("p-")).Run())
@@ -208,9 +208,9 @@ func TestJSONStringifiedNumbers(t *testing.T) {
 		      "repo": "input"
 		    }
 		  },
-			"parallelism_spec": {
-				"constant": "1"
-			},
+		  "parallelism_spec": {
+		    "constant": "1"
+		  },
 		  "transform": {
 		    "cmd": [ "/bin/bash" ],
 		    "stdin": [
@@ -389,22 +389,22 @@ func TestListPipelineFilter(t *testing.T) {
 		pachctl create pipeline -f - <<EOF
 		{
 		"pipeline": {
-			"name": "first"
+		  "name": "first"
 		},
 		"input": {
-			"pfs": {
-			"glob": "/*",
-			"repo": "input"
-			}
+		  "pfs": {
+		    "glob": "/*",
+		    "repo": "input"
+		  }
 		},
-			"parallelism_spec": {
-				"constant": "1"
-			},
+		  "parallelism_spec": {
+		    "constant": "1"
+		  },
 		"transform": {
-			"cmd": [ "/bin/bash" ],
-			"stdin": [
-			"cp /pfs/input/* /pfs/out"
-			]
+		  "cmd": [ "/bin/bash" ],
+		  "stdin": [
+		    "cp /pfs/input/* /pfs/out"
+		  ]
 		}
 		}
 		EOF
@@ -669,7 +669,7 @@ func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
 	require.NoError(t, tu.BashCmd(`
 		cd ../../../../etc/testing/pipeline-build/{{.dir}}
 		pachctl create pipeline <<EOF
-			{{.spec}}
+		{{.spec}}
 		EOF
 		pachctl flush commit in@master
 		`,
@@ -685,7 +685,7 @@ func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
 	require.NoError(t, tu.BashCmd(`
 		cd ../../../../etc/testing/pipeline-build/{{.dir}}
 		pachctl update pipeline <<EOF
-			{{.spec}}
+		{{.spec}}
 		EOF
 		pachctl flush commit in@master
 		`,
@@ -723,7 +723,7 @@ func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
 	require.NoError(t, tu.BashCmd(`
 		cd ../../../../etc/testing/pipeline-build/{{.dir}}
 		pachctl update pipeline --reprocess <<EOF
-			{{.spec}}
+		{{.spec}}
 		EOF
 		pachctl flush commit in@master
 		`,
@@ -755,17 +755,17 @@ func TestMissingPipeline(t *testing.T) {
 	// should fail because there's no pipeline object in the spec
 	require.YesError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
-			{
-			  "transform": {
-			    "image": "ubuntu"
-			  },
-			  "input": {
-			    "pfs": {
-			      "repo": "in",
-			      "glob": "/*"
-			    }
-			  }
-			}
+		  {
+		    "transform": {
+		      "image": "ubuntu"
+		    },
+		    "input": {
+		      "pfs": {
+		        "repo": "in",
+		        "glob": "/*"
+		      }
+		    }
+		  }
 		EOF
 	`).Run())
 }
@@ -777,18 +777,18 @@ func TestUnnamedPipeline(t *testing.T) {
 	// should fail because there's no pipeline name
 	require.YesError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {},
-			  "transform": {
-			    "image": "ubuntu"
-			  },
-			  "input": {
-			    "pfs": {
-			      "repo": "in",
-			      "glob": "/*"
-			    }
-			  }
-			}
+		  {
+		    "pipeline": {},
+		    "transform": {
+		      "image": "ubuntu"
+		    },
+		    "input": {
+		      "pfs": {
+		        "repo": "in",
+		        "glob": "/*"
+		      }
+		    }
+		  }
 		EOF
 	`).Run())
 }
@@ -800,17 +800,17 @@ func TestPipelineBuildSpout(t *testing.T) {
 	// should fail because pipeline build can't be used w/ spouts
 	require.YesError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {
-			    "name": "test"
-			  },
-			  "transform": {
-			    "build": {
-			      "language": "go"
-			    }
-			  },
-			  "spout": {}
-			}
+		  {
+		    "pipeline": {
+		      "name": "test"
+		    },
+		    "transform": {
+		      "build": {
+		        "language": "go"
+		      }
+		    },
+		    "spout": {}
+		  }
 		EOF
 	`).Run())
 }
@@ -822,16 +822,16 @@ func TestPipelineBuildMissingInput(t *testing.T) {
 	// should fail because pipeline build can't be used w/ spouts
 	require.YesError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {
-			    "name": "test"
-			  },
-			  "transform": {
-			    "build": {
-			      "language": "go"
-			    }
-			  }
-			}
+		  {
+		    "pipeline": {
+		      "name": "test"
+		    },
+		    "transform": {
+		      "build": {
+		        "language": "go"
+		      }
+		    }
+		  }
 		EOF
 	`).Run())
 }
@@ -844,44 +844,44 @@ func TestPipelineBuildBadInput(t *testing.T) {
 	// using pipeline builds
 	require.YesError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {
-			    "name": "test"
-			  },
-			  "transform": {
-			    "build": {
-			      "language": "go"
-			    }
-			  },
-			  "input": {
-			    "pfs": {
-			      "name": "build",
-			      "repo": "in",
-			      "glob": "/*"
-			    }
-			  }
-			}
+		  {
+		    "pipeline": {
+		      "name": "test"
+		    },
+		    "transform": {
+		      "build": {
+		        "language": "go"
+		      }
+		    },
+		    "input": {
+		      "pfs": {
+		        "name": "build",
+		        "repo": "in",
+		        "glob": "/*"
+		      }
+		    }
+		  }
 		EOF
 	`).Run())
 	require.YesError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {
-			    "name": "test"
-			  },
-			  "transform": {
-			    "build": {
-			      "language": "go"
-			    }
-			  },
-			  "input": {
-			    "pfs": {
-			      "name": "source",
-			      "repo": "in",
-			      "glob": "/*"
-			    }
-			  }
-			}
+		  {
+		    "pipeline": {
+		      "name": "test"
+		    },
+		    "transform": {
+		      "build": {
+		        "language": "go"
+		      }
+		    },
+		    "input": {
+		      "pfs": {
+		        "name": "source",
+		        "repo": "in",
+		        "glob": "/*"
+		      }
+		    }
+		  }
 		EOF
 	`).Run())
 }
@@ -942,21 +942,21 @@ func runPipelineWithImageGetStderr(t *testing.T, image string) (string, error) {
 
 	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf(`
 		pachctl create pipeline <<EOF
-			{
-			  "pipeline": {
-				"name": "first"
-			  },
-			  "transform": {
-				"image": "%s"
-			  },
-			  "input": {
-			    "pfs": {
-			      "repo": "in",
-			      "glob": "/*"
-			    }
-			  }
-			}
-EOF
+		  {
+		    "pipeline": {
+		      "name": "first"
+		    },
+		    "transform": {
+		      "image": "%s"
+		    },
+		    "input": {
+		      "pfs": {
+		        "repo": "in",
+		        "glob": "/*"
+		      }
+		    }
+		  }
+		EOF
 	`, image))
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
@@ -976,23 +976,23 @@ func TestPipelineBuildRunCron(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		pachctl create pipeline <<EOF
 		{
-			"pipeline": {
-			  "name": "crontest"
-			},
-			"input": {
-			  "cron": {
-				"name": "tick",
-				"spec": "*/1 * * * *",
-				"overwrite": true
-			  }
-			},
-			"transform": {
-			  "build":{
-				"language": "go"
-			  },
-			  "cmd":["echo", "tick"]
-			},
-			"enable_stats": true
+		  "pipeline": {
+		    "name": "crontest"
+		  },
+		  "input": {
+		    "cron": {
+		      "name": "tick",
+		      "spec": "*/1 * * * *",
+		      "overwrite": true
+		    }
+		  },
+		  "transform": {
+		    "build":{
+		      "language": "go"
+		    },
+		    "cmd":["echo", "tick"]
+		  },
+		  "enable_stats": true
 		  }
 		EOF
 	`).Run())


### PR DESCRIPTION
Fix #5345 

Summary: `TestPipelineBuildLifecycleGo` (and `...Python`, etc) were flaking due to an encoutering a race in PutFile. The race is this: `putFile` reads its incoming stream of `PutFileRequest`s using `forEachPutFile`, and `forEachPutFile` spawns a goroutine for each new file in the incoming stream. When multiple independent files are being written, e.g. `/a`, `/b`, ..., `forEachPutFile` spawns a concurrent goroutine to write each of them. This works well and gives us good throughput, as `forEachPutFile` can read data from the incoming stream while child goroutines are waiting for object storage to finish writing.

However, when conflicting operations are sent in the same stream, e.g. `Delete(/)` -> `Put(/src.go)` as in `TestPipelineBuildLifecycle*`, the Go scheduler might choose to run `eg.Go(Put(/src.go))` first, even though it was spawned second, causing `/src.go` to be written and then immediately deleted by `Delete(/)`.

This PR attempts to fix the issue by introducing a new class, `pathlock`, that blocks `forEachPutFile` from running a new operation as long as a conflicting operation (on a parent or child path) is already in progress. Basically, `forEachPutFile` would call `start("/")` and that would block `start("/src.go")` from running (becuase `/src.go` is a child of `/`) until `finish("/")` is called. (Likewise, if the operations were deliberately performed in the reverse order, `start("/src.go")` would block `start("/")` until `finish("/src.go")` is called)

A simpler solution might be to remove all concurrency from `forEachPutFile`, but my understanding is that that would unacceptably hurt `PutFile` throughput. Given that constraint, I tried to keep this simple by only allowing `pathlock.start()` to block a single goroutine at a time (so it works for `forEachPutFile` but not much else, and stays in the `pfs/server` package). A comment in `pathlock.go` elaborates on this constraint.

A few other changes also made in this PR:
- `make lint` was failing silently (which @nitinjainsj found) in CI due to a prior change I made. This PR should fix it
- `PutFile` now writes Debug-level logs at both the start and end of writing/deleting a file within the stream (and the logs are changed to look more like our regular GRPC logs)