### PR TITLE
Don't early-exit from validate.sh when doing a manual release

### DIFF
--- a/etc/testing/deploy-manifests/validate.sh
+++ b/etc/testing/deploy-manifests/validate.sh
@@ -89,8 +89,8 @@ done
 # XXX: for now, skip diffing because 'ci_build' ends up in the version. Not
 # sure how to workaround that.
 # https://app.circleci.com/pipelines/github/pachyderm/pachyderm/80/workflows/088e1426-b4ce-4baa-85e2-f9a20cc75151/jobs/2934
-if [ -z "$RUN_BAD_TESTS" ]; then
-    echo "Skipping because RUN_BAD_TESTS is empty"
+if [ ! -z "$CIRCLE_BRANCH" ] && [ -z "$RUN_BAD_TESTS" ]; then
+    echo "Skipping because RUN_BAD_TESTS is empty (and we are running in CI)"
     exit 0
 fi
 


### PR DESCRIPTION
Only skip `validate.sh` - when `RUN_BAD_TESTS` is unset - in CI.