### PR TITLE
Reference counting for hashtrees in cache

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1365,6 +1365,7 @@ func (d *driver) makeCommit(
 			if err != nil {
 				return nil, err
 			}
+			destroyHashtree(parentTree)
 			defer destroyHashtree(tree)
 			for i, record := range records {
 				if err := d.applyWrite(recordFiles[i], record, tree); err != nil {
@@ -1602,6 +1603,7 @@ func (d *driver) finishCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Com
 		}
 
 		defer func() {
+			destroyHashtree(parentTree)
 			if finishedTree != nil {
 				destroyHashtree(finishedTree)
 			}
@@ -3722,12 +3724,7 @@ func (d *driver) getTreeForFile(pachClient *client.APIClient, file *pfs.File) (h
 			return err
 		}
 		if commitInfo.Finished != nil {
-			t, err := d.getTreeForCommit(txnCtx, file.Commit)
-			if err != nil {
-				return err
-			}
-
-			result, err = t.Copy()
+			result, err = d.getTreeForCommit(txnCtx, file.Commit)
 			return err
 		}
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3727,7 +3727,6 @@ func (d *driver) getTreeForFile(pachClient *client.APIClient, file *pfs.File) (h
 			return err
 		}
 		if commitInfo.Finished != nil {
-			fmt.Printf("Finished commit\n")
 			result, err = d.getTreeForCommit(txnCtx, file.Commit)
 			return err
 		}
@@ -3742,7 +3741,6 @@ func (d *driver) getTreeForFile(pachClient *client.APIClient, file *pfs.File) (h
 		}()
 		result, err = d.getTreeForOpenCommit(txnCtx.Client, file, parentTree)
 
-		fmt.Printf("parent tree %v -> %v\n", parentTree, result)
 		return err
 	})
 	if err != nil {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -3615,6 +3615,7 @@ func (d *driver) copyFile(pachClient *client.APIClient, src *pfs.File, dst *pfs.
 	return nil
 }
 
+// getTreeForCommmit returns a HashTree that should be destroyed after user
 func (d *driver) getTreeForCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Commit) (hashtree.HashTree, error) {
 	if commit == nil || commit.ID == "" {
 		return d.treeCache.GetOrAdd("nil", func() (hashtree.HashTree, error) {
@@ -3735,6 +3736,11 @@ func (d *driver) getTreeForFile(pachClient *client.APIClient, file *pfs.File) (h
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if parentTree != nil {
+				destroyHashtree(parentTree)
+			}
+		}()
 		result, err = d.getTreeForOpenCommit(txnCtx.Client, file, parentTree)
 		return err
 	})

--- a/src/server/pkg/hashtree/cache.go
+++ b/src/server/pkg/hashtree/cache.go
@@ -102,7 +102,16 @@ func (c *Cache) GetOrAdd(key interface{}, generator func() (HashTree, error)) (H
 		if s.err != nil {
 			return nil, s.err
 		} else if value, ok := c.lruCache.Get(key); ok {
-			return castValue(value)
+			db, err := castValue(value)
+			if err != nil {
+				return nil, err
+			}
+
+			// Attempt to get a reference - if the DB is being torn down
+			// this can fail
+			if db.GetRef() {
+				return db, nil
+			}
 		}
 
 		// If we get here, that means the hashtree was evicted between when the

--- a/src/server/pkg/hashtree/cache.go
+++ b/src/server/pkg/hashtree/cache.go
@@ -125,6 +125,7 @@ func (c *Cache) GetOrAdd(key interface{}, generator func() (HashTree, error)) (H
 
 		return nil, err
 	}
+	newValue.GetRef()
 
 	c.lock.Lock()
 	c.lruCache.Add(key, newValue)

--- a/src/server/pkg/hashtree/db.go
+++ b/src/server/pkg/hashtree/db.go
@@ -661,8 +661,9 @@ func (h *dbHashTree) GetRef() bool {
 			if atomic.CompareAndSwapInt64(&h.refs, refs, refs+1) {
 				return true
 			}
+		} else {
+			return false
 		}
-		return false
 	}
 }
 

--- a/src/server/pkg/hashtree/db.go
+++ b/src/server/pkg/hashtree/db.go
@@ -655,10 +655,7 @@ func (h *dbHashTree) Copy() (HashTree, error) {
 // db but fails if the tree is already being deleted.
 func (h *dbHashTree) GetRef() bool {
 	refs := atomic.AddInt64(&h.refs, 1)
-	if refs == -1 {
-		return false
-	}
-	return true
+	return refs != -1
 }
 
 // Destroy decrements the references to db and destroys it

--- a/src/server/pkg/hashtree/interface.go
+++ b/src/server/pkg/hashtree/interface.go
@@ -174,6 +174,9 @@ type HashTree interface {
 	// Deserialize deserializes a HashTree from r, into the receiver of the function.
 	Deserialize(r io.Reader) error
 
+	// GetRef increments the number of references to this tree
+	GetRef() bool
+
 	// Destroy cleans up the on disk structures for the hashtree. Further
 	// operations on the database will error. Blocks for pending txns.
 	Destroy() error


### PR DESCRIPTION
Add reference counting to the hashtree DBs - instead of calling Destroy on trees that aren't in the cache, and depending on eviction to destroy trees in the cache, now we call Destroy on every hashtree in the pfs driver.

- A tree in the cache that isn't being used in the driver, or a tree that is instantiated outside of the cache, has 1 reference. Calling `Destroy` deletes it immediately.
- When a tree is fetched from the cache we increment the references to 2. When the caller is done with the tree they call `Destroy` and decrement the references back to 1. The tree in the cache remains live.
- When a tree is evicted from the cache we call `Destroy`. If the tree is still in use elsewhere, it will remain live until the caller also calls `Destroy`.

This makes both cases safe - whether the tree is closed by caller first, or whether it's evicted from the cache while in use. 