### PR TITLE
Keeps Object Storage and Postgres in Sync

### DIFF
--- a/src/internal/clusterstate/current.go
+++ b/src/internal/clusterstate/current.go
@@ -23,7 +23,7 @@ var DesiredClusterState migrations.State = migrations.InitialState().
 		return track.SetupPostgresTrackerV0(ctx, env.Tx)
 	}).
 	Apply("storage chunk store v0", func(ctx context.Context, env migrations.Env) error {
-		return chunk.SetupPostgresStoreV0(ctx, "storage.chunks", env.Tx)
+		return chunk.SetupPostgresStoreV0(env.Tx)
 	}).
 	Apply("storage fileset store v0", func(ctx context.Context, env migrations.Env) error {
 		return fileset.SetupPostgresStoreV0(ctx, env.Tx)

--- a/src/internal/storage/chunk/client.go
+++ b/src/internal/storage/chunk/client.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	fmt "fmt"
 	"path"
 	"strings"
 	"time"
@@ -11,14 +12,20 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/sirupsen/logrus"
 )
 
-// Client allows manipulation of individual chunks, by maintaining consistency between
+// Client mediates access to a content-addressed store
+type Client interface {
+	Create(ctx context.Context, md Metadata, chunkData []byte) (ID, error)
+	Get(ctx context.Context, chunkID ID, cb kv.ValueCallback) error
+	Close() error
+}
+
+// trackedClient allows manipulation of individual chunks, by maintaining consistency between
 // a tracker and an kv.Store
-type Client struct {
+type trackedClient struct {
 	store   kv.Store
-	mdstore MetadataStore
+	db      *sqlx.DB
 	tracker track.Tracker
 	renewer *track.Renewer
 	ttl     time.Duration
@@ -26,15 +33,14 @@ type Client struct {
 
 // NewClient returns a client which will write to objc, mdstore, and tracker.  Name is used
 // for the set of temporary objects
-func NewClient(store kv.Store, mdstore MetadataStore, tr track.Tracker, name string) *Client {
+func NewClient(store kv.Store, db *sqlx.DB, tr track.Tracker, name string) Client {
 	var renewer *track.Renewer
 	if name != "" {
 		renewer = track.NewRenewer(tr, name, defaultChunkTTL)
 	}
-	c := &Client{
+	c := &trackedClient{
 		store:   store,
 		tracker: tr,
-		mdstore: mdstore,
 		renewer: renewer,
 		ttl:     defaultChunkTTL,
 	}
@@ -43,26 +49,50 @@ func NewClient(store kv.Store, mdstore MetadataStore, tr track.Tracker, name str
 
 // Create creates a new chunk from metadata and chunkData.
 // It returns the ID for the chunk
-func (c *Client) Create(ctx context.Context, md Metadata, chunkData []byte) (_ ID, retErr error) {
+func (c *trackedClient) Create(ctx context.Context, md Metadata, chunkData []byte) (_ ID, retErr error) {
 	chunkID := Hash(chunkData)
 	var pointsTo []string
 	for _, cid := range md.PointsTo {
-		pointsTo = append(pointsTo, ObjectID(cid))
+		pointsTo = append(pointsTo, cid.TrackerID())
 	}
-	chunkOID := ObjectID(chunkID)
-	if err := dbutil.WithTx(ctx, c.mdstore.DB(), func(tx *sqlx.Tx) error {
-		if err := c.mdstore.SetTx(tx, chunkID, md); err != nil && err != ErrMetadataExists {
+	chunkOID := chunkID.TrackerID()
+	var needUpload bool
+	var gen uint64
+	if err := dbutil.WithTx(ctx, c.db, func(tx *sqlx.Tx) error {
+		if err := c.tracker.CreateTx(tx, chunkOID, pointsTo, c.ttl); err != nil {
 			return err
 		}
-		return c.tracker.CreateTx(tx, chunkOID, pointsTo, c.ttl)
+		var ents []Entry
+		if err := tx.Select(&ents, `
+		SELECT hash_id, gen
+		FROM storage.chunk_objects
+		WHERE uploaded = TRUE AND tombstone = FALSE AND chunk_id = $1`, chunkID); err != nil {
+			return err
+		}
+		if len(ents) > 0 {
+			needUpload = false
+			return nil
+		}
+		if err := tx.Get(&gen, `
+		INSERT INTO storage.chunk_objects (chunk_id, size)
+		VALUES ($1, $2)
+		RETURNING gen
+		`, chunkID, md.Size); err != nil {
+			return err
+		}
+		needUpload = true
+		return nil
 	}); err != nil {
 		return nil, err
 	}
 	if err := c.renewer.Add(ctx, chunkOID); err != nil {
 		return nil, err
 	}
+	if !needUpload {
+		return chunkID, nil
+	}
 	// TODO: need to check for existence of specific objects.
-	key := chunkKey(chunkID)
+	key := chunkKey(chunkID, gen)
 	if exists, err := c.store.Exists(ctx, key); err != nil {
 		return nil, err
 	} else if exists {
@@ -75,40 +105,44 @@ func (c *Client) Create(ctx context.Context, md Metadata, chunkData []byte) (_ I
 }
 
 // Get writes data for a chunk with ID chunkID to w.
-func (c *Client) Get(ctx context.Context, chunkID ID, cb kv.ValueCallback) (retErr error) {
-	key := chunkKey(chunkID)
+func (c *trackedClient) Get(ctx context.Context, chunkID ID, cb kv.ValueCallback) (retErr error) {
+	var gen uint64
+	err := c.db.Get(&gen, `
+	SELECT gen
+	FROM storage.chunk_objects
+	WHERE chunk_id = %1
+	LIMIT 1
+	`, chunkID)
+	if err != nil {
+		err = errors.Errorf("no objects for chunk %v", chunkID)
+		return err
+	}
+	key := chunkKey(chunkID, gen)
 	return c.store.Get(ctx, key, cb)
 }
 
 // Close closes the client, stopping the background renewal of created objects
-func (c *Client) Close() error {
+func (c *trackedClient) Close() error {
 	if c.renewer != nil {
 		return c.renewer.Close()
 	}
 	return nil
 }
 
-func chunkPath(chunkID ID) string {
+func chunkPath(chunkID ID, gen uint64) string {
 	if len(chunkID) == 0 {
 		panic("chunkID cannot be empty")
 	}
-	return path.Join(prefix, chunkID.HexString())
+	return path.Join(prefix, fmt.Sprintf("%s.%016x", chunkID, gen))
 }
 
-func chunkKey(chunkID ID) []byte {
-	return []byte(chunkPath(chunkID))
-}
-
-// ObjectID returns an object ID for use with a tracker
-func ObjectID(chunkID ID) string {
-	return prefix + "/" + chunkID.HexString()
+func chunkKey(chunkID ID, gen uint64) []byte {
+	return []byte(chunkPath(chunkID, gen))
 }
 
 var _ track.Deleter = &deleter{}
 
 type deleter struct {
-	mdstore MetadataStore
-	store   kv.Store
 }
 
 func (d *deleter) DeleteTx(tx *sqlx.Tx, id string) error {
@@ -119,15 +153,10 @@ func (d *deleter) DeleteTx(tx *sqlx.Tx, id string) error {
 	if err != nil {
 		return err
 	}
-	if err := d.mdstore.DeleteTx(tx, chunkID); err != nil {
-		return err
-	}
-	// TODO: this is wrong, but at least it's obviously wrong.
-	go func() {
-		ctx := context.Background()
-		if err := d.store.Delete(ctx, chunkKey(chunkID)); err != nil {
-			logrus.Error(err)
-		}
-	}()
-	return nil
+	_, err = tx.Exec(`
+		UPDATE storage.chunk_objects
+		SET tombstone = TRUE
+		WHERE chunk_id = $1
+	`, chunkID)
+	return err
 }

--- a/src/internal/storage/chunk/gc.go
+++ b/src/internal/storage/chunk/gc.go
@@ -1,0 +1,84 @@
+package chunk
+
+import (
+	"context"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/sirupsen/logrus"
+)
+
+// GarbageCollector removes unused chunks from object storage
+type GarbageCollector struct {
+	s *Storage
+}
+
+// RunForever calls RunOnce until the context is cancelled, logging any errors.
+func (gc *GarbageCollector) RunForever(ctx context.Context) error {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		if err := gc.RunOnce(ctx); err != nil {
+			select {
+			case <-ctx.Done():
+				return err
+			default:
+			}
+			logrus.Errorf("during chunk GC: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// RunOnce runs 1 cycle of garbage collection.
+func (gc *GarbageCollector) RunOnce(ctx context.Context) (retErr error) {
+	rows, err := gc.s.db.QueryContext(ctx, `
+	SELECT chunk_id, gen, uploaded FROM storage.chunk_objects
+	WHERE tombstoned = true
+	`)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := rows.Close(); retErr == nil {
+			retErr = err
+		}
+	}()
+	for rows.Next() {
+		var ent Entry
+		if err := sqlx.StructScan(rows, &ent); err != nil {
+			return err
+		}
+		if !ent.Uploaded {
+			logrus.Warnf("possibility for untracked chunk %s", chunkPath(ent.ChunkID, ent.Gen))
+		}
+		if err := gc.deleteOne(ctx, ent); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func (gc *GarbageCollector) deleteOne(ctx context.Context, ent Entry) error {
+	if err := gc.deleteObject(ctx, ent.ChunkID, ent.Gen); err != nil {
+		return err
+	}
+	return gc.deleteEntry(ctx, ent.ChunkID, ent.Gen)
+}
+
+func (gc *GarbageCollector) deleteObject(ctx context.Context, chunkID ID, gen uint64) error {
+	return gc.s.store.Delete(ctx, chunkKey(chunkID, gen))
+}
+
+func (gc *GarbageCollector) deleteEntry(ctx context.Context, chunkID ID, gen uint64) error {
+	_, err := gc.s.db.ExecContext(ctx, `
+	DELETE FROM storage.chunk_objects
+	WHERE chunk_id = $1 AND gen = $2 AND tombstone = TRUE
+	LIMIT 1
+	`, chunkID, gen)
+	return err
+}

--- a/src/internal/storage/chunk/gc.go
+++ b/src/internal/storage/chunk/gc.go
@@ -88,7 +88,6 @@ func (gc *GarbageCollector) deleteEntry(ctx context.Context, chunkID ID, gen uin
 	_, err := gc.s.db.ExecContext(ctx, `
 	DELETE FROM storage.chunk_objects
 	WHERE chunk_id = $1 AND gen = $2 AND tombstone = TRUE
-	LIMIT 1
 	`, chunkID, gen)
 	return err
 }

--- a/src/internal/storage/chunk/gc.go
+++ b/src/internal/storage/chunk/gc.go
@@ -13,6 +13,11 @@ type GarbageCollector struct {
 	s *Storage
 }
 
+// NewGC returns a new garbage collector operating on s
+func NewGC(s *Storage) *GarbageCollector {
+	return &GarbageCollector{s: s}
+}
+
 // RunForever calls RunOnce until the context is cancelled, logging any errors.
 func (gc *GarbageCollector) RunForever(ctx context.Context) error {
 	ticker := time.NewTicker(time.Minute)
@@ -38,7 +43,7 @@ func (gc *GarbageCollector) RunForever(ctx context.Context) error {
 func (gc *GarbageCollector) RunOnce(ctx context.Context) (retErr error) {
 	rows, err := gc.s.db.QueryContext(ctx, `
 	SELECT chunk_id, gen, uploaded FROM storage.chunk_objects
-	WHERE tombstoned = true
+	WHERE tombstone = true
 	`)
 	if err != nil {
 		return err

--- a/src/internal/storage/chunk/gc.go
+++ b/src/internal/storage/chunk/gc.go
@@ -1,10 +1,15 @@
 package chunk
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
+	"strconv"
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/sirupsen/logrus"
 )
 
@@ -86,4 +91,59 @@ func (gc *GarbageCollector) deleteEntry(ctx context.Context, chunkID ID, gen uin
 	LIMIT 1
 	`, chunkID, gen)
 	return err
+}
+
+// ReduceObjectsPerChunk eliminates redundant objects
+func ReduceObjectsPerChunk(ctx context.Context, db *sqlx.DB) error {
+	_, err := db.ExecContext(ctx, `
+	WITH keep as (
+		SELECT chunk_id, max(gen) as gen
+		FROM storage.chunk_objects
+		GROUP BY chunk_id
+	)
+	UPDATE storage.chunk_objects
+	SET tombstone = TRUE
+	WHERE (chunk_id, gen) NOT IN (SELECT * FROM keep)
+	`)
+	return err
+}
+
+// GCObjects walks store to delete untracked objects.
+func GCObjects(ctx context.Context, db *sqlx.DB, store kv.Store) error {
+	return store.Walk(ctx, []byte("chunk/"), func(key []byte) error {
+
+		chunkID, gen, err := parseKey(key)
+		if err != nil {
+			logrus.Error(err)
+			return nil
+		}
+		var count int
+		if err := db.GetContext(ctx, &count, `
+		SELECT count(1) FROM storage.chunk_objects
+		WHERE chunkID = $1 AND gen = $2 AND tombstone = FALSE
+		`, chunkID, gen); err != nil {
+			return err
+		}
+		if count > 0 {
+			return nil
+		}
+		return store.Delete(ctx, key)
+	})
+}
+
+func parseKey(x []byte) (ID, uint64, error) {
+	parts := bytes.SplitN(x, []byte("."), 2)
+	if len(parts) < 2 {
+		return nil, 0, errors.Errorf("invalid key")
+	}
+	id := make([]byte, hex.DecodedLen(len(parts[0])))
+	_, err := hex.Decode(id, parts[0])
+	if err != nil {
+		return nil, 0, err
+	}
+	gen, err := strconv.ParseUint(string(parts[1]), 16, 64)
+	if err != nil {
+		return nil, 0, err
+	}
+	return id, gen, nil
 }

--- a/src/internal/storage/chunk/gc_test.go
+++ b/src/internal/storage/chunk/gc_test.go
@@ -1,0 +1,18 @@
+package chunk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
+)
+
+func TestReduceObjectsPerChunk(t *testing.T) {
+	ctx := context.Background()
+	db := dbutil.NewTestDB(t)
+	tracker := track.NewPostgresTracker(db)
+	NewTestStorage(t, db, tracker)
+	require.NoError(t, ReduceObjectsPerChunk(ctx, db))
+}

--- a/src/internal/storage/chunk/metadata.go
+++ b/src/internal/storage/chunk/metadata.go
@@ -1,7 +1,6 @@
 package chunk
 
 import (
-	"context"
 	"encoding/hex"
 
 	"github.com/jmoiron/sqlx"
@@ -40,8 +39,6 @@ type Metadata struct {
 }
 
 var (
-	// ErrMetadataExists metadata exists
-	ErrMetadataExists = errors.Errorf("metadata exists")
 	// ErrChunkNotExists chunk does not exist
 	ErrChunkNotExists = errors.Errorf("chunk does not exist")
 )
@@ -50,18 +47,19 @@ var (
 type Entry struct {
 	ChunkID   ID     `db:"chunk_id"`
 	Gen       uint64 `db:"gen"`
-	Uploaded  uint64 `db:"uploaded"`
-	Tombstone uint64 `db:"tombstone"`
+	Uploaded  bool   `db:"uploaded"`
+	Tombstone bool   `db:"tombstone"`
 }
 
 // SetupPostgresStoreV0 sets up tables in db
-func SetupPostgresStoreV0(ctx context.Context, tx *sqlx.Tx) error {
-	_, err := tx.ExecContext(ctx, `
+func SetupPostgresStoreV0(tx *sqlx.Tx) error {
+	_, err := tx.Exec(`
 	CREATE TABLE storage.chunk_objects (
 		chunk_id BYTEA NOT NULL,
 		gen BIGSERIAL NOT NULL,
 		uploaded BOOLEAN NOT NULL DEFAULT FALSE,
 		tombstone BOOLEAN NOT NULL DEFAULT FALSE,
+		size INT8 NOT NULL,
 		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
 		PRIMARY KEY(chunk_id, gen)

--- a/src/internal/storage/chunk/metadata.go
+++ b/src/internal/storage/chunk/metadata.go
@@ -2,10 +2,7 @@ package chunk
 
 import (
 	"context"
-	"database/sql"
 	"encoding/hex"
-	fmt "fmt"
-	"regexp"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -31,6 +28,11 @@ func (id ID) HexString() string {
 	return hex.EncodeToString(id)
 }
 
+// TrackerID returns an ID for use with the tracker.
+func (id ID) TrackerID() string {
+	return TrackerPrefix + id.HexString()
+}
+
 // Metadata holds metadata about a chunk
 type Metadata struct {
 	Size     int
@@ -44,76 +46,26 @@ var (
 	ErrChunkNotExists = errors.Errorf("chunk does not exist")
 )
 
-// MetadataStore stores metadata about chunks
-type MetadataStore interface {
-	DB() *sqlx.DB
-	// Set adds chunk metadata to the tracker
-	SetTx(tx *sqlx.Tx, chunkID ID, md Metadata) error
-	// Get returns info about the chunk if it exists
-	Get(ctx context.Context, chunkID ID) (*Metadata, error)
-	// Delete removes chunk metadata from the tracker
-	DeleteTx(tx *sqlx.Tx, chunkID ID) error
-}
-
-var _ MetadataStore = &postgresStore{}
-
-type postgresStore struct {
-	db *sqlx.DB
-}
-
-// NewPostgresStore returns a Metadata backed by db
-func NewPostgresStore(db *sqlx.DB) MetadataStore {
-	return &postgresStore{db: db}
-}
-
-func (s *postgresStore) DB() *sqlx.DB {
-	return s.db
-}
-
-func (s *postgresStore) SetTx(tx *sqlx.Tx, chunkID ID, md Metadata) error {
-	_, err := tx.Exec(
-		`INSERT INTO storage.chunks (hash_id, size) VALUES ($1, $2)
-		ON CONFLICT (hash_id) DO NOTHING
-		`, chunkID, md.Size)
-	return err
-}
-
-func (s *postgresStore) Get(ctx context.Context, chunkID ID) (*Metadata, error) {
-	type chunkRow struct {
-		size int `db:"size"`
-	}
-	var x chunkRow
-	if err := s.db.GetContext(ctx, &x, `SELECT size FROM storage.chunks WHERE hash_id = $1`, chunkID); err != nil {
-		if err == sql.ErrNoRows {
-			err = ErrChunkNotExists
-		}
-		return nil, err
-	}
-	return &Metadata{
-		Size: x.size,
-	}, nil
-}
-
-func (s *postgresStore) DeleteTx(tx *sqlx.Tx, chunkID ID) error {
-	_, err := tx.Exec(`DELETE FROM storage.chunks WHERE hash_id = $1`, chunkID)
-	return err
+// Entry is an chunk object mapping
+type Entry struct {
+	ChunkID   ID     `db:"chunk_id"`
+	Gen       uint64 `db:"gen"`
+	Uploaded  uint64 `db:"uploaded"`
+	Tombstone uint64 `db:"tombstone"`
 }
 
 // SetupPostgresStoreV0 sets up tables in db
-func SetupPostgresStoreV0(ctx context.Context, tableName string, tx *sqlx.Tx) error {
-	ok, err := regexp.MatchString("[A-z_]+", tableName)
-	if err != nil {
-		panic(err)
-	}
-	if !ok {
-		panic("invalid table name: " + tableName)
-	}
-	query := fmt.Sprintf(`
-	CREATE TABLE %s (
-		hash_id BYTEA NOT NULL PRIMARY KEY,
-		size INT8 NOT NULL,
-		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-	);`, tableName)
-	_, err = tx.ExecContext(ctx, query)
+func SetupPostgresStoreV0(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+	CREATE TABLE storage.chunk_objects (
+		chunk_id BYTEA NOT NULL,
+		gen BIGSERIAL NOT NULL,
+		uploaded BOOLEAN NOT NULL DEFAULT FALSE,
+		tombstone BOOLEAN NOT NULL DEFAULT FALSE,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+		PRIMARY KEY(chunk_id, gen)
+	);
+	`)
 	return err
 }

--- a/src/internal/storage/chunk/reader.go
+++ b/src/internal/storage/chunk/reader.go
@@ -14,12 +14,12 @@ import (
 // Reader reads data from chunk storage.
 type Reader struct {
 	ctx      context.Context
-	client   *Client
+	client   Client
 	memCache kv.GetPut
 	dataRefs []*DataRef
 }
 
-func newReader(ctx context.Context, client *Client, memCache kv.GetPut, dataRefs []*DataRef) *Reader {
+func newReader(ctx context.Context, client Client, memCache kv.GetPut, dataRefs []*DataRef) *Reader {
 	return &Reader{
 		ctx:      ctx,
 		client:   client,
@@ -58,14 +58,14 @@ func (r *Reader) Get(w io.Writer) error {
 type DataReader struct {
 	ctx        context.Context
 	memCache   kv.GetPut
-	client     *Client
+	client     Client
 	dataRef    *DataRef
 	seed       *DataReader
 	getChunkMu sync.Mutex
 	chunk      []byte
 }
 
-func newDataReader(ctx context.Context, client *Client, memCache kv.GetPut, dataRef *DataRef, seed *DataReader) *DataReader {
+func newDataReader(ctx context.Context, client Client, memCache kv.GetPut, dataRef *DataRef, seed *DataReader) *DataReader {
 	return &DataReader{
 		ctx:      ctx,
 		client:   client,

--- a/src/internal/storage/chunk/util.go
+++ b/src/internal/storage/chunk/util.go
@@ -1,13 +1,11 @@
 package chunk
 
 import (
-	"context"
 	"math/rand"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
-	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
@@ -15,19 +13,8 @@ import (
 // NewTestStorage creates a local storage instance for testing during the lifetime of
 // the callback.
 func NewTestStorage(t testing.TB, db *sqlx.DB, tr track.Tracker, opts ...StorageOption) (obj.Client, *Storage) {
-	mdstore := NewTestStore(t, db)
 	objC, _ := obj.NewTestClient(t)
-	return objC, NewStorage(objC, kv.NewMemCache(10), mdstore, tr, opts...)
-}
-
-// NewTestStore creates a store for testing.
-func NewTestStore(t testing.TB, db *sqlx.DB) MetadataStore {
-	ctx := context.Background()
-	tx := db.MustBegin()
-	tx.MustExec(`CREATE SCHEMA IF NOT EXISTS STORAGE`)
-	require.NoError(t, SetupPostgresStoreV0(ctx, "storage.chunks", tx))
-	require.NoError(t, tx.Commit())
-	return NewPostgresStore(db)
+	return objC, NewStorage(objC, kv.NewMemCache(10), db, tr, opts...)
 }
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/src/internal/storage/chunk/util.go
+++ b/src/internal/storage/chunk/util.go
@@ -1,11 +1,14 @@
 package chunk
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
@@ -14,6 +17,8 @@ import (
 // the callback.
 func NewTestStorage(t testing.TB, db *sqlx.DB, tr track.Tracker, opts ...StorageOption) (obj.Client, *Storage) {
 	objC, _ := obj.NewTestClient(t)
+	db.MustExec(`CREATE SCHEMA IF NOT EXISTS storage`)
+	require.NoError(t, dbutil.WithTx(context.Background(), db, SetupPostgresStoreV0))
 	return objC, NewStorage(objC, kv.NewMemCache(10), db, tr, opts...)
 }
 

--- a/src/internal/storage/chunk/writer.go
+++ b/src/internal/storage/chunk/writer.go
@@ -50,7 +50,7 @@ type chunkSize struct {
 // Writer splits a byte stream into content defined chunks that are hashed and deduplicated/uploaded to object storage.
 // Chunk split points are determined by a bit pattern in a rolling hash function (buzhash64 at https://github.com/chmduquesne/rollinghash).
 type Writer struct {
-	client     *Client
+	client     Client
 	memCache   kv.GetPut
 	cb         WriterCallback
 	chunkSize  *chunkSize
@@ -71,7 +71,7 @@ type Writer struct {
 	first, last             bool
 }
 
-func newWriter(ctx context.Context, client *Client, memCache kv.GetPut, createOpts CreateOptions, cb WriterCallback, opts ...WriterOption) *Writer {
+func newWriter(ctx context.Context, client Client, memCache kv.GetPut, createOpts CreateOptions, cb WriterCallback, opts ...WriterOption) *Writer {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	w := &Writer{
 		cb:         cb,

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -303,7 +303,7 @@ func (s *Storage) newPrimitive(ctx context.Context, prim *Primitive, ttl time.Du
 	}
 	var pointsTo []string
 	for _, chunkID := range prim.PointsTo() {
-		pointsTo = append(pointsTo, chunk.ObjectID(chunkID))
+		pointsTo = append(pointsTo, chunkID.TrackerID())
 	}
 	err := dbutil.WithTx(ctx, s.store.DB(), func(tx *sqlx.Tx) error {
 		if err := s.store.SetTx(tx, id, md); err != nil {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -117,7 +117,7 @@ func newDriver(env *serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcdPr
 		return nil, err
 	}
 	memCache := env.ChunkMemoryCache()
-	chunkStorage := chunk.NewStorage(objClient, memCache, chunk.NewPostgresStore(db), tracker, chunkStorageOpts...)
+	chunkStorage := chunk.NewStorage(objClient, memCache, db, tracker, chunkStorageOpts...)
 	d.storage = fileset.NewStorage(fileset.NewPostgresStore(db), tracker, chunkStorage, env.FileSetStorageOptions()...)
 	// Setup compaction queue and worker.
 	d.compactionQueue, err = work.NewTaskQueue(context.Background(), etcdClient, etcdPrefix, storageTaskNamespace)

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -7,10 +7,12 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dlock"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -26,7 +28,15 @@ func (d *driver) master(env *serviceenv.ServiceEnv, db *sqlx.DB) {
 			return err
 		}
 		defer masterLock.Unlock(masterCtx)
-		return d.storage.GC(masterCtx)
+		eg, ctx := errgroup.WithContext(masterCtx)
+		eg.Go(func() error {
+			return d.storage.GC(ctx)
+		})
+		eg.Go(func() error {
+			gc := chunk.NewGC(d.storage.ChunkStorage())
+			return gc.RunForever(ctx)
+		})
+		return eg.Wait()
 	}, backoff.NewInfiniteBackOff(), func(err error, _ time.Duration) error {
 		log.Errorf("error in pfs master: %v", err)
 		return nil


### PR DESCRIPTION
These changes let us create and delete chunks without ever ending up with a chunk without a corresponding object in object storage.  It is possible to wind up with multiple objects per chunk, and objects without a Postgres entry, but the existence of these anomalies will not impact correctness, and there are background services to eliminate them eventually.