### PR TITLE
Fix flaky enterprise test TestGetActivationCode

### DIFF
--- a/src/internal/auth/interceptor.go
+++ b/src/internal/auth/interceptor.go
@@ -253,7 +253,7 @@ func (i *Interceptor) InterceptUnary(ctx context.Context, req interface{}, info 
 	username, err := a(pachClient, info.FullMethod)
 
 	if err != nil {
-		logrus.Errorf("denied unary call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
+		logrus.WithError(err).Errorf("denied unary call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
 		return nil, err
 	}
 
@@ -277,7 +277,7 @@ func (i *Interceptor) InterceptStream(srv interface{}, stream grpc.ServerStream,
 	username, err := a(pachClient, info.FullMethod)
 
 	if err != nil {
-		logrus.Errorf("denied streaming call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
+		logrus.WithError(err).Errorf("denied streaming call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
 		return err
 	}
 

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	logrus "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -179,6 +180,8 @@ func (a *apiServer) Activate(ctx context.Context, req *ec.ActivateRequest) (resp
 		return nil, err
 	}
 
+	record := &ec.EnterpriseRecord{License: heartbeatResp.License}
+
 	// If the test heartbeat succeeded, write the state and config to etcd
 	if _, err := col.NewSTM(ctx, a.env.GetEtcdClient(), func(stm col.STM) error {
 		if err := a.configCol.ReadWrite(stm).Put(configKey, &ec.EnterpriseConfig{
@@ -189,18 +192,18 @@ func (a *apiServer) Activate(ctx context.Context, req *ec.ActivateRequest) (resp
 			return err
 		}
 
-		return a.enterpriseTokenCol.ReadWrite(stm).Put(enterpriseTokenKey, &ec.EnterpriseRecord{License: heartbeatResp.License})
+		return a.enterpriseTokenCol.ReadWrite(stm).Put(enterpriseTokenKey, record)
 	}); err != nil {
 		return nil, err
 	}
 
 	// Wait until watcher observes the write to the state key
 	if err := backoff.Retry(func() error {
-		record, ok := a.enterpriseTokenCache.Load().(*ec.EnterpriseRecord)
+		cachedRecord, ok := a.enterpriseTokenCache.Load().(*ec.EnterpriseRecord)
 		if !ok {
 			return errors.Errorf("could not retrieve enterprise expiration time")
 		}
-		if record.License == nil {
+		if !proto.Equal(cachedRecord, record) {
 			return errors.Errorf("enterprise not activated")
 		}
 		return nil


### PR DESCRIPTION
Fix an issue where `TestGetActivationCode` would sometimes fail because the cached value hadn't caught up to etcd writes:
- the test would call `Activate` to enable auth on the cluster with a license and no expiration
- the test would then call `Activate` _again_ with an expiration, to check whether the cluster state would change
- the second call to `Activate` would immediately succeed because there was a license, but the expiration may not have taken effect yet

This change blocks `Activate` until the exact value written to etcd appears in the cache, instead of just blocking until any not-nil value appears.