### PR TITLE
Add go mod file to word count example

### DIFF
--- a/examples/word_count/map/go.mod
+++ b/examples/word_count/map/go.mod
@@ -1,0 +1,3 @@
+module github.com/pachyderm/pachyderm/examples/word_count/map
+
+go 1.15


### PR DESCRIPTION
The latest version of Go has modules on by default, so this example started failing recently since there wasn't a module file.