### PR TITLE
Split generating pipeline tokens out into a separate internal API

### DIFF
--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -144,6 +144,9 @@ type AuthTransactionServer interface {
 
 	GetAuthTokenInTransaction(*TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error)
 	RevokeAuthTokenInTransaction(*TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
+
+	// GetPipelineAuthTokenInTransaction is an internal API used by PPS to generate tokens for pipelines
+	GetPipelineAuthTokenInTransaction(*TransactionContext, string) (string, error)
 }
 
 // PfsTransactionServer is an interface for the transactionally-supported

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -875,6 +875,10 @@ func (a *apiServer) GetAuthTokenInTransaction(txnCtx *txnenv.TransactionContext,
 // GetPipelineAuthTokenInTransaction is an internal API used to create a pipeline token for a given pipeline.
 // Not an RPC.
 func (a *apiServer) GetPipelineAuthTokenInTransaction(txnCtx *txnenv.TransactionContext, pipeline string) (string, error) {
+	if err := a.isActive(); err != nil {
+		return "", err
+	}
+
 	tokenInfo := auth.TokenInfo{
 		Source:  auth.TokenInfo_GET_TOKEN,
 		Subject: auth.PipelinePrefix + pipeline,

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -872,6 +872,22 @@ func (a *apiServer) GetAuthTokenInTransaction(txnCtx *txnenv.TransactionContext,
 	}, nil
 }
 
+// GetPipelineAuthTokenInTransaction is an internal API used to create a pipeline token for a given pipeline.
+// Not an RPC.
+func (a *apiServer) GetPipelineAuthTokenInTransaction(txnCtx *txnenv.TransactionContext, pipeline string) (string, error) {
+	tokenInfo := auth.TokenInfo{
+		Source:  auth.TokenInfo_GET_TOKEN,
+		Subject: auth.PipelinePrefix + pipeline,
+	}
+
+	// generate new token, and write to etcd
+	token := uuid.NewWithoutDashes()
+	if err := a.tokens.ReadWrite(txnCtx.Stm).PutTTL(auth.HashToken(token), &tokenInfo, -1); err != nil {
+		return "", errors.Wrapf(err, "error storing token")
+	}
+	return token, nil
+}
+
 // GetOIDCLogin implements the protobuf auth.GetOIDCLogin RPC
 func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequest) (resp *auth.GetOIDCLoginResponse, retErr error) {
 	a.LogReq(req)

--- a/src/server/auth/testing/auth.go
+++ b/src/server/auth/testing/auth.go
@@ -79,6 +79,11 @@ func (a *InactiveAPIServer) GetAuthTokenInTransaction(*txnenv.TransactionContext
 	return nil, auth.ErrNotActivated
 }
 
+// GetPipelineAuthTokenInTransaction is the same as GetAuthToken but for use inside a running transaction.
+func (a *InactiveAPIServer) GetPipelineAuthTokenInTransaction(*txnenv.TransactionContext, string) (string, error) {
+	return "", auth.ErrNotActivated
+}
+
 // GetOIDCLogin implements the GetOIDCLogin RPC, but just returns NotActivatedError
 func (a *InactiveAPIServer) GetOIDCLogin(context.Context, *auth.GetOIDCLoginRequest) (*auth.GetOIDCLoginResponse, error) {
 	return nil, auth.ErrNotActivated

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2086,23 +2086,20 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			pipelinePtr.Parallelism = uint64(parallelism)
 
 			// Generate new pipeline auth token (added due to & add pipeline to the ACLs of input/output repos
-			if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
+			if err := func() error {
 				oldAuthToken := pipelinePtr.AuthToken
-				tokenResp, err := superCtx.Auth().GetAuthTokenInTransaction(superCtx, &auth.GetAuthTokenRequest{
-					Subject: auth.PipelinePrefix + request.Pipeline.Name,
-					TTL:     -1,
-				})
+				token, err := txnCtx.Auth().GetPipelineAuthTokenInTransaction(txnCtx, request.Pipeline.Name)
 				if err != nil {
 					if auth.IsErrNotActivated(err) {
 						return nil // no auth work to do
 					}
 					return grpcutil.ScrubGRPC(err)
 				}
-				pipelinePtr.AuthToken = tokenResp.Token
+				pipelinePtr.AuthToken = token
 
 				// If getting a new auth token worked, we should revoke the old one
 				if oldAuthToken != "" {
-					_, err := superCtx.Auth().RevokeAuthTokenInTransaction(superCtx,
+					_, err := txnCtx.Auth().RevokeAuthTokenInTransaction(txnCtx,
 						&auth.RevokeAuthTokenRequest{
 							Token: oldAuthToken,
 						})
@@ -2114,7 +2111,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 					}
 				}
 				return nil
-			}); err != nil {
+			}(); err != nil {
 				return err
 			}
 			return nil

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2200,20 +2200,19 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 
 		// Generate pipeline's auth token & add pipeline to the ACLs of input/output
 		// repos
-		if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
-			tokenResp, err := superCtx.Auth().GetAuthTokenInTransaction(superCtx, &auth.GetAuthTokenRequest{
-				Subject: auth.PipelinePrefix + request.Pipeline.Name,
-				TTL:     -1,
-			})
+
+		if err := func() error {
+			token, err := txnCtx.Auth().GetPipelineAuthTokenInTransaction(txnCtx, request.Pipeline.Name)
 			if err != nil {
 				if auth.IsErrNotActivated(err) {
 					return nil // no auth work to do
 				}
 				return grpcutil.ScrubGRPC(err)
 			}
-			pipelinePtr.AuthToken = tokenResp.Token
+
+			pipelinePtr.AuthToken = token
 			return nil
-		}); err != nil {
+		}(); err != nil {
 			return err
 		}
 		// Put a pointer to the new PipelineInfo commit into etcd


### PR DESCRIPTION
Add an unauthenticated, internal API which only generates tokens for PPS pipelines.

This is part of two larger auth initiatives:
- Eliminate the PPS superuser token.
- Replace the `GetToken` RPC with `GetRobotToken` to reduce the types of users that can be impersonated.