### PR TITLE
Performance improvements for reading output repo metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,13 +84,13 @@ require (
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20201116194326-cc9327a14d48
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
-	golang.org/x/tools v0.0.0-20201202200335-bef1c476418a // indirect
+	golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064 // indirect
 	google.golang.org/api v0.14.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/grpc v1.27.0
@@ -99,7 +99,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/src-d/go-git.v4 v4.12.0
 	helm.sh/helm/v3 v3.1.2
-	honnef.co/go/tools v0.0.1-2020.1.6 // indirect
+	honnef.co/go/tools v0.1.0 // indirect
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/cli-runtime v0.17.4

--- a/go.sum
+++ b/go.sum
@@ -1320,8 +1320,8 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -1440,9 +1440,9 @@ golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200306191617-51e69f71924f/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20201202200335-bef1c476418a h1:TYqOq/v+Ri5aADpldxXOj6PmvcPMOJbLjdALzZDQT2M=
-golang.org/x/tools v0.0.0-20201202200335-bef1c476418a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20200609164405-eb789aa7ce50/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064 h1:BmCFkEH4nJrYcAc2L08yX5RhYGD4j58PTMkEUDkpz2I=
+golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -1551,8 +1551,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
-honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
+honnef.co/go/tools v0.1.0 h1:AWNL1W1i7f0wNZ8VwOKNJ0sliKvOF/adn0EHenfUh+c=
+honnef.co/go/tools v0.1.0/go.mod h1:XtegFAyX/PfluP4921rXU5IkjkqBCDnUq4W8VCIoKvM=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.0.0-20190718183219-b59d8169aab5/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/api v0.0.0-20190813020757-36bff7324fb7/go.mod h1:3Iy+myeAORNCLgjd/Xu9ebwN7Vh59Bw0vh9jhoX+V58=

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -89,7 +89,8 @@ type CommitStream interface {
 type collectionFactory func(string) col.Collection
 
 type driver struct {
-	env *serviceenv.ServiceEnv
+	env       *serviceenv.ServiceEnv
+	objClient obj.Client
 	// etcdClient and prefix write repo and other metadata to etcd
 	etcdClient *etcd.Client
 	txnEnv     *txnenv.TransactionEnv
@@ -130,10 +131,22 @@ func newDriver(
 		return nil, errors.Errorf("cannot initialize driver with nil treeCache")
 	}
 	// Initialize driver
+	objClient, err := obj.NewClientFromSecret(storageRoot)
+	if err != nil {
+		return nil, err
+	}
+	if env.StorageDiskCacheSize > 0 {
+		diskCache, err := obj.NewLocalClient(filepath.Join(os.TempDir(), "pfs-cache", uuid.NewWithoutDashes()))
+		if err != nil {
+			return nil, err
+		}
+		objClient = obj.NewCacheClient(objClient, diskCache, env.StorageDiskCacheSize)
+	}
 	etcdClient := env.GetEtcdClient()
 	d := &driver{
 		env:            env,
 		txnEnv:         txnEnv,
+		objClient:      objClient,
 		etcdClient:     etcdClient,
 		prefix:         etcdPrefix,
 		repos:          pfsdb.Repos(etcdClient, etcdPrefix),

--- a/src/server/pfs/server/driver_unix.go
+++ b/src/server/pfs/server/driver_unix.go
@@ -10,15 +10,10 @@ import (
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
-	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
 )
 
 func (d *driver) downloadTree(pachClient *client.APIClient, object *pfs.Object, prefix string) (r io.ReadCloser, retErr error) {
-	objClient, err := obj.NewClientFromSecret(d.storageRoot)
-	if err != nil {
-		return nil, err
-	}
 	info, err := pachClient.InspectObject(object.Hash)
 	if err != nil {
 		return nil, err
@@ -27,11 +22,11 @@ func (d *driver) downloadTree(pachClient *client.APIClient, object *pfs.Object, 
 	if err != nil {
 		return nil, err
 	}
-	offset, size, err := getTreeRange(pachClient.Ctx(), objClient, path, prefix)
+	offset, size, err := getTreeRange(pachClient.Ctx(), d.objClient, path, prefix)
 	if err != nil {
 		return nil, err
 	}
-	objR, err := objClient.Reader(pachClient.Ctx(), path, offset, size)
+	objR, err := d.objClient.Reader(pachClient.Ctx(), path, offset, size)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pfs/server/driver_windows.go
+++ b/src/server/pfs/server/driver_windows.go
@@ -7,17 +7,12 @@ import (
 
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pfs"
-	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 )
 
 // downloadTree implementation for windows, which doesn't support unlinking a
 // file while it's still open, so here we just pass-through the object reader
 // (which doesn't use an intermediary buffer, so is less performant).
 func (d *driver) downloadTree(pachClient *client.APIClient, object *pfs.Object, prefix string) (io.ReadCloser, error) {
-	objClient, err := obj.NewClientFromSecret(d.storageRoot)
-	if err != nil {
-		return nil, err
-	}
 	info, err := pachClient.InspectObject(object.Hash)
 	if err != nil {
 		return nil, err
@@ -26,9 +21,9 @@ func (d *driver) downloadTree(pachClient *client.APIClient, object *pfs.Object, 
 	if err != nil {
 		return nil, err
 	}
-	offset, size, err := getTreeRange(pachClient.Ctx(), objClient, path, prefix)
+	offset, size, err := getTreeRange(pachClient.Ctx(), d.objClient, path, prefix)
 	if err != nil {
 		return nil, err
 	}
-	return objClient.Reader(pachClient.Ctx(), path, offset, size)
+	return d.objClient.Reader(pachClient.Ctx(), path, offset, size)
 }

--- a/src/server/pkg/obj/cache_client.go
+++ b/src/server/pkg/obj/cache_client.go
@@ -2,6 +2,7 @@ package obj
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -15,9 +16,8 @@ var _ Client = &cacheClient{}
 type cacheClient struct {
 	slow, fast Client
 
-	mu           sync.Mutex
-	cache        *simplelru.LRU
-	populateOnce sync.Once
+	mu    sync.Mutex
+	cache *simplelru.LRU
 }
 
 // NewCacheClient returns slow wrapped in an LRU write-through cache using fast for storing
@@ -40,17 +40,44 @@ func NewCacheClient(slow, fast Client, size int) Client {
 }
 
 func (c *cacheClient) Reader(ctx context.Context, p string, offset, size uint64) (io.ReadCloser, error) {
-	c.doPopulateOnce(ctx)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, exists := c.cache.Get(p); exists {
-		return c.fast.Reader(ctx, p, offset, size)
+	cacheP := cachePath(p, offset, size)
+	if _, exists := c.cache.Get(cacheP); exists {
+		return c.fast.Reader(ctx, cacheP, 0, 0)
 	}
-	if err := Copy(ctx, c.slow, c.fast, p, p); err != nil {
+	if err := copyToCache(ctx, c.slow, c.fast, p, offset, size); err != nil {
 		return nil, err
 	}
-	c.cache.Add(p, struct{}{})
-	return c.fast.Reader(ctx, p, offset, size)
+	c.cache.Add(cacheP, struct{}{})
+	return c.fast.Reader(ctx, cacheP, 0, 0)
+}
+
+func cachePath(p string, offset, size uint64) string {
+	return fmt.Sprintf("%v-%v-%v", p, offset, size)
+}
+
+func copyToCache(ctx context.Context, src, dst Client, p string, offset, size uint64) (retErr error) {
+	rc, err := src.Reader(ctx, p, offset, size)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := rc.Close(); retErr == nil {
+			retErr = err
+		}
+	}()
+	wc, err := dst.Writer(ctx, cachePath(p, offset, size))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := wc.Close(); retErr == nil {
+			retErr = err
+		}
+	}()
+	_, err = io.Copy(wc, rc)
+	return err
 }
 
 func (c *cacheClient) Writer(ctx context.Context, p string) (io.WriteCloser, error) {
@@ -58,10 +85,7 @@ func (c *cacheClient) Writer(ctx context.Context, p string) (io.WriteCloser, err
 }
 
 func (c *cacheClient) Delete(ctx context.Context, p string) error {
-	if err := c.slow.Delete(ctx, p); err != nil {
-		return err
-	}
-	return c.deleteFromCache(ctx, p)
+	return c.slow.Delete(ctx, p)
 }
 
 func (c *cacheClient) Exists(ctx context.Context, p string) bool {
@@ -84,19 +108,6 @@ func (c *cacheClient) IsRetryable(err error) bool {
 	return c.fast.IsRetryable(err) || c.slow.IsRetryable(err)
 }
 
-func (c *cacheClient) deleteFromCache(ctx context.Context, p string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.cache.Contains(p) {
-		return nil
-	}
-	if err := c.fast.Delete(ctx, p); err != nil && !c.fast.IsNotExist(err) {
-		return err
-	}
-	c.cache.Remove(p)
-	return nil
-}
-
 // onEvicted is called by the cache implementation.
 // the gorountine executing onEvicted will have c.mu
 func (c *cacheClient) onEvicted(key, value interface{}) {
@@ -106,21 +117,4 @@ func (c *cacheClient) onEvicted(key, value interface{}) {
 	if err := c.fast.Delete(ctx, p); err != nil && !c.fast.IsNotExist(err) {
 		log.Errorf("could not delete from cache's fast store: %v", err)
 	}
-}
-
-func (c *cacheClient) populate(ctx context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.fast.Walk(ctx, "", func(p string) error {
-		c.cache.Add(p, struct{}{})
-		return nil
-	})
-}
-
-func (c *cacheClient) doPopulateOnce(ctx context.Context) {
-	c.populateOnce.Do(func() {
-		if err := c.populate(ctx); err != nil {
-			log.Warnf("could not populate cache: %v", err)
-		}
-	})
 }

--- a/src/server/pkg/testpachd/real_env.go
+++ b/src/server/pkg/testpachd/real_env.go
@@ -78,6 +78,9 @@ func WithRealEnv(cb func(*RealEnv) error, customConfig ...*serviceenv.PachdFullC
 
 		realEnv.LocalStorageDirectory = path.Join(realEnv.Directory, "localStorage")
 		config.StorageRoot = realEnv.LocalStorageDirectory
+		if err := os.Setenv("STORAGE_BACKEND", "LOCAL"); err != nil {
+			panic(err)
+		}
 		realEnv.PFSBlockServer, err = pfsserver.NewBlockAPIServer(
 			realEnv.LocalStorageDirectory,
 			localBlockServerCacheBytes,

--- a/src/server/pkg/testpachd/real_env.go
+++ b/src/server/pkg/testpachd/real_env.go
@@ -79,7 +79,7 @@ func WithRealEnv(cb func(*RealEnv) error, customConfig ...*serviceenv.PachdFullC
 		realEnv.LocalStorageDirectory = path.Join(realEnv.Directory, "localStorage")
 		config.StorageRoot = realEnv.LocalStorageDirectory
 		if err := os.Setenv("STORAGE_BACKEND", "LOCAL"); err != nil {
-			panic(err)
+			return err
 		}
 		realEnv.PFSBlockServer, err = pfsserver.NewBlockAPIServer(
 			realEnv.LocalStorageDirectory,


### PR DESCRIPTION
This PR contains two performance improvements for reading output repo metadata:
- Setup the object client once during driver setup, rather than once per request (fixes #3315)
- Adds a caching layer above the object storage client (this comes in the form of a cache object storage client). This caching layer is only going to apply to the reading of output repo metadata in the interest of keeping this change simple and because we already have caching that applies to input repo metadata as well as Pachyderm objects. In 2.0, this caching strategy will apply to object storage across the board.