### PR TITLE
Fix DeletePipeline with auth enabled

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2715,7 +2715,7 @@ func (a *apiServer) deletePipeline(pachClient *client.APIClient, request *pps.De
 	// the rest of the delete operation continues without any auth checks
 	if _, err := pachClient.InspectRepo(request.Pipeline.Name); err != nil && !isNotFoundErr(err) && !auth.IsErrNoRoleBinding(err) {
 		return nil, err
-	} else if !isNotFoundErr(err) {
+	} else if err == nil {
 		// Check if the caller is authorized to delete this pipeline. This must be
 		// done after cleaning up the spec branch HEAD commit, because the
 		// authorization condition depends on the pipeline's PipelineInfo


### PR DESCRIPTION
Resolves https://github.com/pachyderm/pachyderm/issues/5964

When auth is enabled, calling InspectRepo or DeleteJob on a deleted repo will throw `auth.ErrNoRoleBinding` errors rather than a not-found error. This fixes the behaviour so DeletePipeline works. 