### PR TITLE
Document how to enable groups support in OIDC [ci skip]

### DIFF
--- a/doc/docs/master/enterprise/auth/auth-config.md
+++ b/doc/docs/master/enterprise/auth/auth-config.md
@@ -75,5 +75,6 @@ authentication file:
  | `client_id`      | The Pachyderm ID configured in the IdP. For example, <br> `pachyderm`.
  | `client_secret`  | A shared secret with the ID provider. If your OIDC provider <br> does not use a secret, which is not recommended, the <br> parameter can be omitted for testing. |
  | `redirect_uri`   | The URI on which the OIDC IdP can access Pachyderm. <br> Depends on your network configuration and must have the following <br> format: `http://<ip>:30657/authorization-code/callback`. |
+ | `additional_scopes`| A list of additional OIDC scopes to request from the provider. If `groups` is requested, the groups in the ID token will be synced with pachyderm |
 
 [View a sample config](../oidc/configure-keycloak/#configure-keycloak)

--- a/doc/docs/master/enterprise/auth/auth-config.md
+++ b/doc/docs/master/enterprise/auth/auth-config.md
@@ -55,7 +55,7 @@ authentication file:
 | `group_attribute` | A group configured on the IdP. The parameters enable <br> you to grant permissions on at a group level rather <br> than on an individual level. |
 | `saml_svc_options` | A list of options for SAML services |
 | `acs_url`          | The URL of the `pachd`'s Assertion Consumer Service <br> and Metadata Service (ACS). If Pachyderm runs in a <br> private cluster, the cluster admin must set up <br> the domain name and proxy to resolve to <br> `pachd:654/acs`. For example, <br> `http://localhost:30654/saml/acs`. |
-| `meatadata_url`    | The public URL of Pachd's SAML metadata service. <br> This parameter under the `saml_svc_options` is <br> different from the one under the `saml` option. <br> If Pachyderm runs in a private cluster, you must <br> create this URL, which resolves to <br> `pachd:654/saml/metadata`. For example, <br>`http://localhost:30654/saml/metadata`. |
+| `metadata_url`    | The public URL of Pachd's SAML metadata service. <br> This parameter under the `saml_svc_options` is <br> different from the one under the `saml` option. <br> If Pachyderm runs in a private cluster, you must <br> create this URL, which resolves to <br> `pachd:654/saml/metadata`. For example, <br>`http://localhost:30654/saml/metadata`. |
 | `dash_url`         | The public URL of the Pachyderm dashboard. <br> For example, `https://localhost:30080`. |
 | `session_duration` | The length of a user session in hours (h) or <br> minutes (m). For example, `8h`. If left blank 24 hours session is <br> configured by default. |
 
@@ -76,5 +76,11 @@ authentication file:
  | `client_secret`  | A shared secret with the ID provider. If your OIDC provider <br> does not use a secret, which is not recommended, the <br> parameter can be omitted for testing. |
  | `redirect_uri`   | The URI on which the OIDC IdP can access Pachyderm. <br> Depends on your network configuration and must have the following <br> format: `http://<ip>:30657/authorization-code/callback`. |
  | `additional_scopes`| A list of additional OIDC scopes to request from the provider. If `groups` is requested, the groups in the ID token will be synced with Pachyderm |
+ 
+ ## Groups Support
+
+SAML group membership is synced by setting the `group_attribute` setting in the SAML config.
+
+If an OIDC provider supports the `groups` claim, and that scope is included in `additional_scopes`, their group membership will be synced to Pachyderm on each OIDC login.
 
 [View a sample config](../oidc/configure-keycloak/#configure-keycloak)

--- a/doc/docs/master/enterprise/auth/auth-config.md
+++ b/doc/docs/master/enterprise/auth/auth-config.md
@@ -75,6 +75,6 @@ authentication file:
  | `client_id`      | The Pachyderm ID configured in the IdP. For example, <br> `pachyderm`.
  | `client_secret`  | A shared secret with the ID provider. If your OIDC provider <br> does not use a secret, which is not recommended, the <br> parameter can be omitted for testing. |
  | `redirect_uri`   | The URI on which the OIDC IdP can access Pachyderm. <br> Depends on your network configuration and must have the following <br> format: `http://<ip>:30657/authorization-code/callback`. |
- | `additional_scopes`| A list of additional OIDC scopes to request from the provider. If `groups` is requested, the groups in the ID token will be synced with pachyderm |
+ | `additional_scopes`| A list of additional OIDC scopes to request from the provider. If `groups` is requested, the groups in the ID token will be synced with Pachyderm |
 
 [View a sample config](../oidc/configure-keycloak/#configure-keycloak)

--- a/doc/docs/master/enterprise/auth/auth-config.md
+++ b/doc/docs/master/enterprise/auth/auth-config.md
@@ -76,11 +76,6 @@ authentication file:
  | `client_secret`  | A shared secret with the ID provider. If your OIDC provider <br> does not use a secret, which is not recommended, the <br> parameter can be omitted for testing. |
  | `redirect_uri`   | The URI on which the OIDC IdP can access Pachyderm. <br> Depends on your network configuration and must have the following <br> format: `http://<ip>:30657/authorization-code/callback`. |
  | `additional_scopes`| A list of additional OIDC scopes to request from the provider. If `groups` is requested, the groups in the ID token will be synced with Pachyderm |
- 
- ## Groups Support
 
-SAML group membership is synced by setting the `group_attribute` setting in the SAML config.
-
-If an OIDC provider supports the `groups` claim, and that scope is included in `additional_scopes`, their group membership will be synced to Pachyderm on each OIDC login.
 
 [View a sample config](../oidc/configure-keycloak/#configure-keycloak)

--- a/doc/docs/master/enterprise/auth/manage-users-groups.md
+++ b/doc/docs/master/enterprise/auth/manage-users-groups.md
@@ -9,8 +9,8 @@ which providers support user and group authentication:
 | --------------- | --------------- | --------------- |
 | GitHub          | &#10004;        | X               |
 | Okta (SAML)     | &#10004;        | &#10004;        |
-| Otka (OIDC)     | &#10004;        | X               |
-| Keycloak (OIDC) | &#10004;        | X               |
+| Otka (OIDC)     | &#10004;        | &#10004;        |
+| Keycloak (OIDC) | &#10004;        | &#10004;        |
 | Keycloak (SAML) | &#10004;        | &#10004;        |
 | Google (OIDC)   | &#10004;        | X               | 
 | Auth0 (OIDC)    | &#10004;        | X               |
@@ -93,21 +93,18 @@ To manage user access, complete the following steps:
      github:user1: READER
      ```
 
-## Gonfigure Group Access
+## Configure Group Access
 
 If you have a group of users configured in an identity provider,
 you can grant access to a Pachyderm repository to all users
 in that group.
 
 !!! note
-    Only Okta with SAML currently supports group access.
-
-!!! note
     This functionality is experimental and supported only
     through the command line. The changes will not be
     visible in the UI.
 
-To configure group access, you need to set the `group_attibute` in
+To configure group access for SAML providers, you need to set the `group_attibute` in
 the `id_providers` field of your authentication config:
 
 **Example:**
@@ -121,12 +118,34 @@ the `id_providers` field of your authentication config:
          ...
          "saml": {
            "group_attribute": "memberOf"
-       }
+         }
        }
      ],
    }
    EOF
    ```
+
+To configure groups in OIDC providers, you need to add the `groups` scope to
+`additional_scopes` in your authentication config:
+
+**Example:**
+
+   ```shell
+   pachctl auth set-config <<EOF
+   {
+     ...
+     "id_providers": [
+       {
+         ...
+         "oidc": {
+           "additional_scopes": ["groups"]
+         }
+       }
+     ],
+   }
+   EOF
+   ```
+
 
 !!! note "See also"
     [Configure a SAML User](https://docs.pachyderm.com/latest/enterprise/saml/)


### PR DESCRIPTION
Update the docs to mention the `additional_scopes` field, where users can request the `groups` scope to sync group membership.