### PR TITLE
Altered pachctl diff file command help text - 

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1161,14 +1161,14 @@ $ {{alias}} "foo@master:data/*"`,
 	var diffCmdArg string
 	diffFile := &cobra.Command{
 		Use:   "{{alias}} <new-repo>@<new-branch-or-commit>:<new-path> [<old-repo>@<old-branch-or-commit>:<old-path>]",
-		Short: "Return a diff of two file trees.",
-		Long:  "Return a diff of two file trees.",
+		Short: "Return a diff of two file trees in input repo. Diff of file trees in output repo coming soon.",
+		Long:  "Return a diff of two file trees in input repo. Diff of file trees in output repo coming soon.",
 		Example: `
-# Return the diff of the file "path" of the repo "foo" between the head of the
+# Return the diff of the file "path" of the input repo "foo" between the head of the
 # "master" branch and its parent.
 $ {{alias}} foo@master:path
 
-# Return the diff between the master branches of repos foo and bar at paths
+# Return the diff between the master branches of input repos foo and bar at paths
 # path1 and path2, respectively.
 $ {{alias}} foo@master:path1 bar@master:path2`,
 		Run: cmdutil.RunBoundedArgs(1, 2, func(args []string) error {


### PR DESCRIPTION
Altered pachctl diff file command help text  -
Warns users about the unavailability of the functionality for output repo -> See issue #3685