### PR TITLE
Disable TXT service config lookup in grpc dialer

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -629,6 +629,7 @@ func DefaultDialOptions() []grpc.DialOption {
 	return []grpc.DialOption{
 		// Don't return from Dial() until the connection has been established.
 		grpc.WithBlock(),
+		grpc.WithDisableServiceConfig(),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                20 * time.Second,
 			Timeout:             20 * time.Second,


### PR DESCRIPTION
Resolves https://github.com/pachyderm/pachyderm/issues/5458

It seems like some DNS servers incorrectly return SERVFAIL instead of NXDOMAIN when there's no TXT record for `_grpc_config.<server>`. GRPC 1.26 treats this as a retryable error and backs off until the connection times out.

Example dig output from a bad DNS server:

```
> dig _grpc_config.hub-c0-92zz2shvqr.clusters-staging.pachyderm.io
; <<>> DiG 9.10.6 <<>> _grpc_config.hub-c0-92zz2shvqr.clusters-staging.pachyderm.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 14473
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;_grpc_config.hub-c0-92zz2shvqr.clusters-staging.pachyderm.io. IN A
;; AUTHORITY SECTION:
clusters-staging.pachyderm.io. 900 IN   SOA     ns-526.awsdns-01.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400
;; Query time: 80 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Tue Nov 24 15:02:11 EST 2020
;; MSG SIZE  rcvd: 173
```

Related GRPC issue: https://github.com/grpc/grpc-go/issues/3207

AFAIK nobody uses the service config feature so it's safe to just disable this.