### PR TITLE
Fix listfile deadlock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,5 +118,3 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+inc
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0
 
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190718183610-8e956561bbf5
-
-replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -4132,7 +4132,13 @@ func (d *driver) listFile(pachClient *client.APIClient, file *pfs.File, full boo
 
 	// Handle commits that use the old hashtree format.
 	if !provenantOnInput(commitInfo.Provenance) || commitInfo.Tree != nil {
-		tree, err := d.getTreeForFile(pachClient, client.NewFile(file.Commit.Repo.Name, file.Commit.ID, ""))
+		parentTree, err := d.getTreeForFile(pachClient, client.NewFile(file.Commit.Repo.Name, file.Commit.ID, ""))
+		if err != nil {
+			return err
+		}
+		defer destroyHashtree(parentTree)
+
+		tree, err := parentTree.Copy()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The boltdb transaction documentation says:

```
// Transactions should not be dependent on one another. Opening a read
// transaction and a write transaction in the same goroutine can cause the
// writer to deadlock because the database periodically needs to re-mmap itself
// as it grows and it cannot do that while a read transaction is open.
```

They don't say that it's bad to have two read transactions in the same goroutine _and a write transaction in a different goroutine_, but it is:

- the first read transaction acquires a read lock on `mmaplock` - https://github.com/etcd-io/bbolt/blob/master/db.go#L556
- the write transaction, if it needs to remap memory, blocks on acquiring a write lock on `mmaplock` https://github.com/etcd-io/bbolt/blob/master/db.go#L329
- another read transaction, which the first read transaction depends on, also tries to acquire a read lock on `mmaplock`. According to the documentation for RWMutex, this may not succeed while there's a write locker waiting:

> If a goroutine holds a RWMutex for reading and another goroutine might call Lock, no goroutine should expect to be able  to acquire a read lock until the initial read lock is released. In particular, this prohibits recursive read locking. 

This situation arises in `ListFile` because `Glob` opens a view, and then calls `fileHistory`, which calls `inspectFile`, which calls `hashtree.Get`, which attempts to open a second view within the first (`Glob`) view. This creates exactly the recursive read-lock situation on `mmaplock` which is prohibited by the `RWMutex` docs.

The solution in this PR is to make a read-only copy of the database in `ListFile`, so we can safely make recursive calls to `View` without risking a deadlock. I did a quick review and this seemed to be the only place where we make recursive transactions, but if you know of others we should adopt a similar pattern.