### PR TITLE
Fix error when email_verified is not set in OIDC

### DIFF
--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -319,7 +319,7 @@ func (a *apiServer) validateIDToken(ctx context.Context, rawIDToken string) (*oi
 	}
 
 	if !claims.EmailVerified && !config.IgnoreEmailVerified {
-		return nil, nil, errors.Wrapf(err, "email_verified claim was false")
+		return nil, nil, errors.New("email_verified claim was false, and ignore_email_verified was not set")
 	}
 	return idToken, &claims, nil
 }


### PR DESCRIPTION
`errors.Wrapf` has the annoying property that, if you wrap `nil`, the result is `nil`. In this case if the OIDC provider didn't set the `email_verified` claim, `validateIDToken` would return `(nil, nil, nil)` and callers would get an NPE because `err` was `nil` but no claims were returned.