### PR TITLE
Deflake dex tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ clean-launch-loki:
 	helm uninstall loki
 
 launch-dex:
-	helm repo add --force-update stable https://charts.helm.sh/stable
+	helm repo add stable https://charts.helm.sh/stable
 	helm repo update
 	helm upgrade --install dex stable/dex -f etc/testing/auth/dex.yaml
 	until timeout 1s bash -x ./etc/kube/check_ready.sh 'app.kubernetes.io/name=dex'; do sleep 1; done

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -112,6 +112,7 @@ case "${BUCKET}" in
     fi
     ;;
  AUTH?)
+    make launch-dex
     bucket_num="${BUCKET#AUTH}"
     test_bucket "./src/server/auth/server/testing" test-auth "${bucket_num}" "${AUTH_BUCKETS}"
     ;;

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 
@@ -38,9 +37,6 @@ var OIDCAuthConfig = &auth.AuthConfig{
 // TestOIDCAuthCodeFlow tests that we can configure an OIDC provider and do the
 // auth code flow
 func TestOIDCAuthCodeFlow(t *testing.T) {
-	if os.Getenv("RUN_BAD_TESTS") == "" {
-		t.Skip("Skipping because RUN_BAD_TESTS was empty")
-	}
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -102,9 +98,6 @@ func TestOIDCAuthCodeFlow(t *testing.T) {
 
 // TestOIDCTrustedApp tests using an ID token issued to another OIDC app to authenticate.
 func TestOIDCTrustedApp(t *testing.T) {
-	if os.Getenv("RUN_BAD_TESTS") == "" {
-		t.Skip("Skipping because RUN_BAD_TESTS was empty")
-	}
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}


### PR DESCRIPTION
Install dex on the TestFaster k8s clusters when we're running an auth test bucket.