### PR TITLE
Improve usability of IDP connector configs

### DIFF
--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -163,7 +163,7 @@ func TestLoginEnterprise(t *testing.T) {
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
-		echo '{"username": "admin", "password": "password"}' | pachctl idp create-connector --id test --type mockPassword --name test  --config -
+		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
 		"id", tu.UniqueString("cluster"),
 		"token", tu.RootToken,
@@ -207,7 +207,7 @@ func TestLoginPachd(t *testing.T) {
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
-		echo '{"username": "admin", "password": "password"}' | pachctl idp create-connector --id test --type mockPassword --name test  --config -
+		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
 		"id", tu.UniqueString("cluster"),
 		"token", tu.RootToken,

--- a/src/server/identity/cmds/cmds_test.go
+++ b/src/server/identity/cmds/cmds_test.go
@@ -14,25 +14,25 @@ func TestConnectorCRUD(t *testing.T) {
 	tu.ActivateAuth(t)
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
-		echo '{}' | pachctl idp create-connector --id {{.id}} --name 'testconn' --type 'github' --config -
+		echo '{"id": "{{.id}}", "name": "testconn", "type": "github", "config": {"id": 1234}}' | pachctl idp create-connector 
 		pachctl idp list-connector | match '{{.id}}'
 		pachctl idp get-connector {{.id}} \
-		  | match 'name: testconn' \
-		  | match 'type: github' \
-		  | match 'version: 0' \
-		  | match "{}" 
-		echo '{"client_id": "a"}' | pachctl idp update-connector {{.id}} --version 1 --name 'newname' --config -
+		  | match 'Name: testconn' \
+		  | match 'Type: github' \
+		  | match 'Version: 0' \
+                  | match '    id: 1234' 
+		echo '{"id": "{{.id}}", "version": 1, "config": {"client_id": "a"}}' | pachctl idp update-connector 
 		pachctl idp get-connector {{.id}} \
-		  | match 'name: newname' \
-		  | match 'type: github' \
-		  | match 'version: 1' \
-		  | match '{"client_id": "a"}'
-		pachctl idp update-connector {{.id}} --version 2 --name 'newname2'
+		  | match 'Name: testconn' \
+		  | match 'Type: github' \
+		  | match 'Version: 1' \
+		  | match '    client_id: a'
+		echo '{"id": "{{.id}}", "version": 2, "name": "newname2"}' | pachctl idp update-connector
 		pachctl idp get-connector {{.id}} \
-		  | match 'name: newname2' \
-		  | match 'type: github' \
-		  | match 'version: 2' \
-		  | match '{"client_id": "a"}'
+		  | match 'Name: newname2' \
+		  | match 'Type: github' \
+		  | match 'Version: 2' \
+		  | match '    client_id: a'
 		pachctl idp delete-connector {{.id}}
 		`,
 		"id", tu.UniqueString("connector"),

--- a/src/server/identity/server/dex_api.go
+++ b/src/server/identity/server/dex_api.go
@@ -157,7 +157,7 @@ func (a *dexAPI) updateConnector(in *identity.UpdateIDPConnectorRequest) error {
 			c.Name = in.Connector.Name
 		}
 
-		if in.Connector.JsonConfig != "" {
+		if in.Connector.JsonConfig != "" && in.Connector.JsonConfig != "null" {
 			c.Config = []byte(in.Connector.JsonConfig)
 		}
 


### PR DESCRIPTION
The `pachctl idp create-connector` and `pachctl idp update-connector` commands were thin wrappers around the Dex API, which made them hard to use. This PR aims to make the entire connector config, including the ID, name, type and version, a single YAML file. This is closer to the Dex examples, [which show YAML config](https://dexidp.io/docs/connectors/github/#configuration)

An example of creating, updating and getting back a connector:

```
> pachctl idp create-connector <<EOF
id: mock
type: mockPassword
name: mock
config:
  username: admin
  password: admin
EOF

> pachctl idp update-connector <<EOF
id: mock
type: mockPassword
name: mock
version: 1
config:
  username: admin
  password: admin2
EOF

> pachctl idp get-connector mock
Config:
    password: admin
    username: admin2
ID: mock
Name: mock
Type: mockPassword
Version: 1
```