### PR TITLE
Treat an empty enterprise context as a single cluster deployment

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -70,7 +70,8 @@ func (c *Config) ActiveContext(errorOnNoActive bool) (string, *Context, error) {
 	return c.V2.ActiveContext, context, nil
 }
 
-// ActiveEnterpriseContext gets the active enterprise server context in the config
+// ActiveEnterpriseContext gets the active enterprise server context in the config.
+// If no enterprise context is configured, this returns the active context.
 func (c *Config) ActiveEnterpriseContext(errorOnNoActive bool) (string, *Context, error) {
 	if c.V2 == nil {
 		return "", nil, errors.Errorf("cannot get active context from non-v2 config")
@@ -82,23 +83,18 @@ func (c *Config) ActiveEnterpriseContext(errorOnNoActive bool) (string, *Context
 		}
 		return envContext, context, nil
 	}
+
+	if c.V2.ActiveEnterpriseContext == "" {
+		return c.ActiveContext(errorOnNoActive)
+	}
+
 	context := c.V2.Contexts[c.V2.ActiveEnterpriseContext]
 	if context == nil {
-		if c.V2.ActiveEnterpriseContext == "" {
-			if errorOnNoActive {
-				return "", nil, errors.Errorf("pachctl config error: no active " +
-					"enterprise context configured.\n\nYou can fix your config by setting " +
-					"the active context like so: pachctl config set " +
-					"active-enterprise-context <context>")
-			}
-		} else {
-			return "", nil, errors.Errorf("pachctl config error: pachctl's active "+
-				"enterprise context is %q, but no context named %q has been configured.\n\nYou can fix "+
-				"your config by setting the active context like so: pachctl config set "+
-				"active-enterprise-context <context>",
-				c.V2.ActiveContext, c.V2.ActiveContext)
-		}
-
+		return "", nil, errors.Errorf("pachctl config error: pachctl's active "+
+			"enterprise context is %q, but no context named %q has been configured.\n\nYou can fix "+
+			"your config by setting the active context like so: pachctl config set "+
+			"active-enterprise-context <context>",
+			c.V2.ActiveContext, c.V2.ActiveContext)
 	}
 	return c.V2.ActiveEnterpriseContext, context, nil
 }

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -267,11 +267,6 @@ func contextCreate(namePrefix, namespace, serverCert string, enterpriseServer bo
 	if enterpriseServer {
 		cfg.V2.ActiveEnterpriseContext = newContextName
 	} else {
-		// If the user deploys a pachd and they don't have an enterprise server, they probably want
-		// a single-server deployment. Default to using the new pachd as the enterprise server as well.
-		if cfg.V2.ActiveEnterpriseContext == "" || cfg.V2.ActiveEnterpriseContext == cfg.V2.ActiveContext {
-			cfg.V2.ActiveEnterpriseContext = newContextName
-		}
 		cfg.V2.ActiveContext = newContextName
 	}
 	return cfg.Write()

--- a/src/server/config/cmds.go
+++ b/src/server/config/cmds.go
@@ -104,9 +104,6 @@ func Cmds() []*cobra.Command {
 			if _, ok := cfg.V2.Contexts[args[0]]; !ok {
 				return errors.Errorf("context does not exist: %s", args[0])
 			}
-			if cfg.V2.ActiveContext == cfg.V2.ActiveEnterpriseContext {
-				cfg.V2.ActiveEnterpriseContext = args[0]
-			}
 			cfg.V2.ActiveContext = args[0]
 			return cfg.Write()
 		}),


### PR DESCRIPTION
Initially the plan for the enterprise context was to try and keep it up-to-date with the active context when we suspected a user was working with individual clusters (ex. not in an enterprise setup). I've gotten some feedback that this is confusing. 

This PR changes `config.ActiveEnterpriseContext` to return the active (non-enterprise) context when the enterprise context is blank. It also makes it so `pachctl deploy` and `pachctl config set-active-context` _don't_ configure the enterprise context. The end result is that if a user never deploys an enterprise server then the active enterprise context will never be set, and all RPCs will go to the active context, which seems less confusing.