### PR TITLE
Simplify activating auth on localhost

### DIFF
--- a/dex-assets/static/not-configured.html
+++ b/dex-assets/static/not-configured.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>No identity providers configured</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="/static/main.css" rel="stylesheet">
+    <link href="/theme/styles.css" rel="stylesheet">
+    <link rel="icon" href="/theme/favicon.png">
+  </head>
+
+  <body class="theme-body">
+    <div class="theme-navbar">
+    </div>
+
+    <div class="dex-container">
+      <h2>No identity providers are configured, add one with pachctl idp add-connector</h2>
+    </div>
+  </body>
+</html>

--- a/src/server/identity/server/connector.go
+++ b/src/server/identity/server/connector.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/dexidp/dex/connector"
+	"github.com/dexidp/dex/pkg/log"
+)
+
+var (
+	_ connector.CallbackConnector = &placeholder{}
+)
+
+// placeholder is a fake Dex connector which redirects the user to a static page with instructions.
+// This is necessary because Dex won't start the web server unless a connector is configured.
+type placeholderConfig struct{}
+
+func (placeholderConfig) Open(id string, logger log.Logger) (connector.Connector, error) {
+	return &placeholder{}, nil
+}
+
+type placeholder struct{}
+
+func (*placeholder) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
+	u, err := url.Parse(callbackURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse callbackURL %q: %v", callbackURL, err)
+	}
+	u.Path = "/static/not-configured.html"
+	return u.String(), nil
+}
+
+// HandleCallback parses the request and returns the user's identity
+func (*placeholder) HandleCallback(s connector.Scopes, r *http.Request) (connector.Identity, error) {
+	return connector.Identity{}, fmt.Errorf("no connectors configured")
+}
+
+// Refresh updates the identity during a refresh token request.
+func (*placeholder) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
+	return connector.Identity{}, fmt.Errorf("no connectors configured")
+}


### PR DESCRIPTION
Make `pachctl auth activate`:
- activate auth
- set the issuer in dex to `localhost:30658`
- create a `pachd` client in dex
- configure pachd with the OIDC config for dex

This covers the common case where the user is running pachd in minikube. The only remaining step is for the user to configure the IDP in dex. If the user wants manual control over each step they can call `pachctl auth activate --only activate` to stop after auth is enabled.

The dex web server wouldn't start until a connector was configured. So I also wrote a mock connector that redirects to a static page which just says "no connectors are configured", which is only configured when no other connectors are configured.
