### PR TITLE
Refactor auth test methods into testutils

### DIFF
--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -96,25 +96,26 @@ func TestActivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	// Get anonymous client (this will activate auth, which is about to be
 	// deactivated, but it also activates Pacyderm enterprise, which is needed for
 	// this test to pass)
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
+
 	_, err := adminClient.Deactivate(adminClient.Ctx(), &auth.DeactivateRequest{})
 	require.NoError(t, err)
 	resp, err := adminClient.AuthAPIClient.Activate(context.Background(),
-		&auth.ActivateRequest{Subject: admin})
+		&auth.ActivateRequest{Subject: tu.AdminUser})
 	require.NoError(t, err)
-	tokenMap[admin] = resp.PachToken
 	adminClient.SetAuthToken(resp.PachToken)
+	tu.UpdateAuthToken(tu.AdminUser, resp.PachToken)
 
 	// Check that the token 'c' received from pachd authenticates them as "admin"
 	who, err := adminClient.WhoAmI(adminClient.Ctx(), &auth.WhoAmIRequest{})
 	require.NoError(t, err)
 	require.Equal(t, auth.ClusterRole_SUPER, who.ClusterRoles.Roles[0])
-	require.Equal(t, admin, who.Username)
+	require.Equal(t, tu.AdminUser, who.Username)
 }
 
 // TestSuperAdminRWO tests adding and removing cluster super admins, as well as super admins
@@ -123,16 +124,16 @@ func TestSuperAdminRWO(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
-	adminClient := getPachClient(t, admin)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// The initial set of admins is just the user "admin"
 	resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 	require.NoError(t, err)
-	require.Equal(t, admins(admin)(), resp.Bindings)
+	require.Equal(t, admins(tu.AdminUser)(), resp.Bindings)
 
 	// alice creates a repo (that only she owns) and puts a file
 	repo := tu.UniqueString("TestAdminRWO")
@@ -179,7 +180,7 @@ func TestSuperAdminRWO(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin, gh(bob))(), resp.Bindings,
+			admins(tu.AdminUser, gh(bob))(), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -214,7 +215,7 @@ func TestSuperAdminRWO(t *testing.T) {
 	backoff.Retry(func() error {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin)(), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser)(), resp.Bindings)
 	}, backoff.NewTestingBackOff())
 
 	// bob can no longer read from the repo
@@ -248,16 +249,16 @@ func TestFSAdminRWO(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
-	adminClient := getPachClient(t, admin)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// The initial set of admins is just the user "admin"
 	resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 	require.NoError(t, err)
-	require.Equal(t, admins(admin)(), resp.Bindings)
+	require.Equal(t, admins(tu.AdminUser)(), resp.Bindings)
 
 	// alice creates a repo (that only she owns) and puts a file
 	repo := tu.UniqueString("TestAdminRWO")
@@ -304,7 +305,7 @@ func TestFSAdminRWO(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(bob)), resp.Bindings,
+			admins(tu.AdminUser)(gh(bob)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -339,7 +340,7 @@ func TestFSAdminRWO(t *testing.T) {
 	backoff.Retry(func() error {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin)(), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser)(), resp.Bindings)
 	}, backoff.NewTestingBackOff())
 
 	// bob can no longer read from the repo
@@ -374,11 +375,11 @@ func TestFSAdminFixBrokenRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
-	adminClient := getPachClient(t, admin)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a repo (that only she owns) and puts a file
 	repo := tu.UniqueString("TestAdmin")
@@ -395,7 +396,7 @@ func TestFSAdminFixBrokenRepo(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(bob)), resp.Bindings,
+			admins(tu.AdminUser)(gh(bob)), resp.Bindings,
 		)
 	})
 
@@ -445,15 +446,15 @@ func TestCannotRemoveAllClusterAdminsRace(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Check that the initial set of admins is just "admin"
 	resp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 	require.NoError(t, err)
-	require.Equal(t, admins(admin)(), resp.Bindings)
+	require.Equal(t, admins(tu.AdminUser)(), resp.Bindings)
 
 	var eg errgroup.Group
 	eg.Go(func() error {
@@ -467,7 +468,7 @@ func TestCannotRemoveAllClusterAdminsRace(t *testing.T) {
 			}
 			if _, err = adminClient.ModifyAdmins(adminClient.Ctx(), &auth.ModifyAdminsRequest{
 				Add:    []string{alice},
-				Remove: []string{admin},
+				Remove: []string{tu.AdminUser},
 			}); err != nil && !auth.IsErrNotAuthorized(err) && !strings.Contains(err.Error(), "cannot remove all cluster administrators while auth is active") {
 				t.Log(err)
 			}
@@ -484,7 +485,7 @@ func TestCannotRemoveAllClusterAdminsRace(t *testing.T) {
 				return fmt.Errorf("expected 1 admin but found %d: %v", len(admins.Admins), admins.Admins)
 			}
 			if _, err := aliceClient.ModifyAdmins(aliceClient.Ctx(), &auth.ModifyAdminsRequest{
-				Add:    []string{admin},
+				Add:    []string{tu.AdminUser},
 				Remove: []string{alice},
 			}); err != nil && !auth.IsErrNotAuthorized(err) && !strings.Contains(err.Error(), "cannot remove all cluster administrators while auth is active") {
 				t.Log(err)
@@ -502,7 +503,7 @@ func TestCannotRemoveAllClusterAdminsRace(t *testing.T) {
 	// Try to swap admins as Alice one more time, in case it happened that Alice
 	// is the admin
 	aliceClient.ModifyAdmins(aliceClient.Ctx(), &auth.ModifyAdminsRequest{
-		Add:    []string{admin},
+		Add:    []string{tu.AdminUser},
 		Remove: []string{alice},
 	})
 }
@@ -513,25 +514,25 @@ func TestCannotRemoveAllClusterAdmins(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Check that the initial set of admins is just "admin"
 	resp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 	require.NoError(t, err)
-	require.Equal(t, admins(admin)(), resp.Bindings)
+	require.Equal(t, admins(tu.AdminUser)(), resp.Bindings)
 
 	// admin cannot remove themselves from the list of super admins (otherwise
 	// there would be no admins)
 	_, err = adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
-		&auth.ModifyClusterRoleBindingRequest{Principal: admin})
+		&auth.ModifyClusterRoleBindingRequest{Principal: tu.AdminUser})
 	require.YesError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin)(), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser)(), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 
 	// admin can make alice an FS administrator but admin is still the only super admin
@@ -544,18 +545,18 @@ func TestCannotRemoveAllClusterAdmins(t *testing.T) {
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin)(gh(alice)), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser)(gh(alice)), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 
 	// admin cannot remove themselves from the list of super admins (otherwise
 	// there would be no admins), alice only has fs admin
 	_, err = adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
-		&auth.ModifyClusterRoleBindingRequest{Principal: admin})
+		&auth.ModifyClusterRoleBindingRequest{Principal: tu.AdminUser})
 	require.YesError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin)(gh(alice)), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser)(gh(alice)), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 
 	// admin can make alice a cluster administrator
@@ -568,12 +569,12 @@ func TestCannotRemoveAllClusterAdmins(t *testing.T) {
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin, gh(alice))(), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser, gh(alice))(), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 
 	// Now admin can remove themselves as a cluster admin
 	_, err = adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
-		&auth.ModifyClusterRoleBindingRequest{Principal: admin})
+		&auth.ModifyClusterRoleBindingRequest{Principal: tu.AdminUser})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
@@ -601,14 +602,14 @@ func TestModifyClusterAdminsAllowRobotOnlyAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Check that the initial set of admins is just "admin"
 	resp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 	require.NoError(t, err)
-	require.Equal(t, admins(admin)(), resp.Bindings)
+	require.Equal(t, admins(tu.AdminUser)(), resp.Bindings)
 
 	// 'admin' gets credentials for a robot user, and swaps themself and the robot
 	// so that the only cluster administrator is the robot user
@@ -632,13 +633,13 @@ func TestModifyClusterAdminsAllowRobotOnlyAdmin(t *testing.T) {
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(robot("rob"), admin)(), resp.Bindings)
+		return require.EqualOrErr(admins(robot("rob"), tu.AdminUser)(), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 
 	// Remove admin
 	_, err = adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
 		&auth.ModifyClusterRoleBindingRequest{
-			Principal: admin,
+			Principal: tu.AdminUser,
 		})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
@@ -650,14 +651,14 @@ func TestModifyClusterAdminsAllowRobotOnlyAdmin(t *testing.T) {
 	// The robot user adds admin back as a cluster admin
 	_, err = robotClient.ModifyClusterRoleBinding(robotClient.Ctx(),
 		&auth.ModifyClusterRoleBindingRequest{
-			Principal: admin,
+			Principal: tu.AdminUser,
 			Roles:     superClusterRole(),
 		})
 	require.NoError(t, err)
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(robot("rob"), admin)(), resp.Bindings)
+		return require.EqualOrErr(admins(robot("rob"), tu.AdminUser)(), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 }
 
@@ -665,10 +666,10 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Deactivate auth
 	_, err := adminClient.Deactivate(adminClient.Ctx(), &auth.DeactivateRequest{})
@@ -718,10 +719,10 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 
 	// activate auth
 	resp, err := adminClient.Activate(adminClient.Ctx(), &auth.ActivateRequest{
-		Subject: admin,
+		Subject: tu.AdminUser,
 	})
 	require.NoError(t, err)
-	tokenMap[admin] = resp.PachToken
+	tu.UpdateAuthToken(tu.AdminUser, resp.PachToken)
 	adminClient.SetAuthToken(resp.PachToken)
 
 	// re-authenticate, as old tokens were deleted
@@ -729,7 +730,7 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 		GitHubToken: alice,
 	})
 	require.NoError(t, err)
-	tokenMap[alice] = aliceResp.PachToken
+	tu.UpdateAuthToken(alice, aliceResp.PachToken)
 	aliceClient.SetAuthToken(aliceResp.PachToken)
 
 	// Make sure alice cannot read the input repo (i.e. if the pipeline runs as
@@ -762,10 +763,10 @@ func TestExpirationRepoOnlyAccessibleToAdmins(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString("TestExpirationRepoOnlyAccessibleToAdmins")
@@ -907,10 +908,10 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString("TestPipelinesRunAfterExpiration")
@@ -995,10 +996,10 @@ func TestGetSetScopeAndAclWithExpiredToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString("TestGetSetScopeAndAclWithExpiredToken")
@@ -1110,11 +1111,11 @@ func TestAdminWhoAmI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
-	adminClient := getPachClient(t, admin)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// 'admin' makes bob an FS admin
 	_, err := adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
@@ -1126,7 +1127,7 @@ func TestAdminWhoAmI(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(bob)), resp.Bindings,
+			admins(tu.AdminUser)(gh(bob)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -1139,7 +1140,7 @@ func TestAdminWhoAmI(t *testing.T) {
 	// admin has super admin
 	resp, err = adminClient.WhoAmI(adminClient.Ctx(), &auth.WhoAmIRequest{})
 	require.NoError(t, err)
-	require.Equal(t, admin, resp.Username)
+	require.Equal(t, tu.AdminUser, resp.Username)
 	require.Equal(t, superClusterRole(), resp.ClusterRoles)
 
 	// bob has FS admin
@@ -1156,12 +1157,12 @@ func TestListRepoAdminIsOwnerOfAllRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	// t.Parallel()
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repoWriter := tu.UniqueString("TestListRepoAdminIsOwnerOfAllRepos")
@@ -1188,9 +1189,9 @@ func TestGetAuthToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Generate first set of auth credentials
 	robotUser := robot(tu.UniqueString("optimus_prime"))
@@ -1198,7 +1199,7 @@ func TestGetAuthToken(t *testing.T) {
 		&auth.GetAuthTokenRequest{Subject: robotUser})
 	require.NoError(t, err)
 	token1 := resp.Token
-	robotClient1 := getPachClient(t, "")
+	robotClient1 := tu.GetAuthenticatedPachClient(t, "")
 	robotClient1.SetAuthToken(token1)
 
 	// Confirm identity tied to 'token1'
@@ -1219,7 +1220,7 @@ func TestGetAuthToken(t *testing.T) {
 	require.NoError(t, err)
 	token2 := resp.Token
 	require.NotEqual(t, token1, token2)
-	robotClient2 := getPachClient(t, "")
+	robotClient2 := tu.GetAuthenticatedPachClient(t, "")
 	robotClient2.SetAuthToken(token2)
 
 	// Confirm identity tied to 'token1'
@@ -1302,9 +1303,9 @@ func TestGetIndefiniteAuthToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Generate auth credentials
 	robotUser := robot(tu.UniqueString("rock-em-sock-em"))
@@ -1315,7 +1316,7 @@ func TestGetIndefiniteAuthToken(t *testing.T) {
 		})
 	require.NoError(t, err)
 	token1 := resp.Token
-	robotClient1 := getPachClient(t, "")
+	robotClient1 := tu.GetAuthenticatedPachClient(t, "")
 	robotClient1.SetAuthToken(token1)
 
 	// Confirm identity tied to 'token1'
@@ -1332,9 +1333,9 @@ func TestRobotUserWhoAmI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Generate a robot user auth credential, and create a client for that user
 	robotUser := robot(tu.UniqueString("r2d2"))
@@ -1359,7 +1360,7 @@ func TestRobotUserACL(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Generate a robot user auth credential, and create a client for that user
 	robotUser := robot(tu.UniqueString("voltron"))
@@ -1414,11 +1415,11 @@ func TestRobotUserAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	adminClient := getPachClient(t, admin)
-	aliceClient := getPachClient(t, alice)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// Generate a robot user auth credential, and create a client for that user
 	robotUser := robot(tu.UniqueString("bender"))
@@ -1439,7 +1440,7 @@ func TestRobotUserAdmin(t *testing.T) {
 	require.NoError(t, backoff.Retry(func() error {
 		resp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
-		return require.EqualOrErr(admins(admin, robotUser)(), resp.Bindings)
+		return require.EqualOrErr(admins(tu.AdminUser, robotUser)(), resp.Bindings)
 	}, backoff.NewTestingBackOff()))
 
 	// robotUser mints a token for robotUser2
@@ -1478,9 +1479,9 @@ func TestRobotUserAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	deactivateResp, err := robotClient.AuthAPIClient.Activate(context.Background(),
-		&auth.ActivateRequest{Subject: admin})
+		&auth.ActivateRequest{Subject: tu.AdminUser})
 	require.NoError(t, err)
-	tokenMap[admin] = deactivateResp.PachToken
+	tu.UpdateAuthToken(tu.AdminUser, deactivateResp.PachToken)
 	robotClient.SetAuthToken(deactivateResp.PachToken)
 }
 
@@ -1490,9 +1491,9 @@ func TestTokenTTL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Create repo (so alice has something to list)
 	repo := tu.UniqueString("TestTokenTTL")
@@ -1529,9 +1530,9 @@ func TestTokenTTLExtend(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Create repo (so alice has something to list)
 	repo := tu.UniqueString("TestTokenTTLExtend")
@@ -1592,9 +1593,9 @@ func TestTokenRevoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Create repo (so alice has something to list)
 	repo := tu.UniqueString("TestTokenRevoke")
@@ -1631,11 +1632,11 @@ func TestGetAuthTokenErrorNonAdminUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 	resp, err := aliceClient.GetAuthToken(aliceClient.Ctx(), &auth.GetAuthTokenRequest{
 		Subject: robot(tu.UniqueString("t-1000")),
 	})
@@ -1650,12 +1651,12 @@ func TestGetAuthTokenErrorFSAdminUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
-	adminClient := getPachClient(t, admin)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// 'admin' makes alice an fs admin
 	_, err := adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
@@ -1667,7 +1668,7 @@ func TestGetAuthTokenErrorFSAdminUser(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(alice)), resp.Bindings,
+			admins(tu.AdminUser)(gh(alice)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -1686,11 +1687,11 @@ func TestGetAuthTokenDefaultTTL(t *testing.T) {
 	// if testing.Short() {
 	// 	t.Skip("Skipping integration tests in short mode")
 	// }
-	// deleteAll(t)
-	// defer deleteAll(t)
+	// tu.DeleteAll(t)
+	// defer tu.DeleteAll(t)
 
 	// alice := tu.UniqueString("alice")
-	// aliceClient := getPachClient(t, alice)
+	// aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 	// resp, err := aliceClient.GetAuthToken(aliceClient.Ctx(), &auth.GetAuthTokenRequest{
 	// 	Subject: robot(tu.UniqueString("t-1000")),
 	// })
@@ -1705,11 +1706,11 @@ func TestGetAuthTokenPermanent(t *testing.T) {
 	// if testing.Short() {
 	// 	t.Skip("Skipping integration tests in short mode")
 	// }
-	// deleteAll(t)
-	// defer deleteAll(t)
+	// tu.DeleteAll(t)
+	// defer tu.DeleteAll(t)
 
 	// alice := tu.UniqueString("alice")
-	// aliceClient := getPachClient(t, alice)
+	// aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 	// resp, err := aliceClient.GetAuthToken(aliceClient.Ctx(), &auth.GetAuthTokenRequest{
 	// 	Subject: robot(tu.UniqueString("t-1000")),
 	// })
@@ -1724,13 +1725,13 @@ func TestActivateAsRobotUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
+	client := tu.GetPachClient(t)
 	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(t, tu.ActivateEnterprise(t, seedClient))
+	require.NoError(t, tu.ActivateEnterprise(t, client))
 
-	client := seedClient.WithCtx(context.Background())
 	resp, err := client.Activate(client.Ctx(), &auth.ActivateRequest{
 		Subject: robot("deckard"),
 	})
@@ -1747,22 +1748,22 @@ func TestActivateAsRobotUser(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err = client.AuthAPIClient.Activate(context.Background(),
-		&auth.ActivateRequest{Subject: admin})
+		&auth.ActivateRequest{Subject: tu.AdminUser})
 	require.NoError(t, err)
-	tokenMap[admin] = resp.PachToken
+	tu.UpdateAuthToken(tu.AdminUser, resp.PachToken)
 }
 
 func TestActivateMismatchedUsernames(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
+	client := tu.GetPachClient(t)
 	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(t, tu.ActivateEnterprise(t, seedClient))
+	require.NoError(t, tu.ActivateEnterprise(t, client))
 
-	client := seedClient.WithCtx(context.Background())
 	_, err := client.Activate(client.Ctx(), &auth.ActivateRequest{
 		Subject:     "alice",
 		GitHubToken: "bob",
@@ -1781,11 +1782,11 @@ func TestDeleteAllAfterDeactivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a pipeline
 	repo := tu.UniqueString("TestDeleteAllAfterDeactivate")
@@ -1849,10 +1850,10 @@ func TestDeleteRCInStandby(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	c := getPachClient(t, alice)
+	c := tu.GetAuthenticatedPachClient(t, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -1935,10 +1936,10 @@ func TestNoOutputRepoDoesntCrashPPSMaster(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -2049,10 +2050,10 @@ func TestPipelineFailingWithOpenCommit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -2109,9 +2110,9 @@ func TestOneTimePasswordOtherUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
+	tu.DeleteAll(t)
 
-	adminClient, anonClient := getPachClient(t, admin), getPachClient(t, "")
+	adminClient, anonClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser), tu.GetAuthenticatedPachClient(t, "")
 	otpResp, err := adminClient.GetOneTimePassword(adminClient.Ctx(),
 		&auth.GetOneTimePasswordRequest{
 			Subject: gh("alice"),
@@ -2137,11 +2138,11 @@ func TestFSAdminOneTimePasswordOtherUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
+	tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
-	adminClient := getPachClient(t, admin)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// 'admin' makes alice an fs admin
 	_, err := adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
@@ -2153,7 +2154,7 @@ func TestFSAdminOneTimePasswordOtherUser(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(alice)), resp.Bindings,
+			admins(tu.AdminUser)(gh(alice)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -2174,10 +2175,10 @@ func TestInitialRobotUserGetOTP(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
+	tu.DeleteAll(t)
 	// adminClient will use 'admin's initial Pachyderm token, which does not
 	// expire
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 	// make sure the admin client is a robot user initial admin
 	who, err := adminClient.WhoAmI(adminClient.Ctx(), &auth.WhoAmIRequest{})
 	require.NoError(t, err)

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -4,14 +4,11 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -27,334 +24,6 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	tu "github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 )
-
-const (
-	// admin is the sole cluster admin after getPachClient is called in each test
-	admin          = auth.RobotPrefix + "admin"
-	carol          = auth.GitHubPrefix + "carol"
-	adminTokenFile = "/tmp/pach-auth-test_admin-token"
-)
-
-var (
-	tokenMapMut sync.Mutex // guards both tokenMap and seedClient
-	tokenMap    = make(map[string]string)
-	seedClient  *client.APIClient
-)
-
-// isAuthActive is a helper that checks if auth is currently active in the
-// target cluster
-//
-// Caller must hold tokenMapMut. Currently only called by getPachClient(),
-// activateAuth (which is only called by getPachClient()) and deleteAll()
-func isAuthActive(tb testing.TB, checkConfig bool) bool {
-	_, err := seedClient.GetClusterRoleBindings(context.Background(),
-		&auth.GetClusterRoleBindingsRequest{})
-	switch {
-	case auth.IsErrNotSignedIn(err):
-		adminClient := getPachClientInternal(tb, admin)
-		if checkConfig {
-			if err := backoff.Retry(func() error {
-				resp, err := adminClient.GetConfiguration(adminClient.Ctx(), &auth.GetConfigurationRequest{})
-				if err != nil {
-					return errors.Wrapf(err, "could not get config")
-				}
-				cfg := resp.GetConfiguration()
-				if cfg.SAMLServiceOptions != nil {
-					return errors.Errorf("SAML config in fresh cluster: %+v", cfg)
-				}
-				if len(cfg.IDProviders) != 1 || cfg.IDProviders[0].SAML != nil || cfg.IDProviders[0].GitHub == nil || cfg.IDProviders[0].Name != "GitHub" {
-					return errors.Errorf("problem with ID providers in config in fresh cluster: %+v", cfg)
-				}
-				return nil
-			}, backoff.NewTestingBackOff()); err != nil {
-				panic(err)
-			}
-		}
-		return true
-	case auth.IsErrNotActivated(err), auth.IsErrPartiallyActivated(err):
-		return false
-	default:
-		panic(fmt.Sprintf("could not determine if auth is activated: %v", err))
-	}
-	return false
-}
-
-// getPachClientInternal is a helper function called by getPachClient. It
-// returns (or creates) a pach client authenticated as 'subject', but doesn't
-// do any any checks to confirm that auth is activated and the cluster is
-// configured correctly (those are done by getPachClient). If subject has no
-// prefix, they are assumed to be a GitHub user.
-//
-// Caller must hold tokenMapMut. Currently only called by getPachClient()
-func getPachClientInternal(tb testing.TB, subject string) *client.APIClient {
-	// copy seed, so caller can safely modify result
-	resultClient := seedClient.WithCtx(context.Background())
-	if subject == "" {
-		return resultClient // anonymous client
-	}
-	if token, ok := tokenMap[subject]; ok {
-		resultClient.SetAuthToken(token)
-		return resultClient
-	}
-	if subject == admin {
-		bytes, err := ioutil.ReadFile(adminTokenFile)
-		if err == nil {
-			tb.Logf("couldn't find admin token in cache, reading from %q", adminTokenFile)
-			resultClient.SetAuthToken(string(bytes))
-			return resultClient
-		}
-		tb.Fatalf("couldn't get admin client from cache or %q, no way to reset "+
-			"cluster. Please deactivate auth or redeploy Pachyderm", adminTokenFile)
-	}
-	if !strings.Contains(subject, ":") {
-		subject = gh(subject)
-	}
-	colonIdx := strings.Index(subject, ":")
-	prefix := subject[:colonIdx+1]
-	switch prefix {
-	case auth.RobotPrefix:
-		adminClient := getPachClientInternal(tb, admin)
-		resp, err := adminClient.GetAuthToken(adminClient.Ctx(), &auth.GetAuthTokenRequest{
-			Subject: subject,
-		})
-		require.NoError(tb, err)
-		tokenMap[subject] = resp.Token
-	case auth.GitHubPrefix:
-		resp, err := seedClient.Authenticate(context.Background(),
-			&auth.AuthenticateRequest{
-				// When Pachyderm is deployed locally, GitHubToken automatically
-				// authenicates the caller as a GitHub user whose name is equal to the
-				// provided token
-				GitHubToken: strings.TrimPrefix(subject, auth.GitHubPrefix),
-			})
-		require.NoError(tb, err)
-		tokenMap[subject] = resp.PachToken
-	default:
-		tb.Fatalf("can't give you a client of type %s", prefix)
-	}
-	resultClient.SetAuthToken(tokenMap[subject])
-	return resultClient
-}
-
-// activateAuth activates the auth service in the test cluster
-//
-// Caller must hold tokenMapMut. Currently only called by getPachClient()
-func activateAuth(tb testing.TB) {
-	resp, err := seedClient.AuthAPIClient.Activate(context.Background(),
-		&auth.ActivateRequest{Subject: admin},
-	)
-	if err != nil && !strings.HasSuffix(err.Error(), "already activated") {
-		tb.Fatalf("could not activate auth service: %v", err.Error())
-	}
-	tokenMap[admin] = resp.PachToken
-	ioutil.WriteFile(adminTokenFile, []byte(resp.PachToken), 0644)
-
-	// Wait for the Pachyderm Auth system to activate
-	require.NoError(tb, backoff.Retry(func() error {
-		if isAuthActive(tb, true) {
-			return nil
-		}
-		return errors.Errorf("auth not active yet")
-	}, backoff.NewTestingBackOff()))
-}
-
-// initSeedClient is a helper function called by getPachClient that initializes
-// the 'seedClient' global variable.
-//
-// Caller must hold tokenMapMut. Currently only called by getPachClient() and
-// deleteAll()
-func initSeedClient(tb testing.TB) {
-	tb.Helper()
-	var err error
-	if _, ok := os.LookupEnv("PACHD_PORT_650_TCP_ADDR"); ok {
-		seedClient, err = client.NewInCluster()
-	} else {
-		seedClient, err = client.NewForTest()
-	}
-	require.NoError(tb, err)
-	// discard any credentials from the user's machine (seedClient is
-	// anonymous)
-	seedClient = seedClient.WithCtx(context.Background())
-	seedClient.SetAuthToken("")
-}
-
-// getPachClientConfigAgnostic does not check that the auth config is in the default state.
-// i.e. it can be used to retrieve the pach client even after the auth config has been manipulated
-func getPachClientConfigAgnostic(tb testing.TB, subject string) *client.APIClient {
-	return getPachClientP(tb, subject, false)
-}
-
-// getPachClient explicitly checks that the auth config is set to the default,
-// and will fail otherwise.
-func getPachClient(tb testing.TB, subject string) *client.APIClient {
-	return getPachClientP(tb, subject, true)
-}
-
-// getPachClient creates a seed client with a grpc connection to a pachyderm
-// cluster, and then enable the auth service in that cluster
-func getPachClientP(tb testing.TB, subject string, checkConfig bool) *client.APIClient {
-	tb.Helper()
-	tokenMapMut.Lock()
-	defer tokenMapMut.Unlock()
-
-	// Check if seed client exists -- if not, create it
-	if seedClient == nil {
-		initSeedClient(tb)
-	}
-
-	// Activate Pachyderm Enterprise (if it's not already active)
-	require.NoError(tb, tu.ActivateEnterprise(tb, seedClient))
-
-	// Cluster may be in one of four states:
-	// 1) Auth is off (=> Activate auth)
-	// 2) Auth is on, but client tokens have been invalidated (=> Deactivate +
-	//    Reactivate auth)
-	// 3) Auth is on and client tokens are valid, but the admin isn't "admin"
-	//    (=> reset cluster admins to "admin")
-	// 4) Auth is on, client tokens are valid, and the only admin is "admin" (do
-	//    nothing)
-	if !isAuthActive(tb, checkConfig) {
-		// Case 1: auth is off. Activate auth & return a new client
-		tokenMap = make(map[string]string)
-		activateAuth(tb)
-		return getPachClientInternal(tb, subject)
-	}
-
-	adminClient := getPachClientInternal(tb, admin)
-	getBindingsResp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(),
-		&auth.GetClusterRoleBindingsRequest{})
-
-	// Detect case 2: auth was deactivated during previous test. De/Reactivate
-	// TODO it may may sense to do this between every test, though it would mean
-	// that we can't run tests in parallel. Currently, only the first test that
-	// needs to reset auth will run this block
-	if err != nil && auth.IsErrBadToken(err) {
-		// Don't know which tokens are valid, so clear tokenMap
-		tokenMap = make(map[string]string)
-		adminClient := getPachClientInternal(tb, admin)
-
-		// "admin" may no longer be an admin, so get a list of admins, authorize as
-		// the first admin, and deactivate auth
-		getBindingsResp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(),
-			&auth.GetClusterRoleBindingsRequest{})
-		require.NoError(tb, err)
-		if len(getBindingsResp.Bindings) == 0 {
-			panic("it should not be possible to leave a cluster with no admins")
-		}
-		var currentAdmin string
-		for a := range getBindingsResp.Bindings {
-			currentAdmin = a
-			break
-		}
-		adminClient = getPachClientInternal(tb, currentAdmin)
-		_, err = adminClient.Deactivate(adminClient.Ctx(), &auth.DeactivateRequest{})
-		require.NoError(tb, err)
-
-		// Just deactivated. *All* tokens are now invalid, so clear the map again
-		tokenMap = make(map[string]string)
-		activateAuth(tb)
-		return getPachClientInternal(tb, subject)
-	}
-
-	// Detect case 3: previous change shuffled admins. Reset list to just "admin"
-	if len(getBindingsResp.Bindings) == 0 {
-		panic("it should not be possible to leave a cluster with no admins")
-	}
-	_, hasAdmin := getBindingsResp.Bindings[admin]
-	hasExpectedAdmin := len(getBindingsResp.Bindings) == 1 && hasAdmin
-	if !hasExpectedAdmin {
-		var curAdminClient *client.APIClient
-		for a, roles := range getBindingsResp.Bindings {
-			var isSuper bool
-			for _, r := range roles.Roles {
-				if r == auth.ClusterRole_SUPER {
-					isSuper = true
-					break
-				}
-			}
-			if !isSuper {
-				continue
-			}
-
-			if strings.HasPrefix(a, auth.GitHubPrefix) {
-				curAdminClient = getPachClientInternal(tb, a) // use first GH admin
-				break
-			}
-			if a == admin {
-				curAdminClient = getPachClientInternal(tb, a) // use admin robot
-				break
-			}
-		}
-
-		if curAdminClient == nil {
-			tb.Fatal("cluster has no GitHub admins; no way for auth test to grant itself admin access")
-			// staticcheck does not realize tb.Fatal will not return (because it is an
-			// interface), see https://github.com/dominikh/go-tools/issues/635
-			return nil
-		}
-
-		_, err = curAdminClient.ModifyClusterRoleBinding(curAdminClient.Ctx(), &auth.ModifyClusterRoleBindingRequest{
-			Principal: admin,
-			Roles:     superClusterRole(),
-		})
-		require.NoError(tb, err)
-		for a := range getBindingsResp.Bindings {
-			if a != admin {
-				_, err = curAdminClient.ModifyClusterRoleBinding(curAdminClient.Ctx(), &auth.ModifyClusterRoleBindingRequest{Principal: a})
-				require.NoError(tb, err)
-			}
-		}
-		if curAdminClient == nil {
-			tb.Fatal("cluster has no GitHub admins; no way for auth test to grant itself admin access")
-			// staticcheck does not realize tb.Fatal will not return (because it is an
-			// interface), see https://github.com/dominikh/go-tools/issues/635
-			return nil
-		}
-		// Wait for admin change to take effect
-		require.NoError(tb, backoff.Retry(func() error {
-			getBindingsResp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(),
-				&auth.GetClusterRoleBindingsRequest{})
-			_, hasAdmin := getBindingsResp.Bindings[admin]
-			hasExpectedAdmin := len(getBindingsResp.Bindings) == 1 && hasAdmin
-			if !hasExpectedAdmin {
-				return errors.Errorf("cluster admins haven't yet updated")
-			}
-			return nil
-		}, backoff.NewTestingBackOff()))
-	}
-
-	return getPachClientInternal(tb, subject)
-}
-
-// deleteAll deletes all data in the cluster. This includes deleting all auth
-// tokens, so all pachyderm clients must be recreated after calling deleteAll()
-// (it should generally be called at the beginning or end of tests, before any
-// clients have been created or after they're done being used).
-func deleteAll(tb testing.TB) {
-	tb.Helper()
-	var anonClient *client.APIClient
-	var useAdminClient bool
-	func() {
-		tokenMapMut.Lock() // May initialize the seed client
-		defer tokenMapMut.Unlock()
-
-		if seedClient == nil {
-			initSeedClient(tb)
-		}
-		anonClient = seedClient.WithCtx(context.Background())
-
-		// config might be nil if this is
-		// called after a test that changed
-		// the config
-		useAdminClient = isAuthActive(tb, false)
-	}() // release tokenMapMut before getPachClient
-	if useAdminClient {
-		adminClient := getPachClientConfigAgnostic(tb, admin)
-		require.NoError(tb, adminClient.DeleteAll(), "initial DeleteAll()")
-	} else {
-		require.NoError(tb, anonClient.DeleteAll())
-	}
-}
 
 // aclEntry mirrors auth.ACLEntry, but without XXX_fields, which make
 // auth.ACLEntry invalid to use as a map key
@@ -437,10 +106,10 @@ func TestGetSetBasic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -586,10 +255,10 @@ func TestGetSetReverse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -751,10 +420,10 @@ func TestCreateAndUpdateRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -810,10 +479,10 @@ func TestCreateRepoWithUpdateFlag(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -838,8 +507,8 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	type createArgs struct {
 		client     *client.APIClient
 		name, repo string
@@ -858,7 +527,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 		)
 	}
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -1037,8 +706,8 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	type createArgs struct {
 		client *client.APIClient
 		name   string
@@ -1058,7 +727,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 		)
 	}
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// create two repos, and check that alice is the owner of the new repos
 	dataRepo1 := tu.UniqueString(t.Name())
@@ -1246,10 +915,10 @@ func TestPipelineRevoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo, and adds bob as a reader
 	repo := tu.UniqueString(t.Name())
@@ -1412,10 +1081,10 @@ func TestStopAndDeletePipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1574,9 +1243,9 @@ func TestStopJob(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
+	tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1638,10 +1307,10 @@ func TestListAndInspectRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo and makes Bob a writer
 	repoWriter := tu.UniqueString(t.Name())
@@ -1707,10 +1376,10 @@ func TestUnprivilegedUserCannotMakeSelfOwner(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1733,10 +1402,10 @@ func TestGetScopeRequiresReader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1767,10 +1436,10 @@ func TestListRepoNotLoggedInError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, "")
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1791,13 +1460,13 @@ func TestListRepoNoAuthInfoIfDeactivated(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	// Dont't run this test in parallel, since it deactivates the auth system
 	// globally, so any tests running concurrently will fail
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
-	adminClient := getPachClient(t, admin)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1838,10 +1507,10 @@ func TestCreateRepoAlreadyExistsError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1860,9 +1529,9 @@ func TestCreateRepoNotLoggedInError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	anonClient := getPachClient(t, "")
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	anonClient := tu.GetAuthenticatedPachClient(t, "")
 
 	// anonClient tries and fails to create a repo
 	repo := tu.UniqueString(t.Name())
@@ -1878,10 +1547,10 @@ func TestCreatePipelineRepoAlreadyExistsError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	inputRepo := tu.UniqueString(t.Name())
@@ -1916,9 +1585,9 @@ func TestAuthorizedNoneRole(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
-	adminClient := getPachClient(t, admin)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Deactivate auth
 	_, err := adminClient.Deactivate(adminClient.Ctx(), &auth.DeactivateRequest{})
@@ -1939,7 +1608,7 @@ func TestAuthorizedNoneRole(t *testing.T) {
 
 	// Get new pach clients, re-activating auth
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// Check that the repo has no ACL
 	require.ElementsEqual(t, entries(), getACL(t, adminClient, repo))
@@ -1959,11 +1628,11 @@ func TestAuthorizedEveryone(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2015,11 +1684,11 @@ func TestDeleteAll(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2040,7 +1709,7 @@ func TestDeleteAll(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(alice)), resp.Bindings,
+			admins(tu.AdminUser)(gh(alice)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -2059,10 +1728,10 @@ func TestListDatum(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repoA := tu.UniqueString(t.Name())
@@ -2181,10 +1850,10 @@ func TestListJob(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2274,10 +1943,10 @@ func TestInspectDatum(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2338,10 +2007,10 @@ func TestGetLogs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient, bobClient := getPachClient(t, alice), getPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2435,10 +2104,10 @@ func TestGetLogsFromStats(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2490,10 +2159,10 @@ func TestPipelineNewInput(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// alice creates three repos and commits to them
 	var repo []string
@@ -2582,8 +2251,8 @@ func TestModifyMembers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
 	bob := tu.UniqueString("bob")
@@ -2591,7 +2260,7 @@ func TestModifyMembers(t *testing.T) {
 	engineering := tu.UniqueString("engineering")
 	security := tu.UniqueString("security")
 
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// This is a sequence dependent list of tests
 	tests := []struct {
@@ -2708,15 +2377,15 @@ func TestSetGroupsForUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
 	organization := tu.UniqueString("organization")
 	engineering := tu.UniqueString("engineering")
 	security := tu.UniqueString("security")
 
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	groups := []string{organization, engineering}
 	_, err := adminClient.SetGroupsForUser(adminClient.Ctx(), &auth.SetGroupsForUserRequest{
@@ -2799,15 +2468,15 @@ func TestGetGroupsEmpty(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
 	organization := tu.UniqueString("organization")
 	engineering := tu.UniqueString("engineering")
 	security := tu.UniqueString("security")
 
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	_, err := adminClient.SetGroupsForUser(adminClient.Ctx(), &auth.SetGroupsForUserRequest{
 		Username: alice,
@@ -2815,7 +2484,7 @@ func TestGetGroupsEmpty(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 	groups, err := aliceClient.GetGroups(aliceClient.Ctx(), &auth.GetGroupsRequest{})
 	require.NoError(t, err)
 	require.ElementsEqual(t, []string{organization, engineering, security}, groups.Groups)
@@ -2831,10 +2500,10 @@ func TestGetJobsBugFix(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, "")
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2888,11 +2557,11 @@ func TestGetAuthTokenNoSubject(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, "")
 
 	// Get GetOTP with no subject
 	resp, err := aliceClient.GetAuthToken(aliceClient.Ctx(), &auth.GetAuthTokenRequest{})
@@ -2910,11 +2579,11 @@ func TestOneTimePasswordNoSubject(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, "")
 
 	// Get GetOTP with no subject
 	otpResp, err := aliceClient.GetOneTimePassword(aliceClient.Ctx(),
@@ -2936,11 +2605,11 @@ func TestGetOneTimePassword(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, "")
 
 	// Get GetOTP with subject equal to the caller
 	otpResp, err := aliceClient.GetOneTimePassword(aliceClient.Ctx(),
@@ -2964,11 +2633,11 @@ func TestOneTimePasswordOtherUserError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice, bob := tu.UniqueString("alice"), tu.UniqueString("bob")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 	_, err := aliceClient.GetOneTimePassword(aliceClient.Ctx(),
 		&auth.GetOneTimePasswordRequest{
 			Subject: bob,
@@ -2981,12 +2650,12 @@ func TestOneTimePasswordExpires(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	var authCodeTTL int64 = 10 // seconds
 	alice := tu.UniqueString("alice")
-	aliceClient, anonClient := getPachClient(t, alice), getPachClient(t, "")
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, "")
 	otpResp, err := aliceClient.GetOneTimePassword(aliceClient.Ctx(),
 		&auth.GetOneTimePasswordRequest{
 			TTL: authCodeTTL,
@@ -3011,10 +2680,10 @@ func TestOTPTimeoutShorterThanSessionTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// Change aliceClient to use a short-lived token
 	var tokenLifetime int64 = 15 // seconds (must be >10 per check in api_server)
@@ -3055,7 +2724,7 @@ func TestS3GatewayAuthRequests(t *testing.T) {
 	}
 
 	// generate auth credentials
-	aliceClient := getPachClient(t, tu.UniqueString("alice"))
+	aliceClient := tu.GetAuthenticatedPachClient(t, tu.UniqueString("alice"))
 	authResp, err := aliceClient.GetAuthToken(aliceClient.Ctx(), &auth.GetAuthTokenRequest{})
 	require.NoError(t, err)
 	authToken := authResp.Token
@@ -3091,10 +2760,10 @@ func TestDeleteFailedPipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -3137,10 +2806,10 @@ func TestDeletePipelineMissingRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -3184,11 +2853,11 @@ func TestDisableGitHubAuth(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	// activate auth with initial admin robot:hub
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// confirm config is set to default config
 	cfg, err := adminClient.GetConfiguration(adminClient.Ctx(), &auth.GetConfigurationRequest{})
@@ -3248,11 +2917,11 @@ func TestDisableGitHubAuthFSAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// confirm config is set to default config
 	cfg, err := adminClient.GetConfiguration(adminClient.Ctx(), &auth.GetConfigurationRequest{})
@@ -3275,7 +2944,7 @@ func TestDisableGitHubAuthFSAdmin(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(alice)), resp.Bindings,
+			admins(tu.AdminUser)(gh(alice)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -3296,7 +2965,7 @@ func TestDeactivateFSAdmin(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	alice := tu.UniqueString("alice")
-	aliceClient, adminClient := getPachClient(t, alice), getPachClient(t, admin)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 
 	// admin makes alice an fs admin
 	_, err := adminClient.ModifyClusterRoleBinding(adminClient.Ctx(),
@@ -3308,7 +2977,7 @@ func TestDeactivateFSAdmin(t *testing.T) {
 		resp, err := aliceClient.GetClusterRoleBindings(aliceClient.Ctx(), &auth.GetClusterRoleBindingsRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			admins(admin)(gh(alice)), resp.Bindings,
+			admins(tu.AdminUser)(gh(alice)), resp.Bindings,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -3325,11 +2994,11 @@ func TestDebug(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	defer deleteAll(t)
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
 
 	alice := tu.UniqueString("alice")
-	aliceClient := getPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
 
 	dataRepo := tu.UniqueString("TestDebug_data")
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
@@ -3387,7 +3056,7 @@ func TestDebug(t *testing.T) {
 	// Only admins can collect a debug dump.
 	buf := &bytes.Buffer{}
 	require.YesError(t, aliceClient.Dump(nil, buf))
-	adminClient := getPachClient(t, admin)
+	adminClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 	require.NoError(t, adminClient.Dump(nil, buf))
 	gr, err := gzip.NewReader(buf)
 	require.NoError(t, err)

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/auth"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	tu "github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 )
 
 // Dex's mock connector always returns the same identity for all authentication
@@ -43,8 +44,8 @@ func TestOIDCAuthCodeFlow(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	adminClient, testClient := getPachClient(t, admin), getPachClient(t, "")
+	tu.DeleteAll(t)
+	adminClient, testClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser), tu.GetAuthenticatedPachClient(t, "")
 
 	_, err := adminClient.SetConfiguration(adminClient.Ctx(),
 		&auth.SetConfigurationRequest{Configuration: OIDCAuthConfig})
@@ -96,7 +97,7 @@ func TestOIDCAuthCodeFlow(t *testing.T) {
 	require.Equal(t, "idp:"+dexMockConnectorEmail, whoAmIResp.Username)
 	require.False(t, whoAmIResp.IsAdmin)
 
-	deleteAll(t)
+	tu.DeleteAll(t)
 }
 
 // TestOIDCTrustedApp tests using an ID token issued to another OIDC app to authenticate.
@@ -107,8 +108,8 @@ func TestOIDCTrustedApp(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	deleteAll(t)
-	adminClient, testClient := getPachClient(t, admin), getPachClient(t, "")
+	tu.DeleteAll(t)
+	adminClient, testClient := tu.GetAuthenticatedPachClient(t, tu.AdminUser), tu.GetAuthenticatedPachClient(t, "")
 
 	_, err := adminClient.SetConfiguration(adminClient.Ctx(),
 		&auth.SetConfigurationRequest{Configuration: OIDCAuthConfig})
@@ -143,7 +144,7 @@ func TestOIDCTrustedApp(t *testing.T) {
 	// idp:admin is an admin of the IDP but not Pachyderm
 	require.False(t, whoAmIResp.IsAdmin)
 
-	deleteAll(t)
+	tu.DeleteAll(t)
 }
 
 // Rewrite the Location header to point to the returned path at `host`

--- a/src/server/pkg/testutil/auth.go
+++ b/src/server/pkg/testutil/auth.go
@@ -1,0 +1,364 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client"
+	"github.com/pachyderm/pachyderm/src/client/auth"
+	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+)
+
+const (
+	// AdminUser is the sole cluster admin after GetAuthenticatedPachClient is called
+	AdminUser = auth.RobotPrefix + "admin"
+
+	adminTokenFile = "/tmp/pach-auth-test_admin-token"
+)
+
+var (
+	tokenMapMut sync.Mutex // guards both tokenMap and seedClient
+	tokenMap    = make(map[string]string)
+	seedClient  *client.APIClient
+)
+
+// helper function that prepends auth.GitHubPrefix to 'user'--useful for validating
+// responses
+func gh(user string) string {
+	return auth.GitHubPrefix + user
+}
+
+// helper method to generate a super admin role
+func superClusterRole() *auth.ClusterRoles {
+	return &auth.ClusterRoles{Roles: []auth.ClusterRole{auth.ClusterRole_SUPER}}
+}
+
+// UpdateAuthToken manually updates the auth token for a given user
+func UpdateAuthToken(user string, token string) {
+	tokenMapMut.Lock()
+	defer tokenMapMut.Unlock()
+
+	tokenMap[user] = token
+}
+
+// isAuthActive is a helper that checks if auth is currently active in the
+// target cluster
+//
+// Caller must hold tokenMapMut. Currently only called by getPachClient(),
+// activateAuth (which is only called by getPachClient()) and deleteAll()
+func isAuthActive(tb testing.TB, checkConfig bool) bool {
+	_, err := seedClient.GetClusterRoleBindings(context.Background(),
+		&auth.GetClusterRoleBindingsRequest{})
+	switch {
+	case auth.IsErrNotSignedIn(err):
+		adminClient := getPachClientInternal(tb, AdminUser)
+		if checkConfig {
+			if err := backoff.Retry(func() error {
+				resp, err := adminClient.GetConfiguration(adminClient.Ctx(), &auth.GetConfigurationRequest{})
+				if err != nil {
+					return errors.Wrapf(err, "could not get config")
+				}
+				cfg := resp.GetConfiguration()
+				if cfg.SAMLServiceOptions != nil {
+					return errors.Errorf("SAML config in fresh cluster: %+v", cfg)
+				}
+				if len(cfg.IDProviders) != 1 || cfg.IDProviders[0].SAML != nil || cfg.IDProviders[0].GitHub == nil || cfg.IDProviders[0].Name != "GitHub" {
+					return errors.Errorf("problem with ID providers in config in fresh cluster: %+v", cfg)
+				}
+				return nil
+			}, backoff.NewTestingBackOff()); err != nil {
+				panic(err)
+			}
+		}
+		return true
+	case auth.IsErrNotActivated(err), auth.IsErrPartiallyActivated(err):
+		return false
+	default:
+		panic(fmt.Sprintf("could not determine if auth is activated: %v", err))
+	}
+	return false
+}
+
+// getPachClientInternal is a helper function called by getPachClient. It
+// returns (or creates) a pach client authenticated as 'subject', but doesn't
+// do any any checks to confirm that auth is activated and the cluster is
+// configured correctly (those are done by getPachClient). If subject has no
+// prefix, they are assumed to be a GitHub user.
+//
+// Caller must hold tokenMapMut. Currently only called by getPachClient()
+func getPachClientInternal(tb testing.TB, subject string) *client.APIClient {
+	// copy seed, so caller can safely modify result
+	resultClient := seedClient.WithCtx(context.Background())
+	if subject == "" {
+		return resultClient // anonymous client
+	}
+	if token, ok := tokenMap[subject]; ok {
+		resultClient.SetAuthToken(token)
+		return resultClient
+	}
+	if subject == AdminUser {
+		bytes, err := ioutil.ReadFile(adminTokenFile)
+		if err == nil {
+			tb.Logf("couldn't find admin token in cache, reading from %q", adminTokenFile)
+			resultClient.SetAuthToken(string(bytes))
+			return resultClient
+		}
+		tb.Fatalf("couldn't get admin client from cache or %q, no way to reset "+
+			"cluster. Please deactivate auth or redeploy Pachyderm", adminTokenFile)
+	}
+	if !strings.Contains(subject, ":") {
+		subject = gh(subject)
+	}
+	colonIdx := strings.Index(subject, ":")
+	prefix := subject[:colonIdx+1]
+	switch prefix {
+	case auth.RobotPrefix:
+		adminClient := getPachClientInternal(tb, AdminUser)
+		resp, err := adminClient.GetAuthToken(adminClient.Ctx(), &auth.GetAuthTokenRequest{
+			Subject: subject,
+		})
+		require.NoError(tb, err)
+		tokenMap[subject] = resp.Token
+	case auth.GitHubPrefix:
+		resp, err := seedClient.Authenticate(context.Background(),
+			&auth.AuthenticateRequest{
+				// When Pachyderm is deployed locally, GitHubToken automatically
+				// authenicates the caller as a GitHub user whose name is equal to the
+				// provided token
+				GitHubToken: strings.TrimPrefix(subject, auth.GitHubPrefix),
+			})
+		require.NoError(tb, err)
+		tokenMap[subject] = resp.PachToken
+	default:
+		tb.Fatalf("can't give you a client of type %s", prefix)
+	}
+	resultClient.SetAuthToken(tokenMap[subject])
+	return resultClient
+}
+
+// activateAuth activates the auth service in the test cluster
+//
+// Caller must hold tokenMapMut. Currently only called by getPachClient()
+func activateAuth(tb testing.TB) {
+	resp, err := seedClient.AuthAPIClient.Activate(context.Background(),
+		&auth.ActivateRequest{Subject: AdminUser},
+	)
+	if err != nil && !strings.HasSuffix(err.Error(), "already activated") {
+		tb.Fatalf("could not activate auth service: %v", err.Error())
+	}
+	tokenMap[AdminUser] = resp.PachToken
+	ioutil.WriteFile(adminTokenFile, []byte(resp.PachToken), 0644)
+
+	// Wait for the Pachyderm Auth system to activate
+	require.NoError(tb, backoff.Retry(func() error {
+		if isAuthActive(tb, true) {
+			return nil
+		}
+		return errors.Errorf("auth not active yet")
+	}, backoff.NewTestingBackOff()))
+}
+
+// initSeedClient is a helper function called by getPachClient that initializes
+// the 'seedClient' global variable.
+//
+// Caller must hold tokenMapMut. Currently only called by getPachClient() and
+// deleteAll()
+func initSeedClient(tb testing.TB) {
+	tb.Helper()
+	var err error
+	if _, ok := os.LookupEnv("PACHD_PORT_650_TCP_ADDR"); ok {
+		seedClient, err = client.NewInCluster()
+	} else {
+		seedClient, err = client.NewForTest()
+	}
+	require.NoError(tb, err)
+	// discard any credentials from the user's machine (seedClient is
+	// anonymous)
+	seedClient = seedClient.WithCtx(context.Background())
+	seedClient.SetAuthToken("")
+}
+
+// getPachClientConfigAgnostic does not check that the auth config is in the default state.
+// i.e. it can be used to retrieve the pach client even after the auth config has been manipulated
+func getPachClientConfigAgnostic(tb testing.TB, subject string) *client.APIClient {
+	return getPachClientP(tb, subject, false)
+}
+
+// GetAuthenticatedPachClient explicitly checks that the auth config is set to the default,
+// and will fail otherwise.
+func GetAuthenticatedPachClient(tb testing.TB, subject string) *client.APIClient {
+	return getPachClientP(tb, subject, true)
+}
+
+// getPachClient creates a seed client with a grpc connection to a pachyderm
+// cluster, and then enable the auth service in that cluster
+func getPachClientP(tb testing.TB, subject string, checkConfig bool) *client.APIClient {
+	tb.Helper()
+	tokenMapMut.Lock()
+	defer tokenMapMut.Unlock()
+
+	// Check if seed client exists -- if not, create it
+	if seedClient == nil {
+		initSeedClient(tb)
+	}
+
+	// Activate Pachyderm Enterprise (if it's not already active)
+	require.NoError(tb, ActivateEnterprise(tb, seedClient))
+
+	// Cluster may be in one of four states:
+	// 1) Auth is off (=> Activate auth)
+	// 2) Auth is on, but client tokens have been invalidated (=> Deactivate +
+	//    Reactivate auth)
+	// 3) Auth is on and client tokens are valid, but the admin isn't "admin"
+	//    (=> reset cluster admins to "admin")
+	// 4) Auth is on, client tokens are valid, and the only admin is "admin" (do
+	//    nothing)
+	if !isAuthActive(tb, checkConfig) {
+		// Case 1: auth is off. Activate auth & return a new client
+		tokenMap = make(map[string]string)
+		activateAuth(tb)
+		return getPachClientInternal(tb, subject)
+	}
+
+	adminClient := getPachClientInternal(tb, AdminUser)
+	getBindingsResp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(),
+		&auth.GetClusterRoleBindingsRequest{})
+
+	// Detect case 2: auth was deactivated during previous test. De/Reactivate
+	// TODO it may may sense to do this between every test, though it would mean
+	// that we can't run tests in parallel. Currently, only the first test that
+	// needs to reset auth will run this block
+	if err != nil && auth.IsErrBadToken(err) {
+		// Don't know which tokens are valid, so clear tokenMap
+		tokenMap = make(map[string]string)
+		adminClient := getPachClientInternal(tb, AdminUser)
+
+		// "admin" may no longer be an admin, so get a list of admins, authorize as
+		// the first admin, and deactivate auth
+		getBindingsResp, err := adminClient.GetClusterRoleBindings(adminClient.Ctx(),
+			&auth.GetClusterRoleBindingsRequest{})
+		require.NoError(tb, err)
+		if len(getBindingsResp.Bindings) == 0 {
+			panic("it should not be possible to leave a cluster with no admins")
+		}
+		var currentAdmin string
+		for a := range getBindingsResp.Bindings {
+			currentAdmin = a
+			break
+		}
+		adminClient = getPachClientInternal(tb, currentAdmin)
+		_, err = adminClient.Deactivate(adminClient.Ctx(), &auth.DeactivateRequest{})
+		require.NoError(tb, err)
+
+		// Just deactivated. *All* tokens are now invalid, so clear the map again
+		tokenMap = make(map[string]string)
+		activateAuth(tb)
+		return getPachClientInternal(tb, subject)
+	}
+
+	// Detect case 3: previous change shuffled admins. Reset list to just "admin"
+	if len(getBindingsResp.Bindings) == 0 {
+		panic("it should not be possible to leave a cluster with no admins")
+	}
+	_, hasAdmin := getBindingsResp.Bindings[AdminUser]
+	hasExpectedAdmin := len(getBindingsResp.Bindings) == 1 && hasAdmin
+	if !hasExpectedAdmin {
+		var curAdminClient *client.APIClient
+		for a, roles := range getBindingsResp.Bindings {
+			var isSuper bool
+			for _, r := range roles.Roles {
+				if r == auth.ClusterRole_SUPER {
+					isSuper = true
+					break
+				}
+			}
+			if !isSuper {
+				continue
+			}
+
+			if strings.HasPrefix(a, auth.GitHubPrefix) {
+				curAdminClient = getPachClientInternal(tb, a) // use first GH admin
+				break
+			}
+			if a == AdminUser {
+				curAdminClient = getPachClientInternal(tb, a) // use admin robot
+				break
+			}
+		}
+
+		if curAdminClient == nil {
+			tb.Fatal("cluster has no GitHub admins; no way for auth test to grant itself admin access")
+			// staticcheck does not realize tb.Fatal will not return (because it is an
+			// interface), see https://github.com/dominikh/go-tools/issues/635
+			return nil
+		}
+
+		_, err = curAdminClient.ModifyClusterRoleBinding(curAdminClient.Ctx(), &auth.ModifyClusterRoleBindingRequest{
+			Principal: AdminUser,
+			Roles:     superClusterRole(),
+		})
+		require.NoError(tb, err)
+		for a := range getBindingsResp.Bindings {
+			if a != AdminUser {
+				_, err = curAdminClient.ModifyClusterRoleBinding(curAdminClient.Ctx(), &auth.ModifyClusterRoleBindingRequest{Principal: a})
+				require.NoError(tb, err)
+			}
+		}
+		if curAdminClient == nil {
+			tb.Fatal("cluster has no GitHub admins; no way for auth test to grant itself admin access")
+			// staticcheck does not realize tb.Fatal will not return (because it is an
+			// interface), see https://github.com/dominikh/go-tools/issues/635
+			return nil
+		}
+		// Wait for admin change to take effect
+		require.NoError(tb, backoff.Retry(func() error {
+			getBindingsResp, err = adminClient.GetClusterRoleBindings(adminClient.Ctx(),
+				&auth.GetClusterRoleBindingsRequest{})
+			_, hasAdmin := getBindingsResp.Bindings[AdminUser]
+			hasExpectedAdmin := len(getBindingsResp.Bindings) == 1 && hasAdmin
+			if !hasExpectedAdmin {
+				return errors.Errorf("cluster admins haven't yet updated")
+			}
+			return nil
+		}, backoff.NewTestingBackOff()))
+	}
+
+	return getPachClientInternal(tb, subject)
+}
+
+// DeleteAll deletes all data in the cluster. This includes deleting all auth
+// tokens, so all pachyderm clients must be recreated after calling deleteAll()
+// (it should generally be called at the beginning or end of tests, before any
+// clients have been created or after they're done being used).
+func DeleteAll(tb testing.TB) {
+	tb.Helper()
+	var anonClient *client.APIClient
+	var useAdminClient bool
+	func() {
+		tokenMapMut.Lock() // May initialize the seed client
+		defer tokenMapMut.Unlock()
+
+		if seedClient == nil {
+			initSeedClient(tb)
+		}
+		anonClient = seedClient.WithCtx(context.Background())
+
+		// config might be nil if this is
+		// called after a test that changed
+		// the config
+		useAdminClient = isAuthActive(tb, false)
+	}() // release tokenMapMut before getPachClient
+	if useAdminClient {
+		adminClient := getPachClientConfigAgnostic(tb, AdminUser)
+		require.NoError(tb, adminClient.DeleteAll(), "initial DeleteAll()")
+	} else {
+		require.NoError(tb, anonClient.DeleteAll())
+	}
+}


### PR DESCRIPTION
The `src/server/auth/server/testing` package has methods to manage activating auth, minting auth tokens for arbitrary users, and resetting the cluster to a pristine state. These are potentially useful when integration testing any module that interacts with the auth system.

This PR refactors those methods into the testutils package. I've made a few comments inline where the change is more than just moving the method between modules.