### PR TITLE
Auth commands work against the enterprise server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ launch-dev: check-kubectl check-kubectl-connection install
 launch-enterprise: check-kubectl check-kubectl-connection install
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	$(GOBIN)/pachctl deploy local --no-guaranteed -d --enterprise-server --namespace enterprise --pachd-cpu-request 100m --postgres-cpu-request 100m --etcd-cpu-request 100m --dry-run $(LAUNCH_DEV_ARGS) | kubectl $(KUBECTLFLAGS) apply -f -
+	$(GOBIN)/pachctl deploy local --no-guaranteed -d --enterprise-server --namespace enterprise  --pachd-memory-request 128M --postgres-memory-request 128M --etcd-memory-request 128M --pachd-cpu-request 100m --postgres-cpu-request 100m --etcd-cpu-request 100m --dry-run $(LAUNCH_DEV_ARGS) | kubectl $(KUBECTLFLAGS) apply -f -
 	# wait for the pachyderm to come up
 	until timeout 1s ./etc/kube/check_ready.sh app=pach-enterprise enterprise; do sleep 1; done
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -265,16 +265,24 @@ func (c *Config) Write() error {
 
 // WritePachTokenToConfig sets the auth token for the current pachctl config.
 // Used during tests to ensure we don't lose access to a cluster if a test fails.
-func WritePachTokenToConfig(token string) error {
+func WritePachTokenToConfig(token string, enterpriseContext bool) error {
 	cfg, err := Read(false, false)
 	if err != nil {
 		return errors.Wrapf(err, "error reading Pachyderm config (for cluster address)")
 	}
-	_, context, err := cfg.ActiveContext(true)
-	if err != nil {
-		return errors.Wrapf(err, "error getting the active context")
+	if enterpriseContext {
+		_, context, err := cfg.ActiveEnterpriseContext(true)
+		if err != nil {
+			return errors.Wrapf(err, "error getting the active enterprise context")
+		}
+		context.SessionToken = token
+	} else {
+		_, context, err := cfg.ActiveContext(true)
+		if err != nil {
+			return errors.Wrapf(err, "error getting the active context")
+		}
+		context.SessionToken = token
 	}
-	context.SessionToken = token
 	if err := cfg.Write(); err != nil {
 		return errors.Wrapf(err, "error writing pachyderm config")
 	}

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -32,7 +32,7 @@ func ActivateAuth(tb testing.TB) {
 	if err != nil && !strings.HasSuffix(err.Error(), "already activated") {
 		tb.Fatalf("could not activate auth service: %v", err.Error())
 	}
-	config.WritePachTokenToConfig(RootToken)
+	config.WritePachTokenToConfig(RootToken, false)
 
 	// Activate auth for PPS
 	client = client.WithCtx(context.Background())

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -95,9 +95,7 @@ func ConfigureOIDCProvider(t *testing.T) error {
 }
 
 // DoOAuthExchange does the OAuth dance to log in to the mock provider, given a login URL
-func DoOAuthExchange(t testing.TB, loginURL string) {
-	testClient := GetUnauthenticatedPachClient(t)
-
+func DoOAuthExchange(t testing.TB, pachClient, enterpriseClient *client.APIClient, loginURL string) {
 	// Create an HTTP client that doesn't follow redirects.
 	// We rewrite the host names for each redirect to avoid issues because
 	// pachd is configured to reach dex with kube dns, but the tests might be
@@ -108,7 +106,7 @@ func DoOAuthExchange(t testing.TB, loginURL string) {
 	}
 
 	// Get the initial URL from the grpc, which should point to the dex login page
-	resp, err := c.Get(RewriteURL(t, loginURL, DexHost(testClient)))
+	resp, err := c.Get(RewriteURL(t, loginURL, DexHost(enterpriseClient)))
 	require.NoError(t, err)
 
 	// Because we've only configured username/password login, there's a redirect
@@ -118,15 +116,15 @@ func DoOAuthExchange(t testing.TB, loginURL string) {
 	vals.Add("login", "admin")
 	vals.Add("password", "password")
 
-	resp, err = c.PostForm(RewriteRedirect(t, resp, DexHost(testClient)), vals)
+	resp, err = c.PostForm(RewriteRedirect(t, resp, DexHost(enterpriseClient)), vals)
 	require.NoError(t, err)
 
 	// The username/password flow redirects back to the dex /approval endpoint
-	resp, err = c.Get(RewriteRedirect(t, resp, DexHost(testClient)))
+	resp, err = c.Get(RewriteRedirect(t, resp, DexHost(enterpriseClient)))
 	require.NoError(t, err)
 
 	// Follow the resulting redirect back to pachd to complete the flow
-	_, err = c.Get(RewriteRedirect(t, resp, pachHost(testClient)))
+	_, err = c.Get(RewriteRedirect(t, resp, pachHost(pachClient)))
 	require.NoError(t, err)
 }
 
@@ -204,6 +202,9 @@ func DexHost(c *client.APIClient) string {
 	if parts[1] == "650" {
 		return parts[0] + ":658"
 	}
+	if parts[1] == "31650" {
+		return parts[0] + ":31658"
+	}
 	return parts[0] + ":30658"
 }
 
@@ -211,6 +212,9 @@ func pachHost(c *client.APIClient) string {
 	parts := strings.Split(c.GetAddress(), ":")
 	if parts[1] == "650" {
 		return parts[0] + ":657"
+	}
+	if parts[1] == "31650" {
+		return parts[0] + ":31657"
 	}
 	return parts[0] + ":30657"
 }

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -111,7 +111,10 @@ func (t *TransactionContext) finish() error {
 			return err
 		}
 	}
-	return t.pfsPropagater.Run()
+	if t.pfsPropagater != nil {
+		return t.pfsPropagater.Run()
+	}
+	return nil
 }
 
 // FinishPipelineCommits saves a pipeline output branch to have its commits

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -56,16 +56,23 @@ func printRoleBinding(b *auth.RoleBinding) {
 	}
 }
 
+func newClient(enterprise bool) (*client.APIClient, error) {
+	if enterprise {
+		return client.NewEnterpriseClientOnUserMachine("user")
+	}
+	return client.NewOnUserMachine("user")
+}
+
 // ActivateCmd returns a cobra.Command to activate Pachyderm's auth system
 func ActivateCmd() *cobra.Command {
-	var supplyRootToken, onlyActivate bool
+	var enterprise, supplyRootToken, onlyActivate bool
 	var trustedPeers []string
 	activate := &cobra.Command{
 		Short: "Activate Pachyderm's auth system",
 		Long: `
 Activate Pachyderm's auth system, and restrict access to existing data to the root user`[1:],
 		Run: cmdutil.Run(func(args []string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -89,7 +96,7 @@ Activate Pachyderm's auth system, and restrict access to existing data to the ro
 			// If auth is already activated we won't get back a root token,
 			// retry activating auth in PPS with the currently configured token
 			if !auth.IsErrAlreadyActivated(err) {
-				if err := config.WritePachTokenToConfig(resp.PachToken); err != nil {
+				if err := config.WritePachTokenToConfig(resp.PachToken, enterprise); err != nil {
 					return err
 				}
 
@@ -145,6 +152,7 @@ Activate Pachyderm's auth system, and restrict access to existing data to the ro
 	activate.PersistentFlags().BoolVar(&supplyRootToken, "supply-root-token", false, `
 Prompt the user to input a root token on stdin, rather than generating a random one.`[1:])
 	activate.PersistentFlags().BoolVar(&onlyActivate, "only-activate", false, "Activate auth without configuring the OIDC service")
+	activate.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Activate auth on the active enterprise context")
 	activate.PersistentFlags().StringSliceVar(&trustedPeers, "trusted-peers", []string{}, "Comma-separated list of OIDC client IDs to trust")
 
 	return cmdutil.CreateAlias(activate, "auth activate")
@@ -153,6 +161,7 @@ Prompt the user to input a root token on stdin, rather than generating a random 
 // DeactivateCmd returns a cobra.Command to delete all ACLs, tokens, and admins,
 // deactivating Pachyderm's auth system
 func DeactivateCmd() *cobra.Command {
+	var enterprise bool
 	deactivate := &cobra.Command{
 		Short: "Delete all ACLs, tokens, and admins, and deactivate Pachyderm auth",
 		Long: "Deactivate Pachyderm's auth system, which will delete ALL auth " +
@@ -168,7 +177,7 @@ func DeactivateCmd() *cobra.Command {
 			if !strings.Contains("yY", confirm[:1]) {
 				return errors.Errorf("operation aborted")
 			}
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -177,6 +186,7 @@ func DeactivateCmd() *cobra.Command {
 			return grpcutil.ScrubGRPC(err)
 		}),
 	}
+	deactivate.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Deactivate auth on the active enterprise context")
 	return cmdutil.CreateAlias(deactivate, "auth deactivate")
 }
 
@@ -184,14 +194,14 @@ func DeactivateCmd() *cobra.Command {
 // GitHub account. Any resources that have been restricted to the email address
 // registered with your GitHub account will subsequently be accessible.
 func LoginCmd() *cobra.Command {
-	var noBrowser, idToken bool
+	var noBrowser, enterprise, idToken bool
 	login := &cobra.Command{
 		Short: "Log in to Pachyderm",
 		Long: "Login to Pachyderm. Any resources that have been restricted to " +
 			"the account you have with your ID provider (e.g. GitHub, Okta) " +
 			"account will subsequently be accessible.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -230,14 +240,17 @@ func LoginCmd() *cobra.Command {
 					return fmt.Errorf("no authentication providers are configured")
 				}
 			}
-			// Write new Pachyderm token to config
-			return config.WritePachTokenToConfig(resp.PachToken)
+			if authErr != nil {
+				return errors.Wrapf(grpcutil.ScrubGRPC(authErr), "error authenticating with Pachyderm cluster")
+			}
+			return config.WritePachTokenToConfig(resp.PachToken, enterprise)
 		}),
 	}
 	login.PersistentFlags().BoolVarP(&noBrowser, "no-browser", "b", false,
 		"If set, don't try to open a web browser")
 	login.PersistentFlags().BoolVarP(&idToken, "id-token", "t", false,
 		"If set, read an ID token on stdin to authenticate the user")
+	login.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Login for the active enterprise context")
 	return cmdutil.CreateAlias(login, "auth login")
 }
 
@@ -245,6 +258,7 @@ func LoginCmd() *cobra.Command {
 // credential, logging you out of your cluster. Note that this is not necessary
 // to do before logging in as another user, but is useful for testing.
 func LogoutCmd() *cobra.Command {
+	var enterprise bool
 	logout := &cobra.Command{
 		Short: "Log out of Pachyderm by deleting your local credential",
 		Long: "Log out of Pachyderm by deleting your local credential. Note that " +
@@ -256,14 +270,24 @@ func LogoutCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "error reading Pachyderm config (for cluster address)")
 			}
-			_, context, err := cfg.ActiveContext(true)
-			if err != nil {
-				return errors.Wrapf(err, "error getting the active context")
+			if enterprise {
+				_, context, err := cfg.ActiveEnterpriseContext(true)
+				if err != nil {
+					return errors.Wrapf(err, "error getting the active context")
+				}
+				context.SessionToken = ""
+			} else {
+				_, context, err := cfg.ActiveContext(true)
+				if err != nil {
+					return errors.Wrapf(err, "error getting the active context")
+				}
+				context.SessionToken = ""
 			}
-			context.SessionToken = ""
+
 			return cfg.Write()
 		}),
 	}
+	logout.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Log out of the active enterprise context")
 	return cmdutil.CreateAlias(logout, "auth logout")
 }
 
@@ -271,11 +295,12 @@ func LogoutCmd() *cobra.Command {
 // credential, logging you out of your cluster. Note that this is not necessary
 // to do before logging in as another user, but is useful for testing.
 func WhoamiCmd() *cobra.Command {
+	var enterprise bool
 	whoami := &cobra.Command{
 		Short: "Print your Pachyderm identity",
 		Long:  "Print your Pachyderm identity.",
 		Run: cmdutil.Run(func([]string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -291,6 +316,7 @@ func WhoamiCmd() *cobra.Command {
 			return nil
 		}),
 	}
+	whoami.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "")
 	return cmdutil.CreateAlias(whoami, "auth whoami")
 }
 
@@ -350,6 +376,7 @@ func GetAuthTokenCmd() *cobra.Command {
 // GetRobotTokenCmd returns a cobra command that lets a user get a pachyderm
 // token on behalf of themselves or another user
 func GetRobotTokenCmd() *cobra.Command {
+	var enterprise bool
 	var quiet bool
 	var ttl string
 	getAuthToken := &cobra.Command{
@@ -357,7 +384,7 @@ func GetRobotTokenCmd() *cobra.Command {
 		Short: "Get an auth token for a robot user with the specified name.",
 		Long:  "Get an auth token for a robot user with the specified name.",
 		Run: cmdutil.RunBoundedArgs(1, 1, func(args []string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -391,12 +418,14 @@ func GetRobotTokenCmd() *cobra.Command {
 	getAuthToken.PersistentFlags().StringVar(&ttl, "ttl", "", "if set, the "+
 		"resulting auth token will have the given lifetime. If not set, the token does not expire."+
 		" This flag should be a golang duration (e.g. \"30s\" or \"1h2m3s\").")
+	getAuthToken.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Get a robot token for the enterprise context")
 	return cmdutil.CreateAlias(getAuthToken, "auth get-robot-token")
 }
 
 // UseAuthTokenCmd returns a cobra command that lets a user get a pachyderm
 // token on behalf of themselves or another user
 func UseAuthTokenCmd() *cobra.Command {
+	var enterprise bool
 	useAuthToken := &cobra.Command{
 		Short: "Read a Pachyderm auth token from stdin, and write it to the " +
 			"current user's Pachyderm config file",
@@ -408,10 +437,11 @@ func UseAuthTokenCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "error reading token")
 			}
-			config.WritePachTokenToConfig(strings.TrimSpace(token)) // drop trailing newline
+			config.WritePachTokenToConfig(strings.TrimSpace(token), enterprise) // drop trailing newline
 			return nil
 		}),
 	}
+	useAuthToken.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Use the token for the enterprise context")
 	return cmdutil.CreateAlias(useAuthToken, "auth use-auth-token")
 }
 
@@ -549,6 +579,57 @@ func GetClusterRoleBindingCmd() *cobra.Command {
 	return cmdutil.CreateAlias(get, "auth get cluster")
 }
 
+// SetEnterpriseRoleBindingCmd returns a cobra command that sets the roles for a user on a resource
+func SetEnterpriseRoleBindingCmd() *cobra.Command {
+	setScope := &cobra.Command{
+		Use:   "{{alias}} [role1,role2 | none ] subject",
+		Short: "Set the roles that 'username' has on the enterprise server",
+		Long:  "Set the roles that 'username' has on the enterprise server",
+		Run: cmdutil.RunFixedArgs(2, func(args []string) error {
+			var roles []string
+			if args[0] == "none" {
+				roles = []string{}
+			} else {
+				roles = strings.Split(args[0], ",")
+			}
+
+			subject := args[1]
+			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			if err != nil {
+				return errors.Wrapf(err, "could not connect")
+			}
+			defer c.Close()
+			err = c.ModifyClusterRoleBinding(subject, roles)
+			return grpcutil.ScrubGRPC(err)
+		}),
+	}
+	return cmdutil.CreateAlias(setScope, "auth set enterprise")
+}
+
+// GetEnterpriseRoleBindingCmd returns a cobra command that gets the role bindings for a resource
+func GetEnterpriseRoleBindingCmd() *cobra.Command {
+	get := &cobra.Command{
+		Use:   "{{alias}}",
+		Short: "Get the role bindings for the enterprise server",
+		Long:  "Get the role bindings for the enterprise server",
+		Run: cmdutil.RunBoundedArgs(0, 0, func(args []string) error {
+			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			if err != nil {
+				return errors.Wrapf(err, "could not connect")
+			}
+			defer c.Close()
+			resp, err := c.GetClusterRoleBinding()
+			if err != nil {
+				return grpcutil.ScrubGRPC(err)
+			}
+
+			printRoleBinding(resp)
+			return nil
+		}),
+	}
+	return cmdutil.CreateAlias(get, "auth get enterprise")
+}
+
 // Cmds returns a list of cobra commands for authenticating and authorizing
 // users in an auth-enabled Pachyderm cluster.
 func Cmds() []*cobra.Command {
@@ -593,5 +674,7 @@ func Cmds() []*cobra.Command {
 	commands = append(commands, SetRepoRoleBindingCmd())
 	commands = append(commands, GetClusterRoleBindingCmd())
 	commands = append(commands, SetClusterRoleBindingCmd())
+	commands = append(commands, GetEnterpriseRoleBindingCmd())
+	commands = append(commands, SetEnterpriseRoleBindingCmd())
 	return commands
 }

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -41,11 +41,12 @@ func TestLogin(t *testing.T) {
 	out, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 
+	c := tu.GetUnauthenticatedPachClient(t)
 	require.NoError(t, cmd.Start())
 	sc := bufio.NewScanner(out)
 	for sc.Scan() {
 		if strings.HasPrefix(strings.TrimSpace(sc.Text()), "http://") {
-			tu.DoOAuthExchange(t, sc.Text())
+			tu.DoOAuthExchange(t, c, c, sc.Text())
 			break
 		}
 	}

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -24,7 +24,7 @@ func loginAsUser(t *testing.T, user string) {
 	robot := strings.TrimPrefix(user, auth.RobotPrefix)
 	token, err := rootClient.GetRobotToken(rootClient.Ctx(), &auth.GetRobotTokenRequest{Robot: robot})
 	require.NoError(t, err)
-	config.WritePachTokenToConfig(token.Token)
+	config.WritePachTokenToConfig(token.Token, false)
 }
 
 func TestLogin(t *testing.T) {

--- a/src/server/auth/cmds/configure.go
+++ b/src/server/auth/cmds/configure.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
@@ -20,12 +19,13 @@ import (
 // GetConfigCmd returns a cobra command that lets the caller see the configured
 // auth backends in Pachyderm
 func GetConfigCmd() *cobra.Command {
+	var enterprise bool
 	var format string
 	getConfig := &cobra.Command{
 		Short: "Retrieve Pachyderm's current auth configuration",
 		Long:  "Retrieve Pachyderm's current auth configuration",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -62,6 +62,7 @@ func GetConfigCmd() *cobra.Command {
 			return nil
 		}),
 	}
+	getConfig.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Get auth config for the active enterprise context")
 	getConfig.Flags().StringVarP(&format, "output-format", "o", "json", "output "+
 		"format (\"json\" or \"yaml\")")
 	return cmdutil.CreateAlias(getConfig, "auth get-config")
@@ -70,12 +71,13 @@ func GetConfigCmd() *cobra.Command {
 // SetConfigCmd returns a cobra command that lets the caller configure auth
 // backends in Pachyderm
 func SetConfigCmd() *cobra.Command {
+	var enterprise bool
 	var file string
 	setConfig := &cobra.Command{
 		Short: "Set Pachyderm's current auth configuration",
 		Long:  "Set Pachyderm's current auth configuration",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(enterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -109,6 +111,7 @@ func SetConfigCmd() *cobra.Command {
 			return grpcutil.ScrubGRPC(err)
 		}),
 	}
+	setConfig.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Set auth config for the active enterprise context")
 	setConfig.Flags().StringVarP(&file, "file", "f", "-", "input file (to use "+
 		"as the new config")
 	return cmdutil.CreateAlias(setConfig, "auth set-config")

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -22,7 +22,7 @@ func TestOIDCAuthCodeFlow(t *testing.T) {
 	loginInfo, err := testClient.GetOIDCLogin(testClient.Ctx(), &auth.GetOIDCLoginRequest{})
 	require.NoError(t, err)
 
-	tu.DoOAuthExchange(t, loginInfo.LoginURL)
+	tu.DoOAuthExchange(t, testClient, testClient, loginInfo.LoginURL)
 	// Check that pachd recorded the response from the redirect
 	authResp, err := testClient.Authenticate(testClient.Ctx(),
 		&auth.AuthenticateRequest{OIDCState: loginInfo.State})

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -124,8 +124,6 @@ func RegisterCmd() *cobra.Command {
 			}
 			defer ec.Close()
 
-			fmt.Printf("ec: %v\nc: %v\n", ec, c)
-
 			// Register the pachd with the license server
 			resp, err := ec.License.AddCluster(ec.Ctx(),
 				&license.AddClusterRequest{


### PR DESCRIPTION
The enterprise server has it's own set of role bindings, tokens, auth config, etc. This PR adds an option to run most auth commands against the configured enterprise server with the `--enterprise` flag. It also adds integration tests for authenticating to the enterprise server and pachd.

Depends on https://github.com/pachyderm/pachyderm/pull/5834