### PR TITLE
Define the Prometheus metrics port

### DIFF
--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -67,7 +67,8 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services"
+        "services",
+        "replicationcontrollers/scale"
       ]
     },
     {
@@ -419,6 +420,13 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
+      },
+      {
+        "name": "prom-metrics",
+        "protocol": "TCP",
+        "port": 656,
+        "targetPort": 656,
+        "nodePort": 30656
       }
     ],
     "selector": {
@@ -507,7 +515,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.1",
+            "image": "pachyderm/pachd:1.13.0",
             "command": [
               "/pachd"
             ],
@@ -545,6 +553,11 @@
                 "name": "oidc-port",
                 "containerPort": 657,
                 "protocol": "TCP"
+              },
+              {
+                "name": "prom-metrics",
+                "containerPort": 656,
+                "protocol": "TCP"
               }
             ],
             "env": [
@@ -568,14 +581,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.1"
+                "value": "pachyderm/worker:1.13.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.1"
+                "value": "pachyderm/pachd:1.13.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -587,7 +600,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.1"
+                "value": "1.13.0"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.json
@@ -67,8 +67,7 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services",
-        "replicationcontrollers/scale"
+        "services"
       ]
     },
     {
@@ -420,13 +419,6 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
-      },
-      {
-        "name": "prometheus-metrics",
-        "protocol": "TCP",
-        "port": 656,
-        "targetPort": 656,
-        "nodePort": 30656
       }
     ],
     "selector": {
@@ -515,7 +507,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.13.0",
+            "image": "pachyderm/pachd:1.12.1",
             "command": [
               "/pachd"
             ],
@@ -576,14 +568,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.13.0"
+                "value": "pachyderm/worker:1.12.1"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.13.0"
+                "value": "pachyderm/pachd:1.12.1"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -595,7 +587,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.13.0"
+                "value": "1.12.1"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -44,6 +44,7 @@ rules:
   resources:
   - replicationcontrollers
   - services
+  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -292,6 +293,11 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
+  - name: prom-metrics
+    nodePort: 30656
+    port: 656
+    protocol: TCP
+    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -358,16 +364,16 @@ spec:
           value: AMAZON
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.1
+          value: pachyderm/worker:1.13.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.1
+          value: pachyderm/pachd:1.13.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.1
+          value: 1.13.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -589,7 +595,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.1
+        image: pachyderm/pachd:1.13.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -612,6 +618,9 @@ spec:
           protocol: TCP
         - containerPort: 657
           name: oidc-port
+          protocol: TCP
+        - containerPort: 656
+          name: prom-metrics
           protocol: TCP
         readinessProbe:
           exec:

--- a/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/amazon-deploy-manifest.yaml
@@ -44,7 +44,6 @@ rules:
   resources:
   - replicationcontrollers
   - services
-  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -293,11 +292,6 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
-  - name: prometheus-metrics
-    nodePort: 30656
-    port: 656
-    protocol: TCP
-    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -364,16 +358,16 @@ spec:
           value: AMAZON
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.13.0
+          value: pachyderm/worker:1.12.1
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.13.0
+          value: pachyderm/pachd:1.12.1
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.13.0
+          value: 1.12.1
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -595,7 +589,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.13.0
+        image: pachyderm/pachd:1.12.1
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -67,8 +67,7 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services",
-        "replicationcontrollers/scale"
+        "services"
       ]
     },
     {
@@ -403,13 +402,6 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
-      },
-      {
-        "name": "prometheus-metrics",
-        "protocol": "TCP",
-        "port": 656,
-        "targetPort": 656,
-        "nodePort": 30656
       }
     ],
     "selector": {
@@ -498,7 +490,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.13.0",
+            "image": "pachyderm/pachd:1.12.1",
             "command": [
               "/pachd"
             ],
@@ -559,14 +551,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.13.0"
+                "value": "pachyderm/worker:1.12.1"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.13.0"
+                "value": "pachyderm/pachd:1.12.1"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -578,7 +570,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.13.0"
+                "value": "1.12.1"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.json
@@ -67,7 +67,8 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services"
+        "services",
+        "replicationcontrollers/scale"
       ]
     },
     {
@@ -402,6 +403,13 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
+      },
+      {
+        "name": "prom-metrics",
+        "protocol": "TCP",
+        "port": 656,
+        "targetPort": 656,
+        "nodePort": 30656
       }
     ],
     "selector": {
@@ -490,7 +498,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.1",
+            "image": "pachyderm/pachd:1.13.0",
             "command": [
               "/pachd"
             ],
@@ -528,6 +536,11 @@
                 "name": "oidc-port",
                 "containerPort": 657,
                 "protocol": "TCP"
+              },
+              {
+                "name": "prom-metrics",
+                "containerPort": 656,
+                "protocol": "TCP"
               }
             ],
             "env": [
@@ -551,14 +564,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.1"
+                "value": "pachyderm/worker:1.13.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.1"
+                "value": "pachyderm/pachd:1.13.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -570,7 +583,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.1"
+                "value": "1.13.0"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -44,7 +44,6 @@ rules:
   resources:
   - replicationcontrollers
   - services
-  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -280,11 +279,6 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
-  - name: prometheus-metrics
-    nodePort: 30656
-    port: 656
-    protocol: TCP
-    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -351,16 +345,16 @@ spec:
           value: AMAZON
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.13.0
+          value: pachyderm/worker:1.12.1
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.13.0
+          value: pachyderm/pachd:1.12.1
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.13.0
+          value: 1.12.1
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -582,7 +576,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.13.0
+        image: pachyderm/pachd:1.12.1
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:

--- a/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/custom-deploy-manifest.yaml
@@ -44,6 +44,7 @@ rules:
   resources:
   - replicationcontrollers
   - services
+  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -279,6 +280,11 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
+  - name: prom-metrics
+    nodePort: 30656
+    port: 656
+    protocol: TCP
+    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -345,16 +351,16 @@ spec:
           value: AMAZON
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.1
+          value: pachyderm/worker:1.13.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.1
+          value: pachyderm/pachd:1.13.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.1
+          value: 1.13.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -576,7 +582,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.1
+        image: pachyderm/pachd:1.13.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -599,6 +605,9 @@ spec:
           protocol: TCP
         - containerPort: 657
           name: oidc-port
+          protocol: TCP
+        - containerPort: 656
+          name: prom-metrics
           protocol: TCP
         readinessProbe:
           exec:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -67,7 +67,8 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services"
+        "services",
+        "replicationcontrollers/scale"
       ]
     },
     {
@@ -419,6 +420,13 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
+      },
+      {
+        "name": "prom-metrics",
+        "protocol": "TCP",
+        "port": 656,
+        "targetPort": 656,
+        "nodePort": 30656
       }
     ],
     "selector": {
@@ -507,7 +515,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.1",
+            "image": "pachyderm/pachd:1.13.0",
             "command": [
               "/pachd"
             ],
@@ -545,6 +553,11 @@
                 "name": "oidc-port",
                 "containerPort": 657,
                 "protocol": "TCP"
+              },
+              {
+                "name": "prom-metrics",
+                "containerPort": 656,
+                "protocol": "TCP"
               }
             ],
             "env": [
@@ -568,14 +581,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.1"
+                "value": "pachyderm/worker:1.13.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.1"
+                "value": "pachyderm/pachd:1.13.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -587,7 +600,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.1"
+                "value": "1.13.0"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.json
@@ -67,8 +67,7 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services",
-        "replicationcontrollers/scale"
+        "services"
       ]
     },
     {
@@ -420,13 +419,6 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
-      },
-      {
-        "name": "prometheus-metrics",
-        "protocol": "TCP",
-        "port": 656,
-        "targetPort": 656,
-        "nodePort": 30656
       }
     ],
     "selector": {
@@ -515,7 +507,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.13.0",
+            "image": "pachyderm/pachd:1.12.1",
             "command": [
               "/pachd"
             ],
@@ -576,14 +568,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.13.0"
+                "value": "pachyderm/worker:1.12.1"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.13.0"
+                "value": "pachyderm/pachd:1.12.1"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -595,7 +587,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.13.0"
+                "value": "1.12.1"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -44,6 +44,7 @@ rules:
   resources:
   - replicationcontrollers
   - services
+  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -292,6 +293,11 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
+  - name: prom-metrics
+    nodePort: 30656
+    port: 656
+    protocol: TCP
+    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -358,16 +364,16 @@ spec:
           value: GOOGLE
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.1
+          value: pachyderm/worker:1.13.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.1
+          value: pachyderm/pachd:1.13.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.1
+          value: 1.13.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -589,7 +595,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.1
+        image: pachyderm/pachd:1.13.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -612,6 +618,9 @@ spec:
           protocol: TCP
         - containerPort: 657
           name: oidc-port
+          protocol: TCP
+        - containerPort: 656
+          name: prom-metrics
           protocol: TCP
         readinessProbe:
           exec:

--- a/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/google-deploy-manifest.yaml
@@ -44,7 +44,6 @@ rules:
   resources:
   - replicationcontrollers
   - services
-  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -293,11 +292,6 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
-  - name: prometheus-metrics
-    nodePort: 30656
-    port: 656
-    protocol: TCP
-    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -364,16 +358,16 @@ spec:
           value: GOOGLE
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.13.0
+          value: pachyderm/worker:1.12.1
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.13.0
+          value: pachyderm/pachd:1.12.1
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.13.0
+          value: 1.12.1
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -595,7 +589,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.13.0
+        image: pachyderm/pachd:1.12.1
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -67,8 +67,7 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services",
-        "replicationcontrollers/scale"
+        "services"
       ]
     },
     {
@@ -400,13 +399,6 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
-      },
-      {
-        "name": "prometheus-metrics",
-        "protocol": "TCP",
-        "port": 656,
-        "targetPort": 656,
-        "nodePort": 30656
       }
     ],
     "selector": {
@@ -495,7 +487,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.13.0",
+            "image": "pachyderm/pachd:1.12.1",
             "command": [
               "/pachd"
             ],
@@ -556,14 +548,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.13.0"
+                "value": "pachyderm/worker:1.12.1"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.13.0"
+                "value": "pachyderm/pachd:1.12.1"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -575,7 +567,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.13.0"
+                "value": "1.12.1"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.json
@@ -67,7 +67,8 @@
       ],
       "resources": [
         "replicationcontrollers",
-        "services"
+        "services",
+        "replicationcontrollers/scale"
       ]
     },
     {
@@ -399,6 +400,13 @@
         "port": 600,
         "targetPort": 0,
         "nodePort": 30600
+      },
+      {
+        "name": "prom-metrics",
+        "protocol": "TCP",
+        "port": 656,
+        "targetPort": 656,
+        "nodePort": 30656
       }
     ],
     "selector": {
@@ -487,7 +495,7 @@
         "containers": [
           {
             "name": "pachd",
-            "image": "pachyderm/pachd:1.12.1",
+            "image": "pachyderm/pachd:1.13.0",
             "command": [
               "/pachd"
             ],
@@ -525,6 +533,11 @@
                 "name": "oidc-port",
                 "containerPort": 657,
                 "protocol": "TCP"
+              },
+              {
+                "name": "prom-metrics",
+                "containerPort": 656,
+                "protocol": "TCP"
               }
             ],
             "env": [
@@ -548,14 +561,14 @@
               },
               {
                 "name": "WORKER_IMAGE",
-                "value": "pachyderm/worker:1.12.1"
+                "value": "pachyderm/worker:1.13.0"
               },
               {
                 "name": "IMAGE_PULL_SECRET"
               },
               {
                 "name": "WORKER_SIDECAR_IMAGE",
-                "value": "pachyderm/pachd:1.12.1"
+                "value": "pachyderm/pachd:1.13.0"
               },
               {
                 "name": "WORKER_IMAGE_PULL_POLICY",
@@ -567,7 +580,7 @@
               },
               {
                 "name": "PACHD_VERSION",
-                "value": "1.12.1"
+                "value": "1.13.0"
               },
               {
                 "name": "METRICS",

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -44,6 +44,7 @@ rules:
   resources:
   - replicationcontrollers
   - services
+  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -277,6 +278,11 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
+  - name: prom-metrics
+    nodePort: 30656
+    port: 656
+    protocol: TCP
+    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -343,16 +349,16 @@ spec:
           value: MICROSOFT
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.12.1
+          value: pachyderm/worker:1.13.0
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.12.1
+          value: pachyderm/pachd:1.13.0
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.12.1
+          value: 1.13.0
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -574,7 +580,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.12.1
+        image: pachyderm/pachd:1.13.0
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:
@@ -597,6 +603,9 @@ spec:
           protocol: TCP
         - containerPort: 657
           name: oidc-port
+          protocol: TCP
+        - containerPort: 656
+          name: prom-metrics
           protocol: TCP
         readinessProbe:
           exec:

--- a/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
+++ b/etc/testing/deploy-manifests/golden/microsoft-deploy-manifest.yaml
@@ -44,7 +44,6 @@ rules:
   resources:
   - replicationcontrollers
   - services
-  - replicationcontrollers/scale
   verbs:
   - get
   - list
@@ -278,11 +277,6 @@ spec:
     nodePort: 30600
     port: 600
     targetPort: 0
-  - name: prometheus-metrics
-    nodePort: 30656
-    port: 656
-    protocol: TCP
-    targetPort: 656
   selector:
     app: pachd
   type: NodePort
@@ -349,16 +343,16 @@ spec:
           value: MICROSOFT
         - name: STORAGE_HOST_PATH
         - name: WORKER_IMAGE
-          value: pachyderm/worker:1.13.0
+          value: pachyderm/worker:1.12.1
         - name: IMAGE_PULL_SECRET
         - name: WORKER_SIDECAR_IMAGE
-          value: pachyderm/pachd:1.13.0
+          value: pachyderm/pachd:1.12.1
         - name: WORKER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: WORKER_SERVICE_ACCOUNT
           value: pachyderm-worker
         - name: PACHD_VERSION
-          value: 1.13.0
+          value: 1.12.1
         - name: METRICS
           value: "true"
         - name: LOG_LEVEL
@@ -580,7 +574,7 @@ spec:
           value: "100"
         - name: STORAGE_V2
           value: "false"
-        image: pachyderm/pachd:1.13.0
+        image: pachyderm/pachd:1.12.1
         imagePullPolicy: IfNotPresent
         name: pachd
         ports:

--- a/src/server/pkg/deploy/assets/assets.go
+++ b/src/server/pkg/deploy/assets/assets.go
@@ -783,6 +783,11 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend Backend, hostPath strin
 									Protocol:      "TCP",
 									Name:          "oidc-port",
 								},
+								{
+									ContainerPort: int32(PrometheusPort),
+									Protocol:      "TCP",
+									Name:          "prom-metrics",
+								},
 							},
 							VolumeMounts:    volumeMounts,
 							ImagePullPolicy: "IfNotPresent",
@@ -862,7 +867,7 @@ func PachdService(opts *AssetOpts) *v1.Service {
 				},
 				{
 					Port:       656,
-					Name:       "prometheus-metrics",
+					Name:       "prom-metrics",
 					NodePort:   30656,
 					Protocol:   v1.ProtocolTCP,
 					TargetPort: intstr.FromInt(656),


### PR DESCRIPTION
Deployment port names are limited by Kubernetes to 15 characters, so use
`prom-metrics` for both the deployment and service port names.
Cf. https://github.com/pachyderm/helmchart/pull/42