### PR TITLE
Support adding groups to role bindings

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -37,6 +37,9 @@ const (
 	// PachPrefix indicates that this Subject is an internal Pachyderm user.
 	PachPrefix = "pach:"
 
+	// GroupPrefix indicates that this Subject is a group.
+	GroupPrefix = "group:"
+
 	// RootUser is the user created when auth is initialized. Only one token
 	// can be created for this user (during auth activation) and they cannot
 	// be removed from the set of cluster super-admins.

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1282,7 +1282,7 @@ func (a *apiServer) checkCanonicalSubject(subject string) error {
 	// check against fixed prefixes
 	prefix += ":" // append ":" to match constants
 	switch prefix {
-	case auth.PipelinePrefix, auth.RobotPrefix, auth.PachPrefix, auth.UserPrefix:
+	case auth.PipelinePrefix, auth.RobotPrefix, auth.PachPrefix, auth.UserPrefix, auth.GroupPrefix:
 		break
 	default:
 		return errors.Errorf("subject has unrecognized prefix: %s", subject[:colonIdx+1])

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -41,6 +41,10 @@ func user(email string) string {
 	return auth.UserPrefix + email
 }
 
+func group(group string) string {
+	return auth.GroupPrefix + group
+}
+
 func pl(pipeline string) string {
 	return auth.PipelinePrefix + pipeline
 }
@@ -794,6 +798,35 @@ func TestRobotUserACL(t *testing.T) {
 	commit, err = robotClient.StartCommit(repo2, "master")
 	require.NoError(t, err)
 	require.NoError(t, robotClient.FinishCommit(repo2, commit.ID))
+}
+
+// TestGroupRoleBinding tests that a group can be added to a role binding
+// and confers access to members
+func TestGroupRoleBinding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	alice := robot(tu.UniqueString("alice"))
+	group := group(tu.UniqueString("testGroup"))
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+
+	// root creates a repo and adds a group writer access
+	repo := tu.UniqueString("TestGroupRoleBinding")
+	require.NoError(t, rootClient.CreateRepo(repo))
+	require.NoError(t, rootClient.ModifyRepoRoleBinding(repo, group, []string{auth.RepoWriterRole}))
+	require.Equal(t, buildBindings(group, auth.RepoWriterRole, auth.RootUser, auth.RepoOwnerRole), getRepoRoleBinding(t, rootClient, repo))
+
+	// add alice to the group
+	_, err := rootClient.ModifyMembers(rootClient.Ctx(), &auth.ModifyMembersRequest{
+		Group: group,
+		Add:   []string{alice},
+	})
+	require.NoError(t, err)
+
+	// test that alice can commit to the repo
+	commit, err := aliceClient.StartCommit(repo, "master")
+	require.NoError(t, err)
+	require.NoError(t, aliceClient.FinishCommit(repo, commit.ID))
 }
 
 // TestRobotUserAdmin tests that robot users can


### PR DESCRIPTION
In her testing @nadegepepin found that we had broken support for groups in role bindings, because we have no tests for groups 😿  This fixes support for groups and adds a basic test that we can add a group to role bindings, and that group membership is tested.