### PR TITLE
Set path in kube_debug.sh script

### DIFF
--- a/etc/testing/kube_debug.sh
+++ b/etc/testing/kube_debug.sh
@@ -28,7 +28,7 @@ cmds=(
   'kubectl describe pod -l suite=pachyderm,app=etcd'
   # Set --tail b/c by default 'kubectl logs' only outputs 10 lines if -l is set
   'kubectl logs --tail=500 -l suite=pachyderm,app=pachd'
-  'kubectl logs --tail=1000 -l suite=pachyderm,app=pachd --previous # if pachd restarted'
+  'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd --previous # if pachd restarted'
   'sudo dmesg | tail -n 40'
   'minikube logs | tail -n 100'
   'top -b -n 1 | head -n 40'

--- a/etc/testing/kube_debug.sh
+++ b/etc/testing/kube_debug.sh
@@ -2,6 +2,9 @@
 
 echo "=== TEST FAILED OR TIMED OUT, DUMPING DEBUG INFO ==="
 
+export GOPATH=/root/go
+export PATH="${GOPATH}/bin:${PATH}"
+
 # TODO: Extend this to show kubectl describe output for failed pods, this will
 # probably show why things are hanging.
 


### PR DESCRIPTION
pachctl commands running in `kube_debug.sh` weren't working because `GOPATH` was never added to `PATH` when this script was run in CircleCI/TestFaster. `kube_debug.sh` sets these variables now, so that the post-test-failure debugging info is more complete.