### PR TITLE
Widen retry logic in PPS master.

### DIFF
--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -197,7 +197,7 @@ func (m *ppsMaster) attemptStep(ctx context.Context, e *pipelineEvent) error {
 				return nil
 			}
 		}
-		return errors.Wrapf(err, "could not update resource for pipeline %q: %v", e.pipeline)
+		return errors.Wrapf(err, "could not update resource for pipeline %q", e.pipeline)
 	})
 	// we've given up on the step, check if the error indicated that the pipeline should fail
 	if err != nil && errors.As(err, &stepErr) && stepErr.failPipeline {
@@ -267,7 +267,7 @@ func (m *ppsMaster) deletePipelineResources(pipelineName string) (retErr error) 
 	for _, rc := range rcs.Items {
 		if err := kubeClient.CoreV1().ReplicationControllers(namespace).Delete(rc.Name, opts); err != nil {
 			if !isNotFoundErr(err) {
-				return errors.Wrapf(err, "could not delete RC %q: %v", rc.Name)
+				return errors.Wrapf(err, "could not delete RC %q", rc.Name)
 			}
 		}
 	}

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -22,8 +21,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const maxErrCount = 3 // gives all retried operations ~4.5s total to finish
 
 type rcExpectation byte
 
@@ -95,9 +92,7 @@ func (m *ppsMaster) step(pipeline string, keyVer, keyRev int64) (retErr error) {
 	// Retrieve pipelineInfo from the spec repo
 	op, err := m.newPipelineOp(m.masterClient.WithCtx(opCtx), pipeline)
 	if err != nil {
-		// op is nil, so can't use op.failPipeline
-		return m.a.setPipelineFailure(opCtx, pipeline,
-			fmt.Sprintf("couldn't initialize pipeline op: %v", err))
+		return failPipelineError{fmt.Errorf("couldn't initialize pipeline op: %w", err), false}
 	}
 	// set op.rc
 	// TODO(msteffen) should this fail the pipeline? (currently getRC will restart
@@ -203,7 +198,11 @@ func (op *pipelineOp) run() error {
 		}
 		// deletePipelineResources calls cancelMonitor() and cancelCrashingMonitor()
 		// in addition to deleting the RC, so those calls aren't necessary here.
-		return op.deletePipelineResources()
+		if err := op.deletePipelineResources(); err != nil {
+			log.Errorf("PPS master: error deleting resources for failing pipeline %q: %v", op.name, err)
+		}
+		// don't bother retrying the delete for a failed pipeline
+		return nil
 	case pps.PipelineState_PIPELINE_CRASHING:
 		if !op.rcIsFresh() {
 			return op.restartPipeline("stale RC") // step() will be called again after etcd write
@@ -232,26 +231,18 @@ func (op *pipelineOp) run() error {
 // should be one of the first calls made on 'op', as most other methods (e.g.
 // getRC, though not failPipeline) assume that op.pipelineInfo is set.
 //
-// Like other functions in this file, it takes responsibility for failing op's
-// pipeline if it can't read the pipeline's info, and then returns an error to
-// the caller to indicate that the caller shouldn't continue.
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline
 func (op *pipelineOp) getPipelineInfo() error {
-	var errCount int
-	return backoff.RetryNotify(func() error {
-		return op.m.a.sudo(op.opClient, func(superUserClient *client.APIClient) error {
-			var err error
-			op.pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, op.name, op.ptr)
-			return err
-		})
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		if errCount++; errCount >= maxErrCount {
-			// don't restart PPS master, which might not fix the problem (crashloop)
-			return op.failPipeline(fmt.Sprintf("error retrieving spec for %q after %d attempts: %v",
-				op.name, maxErrCount, err))
-		}
-		log.Errorf("PPS master: error retrieving spec for %q: %v; retrying in %v", op.name, err, d)
-		return nil
+	err := op.m.a.sudo(op.opClient, func(superUserClient *client.APIClient) error {
+		var err error
+		op.pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, op.name, op.ptr)
+		return err
 	})
+	if err != nil {
+		return failPipelineError{fmt.Errorf("error retrieving spec for %q: %v", op.name, err), true}
+	}
+	return nil
 }
 
 // getRC reads the RC associated with 'op's pipeline. op.pipelineInfo must be
@@ -259,10 +250,10 @@ func (op *pipelineOp) getPipelineInfo() error {
 // exist--if set to 'rcExpected', getRC will restart the pipeline if no RC is
 // found after three retries. If set to 'noRCExpected', then getRC will return
 // after the first "not found" error. If set to noExpectation, then getRC will
-// retry the kubeclient.List() RPC, but will no restart the pipeline if no RC is
-// found
+// retry the kubeclient.List() RPC, but will not restart the pipeline if no RC
+// is found
 //
-// Like other functions in this file, it takes responsibility for restarting
+// Unike other functions in this file, it takes responsibility for restarting
 // op's pipeline if it can't read the pipeline's RC (or if the RC is stale or
 // redundant), and then returns an error to the caller to indicate that the
 // caller shouldn't continue with other operations
@@ -384,51 +375,33 @@ func (op *pipelineOp) rcIsFresh() bool {
 // setPipelineState set's op's state in etcd to 'state'. This will trigger an
 // etcd watch event and cause step() to eventually run again.
 //
-// Like other functions in this file, setPipelineState handles its own retries,
-// though if it can't eventually update the pipeline state, it just returns an
-// error (to indicate to the caller that it shouldn't continue with other
-// operations) but doesn't fail the pipeline as the pipeline state is already
-// unsettable.
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline.
+// While failing the pipeline is unlikely to succeed if the state can't be set,
+// this error will be ignored and PPS master will move on.
 func (op *pipelineOp) setPipelineState(state pps.PipelineState, reason string) error {
-	var errCount int
-	return backoff.RetryNotify(func() error {
-		return op.m.a.setPipelineState(op.opClient.Ctx(),
-			op.pipelineInfo.Pipeline.Name, state, reason)
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		if errCount++; errCount >= maxErrCount {
-			return errors.Wrapf(err, "could not set pipeline state for %q to %v"+
-				"(you may need to restart pachd to un-stick the pipeline)", op.name, state)
-		}
-		return nil
-	})
+	if err := op.m.a.setPipelineState(op.opClient.Ctx(),
+		op.pipelineInfo.Pipeline.Name, state, reason); err != nil {
+		return failPipelineError{errors.Wrapf(err, "could not set pipeline state to %v"+
+			"(you may need to restart pachd to un-stick the pipeline)", state), true}
+	}
+	return nil
 }
 
 // createPipelineResources creates the RC and any services for op's pipeline.
 //
-// Like other functions in this file, it takes responsibility for failing op's
-// pipeline if it can't create the resources, and then returns an error to the
-// caller to indicate that the caller shouldn't continue.
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline
 func (op *pipelineOp) createPipelineResources() error {
 	log.Infof("PPS master: creating resources for pipeline %q", op.name)
-	var errCount int
-	return backoff.RetryNotify(func() error {
-		return op.m.a.createWorkerSvcAndRc(op.opClient.Ctx(), op.ptr, op.pipelineInfo)
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		invalidOpts := errors.As(err, &noValidOptionsErr{})
-		errCount++
-		switch {
-		case invalidOpts:
-			// these errors indicate invalid pipelineInfo
-			return op.failPipeline(fmt.Sprintf("could not generate RC options: %v", err))
-		case errCount >= maxErrCount:
-			return op.failPipeline(fmt.Sprintf(
-				"failed to create RC/service after %d attempts: %v", errCount, err))
-		default:
-			log.Errorf("PPS master: error creating resources for pipeline %q: %v; retrying in %v",
-				op.name, err, d)
-			return nil
+	if err := op.m.a.createWorkerSvcAndRc(op.opClient.Ctx(), op.ptr, op.pipelineInfo); err != nil {
+		if errors.As(err, &noValidOptionsErr{}) {
+			// these errors indicate invalid pipelineInfo, don't retry
+			return failPipelineError{fmt.Errorf("could not generate RC options: %v", err), false}
 		}
-	})
+		return failPipelineError{fmt.Errorf("error creating resources: %v", err), true}
+	}
+	return nil
 }
 
 // startPipelineMonitor spawns a monitorPipeline() goro for this pipeline (if
@@ -459,8 +432,8 @@ func (op *pipelineOp) stopCrashingPipelineMonitor() {
 // has created jobs) those will not be updated, but they should be FAILED
 //
 // Unlike other functions in this file, finishPipelineOutputCommits doesn't
-// retry if it encounters an error. Currently. it's only called by step() in the
-// case where op's pipeline is already in FAILURE. If it returns an error in
+// cause retries if it encounters an error. Currently. it's only called by step()
+// in the case where op's pipeline is already in FAILURE. If it returns an error in
 // that case, the pps master will log the error and move on to the next pipeline
 // event. This pipeline's output commits will stay open until another watch
 // event arrives for the pipeline and finishPipelineOutputCommits is retried.
@@ -507,19 +480,14 @@ func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
 
 // deletePipelineResources deletes the RC and services associated with op's
 // pipeline.
-//
-// Unlike other functions in this file, deletePipelineResources doesn't retry.
-// It's called in two places:
-// - step(), if the pipeline is in FAILURE(). In this case, the error will be
-//   logged and the pipeline's resources will be left around until a new etcd
-//   event arrives for the pipeline.
-// - op.restartPipeline(). Because restartPipeline does retry,
-//   deletePipelineResources will be retried a limited number of times and then
-//   the pipeline will be failed. If the pipeline's resources still can't be
-//   deleted, then (per step() above) the error will be logged and the PPS
-//   master will move on
+
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline
 func (op *pipelineOp) deletePipelineResources() error {
-	return op.m.deletePipelineResources(op.name)
+	if err := op.m.deletePipelineResources(op.name); err != nil {
+		return failPipelineError{err, true}
+	}
+	return nil
 }
 
 // updateRC is a helper for {scaleUp,scaleDown}Pipeline. It includes all of the
@@ -528,45 +496,29 @@ func (op *pipelineOp) deletePipelineResources() error {
 // updated is already available to the caller in op.rc, but update() may be
 // called muliple times if the k8s write fails. It may be helpful to think of
 // the rc passed to update() as mutable, while op.rc is immutable.
-//
-// Like other functions in this file, it takes responsibility for
-// failing/restarting op's pipeline if it can't update its RC. If this happens,
-// it will return an error to the caller to indicate that the caller shouldn't
-// continue with further operations
+
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline
 func (op *pipelineOp) updateRC(update func(rc *v1.ReplicationController)) error {
 	kubeClient := op.m.a.env.GetKubeClient()
 	namespace := op.m.a.namespace
 	rc := kubeClient.CoreV1().ReplicationControllers(namespace)
 
-	var errCount int
-	return backoff.RetryNotify(func() error {
-		newRC := *op.rc
-		// Apply op's update to rc
-		update(&newRC)
-		// write updated RC to k8s
-		_, err := rc.Update(&newRC)
-		return err
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		errCount++
-		if strings.Contains(err.Error(), "try again") {
-			// refresh RC--sometimes kubernetes complains that the RC is stale
-			if err := op.getRC(rcExpected); err != nil {
-				return err // getRC will log & restart pipeline--just don't proceed
-			}
-		} else if errCount >= maxErrCount {
-			return op.failPipeline(fmt.Sprintf("failed to update RC after %d attempts: %v",
-				errCount, err))
-		}
-		log.Errorf("PPS master: error updating RC for pipeline %q: %v; retrying in %v", op.name, err, d)
-		return nil
-	})
+	newRC := *op.rc
+	// Apply op's update to rc
+	update(&newRC)
+	// write updated RC to k8s
+	if _, err := rc.Update(&newRC); err != nil {
+		return failPipelineError{fmt.Errorf("error updating RC: %v", err), true}
+	}
+	return nil
 }
 
 // scaleUpPipeline edits the RC associated with op's pipeline & spins up the
 // configured number of workers.
 //
-// Like other functions in this file, it takes responsibility for
-// failing/restarting op's pipeline if it can't update its RC (via updateRC)
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline
 func (op *pipelineOp) scaleUpPipeline() (retErr error) {
 	log.Infof("PPS master: scaling up workers for %q", op.name)
 	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
@@ -599,8 +551,8 @@ func (op *pipelineOp) scaleUpPipeline() (retErr error) {
 // scaleDownPipeline edits the RC associated with op's pipeline & spins down the
 // configured number of workers.
 //
-// Like other functions in this file, it takes responsibility for
-// failing/restarting op's pipeline if it can't update its RC (via updateRC)
+// Like other functions in this file, its errors signal that the whole step
+// should be retried, eventually failing op's pipeline
 func (op *pipelineOp) scaleDownPipeline() (retErr error) {
 	log.Infof("PPS master: scaling down workers for %q", op.name)
 	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
@@ -636,49 +588,22 @@ func (op *pipelineOp) scaleDownPipeline() (retErr error) {
 //   return op.restartPipeline("entered error state")
 // }
 //
-// Like other functions in this file, restartPipeline takes responsibility for
-// retrying and eventually failing op's pipeline if restartPipeline can't
-// restart it.
+// Like other functions in this file, its (wrapped) errors signal that the whole
+// step should be retried, eventually failing op's pipeline
 func (op *pipelineOp) restartPipeline(reason string) error {
-	var errCount int
-	if err := backoff.RetryNotify(func() error {
-		if op.rc != nil && !op.rcIsFresh() {
-			// delete old RC, monitorPipeline goro, and worker service
-			if err := op.deletePipelineResources(); err != nil {
-				return err
-			}
+	if op.rc != nil && !op.rcIsFresh() {
+		// delete old RC, monitorPipeline goro, and worker service
+		if err := op.deletePipelineResources(); err != nil {
+			return fmt.Errorf("error deleting resources for restart: %w", err)
 		}
-		// create up-to-date RC
-		if err := op.createPipelineResources(); err != nil {
-			return err
-		}
-		return op.setPipelineState(pps.PipelineState_PIPELINE_RESTARTING, "")
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		if errCount++; errCount >= maxErrCount {
-			return err
-		}
-		log.Errorf("PPS master: error restarting pipeline %q: %v; retrying in %v", op.name, err, d)
-		return nil
-	}); err != nil {
-		return op.failPipeline(fmt.Sprintf("could not restart after %d attempts: %v", errCount, err))
 	}
-	return errors.Errorf("restarting pipeline %q: %v", op.name, reason)
-}
+	// create up-to-date RC
+	if err := op.createPipelineResources(); err != nil {
+		return fmt.Errorf("error creating resources for restart: %w", err)
+	}
+	if err := op.setPipelineState(pps.PipelineState_PIPELINE_RESTARTING, ""); err != nil {
+		return fmt.Errorf("error restarting pipeline: %w", err)
+	}
 
-// failPipeline fails op's pipeline. failPipeline is an error-handling codepath,
-// so it's guaranteed to return an error (typically wrapping 'reason', though if
-// the restart process fails that error will take precendence) so that callers
-// can use it like so:
-//
-// if errorState {
-//   return op.failPipeline("entered error state")
-// }
-//
-// Like other functions in this file, failPipeline takes responsibility for
-// retrying.
-func (op *pipelineOp) failPipeline(reason string) error {
-	if err := op.m.a.setPipelineFailure(op.opClient.Ctx(), op.name, reason); err != nil {
-		return errors.Wrapf(err, "error failing pipeline %q", op.name)
-	}
-	return errors.Errorf("failing pipeline %q: %v", op.name, reason)
+	return errors.Errorf("restarting pipeline %q: %v", op.name, reason)
 }

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -398,7 +398,7 @@ func (op *pipelineOp) createPipelineResources() error {
 		if errors.As(err, &noValidOptionsErr{}) {
 			// these errors indicate invalid pipelineInfo, don't retry
 			return stepError{
-				error:        errors.Wrap(err, "could not generate RC options: %v"),
+				error:        errors.Wrap(err, "could not generate RC options"),
 				failPipeline: true,
 			}
 		}
@@ -593,5 +593,5 @@ func (op *pipelineOp) restartPipeline(reason string) error {
 		return errors.Wrap(err, "error restarting pipeline")
 	}
 
-	return errors.Errorf("restarting pipeline %q: %v", op.name, reason)
+	return errors.Errorf("restarting pipeline %q: %s", op.name, reason)
 }


### PR DESCRIPTION
In some cases, a "step" operation failing to complete can indicate that
the underlying pipeline state has changed, making the step obsolete.
Instead of myopically retrying the same operation and eventually
failing, retrying the step from the beginning provides more confidence
that PPS master is acting based on up-to-date information.

Fix #5557 