### PR TITLE
Fix beginner tutorial warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ clean-launch: check-kubectl install
 	yes | $(GOBIN)/pachctl undeploy
 
 clean-launch-dev: check-kubectl install
-	yes | $(GOBIN)pachctl undeploy
+	yes | $(GOBIN)/pachctl undeploy
 
 full-clean-launch: check-kubectl
 	kubectl $(KUBECTLFLAGS) delete --ignore-not-found job -l suite=pachyderm

--- a/examples/opencv/montage.json
+++ b/examples/opencv/montage.json
@@ -19,7 +19,7 @@
   },
   "transform": {
     "cmd": [ "sh" ],
-    "image": "v4tech/imagemagick",
+    "image": "dpokidov/imagemagick:7.0.10-58",
     "stdin": [ "montage -shadow -background SkyBlue -geometry 300x300+2+2 $(find /pfs -type f | sort) /pfs/out/montage.png" ]
   }
 }


### PR DESCRIPTION
The existing `montage.json` uses the image `v4tech/imagemagick`, with no tag indicated.  This results in a warning:

```
WARNING: please specify a tag for the docker image in your transform.image spec.
For example, change 'python' to 'python:3' or 'bash' to 'bash:5'. This improves
reproducibility of your pipelines.
```

Using the `latest` tag results in a different warning:

```
WARNING: please do not specify the ':latest' tag for the docker image in your
transform.image spec. For example, change 'python:latest' to 'python:3' or
'bash:latest' to 'bash:5'. This improves reproducibility of your
pipelines.
```

The `v4tech/imagemagick` repo has no other tags; also, it has not been updated in four years.

There is an alternate repo `dpokidov/imagemagick`; I tested `dpokidov/imagemagick:7.0.10-58` and it generates (visually) the same montage image with the example data.

This also fixes a typo I noticed in the `Makefile`.