### PR TITLE
[WIP] Implement ServiceEnv for testetcd/testpachd

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -8335,12 +8335,9 @@ func TestCancelManyJobs(t *testing.T) {
 	// Create 10 input commits, to spawn 10 jobs
 	var commits [10]*pfs.Commit
 	var err error
-	commits[0], err = c.StartCommit(repo, "master")
-	require.NoError(t, err)
-	require.NoError(t, c.PutFile(repo, commits[0].ID, "file", strings.NewReader("foo"), client.WithAppendPutFile()))
-	require.NoError(t, c.FinishCommit(repo, commits[0].ID))
-	for i := 1; i < 10; i++ {
+	for i := 0; i < 10; i++ {
 		commits[i], err = c.StartCommit(repo, "master")
+		require.NoError(t, c.PutFile(repo, commits[i].ID, "file", strings.NewReader("foo"), client.WithAppendPutFile()))
 		require.NoError(t, err)
 		require.NoError(t, c.FinishCommit(repo, commits[i].ID))
 	}


### PR DESCRIPTION
This is Part 2 of [the ServiceEnv refactor](https://docs.google.com/document/d/10PhfYU_HbD6j0qneVYHAGQcK_a8adlLRYp-ipdFYL1o/edit) (to remove redundant arguments from APIServer constructors)