### PR TITLE
[ci skip] Add supported release and features doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,7 +311,7 @@ Deprecation notice: Support for S3V2 signatures is deprecated in 1.11.0 and will
 ## 1.8.6
 
 - The semantics of Cron inputs have changed slightly, each tick will now be a separate file unless the `Overwrite` flag is set to true, which will get you the old behavior. The name of the emitted file is now the timestamp that triggered the cron, rather than a static filename. Pipelines that use cron will need to be updated to work in 1.8.6. See [the docs](https://docs-archive.pachyderm.com/en/v1.8.6/reference/pipeline_spec.html#cron-input) for more info. (#3509)
-- 1.8.6 contains alpha support for a new kind of pipeline, spouts, which take no inputs and run continuously outputting (or spouting) data. Documentation and an example of spout usage will be in a future release. (#3531)
+- 1.8.6 contains unstable support for a new kind of pipeline, spouts, which take no inputs and run continuously outputting (or spouting) data. Documentation and an example of spout usage will be in a future release. (#3531)
 - New debug commands have been added to `pachctl` to easily profile running pachyderm clusters. They are `debug-profile` `debug-binary` and `debug-pprof`.  See the docs for these commands for more information. (#3559)
 - The performance of `list-job` has been greatly improved. (#3557)
 - `pachctl undeploy` now asks for confirmation in all cases. (#3535)
@@ -665,7 +665,7 @@ New Features:
 
 ### New features
 
-* Pachyderm now ships with a web UI!  To deploy a new Pachyderm cluster with the UI, use `pachctl deploy <arguments> --dashboard`.  To deploy the UI onto an existing cluster, use `pachctl deploy <arguments> --dashboard-only`.  To access the UI, simply `pachctl port-forward`, then go to `localhost:38080`.  Note that the web UI is currently in alpha; expect bugs and significant changes.   
+* Pachyderm now ships with a web UI!  To deploy a new Pachyderm cluster with the UI, use `pachctl deploy <arguments> --dashboard`.  To deploy the UI onto an existing cluster, use `pachctl deploy <arguments> --dashboard-only`.  To access the UI, simply `pachctl port-forward`, then go to `localhost:38080`.  Note that the web UI is currently unstable; expect bugs and significant changes.   
 * You can now specify the amount of resources (i.e. CPU & memory) used by Pachyderm and etcd.  See `pachctl deploy --help` for details. (#1676)
 * You can now specify the amount of resources (i.e. CPU & memory) used by your pipelines. (#1683)
 

--- a/doc/docs/1.12.x/contributing/supported-releases.md
+++ b/doc/docs/1.12.x/contributing/supported-releases.md
@@ -1,0 +1,106 @@
+# Pachyderm Supported Releases and Features
+
+Pachyderm lists the status for each release and feature, so that you can understand expectations for support and stability.
+ 
+## Supported Releases
+
+Pachyderm supports the latest Generally Available (GA) release and the previous two major and minor GA releases. Releases three or more major and minor versions back are considered End of Life (EOL).
+
+## Release Status by Version
+
+| Version  | Release Status | Support |
+| -------- | -------------- | ------- |
+| 2.0.0    | beta           | No      |
+| 1.12.1   | GA             | Yes     |
+| 1.11.9   | GA             | Yes     |
+| 1.10.5   | GA             | Yes     |
+| < 1.9.11 | EOL            | No      |
+
+## Releases Under Development
+
+A release under development may undergo several pre-release stages before becoming Generally Available (GA). These pre-releases enable the Pachyderm team to do development and testing in partnership with our users before a release is considered ready for a Generally Availability (GA).
+
+`alpha > beta > Release Candidate (RC) > Generally Available (GA)`
+
+## Release Status
+
+### Alpha
+
+`alpha` releases are a pre-release version of a product, intended for development and testing purposes only. `alpha` releases include many bugs and unfinished features, and are only suitable for early technical feedback. `alpha` releases should not be used in a production environment.
+
+### Beta
+
+`beta` releases are a pre-release version of a product, intended for development and testing purposes only, and include a wider range of users than an `alpha` release. `beta` releases should not be used in a production environment.
+
+### Release Candidate (RC)
+
+`Release Candidate` or `RC` releases are a pre-release version of a product, intended for users to prepare for a `GA` release. `RC` releases should not be used in a production environment.
+
+### Generally Available (GA)
+
+`Generally Available` or `GA` releases are considered stable and intended for production usage.
+
+- Contain new features, fixed defects, and patched security vulnerabilities.
+- Support is available from Pachyderm.
+
+### End of Life (EOL)
+
+`End of Life` or `EOL` indicates the release will no longer receive support.
+
+- Documentation will be archived.
+- Release artifacts will remain available. We keep release artifacts on [Github](https://github.com/pachyderm/pachyderm/releases) and [Docker Hub](https://hub.docker.com/u/pachyderm).
+- Support is no longer available for End of Life (EOL) releases. Support can assist with upgrading to a newer version.
+
+## Supported Features
+
+### Stable
+
+`stable` indicates that the Pachyderm team believes the feature is ready for use in a production environment.
+
+- The feature's API is stable and unlikely to change.
+- There are no major defects for the feature.
+- The Pachyderm team believes there is a sufficient amount of testing, including automated tests, community testing, and user production environments.
+- Support is available from Pachyderm.
+
+### Experimental
+
+`experimental` indicates that a feature has not met the Pachyderm team's criteria for production use. Therefore, these features should be used with caution in production environments. `experimental` features are likely to change, have outstanding defects, and/or missing documentation. Users considering using `experimental` features should contact Pachyderm for guidance.
+
+- Production use is not recommended without guidance from Pachyderm.
+- These features may have missing documentation, lack of examples, and lack of content.
+- Support is available from Pachyderm, which may be limited in scope based on our guidance.
+
+### Deprecated
+
+`deprecated` indicates that a feature is no longer developed. Users of deprecated features are encouraged to upgrade or migrate to newer versions or compatible features. `deprecated` features become `End of Life` (EOL) features after 6 months.
+
+- Users continuing to use deprecated features should contact support to migrate to features.
+- Support is available from Pachyderm. 
+
+### End of Life (EOL) Features
+
+`End of Life` or `EOL` indicates that a feature is no longer supported.
+
+- Documentation will be archived.
+- Support is no longer available for End of Life (EOL) features. Support can assist upgrading to a newer version.
+
+## Experimental Features
+
+| Feature           | Version | Date       |
+| ----------------- | --------| ---------- |
+| Build Pipelines   | 1.11.0  | 2019-01-05 |
+| Service Pipelines | 1.9.9   | 2019-11-06 |
+| Git Inputs        | 1.4.0   | 2017-03-27 |
+
+## Deprecated Features
+
+| Feature             | Version | EOL Date   |
+| ------------------- | --------| ---------- |
+| Spouts: Named Pipes | 1.12.0  | 2021-07-05 |
+
+## End of Life (EOL) Features
+
+| Feature           | Version | EOL Date   |
+| ----------------- | --------| ---------- |
+| S3v2 signatures   | 1.12.0  | 2021-01-05 |
+| atom inputs       | 1.9.0   | 2019-06-12 |

--- a/doc/docs/1.12.x/reference/pipeline_spec.md
+++ b/doc/docs/1.12.x/reference/pipeline_spec.md
@@ -842,7 +842,10 @@ you want to join with other data.
 * `input.pfs.lazy` — see the description in [PFS Input](#pfs-input).
 * `input.pfs.empty_files` — see the description in [PFS Input](#pfs-input).
 
-#### Git Input (alpha feature)
+#### Git Input
+
+!!! Warning
+  Git Inputs are an [experimental feature](../contributing/supported-releases#experimental).
 
 Git inputs allow you to pull code from a public git URL and execute that code as part of your pipeline. A pipeline with a Git Input will get triggered (i.e. will see a new input commit and will spawn a job) whenever you commit to your git repository.
 
@@ -928,7 +931,10 @@ exists, the storage space used by the stats cannot be released.
     snapshots of the `/pfs` directory that are the largest stored assets
     do not require extra space.
 
-### Service (alpha feature, optional)
+### Service (optional)
+
+!!! Warning
+  Service Pipelines are an [experimental feature](../contributing/supported-releases#experimental).
 
 `service` specifies that the pipeline should be treated as a long running
 service rather than a data transformation. This means that `transform.cmd` is

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -74,7 +74,6 @@ A release under development may undergo several pre-release stages before becomi
 
 `deprecated` indicates that a feature is no longer developed. Users of deprecated features are encouraged to upgrade or migrate to newer versions or compatible features. `deprecated` features become `End of Life` (EOL) features after 6 months.
 
-- Releases are only provided for critical defects or security vulnerabilities.
 - Users continuing to use deprecated features should contact support to migrate to features.
 - Support is available from Pachyderm. 
 

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -62,9 +62,9 @@ A release under development may undergo several pre-release stages before becomi
 - The Pachyderm team believes there is a sufficient amount of testing, including automated tests, community testing, and user production environments.
 - Support is available from Pachyderm.
 
-### Unstable
+### Experimental
 
-`unstable` indicates that a feature has not met the Pachyderm team's critera for production use. Therefore, these features should be used with caution in production environments. `unstable` features are likely to change, have outstanding defects, and/or missing documentation. Users considering using `unstable` features should contact Pachyderm for guidance.
+`experimental` indicates that a feature has not met the Pachyderm team's criteria for production use. Therefore, these features should be used with caution in production environments. `experimental` features are likely to change, have outstanding defects, and/or missing documentation. Users considering using `experimental` features should contact Pachyderm for guidance.
 
 - Production use is not recommended without guidance from Pachyderm.
 - These features may have missing documentation, lack of examples, and lack of content.
@@ -84,7 +84,7 @@ A release under development may undergo several pre-release stages before becomi
 - Documentation will be archived.
 - Support is no longer available for End of Life (EOL) features. Support can assist upgrading to a newer version.
 
-## Unstable Features
+## Experimental Features
 
 | Feature           | Version | Date       |
 | ----------------- | --------| ---------- |

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -79,7 +79,7 @@ A release under development may undergo several pre-release stages before becomi
 
 ### End of Life (EOL) Features
 
-`End of Life` or `EOL` inidicates that a feature is no longer supported.
+`End of Life` or `EOL` indicates that a feature is no longer supported.
 
 - Documentation will be archived.
 - Support is no longer available for End of Life (EOL) features. Support can assist upgrading to a newer version.

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -1,0 +1,205 @@
+# Pachyderm Supported Releases and Features
+
+Pachyderm lists the status for each release and feature, so that you can understand expectations for support and stability.
+ 
+## Supported Releases
+
+Pachyderm supports the latest Generally Available (GA) release and the previous two major and minor GA releases. Releases three or more major and minor versions back are considered End of Life (EOL).
+
+## Release Status by Version
+
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Version</th>
+<th>Release Status</th>
+<th>Support</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>2.0.0</td>
+<td>beta</td>
+<td>No</td>
+</tr>
+<tr class="even">
+<td>1.12.1</td>
+<td>GA</td>
+<td>Yes</td>
+</tr>
+<tr class="odd">
+<td>1.11.9</td>
+<td>GA</td>
+<td>Yes</td>
+</tr>
+<tr class="even">
+<td>1.10.5</td>
+<td>GA</td>
+<td>Yes</td>
+</tr>
+<tr class="odd">
+<td> < 1.9.11</td>
+<td>EOL</td>
+<td>No</td>
+</tr>
+</tbody>
+</table>
+
+## Releases Under Development
+
+A release under development may undergo several pre-release stages before becoming Generally Available (GA). These pre-releases enable the Pachyderm team to do development and testing in partnership with our users before a release is considered ready for a Generally Availability (GA).
+
+`alpha > beta > Release Candidate (RC) > Generally Available (GA)`
+
+## Release Status
+
+### Alpha
+
+`alpha` releases are a pre-release version of a product, intended for development and testing purposes only. `alpha` releases include many bugs and unfinished features, and are only suitable for early technical feedback. `alpha` releases should not be used in a production environment.
+
+### Beta
+
+`beta` releases are a pre-release version of a product, intended for development and testing purposes only, and include a wider range of users than an `alpha` release. `beta` releases should not be used in a production environment.
+
+### Release Candidate (RC)
+
+`Release Candidate` or `RC` releases are a pre-release version of a product, intended for users to prepare for a `GA` release. `RC` releases should not be used in a production environment.
+
+### Generally Available (GA)
+
+`Generally Available` or `GA` releases are considered stable and intended for production usage.
+
+- Contain new features, fixed defects, and patched security vulnerabilities.
+- Support is available from Pachyderm.
+
+### End of Life (EOL)
+
+`End of Life` or `EOL` indicates the release will no longer receive support.
+
+- Documentation will be archived.
+- Release artifacts will remain available. We keep release artifacts on [Github](https://github.com/pachyderm/pachyderm/releases) and [Docker Hub](https://hub.docker.com/u/pachyderm).
+- Support is no longer available for End of Life (EOL) releases. Support can assist with upgrading to a newer version.
+
+## Supported Features
+
+### Stable
+
+`stable` indicates that the Pachyderm team believes the feature is ready for use in a production environment.
+
+- The feature's API is stable and unlikely to change.
+- There are no major defects for the feature.
+- The Pachyderm team believes there is a sufficient amount of testing, including automated tests, community testing, and user production environments.
+- Support is available from Pachyderm.
+
+### Unstable
+
+`unstable` indicates that a feature has not met the Pachyderm team's critera for production use. Therefore, these features should be used with caution in production environments. `unstable` features are likely to change, have outstanding defects, and/or missing documentation. Users considering using `unstable` features should contact Pachyderm for guidance.
+
+- Production use is not recommended without guidance from Pachyderm.
+- These features may have missing documentation, lack of examples, and lack of content.
+- Support is available from Pachyderm, which may be limited in scope based on our guidance.
+
+### Deprecated
+
+`deprecated` indicates that a feature is no longer developed. Users of deprecated features are encouraged to upgrade or migrate to newer versions or compatible features. `deprecated` features become `End of Life` (EOL) features after 6 months.
+
+- Releases are only provided for critical defects or security vulnerabilities.
+- Users continuing to use deprecated features should contact support to migrate to features.
+- Support is available from Pachyderm. 
+
+### End of Life (EOL) Features
+
+`End of Life` or `EOL` inidicates that a feature is no longer supported.
+
+- Documentation will be archived.
+- Support is no longer available for End of Life (EOL) features. Support can assist upgrading to a newer version.
+
+## Unstable Features
+
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Feature</th>
+<th>Version</th>
+<th>Date</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Build Pipelines</td>
+<td>1.11.0</td>
+<td>2019-01-05</td>
+</tr>
+<tr class="even">
+<td>Service Pipelines</td>
+<td>1.9.9</td>
+<td>2019-11-06</td>
+</tr>
+</tbody>
+</table>
+
+## Deprecated Features
+
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Feature</th>
+<th>Deprecated Version</th>
+<th>EOL Date</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Spouts using named pipes</td>
+<td>1.12.0</td>
+<td>2021-07-05</td>
+</tr>
+</tbody>
+</table>
+
+## End of Life (EOL) Features
+
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Feature</th>
+<th>EOL Version</th>
+<th>EOL Date</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>S3V2 signatures</td>
+<td>1.12.0</td>
+<td>2021-01-05</td>
+</tr>
+<tr class="even">
+<td>atom inputs</td>
+<td>1.9.0</td>
+<td>2019-06-12</td>
+</tr>
+</tbody>
+</table>

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -8,47 +8,13 @@ Pachyderm supports the latest Generally Available (GA) release and the previous 
 
 ## Release Status by Version
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Version</th>
-<th>Release Status</th>
-<th>Support</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>2.0.0</td>
-<td>beta</td>
-<td>No</td>
-</tr>
-<tr class="even">
-<td>1.12.1</td>
-<td>GA</td>
-<td>Yes</td>
-</tr>
-<tr class="odd">
-<td>1.11.9</td>
-<td>GA</td>
-<td>Yes</td>
-</tr>
-<tr class="even">
-<td>1.10.5</td>
-<td>GA</td>
-<td>Yes</td>
-</tr>
-<tr class="odd">
-<td> < 1.9.11</td>
-<td>EOL</td>
-<td>No</td>
-</tr>
-</tbody>
-</table>
+| Version  | Release Status | Support |
+| -------- | -------------- | ------- |
+| 2.0.0    | beta           | No      |
+| 1.12.1   | GA             | Yes     |
+| 1.11.9   | GA             | Yes     |
+| 1.10.5   | GA             | Yes     |
+| < 1.9.11 | EOL            | No      |
 
 ## Releases Under Development
 
@@ -121,90 +87,21 @@ A release under development may undergo several pre-release stages before becomi
 
 ## Unstable Features
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Feature</th>
-<th>Version</th>
-<th>Date</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>Build Pipelines</td>
-<td>1.11.0</td>
-<td>2019-01-05</td>
-</tr>
-<tr class="even">
-<td>Service Pipelines</td>
-<td>1.9.9</td>
-<td>2019-11-06</td>
-</tr>
-<tr class="odd">
-<td>Git Inputs</td>
-<td>1.4.0</td>
-<td>2017-03-27</td>
-</tr>
-</tbody>
-</table>
+| Feature           | Version | Date       |
+| ----------------- | --------| ---------- |
+| Build Pipelines   | 1.11.0  | 2019-01-05 |
+| Service Pipelines | 1.9.9   | 2019-11-06 |
+| Git Inputs        | 1.4.0   | 2017-03-27 |
 
 ## Deprecated Features
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Feature</th>
-<th>Deprecated Version</th>
-<th>EOL Date</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>Spouts using named pipes</td>
-<td>1.12.0</td>
-<td>2021-07-05</td>
-</tr>
-</tbody>
-</table>
+| Feature             | Version | EOL Date   |
+| ------------------- | --------| ---------- |
+| Spouts: Named Pipes | 1.12.0  | 2021-07-05 |
 
 ## End of Life (EOL) Features
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Feature</th>
-<th>EOL Version</th>
-<th>EOL Date</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>S3V2 signatures</td>
-<td>1.12.0</td>
-<td>2021-01-05</td>
-</tr>
-<tr class="even">
-<td>atom inputs</td>
-<td>1.9.0</td>
-<td>2019-06-12</td>
-</tr>
-</tbody>
-</table>
+| Feature           | Version | EOL Date   |
+| ----------------- | --------| ---------- |
+| S3v2 signatures   | 1.12.0  | 2021-01-05 |
+| atom inputs       | 1.9.0   | 2019-06-12 |

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -146,6 +146,11 @@ A release under development may undergo several pre-release stages before becomi
 <td>1.9.9</td>
 <td>2019-11-06</td>
 </tr>
+<tr class="odd">
+<td>Git Inputs</td>
+<td>1.4.0</td>
+<td>2017-03-27</td>
+</tr>
 </tbody>
 </table>
 

--- a/doc/docs/master/reference/pachctl/pachctl_deploy_amazon.md
+++ b/doc/docs/master/reference/pachctl/pachctl_deploy_amazon.md
@@ -17,7 +17,7 @@ pachctl deploy amazon <bucket-name> <region> <disk-size> [flags]
 
 ```
       --block-cache-size string          Size of pachd's in-memory cache for PFS files. Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc).
-      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an alpha feature. No security restrictions have beenapplied to cloudfront, making all data public (obscured but not secured)
+      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an unstable feature. No security restrictions have been applied to cloudfront, making all data public (obscured but not secured)
       --cluster-deployment-id string     Set an ID for the cluster deployment. Defaults to a random value.
   -c, --context string                   Name of the context to add to the pachyderm config. If unspecified, a context name will automatically be derived.
       --create-context --dry-run         Create a context, even with --dry-run.

--- a/doc/docs/master/reference/pachctl/pachctl_deploy_amazon.md
+++ b/doc/docs/master/reference/pachctl/pachctl_deploy_amazon.md
@@ -17,7 +17,7 @@ pachctl deploy amazon <bucket-name> <region> <disk-size> [flags]
 
 ```
       --block-cache-size string          Size of pachd's in-memory cache for PFS files. Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc).
-      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an unstable feature. No security restrictions have been applied to cloudfront, making all data public (obscured but not secured)
+      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an experimental feature. No security restrictions have been applied to cloudfront, making all data public (obscured but not secured)
       --cluster-deployment-id string     Set an ID for the cluster deployment. Defaults to a random value.
   -c, --context string                   Name of the context to add to the pachyderm config. If unspecified, a context name will automatically be derived.
       --create-context --dry-run         Create a context, even with --dry-run.

--- a/doc/docs/master/reference/pachctl/pachctl_deploy_aws.md
+++ b/doc/docs/master/reference/pachctl/pachctl_deploy_aws.md
@@ -17,7 +17,7 @@ pachctl deploy aws <bucket-name> <region> <disk-size> [flags]
 
 ```
       --block-cache-size string          Size of pachd's in-memory cache for PFS files. Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc).
-      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an alpha feature. No security restrictions have beenapplied to cloudfront, making all data public (obscured but not secured)
+      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an unstable feature. No security restrictions have been applied to cloudfront, making all data public (obscured but not secured)
       --cluster-deployment-id string     Set an ID for the cluster deployment. Defaults to a random value.
   -c, --context string                   Name of the context to add to the pachyderm config. If unspecified, a context name will automatically be derived.
       --create-context --dry-run         Create a context, even with --dry-run.

--- a/doc/docs/master/reference/pachctl/pachctl_deploy_aws.md
+++ b/doc/docs/master/reference/pachctl/pachctl_deploy_aws.md
@@ -17,7 +17,7 @@ pachctl deploy aws <bucket-name> <region> <disk-size> [flags]
 
 ```
       --block-cache-size string          Size of pachd's in-memory cache for PFS files. Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc).
-      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an unstable feature. No security restrictions have been applied to cloudfront, making all data public (obscured but not secured)
+      --cloudfront-distribution string   Deploying on AWS with cloudfront is currently an experimental feature. No security restrictions have been applied to cloudfront, making all data public (obscured but not secured)
       --cluster-deployment-id string     Set an ID for the cluster deployment. Defaults to a random value.
   -c, --context string                   Name of the context to add to the pachyderm config. If unspecified, a context name will automatically be derived.
       --create-context --dry-run         Create a context, even with --dry-run.

--- a/doc/docs/master/reference/pipeline_spec.md
+++ b/doc/docs/master/reference/pipeline_spec.md
@@ -842,7 +842,10 @@ you want to join with other data.
 * `input.pfs.lazy` — see the description in [PFS Input](#pfs-input).
 * `input.pfs.empty_files` — see the description in [PFS Input](#pfs-input).
 
-#### Git Input (alpha feature)
+#### Git Input
+
+!!! warning
+  Git Inputs are an [unstable feature](../contributing/supported-releases.md).
 
 Git inputs allow you to pull code from a public git URL and execute that code as part of your pipeline. A pipeline with a Git Input will get triggered (i.e. will see a new input commit and will spawn a job) whenever you commit to your git repository.
 
@@ -928,7 +931,10 @@ exists, the storage space used by the stats cannot be released.
     snapshots of the `/pfs` directory that are the largest stored assets
     do not require extra space.
 
-### Service (alpha feature, optional)
+### Service (optional)
+
+!!! warning
+  Service Pipelines are an [unstable feature](../contributing/supported-releases.md).
 
 `service` specifies that the pipeline should be treated as a long running
 service rather than a data transformation. This means that `transform.cmd` is

--- a/doc/docs/master/reference/pipeline_spec.md
+++ b/doc/docs/master/reference/pipeline_spec.md
@@ -845,7 +845,7 @@ you want to join with other data.
 #### Git Input
 
 !!! warning
-  Git Inputs are an [unstable feature](../contributing/supported-releases.md).
+  Git Inputs are an [experimental feature](../contributing/supported-releases.md).
 
 Git inputs allow you to pull code from a public git URL and execute that code as part of your pipeline. A pipeline with a Git Input will get triggered (i.e. will see a new input commit and will spawn a job) whenever you commit to your git repository.
 
@@ -934,7 +934,7 @@ exists, the storage space used by the stats cannot be released.
 ### Service (optional)
 
 !!! warning
-  Service Pipelines are an [unstable feature](../contributing/supported-releases.md).
+  Service Pipelines are an [experimental feature](../contributing/supported-releases.md).
 
 `service` specifies that the pipeline should be treated as a long running
 service rather than a data transformation. This means that `transform.cmd` is

--- a/doc/docs/master/reference/pipeline_spec.md
+++ b/doc/docs/master/reference/pipeline_spec.md
@@ -844,8 +844,8 @@ you want to join with other data.
 
 #### Git Input
 
-!!! warning
-  Git Inputs are an [experimental feature](../contributing/supported-releases.md).
+!!! Warning
+  Git Inputs are an [experimental feature](../contributing/supported-releases#experimental).
 
 Git inputs allow you to pull code from a public git URL and execute that code as part of your pipeline. A pipeline with a Git Input will get triggered (i.e. will see a new input commit and will spawn a job) whenever you commit to your git repository.
 
@@ -933,8 +933,8 @@ exists, the storage space used by the stats cannot be released.
 
 ### Service (optional)
 
-!!! warning
-  Service Pipelines are an [experimental feature](../contributing/supported-releases.md).
+!!! Warning
+  Service Pipelines are an [experimental feature](../contributing/supported-releases#experimental).
 
 `service` specifies that the pipeline should be treated as a long running
 service rather than a data transformation. This means that `transform.cmd` is

--- a/doc/mkdocs-1.12.x.yml
+++ b/doc/mkdocs-1.12.x.yml
@@ -99,10 +99,11 @@ nav:
         - Welcome: index.md
         - Contributing:
             - Setup for Contributors: contributing/setup.md
-            - Gcloud Cluster Setup: contributing/gcloud-setup.md
             - Repo Layout: contributing/repo-layout.md
+            - Supported releases: contributing/supported-releases.md   
             - Coding Conventions: contributing/coding-conventions.md
             - Documentation Style Guide: contributing/docs-style-guide.md
+            - Gcloud Cluster Setup: contributing/gcloud-setup.md 
             - Developing Pachyderm in Windows with VSCode: contributing/windows.md
     - Getting Started:
         - Overview: getting_started/index.md

--- a/doc/mkdocs-master.yml
+++ b/doc/mkdocs-master.yml
@@ -99,10 +99,11 @@ nav:
         - Welcome: index.md
         - Contributing:
             - Setup for Contributors: contributing/setup.md
-            - Gcloud Cluster Setup: contributing/gcloud-setup.md
             - Repo Layout: contributing/repo-layout.md
+            - Supported releases: contributing/supported-releases.md   
             - Coding Conventions: contributing/coding-conventions.md
             - Documentation Style Guide: contributing/docs-style-guide.md
+            - Gcloud Cluster Setup: contributing/gcloud-setup.md 
             - Developing Pachyderm in Windows with VSCode: contributing/windows.md
     - Getting Started:
         - Overview: getting_started/index.md

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -765,7 +765,7 @@ If <object store backend> is \"s3\", then the arguments are:
 			}
 			if strings.TrimSpace(cloudfrontDistribution) != "" {
 				log.Warningf("you specified a cloudfront distribution; deploying on " +
-					"AWS with cloudfront is currently an unstable feature. No security " +
+					"AWS with cloudfront is currently an experimental feature. No security " +
 					"restrictions have been applied to cloudfront, making all data " +
 					"public (obscured but not secured)\n")
 			}

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -765,7 +765,7 @@ If <object store backend> is \"s3\", then the arguments are:
 			}
 			if strings.TrimSpace(cloudfrontDistribution) != "" {
 				log.Warningf("you specified a cloudfront distribution; deploying on " +
-					"AWS with cloudfront is currently an alpha feature. No security " +
+					"AWS with cloudfront is currently an unstable feature. No security " +
 					"restrictions have been applied to cloudfront, making all data " +
 					"public (obscured but not secured)\n")
 			}


### PR DESCRIPTION
Signed-off-by: echohack <git@echohack.app>

This document covers Pachyderm's expected levels of support for releases and features, and defines the nomenclature for each.

Historically, Pachyderm has used "alpha" and "beta" to refer to both features and releases, and this can cause confusion as the level of support provided, and the expectations for each of these is unknown.

There's a few goals for this document:

1. Establish a standard nomenclature around releases and features.
2. Ensure that there are no collisions in the nomenclature around releases and features.
3. Begin to mark and categorize features where appropriate.
4. Set expectations for support, including when a release or a feature is not supported.
5. Set a level of caution for features that are not production-ready.

Ultimately this document can give users clearer expectations around releases and features going forward.