### PR TITLE
Fix metrics group inputs (1.12.x)

### DIFF
--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -200,7 +200,6 @@ func inputMetrics(input *pps.Input, metrics *Metrics) {
 	}
 	if input.Group != nil {
 		metrics.InputGroup++
-		inputMetrics(input, metrics)
 		for _, item := range input.Group {
 			if item.Pfs != nil {
 				pfsInputMetrics(item.Pfs, metrics)


### PR DESCRIPTION
This PR fixes an infinite recursion that occurs when collecting metrics for a group input.

Fixes #5751