### PR TITLE
Reduce the number of test buckets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,7 @@ jobs:
         type: string
 
     environment:
-      PPS_BUCKETS: "6"
-      AUTH_BUCKETS: "2"
+      PPS_BUCKETS: "3"
       GOPROXY: https://proxy.golang.org
       BUCKET: << parameters.bucket >>
       RUN_BAD_TESTS: << pipeline.parameters.run_flaky_tests >>
@@ -97,18 +96,13 @@ workflows:
             parameters:
               bucket:
               - MISC
-              # If you want to update the number of PPS or auth buckets, you'll neet to
-              # update the value of PPS_BUCKETS or AUTH_BUCKETS above
+              # If you want to update the number of PPS buckets, you'll neet to
+              # update the value of PPS_BUCKETS above
               - ADMIN
-              - AUTH1
-              - AUTH2
-              - IDENTITY
+              - AUTH
               - PFS
               - PPS1
               - PPS2
               - PPS3
-              - PPS4
-              - PPS5
-              - PPS6
               - EXAMPLES
               - OBJECT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
         type: string
 
     environment:
-      PPS_BUCKETS: "3"
+      PPS_BUCKETS: "4"
       GOPROXY: https://proxy.golang.org
       BUCKET: << parameters.bucket >>
       RUN_BAD_TESTS: << pipeline.parameters.run_flaky_tests >>

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -112,15 +112,12 @@ case "${BUCKET}" in
       go test -v -count=1 ./src/server/pps/server -timeout 300s
     fi
     ;;
-  AUTH?)
-    bucket_num="${BUCKET#AUTH}"
-    test_bucket "./src/server/auth/server/testing" test-auth "${bucket_num}" "${AUTH_BUCKETS}"
+  AUTH)
+    make test-auth
+    make test-identity
     ;;
   OBJECT)
     make test-object-clients
-    ;;
-  IDENTITY)
-    make test-identity
     ;;
   *)
     echo "Unknown bucket"


### PR DESCRIPTION
We've removed a lot of auth tests, and identity tests run quickly, so combine them into one bucket. Also reduce the PPS buckets, to try and make all buckets complete in about the same amount of time.