### PR TITLE
Fix lint in CI

### DIFF
--- a/src/server/pkg/obj/microsoft_client.go
+++ b/src/server/pkg/obj/microsoft_client.go
@@ -163,9 +163,9 @@ func (w *microsoftWriter) writeBlock(block []byte) (retErr error) {
 	w.numBlocks++
 	w.limiter.Acquire()
 
-	//lint:ignore SA6002 []byte is sufficiently pointer-like for our purposes
 	w.eg.Go(func() error {
 		defer w.limiter.Release()
+		//lint:ignore SA6002 []byte is sufficiently pointer-like for our purposes
 		defer bufPool.Put(block[:cap(block)])
 		if err := w.blob.PutBlock(blockID, block, nil); err != nil {
 			w.err = err

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -141,7 +141,6 @@ func (s *sidecarS3G) createK8sServices() {
 				s3gSidecarLockPath,
 				s.pipelineInfo.Pipeline.Name,
 				s.pipelineInfo.Salt))
-		//lint:ignore SA4006 'env' is passed to 'Unlock' below
 		ctx, err := masterLock.Lock(s.pachClient.Ctx())
 		if err != nil {
 			// retry obtaining lock


### PR DESCRIPTION
Maybe a new version of the linter?  A couple breakages: 

```
src\server\pkg\obj\microsoft_client.go:166:2: this linter directive didn't match anything; should it be removed? (staticcheck)
src\server\pkg\obj\microsoft_client.go:169:21: argument should be pointer-like to avoid allocations (SA6002)
src\server\pps\server\s3g_sidecar.go:144:3: this linter directive didn't match anything; should it be removed? (staticcheck)
```