### PR TITLE
Support protocol in license/enterprise server config

### DIFF
--- a/src/internal/testutil/enterprise.go
+++ b/src/internal/testutil/enterprise.go
@@ -34,7 +34,7 @@ func ActivateEnterprise(t testing.TB, c *client.APIClient) {
 		&license.AddClusterRequest{
 			Id:      "localhost",
 			Secret:  "localhost",
-			Address: "localhost:650",
+			Address: "grpc://localhost:650",
 		})
 	if err != nil && !license.IsErrDuplicateClusterID(err) {
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func ActivateEnterprise(t testing.TB, c *client.APIClient) {
 		&enterprise.ActivateRequest{
 			Id:            "localhost",
 			Secret:        "localhost",
-			LicenseServer: "localhost:650",
+			LicenseServer: "grpc://localhost:650",
 		})
 	require.NoError(t, err)
 }

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -54,7 +54,7 @@ func ActivateCmd() *cobra.Command {
 			resp, err := c.License.AddCluster(c.Ctx(),
 				&license.AddClusterRequest{
 					Id:      "localhost",
-					Address: "localhost:650",
+					Address: "grpc://localhost:653",
 				})
 			if err != nil {
 				return errors.Wrapf(err, "could not register pachd with the license service")
@@ -65,7 +65,7 @@ func ActivateCmd() *cobra.Command {
 				&enterprise.ActivateRequest{
 					Id:            "localhost",
 					Secret:        resp.Secret,
-					LicenseServer: "localhost:650",
+					LicenseServer: "grpc://localhost:653",
 				})
 			if err != nil {
 				return errors.Wrapf(err, "could not activate the enterprise service")

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -61,7 +61,7 @@ func TestGetState(t *testing.T) {
 		&enterprise.ActivateRequest{
 			Id:            "localhost",
 			Secret:        "localhost",
-			LicenseServer: "localhost:650",
+			LicenseServer: "grpc://localhost:650",
 		})
 	require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestGetActivationCode(t *testing.T) {
 		&enterprise.ActivateRequest{
 			Id:            "localhost",
 			Secret:        "localhost",
-			LicenseServer: "localhost:650",
+			LicenseServer: "grpc://localhost:650",
 		})
 	require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestHeartbeatDeleted(t *testing.T) {
 		&lc.AddClusterRequest{
 			Id:      "localhost",
 			Secret:  "localhost",
-			Address: "localhost:650",
+			Address: "grpc://localhost:650",
 		})
 	require.NoError(t, err)
 

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -35,7 +35,7 @@ func TestRegisterPachd(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl enterprise activate
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
 		  | match 'id: {{.id}}' \
@@ -55,7 +55,7 @@ func TestRegisterAuthenticated(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl enterprise activate
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
@@ -78,7 +78,7 @@ func TestEnterpriseRoleBindings(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl enterprise activate
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth set enterprise clusterAdmin robot:test1
 		pachctl auth get enterprise | match robot:test1
@@ -98,7 +98,7 @@ func TestGetAndUseRobotToken(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl enterprise activate
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth get-robot-token --enterprise -q {{.alice}} | pachctl auth use-auth-token --enterprise
 		pachctl auth get-robot-token -q {{.bob}} | pachctl auth use-auth-token
@@ -161,7 +161,7 @@ func TestLoginEnterprise(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl enterprise activate
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"username": "admin", "password": "password"}' | pachctl idp create-connector --id test --type mockPassword --name test  --config -
 		`,
@@ -205,7 +205,7 @@ func TestLoginPachd(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl enterprise activate
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"username": "admin", "password": "password"}' | pachctl idp create-connector --id test --type mockPassword --name test  --config -
 		`,

--- a/src/server/license/cmds/cmds_test.go
+++ b/src/server/license/cmds/cmds_test.go
@@ -30,19 +30,19 @@ func TestClusterCRUD(t *testing.T) {
 	tu.ActivateEnterprise(t, tu.GetPachClient(t))
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
-		pachctl license add-cluster --id {{.id}} --address localhost:653
+		pachctl license add-cluster --id {{.id}} --address grpc://localhost:653
 		pachctl license list-clusters \
                   | match 'id: {{.id}}' \
-                  | match 'address: localhost:653' \
+                  | match 'address: grpc://localhost:653' \
                   | match 'id: localhost' \
-                  | match 'address: localhost:650'
-		pachctl license update-cluster --id {{.id}} --address 127.0.0.1:650
+                  | match 'address: grpc://localhost:650'
+		pachctl license update-cluster --id {{.id}} --address grpc://127.0.0.1:650
 		pachctl license list-clusters \
-                  | match 'address: 127.0.0.1:650' \
-                  | match 'address: localhost:650'
+                  | match 'address: grpc://127.0.0.1:650' \
+                  | match 'address: grpc://localhost:650'
 		pachctl license delete-cluster --id {{.id}}
 		pachctl license list-clusters \
-		  | match -v 'address: 127.0.0.1:650' \
+		  | match -v 'address: grpc://127.0.0.1:650' \
 		  | match -v 'id: {{.id}}'
 		`,
 		"id", tu.UniqueString("cluster"),

--- a/src/server/license/server/license_test.go
+++ b/src/server/license/server/license_test.go
@@ -255,7 +255,7 @@ func TestUpdateClusterUnreachable(t *testing.T) {
 
 	_, err := client.License.UpdateCluster(client.Ctx(), &license.UpdateClusterRequest{
 		Id:      "localhost",
-		Address: "invalid://bad.example",
+		Address: "grpc://bad.example",
 	})
 	require.YesError(t, err)
 	require.Matches(t, "unable to create client", err.Error())

--- a/src/server/license/server/license_test.go
+++ b/src/server/license/server/license_test.go
@@ -157,7 +157,7 @@ func TestClusterCRUD(t *testing.T) {
 	// Add a new cluster
 	newCluster, err := client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
 		Id:      "new",
-		Address: "localhost:650",
+		Address: "grpc://localhost:650",
 	})
 	require.NoError(t, err)
 	require.True(t, len(newCluster.Secret) >= 30)
@@ -166,11 +166,11 @@ func TestClusterCRUD(t *testing.T) {
 	expected := map[string]*license.ClusterStatus{
 		"localhost": {
 			Id:      "localhost",
-			Address: "localhost:650",
+			Address: "grpc://localhost:650",
 		},
 		"new": {
 			Id:      "new",
-			Address: "localhost:650",
+			Address: "grpc://localhost:650",
 		},
 	}
 
@@ -234,7 +234,7 @@ func TestAddClusterUnreachable(t *testing.T) {
 
 	_, err := client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
 		Id:      "new",
-		Address: "invalid://bad.example",
+		Address: "grpc://bad.example",
 	})
 	require.YesError(t, err)
 	require.Matches(t, "unable to create client", err.Error())
@@ -274,7 +274,7 @@ func TestAddClusterNoLicense(t *testing.T) {
 	client := tu.GetPachClient(t)
 	_, err := client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
 		Id:      "new",
-		Address: "localhost:650",
+		Address: "grpc://localhost:650",
 	})
 	require.YesError(t, err)
 	require.Matches(t, "enterprise license is not valid", err.Error())


### PR DESCRIPTION
When license server and enterprise server communicate, previously we only accepted an address and not a protocol. This meant users couldn't connect to a server using TLS. Update the codebase to accept a protocol and use the system CAs for a TLS connection if specified.