### PR TITLE
Move S3 Gateway clientFactory -> ServiceEnv

### DIFF
--- a/.testfaster.yml
+++ b/.testfaster.yml
@@ -59,7 +59,7 @@ base:
     # the linter uses (we don't really care if the linter passes)
     RUN git clone https://github.com/pachyderm/pachyderm && \
         cd pachyderm && \
-        git checkout ac9eb9e4d07dd9bb9a9720f7fb9ea85338b7d01f && \
+        git checkout f741e2949877345c6fb7990fecb93d025119c19e && \
         CIRCLE_BRANCH=1 make install && \
         PATH="/root/go/bin:${PATH}" etc/testing/lint.sh || true
     RUN wget -nv https://github.com/instrumenta/kubeval/releases/download/0.15.0/kubeval-linux-amd64.tar.gz && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     - ${HOME}/cached-deps
     - ${HOME}/gopath/pkg/mod
     - "$(python3 -c 'import site; print(site.USER_BASE)')"
+    - /var/lib/docker
 
 language: go
 go:

--- a/etc/testing/travis.sh
+++ b/etc/testing/travis.sh
@@ -11,6 +11,9 @@ set -ex
     done
 ) &
 
+# Log in to docker, so we don't get rate-limited if we're pulling images
+docker login -u pachydermbuildbot -p "${DOCKER_PWD}"
+
 # Repeatedly restart minikube until it comes up. This corrects for an issue in
 # Travis, where minikube will get stuck on startup and never recover
 while true; do
@@ -53,8 +56,9 @@ else
     popd
 fi
 
-make launch-loki
-
+if [[ "${BUCKET}" = "PPS3" ]]; then
+    make launch-loki
+fi
 for i in $(seq 3); do
     make clean-launch-dev || true # may be nothing to delete
     make launch-dev && break

--- a/etc/testing/travis_cache.sh
+++ b/etc/testing/travis_cache.sh
@@ -28,3 +28,7 @@ for dir in "${dirs[@]}"; do
   # Loosen permissions so build processes can write and Travis can cache
   chmod 777 -R "${dir}"
 done
+
+# Handle docker cache separately, as that should not be owned by $USER
+sudo mkdir -p "/var/lib/docker"
+sudo chmod 777 -R "/var/lib/docker"

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -11,7 +11,6 @@ import (
 	"runtime/pprof"
 	"strconv"
 
-	"github.com/pachyderm/pachyderm/src/client"
 	adminclient "github.com/pachyderm/pachyderm/src/client/admin"
 	authclient "github.com/pachyderm/pachyderm/src/client/auth"
 	debugclient "github.com/pachyderm/pachyderm/src/client/debug"
@@ -716,9 +715,7 @@ func doFullMode(config interface{}) (retErr error) {
 		return githook.RunGitHookServer(address, etcdAddress, path.Join(env.EtcdPrefix, env.PPSEtcdPrefix))
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
-		server, err := s3.Server(env.S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
-			return client.NewFromAddress(fmt.Sprintf("localhost:%d", env.PeerPort))
-		})
+		server, err := s3.Server(env, s3.NewMasterDriver())
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/s3/auth.go
+++ b/src/server/pfs/s3/auth.go
@@ -11,15 +11,12 @@ import (
 func (c *controller) SecretKey(r *http.Request, accessKey string, region *string) (*string, error) {
 	c.logger.Debugf("SecretKey: %+v", region)
 
-	pc, err := c.clientFactory()
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not create a pach client for auth")
-	}
+	pc := c.env.GetPachClient(r.Context())
 	pc.SetAuthToken(accessKey)
 
 	// WhoAmI will simultaneously check that auth is enabled, and that the
 	// user is who they say they are
-	_, err = pc.WhoAmI(pc.Ctx(), &auth.WhoAmIRequest{})
+	_, err := pc.WhoAmI(pc.Ctx(), &auth.WhoAmIRequest{})
 	if err != nil {
 		// Some S3 clients (like minio) require the use of authenticated
 		// requests, so in the case that auth is not enabled on pachyderm,
@@ -41,11 +38,7 @@ func (c *controller) SecretKey(r *http.Request, accessKey string, region *string
 func (c *controller) CustomAuth(r *http.Request) (bool, error) {
 	c.logger.Debug("CustomAuth")
 
-	pc, err := c.clientFactory()
-	if err != nil {
-		return false, errors.Wrapf(err, "could not create a pach client for auth")
-	}
-
+	pc := c.env.GetPachClient(r.Context())
 	active, err := pc.IsAuthActive()
 	if err != nil {
 		return false, errors.Wrapf(err, "could not check whether auth is active")

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -17,6 +17,7 @@ import (
 	minio "github.com/minio/minio-go/v6"
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 )
 
 func getObject(t *testing.T, minioClient *minio.Client, bucket, file string) (string, error) {
@@ -132,7 +133,11 @@ func fileHash(t *testing.T, name string) (int64, []byte) {
 }
 
 func testRunner(t *testing.T, group string, driver Driver, runner func(t *testing.T, pachClient *client.APIClient, minioClient *minio.Client)) {
-	server, err := Server(0, driver, client.NewForTest)
+	env := serviceenv.InitPachOnlyTestEnv(t, &serviceenv.Configuration{
+		GlobalConfiguration: &serviceenv.GlobalConfiguration{
+			S3GatewayPort: 0,
+		}})
+	server, err := Server(env, driver)
 	require.NoError(t, err)
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/pachyderm/pachyderm/src/client"
@@ -96,6 +97,19 @@ func InitServiceEnv(config *Configuration) *ServiceEnv {
 func InitWithKube(config *Configuration) *ServiceEnv {
 	env := InitServiceEnv(config)
 	env.kubeEg.Go(env.initKubeClient)
+	return env // env is not ready yet
+}
+
+// InitPachOnlyTestEnv is like InitPachOnlyEnv, but initializes a pachd client
+// for tests (using client.NewForTest())
+func InitPachOnlyTestEnv(t *testing.T, config *Configuration) *ServiceEnv {
+	env := &ServiceEnv{Configuration: config}
+
+	var err error
+	env.pachClient, err = client.NewForTest()
+	if err != nil {
+		t.Fatalf("could not intialize pach client for test: %v", err)
+	}
 	return env // env is not ready yet
 }
 


### PR DESCRIPTION
1.13.x version of #5955

This gets us away from clientFactory, which was leaking ports, and moves us to serviceenv which is the intended library for initializing clients (and is designed to solve this problem)