### PR TITLE
Fix activating enterprise with localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ test-cmds:
 	go test -v -count=1 ./src/server/config -timeout $(TIMEOUT)
 	@# TODO(msteffen) does this test leave auth active? If so it must run last
 	go test -v -count=1 ./src/server/auth/cmds -timeout $(TIMEOUT)
+	go test -v -count=1 ./src/server/enterprise/cmds -timeout $(TIMEOUT)
 	go test -v -count=1 ./src/server/identity/cmds -timeout $(TIMEOUT)
 
 test-transaction:

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -844,6 +844,17 @@ func doFullMode(config interface{}) (retErr error) {
 		}); err != nil {
 			return err
 		}
+		if err := logGRPCServerSetup("License API", func() error {
+			licenseAPIServer, err := licenseserver.New(
+				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+			if err != nil {
+				return err
+			}
+			licenseclient.RegisterAPIServer(internalServer.Server, licenseAPIServer)
+			return nil
+		}); err != nil {
+			return err
+		}
 		if err := logGRPCServerSetup("Enterprise API", func() error {
 			enterpriseAPIServer, err := eprsserver.NewEnterpriseServer(
 				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))

--- a/src/server/enterprise/cmds/cmds_test.go
+++ b/src/server/enterprise/cmds/cmds_test.go
@@ -30,7 +30,7 @@ func TestManuallyJoinLicenseServer(t *testing.T) {
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		pachctl enterprise register --id {{.id}} --enterprise-server-address localhost:650 --pachd-address localhost:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://localhost:653 --pachd-address grpc://localhost:653
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
 		  | match 'id: {{.id}}' \


### PR DESCRIPTION
These tests weren't running, and consequently I didn't know that enterprise activation was broken because the license server got removed from the internal server.