### PR TITLE
Remove admin test bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ workflows:
               - MISC
               # If you want to update the number of PPS buckets, you'll neet to
               # update the value of PPS_BUCKETS above
-              - ADMIN
               - AUTH
               - ENTERPRISE
               - PFS

--- a/.testfaster.yml
+++ b/.testfaster.yml
@@ -132,8 +132,8 @@ runtime:
   memory: 16GB
   disk: 50GB
 
-prewarm_pool_size: 11
-max_pool_size: 22
+prewarm_pool_size: 10
+max_pool_size: 20
 # timeout vms after 6 hours. hopefully tests will clean them up sooner, but if
 # the tests themselves timeout and cleanup doesn't get run, we don't want old
 # VMs building up and stopping new ones getting scheduled.

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -90,9 +90,6 @@ case "${BUCKET}" in
         make test-tls
     fi
     ;;
-  ADMIN)
-    make test-admin
-    ;;
   EXAMPLES)
     echo "Running the example test suite"
     ./etc/testing/examples.sh


### PR DESCRIPTION
There's no tests in `src/server/admin/...` since we removed extract/restore - remove the test bucket so we don't do a whole VM allocation and build for no reason.