### PR TITLE
Bump PPS buckets to 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
         type: string
 
     environment:
-      PPS_BUCKETS: "4"
+      PPS_BUCKETS: "8"
       GOPROXY: https://proxy.golang.org
       BUCKET: << parameters.bucket >>
       RUN_BAD_TESTS: << pipeline.parameters.run_flaky_tests >>
@@ -115,5 +115,9 @@ workflows:
               - PPS2
               - PPS3
               - PPS4
+              - PPS5
+              - PPS6
+              - PPS7
+              - PPS8
               - EXAMPLES
               - OBJECT

--- a/.testfaster.yml
+++ b/.testfaster.yml
@@ -132,8 +132,8 @@ runtime:
   memory: 16GB
   disk: 50GB
 
-prewarm_pool_size: 10
-max_pool_size: 20
+prewarm_pool_size: 14
+max_pool_size: 28
 # timeout vms after 6 hours. hopefully tests will clean them up sooner, but if
 # the tests themselves timeout and cleanup doesn't get run, we don't want old
 # VMs building up and stopping new ones getting scheduled.


### PR DESCRIPTION
Increase parallelism in PPS to attempt to reduce end-to-end latency.