### PR TITLE
documentation- fixed link to latest version of pachyderm in top banner

### DIFF
--- a/doc/mkdocs-1.10.x.yml
+++ b/doc/mkdocs-1.10.x.yml
@@ -11,6 +11,7 @@ edit_uri: ""
 
 # Copyright
 copyright: 'Copyright Pachyderm Inc, 2020'
+pach_latest_version: '1.11.7'
 
 # Configuration
 theme:

--- a/doc/mkdocs-1.11.x.yml
+++ b/doc/mkdocs-1.11.x.yml
@@ -11,6 +11,7 @@ edit_uri: ""
 
 # Copyright
 copyright: 'Copyright Pachyderm Inc, 2020'
+pach_latest_version: '1.11.7'
 
 # Configuration
 theme:

--- a/doc/mkdocs-1.9.x.yml
+++ b/doc/mkdocs-1.9.x.yml
@@ -11,6 +11,7 @@ edit_uri: ""
 
 # Copyright
 copyright: 'Copyright Pachyderm Inc, 2019'
+pach_latest_version: '1.11.7'
 
 # Configuration
 theme:

--- a/doc/mkdocs-master.yml
+++ b/doc/mkdocs-master.yml
@@ -11,6 +11,7 @@ edit_uri: ""
 
 # Copyright
 copyright: 'Copyright Pachyderm Inc, 2020'
+pach_latest_version: '1.11.7'
 
 # Configuration
 theme:

--- a/doc/overrides/main.html
+++ b/doc/overrides/main.html
@@ -84,7 +84,7 @@
  <!-- Announcement bar -->
 {% block announce %}
    <style>.md-announce a,.md-announce a:focus,.md-announce a:hover{color:currentColor}.md-announce strong{white-space:nowrap}.md-announce .twitter{margin-left:.2em;color:#00acee}.md-announce .md-link1{font-family:'Montserrat', sans-serif;color:white;font-weight:400;text-decoration:none;font-size:.685rem;line-height:24px;background:transparent;}</style>
-   <a href="https://github.com/pachyderm/pachyderm/releases/tag/v1.11.0" class="md-announce md-link1">
-     Pachyderm 1.11.0 is out! Download <strong>here.</strong>
+   <a href="https://github.com/pachyderm/pachyderm/releases/tag/v{{ config.pach_latest_version }}" class="md-announce md-link1">
+     Pachyderm {{ config.pach_latest_version }} is out! Download <strong>here.</strong>
    </a>
 {% endblock %}


### PR DESCRIPTION
Fixed link to the latest version (1.11.7) of pachyderm in top banner. Same link advertized on all versions of the doc (1.9, 1.10).