### PR TITLE
Log HeartbeatRequest without secret instead of logging the HeartbeatResponse

### DIFF
--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -237,8 +237,9 @@ func stripSecretFromRequest(req *lc.HeartbeatRequest) *lc.HeartbeatRequest {
 }
 
 func (a *apiServer) Heartbeat(ctx context.Context, req *lc.HeartbeatRequest) (resp *lc.HeartbeatResponse, retErr error) {
-	a.LogReq(nil)
-	defer func(start time.Time) { a.pachLogger.Log(stripSecretFromRequest(req), nil, retErr, time.Since(start)) }(time.Now())
+	redactedRequest := stripSecretFromRequest(req)
+	a.LogReq(redactedRequest)
+	defer func(start time.Time) { a.pachLogger.Log(redactedRequest, nil, retErr, time.Since(start)) }(time.Now())
 
 	var count int
 	if err := a.env.GetDBClient().GetContext(ctx, &count, `SELECT COUNT(*) FROM license.clusters WHERE id=$1 and secret=$2`, req.Id, req.Secret); err != nil {

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -230,9 +230,15 @@ func (a *apiServer) AddCluster(ctx context.Context, req *lc.AddClusterRequest) (
 	}, nil
 }
 
+func stripSecretFromRequest(req *lc.HeartbeatRequest) *lc.HeartbeatRequest {
+	r := *req
+	r.Secret = ""
+	return &r
+}
+
 func (a *apiServer) Heartbeat(ctx context.Context, req *lc.HeartbeatRequest) (resp *lc.HeartbeatResponse, retErr error) {
 	a.LogReq(nil)
-	defer func(start time.Time) { a.pachLogger.Log(nil, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.pachLogger.Log(stripSecretFromRequest(req), nil, retErr, time.Since(start)) }(time.Now())
 
 	var count int
 	if err := a.env.GetDBClient().GetContext(ctx, &count, `SELECT COUNT(*) FROM license.clusters WHERE id=$1 and secret=$2`, req.Id, req.Secret); err != nil {


### PR DESCRIPTION
To avoid logging the enterprise token stored in the HeartbeatResponse, the HeartbeatRequest is logged instead with its `Secret` field value stripped.