### PR TITLE
Remove PFS user as cluster admin

### DIFF
--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -299,8 +299,7 @@ func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (re
 
 	// Activating an already activated auth service should fail, because
 	// otherwise anyone can just activate the service again and set
-	// themselves as an admin. If activation failed in PFS, calling auth.Activate
-	// again should work (in this state, the only admin will be 'ppsUser')
+	// themselves as an admin.
 	if err := a.isActive(); err == nil {
 		return nil, auth.ErrAlreadyActivated
 	}
@@ -320,7 +319,6 @@ func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (re
 		if err := roleBindings.Put(clusterRoleBindingKey, &auth.RoleBinding{
 			Entries: map[string]*auth.Roles{
 				auth.RootUser: &auth.Roles{Roles: map[string]bool{auth.ClusterAdminRole: true}},
-				auth.PpsUser:  &auth.Roles{Roles: map[string]bool{auth.ClusterAdminRole: true}},
 			},
 		}); err != nil {
 			return err

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -54,8 +54,7 @@ func robot(robot string) string {
 
 func buildClusterBindings(s ...string) *auth.RoleBinding {
 	return buildBindings(append(s,
-		auth.RootUser, auth.ClusterAdminRole,
-		auth.PpsUser, auth.ClusterAdminRole)...)
+		auth.RootUser, auth.ClusterAdminRole)...)
 }
 
 func buildBindings(s ...string) *auth.RoleBinding {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -3221,6 +3221,11 @@ func (a *apiServer) ActivateAuth(ctx context.Context, req *pps.ActivateAuthReque
 		return nil, errors.Wrapf(grpcutil.ScrubGRPC(err), "cannot configure role binding on spec repo")
 	}
 
+	// Set the permissions on the spec repo so the PPS user can write to it
+	if err := pachClient.ModifyRepoRoleBinding(ppsconsts.SpecRepo, auth.PpsUser, []string{auth.RepoWriterRole}); err != nil {
+		return nil, errors.Wrapf(grpcutil.ScrubGRPC(err), "cannot configure role binding on spec repo")
+	}
+
 	// Unauthenticated users can't create new pipelines or repos, and users can't
 	// log in while auth is in an intermediate state, so 'pipelines' is exhaustive
 	var pipelines []*pps.PipelineInfo


### PR DESCRIPTION
At this point the PFS token should only be used for accessing the spec repo - remove the cluster-wide admin permission and give it writer on the spec repo instead.