### PR TITLE
Caching WhoAmI result in the Request Context 

### DIFF
--- a/src/internal/auth/handler.go
+++ b/src/internal/auth/handler.go
@@ -5,63 +5,58 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 )
 
-// an authHandler can optionally return a key-value that will be cached in the request's context
-type authHandler func(*client.APIClient, string) (*keyValue, error)
+// an authHandler can optionally return a username string that will be cached in the request's context
+type authHandler func(*client.APIClient, string) (string, error)
 
-type ctxKey string
+type ContextKey string
 
-type keyValue struct {
-	k ctxKey
-	v interface{}
-}
-
-const whoAmIKey ctxKey = "ctxKey_WhoAmI"
+const WhoAmIResultKey = ContextKey("WhoAmI")
 
 // authDisabledOr wraps an authHandler and permits the RPC if authHandler succeeds or
 // if auth is disabled on the cluster
 func authDisabledOr(h authHandler) authHandler {
-	return func(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
-		memoized, err := h(pachClient, fullMethod)
+	return func(pachClient *client.APIClient, fullMethod string) (string, error) {
+		username, err := h(pachClient, fullMethod)
 
 		// TODO: check this
 		if auth.IsErrNotActivated(err) {
-			return nil, nil
+			return "", nil
 		}
-		return memoized, err
+		return username, err
 	}
 }
 
 // unauthenticated permits any RPC even if the user has no authentication token
-func unauthenticated(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
-	return nil, nil
+func unauthenticated(pachClient *client.APIClient, fullMethod string) (string, error) {
+	return "", nil
 }
 
 // authenticated permits an RPC if auth is fully enabled and the user is authenticated
-func authenticated(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
+func authenticated(pachClient *client.APIClient, fullMethod string) (string, error) {
 	// consider the request authenticated if WhoAmI has a value
-	if v := pachClient.Ctx().Value(whoAmIKey); v != nil {
-		return nil, nil
+	if v := pachClient.Ctx().Value(WhoAmIResultKey); v != nil {
+		return "", nil
 	}
 	r, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{})
-	return &keyValue{whoAmIKey, r}, err
+	return r.Username, err
 }
 
 // clusterPermissions permits an RPC if the user is authorized with the given permissions on the cluster
 func clusterPermissions(permissions ...auth.Permission) authHandler {
-	return func(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
+	return func(pachClient *client.APIClient, fullMethod string) (string, error) {
 		resp, err := pachClient.Authorize(pachClient.Ctx(), &auth.AuthorizeRequest{
 			Resource:    &auth.Resource{Type: auth.ResourceType_CLUSTER},
 			Permissions: permissions,
 		})
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
 		if resp.Authorized {
-			return nil, nil
+			return "", nil
 		}
 
-		return nil, &auth.ErrNotAuthorized{
+		return "", &auth.ErrNotAuthorized{
 			Subject:  resp.Principal,
 			Resource: auth.Resource{Type: auth.ResourceType_CLUSTER},
 			Required: permissions,

--- a/src/internal/auth/handler.go
+++ b/src/internal/auth/handler.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 )
@@ -34,10 +35,15 @@ func unauthenticated(pachClient *client.APIClient, fullMethod string) (string, e
 func authenticated(pachClient *client.APIClient, fullMethod string) (string, error) {
 	// consider the request authenticated if WhoAmI has a value
 	if v := pachClient.Ctx().Value(WhoAmIResultKey); v != nil {
-		return "", nil
+		return fmt.Sprintf("%v", v), nil
 	}
 	r, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{})
-	return r.Username, err
+
+	var username = ""
+	if r != nil {
+		username = r.Username
+	}
+	return username, err
 }
 
 // clusterPermissions permits an RPC if the user is authorized with the given permissions on the cluster

--- a/src/internal/auth/handler.go
+++ b/src/internal/auth/handler.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 )
@@ -34,15 +33,10 @@ func unauthenticated(pachClient *client.APIClient, fullMethod string) (string, e
 
 // authenticated permits an RPC if auth is fully enabled and the user is authenticated
 func authenticated(pachClient *client.APIClient, fullMethod string) (string, error) {
-	// consider the request authenticated if WhoAmI is set in the client's context
-	if v := GetWhoAmI(pachClient.Ctx()); v != "" {
-		return v, nil
-	}
-
 	r, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{})
 
 	var username string
-	if r != nil {
+	if err == nil {
 		username = r.Username
 	}
 	return username, err
@@ -73,7 +67,7 @@ func clusterPermissions(permissions ...auth.Permission) authHandler {
 
 func GetWhoAmI(ctx context.Context) string {
 	if v := ctx.Value(whoAmIResultKey); v != nil {
-		return fmt.Sprintf("%v", v)
+		return v.(string)
 	}
 	return ""
 }

--- a/src/internal/auth/handler.go
+++ b/src/internal/auth/handler.go
@@ -18,7 +18,6 @@ func authDisabledOr(h authHandler) authHandler {
 	return func(pachClient *client.APIClient, fullMethod string) (string, error) {
 		username, err := h(pachClient, fullMethod)
 
-		// TODO: check this
 		if auth.IsErrNotActivated(err) {
 			return "", nil
 		}

--- a/src/internal/auth/handler.go
+++ b/src/internal/auth/handler.go
@@ -5,47 +5,63 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 )
 
-type authHandler func(*client.APIClient, string) error
+// an authHandler can optionally return a key-value that will be cached in the request's context
+type authHandler func(*client.APIClient, string) (*keyValue, error)
+
+type ctxKey string
+
+type keyValue struct {
+	k ctxKey
+	v interface{}
+}
+
+const whoAmIKey ctxKey = "ctxKey_WhoAmI"
 
 // authDisabledOr wraps an authHandler and permits the RPC if authHandler succeeds or
 // if auth is disabled on the cluster
 func authDisabledOr(h authHandler) authHandler {
-	return func(pachClient *client.APIClient, fullMethod string) error {
-		err := h(pachClient, fullMethod)
+	return func(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
+		memoized, err := h(pachClient, fullMethod)
+
+		// TODO: check this
 		if auth.IsErrNotActivated(err) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return memoized, err
 	}
 }
 
 // unauthenticated permits any RPC even if the user has no authentication token
-func unauthenticated(pachClient *client.APIClient, fullMethod string) error {
-	return nil
+func unauthenticated(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
+	return nil, nil
 }
 
 // authenticated permits an RPC if auth is fully enabled and the user is authenticated
-func authenticated(pachClient *client.APIClient, fullMethod string) error {
-	_, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{})
-	return err
+func authenticated(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
+	// consider the request authenticated if WhoAmI has a value
+	if v := pachClient.Ctx().Value(whoAmIKey); v != nil {
+		return nil, nil
+	}
+	r, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{})
+	return &keyValue{whoAmIKey, r}, err
 }
 
 // clusterPermissions permits an RPC if the user is authorized with the given permissions on the cluster
 func clusterPermissions(permissions ...auth.Permission) authHandler {
-	return func(pachClient *client.APIClient, fullMethod string) error {
+	return func(pachClient *client.APIClient, fullMethod string) (*keyValue, error) {
 		resp, err := pachClient.Authorize(pachClient.Ctx(), &auth.AuthorizeRequest{
 			Resource:    &auth.Resource{Type: auth.ResourceType_CLUSTER},
 			Permissions: permissions,
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if resp.Authorized {
-			return nil
+			return nil, nil
 		}
 
-		return &auth.ErrNotAuthorized{
+		return nil, &auth.ErrNotAuthorized{
 			Subject:  resp.Principal,
 			Resource: auth.Resource{Type: auth.ResourceType_CLUSTER},
 			Required: permissions,

--- a/src/internal/auth/interceptor.go
+++ b/src/internal/auth/interceptor.go
@@ -288,8 +288,7 @@ func (i *Interceptor) InterceptUnary(ctx context.Context, req interface{}, info 
 		return nil, err
 	}
 
-	// add username to context if provided
-	if canSetWhoAmI(ctx, username) {
+	if username != "" {
 		ctx = setWhoAmI(ctx, username)
 	}
 
@@ -313,8 +312,7 @@ func (i *Interceptor) InterceptStream(srv interface{}, stream grpc.ServerStream,
 		return err
 	}
 
-	// add username to context if it's provided and hasn't been previously set
-	if canSetWhoAmI(ctx, username) {
+	if username != "" {
 		newCtx := setWhoAmI(ctx, username)
 		stream = ServerStreamWrapper{stream, newCtx}
 	}
@@ -326,10 +324,4 @@ func nameOrUnauthenticated(name string) string {
 		return "unauthenticated"
 	}
 	return name
-}
-
-// set username in context if value is provided, and one hasn't previously been set.
-// this function implies that WhoAmI value is not expected to change within a request's processing.
-func canSetWhoAmI(ctx context.Context, username string) bool {
-	return username != "" && GetWhoAmI(ctx) == ""
 }

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1302,14 +1302,6 @@ func setToList(set map[string]bool) []string {
 }
 
 func (a *apiServer) getAuthenticatedUser(ctx context.Context) (*auth.TokenInfo, error) {
-	// first try to lookup pre-computed subject
-	if subject := internalauth.GetWhoAmI(ctx); subject != "" {
-		return &auth.TokenInfo{
-			Subject: subject,
-			Source:  auth.TokenInfo_GET_TOKEN,
-		}, nil
-	}
-
 	token, err := auth.GetAuthToken(ctx)
 	if err != nil {
 		return nil, err
@@ -1321,6 +1313,14 @@ func (a *apiServer) getAuthenticatedUser(ctx context.Context) (*auth.TokenInfo, 
 		// this check should happen in authorize
 		return &auth.TokenInfo{
 			Subject: auth.PpsUser,
+			Source:  auth.TokenInfo_GET_TOKEN,
+		}, nil
+	}
+
+	// try to lookup pre-computed subject
+	if subject := internalauth.GetWhoAmI(ctx); subject != "" {
+		return &auth.TokenInfo{
+			Subject: subject,
 			Source:  auth.TokenInfo_GET_TOKEN,
 		}, nil
 	}

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	enterpriseclient "github.com/pachyderm/pachyderm/v2/src/enterprise"
+	internalauth "github.com/pachyderm/pachyderm/v2/src/internal/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -1301,13 +1302,19 @@ func setToList(set map[string]bool) []string {
 }
 
 func (a *apiServer) getAuthenticatedUser(ctx context.Context) (*auth.TokenInfo, error) {
-	// TODO(msteffen) cache these lookups, especially since users always authorize
-	// themselves at the beginning of a request. Don't want to look up the same
-	// token -> username entry twice.
+	// first try to lookup pre-computed subject
+	if subject := internalauth.GetWhoAmI(ctx); subject != "" {
+		return &auth.TokenInfo{
+			Subject: subject,
+			Source:  auth.TokenInfo_GET_TOKEN,
+		}, nil
+	}
+
 	token, err := auth.GetAuthToken(ctx)
 	if err != nil {
 		return nil, err
 	}
+
 	if token == a.ppsToken {
 		// TODO(msteffen): This is a hack. The idea is that there is a logical user
 		// entry mapping ppsToken to ppsUser. Soon, ppsUser will go away and


### PR DESCRIPTION

Here's what I'm thinking for caching WhoAmI requests. 

Limitation - 'cache inserts' can only happen in Middleware (Interceptor)