### PR TITLE
Revert golden manifests on master back to 1.12

### DIFF
--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -1077,7 +1077,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.48",
+            "image": "pachyderm/dash:0.5.57",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -507,7 +507,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.0-rc1",
+            "image": "pachyderm/pachd:1.12.0",
             "command": [
               "/pachd"
             ],
@@ -568,14 +568,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.0-rc1"
+                "value": "pachyderm/worker:1.12.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.0-rc1"
+                "value": "pachyderm/pachd:1.12.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -587,7 +587,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.0-rc1"
+                "value": "1.12.0"
               },
               {
                 "name": "METRICS",
@@ -1077,7 +1077,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.57",
+            "image": "pachyderm/dash:0.5.48",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -689,7 +689,7 @@ spec:
       namespace: default
     spec:
       containers:
-      - image: pachyderm/dash:0.5.48
+      - image: pachyderm/dash:0.5.57
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -358,16 +358,16 @@ spec:
           value: AMAZON
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.0-rc1
+          value: pachyderm/worker:1.12.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.0-rc1
+          value: pachyderm/pachd:1.12.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.0-rc1
+          value: 1.12.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -589,7 +589,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.0-rc1
+        image: pachyderm/pachd:1.12.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -689,7 +689,7 @@ spec:
       namespace: default
     spec:
       containers:
-      - image: pachyderm/dash:0.5.57
+      - image: pachyderm/dash:0.5.48
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -490,7 +490,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.0-rc1",
+            "image": "pachyderm/pachd:1.12.0",
             "command": [
               "/pachd"
             ],
@@ -551,14 +551,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.0-rc1"
+                "value": "pachyderm/worker:1.12.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.0-rc1"
+                "value": "pachyderm/pachd:1.12.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -570,7 +570,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.0-rc1"
+                "value": "1.12.0"
               },
               {
                 "name": "METRICS",
@@ -1060,7 +1060,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.57",
+            "image": "pachyderm/dash:0.5.48",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -1060,7 +1060,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.48",
+            "image": "pachyderm/dash:0.5.57",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -676,7 +676,7 @@ spec:
       namespace: pachyderm
     spec:
       containers:
-      - image: pachyderm/dash:0.5.48
+      - image: pachyderm/dash:0.5.57
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -345,16 +345,16 @@ spec:
           value: AMAZON
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.0-rc1
+          value: pachyderm/worker:1.12.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.0-rc1
+          value: pachyderm/pachd:1.12.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.0-rc1
+          value: 1.12.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -576,7 +576,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.0-rc1
+        image: pachyderm/pachd:1.12.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -676,7 +676,7 @@ spec:
       namespace: pachyderm
     spec:
       containers:
-      - image: pachyderm/dash:0.5.57
+      - image: pachyderm/dash:0.5.48
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -1077,7 +1077,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.48",
+            "image": "pachyderm/dash:0.5.57",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -507,7 +507,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.0-rc1",
+            "image": "pachyderm/pachd:1.12.0",
             "command": [
               "/pachd"
             ],
@@ -568,14 +568,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.0-rc1"
+                "value": "pachyderm/worker:1.12.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.0-rc1"
+                "value": "pachyderm/pachd:1.12.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -587,7 +587,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.0-rc1"
+                "value": "1.12.0"
               },
               {
                 "name": "METRICS",
@@ -1077,7 +1077,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.57",
+            "image": "pachyderm/dash:0.5.48",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -689,7 +689,7 @@ spec:
       namespace: default
     spec:
       containers:
-      - image: pachyderm/dash:0.5.48
+      - image: pachyderm/dash:0.5.57
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -358,16 +358,16 @@ spec:
           value: GOOGLE
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.0-rc1
+          value: pachyderm/worker:1.12.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.0-rc1
+          value: pachyderm/pachd:1.12.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.0-rc1
+          value: 1.12.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -589,7 +589,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.0-rc1
+        image: pachyderm/pachd:1.12.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -689,7 +689,7 @@ spec:
       namespace: default
     spec:
       containers:
-      - image: pachyderm/dash:0.5.57
+      - image: pachyderm/dash:0.5.48
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -487,7 +487,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.0-rc1",
+            "image": "pachyderm/pachd:1.12.0",
             "command": [
               "/pachd"
             ],
@@ -548,14 +548,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.0-rc1"
+                "value": "pachyderm/worker:1.12.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.0-rc1"
+                "value": "pachyderm/pachd:1.12.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -567,7 +567,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.0-rc1"
+                "value": "1.12.0"
               },
               {
                 "name": "METRICS",
@@ -1057,7 +1057,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.57",
+            "image": "pachyderm/dash:0.5.48",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -1057,7 +1057,7 @@
         "containers": [
           {
             "name": "dash",
-            "image": "pachyderm/dash:0.5.48",
+            "image": "pachyderm/dash:0.5.57",
             "ports": [
               {
                 "name": "dash-http",

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -343,16 +343,16 @@ spec:
           value: MICROSOFT
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.0-rc1
+          value: pachyderm/worker:1.12.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.0-rc1
+          value: pachyderm/pachd:1.12.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.0-rc1
+          value: 1.12.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -574,7 +574,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.0-rc1
+        image: pachyderm/pachd:1.12.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -674,7 +674,7 @@ spec:
       namespace: default
     spec:
       containers:
-      - image: pachyderm/dash:0.5.57
+      - image: pachyderm/dash:0.5.48
         imagePullPolicy: IfNotPresent
         name: dash
         ports:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -674,7 +674,7 @@ spec:
       namespace: default
     spec:
       containers:
-      - image: pachyderm/dash:0.5.48
+      - image: pachyderm/dash:0.5.57
         imagePullPolicy: IfNotPresent
         name: dash
         ports:


### PR DESCRIPTION
Tests are failing on master because the AdditionalVersion isn't set to -rc1 in typical master builds. This was a mistake committed when releasing rc1.