### PR TITLE
[docs] update style guide to use correct shell indicator

### DIFF
--- a/doc/docs/master/contributing/docs-style-guide.md
+++ b/doc/docs/master/contributing/docs-style-guide.md
@@ -104,7 +104,7 @@ a preposition.
 | ---------- | --- |
 | The `put file` API includes an option for splitting **up** the file into separate datums automatically. | The `put file` API includes an option for splitting the file into separate datums automatically. |
 
-##Use meaningful links
+## Use meaningful links
 
 Link text should mean something to the users when they read it. Phrases
 like **Click here** and **Read more** do not provide useful information.
@@ -137,15 +137,40 @@ and Markdown does not support starting lists from an arbitrary number.
 
 * Enclose code blocks in "```" and specify the correct highlighting.
 
-* While PyMdown Extensions provide advanced UI features, use them sparingly because not all browsers fully support all of them.
+* While PyMdown Extensions provide advanced UI features, use them sparingly
+because not all browsers fully support all of them.
 
-* Do not use the dollar sign `$` in code snippets. While the dollar sign
-signifies the beginning of a line, it creates usability issues. When users
-copy commands from a code block, they copy everything from that code
-block, including the dollar sign. Then, they need to navigate to the
-begining of the command prompt to remove the dollar sign, which is quite annoying.
-Most of the commands that are described in the Pachyderm documentation
-are run from a UNIX shell as a normal user.
+## Command Line Syntax
+
+Start lines for single-line or multi-line commands with the `$` prompt symbol.
+
+Don't show the current path before the prompt. However, when changing contexts
+of the prompt--such as from a local to a remote machine, then add an additional
+prompt indicator.
+
+If you need to show the output of the command, include the output in the same
+code block as the command.
+
+If additional output exists, but is cumbersome and unnecessary to show, use an
+ellipsis `...` and truncate the output.
+
+#### Examples
+
+```shell
+$ pachctl version
+COMPONENT           VERSION
+pachctl             1.11.7
+pachd               1.11.7
+```
+
+```shell
+remote@ $ pachctl logs
+started setting up External Pachd GRPC Server
+started setting up PFS API GRPC Server
+finished setting up PFS API GRPC Server
+started setting up PPS API GRPC Server
+...
+```
 
 ## Preview the Documentation Locally
 


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

Directing a user to invoke a command via documentation is done by using a prompt indicator--`$` is a standard convention. Using a prompt indicator avoids confusing situations where commands are followed by output, other commands, or commands run on a remote shell.

Using the prompt indicator offers an advantage as it allows you to specify the output of commands in the same code block. The proximity of the command and output prevents unnecessarily breaking the output apart from the command, while retaining clarity of the command that was executed.

Using a prompt indicator introduces a usability problem, where users cannot easily copy and paste the command from the documentation. This is an accepted drawback. One workaround is that static site generators may provide a copy button for code blocks, which will copy the code without the prompt indicator or any output following the command.

If this pull request is accepted, I will followup with another PR to fix all existing code examples to use the correct prompt indicator.