### PR TITLE
Close s3 client grpc connections.

### DIFF
--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -925,7 +925,7 @@ func doFullMode(config interface{}) (retErr error) {
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
 		server, err := s3.Server(env.Config().S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
-			return client.NewFromAddress(fmt.Sprintf("localhost:%d", env.Config().PeerPort))
+			return env.GetPachClient(context.Background()), nil
 		})
 		if err != nil {
 			return err

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -8335,12 +8335,9 @@ func TestCancelManyJobs(t *testing.T) {
 	// Create 10 input commits, to spawn 10 jobs
 	var commits [10]*pfs.Commit
 	var err error
-	commits[0], err = c.StartCommit(repo, "master")
-	require.NoError(t, err)
-	require.NoError(t, c.PutFile(repo, commits[0].ID, "file", strings.NewReader("foo"), client.WithAppendPutFile()))
-	require.NoError(t, c.FinishCommit(repo, commits[0].ID))
-	for i := 1; i < 10; i++ {
+	for i := 0; i < 10; i++ {
 		commits[i], err = c.StartCommit(repo, "master")
+		require.NoError(t, c.PutFile(repo, commits[i].ID, "file", strings.NewReader("foo"), client.WithAppendPutFile()))
 		require.NoError(t, err)
 		require.NoError(t, c.FinishCommit(repo, commits[i].ID))
 	}


### PR DESCRIPTION
The s3 client opens a new grpc connection for every request. Regardless
of whether this is necessary, it should at least clean up after itself.

Fix #5856, though maybe some more changes are worthwhile.