### PR TITLE
Remove ClearPachClientState from testauth

### DIFF
--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -537,8 +537,7 @@ func (c *commitInfoIterator) Next() (*pfs.CommitInfo, error) {
 
 func (c *commitInfoIterator) Close() {
 	c.cancel()
-	// this is completely retarded, but according to this thread it's
-	// necessary for closing a server-side stream from the client side.
+	// It's necessary to drain a server-side stream before closing from the client side.
 	// https://github.com/grpc/grpc-go/issues/188
 	for {
 		if _, err := c.stream.Recv(); err != nil {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -11079,7 +11079,6 @@ func TestSpoutPachctl(t *testing.T) {
 		}
 
 		// now let's authenticate, and make sure the spout fails due to a lack of authorization
-		tu.ClearPachClientState(t)
 		c = tu.GetAuthenticatedPachClient(t, tu.AdminUser)
 		defer tu.DeleteAll(t)
 

--- a/src/server/pkg/collection/collection.go
+++ b/src/server/pkg/collection/collection.go
@@ -45,9 +45,8 @@ type collection struct {
 	// tuned when requests fail so it's stored per collection.
 	limit int64
 	// We need this to figure out the concrete type of the objects
-	// that this collection is storing. It's pretty retarded, but
-	// not sure what else we can do since types in Go are not first-class
-	// objects.
+	// that this collection is storing. Not sure ure what else we can do
+	// since types in Go are not first-class objects.
 	// To be clear, this is only necessary because of `Delete`, where we
 	// need to know the type in order to properly remove secondary indexes.
 	template proto.Message

--- a/src/server/pkg/testutil/auth.go
+++ b/src/server/pkg/testutil/auth.go
@@ -193,12 +193,6 @@ func getPachClientConfigAgnostic(tb testing.TB, subject string) *client.APIClien
 	return getPachClientP(tb, subject, false)
 }
 
-// ClearPachClientState clears the state of the pipeline
-func ClearPachClientState(tb testing.TB) {
-	seedClient = nil
-
-}
-
 // GetAuthenticatedPachClient explicitly checks that the auth config is set to the default,
 // and will fail otherwise.
 func GetAuthenticatedPachClient(tb testing.TB, subject string) *client.APIClient {


### PR DESCRIPTION
`ClearPachClientState` was added but it's not clear what it was doing, the tests pass locally for me without it. 