### PR TITLE
Deprecate Vault Plugin in 1.12.5

### DIFF
--- a/doc/docs/1.12.x/contributing/supported-releases.md
+++ b/doc/docs/1.12.x/contributing/supported-releases.md
@@ -97,6 +97,7 @@ A release under development may undergo several pre-release stages before becomi
 | Feature             | Version | EOL Date   |
 | ------------------- | --------| ---------- |
 | Spouts: Named Pipes | 1.12.0  | 2021-07-05 |
+| Vault Plugin        | 1.12.5  | 2021-09-12 |
 
 ## End of Life (EOL) Features
 

--- a/doc/docs/master/contributing/supported-releases.md
+++ b/doc/docs/master/contributing/supported-releases.md
@@ -97,6 +97,8 @@ A release under development may undergo several pre-release stages before becomi
 | Feature             | Version | EOL Date   |
 | ------------------- | --------| ---------- |
 | Spouts: Named Pipes | 1.12.0  | 2021-07-05 |
+| Vault Plugin        | 1.12.5  | 2021-09-12 |
+
 
 ## End of Life (EOL) Features
 


### PR DESCRIPTION
Add a notice to the docs that the Vault plugin is deprecated as of the next release (1.12.5).