### PR TITLE
Timeout testfaster VMs to stop the main pool getting clogged up

### DIFF
--- a/.testfaster.yml
+++ b/.testfaster.yml
@@ -134,4 +134,7 @@ runtime:
 
 prewarm_pool_size: 11
 max_pool_size: 22
-default_lease_timeout: ""
+# timeout vms after 6 hours. hopefully tests will clean them up sooner, but if
+# the tests themselves timeout and cleanup doesn't get run, we don't want old
+# VMs building up and stopping new ones getting scheduled.
+default_lease_timeout: 6h


### PR DESCRIPTION
6 hours is a reasonable balance between wanting to be able to SSH into failed test VMs to deflake the tests and not clogging up the pool.

Assuming this works, we should apply the same fix to our other main branches too.