### PR TITLE
Add CLI command to log in with an ID token

### DIFF
--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -1,10 +1,13 @@
 package testutil
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+
+	"golang.org/x/oauth2"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -125,6 +128,60 @@ func DoOAuthExchange(t testing.TB, loginURL string) {
 	// Follow the resulting redirect back to pachd to complete the flow
 	_, err = c.Get(RewriteRedirect(t, resp, pachHost(testClient)))
 	require.NoError(t, err)
+}
+
+func GetOIDCTokenForTrustedApp(t testing.TB) string {
+	// Create an HTTP client that doesn't follow redirects.
+	// We rewrite the host names for each redirect to avoid issues because
+	// pachd is configured to reach dex with kube dns, but the tests might be
+	// outside the cluster.
+	c := &http.Client{}
+	c.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	testClient := GetUnauthenticatedPachClient(t)
+
+	oauthConfig := oauth2.Config{
+		ClientID:     "testapp",
+		ClientSecret: "test",
+		RedirectURL:  "http://test.example.com:657/authorization-code/callback",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  RewriteURL(t, "http://pachd:30658/auth", DexHost(testClient)),
+			TokenURL: RewriteURL(t, "http://pachd:30658/token", DexHost(testClient)),
+		},
+		Scopes: []string{
+			"openid",
+			"profile",
+			"email",
+			"audience:server:client_id:pachyderm",
+		},
+	}
+
+	// Hit the dex login page for the test client with a fixed nonce
+	resp, err := c.Get(oauthConfig.AuthCodeURL("state"))
+	require.NoError(t, err)
+
+	// Because we've only configured username/password login, there's a redirect
+	// to the login page. The params have the session state. POST our hard-coded
+	// credentials to the login page.
+	vals := make(url.Values)
+	vals.Add("login", "admin")
+	vals.Add("password", "password")
+
+	resp, err = c.PostForm(RewriteRedirect(t, resp, DexHost(testClient)), vals)
+	require.NoError(t, err)
+
+	// The username/password flow redirects back to the dex /approval endpoint
+	resp, err = c.Get(RewriteRedirect(t, resp, DexHost(testClient)))
+	require.NoError(t, err)
+
+	codeURL, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+
+	token, err := oauthConfig.Exchange(context.Background(), codeURL.Query().Get("code"))
+	require.NoError(t, err)
+
+	return token.Extra("id_token").(string)
 }
 
 // RewriteRedirect rewrites the Location header to point to the returned path at `host`

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -1,12 +1,7 @@
 package server
 
 import (
-	"context"
-	"net/http"
-	"net/url"
 	"testing"
-
-	"golang.org/x/oauth2"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
@@ -52,58 +47,11 @@ func TestOIDCTrustedApp(t *testing.T) {
 	defer tu.DeleteAll(t)
 	testClient := tu.GetUnauthenticatedPachClient(t)
 
-	// Create an HTTP client that doesn't follow redirects.
-	// We rewrite the host names for each redirect to avoid issues because
-	// pachd is configured to reach dex with kube dns, but the tests might be
-	// outside the cluster.
-	c := &http.Client{}
-	c.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-
-	oauthConfig := oauth2.Config{
-		ClientID:     "testapp",
-		ClientSecret: "test",
-		RedirectURL:  "http://test.example.com:657/authorization-code/callback",
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  tu.RewriteURL(t, "http://pachd:30658/auth", tu.DexHost(testClient)),
-			TokenURL: tu.RewriteURL(t, "http://pachd:30658/token", tu.DexHost(testClient)),
-		},
-		Scopes: []string{
-			"openid",
-			"profile",
-			"email",
-			"audience:server:client_id:pachyderm",
-		},
-	}
-
-	// Hit the dex login page for the test client with a fixed nonce
-	resp, err := c.Get(oauthConfig.AuthCodeURL("state"))
-	require.NoError(t, err)
-
-	// Because we've only configured username/password login, there's a redirect
-	// to the login page. The params have the session state. POST our hard-coded
-	// credentials to the login page.
-	vals := make(url.Values)
-	vals.Add("login", "admin")
-	vals.Add("password", "password")
-
-	resp, err = c.PostForm(tu.RewriteRedirect(t, resp, tu.DexHost(testClient)), vals)
-	require.NoError(t, err)
-
-	// The username/password flow redirects back to the dex /approval endpoint
-	resp, err = c.Get(tu.RewriteRedirect(t, resp, tu.DexHost(testClient)))
-	require.NoError(t, err)
-
-	codeURL, err := url.Parse(resp.Header.Get("Location"))
-	require.NoError(t, err)
-
-	token, err := oauthConfig.Exchange(context.Background(), codeURL.Query().Get("code"))
-	require.NoError(t, err)
+	token := tu.GetOIDCTokenForTrustedApp(t)
 
 	// Use the id token from the previous OAuth flow with Pach
 	authResp, err := testClient.Authenticate(testClient.Ctx(),
-		&auth.AuthenticateRequest{IdToken: token.Extra("id_token").(string)})
+		&auth.AuthenticateRequest{IdToken: token})
 	require.NoError(t, err)
 	testClient.SetAuthToken(authResp.PachToken)
 


### PR DESCRIPTION
Add a way for users to convert an ID token from a trusted peer app into a pach auth token using the CLI. We'll use this in the IDE to configure pachctl.