### PR TITLE
Usernames are fully qualified when syncing group membership from IDPs

### DIFF
--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -337,10 +337,10 @@ func (a *apiServer) validateIDToken(ctx context.Context, rawIDToken string) (*oi
 func (a *apiServer) syncGroupMembership(ctx context.Context, claims *IDTokenClaims) error {
 	groups := make([]string, len(claims.Groups))
 	for i, g := range claims.Groups {
-		groups[i] = fmt.Sprintf("group:%s", g)
+		groups[i] = fmt.Sprintf("%s:%s", auth.GroupPrefix, g)
 	}
 	// Sync group membership based on the groups claim, if any
-	return a.setGroupsForUserInternal(ctx, claims.Email, groups)
+	return a.setGroupsForUserInternal(ctx, auth.UserPrefix+claims.Email, groups)
 }
 
 // handleOIDCExchangeInternal is a convenience function for converting an


### PR DESCRIPTION
Group syncing wasn't working because we weren't using the fully-qualfiied names for the users (with the `user:` prefix).