### PR TITLE
Use consistent cluster id when launching dev cluster with a VSCode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "launch-dev",
       "type": "shell",
-      "command": "eval $(minikube docker-env --shell bash); make launch-dev",
+      "command": "eval $(minikube docker-env --shell bash); LAUNCH_DEV_ARGS='--cluster-deployment-id=dev' make launch-dev",
       "problemMatcher": []
     },
     {


### PR DESCRIPTION
Provide a consistent `--cluster-deployment-id` flag (`=dev`) when launching a cluster to prevent pachctl from freaking out about the wrong ID.

Could have put this in the `Makefile`, but it might break people's existing dev environments - this is how the VSCode task used to work until it was changed to use the `Makefile` in #5487.