### PR TITLE
Check if binaries already exist during worker init.

### DIFF
--- a/etc/worker/init.go
+++ b/etc/worker/init.go
@@ -6,6 +6,17 @@ import (
 )
 
 func cp(src, dst string) error {
+	// init containers can be restarted spuriously, so make sure we actually need to copy
+	info, err := os.Stat(dst)
+	if err == nil {
+		// if the file already exists and is executable, assume it's correct
+		if info.Mode() == os.ModePerm {
+			return nil
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
This makes the init container (more) idempotent, in case it gets
restarted.

Fix #5559 