### PR TITLE
Tests produce Junit output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,9 @@ jobs:
           command: |
             etc/testing/upload_stats.sh
 
+      - store_test_results:
+          path: /tmp/test-results
+
       - run:
           name: Dump debugging info in case of failure
           when: on_fail

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -17,6 +17,8 @@ PATH="${GOPATH}/bin:${PATH}"
 export PATH
 TESTFLAGS="-v | stdbuf -i0 tee -a /tmp/results"
 export TESTFLAGS
+SHELL="/bin/bash -o pipefail"
+export SHELL
 
 # Some tests (e.g. TestMigrateFrom1_7) expect
 # $GOPATH/src/github.com/pachyderm/pachyderm to point to .

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -17,8 +17,6 @@ PATH="${GOPATH}/bin:${PATH}"
 export PATH
 TESTFLAGS="-v | stdbuf -i0 tee -a /tmp/results"
 export TESTFLAGS
-SHELL="/bin/bash -o pipefail"
-export SHELL
 
 # Some tests (e.g. TestMigrateFrom1_7) expect
 # $GOPATH/src/github.com/pachyderm/pachyderm to point to .

--- a/etc/testing/report_junit.sh
+++ b/etc/testing/report_junit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+GOPATH=/root/go/workspace
+export GOPATH
+PATH="${GOPATH}/bin:/root/go/bin:${PATH}"
+export PATH
+
+if [ -f /tmp/results ]; then
+  go get -u github.com/jstemmer/go-junit-report
+  go-junit-report < /tmp/results
+fi

--- a/etc/testing/upload_stats.sh
+++ b/etc/testing/upload_stats.sh
@@ -13,3 +13,7 @@ for VAR in "${ENV_VARS[@]}"; do
 done
 
 etc/testing/testctl-ssh.sh "${TESTCTL_OPTIONS[@]}" -- ./project/pachyderm/etc/testing/upload_stats_inner.sh
+
+mkdir -p /tmp/test-results
+
+etc/testing/testctl-ssh.sh "${TESTCTL_OPTIONS[@]}" -- ./project/pachyderm/etc/testing/report_junit.sh > /tmp/test-results/results.xml


### PR DESCRIPTION
This is a freebie since we already pipe stdout into a file, we can convert it to JUnit XML and get test reports from Circle. This doesn't work for non-Go tests or some failures where the test binary stack traces, but in some cases it makes parsing the failure output simpler.

Example of useful and less-useful output depending on the nature of the test failure:
<img width="385" alt="Screen Shot 2021-04-26 at 4 43 51 PM" src="https://user-images.githubusercontent.com/3100188/116148221-9f2d5280-a6ae-11eb-9d42-c6487941edbf.png">
