### PR TITLE
Allow pipeline creation with extant output repo.

### DIFF
--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -435,3 +435,14 @@ func TestMain(m *testing.M) {
 	}, backoff.RetryEvery(time.Second))
 	os.Exit(m.Run())
 }
+
+func TestAuthorizedPipelineBuildLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	tu.BashCmd("yes | pachctl delete all").Run()
+	activateAuth(t)
+	defer deactivateAuth(t)
+
+	tu.TestPipelineBuildLifecycle(t, "go", "go", 4)
+}

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -1581,11 +1581,11 @@ func TestCreatePipelineRepoAlreadyExistsPermissions(t *testing.T) {
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
 
-	// alice gives bob writer scope
+	// alice gives bob writer scope on pipeline output repo
 	aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
 		Username: bob,
 		Scope:    auth.Scope_WRITER,
-		Repo:     inputRepo,
+		Repo:     pipeline,
 	})
 	require.NoError(t, bobClient.CreatePipeline(
 		pipeline,
@@ -3219,19 +3219,6 @@ func TestDebug(t *testing.T) {
 		}
 	}
 	require.Equal(t, 0, len(expectedFiles))
-}
-
-func TestAuthorizedPipelineBuildLifecycle(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-
-	// just for side effects, ensuring auth is active
-	tu.GetAuthenticatedPachClient(t, tu.UniqueString("unused"))
-
-	tu.TestPipelineBuildLifecycle(t, "go", "go", 5)
 }
 
 func collectCommitInfos(t testing.TB, commitInfoIter client.CommitInfoIterator) []*pfs.CommitInfo {

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -1543,10 +1543,11 @@ func TestCreateRepoNotLoggedInError(t *testing.T) {
 	require.Matches(t, "no authentication token", err.Error())
 }
 
-// Creating a pipeline when the output repo already exists gives you an error to
-// that effect, even when auth is already activated (rather than "access
-// denied")
-func TestCreatePipelineRepoAlreadyExistsError(t *testing.T) {
+// Creating a pipeline when the output repo already exists gives is allowed
+// (assuming write permission)
+// this used to return a specific error regardless of permissions, in contrast
+// to the auth-disabled behavior
+func TestCreatePipelineRepoAlreadyExistsPermissions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -1566,8 +1567,7 @@ func TestCreatePipelineRepoAlreadyExistsError(t *testing.T) {
 	pipeline := tu.UniqueString("pipeline")
 	require.NoError(t, aliceClient.CreateRepo(pipeline))
 
-	// bob creates a pipeline, and should get an error to the effect that the
-	// repo already exists (rather than "access denied")
+	// bob creates a pipeline, and should get an "access denied" error
 	err := bobClient.CreatePipeline(
 		pipeline,
 		"", // default image: ubuntu:16.04
@@ -1579,7 +1579,24 @@ func TestCreatePipelineRepoAlreadyExistsError(t *testing.T) {
 		false, // Don't update -- we want an error
 	)
 	require.YesError(t, err)
-	require.Matches(t, "cannot overwrite repo", err.Error())
+	require.Matches(t, "not authorized", err.Error())
+
+	// alice gives bob writer scope
+	aliceClient.SetScope(aliceClient.Ctx(), &auth.SetScopeRequest{
+		Username: bob,
+		Scope:    auth.Scope_WRITER,
+		Repo:     inputRepo,
+	})
+	require.NoError(t, bobClient.CreatePipeline(
+		pipeline,
+		"", // default image: ubuntu:16.04
+		[]string{"bash"},
+		[]string{"cp /pfs/*/* /pfs/out/"},
+		&pps.ParallelismSpec{Constant: 1},
+		client.NewPFSInput(inputRepo, "/*"),
+		"",    // default output branch: master
+		false, // Don't update -- we want an error
+	))
 }
 
 // TestAuthorizedNoneRole tests that Authorized(user, repo, NONE) yields 'true',
@@ -3202,6 +3219,19 @@ func TestDebug(t *testing.T) {
 		}
 	}
 	require.Equal(t, 0, len(expectedFiles))
+}
+
+func TestAuthorizedPipelineBuildLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+
+	// just for side effects, ensuring auth is active
+	tu.GetAuthenticatedPachClient(t, tu.UniqueString("unused"))
+
+	tu.TestPipelineBuildLifecycle(t, "go", "go", 5)
 }
 
 func collectCommitInfos(t testing.TB, commitInfoIter client.CommitInfoIterator) []*pfs.CommitInfo {

--- a/src/server/pkg/testutil/build_pipeline.go
+++ b/src/server/pkg/testutil/build_pipeline.go
@@ -1,0 +1,134 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+)
+
+// TestPipelineBuildLifecycle is a parameterizable test for build pipelines,
+// used by both pps cli and auth
+func TestPipelineBuildLifecycle(t *testing.T, lang, dir string, directoryDepth int) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	prefix := strings.Repeat("../", directoryDepth)
+
+	// reset and create some test input
+	require.NoError(t, BashCmd(`
+		yes | pachctl delete all
+		pachctl create repo in
+		pachctl put file -r in@master:/ -f {{.prefix}}etc/testing/pipeline-build/input
+	`, "prefix", prefix).Run())
+
+	// give pipeline a unique name to work around
+	// github.com/kubernetes/kubernetes/issues/82130
+	pipeline := UniqueString("test-pipeline-build")
+	spec := fmt.Sprintf(`
+		{
+		  "pipeline": {
+		    "name": %q
+		  },
+		  "transform": {
+		    "build": {
+		      "language": %q
+		    }
+		  },
+		  "input": {
+		    "pfs": {
+		      "repo": "in",
+		      "glob": "/*"
+		    }
+		  }
+		}
+	`, pipeline, lang)
+
+	// test a barebones pipeline with a build spec and verify results
+	require.NoError(t, BashCmd(`
+		cd {{.prefix}}/etc/testing/pipeline-build/{{.dir}}
+		pachctl create pipeline <<EOF
+		{{.spec}}
+		EOF
+		pachctl flush commit in@master
+		`,
+		"dir", dir,
+		"spec", spec,
+		"prefix", prefix,
+	).Run())
+	require.YesError(t, BashCmd(fmt.Sprintf(`
+		pachctl list pipeline --state failure | match %s
+	`, pipeline)).Run())
+	verifyPipelineBuildOutput(t, pipeline, "0")
+
+	// update the barebones pipeline and verify results
+	require.NoError(t, BashCmd(`
+		cd {{.prefix}}etc/testing/pipeline-build/{{.dir}}
+		pachctl update pipeline <<EOF
+		{{.spec}}
+		EOF
+		pachctl flush commit in@master
+		`,
+		"dir", dir,
+		"spec", spec,
+		"prefix", prefix,
+	).Run())
+	verifyPipelineBuildOutput(t, pipeline, "0")
+
+	// update the pipeline with a custom cmd and verify results
+	spec = fmt.Sprintf(`
+		{
+		  "pipeline": {
+		    "name": %q
+		  },
+		  "transform": {
+		    "cmd": [
+		      "sh",
+		      "/pfs/build/run.sh",
+		      "_"
+		    ],
+		    "build": {
+		      "language": %q,
+		      "path": "."
+		    }
+		  },
+		  "input": {
+		    "pfs": {
+		      "repo": "in",
+		      "glob": "/*"
+		    }
+		  }
+		}
+	`, pipeline, lang)
+
+	require.NoError(t, BashCmd(`
+		cd {{.prefix}}etc/testing/pipeline-build/{{.dir}}
+		pachctl update pipeline --reprocess <<EOF
+		{{.spec}}
+		EOF
+		pachctl flush commit in@master
+		`,
+		"dir", dir,
+		"spec", spec,
+		"prefix", prefix,
+	).Run())
+	verifyPipelineBuildOutput(t, pipeline, "_")
+	return pipeline
+}
+
+func verifyPipelineBuildOutput(t *testing.T, pipeline, prefix string) {
+	t.Helper()
+
+	require.NoError(t, BashCmd(`
+		pachctl flush commit in@master
+		pachctl get file {{.pipeline}}@master:/1.txt | match {{.prefix}}{{.prefix}}{{.prefix}}1
+		pachctl get file {{.pipeline}}@master:/11.txt | match {{.prefix}}{{.prefix}}11
+		pachctl get file {{.pipeline}}@master:/111.txt | match {{.prefix}}111
+		`,
+		"pipeline", pipeline,
+		"prefix", prefix,
+	).Run())
+}

--- a/src/server/pkg/testutil/build_pipeline.go
+++ b/src/server/pkg/testutil/build_pipeline.go
@@ -20,7 +20,6 @@ func TestPipelineBuildLifecycle(t *testing.T, lang, dir string, directoryDepth i
 
 	// reset and create some test input
 	require.NoError(t, BashCmd(`
-		yes | pachctl delete all
 		pachctl create repo in
 		pachctl put file -r in@master:/ -f {{.prefix}}etc/testing/pipeline-build/input
 	`, "prefix", prefix).Run())

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -622,7 +622,7 @@ func TestPipelineBuildLifecyclePython(t *testing.T) {
 	if os.Getenv("RUN_BAD_TESTS") == "" {
 		t.Skip("Skipping because RUN_BAD_TESTS was empty")
 	}
-
+	require.NoError(t, tu.BashCmd("yes | pachctl delete all").Run())
 	pipeline := tu.TestPipelineBuildLifecycle(t, "python", "python", 4)
 
 	// the python example also contains a `.pachignore`, so we can verify it's
@@ -639,6 +639,7 @@ func TestPipelineBuildLifecyclePythonNoDeps(t *testing.T) {
 	if os.Getenv("RUN_BAD_TESTS") == "" {
 		t.Skip("Skipping because RUN_BAD_TESTS was empty")
 	}
+	require.NoError(t, tu.BashCmd("yes | pachctl delete all").Run())
 	tu.TestPipelineBuildLifecycle(t, "python", "python_no_deps", 4)
 }
 
@@ -646,6 +647,7 @@ func TestPipelineBuildLifecycleGo(t *testing.T) {
 	if os.Getenv("RUN_BAD_TESTS") == "" {
 		t.Skip("Skipping because RUN_BAD_TESTS was empty")
 	}
+	require.NoError(t, tu.BashCmd("yes | pachctl delete all").Run())
 	tu.TestPipelineBuildLifecycle(t, "go", "go", 4)
 }
 

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -26,7 +26,6 @@ package cmds
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"testing"
 
@@ -624,7 +623,7 @@ func TestPipelineBuildLifecyclePython(t *testing.T) {
 		t.Skip("Skipping because RUN_BAD_TESTS was empty")
 	}
 
-	pipeline := testPipelineBuildLifecycle(t, "python", "python")
+	pipeline := tu.TestPipelineBuildLifecycle(t, "python", "python", 4)
 
 	// the python example also contains a `.pachignore`, so we can verify it's
 	// intended behavior here
@@ -640,132 +639,14 @@ func TestPipelineBuildLifecyclePythonNoDeps(t *testing.T) {
 	if os.Getenv("RUN_BAD_TESTS") == "" {
 		t.Skip("Skipping because RUN_BAD_TESTS was empty")
 	}
-	testPipelineBuildLifecycle(t, "python", "python_no_deps")
+	tu.TestPipelineBuildLifecycle(t, "python", "python_no_deps", 4)
 }
 
 func TestPipelineBuildLifecycleGo(t *testing.T) {
 	if os.Getenv("RUN_BAD_TESTS") == "" {
 		t.Skip("Skipping because RUN_BAD_TESTS was empty")
 	}
-	testPipelineBuildLifecycle(t, "go", "go")
-}
-
-func testPipelineBuildLifecycle(t *testing.T, lang, dir string) string {
-	t.Helper()
-	if testing.Short() {
-		t.Skip("Skipping integration tests in short mode")
-	}
-
-	// reset and create some test input
-	require.NoError(t, tu.BashCmd(`
-		yes | pachctl delete all
-		pachctl create repo in
-		pachctl put file -r in@master:/ -f ../../../../etc/testing/pipeline-build/input
-	`).Run())
-
-	// give pipeline a unique name to work around
-	// github.com/kubernetes/kubernetes/issues/82130
-	pipeline := tu.UniqueString("test-pipeline-build")
-	spec := fmt.Sprintf(`
-		{
-		  "pipeline": {
-		    "name": %q
-		  },
-		  "transform": {
-		    "build": {
-		      "language": %q
-		    }
-		  },
-		  "input": {
-		    "pfs": {
-		      "repo": "in",
-		      "glob": "/*"
-		    }
-		  }
-		}
-	`, pipeline, lang)
-
-	// test a barebones pipeline with a build spec and verify results
-	require.NoError(t, tu.BashCmd(`
-		cd ../../../../etc/testing/pipeline-build/{{.dir}}
-		pachctl create pipeline <<EOF
-		{{.spec}}
-		EOF
-		pachctl flush commit in@master
-		`,
-		"dir", dir,
-		"spec", spec,
-	).Run())
-	require.YesError(t, tu.BashCmd(fmt.Sprintf(`
-		pachctl list pipeline --state failure | match %s
-	`, pipeline)).Run())
-	verifyPipelineBuildOutput(t, pipeline, "0")
-
-	// update the barebones pipeline and verify results
-	require.NoError(t, tu.BashCmd(`
-		cd ../../../../etc/testing/pipeline-build/{{.dir}}
-		pachctl update pipeline <<EOF
-		{{.spec}}
-		EOF
-		pachctl flush commit in@master
-		`,
-		"dir", dir,
-		"spec", spec,
-	).Run())
-	verifyPipelineBuildOutput(t, pipeline, "0")
-
-	// update the pipeline with a custom cmd and verify results
-	spec = fmt.Sprintf(`
-		{
-		  "pipeline": {
-		    "name": %q
-		  },
-		  "transform": {
-		    "cmd": [
-		      "sh",
-		      "/pfs/build/run.sh",
-		      "_"
-		    ],
-		    "build": {
-		      "language": %q,
-		      "path": "."
-		    }
-		  },
-		  "input": {
-		    "pfs": {
-		      "repo": "in",
-		      "glob": "/*"
-		    }
-		  }
-		}
-	`, pipeline, lang)
-
-	require.NoError(t, tu.BashCmd(`
-		cd ../../../../etc/testing/pipeline-build/{{.dir}}
-		pachctl update pipeline --reprocess <<EOF
-		{{.spec}}
-		EOF
-		pachctl flush commit in@master
-		`,
-		"dir", dir,
-		"spec", spec,
-	).Run())
-	verifyPipelineBuildOutput(t, pipeline, "_")
-	return pipeline
-}
-
-func verifyPipelineBuildOutput(t *testing.T, pipeline, prefix string) {
-	t.Helper()
-
-	require.NoError(t, tu.BashCmd(`
-		pachctl flush commit in@master
-		pachctl get file {{.pipeline}}@master:/1.txt | match {{.prefix}}{{.prefix}}{{.prefix}}1
-		pachctl get file {{.pipeline}}@master:/11.txt | match {{.prefix}}{{.prefix}}11
-		pachctl get file {{.pipeline}}@master:/111.txt | match {{.prefix}}111
-		`,
-		"pipeline", pipeline,
-		"prefix", prefix,
-	).Run())
+	tu.TestPipelineBuildLifecycle(t, "go", "go", 4)
 }
 
 func TestMissingPipeline(t *testing.T) {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -500,7 +500,8 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 			if _, err := txnCtx.Pfs().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
 				Repo: &pfs.Repo{Name: output},
 			}); err == nil {
-				return errors.Errorf("cannot overwrite repo \"%s\" with new output repo", output)
+				// the repo already exists, so we need the same permissions as update
+				required = auth.Scope_WRITER
 			} else if !isNotFoundErr(err) {
 				return err
 			}


### PR DESCRIPTION
With auth enabled, this resulted in an error, preventing the creation of
build pipelines.