### PR TITLE
Don't use bash double-bracket conditional in the Makefile because it doesn't work in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ check-kubectl:
 		echo "error: kubectl not found"; \
 		exit 1; \
 	}
-	@if [[ $(shell kubectl config current-context) == *gke_pachub* ]]; then \
+	@if expr match $(shell kubectl config current-context) gke_pachub > /dev/null; then \
 		echo "ERROR: The active kubectl context is pointing to a pachub GKE cluster"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
CI logged this error:
```
Dec 04 18:12:22 /bin/sh: 1: [[: not found
```

This appears to be because the shell used by `make` doesn't support double-bracket conditional syntax, so change it to use a different command.  The error itself is more noise than anything else, as the conditional is only there to prevent accidentally deploying pachyderm to the wrong kubernetes cluster which has no reason to even be configured on a CI machine, and it doesn't appear to be blocking anything.