### PR TITLE
Move S3 gateway from clientFactory to serviceenv

### DIFF
--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -12,7 +12,6 @@ import (
 
 	adminclient "github.com/pachyderm/pachyderm/v2/src/admin"
 	authclient "github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/client"
 	debugclient "github.com/pachyderm/pachyderm/v2/src/debug"
 	eprsclient "github.com/pachyderm/pachyderm/v2/src/enterprise"
 	healthclient "github.com/pachyderm/pachyderm/v2/src/health"

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -485,9 +485,7 @@ func RunLocal() (retErr error) {
 		return githook.RunGitHookServer(address, etcdAddress, path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix))
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
-		server, err := s3.Server(env.Config().S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
-			return client.NewFromAddress(fmt.Sprintf("localhost:%d", env.Config().PeerPort))
-		})
+		server, err := s3.Server(env, s3.NewMasterDriver())
 		if err != nil {
 			return err
 		}

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -12,7 +12,6 @@ import (
 
 	adminclient "github.com/pachyderm/pachyderm/v2/src/admin"
 	authclient "github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/client"
 	debugclient "github.com/pachyderm/pachyderm/v2/src/debug"
 	eprsclient "github.com/pachyderm/pachyderm/v2/src/enterprise"
 	healthclient "github.com/pachyderm/pachyderm/v2/src/health"
@@ -935,9 +934,7 @@ func doFullMode(config interface{}) (retErr error) {
 		return githook.RunGitHookServer(address, etcdAddress, path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix))
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
-		server, err := s3.Server(env.Config().S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
-			return env.GetPachClient(context.Background()), nil
-		})
+		server, err := s3.Server(env, s3.NewMasterDriver())
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/s3/auth.go
+++ b/src/server/pfs/s3/auth.go
@@ -10,16 +10,10 @@ import (
 
 func (c *controller) SecretKey(r *http.Request, accessKey string, region *string) (*string, error) {
 	c.logger.Debugf("SecretKey: %+v", region)
-
-	pc, err := c.clientFactory()
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not create a pach client for auth")
-	}
+	pc := c.env.GetPachClient(r.Context())
 	pc.SetAuthToken(accessKey)
 
-	// WhoAmI will simultaneously check that auth is enabled, and that the
-	// user is who they say they are
-	_, err = pc.WhoAmI(pc.Ctx(), &auth.WhoAmIRequest{})
+	_, err := pc.WhoAmI(pc.Ctx(), &auth.WhoAmIRequest{})
 	if err != nil {
 		// Some S3 clients (like minio) require the use of authenticated
 		// requests, so in the case that auth is not enabled on pachyderm,
@@ -40,11 +34,7 @@ func (c *controller) SecretKey(r *http.Request, accessKey string, region *string
 
 func (c *controller) CustomAuth(r *http.Request) (bool, error) {
 	c.logger.Debug("CustomAuth")
-
-	pc, err := c.clientFactory()
-	if err != nil {
-		return false, errors.Wrapf(err, "could not create a pach client for auth")
-	}
+	pc := c.env.GetPachClient(r.Context())
 
 	active, err := pc.IsAuthActive()
 	if err != nil {

--- a/src/server/pfs/s3/s3.go
+++ b/src/server/pfs/s3/s3.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 
 	"github.com/pachyderm/s2"
 	"github.com/sirupsen/logrus"
@@ -35,9 +36,13 @@ const (
 var defaultUser = s2.User{ID: "00000000000000000000000000000000", DisplayName: "pachyderm"}
 
 type controller struct {
+	// app environment -- clients to other services, env vars, etc
+	env serviceenv.ServiceEnv
+
+	// custom logger
 	logger *logrus.Entry
 
-	// Name of the PFS repo holding multipart content
+	// name of the PFS repo holding multipart content
 	repo string
 
 	// the maximum number of allowed parts that can be associated with any
@@ -45,17 +50,12 @@ type controller struct {
 	maxAllowedParts int
 
 	driver Driver
-
-	clientFactory ClientFactory
 }
 
-// requestPachClient uses the clientFactory to construct a request-scoped
-// pachyderm client
+// requestPachClient uses serviceenv to construct a request-scoped pachyderm
+// client
 func (c *controller) requestClient(r *http.Request) (*client.APIClient, error) {
-	pc, err := c.clientFactory()
-	if err != nil {
-		return nil, err
-	}
+	pc := c.env.GetPachClient(r.Context())
 
 	vars := mux.Vars(r)
 	if vars["s3gAuth"] != "disabled" {
@@ -90,17 +90,17 @@ func (c *controller) requestClient(r *http.Request) (*client.APIClient, error) {
 // Note: In `s3cmd`, you must set the access key and secret key, even though
 // this API will ignore them - otherwise, you'll get an opaque config error:
 // https://github.com/s3tools/s3cmd/issues/845#issuecomment-464885959
-func Server(port uint16, driver Driver, clientFactory ClientFactory) (*http.Server, error) {
+func Server(env serviceenv.ServiceEnv, driver Driver) (*http.Server, error) {
 	logger := logrus.WithFields(logrus.Fields{
 		"source": "s3gateway",
 	})
 
 	c := &controller{
+		env:             env,
 		logger:          logger,
 		repo:            multipartRepo,
 		maxAllowedParts: maxAllowedParts,
 		driver:          driver,
-		clientFactory:   clientFactory,
 	}
 
 	s3Server := s2.NewS2(logger, maxRequestBodyLength, readBodyTimeout)
@@ -112,7 +112,7 @@ func Server(port uint16, driver Driver, clientFactory ClientFactory) (*http.Serv
 	router := s3Server.Router()
 
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%d", port),
+		Addr:         fmt.Sprintf(":%d", env.Config().S3GatewayPort),
 		ReadTimeout:  requestTimeout,
 		WriteTimeout: requestTimeout,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -213,9 +213,7 @@ func (s *s3InstanceCreatingJobHandler) OnCreate(ctx context.Context, jobInfo *pp
 	var server *http.Server
 	err := backoff.RetryNotify(func() error {
 		var err error
-		server, err = s3.Server(port, driver, func() (*client.APIClient, error) {
-			return s.s.apiServer.env.GetPachClient(s.s.pachClient.Ctx()), nil // clones s.pachClient
-		})
+		server, err = s3.Server(s.s.apiServer.env, driver)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't initialize s3 gateway server")
 		}


### PR DESCRIPTION
This gets us away from clientFactory, which was leaking TCP sessions, and moves us to serviceenv which is the intended library for initializing clients (and is designed to solve this problem)