### PR TITLE
Fix incorrect trigger behavior on pipeline update and race condition on triggering with rapid commits

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "launch-dev",
       "type": "shell",
-      "command": "eval $(minikube docker-env --shell bash); LAUNCH_DEV_ARGS='--cluster-deployment-id=dev' make launch-dev",
+      "command": "eval $(minikube docker-env --shell bash); yes | pachctl undeploy; LAUNCH_DEV_ARGS='--cluster-deployment-id=dev' make launch-dev",
       "problemMatcher": []
     },
     {

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -34,7 +34,9 @@ func (d *driver) triggerCommit(
 	}
 	// find which branches this commit is the head of
 	headBranches := make(map[string]bool)
-	headBranches[newHead.Branch.Name] = true
+	if newHead.Branch != nil {
+		headBranches[newHead.Branch.Name] = true
+	}
 	for _, b := range repoInfo.Branches {
 		bi := &pfs.BranchInfo{}
 		if err := branches.Get(b.Name, bi); err != nil {

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -35,6 +35,12 @@ func (d *driver) triggerCommit(
 	// find which branches this commit is the head of
 	headBranches := make(map[string]bool)
 	if newHead.Branch != nil {
+		// If the commit was made as part of a branch, then it _was_ the branch head
+		// at some point in time, although it is not guaranteed to still be the
+		// branch head. This can happen on a downstream pipeline with triggers - the
+		// upstream pipeline may have multiple unfinished commits in its output
+		// branch that will be finished one at a time. Without this code, only
+		// finishing the _last_ commit would have a chance of triggering.
 		headBranches[newHead.Branch.Name] = true
 	}
 	for _, b := range repoInfo.Branches {

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -34,6 +34,7 @@ func (d *driver) triggerCommit(
 	}
 	// find which branches this commit is the head of
 	headBranches := make(map[string]bool)
+	headBranches[newHead.Branch.Name] = true
 	for _, b := range repoInfo.Branches {
 		bi := &pfs.BranchInfo{}
 		if err := branches.Get(b.Name, bi); err != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2607,8 +2607,20 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 			return
 		}
 		if input.Pfs != nil && input.Pfs.Trigger != nil {
+			var prevHead *pfs.Commit
+			_, err := pfsClient.InspectBranch(ctx, &pfs.InspectBranchRequest{
+				Branch: client.NewBranch(input.Pfs.Repo, input.Pfs.Branch),
+			})
+
+			if err != nil && !isNotFoundErr(err) {
+				visitErr = err
+				return
+			} else if err == nil {
+				prevHead = client.NewCommit(input.Pfs.Repo, input.Pfs.Branch)
+			}
 			_, visitErr = pfsClient.CreateBranch(ctx, &pfs.CreateBranchRequest{
 				Branch:  client.NewBranch(input.Pfs.Repo, input.Pfs.Branch),
+				Head:    prevHead,
 				Trigger: input.Pfs.Trigger,
 			})
 		}


### PR DESCRIPTION
Debugged with @PFedak and @jdoliner.  The `TestTrigger` test was broken in a couple ways in PPS and PFS.

First, when updating a pipeline with a trigger, it would not set a new `Head` which would cause the trigger code to reset the trigger condition (as if it were a new branch).

Secondly, when finishing commits, the trigger code would only proceed if the new commit was the head of a branch.  With pipelines, this is actually not guaranteed because there may be several output commits created before the first output commit finishes (and at this point it is no longer the head of its branch).  To avoid this, we always consider a commit to be the head of its branch when running the trigger code within `FinishCommit`.