### PR TITLE
Remove sudo from PPS monitor, pipeline controller and worker

### DIFF
--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -61,7 +61,7 @@ const crashingBackoff = time.Second * 15
 // corresponding goroutine running monitorPipeline() that puts the pipeline in
 // and out of standby in response to new output commits appearing in that
 // pipeline's output repo.
-func (m *ppsMaster) startMonitor(pipelineInfo *pps.PipelineInfo) {
+func (m *ppsMaster) startMonitor(pipelineInfo *pps.PipelineInfo, ptr *pps.EtcdPipelineInfo) {
 	pipeline := pipelineInfo.Pipeline.Name
 	m.monitorCancelsMu.Lock()
 	defer m.monitorCancelsMu.Unlock()
@@ -70,14 +70,8 @@ func (m *ppsMaster) startMonitor(pipelineInfo *pps.PipelineInfo) {
 			"monitorPipeline for "+pipeline, func(pachClient *client.APIClient) {
 				// monitorPipeline needs auth privileges to call subscribeCommit and
 				// blockCommit
-				// TODO(msteffen): run the pipeline monitor as the pipeline user, rather
-				// than as the PPS superuser
-				if err := m.a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-					m.monitorPipeline(superUserClient, pipelineInfo)
-					return nil
-				}); err != nil {
-					log.Errorf("error monitoring %q: %v", pipeline, err)
-				}
+				pachClient.SetAuthToken(ptr.AuthToken)
+				m.monitorPipeline(pachClient, pipelineInfo)
 			})
 	}
 }

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -413,7 +413,7 @@ func (op *pipelineOp) createPipelineResources() error {
 // Note: this is called by every run through step(), so must be idempotent
 func (op *pipelineOp) startPipelineMonitor() {
 	op.stopCrashingPipelineMonitor()
-	op.m.startMonitor(op.pipelineInfo)
+	op.m.startMonitor(op.pipelineInfo, op.ptr)
 }
 
 func (op *pipelineOp) startCrashingPipelineMonitor() {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -9,13 +9,11 @@ import (
 	"strconv"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/pachyderm/pachyderm/v2/src/auth"
 	client "github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/deploy/assets"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"github.com/pachyderm/pachyderm/v2/src/pps"

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -825,26 +825,6 @@ func (a *apiServer) createWorkerSvcAndRc(ctx context.Context, ptr *pps.EtcdPipel
 		}
 	}
 
-	// Generate pipeline's auth token & add pipeline to the ACLs of input/output
-	// repos
-	pachClient := a.env.GetPachClient(ctx)
-	if err := a.sudo(pachClient, func(superUserClient *client.APIClient) error {
-		tokenResp, err := superUserClient.GetAuthToken(superUserClient.Ctx(), &auth.GetAuthTokenRequest{
-			Subject: auth.PipelinePrefix + pipelineInfo.Pipeline.Name,
-			TTL:     -1,
-		})
-		if err != nil {
-			if auth.IsErrNotActivated(err) {
-				return nil // no auth work to do
-			}
-			return grpcutil.ScrubGRPC(err)
-		}
-		ptr.AuthToken = tokenResp.Token
-		return nil
-	}); err != nil {
-		return err
-	}
-
 	// True if the pipeline has a git input
 	var hasGitInput bool
 	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {


### PR DESCRIPTION
Run `monitorPipeline` and `finishPipelineOutputCommits` using the pipeline's auth token instead of the superuser token. Also remove what seems like an extraneous `GetAuthToken` from the worker.