### PR TITLE
Deflake TestService in 2.0

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6986,7 +6986,6 @@ func TestHTTPGetFile(t *testing.T) {
 }
 
 func TestService(t *testing.T) {
-
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6986,6 +6986,7 @@ func TestHTTPGetFile(t *testing.T) {
 }
 
 func TestService(t *testing.T) {
+
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7072,8 +7072,11 @@ func TestService(t *testing.T) {
 		return address
 	}()
 
+	httpClient := &http.Client{
+		Timeout: 3 * time.Second,
+	}
 	require.NoError(t, backoff.Retry(func() error {
-		resp, err := http.Get(fmt.Sprintf("http://%s/%s/file1", serviceAddr, dataRepo))
+		resp, err := httpClient.Get(fmt.Sprintf("http://%s/%s/file1", serviceAddr, dataRepo))
 		if err != nil {
 			return err
 		}
@@ -7100,7 +7103,7 @@ func TestService(t *testing.T) {
 	httpAPIAddr := net.JoinHostPort(host, port)
 	url := fmt.Sprintf("http://%s/v1/pps/services/%s/%s/file1", httpAPIAddr, pipeline, dataRepo)
 	require.NoError(t, backoff.Retry(func() error {
-		resp, err := http.Get(url)
+		resp, err := httpClient.Get(url)
 		if err != nil {
 			return err
 		}
@@ -7123,7 +7126,7 @@ func TestService(t *testing.T) {
 	require.NoError(t, c.FinishCommit(dataRepo, commit2.ID))
 
 	require.NoError(t, backoff.Retry(func() error {
-		resp, err := http.Get(fmt.Sprintf("http://%s/%s/file2", serviceAddr, dataRepo))
+		resp, err := httpClient.Get(fmt.Sprintf("http://%s/%s/file2", serviceAddr, dataRepo))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR is intended to deflake TestService, which appears to be flaky in 2.0 as well.