### PR TITLE
Remove the partial auth activation state

### DIFF
--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -62,10 +62,9 @@ var (
 	// it also needs to be updated in the UI code
 	ErrNotActivated = status.Error(codes.Unimplemented, "the auth service is not activated")
 
-	// ErrPartiallyActivated is returned by the auth API to indicated that it's
-	// in an intermediate state (in this state, users can retry Activate() or
-	// revert with Deactivate(), but not much else)
-	ErrPartiallyActivated = status.Error(codes.Unavailable, "the auth service is only partially activated")
+	// ErrAlreadyActivated is returned by Activate if the Auth service
+	// is already activated.
+	ErrAlreadyActivated = status.Error(codes.Unimplemented, "the auth service is already activated")
 
 	// ErrNotSignedIn indicates that the caller isn't signed in
 	//
@@ -86,6 +85,14 @@ var (
 	ErrExpiredToken = status.Error(codes.Internal, "token expiration is in the past")
 )
 
+// IsErrAlreadyActivated checks if an error is a ErrAlreadyActivated
+func IsErrAlreadyActivated(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), status.Convert(ErrAlreadyActivated).Message())
+}
+
 // IsErrNotActivated checks if an error is a ErrNotActivated
 func IsErrNotActivated(err error) bool {
 	if err == nil {
@@ -94,16 +101,6 @@ func IsErrNotActivated(err error) bool {
 	// TODO(msteffen) This is unstructured because we have no way to propagate
 	// structured errors across GRPC boundaries. Fix
 	return strings.Contains(err.Error(), status.Convert(ErrNotActivated).Message())
-}
-
-// IsErrPartiallyActivated checks if an error is a ErrPartiallyActivated
-func IsErrPartiallyActivated(err error) bool {
-	if err == nil {
-		return false
-	}
-	// TODO(msteffen) This is unstructured because we have no way to propagate
-	// structured errors across GRPC boundaries. Fix
-	return strings.Contains(err.Error(), status.Convert(ErrPartiallyActivated).Message())
 }
 
 // IsErrNotSignedIn returns true if 'err' is a ErrNotSignedIn

--- a/src/client/auth/auth_err_test.go
+++ b/src/client/auth/auth_err_test.go
@@ -19,10 +19,10 @@ func TestIsErrNotActivated(t *testing.T) {
 	require.True(t, IsErrNotActivated(grpcify(ErrNotActivated)))
 }
 
-func TestIsErrPartiallyActivated(t *testing.T) {
-	require.False(t, IsErrPartiallyActivated(nil))
-	require.True(t, IsErrPartiallyActivated(ErrPartiallyActivated))
-	require.True(t, IsErrPartiallyActivated(grpcify(ErrPartiallyActivated)))
+func TestIsErrAlreadyActivated(t *testing.T) {
+	require.False(t, IsErrAlreadyActivated(nil))
+	require.True(t, IsErrAlreadyActivated(ErrAlreadyActivated))
+	require.True(t, IsErrAlreadyActivated(grpcify(ErrAlreadyActivated)))
 }
 
 func TestIsErrNotSignedIn(t *testing.T) {

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -89,7 +89,7 @@ Activate Pachyderm's auth system, and restrict access to existing data to the ro
 			}
 
 			if _, err := c.ActivateAuth(c.Ctx(), &pps.ActivateAuthRequest{}); err != nil {
-				return errors.Wrapf(grpcutil.ScrubGRPC(err), "error configured auth for existing PPS pipelines - run this command again")
+				return errors.Wrapf(grpcutil.ScrubGRPC(err), "error configuring auth for existing PPS pipelines - run `pachctl auth activate` again")
 			}
 			return nil
 		}),

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/config"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
+	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/cmdutil"
 	"github.com/pkg/browser"
 
@@ -69,17 +70,27 @@ Activate Pachyderm's auth system, and restrict access to existing data to the ro
 			resp, err := c.Activate(c.Ctx(), &auth.ActivateRequest{
 				RootToken: strings.TrimSpace(rootToken),
 			})
-			if err != nil {
+			if err != nil && !auth.IsErrAlreadyActivated(err) {
 				return errors.Wrapf(grpcutil.ScrubGRPC(err), "error activating Pachyderm auth")
 			}
 
-			if err := config.WritePachTokenToConfig(resp.PachToken); err != nil {
-				return err
+			// If auth is already activated we won't get back a root token,
+			// retry activating auth in PPS with the currently configured token
+			if !auth.IsErrAlreadyActivated(err) {
+				if err := config.WritePachTokenToConfig(resp.PachToken); err != nil {
+					return err
+				}
+
+				fmt.Println("WARNING: DO NOT LOSE THE AUTH TOKEN BELOW. STORE IT SECURELY FOR THE LIFE OF THE CLUSTER." +
+					"THIS TOKEN WILL ALWAYS HAVE ADMIN ACCESS TO FIX THE CLUSTER CONFIGURATION.")
+				fmt.Printf("Pachyderm root token:\n%s\n", resp.PachToken)
+
+				c.SetAuthToken(resp.PachToken)
 			}
 
-			fmt.Println("WARNING: DO NOT LOSE THE AUTH TOKEN BELOW. STORE IT SECURELY FOR THE LIFE OF THE CLUSTER." +
-				"THIS TOKEN WILL ALWAYS HAVE ADMIN ACCESS TO FIX THE CLUSTER CONFIGURATION.")
-			fmt.Printf("Pachyderm root token:\n%s\n", resp.PachToken)
+			if _, err := c.ActivateAuth(c.Ctx(), &pps.ActivateAuthRequest{}); err != nil {
+				return errors.Wrapf(grpcutil.ScrubGRPC(err), "error configured auth for existing PPS pipelines - run this command again")
+			}
 			return nil
 		}),
 	}
@@ -155,7 +166,7 @@ func LoginCmd() *cobra.Command {
 				resp, authErr = c.Authenticate(
 					c.Ctx(),
 					&auth.AuthenticateRequest{OIDCState: state})
-				if authErr != nil && !auth.IsErrPartiallyActivated(authErr) {
+				if authErr != nil {
 					return errors.Wrapf(grpcutil.ScrubGRPC(authErr),
 						"authorization failed (OIDC state token: %q; Pachyderm logs may "+
 							"contain more information)",
@@ -167,12 +178,7 @@ func LoginCmd() *cobra.Command {
 			}
 
 			// Write new Pachyderm token to config
-			if auth.IsErrPartiallyActivated(authErr) {
-				return errors.Wrapf(authErr, "Pachyderm auth is partially activated "+
-					"(if pachyderm is stuck in this state, you can revert by running "+
-					"'pachctl auth deactivate' or retry by running 'pachctl auth "+
-					"activate' again)")
-			} else if authErr != nil {
+			if authErr != nil {
 				return errors.Wrapf(grpcutil.ScrubGRPC(authErr), "error authenticating with Pachyderm cluster")
 			}
 			return config.WritePachTokenToConfig(resp.PachToken)
@@ -405,11 +411,6 @@ func ModifyAdminsCmd() *cobra.Command {
 				Add:    add,
 				Remove: remove,
 			})
-			if auth.IsErrPartiallyActivated(err) {
-				return errors.Wrapf(err, "Errored, if pachyderm is stuck in this state, you "+
-					"can revert by running 'pachctl auth deactivate' or retry by "+
-					"running 'pachctl auth activate' again")
-			}
 			return grpcutil.ScrubGRPC(err)
 		}),
 	}

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -624,6 +624,10 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 	require.NoError(t, err)
 	rootClient.SetAuthToken(resp.PachToken)
 
+	// activate auth in PPS
+	_, err = rootClient.ActivateAuth(rootClient.Ctx(), &pps.ActivateAuthRequest{})
+	require.NoError(t, err)
+
 	// re-authenticate, as old tokens were deleted
 	aliceClient = tu.GetAuthenticatedPachClient(t, alice)
 

--- a/src/server/pkg/testutil/auth.go
+++ b/src/server/pkg/testutil/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pkg/config"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 )
 
@@ -42,6 +43,12 @@ func ActivateAuth(tb testing.TB) {
 		}
 		return errors.Errorf("auth not active yet")
 	}, backoff.NewTestingBackOff()))
+
+	// Activate auth for PPS
+	client = client.WithCtx(context.Background())
+	client.SetAuthToken(RootToken)
+	_, err = client.ActivateAuth(client.Ctx(), &pps.ActivateAuthRequest{})
+	require.NoError(tb, err)
 }
 
 // GetAuthenticatedPachClient activates auth, if it is not activated, and returns


### PR DESCRIPTION
The `auth.Activate` RPC used to follow this process: 
- enable partial auth, which locks out all users except the PPS token
- iterate over all existing PPS pipelines, set permissions and generate auth tokens for the pipelines by calling `pps.ActivateAuth`
- enable full auth, make the root user an admin and return the root token to the user

The partial auth state was designed to avoid a user rapidly calling `Authenticate` and `CreatePipeline` on a cluster during `pps.ActivateAuth`. If this happened the newly created pipeline would not have an auth token and would fail to start. 

In 2.0 there are no authentication methods configured by default  - a user can't call `Authenticate` until the root user configures auth. This means the cluster is locked from the time `auth.Activate` starts. 

This PR removes the partial activation state and removes the call to `pps.ActivateAuth` from `auth.Activate`. Instead, the user who activates auth on the cluster will get the root token and use that token to call `ActivateAuth`. This has a few benefits:
- simplifies auth checks, since auth state is now binary instead of ternary
- removes latency - previously `auth.Activate` had 2 one second sleep calls to wait for the admin cache to converge
- removes the dependency on PPS from `auth.Activate` - in the standalone Enterprise Server PPS won't be running so this would be unnecessary