### PR TITLE
[DOC] fix protobufs location

### DIFF
--- a/doc/docs/1.13.x/reference/clients.md
+++ b/doc/docs/1.13.x/reference/clients.md
@@ -50,4 +50,4 @@ Our users are currently working on a Scala client for Pachyderm. Please contact 
 
 ## Other languages
 
-Pachyderm uses a simple [protocol buffer API](https://github.com/pachyderm/pachyderm/blob/master/src/client/pfs/pfs.proto). Protobufs support [a bunch of other languages](https://developers.google.com/protocol-buffers/), any of which can be used to programmatically use Pachyderm. We haven’t built clients for them yet, but it’s not too hard. It’s an easy way to contribute to Pachyderm if you’re looking to get involved.
+Pachyderm uses a simple [protocol buffer API](https://github.com/pachyderm/pachyderm/blob/master/src/pfs/pfs.proto). Protobufs support [a bunch of other languages](https://developers.google.com/protocol-buffers/), any of which can be used to programmatically use Pachyderm. We haven’t built clients for them yet, but it’s not too hard. It’s an easy way to contribute to Pachyderm if you’re looking to get involved.


### PR DESCRIPTION
the client docs are pointing to an old/incorrect location