### PR TITLE
Support Pachyderm services with no port

### DIFF
--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -794,13 +794,13 @@ func (a *apiServer) createWorkerSvcAndRc(ctx context.Context, ptr *pps.EtcdPipel
 		}
 	}
 
-	if options.service != nil {
-		var servicePort = []v1.ServicePort{
-			{
-				Port:       options.service.ExternalPort,
-				TargetPort: intstr.FromInt(int(options.service.InternalPort)),
-				Name:       "user-port",
-			},
+	if options.service != nil && options.service.ExternalPort != 0 {
+		var servicePort = []v1.ServicePort{{
+			Port: options.service.ExternalPort,
+			Name: "user-port",
+		}}
+		if options.service.InternalPort != 0 {
+			servicePort[0].TargetPort = intstr.FromInt(int(options.service.InternalPort))
 		}
 		var serviceType = v1.ServiceType(options.service.Type)
 		if serviceType == v1.ServiceTypeNodePort {

--- a/src/server/worker/pipeline/service/service.go
+++ b/src/server/worker/pipeline/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/sync/errgroup"
 
@@ -104,7 +105,11 @@ func Run(driver driver.Driver, logger logs.TaggedLogger) error {
 			}
 
 			if err := eg.Wait(); err != nil {
-				logger.Logf("error running user code: %+v", err)
+				reason := fmt.Sprintf("error running user code: %v", err)
+				if err := driver.UpdateJobState(job.ID, pps.JobState_JOB_FAILURE, reason); err != nil {
+					logger.Logf("error updating job progress: %+v", err)
+				}
+				logger.Logf(reason)
 			}
 
 			// Only want to update this stuff if we were canceled due to a new commit

--- a/src/server/worker/pipeline/service/service.go
+++ b/src/server/worker/pipeline/service/service.go
@@ -105,11 +105,7 @@ func Run(driver driver.Driver, logger logs.TaggedLogger) error {
 			}
 
 			if err := eg.Wait(); err != nil {
-				reason := fmt.Sprintf("error running user code: %v", err)
-				if err := driver.UpdateJobState(job.ID, pps.JobState_JOB_FAILURE, reason); err != nil {
-					logger.Logf("error updating job progress: %+v", err)
-				}
-				logger.Logf(reason)
+				logger.Logf("error running user code: %+v", err)
 			}
 
 			// Only want to update this stuff if we were canceled due to a new commit

--- a/src/server/worker/pipeline/service/service.go
+++ b/src/server/worker/pipeline/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"golang.org/x/sync/errgroup"
 


### PR DESCRIPTION
While services are normally meant for e.g. dashboards, the facts that they
- must have one datum, and
- don't skip datums

make them useful for propagating branch changes to the outside world. Currently our seldon demo requires a complicated `start transaction; create branch ...; update pipeline --reprocess; finish transaction` sequence to roll back to a prior version of a model and deploy it (without `--reprocess`, the deploy pipeline skips the prior model's datum and exits without deploying anything). With this change, the seldon deployment pipeline can be packaged into a service, and then simply running `pachctl create branch model@master model@master~1` does the right thing: consistently redeploy the prior model to seldon.

~Services actually mostly work for this already (if the user code running in a service exits, the job goes into SUCCESS)~ This is a bug in 1.12.x. However, independent of whether the user code exits, a benefit of services is that they can keep the s3 gateway open for the duration of the service. In these cases, it's not necessary to expose a public port, as the data being served is internal: the job's input data via the S3 gateway is going to another k8s pod (Seldon in this example)