### PR TITLE
Stop pipelines before fsck in spout tests.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1393,7 +1393,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -1445,7 +1444,6 @@ golang.org/x/tools v0.0.0-20201202200335-bef1c476418a h1:TYqOq/v+Ri5aADpldxXOj6P
 golang.org/x/tools v0.0.0-20201202200335-bef1c476418a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10819,6 +10819,7 @@ func TestSpoutPipe(t *testing.T) {
 			}
 		}
 
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -10955,6 +10956,8 @@ time.Sleep(5)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(commitInfo.Subvenance))
 
+		require.NoError(t, c.StopPipeline(pipeline))
+		require.NoError(t, c.StopPipeline(downstreamPipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11031,6 +11034,7 @@ func TestSpoutPachctl(t *testing.T) {
 		err = c.DeleteCommit(pipeline, "master")
 		require.NoError(t, err)
 
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11120,6 +11124,7 @@ func TestSpoutPachctl(t *testing.T) {
 			require.Equal(t, 1, len(files))
 		}
 
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11219,6 +11224,8 @@ func testSpout(t *testing.T, usePachctl bool) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(commitInfo.Subvenance))
 
+		require.NoError(t, c.StopPipeline(pipeline))
+		require.NoError(t, c.StopPipeline(downstreamPipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11276,6 +11283,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 			}
 			prevLength = fileLength
 		}
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11376,6 +11384,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 				require.Equal(t, provenanceID, provenance.ID)
 			}
 		}
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11482,6 +11491,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 		require.NoError(t, err)
 		require.Equal(t, buf.String(), "foo")
 
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -11690,6 +11700,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 				t.Errorf("line did not have the expected form %v, '%v'", len(line), line)
 			}
 		}
+		require.NoError(t, c.StopPipeline(pipeline))
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {


### PR DESCRIPTION
Fsck doesn't attempt to read consistent pfs state, so any commits made
while it is running will cause missing commit errors.

Fixes #4226, hopefully.