### PR TITLE
Add local testing scripts for OS X

### DIFF
--- a/etc/testing/local.sh
+++ b/etc/testing/local.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+forward() {
+  NAME=$1
+  PORT=$2
+  if [ -f /tmp/pach/port-forwards/$NAME.pid ]; then
+    kill $(cat /tmp/pach/port-forwards/$NAME.pid) || true
+  fi
+  
+  kubectl port-forward service/$NAME $PORT --address 127.0.0.1 >/dev/null 2>&1 &
+  PID=$!
+  
+  mkdir -p /tmp/pach/port-forwards
+  echo $PID > /tmp/pach/port-forwards/$NAME.pid
+}
+
+# make sure we're testing against minikube
+kubectl config use-context minikube
+
+# port-forward postgres and etcd
+forward postgres 32228:5432
+forward etcd 2379
+
+echo '{"pachd_address": "grpc://localhost:650", "source": 2}' | pachctl config set context "local" --overwrite && pachctl config set active-context "local"
+
+export ETCD_SERVICE_HOST="127.0.0.1"
+export ETCD_SERVICE_PORT=2379
+export POSTGRES_SERVICE_HOST="127.0.0.1"
+export POSTGRES_SERVICE_PORT=32228
+export POSTGRES_SERVICE_SSL=disable
+export STORAGE_BACKEND=LOCAL
+export WORKER_IMAGE=pachyderm/worker:local
+export WORKER_SIDECAR_IMAGE=pachyderm/pachd:local
+export STORAGE_UPLOAD_CONCURRENCY_LIMIT=100
+
+export PACH_ROOT=/tmp/pach/storage
+export STORAGE_HOST_PATH=/tmp/pach/storage
+export PACH_CACHE_ROOT=/tmp/pach/cache
+
+# connect to the k8s API in minikube
+export KUBERNETES_PORT_443_TCP_ADDR=$(minikube ip)
+export KUBERNETES_PORT=8443
+
+# mount the bearer token for the default k8s service account
+export KUBERNETES_BEARER_TOKEN_FILE=/tmp/pach/kubernetes-default-token
+kubectl get -n kube-system -o json secret $(kubectl -n kube-system get secrets  | grep 'default-token' | awk '{print $1}') | jq -r '.data.token' | base64 -D > $KUBERNETES_BEARER_TOKEN_FILE
+
+export LOCAL_TEST=true
+
+$@

--- a/etc/testing/start-local.sh
+++ b/etc/testing/start-local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Mount the shared folder in the minikube VM
+minikube stop
+VBoxManage sharedfolder add minikube --name pach --hostpath /tmp/pach || true
+minikube ssh 'mkdir -p /tmp/pach && sudo mount -t vboxsf pach /tmp/pach' || true
+minikube start
+
+# Disable the pachd running in minikube
+kubectl scale --replicas=0 deployment/pachd

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -161,8 +161,14 @@ func (env *ServiceEnv) initKubeClient() error {
 			if !ok {
 				return errors.Wrapf(err, "can't fall back to insecure kube client due to missing env var (failed to retrieve in-cluster config")
 			}
+			kubePort, ok := os.LookupEnv("KUBERNETES_PORT")
+			if !ok {
+				kubePort = ":443"
+			}
+			bearerToken, _ := os.LookupEnv("KUBERNETES_BEARER_TOKEN_FILE")
 			cfg = &rest.Config{
-				Host: fmt.Sprintf("%s:443", kubeAddr),
+				Host:            fmt.Sprintf("%s:%s", kubeAddr, kubePort),
+				BearerTokenFile: bearerToken,
 				TLSClientConfig: rest.TLSClientConfig{
 					Insecure: true,
 				},

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -1,0 +1,566 @@
+package local
+
+import (
+	gotls "crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"runtime/debug"
+	"runtime/pprof"
+
+	adminclient "github.com/pachyderm/pachyderm/v2/src/admin"
+	authclient "github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	debugclient "github.com/pachyderm/pachyderm/v2/src/debug"
+	eprsclient "github.com/pachyderm/pachyderm/v2/src/enterprise"
+	healthclient "github.com/pachyderm/pachyderm/v2/src/health"
+	identityclient "github.com/pachyderm/pachyderm/v2/src/identity"
+	"github.com/pachyderm/pachyderm/v2/src/internal/auth"
+	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
+	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
+	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/deploy/assets"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
+	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/netutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/tls"
+	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
+	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+	licenseclient "github.com/pachyderm/pachyderm/v2/src/license"
+	pfsclient "github.com/pachyderm/pachyderm/v2/src/pfs"
+	ppsclient "github.com/pachyderm/pachyderm/v2/src/pps"
+	adminserver "github.com/pachyderm/pachyderm/v2/src/server/admin/server"
+	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
+	debugserver "github.com/pachyderm/pachyderm/v2/src/server/debug/server"
+	eprsserver "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
+	"github.com/pachyderm/pachyderm/v2/src/server/health"
+	identity_server "github.com/pachyderm/pachyderm/v2/src/server/identity/server"
+	licenseserver "github.com/pachyderm/pachyderm/v2/src/server/license/server"
+	"github.com/pachyderm/pachyderm/v2/src/server/pfs/s3"
+	pfs_server "github.com/pachyderm/pachyderm/v2/src/server/pfs/server"
+	pps_server "github.com/pachyderm/pachyderm/v2/src/server/pps/server"
+	"github.com/pachyderm/pachyderm/v2/src/server/pps/server/githook"
+	txnserver "github.com/pachyderm/pachyderm/v2/src/server/transaction/server"
+	transactionclient "github.com/pachyderm/pachyderm/v2/src/transaction"
+	"github.com/pachyderm/pachyderm/v2/src/version"
+	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+func RunLocal() (retErr error) {
+	config := &serviceenv.PachdFullConfiguration{}
+	cmdutil.Populate(config)
+
+	config.PostgresServiceSSL = "disable"
+
+	f, err := os.OpenFile("/tmp/pach/pachd-log", os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		log.WithError(err).Error("unable to open log file")
+	}
+	defer f.Close()
+	log.SetOutput(f)
+
+	defer func() {
+		if retErr != nil {
+			log.Errorf("error: %v", retErr)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+		}
+	}()
+	switch logLevel := os.Getenv("LOG_LEVEL"); logLevel {
+	case "debug":
+		log.SetLevel(log.DebugLevel)
+	case "error":
+		log.SetLevel(log.ErrorLevel)
+	case "info", "":
+		log.SetLevel(log.InfoLevel)
+	default:
+		log.Errorf("Unrecognized log level %s, falling back to default of \"info\"", logLevel)
+		log.SetLevel(log.InfoLevel)
+	}
+
+	// must run InstallJaegerTracer before InitWithKube/pach client initialization
+	if endpoint := tracing.InstallJaegerTracerFromEnv(); endpoint != "" {
+		log.Printf("connecting to Jaeger at %q", endpoint)
+	} else {
+		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
+	}
+	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
+	debug.SetGCPercent(env.GCPercent)
+	if env.EtcdPrefix == "" {
+		env.EtcdPrefix = col.DefaultPrefix
+	}
+
+	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
+	if err := migrations.ApplyMigrations(context.Background(), env.GetDBClient(), migrations.Env{}, clusterstate.DesiredClusterState); err != nil {
+		return err
+	}
+	if err := migrations.BlockUntil(context.Background(), env.GetDBClient(), clusterstate.DesiredClusterState); err != nil {
+		return err
+	}
+
+	clusterID, err := getClusterID(env.GetEtcdClient())
+	if err != nil {
+		return errors.Wrapf(err, "getClusterID")
+	}
+	var reporter *metrics.Reporter
+	if env.Metrics {
+		reporter = metrics.NewReporter(clusterID, env)
+	}
+	etcdAddress := fmt.Sprintf("http://%s", net.JoinHostPort(env.EtcdHost, env.EtcdPort))
+	ip, err := netutil.ExternalIP()
+	if err != nil {
+		return errors.Wrapf(err, "error getting pachd external ip")
+	}
+	address := net.JoinHostPort(ip, fmt.Sprintf("%d", env.PeerPort))
+	kubeNamespace := env.Namespace
+	requireNoncriticalServers := !env.RequireCriticalServersOnly
+
+	// Setup External Pachd GRPC Server.
+	authInterceptor := auth.NewInterceptor(env)
+	externalServer, err := grpcutil.NewServer(
+		context.Background(),
+		true,
+		grpc.ChainUnaryInterceptor(
+			tracing.UnaryServerInterceptor(),
+			authInterceptor.InterceptUnary,
+		),
+		grpc.ChainStreamInterceptor(
+			tracing.StreamServerInterceptor(),
+			authInterceptor.InterceptStream,
+		),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	identityStorageProvider := identity_server.NewLazyPostgresStorage(
+		env.PostgresServiceHost,
+		env.IdentityServerDatabase,
+		env.IdentityServerUser,
+		env.IdentityServerPassword,
+		env.PostgresServiceSSL,
+		env.PostgresServicePort,
+	)
+
+	if err := logGRPCServerSetup("External Pachd", func() error {
+		txnEnv := &txnenv.TransactionEnv{}
+		var pfsAPIServer pfs_server.APIServer
+		if err := logGRPCServerSetup("PFS API", func() error {
+			pfsAPIServer, err = pfs_server.NewAPIServer(env, txnEnv, path.Join(env.EtcdPrefix, env.PFSEtcdPrefix), env.GetDBClient())
+			if err != nil {
+				return err
+			}
+			pfsclient.RegisterAPIServer(externalServer.Server, pfsAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		var ppsAPIServer pps_server.APIServer
+		if err := logGRPCServerSetup("PPS API", func() error {
+			ppsAPIServer, err = pps_server.NewAPIServer(
+				env,
+				txnEnv,
+				path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+				kubeNamespace,
+				env.WorkerImage,
+				env.WorkerSidecarImage,
+				env.WorkerImagePullPolicy,
+				env.StorageRoot,
+				env.StorageBackend,
+				env.StorageHostPath,
+				env.CacheRoot,
+				env.IAMRole,
+				env.ImagePullSecret,
+				env.NoExposeDockerSocket,
+				reporter,
+				env.WorkerUsesRoot,
+				env.PPSWorkerPort,
+				env.Port,
+				env.HTTPPort,
+				env.PeerPort,
+				env.GCPercent,
+			)
+			if err != nil {
+				return err
+			}
+			ppsclient.RegisterAPIServer(externalServer.Server, ppsAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		if err := logGRPCServerSetup("Identity API", func() error {
+			idAPIServer, err := identity_server.NewIdentityServer(
+				env,
+				identityStorageProvider,
+				true,
+				path.Join(env.EtcdPrefix, env.IdentityEtcdPrefix),
+			)
+			if err != nil {
+				return err
+			}
+			identityclient.RegisterAPIServer(externalServer.Server, idAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		var authAPIServer authserver.APIServer
+		if err := logGRPCServerSetup("Auth API", func() error {
+			authAPIServer, err = authserver.NewAuthServer(
+				env, txnEnv, path.Join(env.EtcdPrefix, env.AuthEtcdPrefix), true, requireNoncriticalServers)
+			if err != nil {
+				return err
+			}
+			authclient.RegisterAPIServer(externalServer.Server, authAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		var transactionAPIServer txnserver.APIServer
+		if err := logGRPCServerSetup("Transaction API", func() error {
+			transactionAPIServer, err = txnserver.NewAPIServer(
+				env,
+				txnEnv,
+				path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+			)
+			if err != nil {
+				return err
+			}
+			transactionclient.RegisterAPIServer(externalServer.Server, transactionAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Enterprise API", func() error {
+			enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
+				env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
+			if err != nil {
+				return err
+			}
+			eprsclient.RegisterAPIServer(externalServer.Server, enterpriseAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("License API", func() error {
+			licenseAPIServer, err := licenseserver.New(
+				env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
+			if err != nil {
+				return err
+			}
+			licenseclient.RegisterAPIServer(externalServer.Server, licenseAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Admin API", func() error {
+			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
+				ID:           clusterID,
+				DeploymentID: env.DeploymentID,
+			}))
+			return nil
+		}); err != nil {
+			return err
+		}
+		healthServer := health.NewHealthServer()
+		if err := logGRPCServerSetup("Health", func() error {
+			healthclient.RegisterHealthServer(externalServer.Server, healthServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Version API", func() error {
+			versionpb.RegisterAPIServer(externalServer.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Debug", func() error {
+			debugclient.RegisterDebugServer(externalServer.Server, debugserver.NewDebugServer(
+				env,
+				env.PachdPodName,
+				nil,
+			))
+			return nil
+		}); err != nil {
+			return err
+		}
+		txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer, ppsAPIServer)
+		log.Printf("listening on %v", env.Port)
+		if _, err := externalServer.ListenTCP("", env.Port); err != nil {
+			return err
+		}
+		healthServer.Ready()
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Setup Internal Pachd GRPC Server.
+	internalServer, err := grpcutil.NewServer(context.Background(), false, grpc.ChainUnaryInterceptor(tracing.UnaryServerInterceptor(), authInterceptor.InterceptUnary), grpc.StreamInterceptor(authInterceptor.InterceptStream))
+	if err != nil {
+		return err
+	}
+	if err := logGRPCServerSetup("Internal Pachd", func() error {
+		txnEnv := &txnenv.TransactionEnv{}
+		var pfsAPIServer pfs_server.APIServer
+		if err := logGRPCServerSetup("PFS API", func() error {
+			pfsAPIServer, err = pfs_server.NewAPIServer(
+				env,
+				txnEnv,
+				path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+				env.GetDBClient(),
+			)
+			if err != nil {
+				return err
+			}
+			pfsclient.RegisterAPIServer(internalServer.Server, pfsAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		var ppsAPIServer pps_server.APIServer
+		if err := logGRPCServerSetup("PPS API", func() error {
+			ppsAPIServer, err = pps_server.NewAPIServer(
+				env,
+				txnEnv,
+				path.Join(env.EtcdPrefix, env.PPSEtcdPrefix),
+				kubeNamespace,
+				env.WorkerImage,
+				env.WorkerSidecarImage,
+				env.WorkerImagePullPolicy,
+				env.StorageRoot,
+				env.StorageBackend,
+				env.StorageHostPath,
+				env.CacheRoot,
+				env.IAMRole,
+				env.ImagePullSecret,
+				env.NoExposeDockerSocket,
+				reporter,
+				env.WorkerUsesRoot,
+				env.PPSWorkerPort,
+				env.Port,
+				env.HTTPPort,
+				env.PeerPort,
+				env.GCPercent,
+			)
+			if err != nil {
+				return err
+			}
+			ppsclient.RegisterAPIServer(internalServer.Server, ppsAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Identity API", func() error {
+			idAPIServer, err := identity_server.NewIdentityServer(
+				env,
+				identityStorageProvider,
+				false,
+				path.Join(env.EtcdPrefix, env.IdentityEtcdPrefix),
+			)
+			if err != nil {
+				return err
+			}
+			identityclient.RegisterAPIServer(internalServer.Server, idAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		var authAPIServer authserver.APIServer
+		if err := logGRPCServerSetup("Auth API", func() error {
+			authAPIServer, err = authserver.NewAuthServer(
+				env,
+				txnEnv,
+				path.Join(env.EtcdPrefix, env.AuthEtcdPrefix),
+				false,
+				requireNoncriticalServers,
+			)
+			if err != nil {
+				return err
+			}
+			authclient.RegisterAPIServer(internalServer.Server, authAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		var transactionAPIServer txnserver.APIServer
+		if err := logGRPCServerSetup("Transaction API", func() error {
+			transactionAPIServer, err = txnserver.NewAPIServer(
+				env,
+				txnEnv,
+				path.Join(env.EtcdPrefix, env.PFSEtcdPrefix),
+			)
+			if err != nil {
+				return err
+			}
+			transactionclient.RegisterAPIServer(internalServer.Server, transactionAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Enterprise API", func() error {
+			enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
+				env, path.Join(env.EtcdPrefix, env.EnterpriseEtcdPrefix))
+			if err != nil {
+				return err
+			}
+			eprsclient.RegisterAPIServer(internalServer.Server, enterpriseAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		healthServer := health.NewHealthServer()
+		if err := logGRPCServerSetup("Health", func() error {
+			healthclient.RegisterHealthServer(internalServer.Server, healthServer)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Version API", func() error {
+			versionpb.RegisterAPIServer(internalServer.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Admin API", func() error {
+			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
+				ID:           clusterID,
+				DeploymentID: env.DeploymentID,
+			}))
+			return nil
+		}); err != nil {
+			return err
+		}
+		txnEnv.Initialize(env, transactionAPIServer, authAPIServer, pfsAPIServer, ppsAPIServer)
+		if _, err := internalServer.ListenTCP("", env.PeerPort); err != nil {
+			return err
+		}
+		healthServer.Ready()
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Create the goroutines for the servers.
+	// Any server error is considered critical and will cause Pachd to exit.
+	// The first server that errors will have its error message logged.
+	errChan := make(chan error, 1)
+	go waitForError("External Pachd GRPC Server", errChan, true, func() error {
+		return externalServer.Wait()
+	})
+	go waitForError("Internal Pachd GRPC Server", errChan, true, func() error {
+		return internalServer.Wait()
+	})
+	// TODO: Make http server work with V2.
+	//go waitForError("HTTP Server", errChan, requireNoncriticalServers, func() error {
+	//	httpServer, err := pach_http.NewHTTPServer(address)
+	//	if err != nil {
+	//		return err
+	//	}
+	//	server := http.Server{
+	//		Addr:    fmt.Sprintf(":%v", env.HTTPPort),
+	//		Handler: httpServer,
+	//	}
+
+	//	certPath, keyPath, err := tls.GetCertPaths()
+	//	if err != nil {
+	//		log.Warnf("pfs-over-HTTP - TLS disabled: %v", err)
+	//		return server.ListenAndServe()
+	//	}
+
+	//	cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
+	//	err = cLoader.LoadAndStart()
+	//	if err != nil {
+	//		return errors.Wrapf(err, "couldn't load TLS cert for pfs-over-http: %v", err)
+	//	}
+
+	//	server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
+
+	//	return server.ListenAndServeTLS(certPath, keyPath)
+	//})
+	go waitForError("Githook Server", errChan, requireNoncriticalServers, func() error {
+		return githook.RunGitHookServer(address, etcdAddress, path.Join(env.EtcdPrefix, env.PPSEtcdPrefix))
+	})
+	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
+		server, err := s3.Server(env.S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
+			return client.NewFromAddress(fmt.Sprintf("localhost:%d", env.PeerPort))
+		})
+		if err != nil {
+			return err
+		}
+		certPath, keyPath, err := tls.GetCertPaths()
+		if err != nil {
+			log.Warnf("s3gateway TLS disabled: %v", err)
+			return server.ListenAndServe()
+		}
+		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
+		// Read TLS cert and key
+		err = cLoader.LoadAndStart()
+		if err != nil {
+			return errors.Wrapf(err, "couldn't load TLS cert for s3gateway: %v", err)
+		}
+		server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
+		return server.ListenAndServeTLS(certPath, keyPath)
+	})
+	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
+		http.Handle("/metrics", promhttp.Handler())
+		return http.ListenAndServe(fmt.Sprintf(":%v", assets.PrometheusPort), nil)
+	})
+	return <-errChan
+}
+
+const clusterIDKey = "cluster-id"
+
+func getClusterID(client *etcd.Client) (string, error) {
+	resp, err := client.Get(context.Background(),
+		clusterIDKey)
+
+	// if it's a key not found error then we create the key
+	if resp.Count == 0 {
+		// This might error if it races with another pachd trying to set the
+		// cluster id so we ignore the error.
+		client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes())
+	} else if err != nil {
+		return "", err
+	} else {
+		// We expect there to only be one value for this key
+		id := string(resp.Kvs[0].Value)
+		return id, nil
+	}
+
+	return getClusterID(client)
+}
+
+func logGRPCServerSetup(name string, f func() error) (retErr error) {
+	log.Printf("started setting up %v GRPC Server", name)
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Wrapf(retErr, "error setting up %v GRPC Server", name)
+		} else {
+			log.Printf("finished setting up %v GRPC Server", name)
+		}
+	}()
+	return f()
+}
+
+func waitForError(name string, errChan chan error, required bool, f func() error) {
+	if err := f(); !errors.Is(err, http.ErrServerClosed) {
+		if !required {
+			log.Errorf("error setting up and/or running %v: %v", name, err)
+		} else {
+			errChan <- errors.Wrapf(err, "error setting up and/or running %v (use --require-critical-servers-only deploy flag to ignore errors from noncritical servers)", name)
+		}
+	}
+}

--- a/src/server/auth/server/testing/local_test.go
+++ b/src/server/auth/server/testing/local_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"os"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil/local"
+)
+
+func init() {
+	if v := os.Getenv("LOCAL_TEST"); v != "" {
+		go func() {
+			if err := local.RunLocal(); err != nil {
+				panic(err)
+			}
+		}()
+	}
+}


### PR DESCRIPTION
The iteration cycle for developing pachd on OS X is pretty slow - change some code, rebuild the docker image, redeploy in minikube, run the unit tests. Running pachd in a separate process from the tests also means we aren't able to get coverage stats.

This is a prototype for a different way to run pachd tests:
- postgres and etcd are port-forwarded from within minikube
- the storage data directory is a shared folder from the host machine, so it can be accessed by pachd and the storage sidecars in minikube
- pachd is configured to talk to the k8s master at the minikube ip, using a service account token we pull from the cluster secrets, so it can talk to the API server as if it was in the cluster
- the local pach context is pointed to localhost:650 so the test client hits the pachd that's running in the test process

The advantage of this approach versus splitting code into an API server and a driver is that we only need one set of tests. Running locally you can iterate quickly on tests that make RPCs to the in-memory pachd, but those same tests will run in CI against a dockerified pachd in k8s.

To try it out:
- make sure minikube is running with the virtualbox driver (`minikube start --driver=virtualbox`)
- run `etc/reset.py` to deploy postgres, etcd and build the images for workers in minikube
- run `etc/testing/start-local.sh` to turn down the pachd in minikube and mount the local data directory
- run `etc/testing/local.sh go test -v ./src/server/auth/server/testing/` to run the auth tests against an in-memory pachd

NB: If you want test coverage stats for the auth package you need to specify `-coverpkg ./src/server/auth/server` because the tests are in a different package from the code itself.

Next steps:
- refactor the pachd setup code to reduce duplication
- dedicated scripts to deploy postgres, etcd and build docker images without running reset.py