### PR TITLE
Remove enterprise server from sidecar

### DIFF
--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -484,17 +484,6 @@ func doSidecarMode(config interface{}) (retErr error) {
 	}); err != nil {
 		return err
 	}
-	if err := logGRPCServerSetup("Enterprise API", func() error {
-		enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
-			env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
-		if err != nil {
-			return err
-		}
-		eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
-		return nil
-	}); err != nil {
-		return err
-	}
 	if err := logGRPCServerSetup("Health", func() error {
 		healthclient.RegisterHealthServer(server.Server, health.NewHealthServer())
 		return nil


### PR DESCRIPTION
Watches are expensive in postgres, so we can't use them in the sidecar. We also don't want to heartbeat. It turns out we don't need the enterprise service in the sidecar at all, since we only call auth.Authorize and it doesn't check the enterprise license state.