### PR TITLE
Chunk writes in putObjWriteCloser

### DIFF
--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -1624,11 +1624,13 @@ func (c APIClient) newPutObjectWriteCloser(tags ...string) (*putObjectWriteClose
 }
 
 func (w *putObjectWriteCloser) Write(p []byte) (int, error) {
-	w.request.Value = p
-	if err := w.client.Send(w.request); err != nil {
-		return 0, grpcutil.ScrubGRPC(err)
+	for _, dataSlice := range grpcutil.Chunk(p) {
+		w.request.Value = dataSlice
+		if err := w.client.Send(w.request); err != nil {
+			return 0, grpcutil.ScrubGRPC(err)
+		}
+		w.request.Tags = nil
 	}
-	w.request.Tags = nil
 	return len(p), nil
 }
 
@@ -1755,9 +1757,11 @@ func (c APIClient) newPutObjectSplitWriteCloser() (*putObjectSplitWriteCloser, e
 }
 
 func (w *putObjectSplitWriteCloser) Write(p []byte) (int, error) {
-	w.request.Value = p
-	if err := w.client.Send(w.request); err != nil {
-		return 0, grpcutil.ScrubGRPC(err)
+	for _, dataSlice := range grpcutil.Chunk(p) {
+		w.request.Value = dataSlice
+		if err := w.client.Send(w.request); err != nil {
+			return 0, grpcutil.ScrubGRPC(err)
+		}
 	}
 	return len(p), nil
 }
@@ -1826,11 +1830,13 @@ func (c APIClient) newPutBlockWriteCloser(hash string) (*putBlockWriteCloser, er
 }
 
 func (w *putBlockWriteCloser) Write(p []byte) (int, error) {
-	w.request.Value = p
-	if err := w.client.Send(w.request); err != nil {
-		return 0, grpcutil.ScrubGRPC(err)
+	for _, dataSlice := range grpcutil.Chunk(p) {
+		w.request.Value = dataSlice
+		if err := w.client.Send(w.request); err != nil {
+			return 0, grpcutil.ScrubGRPC(err)
+		}
+		w.request.Block = nil
 	}
-	w.request.Block = nil
 	return len(p), nil
 }
 
@@ -1863,7 +1869,7 @@ func (c APIClient) newPutObjWriteCloser(obj string) (*putObjWriteCloser, error) 
 }
 
 func (w *putObjWriteCloser) Write(p []byte) (int, error) {
-	for _, dataSlice := range grpcutil.Chunk(p, grpcutil.MaxMsgPayloadSize) {
+	for _, dataSlice := range grpcutil.Chunk(p) {
 		w.request.Value = dataSlice
 		if err := w.client.Send(w.request); err != nil {
 			return 0, grpcutil.ScrubGRPC(err)

--- a/src/client/pkg/grpcutil/stream.go
+++ b/src/client/pkg/grpcutil/stream.go
@@ -22,7 +22,8 @@ var (
 
 // Chunk splits a piece of data up, this is useful for splitting up data that's
 // bigger than MaxMsgPayloadSize.
-func Chunk(data []byte, chunkSize int) [][]byte {
+func Chunk(data []byte) [][]byte {
+	chunkSize := MaxMsgPayloadSize
 	var result [][]byte
 	for i := 0; i < len(data); i += chunkSize {
 		end := i + chunkSize
@@ -160,7 +161,7 @@ type streamingBytesWriter struct {
 
 func (s *streamingBytesWriter) Write(data []byte) (int, error) {
 	var bytesWritten int
-	for _, val := range Chunk(data, MaxMsgPayloadSize) {
+	for _, val := range Chunk(data) {
 		if err := s.streamingBytesServer.Send(&types.BytesValue{Value: val}); err != nil {
 			return bytesWritten, err
 		}

--- a/src/server/worker/logs/logger.go
+++ b/src/server/worker/logs/logger.go
@@ -110,7 +110,7 @@ func NewLogger(pipelineInfo *pps.PipelineInfo, pachClient *client.APIClient) (Ta
 		result.putObjClient = putObjClient
 		result.eg.Go(func() error {
 			for msg := range result.msgCh {
-				for _, chunk := range grpcutil.Chunk([]byte(msg), grpcutil.MaxMsgSize/2) {
+				for _, chunk := range grpcutil.Chunk([]byte(msg)) {
 					if err := result.putObjClient.Send(&pfs.PutObjectRequest{
 						Value: chunk,
 					}); err != nil && !errors.Is(err, io.EOF) {


### PR DESCRIPTION
Objects large than the maximum message size cannot be written to the `putObjWriteCloser`.  A single call to write needs to send multiple gRPC messages.