### PR TITLE
Backport disabling grpc service config lookup to 1.11.x

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -612,6 +612,12 @@ func (c *APIClient) connect(timeout time.Duration) error {
 	if !strings.HasPrefix(addr, "dns:///") {
 		addr = "dns:///" + c.addr
 	}
+
+	// TODO: the 'dns:///' prefix above causes connecting to hang on windows
+	// unless we also prevent the resolver from fetching a service config (which
+	// we don't use anyway).  Don't ask me why.
+	dialOptions = append(dialOptions, grpc.WithDisableServiceConfig())
+
 	clientConn, err := grpc.DialContext(ctx, addr, dialOptions...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport this fix to 1.11.x, it affects any users who have poorly-configured DNS servers (https://github.com/pachyderm/pachyderm/issues/5458)