### PR TITLE
Move S3 Gateway clientFactory -> ServiceEnv

### DIFF
--- a/.testfaster.yml
+++ b/.testfaster.yml
@@ -59,7 +59,7 @@ base:
     # the linter uses (we don't really care if the linter passes)
     RUN git clone https://github.com/pachyderm/pachyderm && \
         cd pachyderm && \
-        git checkout dfd090dcd0aa91a794097720e36adca3cccb307c && \
+        git checkout 43457e154631664b39942d4666deb1d4584a53c7 && \
         CIRCLE_BRANCH=1 make install && \
         PATH="/root/go/bin:${PATH}" etc/testing/lint.sh || true
     RUN wget -nv https://github.com/instrumenta/kubeval/releases/download/0.15.0/kubeval-linux-amd64.tar.gz && \

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -11,7 +11,6 @@ import (
 	"runtime/pprof"
 	"strconv"
 
-	"github.com/pachyderm/pachyderm/src/client"
 	adminclient "github.com/pachyderm/pachyderm/src/client/admin"
 	authclient "github.com/pachyderm/pachyderm/src/client/auth"
 	debugclient "github.com/pachyderm/pachyderm/src/client/debug"
@@ -709,9 +708,7 @@ func doFullMode(config interface{}) (retErr error) {
 		return githook.RunGitHookServer(address, etcdAddress, path.Join(env.EtcdPrefix, env.PPSEtcdPrefix))
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
-		server, err := s3.Server(env.S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
-			return client.NewFromAddress(fmt.Sprintf("localhost:%d", env.PeerPort))
-		})
+		server, err := s3.Server(env, s3.NewMasterDriver())
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/s3/auth.go
+++ b/src/server/pfs/s3/auth.go
@@ -11,15 +11,12 @@ import (
 func (c *controller) SecretKey(r *http.Request, accessKey string, region *string) (*string, error) {
 	c.logger.Debugf("SecretKey: %+v", region)
 
-	pc, err := c.clientFactory()
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not create a pach client for auth")
-	}
+	pc := c.env.GetPachClient(r.Context())
 	pc.SetAuthToken(accessKey)
 
 	// WhoAmI will simultaneously check that auth is enabled, and that the
 	// user is who they say they are
-	_, err = pc.WhoAmI(pc.Ctx(), &auth.WhoAmIRequest{})
+	_, err := pc.WhoAmI(pc.Ctx(), &auth.WhoAmIRequest{})
 	if err != nil {
 		// Some S3 clients (like minio) require the use of authenticated
 		// requests, so in the case that auth is not enabled on pachyderm,
@@ -41,11 +38,7 @@ func (c *controller) SecretKey(r *http.Request, accessKey string, region *string
 func (c *controller) CustomAuth(r *http.Request) (bool, error) {
 	c.logger.Debug("CustomAuth")
 
-	pc, err := c.clientFactory()
-	if err != nil {
-		return false, errors.Wrapf(err, "could not create a pach client for auth")
-	}
-
+	pc := c.env.GetPachClient(r.Context())
 	active, err := pc.IsAuthActive()
 	if err != nil {
 		return false, errors.Wrapf(err, "could not check whether auth is active")

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -17,6 +17,7 @@ import (
 	minio "github.com/minio/minio-go/v6"
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/pkg/require"
+	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 )
 
 func getObject(t *testing.T, minioClient *minio.Client, bucket, file string) (string, error) {
@@ -132,7 +133,11 @@ func fileHash(t *testing.T, name string) (int64, []byte) {
 }
 
 func testRunner(t *testing.T, group string, driver Driver, runner func(t *testing.T, pachClient *client.APIClient, minioClient *minio.Client)) {
-	server, err := Server(0, driver, client.NewForTest)
+	env := serviceenv.InitPachOnlyTestEnv(t, &serviceenv.Configuration{
+		GlobalConfiguration: &serviceenv.GlobalConfiguration{
+			S3GatewayPort: 0,
+		}})
+	server, err := Server(env, driver)
 	require.NoError(t, err)
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/pachyderm/pachyderm/src/client"
@@ -96,6 +97,19 @@ func InitServiceEnv(config *Configuration) *ServiceEnv {
 func InitWithKube(config *Configuration) *ServiceEnv {
 	env := InitServiceEnv(config)
 	env.kubeEg.Go(env.initKubeClient)
+	return env // env is not ready yet
+}
+
+// InitPachOnlyTestEnv is like InitPachOnlyEnv, but initializes a pachd client
+// for tests (using client.NewForTest())
+func InitPachOnlyTestEnv(t *testing.T, config *Configuration) *ServiceEnv {
+	env := &ServiceEnv{Configuration: config}
+
+	var err error
+	env.pachClient, err = client.NewForTest()
+	if err != nil {
+		t.Fatalf("could not intialize pach client for test: %v", err)
+	}
 	return env // env is not ready yet
 }
 


### PR DESCRIPTION
1.12.x version of #5955

This gets us away from clientFactory, which was leaking ports, and moves us to serviceenv which is the intended library for initializing clients (and is designed to solve this problem)