### PR TITLE
Fixes issue with boltdb cursor usage when deleting directories

### DIFF
--- a/src/server/pkg/hashtree/db.go
+++ b/src/server/pkg/hashtree/db.go
@@ -908,7 +908,7 @@ func (h *dbHashTree) PutDir(path string) error {
 func deleteDir(tx *bolt.Tx, path string) error {
 	c := fs(tx).Cursor()
 	prefix := append(b(path), nullByte[0])
-	for k, _ := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+	for k, _ := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Seek(prefix) {
 		if err := c.Delete(); err != nil {
 			return errors.EnsureStack(err)
 		}


### PR DESCRIPTION
Deleting keys while traversing with a cursor results with undefined behavior. The recommended solution is to reposition (seek) the cursor after each deletion according to the docs: https://godoc.org/github.com/boltdb/bolt#Cursor. I added a test that surfaces the original issue this is addressing (a directory deletion not deleting all of the files) and creates a scenario where a deletion progresses the cursor and one that doesn't (my original attempt at solving this was based on the observation that deleting a key progressed the cursor, but that is not consistent behavior).