### PR TITLE
Simplify constructor arguments

### DIFF
--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -29,7 +29,7 @@ type Reporter struct {
 
 // NewReporter creates a new reporter and kicks off the loop to report cluster
 // metrics
-func NewReporter(clusterID string, env serviceenv.ServiceEnv) *Reporter {
+func NewReporter(env serviceenv.ServiceEnv) *Reporter {
 	var r *router
 	if env.Config().MetricsEndpoint != "" {
 		r = newRouter(env.Config().MetricsEndpoint)
@@ -38,7 +38,7 @@ func NewReporter(clusterID string, env serviceenv.ServiceEnv) *Reporter {
 	}
 	reporter := &Reporter{
 		router:    r,
-		clusterID: clusterID,
+		clusterID: env.ClusterID(),
 		env:       env,
 	}
 	go reporter.reportClusterMetrics()

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 
 	etcd "github.com/coreos/etcd/clientv3"
 	loki "github.com/grafana/loki/pkg/logcli/client"
@@ -21,6 +22,8 @@ import (
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+const clusterIDKey = "cluster-id"
 
 // ServiceEnv contains connections to other services in the
 // cluster. In pachd, there is only one instance of this struct, but tests may
@@ -33,6 +36,7 @@ type ServiceEnv interface {
 	GetKubeClient() *kube.Clientset
 	GetLokiClient() (*loki.Client, error)
 	GetDBClient() *sqlx.DB
+	ClusterID() string
 	Context() context.Context
 	Close() error
 }
@@ -74,6 +78,10 @@ type NonblockingServiceEnv struct {
 	// there's no errgroup associated with it.
 	lokiClient *loki.Client
 
+	// clusterId is the unique ID for this pach cluster
+	clusterId   string
+	clusterIdEg errgroup.Group
+
 	// dbClient is a database client.
 	dbClient *sqlx.DB
 	// dbEg coordinates the initialization of dbClient (see pachdEg)
@@ -110,6 +118,7 @@ func InitServiceEnv(config *Configuration) *NonblockingServiceEnv {
 	env := InitPachOnlyEnv(config)
 	env.etcdAddress = fmt.Sprintf("http://%s", net.JoinHostPort(env.config.EtcdHost, env.config.EtcdPort))
 	env.etcdEg.Go(env.initEtcdClient)
+	env.clusterIdEg.Go(env.initClusterID)
 	env.dbEg.Go(env.initDBClient)
 	if env.config.LokiHost != "" && env.config.LokiPort != "" {
 		env.lokiClient = &loki.Client{
@@ -129,6 +138,26 @@ func InitWithKube(config *Configuration) *NonblockingServiceEnv {
 
 func (env *NonblockingServiceEnv) Config() *Configuration {
 	return env.config
+}
+
+func (env *NonblockingServiceEnv) initClusterID() error {
+	client := env.GetEtcdClient()
+	for {
+		resp, err := client.Get(context.Background(), clusterIDKey)
+
+		// if it's a key not found error then we create the key
+		if resp.Count == 0 {
+			// This might error if it races with another pachd trying to set the
+			// cluster id so we ignore the error.
+			client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes())
+		} else if err != nil {
+			return err
+		} else {
+			// We expect there to only be one value for this key
+			env.clusterId = string(resp.Kvs[0].Value)
+			return nil
+		}
+	}
 }
 
 func (env *NonblockingServiceEnv) initPachClient() error {
@@ -277,6 +306,14 @@ func (env *NonblockingServiceEnv) GetDBClient() *sqlx.DB {
 		panic("service env never connected to the database")
 	}
 	return env.dbClient
+}
+
+func (env *NonblockingServiceEnv) ClusterID() string {
+	if err := env.clusterIdEg.Wait(); err != nil {
+		panic(err)
+	}
+
+	return env.clusterId
 }
 
 func (env *NonblockingServiceEnv) Context() context.Context {

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -48,6 +48,10 @@ func (s *TestServiceEnv) Context() context.Context {
 	return s.Ctx
 }
 
+func (s *TestServiceEnv) ClusterID() string {
+	return "testing"
+}
+
 func (s *TestServiceEnv) Close() error {
 	eg := &errgroup.Group{}
 	eg.Go(s.GetPachClient(context.Background()).Close)

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -123,7 +123,6 @@ func RunLocal() (retErr error) {
 		return errors.Wrapf(err, "error getting pachd external ip")
 	}
 	address := net.JoinHostPort(ip, fmt.Sprintf("%d", env.Config().PeerPort))
-	kubeNamespace := env.Config().Namespace
 	requireNoncriticalServers := !env.Config().RequireCriticalServersOnly
 
 	// Setup External Pachd GRPC Server.
@@ -168,25 +167,7 @@ func RunLocal() (retErr error) {
 			ppsAPIServer, err = pps_server.NewAPIServer(
 				env,
 				txnEnv,
-				path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix),
-				kubeNamespace,
-				env.Config().WorkerImage,
-				env.Config().WorkerSidecarImage,
-				env.Config().WorkerImagePullPolicy,
-				env.Config().StorageRoot,
-				env.Config().StorageBackend,
-				env.Config().StorageHostPath,
-				env.Config().CacheRoot,
-				env.Config().IAMRole,
-				env.Config().ImagePullSecret,
-				env.Config().NoExposeDockerSocket,
 				reporter,
-				env.Config().WorkerUsesRoot,
-				env.Config().PPSWorkerPort,
-				env.Config().Port,
-				env.Config().HTTPPort,
-				env.Config().PeerPort,
-				env.Config().GCPercent,
 			)
 			if err != nil {
 				return err
@@ -330,25 +311,7 @@ func RunLocal() (retErr error) {
 			ppsAPIServer, err = pps_server.NewAPIServer(
 				env,
 				txnEnv,
-				path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix),
-				kubeNamespace,
-				env.Config().WorkerImage,
-				env.Config().WorkerSidecarImage,
-				env.Config().WorkerImagePullPolicy,
-				env.Config().StorageRoot,
-				env.Config().StorageBackend,
-				env.Config().StorageHostPath,
-				env.Config().CacheRoot,
-				env.Config().IAMRole,
-				env.Config().ImagePullSecret,
-				env.Config().NoExposeDockerSocket,
 				reporter,
-				env.Config().WorkerUsesRoot,
-				env.Config().PPSWorkerPort,
-				env.Config().Port,
-				env.Config().HTTPPort,
-				env.Config().PeerPort,
-				env.Config().GCPercent,
 			)
 			if err != nil {
 				return err

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/tls"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
-	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	licenseclient "github.com/pachyderm/pachyderm/v2/src/license"
 	pfsclient "github.com/pachyderm/pachyderm/v2/src/pfs"
 	ppsclient "github.com/pachyderm/pachyderm/v2/src/pps"
@@ -51,7 +50,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/version"
 	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
 
-	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -109,13 +107,9 @@ func RunLocal() (retErr error) {
 		return err
 	}
 
-	clusterID, err := getClusterID(env.GetEtcdClient())
-	if err != nil {
-		return errors.Wrapf(err, "getClusterID")
-	}
 	var reporter *metrics.Reporter
 	if env.Config().Metrics {
-		reporter = metrics.NewReporter(clusterID, env)
+		reporter = metrics.NewReporter(env)
 	}
 	etcdAddress := fmt.Sprintf("http://%s", net.JoinHostPort(env.Config().EtcdHost, env.Config().EtcdPort))
 	ip, err := netutil.ExternalIP()
@@ -243,10 +237,7 @@ func RunLocal() (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("Admin API", func() error {
-			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
-				ID:           clusterID,
-				DeploymentID: env.Config().DeploymentID,
-			}))
+			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err
@@ -390,10 +381,7 @@ func RunLocal() (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("Admin API", func() error {
-			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
-				ID:           clusterID,
-				DeploymentID: env.Config().DeploymentID,
-			}))
+			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err
@@ -473,28 +461,6 @@ func RunLocal() (retErr error) {
 		return http.ListenAndServe(fmt.Sprintf(":%v", assets.PrometheusPort), nil)
 	})
 	return <-errChan
-}
-
-const clusterIDKey = "cluster-id"
-
-func getClusterID(client *etcd.Client) (string, error) {
-	resp, err := client.Get(context.Background(),
-		clusterIDKey)
-
-	// if it's a key not found error then we create the key
-	if resp.Count == 0 {
-		// This might error if it races with another pachd trying to set the
-		// cluster id so we ignore the error.
-		client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes())
-	} else if err != nil {
-		return "", err
-	} else {
-		// We expect there to only be one value for this key
-		id := string(resp.Kvs[0].Value)
-		return id, nil
-	}
-
-	return getClusterID(client)
 }
 
 func logGRPCServerSetup(name string, f func() error) (retErr error) {

--- a/src/server/admin/server/server.go
+++ b/src/server/admin/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"github.com/pachyderm/pachyderm/v2/src/admin"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 )
 
 // APIServer represents and APIServer
@@ -11,9 +12,12 @@ type APIServer interface {
 }
 
 // NewAPIServer returns a new admin.APIServer
-func NewAPIServer(clusterInfo *admin.ClusterInfo) APIServer {
+func NewAPIServer(env serviceenv.ServiceEnv) APIServer {
 	return &apiServer{
-		Logger:      log.NewLogger("admin.API"),
-		clusterInfo: clusterInfo,
+		Logger: log.NewLogger("admin.API"),
+		clusterInfo: &admin.ClusterInfo{
+			ID:           env.ClusterID(),
+			DeploymentID: env.Config().DeploymentID,
+		},
 	}
 }

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -572,7 +572,6 @@ func doFullMode(config interface{}) (retErr error) {
 		return errors.Wrapf(err, "error getting pachd external ip")
 	}
 	address := net.JoinHostPort(ip, fmt.Sprintf("%d", env.Config().PeerPort))
-	kubeNamespace := env.Config().Namespace
 	requireNoncriticalServers := !env.Config().RequireCriticalServersOnly
 
 	// Setup External Pachd GRPC Server.
@@ -612,25 +611,7 @@ func doFullMode(config interface{}) (retErr error) {
 			ppsAPIServer, err = pps_server.NewAPIServer(
 				env,
 				txnEnv,
-				path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix),
-				kubeNamespace,
-				env.Config().WorkerImage,
-				env.Config().WorkerSidecarImage,
-				env.Config().WorkerImagePullPolicy,
-				env.Config().StorageRoot,
-				env.Config().StorageBackend,
-				env.Config().StorageHostPath,
-				env.Config().CacheRoot,
-				env.Config().IAMRole,
-				env.Config().ImagePullSecret,
-				env.Config().NoExposeDockerSocket,
 				reporter,
-				env.Config().WorkerUsesRoot,
-				env.Config().PPSWorkerPort,
-				env.Config().Port,
-				env.Config().HTTPPort,
-				env.Config().PeerPort,
-				env.Config().GCPercent,
 			)
 			if err != nil {
 				return err
@@ -770,25 +751,7 @@ func doFullMode(config interface{}) (retErr error) {
 			ppsAPIServer, err = pps_server.NewAPIServer(
 				env,
 				txnEnv,
-				path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix),
-				kubeNamespace,
-				env.Config().WorkerImage,
-				env.Config().WorkerSidecarImage,
-				env.Config().WorkerImagePullPolicy,
-				env.Config().StorageRoot,
-				env.Config().StorageBackend,
-				env.Config().StorageHostPath,
-				env.Config().CacheRoot,
-				env.Config().IAMRole,
-				env.Config().ImagePullSecret,
-				env.Config().NoExposeDockerSocket,
 				reporter,
-				env.Config().WorkerUsesRoot,
-				env.Config().PPSWorkerPort,
-				env.Config().Port,
-				env.Config().HTTPPort,
-				env.Config().PeerPort,
-				env.Config().GCPercent,
 			)
 			if err != nil {
 				return err

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/tls"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
-	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	licenseclient "github.com/pachyderm/pachyderm/v2/src/license"
 	pfsclient "github.com/pachyderm/pachyderm/v2/src/pfs"
 	ppsclient "github.com/pachyderm/pachyderm/v2/src/pps"
@@ -54,7 +53,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
 	"go.uber.org/automaxprocs/maxprocs"
 
-	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -153,11 +151,6 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		return err
 	}
 
-	clusterID, err := getClusterID(env.GetEtcdClient())
-	if err != nil {
-		return errors.Wrapf(err, "getClusterID")
-	}
-
 	identityStorageProvider, err := identity_server.NewStorageProvider(env)
 	if err != nil {
 		return err
@@ -217,10 +210,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		}
 
 		if err := logGRPCServerSetup("Admin API", func() error {
-			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
-				ID:           clusterID,
-				DeploymentID: env.Config().DeploymentID,
-			}))
+			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err
@@ -314,10 +304,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		}
 
 		if err := logGRPCServerSetup("Admin API", func() error {
-			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
-				ID:           clusterID,
-				DeploymentID: env.Config().DeploymentID,
-			}))
+			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err
@@ -394,13 +381,9 @@ func doSidecarMode(config interface{}) (retErr error) {
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}
-	clusterID, err := getClusterID(env.GetEtcdClient())
-	if err != nil {
-		return errors.Wrapf(err, "getClusterID")
-	}
 	var reporter *metrics.Reporter
 	if env.Config().Metrics {
-		reporter = metrics.NewReporter(clusterID, env)
+		reporter = metrics.NewReporter(env)
 	}
 	authInterceptor := auth.NewInterceptor(env)
 	server, err := grpcutil.NewServer(
@@ -552,11 +535,6 @@ func doFullMode(config interface{}) (retErr error) {
 		return err
 	}
 
-	clusterID, err := getClusterID(env.GetEtcdClient())
-	if err != nil {
-		return errors.Wrapf(err, "getClusterID")
-	}
-
 	identityStorageProvider, err := identity_server.NewStorageProvider(env)
 	if err != nil {
 		return err
@@ -564,7 +542,7 @@ func doFullMode(config interface{}) (retErr error) {
 
 	var reporter *metrics.Reporter
 	if env.Config().Metrics {
-		reporter = metrics.NewReporter(clusterID, env)
+		reporter = metrics.NewReporter(env)
 	}
 	etcdAddress := fmt.Sprintf("http://%s", net.JoinHostPort(env.Config().EtcdHost, env.Config().EtcdPort))
 	ip, err := netutil.ExternalIP()
@@ -684,10 +662,7 @@ func doFullMode(config interface{}) (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("Admin API", func() error {
-			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
-				ID:           clusterID,
-				DeploymentID: env.Config().DeploymentID,
-			}))
+			adminclient.RegisterAPIServer(externalServer.Server, adminserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err
@@ -841,10 +816,7 @@ func doFullMode(config interface{}) (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("Admin API", func() error {
-			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(&adminclient.ClusterInfo{
-				ID:           clusterID,
-				DeploymentID: env.Config().DeploymentID,
-			}))
+			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err
@@ -923,28 +895,6 @@ func doFullMode(config interface{}) (retErr error) {
 		return http.ListenAndServe(fmt.Sprintf(":%v", assets.PrometheusPort), nil)
 	})
 	return <-errChan
-}
-
-const clusterIDKey = "cluster-id"
-
-func getClusterID(client *etcd.Client) (string, error) {
-	resp, err := client.Get(context.Background(),
-		clusterIDKey)
-
-	// if it's a key not found error then we create the key
-	if resp.Count == 0 {
-		// This might error if it races with another pachd trying to set the
-		// cluster id so we ignore the error.
-		client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes())
-	} else if err != nil {
-		return "", err
-	} else {
-		// We expect there to only be one value for this key
-		id := string(resp.Kvs[0].Value)
-		return id, nil
-	}
-
-	return getClusterID(client)
 }
 
 func logGRPCServerSetup(name string, f func() error) (retErr error) {

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"path"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
@@ -19,51 +21,34 @@ type APIServer interface {
 func NewAPIServer(
 	env serviceenv.ServiceEnv,
 	txnEnv *txnenv.TransactionEnv,
-	etcdPrefix string,
-	namespace string,
-	workerImage string,
-	workerSidecarImage string,
-	workerImagePullPolicy string,
-	storageRoot string,
-	storageBackend string,
-	storageHostPath string,
-	cacheRoot string,
-	iamRole string,
-	imagePullSecret string,
-	noExposeDockerSocket bool,
 	reporter *metrics.Reporter,
-	workerUsesRoot bool,
-	workerGrpcPort uint16,
-	port uint16,
-	httpPort uint16,
-	peerPort uint16,
-	gcPercent int,
 ) (APIServer, error) {
+	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix)
 	apiServer := &apiServer{
 		Logger:                log.NewLogger("pps.API"),
 		env:                   env,
 		txnEnv:                txnEnv,
 		etcdPrefix:            etcdPrefix,
-		namespace:             namespace,
-		workerImage:           workerImage,
-		workerSidecarImage:    workerSidecarImage,
-		workerImagePullPolicy: workerImagePullPolicy,
-		storageRoot:           storageRoot,
-		storageBackend:        storageBackend,
-		storageHostPath:       storageHostPath,
-		cacheRoot:             cacheRoot,
-		iamRole:               iamRole,
-		imagePullSecret:       imagePullSecret,
-		noExposeDockerSocket:  noExposeDockerSocket,
+		namespace:             env.Config().Namespace,
+		workerImage:           env.Config().WorkerImage,
+		workerSidecarImage:    env.Config().WorkerSidecarImage,
+		workerImagePullPolicy: env.Config().WorkerImagePullPolicy,
+		storageRoot:           env.Config().StorageRoot,
+		storageBackend:        env.Config().StorageBackend,
+		storageHostPath:       env.Config().StorageHostPath,
+		cacheRoot:             env.Config().CacheRoot,
+		iamRole:               env.Config().IAMRole,
+		imagePullSecret:       env.Config().ImagePullSecret,
+		noExposeDockerSocket:  env.Config().NoExposeDockerSocket,
 		reporter:              reporter,
-		workerUsesRoot:        workerUsesRoot,
+		workerUsesRoot:        env.Config().WorkerUsesRoot,
 		pipelines:             ppsdb.Pipelines(env.GetEtcdClient(), etcdPrefix),
 		jobs:                  ppsdb.Jobs(env.GetEtcdClient(), etcdPrefix),
-		workerGrpcPort:        workerGrpcPort,
-		port:                  port,
-		httpPort:              httpPort,
-		peerPort:              peerPort,
-		gcPercent:             gcPercent,
+		workerGrpcPort:        env.Config().PPSWorkerPort,
+		port:                  env.Config().Port,
+		httpPort:              env.Config().HTTPPort,
+		peerPort:              env.Config().PeerPort,
+		gcPercent:             env.Config().GCPercent,
 	}
 	apiServer.validateKube()
 	go apiServer.master()


### PR DESCRIPTION
Reduce the amount of code in main, to make it easier to instantiate API servers without a lot of copy-paste. Moving the clusterID generation/fetching to an error group might also reduce time to pod readiness.