### PR TITLE
Retry checking admins in auth cmd test

### DIFF
--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -141,9 +141,6 @@ func TestCheckGetSet(t *testing.T) {
 }
 
 func TestAdmins(t *testing.T) {
-	if os.Getenv("RUN_BAD_TESTS") == "" {
-		t.Skip("Skipping because RUN_BAD_TESTS was empty")
-	}
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -172,10 +169,14 @@ func TestAdmins(t *testing.T) {
 	require.NoError(t, tu.BashCmd("echo admin2 | pachctl auth login").Run())
 	require.NoError(t, tu.BashCmd(`
 		pachctl auth modify-admins --add admin --remove admin2
-		pachctl auth list-admins \
+	`).Run())
+	require.NoError(t, backoff.Retry(func() error {
+		return tu.BashCmd(`pachctl auth list-admins \
 			| match -v "admin2" \
 			| match "admin"
-		`).Run())
+		`).Run()
+	}, backoff.NewTestingBackOff()))
+
 }
 
 func TestGetAndUseAuthToken(t *testing.T) {


### PR DESCRIPTION
This test is flaky because we write the updated admins to etcd but we read them back from the cache, which is populated by the watcher. Adds a retry loop with a backoff, which is how we currently handle this issue in other tests.