### PR TITLE
Make `make lint` faster

### DIFF
--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,7 +18,10 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-go get -u golang.org/x/lint/golint
+if [ -z "$(find "$(which golint)" -mtime -1)" ]; then
+  go get -u golang.org/x/lint/golint
+fi
+
 find "./src" \
   \( -path "*.pb.go" -o -path "*internal/tar*" "${skip_paths[@]}" \) -prune -o -name '*.go' -print \
 | while read -r file; do
@@ -32,7 +35,9 @@ if [[ -n "${files}" ]]; then
     exit 1
 fi
 
-go get honnef.co/go/tools/cmd/staticcheck
+if [ -z "$(find "$(which staticcheck)" -mtime -1)" ]; then
+  go get honnef.co/go/tools/cmd/staticcheck
+fi
 staticcheck "${GIT_REPO_DIR}/..."
 
 # shellcheck disable=SC2046

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,15 +18,14 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-if [ -z "$(find "$(which golint)" -mtime -1)" ]; then
+# Update golint once a day, or if it isn't installed
+if [ -z "$(find "$(command -v golint)" -mtime -1 2>/dev/null)" ]; then
   go get -u golang.org/x/lint/golint
 fi
 
 find "./src" \
-  \( -path "*.pb.go" -o -path "*internal/tar*" "${skip_paths[@]}" \) -prune -o -name '*.go' -print \
-| while read -r file; do
-    golint -set_exit_status "$file";
-done;
+  \( -path "*.pb.go" -o -path "*internal/tar*" "${skip_paths[@]}" \) -prune -o -name '*.go' -print0 \
+| xargs -P32 -n 1 golint -set_exit_status 
 
 files=$(gofmt -l "${GIT_REPO_DIR}/src" || true)
 if [[ -n "${files}" ]]; then
@@ -35,14 +34,13 @@ if [[ -n "${files}" ]]; then
     exit 1
 fi
 
-if [ -z "$(find "$(which staticcheck)" -mtime -1)" ]; then
-  go get honnef.co/go/tools/cmd/staticcheck
+# Update staticcheck once a day, or if it isn't installed
+if [ -z "$(find "$(command -v staticcheck)" -mtime -1 2>/dev/null)" ]; then
+  go get -u honnef.co/go/tools/cmd/staticcheck
 fi
 staticcheck "${GIT_REPO_DIR}/..."
 
 # shellcheck disable=SC2046
 find . \
-  \( -path ./etc/plugin "${skip_paths[@]}" \) -prune -o -name "*.sh" -print \
-| while read -r file; do
-    shellcheck -e SC1091 -e SC2010 -e SC2181 -e SC2004 -e SC2219 "${file}"
-done
+  \( -path ./etc/plugin "${skip_paths[@]}" \) -prune -o -name "*.sh" -print0 \
+| xargs -P 16 shellcheck -e SC1091 -e SC2010 -e SC2181 -e SC2004 -e SC2219


### PR DESCRIPTION
I call `make lint` pretty frequently while iterating on code, and it takes ~15s to run each time. This PR gets it down to 6 seconds, which is still not great but it's almost exclusively spent in `staticcheck`. The big improvement is not calling `go get` for golint and staticcheck if they exist on the path and they're less than a day old, but I also added some xargs parallelism.