### PR TITLE
Fix 1.12.x python-pachyderm issues

### DIFF
--- a/etc/pipeline-build/python/Dockerfile
+++ b/etc/pipeline-build/python/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3
 
+RUN apt update && apt install -y libgl1-mesa-glx
+
 WORKDIR /app
 ADD etc/pipeline-build/python/build.sh .
 ADD etc/pipeline-build/python/run.sh .

--- a/etc/testing/travis_install.sh
+++ b/etc/testing/travis_install.sh
@@ -37,7 +37,7 @@ sudo chown root:root /etc/fuse.conf
 
 # Install aws CLI (for TLS test)
 pip3 install --upgrade --user wheel
-pip3 install --upgrade --user awscli
+pip3 install --upgrade --user awscli s3transfer==0.3.4
 
 # Install kubectl
 # To get the latest kubectl version:


### PR DESCRIPTION
I don't fully understand what's going on in the Python packaging ecosystem, but:

- s3transfer released a new version (0.3.5) that changes the format of their setup.cfg, and it breaks installing dependencies for tests in travis (https://github.com/boto/s3transfer/commit/a831d91daf04b480a22e946880049794f650d287). This pins the 0.3.4 version so CI can run.

- Between Pachyderm 1.12.1 and 1.12.2, the python 3 Docker image moved from pip 20.3.3 to 21.0.1, which made it impossible to install the older, pinned version of opencv-python the examples used. Newer versions don't bundle libgl.so.1, so we need to install libgl in the image to make them work. This seems like a good thing to include generally, considering the popularity of opencv?