### PR TITLE
Doc - RBAC page macro rendering error fixed + example in TLS page fixed

### DIFF
--- a/doc/docs/1.12.x/deploy-manage/deploy/deploy_w_tls.md
+++ b/doc/docs/1.12.x/deploy-manage/deploy/deploy_w_tls.md
@@ -26,9 +26,8 @@ Pachyderm context with the cluster IP address that starts with `grpcs://`.
 You can do so by running the following command:
 
 !!! example
-    ```shell
-    echo '{"pachd_address": "grpcs://<cluster-ip>:31400"}' | pachctl config
-    pachctl config update context `p config get active-context` --pachd_address "grpcs://<cluster-ip>:31400"
+    ```shell   
+    echo '{"pachd_address": "grpcs://<cluster-ip:30650"}' | pachctl config set context "local-grpcs" --overwrite && pachctl config set active-context "local-grpcs"   
     ```
 
 !!! note "See Also:"

--- a/doc/docs/1.12.x/deploy-manage/deploy/rbac.md
+++ b/doc/docs/1.12.x/deploy-manage/deploy/rbac.md
@@ -1,5 +1,4 @@
 # RBAC
-
 Pachyderm has support for Kubernetes Role-Based Access
 Controls (RBAC), which is a default part of all
 Pachyderm deployments. In most use cases, Pachyderm
@@ -10,22 +9,26 @@ RBAC permissions by default. Therefore, you need to
 contact your Kubernetes administrator and provide the
 following list of required permissions:
 
-```
+{% raw %}
+
+```shell
 Rules: []rbacv1.PolicyRule{{
-	APIGroups: []string{""},
-	Verbs:     []string{"get", "list", "watch"},
-	Resources: []string{"nodes", "pods", "pods/log", "endpoints"},
-}, {
-	APIGroups: []string{""},
-	Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-	Resources: []string{"replicationcontrollers", "services"},
-}, {
-	APIGroups:     []string{""},
-	Verbs:         []string{"get", "list", "watch", "create", "update", "delete"},
-	Resources:     []string{"secrets"},
-	ResourceNames: []string{client.StorageSecretName},
-}},
+		APIGroups: []string{""},
+		Verbs:     []string{"get", "list", "watch"},
+		Resources: []string{"nodes", "pods", "pods/log", "endpoints"},
+		}, {
+		APIGroups: []string{""},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+		Resources: []string{"replicationcontrollers", "services"},
+		}, {
+		APIGroups:     []string{""},
+		Verbs:         []string{"get", "list", "watch", "create", "update", "delete"},
+		Resources:     []string{"secrets"},
+		ResourceNames: []string{client.StorageSecretName},
+		}},
 ```
+
+{% endraw %}
 
 The following table explains how Pachyderm uses those permissions:
 

--- a/doc/docs/master/deploy-manage/deploy/deploy_w_tls.md
+++ b/doc/docs/master/deploy-manage/deploy/deploy_w_tls.md
@@ -26,9 +26,8 @@ Pachyderm context with the cluster IP address that starts with `grpcs://`.
 You can do so by running the following command:
 
 !!! example
-    ```shell
-    echo '{"pachd_address": "grpcs://<cluster-ip>:31400"}' | pachctl config
-    pachctl config update context `p config get active-context` --pachd_address "grpcs://<cluster-ip>:31400"
+    ```shell   
+    echo '{"pachd_address": "grpcs://<cluster-ip:30650"}' | pachctl config set context "local-grpcs" --overwrite && pachctl config set active-context "local-grpcs"   
     ```
 
 !!! note "See Also:"

--- a/doc/docs/master/deploy-manage/deploy/rbac.md
+++ b/doc/docs/master/deploy-manage/deploy/rbac.md
@@ -1,5 +1,4 @@
 # RBAC
-
 Pachyderm has support for Kubernetes Role-Based Access
 Controls (RBAC), which is a default part of all
 Pachyderm deployments. In most use cases, Pachyderm
@@ -10,22 +9,26 @@ RBAC permissions by default. Therefore, you need to
 contact your Kubernetes administrator and provide the
 following list of required permissions:
 
-```
+{% raw %}
+
+```shell
 Rules: []rbacv1.PolicyRule{{
-	APIGroups: []string{""},
-	Verbs:     []string{"get", "list", "watch"},
-	Resources: []string{"nodes", "pods", "pods/log", "endpoints"},
-}, {
-	APIGroups: []string{""},
-	Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-	Resources: []string{"replicationcontrollers", "services"},
-}, {
-	APIGroups:     []string{""},
-	Verbs:         []string{"get", "list", "watch", "create", "update", "delete"},
-	Resources:     []string{"secrets"},
-	ResourceNames: []string{client.StorageSecretName},
-}},
+		APIGroups: []string{""},
+		Verbs:     []string{"get", "list", "watch"},
+		Resources: []string{"nodes", "pods", "pods/log", "endpoints"},
+		}, {
+		APIGroups: []string{""},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+		Resources: []string{"replicationcontrollers", "services"},
+		}, {
+		APIGroups:     []string{""},
+		Verbs:         []string{"get", "list", "watch", "create", "update", "delete"},
+		Resources:     []string{"secrets"},
+		ResourceNames: []string{client.StorageSecretName},
+		}},
 ```
+
+{% endraw %}
 
 The following table explains how Pachyderm uses those permissions:
 


### PR DESCRIPTION
- In Deploy Pachyderm with TLS page, the  `echo '{"pachd_address": "grpcs://<cluster-ip>...` was wrong.

- The configure RBAC page was not rendered (Macro rendering error)