### PR TITLE
Rework `pachctl deploy ide` for 2.0

### DIFF
--- a/src/client/auth.go
+++ b/src/client/auth.go
@@ -11,12 +11,16 @@ func (c APIClient) IsAuthActive() (bool, error) {
 		Resource: &auth.Resource{Type: auth.ResourceType_CLUSTER},
 	})
 	switch {
+	case err == nil:
+		return true, nil
+	case auth.IsErrNotAuthorized(err):
+		return true, nil
 	case auth.IsErrNotSignedIn(err):
 		return true, nil
 	case auth.IsErrNotActivated(err):
 		return false, nil
 	default:
-		return true, grpcutil.ScrubGRPC(err)
+		return false, grpcutil.ScrubGRPC(err)
 	}
 }
 

--- a/src/client/auth.go
+++ b/src/client/auth.go
@@ -16,7 +16,7 @@ func (c APIClient) IsAuthActive() (bool, error) {
 	case auth.IsErrNotActivated(err):
 		return false, nil
 	default:
-		return false, grpcutil.ScrubGRPC(err)
+		return true, grpcutil.ScrubGRPC(err)
 	}
 }
 

--- a/src/client/portforwarder.go
+++ b/src/client/portforwarder.go
@@ -70,10 +70,14 @@ func NewPortForwarder(context *config.Context, namespace string) (*PortForwarder
 
 // Run starts the port forwarder. Returns after initialization is begun with
 // the locally bound port and any initialization errors.
-func (f *PortForwarder) Run(appName string, localPort, remotePort uint16) (uint16, error) {
+func (f *PortForwarder) Run(appName string, localPort, remotePort uint16, selectors ...string) (uint16, error) {
 	podNameSelector := map[string]string{
 		"suite": "pachyderm",
 		"app":   appName,
+	}
+
+	for i := 1; i < len(selectors); i += 2 {
+		podNameSelector[selectors[i-1]] = selectors[i]
 	}
 
 	podList, err := f.core.Pods(f.namespace).List(metav1.ListOptions{
@@ -192,6 +196,11 @@ func (f *PortForwarder) RunForPFS(localPort uint16) (uint16, error) {
 // RunForS3Gateway creates a port forwarder for the s3gateway.
 func (f *PortForwarder) RunForS3Gateway(localPort uint16) (uint16, error) {
 	return f.Run("pachd", localPort, 600)
+}
+
+// RunForIDE creates a port forwarder for the IDE
+func (f *PortForwarder) RunForIDE(localPort, remotePort uint16) (uint16, error) {
+	return f.Run("jupyterhub", localPort, remotePort, "component", "proxy")
 }
 
 // Close shuts down port forwarding.

--- a/src/identity/identity.go
+++ b/src/identity/identity.go
@@ -1,0 +1,32 @@
+package identity
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// ErrInvalidID is returned if the client or connector ID does not exist
+	ErrInvalidID = status.Error(codes.Internal, "ID does not exist")
+
+	// ErrAlreadyExists is returned if the clientor connector ID already exists
+	ErrAlreadyExists = status.Error(codes.Internal, "ID already exists")
+)
+
+// IsErrInvalidID checks if an error is a ErrAlreadyActivated
+func IsErrInvalidID(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), status.Convert(ErrInvalidID).Message())
+}
+
+// IsErrAlreadyExists checks if an error is a ErrAlreadyExists
+func IsErrAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), status.Convert(ErrAlreadyExists).Message())
+}

--- a/src/identity/identity.go
+++ b/src/identity/identity.go
@@ -11,7 +11,7 @@ var (
 	// ErrInvalidID is returned if the client or connector ID does not exist
 	ErrInvalidID = status.Error(codes.Internal, "ID does not exist")
 
-	// ErrAlreadyExists is returned if the clientor connector ID already exists
+	// ErrAlreadyExists is returned if the client or connector ID already exists
 	ErrAlreadyExists = status.Error(codes.Internal, "ID already exists")
 )
 

--- a/src/identity/identity.go
+++ b/src/identity/identity.go
@@ -15,7 +15,7 @@ var (
 	ErrAlreadyExists = status.Error(codes.Internal, "ID already exists")
 )
 
-// IsErrInvalidID checks if an error is a ErrAlreadyActivated
+// IsErrInvalidID checks if an error is a ErrInvalidID
 func IsErrInvalidID(err error) bool {
 	if err == nil {
 		return false

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -1120,13 +1120,6 @@ func Cmds() []*cobra.Command {
 				return errors.Wrapf(grpcutil.ScrubGRPC(err), "could not get the current logged in user")
 			}
 
-			authTokenResp, err := c.GetAuthToken(c.Ctx(), &auth.GetAuthTokenRequest{
-				Subject: whoamiResp.Username,
-			})
-			if err != nil {
-				return errors.Wrapf(grpcutil.ScrubGRPC(err), "could not get an auth token")
-			}
-
 			if jupyterhubChartVersion == "" {
 				jupyterhubChartVersion = getCompatibleVersion("jupyterhub", "/jupyterhub", defaultIDEChartVersion)
 			}
@@ -1168,9 +1161,6 @@ func Cmds() []*cobra.Command {
 					"type": "custom",
 					"custom": map[string]interface{}{
 						"className": "pachyderm_authenticator.PachydermAuthenticator",
-						"config": map[string]interface{}{
-							"pach_auth_token": authTokenResp.Token,
-						},
 					},
 					"admin": map[string]interface{}{
 						"users": []string{whoamiResp.Username},

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -56,7 +56,7 @@ const (
 	defaultIDEHubImage  = "pachyderm/ide-hub"
 	defaultIDEUserImage = "pachyderm/ide-user"
 
-	defaultIDEVersion      = "1.1.0"
+	defaultIDEVersion      = "2.0.0-a1"
 	defaultIDEChartVersion = "0.9.1" // see https://jupyterhub.github.io/helm-chart/
 
 	etcdNodePort = 32379

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -537,6 +537,7 @@ This resets the cluster to its initial state.`,
 	var s3gatewayPort uint16
 	var dexPort uint16
 	var remoteDexPort uint16
+	var idePort, remoteIDEPort uint16
 	var namespace string
 	portForward := &cobra.Command{
 		Short: "Forward a port on the local machine to pachd. This command blocks.",
@@ -648,6 +649,16 @@ This resets the cluster to its initial state.`,
 				successCount++
 			}
 
+			fmt.Println("Forwarding the IDE service port...")
+			port, err = fw.RunForIDE(idePort, remoteIDEPort)
+			if err != nil {
+				fmt.Printf("port forwarding failed: %v\n", err)
+			} else {
+				fmt.Printf("listening on port %d\n", port)
+				context.PortForwarders["ide"] = uint32(port)
+				successCount++
+			}
+
 			if successCount == 0 {
 				return errors.New("failed to start port forwarders")
 			}
@@ -693,6 +704,8 @@ This resets the cluster to its initial state.`,
 	portForward.Flags().Uint16VarP(&s3gatewayPort, "s3gateway-port", "s", 30600, "The local port to bind the s3gateway to.")
 	portForward.Flags().Uint16Var(&dexPort, "dex-port", 30658, "The local port to bind the identity service to.")
 	portForward.Flags().Uint16Var(&remoteDexPort, "remote-dex-port", 658, "The local port to bind the identity service to.")
+	portForward.Flags().Uint16Var(&idePort, "ide-port", 30659, "The local port to bind the IDE service to.")
+	portForward.Flags().Uint16Var(&remoteIDEPort, "remote-ide-port", 8000, "The local port to bind the IDE service to.")
 	portForward.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace Pachyderm is deployed in.")
 	subcommands = append(subcommands, cmdutil.CreateAlias(portForward, "port-forward"))
 

--- a/src/server/identity/server/dex_api.go
+++ b/src/server/identity/server/dex_api.go
@@ -170,7 +170,7 @@ func (a *dexAPI) createConnector(req *identity.CreateIDPConnectorRequest) error 
 
 	if err := storage.CreateConnector(conn); err != nil {
 		if errors.Is(err, dex_storage.ErrAlreadyExists) {
-			return nil, identity.ErrAlreadyExists
+			return identity.ErrAlreadyExists
 		}
 		return err
 	}


### PR DESCRIPTION
Update `pachctl deploy ide` to use the identity server over OIDC for 2.0. 

Using OIDC presents a lot of complications, because we need to know:
- the URL for the identity server (from the user's laptop)
- the URL for the identity server (from the IDE pod) 
- the URL for the IDE (for the redirect)

I've tried to make this simple for users getting started by having everything go through `pachctl port-forward`, which makes the URLs predictable from the user's perspective. In a production deployment users will need to customize the public URLs so everyone can access them (or I guess have every port-forward).

We also need to register a new client ID with the appropriate redirect and secret. This is idempotent, so a user can re-run the deploy and we'll reuse the existing client ID unless the redirect has changed. We also register the client ID as a peer of pachd so the IDE can get a token for the pachd audience.

The end result is that users can still run the following to get a working IDE:
```
pachctl deploy local
pachctl enterprise activate
pachctl auth activate
pachctl idp add-connector <config for some auth connector>
pachctl deploy ide
pachctl port-forward
```