### PR TITLE
Fix makefile GOPATH/PACHCTL vars for windows

### DIFF
--- a/etc/govars.mk
+++ b/etc/govars.mk
@@ -6,11 +6,7 @@
 # workflows. All variables assigned here use ?= so that they can be overridden
 # by environment variables/other Makefiles
 
-ifeq ($(OS),Windows_NT)
-  export GOPATH ?= $(shell cygpath -u $(shell go env GOPATH))
-else
-  export GOPATH ?= $(shell go env GOPATH)
-endif
+export GOPATH ?= $(shell go env GOPATH)
 
 # Set GOBIN based on GOPATH
 # TODO(msteffen) As of Apr. 2021, 'go env GOBIN' doesn't always return a path,
@@ -19,4 +15,8 @@ export GOBIN ?= $(GOPATH)/bin
 
 # Set PACHCTL based on GOBIN (want compiled pachctl to override system
 # pachctl, if any)
-export PACHCTL ?= $(GOBIN)/pachctl
+ifeq ($(OS),Windows_NT)
+  export PACHCTL ?= $(shell cygpath -u $(GOBIN)/pachctl)
+else
+  export PACHCTL ?= $(GOBIN)/pachctl
+endif


### PR DESCRIPTION
No idea how this worked before and what exactly broke it in the recent changes, but `pachctl` would no longer work with the error: 

```
GOPATH entry is relative; must be absolute path: "/c/Users/grey/go"
```

But then once I got that working by using `GOPATH="C:\Users\grey\go"` (the default for golang), the `PACHCTL` var wouldn't work with:

```
C:\Users\grey\go/bin/pachctl deploy local --no-guaranteed -d --dry-run  | kubectl  apply -f -
/usr/bin/sh: C:Usersgreygo/bin/pachctl: No such file or directory
```

So this appears to be the correct combination of directory conversion magic for my environment - not sure if anyone else is dealing with this.  Note that I could also get this working by adding quotes to `"$(GOBIN)/pachctl"`, but I'm not confident enough that this won't break other environments since Makefile semantics are strange and frightening.