### PR TITLE
Disable auth service watches in sidecar

### DIFF
--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -215,7 +215,7 @@ func RunLocal() (retErr error) {
 		var authAPIServer authserver.APIServer
 		if err := logGRPCServerSetup("Auth API", func() error {
 			authAPIServer, err = authserver.NewAuthServer(
-				env, txnEnv, path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix), true, requireNoncriticalServers)
+				env, txnEnv, path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix), true, requireNoncriticalServers, true)
 			if err != nil {
 				return err
 			}
@@ -378,6 +378,7 @@ func RunLocal() (retErr error) {
 				path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix),
 				false,
 				requireNoncriticalServers,
+				true,
 			)
 			if err != nil {
 				return err

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -98,6 +98,13 @@ type apiServer struct {
 	// service should export the SAML ACS and Metadata services, so if public
 	// is true and auth is active, this may export those SAML services
 	public bool
+
+	// watchesEnabled controls whether we cache the auth config and cluster role bindings
+	// in the auth service, or whether we look them up each time. Watches are expensive in
+	// postgres, so we can't afford to have each sidecar run watches. Pipelines always have
+	// direct access to a repo anyways, so the cluster role bindings don't affect their access,
+	// and the OIDC server doesn't run in the sidecar so the config doesn't matter.
+	watchesEnabled bool
 }
 
 // LogReq is like log.Logger.Log(), but it assumes that it's being called from
@@ -130,6 +137,7 @@ func NewAuthServer(
 	etcdPrefix string,
 	public bool,
 	requireNoncriticalServers bool,
+	watchesEnabled bool,
 ) (APIServer, error) {
 
 	authConfig := col.NewCollection(
@@ -184,11 +192,10 @@ func NewAuthServer(
 			nil,
 			nil,
 		),
-		authConfig:              authConfig,
-		roleBindings:            roleBindings,
-		configCache:             keycache.NewCache(authConfig, configKey, &DefaultOIDCConfig),
-		clusterRoleBindingCache: keycache.NewCache(roleBindings, clusterRoleBindingKey, &auth.RoleBinding{}),
-		public:                  public,
+		authConfig:     authConfig,
+		roleBindings:   roleBindings,
+		public:         public,
+		watchesEnabled: watchesEnabled,
 	}
 	go s.retrieveOrGeneratePPSToken()
 
@@ -197,11 +204,16 @@ func NewAuthServer(
 		go waitForError("OIDC HTTP Server", requireNoncriticalServers, s.serveOIDC)
 	}
 
-	// Watch for new auth config options
-	go s.configCache.Watch()
+	if watchesEnabled {
+		s.configCache = keycache.NewCache(authConfig, configKey, &DefaultOIDCConfig)
+		s.clusterRoleBindingCache = keycache.NewCache(roleBindings, clusterRoleBindingKey, &auth.RoleBinding{})
 
-	// Watch for changes to the cluster role binding
-	go s.clusterRoleBindingCache.Watch()
+		// Watch for new auth config options
+		go s.configCache.Watch()
+
+		// Watch for changes to the cluster role binding
+		go s.clusterRoleBindingCache.Watch()
+	}
 	return s, nil
 }
 
@@ -214,17 +226,35 @@ func waitForError(name string, required bool, cb func() error) {
 	}
 }
 
-// isActive returns an error when auth is not enabled. If there are no cluster role bindings auth has not been enabled.
-func (a *apiServer) isActive() error {
-	bindings, ok := a.clusterRoleBindingCache.Load().(*auth.RoleBinding)
-	if !ok {
-		return errors.New("cached cluster binding had unexpected type")
+// getClusterRoleBinding attempts to get the current cluster role bindings,
+// and returns an error if auth is not activated. This can require hitting
+// postgres if watches are not enabled (in the worker sidecar).
+func (a *apiServer) getClusterRoleBinding(ctx context.Context) (*auth.RoleBinding, error) {
+	if a.watchesEnabled {
+		bindings, ok := a.clusterRoleBindingCache.Load().(*auth.RoleBinding)
+		if !ok {
+			return nil, errors.New("cached cluster binding had unexpected type")
+		}
+
+		if bindings.Entries == nil {
+			return nil, auth.ErrNotActivated
+		}
+		return bindings, nil
 	}
 
-	if bindings.Entries == nil {
-		return auth.ErrNotActivated
+	var binding auth.RoleBinding
+	if err := a.tokens.ReadOnly(ctx).Get(clusterRoleBindingKey, &binding); err != nil {
+		if col.IsErrNotFound(err) {
+			return nil, auth.ErrNotActivated
+		}
+		return nil, err
 	}
-	return nil
+	return &binding, nil
+}
+
+func (a *apiServer) isActive(ctx context.Context) error {
+	_, err := a.getClusterRoleBinding(ctx)
+	return err
 }
 
 // Retrieve the PPS master token, or generate it and put it in etcd.
@@ -296,7 +326,7 @@ func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (re
 	// Activating an already activated auth service should fail, because
 	// otherwise anyone can just activate the service again and set
 	// themselves as an admin.
-	if err := a.isActive(); err == nil {
+	if err := a.isActive(ctx); err == nil {
 		return nil, auth.ErrAlreadyActivated
 	}
 
@@ -333,7 +363,7 @@ func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (re
 	// (changing the activation state), so that Activate() is less likely to
 	// race with subsequent calls that expect auth to be activated.
 	if err := backoff.Retry(func() error {
-		if err := a.isActive(); err != nil {
+		if err := a.isActive(ctx); err != nil {
 			return errors.Errorf("auth never activated")
 		}
 		return nil
@@ -364,7 +394,7 @@ func (a *apiServer) Deactivate(ctx context.Context, req *auth.DeactivateRequest)
 	// so that Deactivate() is less likely to race with subsequent calls that
 	// expect auth to be deactivated.
 	if err := backoff.Retry(func() error {
-		if err := a.isActive(); err == nil {
+		if err := a.isActive(ctx); err == nil {
 			return errors.Errorf("auth still activated")
 		}
 		return nil
@@ -402,7 +432,7 @@ func (a *apiServer) expiredEnterpriseCheck(ctx context.Context) error {
 
 // Authenticate implements the protobuf auth.Authenticate RPC
 func (a *apiServer) Authenticate(ctx context.Context, req *auth.AuthenticateRequest) (resp *auth.AuthenticateResponse, retErr error) {
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
 
@@ -500,7 +530,8 @@ func (a *apiServer) AuthorizeInTransaction(
 	txnCtx *txnenv.TransactionContext,
 	req *auth.AuthorizeRequest,
 ) (resp *auth.AuthorizeResponse, retErr error) {
-	if err := a.isActive(); err != nil {
+	binding, err := a.getClusterRoleBinding(txnCtx.ClientContext)
+	if err != nil {
 		return nil, err
 	}
 
@@ -512,10 +543,6 @@ func (a *apiServer) AuthorizeInTransaction(
 	request := newAuthorizeRequest(callerInfo.Subject, req.Permissions, a.getGroups)
 
 	// Check the permissions at the cluster level
-	binding, ok := a.clusterRoleBindingCache.Load().(*auth.RoleBinding)
-	if !ok {
-		return nil, errors.New("cached cluster role binding had unexpected type")
-	}
 	if err := request.evaluateRoleBinding(txnCtx.ClientContext, binding); err != nil {
 		return nil, err
 	}
@@ -576,7 +603,7 @@ func (a *apiServer) WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (resp *
 	a.pachLogger.LogAtLevelFromDepth(req, nil, nil, 0, logrus.DebugLevel, 2)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
 
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
 
@@ -609,7 +636,7 @@ func (a *apiServer) WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (resp *
 // It doesn't do any auth checks itself - the calling method should ensure the user is allowed to delete this resource.
 // This is not an RPC, this is only called in-process.
 func (a *apiServer) DeleteRoleBindingInTransaction(txnCtx *txnenv.TransactionContext, resource *auth.Resource) error {
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(txnCtx.ClientContext); err != nil {
 		return err
 	}
 
@@ -724,7 +751,7 @@ func (a *apiServer) ModifyRoleBindingInTransaction(
 	txnCtx *txnenv.TransactionContext,
 	req *auth.ModifyRoleBindingRequest,
 ) (*auth.ModifyRoleBindingResponse, error) {
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(txnCtx.ClientContext); err != nil {
 		return nil, err
 	}
 
@@ -829,7 +856,7 @@ func (a *apiServer) GetRoleBindingInTransaction(
 	txnCtx *txnenv.TransactionContext,
 	req *auth.GetRoleBindingRequest,
 ) (*auth.GetRoleBindingResponse, error) {
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(txnCtx.ClientContext); err != nil {
 		return nil, err
 	}
 
@@ -896,7 +923,7 @@ func (a *apiServer) GetRobotToken(ctx context.Context, req *auth.GetRobotTokenRe
 // GetPipelineAuthTokenInTransaction is an internal API used to create a pipeline token for a given pipeline.
 // Not an RPC.
 func (a *apiServer) GetPipelineAuthTokenInTransaction(txnCtx *txnenv.TransactionContext, pipeline string) (string, error) {
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(txnCtx.ClientContext); err != nil {
 		return "", err
 	}
 
@@ -941,7 +968,7 @@ func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTok
 }
 
 func (a *apiServer) RevokeAuthTokenInTransaction(txnCtx *txnenv.TransactionContext, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(txnCtx.ClientContext); err != nil {
 		return nil, err
 	}
 
@@ -1268,6 +1295,10 @@ func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigura
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
 
+	if !a.watchesEnabled {
+		return nil, errors.New("watches are not enabled, unable to get current config")
+	}
+
 	config, ok := a.configCache.Load().(*auth.OIDCConfig)
 	if !ok {
 		return nil, errors.New("cached auth config had unexpected type")
@@ -1282,6 +1313,10 @@ func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigura
 func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigurationRequest) (resp *auth.SetConfigurationResponse, retErr error) {
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+
+	if !a.watchesEnabled {
+		return nil, errors.New("watches are not enabled, unable to set config")
+	}
 
 	var configToStore *auth.OIDCConfig
 	if req.Configuration != nil {
@@ -1323,7 +1358,7 @@ func (a *apiServer) ExtractAuthTokens(ctx context.Context, req *auth.ExtractAuth
 	// credentials.
 	a.LogReq(req)
 	defer func(start time.Time) { a.LogResp(nil, nil, retErr, time.Since(start)) }(time.Now())
-	if err := a.isActive(); err != nil {
+	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
 

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -243,7 +243,7 @@ func (a *apiServer) getClusterRoleBinding(ctx context.Context) (*auth.RoleBindin
 	}
 
 	var binding auth.RoleBinding
-	if err := a.tokens.ReadOnly(ctx).Get(clusterRoleBindingKey, &binding); err != nil {
+	if err := a.roleBindings.ReadOnly(ctx).Get(clusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, auth.ErrNotActivated
 		}

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -171,6 +171,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 				path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix),
 				true,
 				true,
+				true,
 			)
 			if err != nil {
 				return err
@@ -267,6 +268,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 				path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix),
 				false,
 				false,
+				true,
 			)
 			if err != nil {
 				return err
@@ -458,6 +460,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 			env,
 			txnEnv,
 			path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix),
+			false,
 			false,
 			false,
 		)
@@ -652,7 +655,7 @@ func doFullMode(config interface{}) (retErr error) {
 		var authAPIServer authserver.APIServer
 		if err := logGRPCServerSetup("Auth API", func() error {
 			authAPIServer, err = authserver.NewAuthServer(
-				env, txnEnv, path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix), true, requireNoncriticalServers)
+				env, txnEnv, path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix), true, requireNoncriticalServers, true)
 			if err != nil {
 				return err
 			}
@@ -814,6 +817,7 @@ func doFullMode(config interface{}) (retErr error) {
 				path.Join(env.Config().EtcdPrefix, env.Config().AuthEtcdPrefix),
 				false,
 				requireNoncriticalServers,
+				true,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
We're severely limited in how many postgres watches we can have, unlike in etcd, so sidecars cannot use watches. The auth service uses watches to monitor the OIDC config and the cluster role bindings.

This PR disables the watches in the auth service. This makes it impossible to get/set the OIDC config from the sidecar. It also makes `Authorize` do a postgres query for the cluster role bindings on each request. 

We discussed proxying all the sidecar auth requests to a full pachd, but that seemed like a bigger lift that might not scale well as the number of pipelines grows. This approach has the advantage that we could slap a small LRU cache on the Authorize results in the sidecar and every request should be for the pipeline user and either one of the input repos or output repo.