### PR TITLE
Fix postgres deployment manifest on windows using incorrect path separators

### DIFF
--- a/src/server/pkg/deploy/assets/postgres.go
+++ b/src/server/pkg/deploy/assets/postgres.go
@@ -2,7 +2,7 @@ package assets
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/pachyderm/pachyderm/src/server/pkg/dbutil"
 	apps "k8s.io/api/apps/v1"
@@ -68,7 +68,7 @@ func PostgresDeployment(opts *AssetOpts, hostPath string) *apps.Deployment {
 				Name: "postgres-storage",
 				VolumeSource: v1.VolumeSource{
 					HostPath: &v1.HostPathVolumeSource{
-						Path: filepath.Join(hostPath, "postgres"),
+						Path: path.Join(hostPath, "postgres"),
 					},
 				},
 			},


### PR DESCRIPTION
The `assets` package was using `filepath` for the disk path, but the manifest needs to always use unix-like separators rather than whichever OS is running `pachctl deploy`.  Changed to use `path` instead, which is always unix-like.