### PR TITLE
Few changes that should improve put file performance for small files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	google.golang.org/api v0.15.0
 	google.golang.org/appengine v1.6.6 // indirect
-	google.golang.org/grpc v1.27.0
+	google.golang.org/grpc v1.36.1
 	gopkg.in/go-playground/webhooks.v5 v5.11.0
 	gopkg.in/pachyderm/yaml.v3 v3.0.0-20200130061037-1dd3d7bd0850
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,6 @@ github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hanwen/go-fuse v1.0.0 h1:GxS9Zrn6c35/BnfiVsZVWmsG803xwE7eVRDvcf/BEVc=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
-github.com/hanwen/go-fuse/v2 v2.0.2 h1:BtsqKI5RXOqDMnTgpCb0IWgvRgGLJdqYVZ/Hm6KgKto=
-github.com/hanwen/go-fuse/v2 v2.0.2/go.mod h1:HH3ygZOoyRbP9y2q7y3+JM6hPL+Epe29IbWaS0UA81o=
 github.com/hanwen/go-fuse/v2 v2.0.3 h1:kpV28BKeSyVgZREItBLnaVBvOEwv2PuhNdKetwnvNHo=
 github.com/hanwen/go-fuse/v2 v2.0.3/go.mod h1:0EQM6aH2ctVpvZ6a+onrQ/vaykxh2GH7hy3e13vzTUY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
@@ -846,6 +844,7 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.3 h1:5OfyWorkyO7xP52Mq7tB36ajHDG5OHrmBGIS/DtakQI=
 github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
@@ -1676,8 +1675,6 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-honnef.co/go/tools v0.1.1 h1:EVDuO03OCZwpV2t/tLLxPmPiomagMoBOgfPt0FM+4IY=
-honnef.co/go/tools v0.1.1/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 honnef.co/go/tools v0.1.3 h1:qTakTkI6ni6LFD5sBwwsdSO+AQqbSIxOauHTTQKZ/7o=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1462,12 +1462,14 @@ func putFileHelper(c *client.APIClient, pfc client.PutFileClient,
 				return nil
 			}
 			childDest := filepath.Join(path, strings.TrimPrefix(filePath, source))
+			limiter.Acquire()
 			eg.Go(func() error {
+				defer limiter.Release()
 				// don't do a second recursive 'put file', just put the one file at
 				// filePath into childDest, and then this walk loop will go on to the
 				// next one
 				return putFileHelper(c, pfc, repo, commit, childDest, filePath, false,
-					overwrite, limiter, split, targetFileDatums, targetFileBytes,
+					overwrite, limit.New(0), split, targetFileDatums, targetFileBytes,
 					headerRecords, filesPut)
 			})
 			return nil

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -43,8 +43,9 @@ func newAPIServer(
 	treeCache *hashtree.Cache,
 	storageRoot string,
 	memoryRequest int64,
+	directBlockAPIServer *objBlockAPIServer,
 ) (*apiServer, error) {
-	d, err := newDriver(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest)
+	d, err := newDriver(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest, directBlockAPIServer)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pfs/server/api_server_v2.go
+++ b/src/server/pfs/server/api_server_v2.go
@@ -27,7 +27,7 @@ type apiServerV2 struct {
 }
 
 func newAPIServerV2(env *serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcdPrefix string, treeCache *hashtree.Cache, storageRoot string, memoryRequest int64) (*apiServerV2, error) {
-	s1, err := newAPIServer(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest)
+	s1, err := newAPIServer(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pfs/server/driver_v2.go
+++ b/src/server/pfs/server/driver_v2.go
@@ -51,7 +51,7 @@ type driverV2 struct {
 
 // newDriver is used to create a new Driver instance
 func newDriverV2(env *serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcdPrefix string, treeCache *hashtree.Cache, storageRoot string, memoryRequest int64) (*driverV2, error) {
-	d1, err := newDriver(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest)
+	d1, err := newDriver(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -36,6 +36,7 @@ func NewAPIServer(
 	treeCache *hashtree.Cache,
 	storageRoot string,
 	memoryRequest int64,
+	blockAPIServer BlockAPIServer,
 ) (APIServer, error) {
 	if env.StorageV2 {
 		a, err := newAPIServerV2(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest)
@@ -44,7 +45,8 @@ func NewAPIServer(
 		}
 		return newValidatedAPIServer(a, env), nil
 	}
-	return newAPIServer(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest)
+	directBlockAPIServer := blockAPIServer.(*objBlockAPIServer)
+	return newAPIServer(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest, directBlockAPIServer)
 }
 
 // NewBlockAPIServer creates a BlockAPIServer using the credentials it finds in

--- a/src/server/pfs/server/testing.go
+++ b/src/server/pfs/server/testing.go
@@ -125,7 +125,7 @@ func GetPachClient(t testing.TB, config *serviceenv.Configuration) *client.APICl
 
 	txnEnv := &txnenv.TransactionEnv{}
 
-	apiServer, err := newAPIServer(env, txnEnv, etcdPrefix, treeCache, "/tmp", 64*1024*1024)
+	apiServer, err := newAPIServer(env, txnEnv, etcdPrefix, treeCache, "/tmp", 64*1024*1024, blockAPIServer)
 	require.NoError(t, err)
 
 	txnEnv.Initialize(env, nil, &authtesting.InactiveAPIServer{}, apiServer, txnenv.NewMockPpsTransactionServer())

--- a/src/server/pkg/testpachd/real_env.go
+++ b/src/server/pkg/testpachd/real_env.go
@@ -107,6 +107,7 @@ func WithRealEnv(cb func(*RealEnv) error, customConfig ...*serviceenv.PachdFullC
 			realEnv.treeCache,
 			realEnv.LocalStorageDirectory,
 			64*1024*1024,
+			realEnv.PFSBlockServer,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR will hold a few changes that should improve put file performance. I'll update this comment with more information once we are ready to commit to a set of changes.

Current changes:
- Added buffering of single message in code that receives PutFile messages.
- Removed rpc from PFS gRPC server to Block gRPC server when doing a put file. PFS gRPC server now makes calls directly on the Block gRPC server struct.
- Fixed bug where pachctl put file with the recursive flag was not respecting the parallelism limiter in terms of the goroutines being spawned. (This will probably be the most impactful for users seeing extremely slow put file recursive calls).
- Upgraded gRPC-Go to 1.36.1.