### PR TITLE
[Parallel Tests] -  Support connecting to pachd over a unix socket

### DIFF
--- a/examples/opencv/goclient-example/opencv-example.go
+++ b/examples/opencv/goclient-example/opencv-example.go
@@ -19,7 +19,7 @@ func main() {
 	// Replace the IP address with your `pachd` address.
 	// If running in minikube, this will be your minikube
 	// IP.
-	c, err := client.NewFromAddress("localhost:30650")
+	c, err := client.NewFromURI("grpc://localhost:30650")
 	if err != nil {
 		panic(err)
 	}

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -46,7 +46,7 @@ func TestInterceptors(t *testing.T) {
 	pfs.RegisterAPIServer(server.Server, new(pfs.UnimplementedAPIServer))
 
 	interceptor := new(countingInterceptor)
-	c, err := NewFromAddress(listener.Addr().String(), WithAdditionalUnaryClientInterceptors(interceptor.unary()), WithAdditionalStreamClientInterceptors(interceptor.stream()))
+	c, err := NewFromURI(listener.Addr().String(), WithAdditionalUnaryClientInterceptors(interceptor.unary()), WithAdditionalStreamClientInterceptors(interceptor.stream()))
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}

--- a/src/client/godoc_test.go
+++ b/src/client/godoc_test.go
@@ -13,7 +13,7 @@ func ExampleAPIClient_CreateRepo() {
 
 	// Create a repo called "test" and print the list of
 	// repositories.
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +41,7 @@ func ExampleAPIClient_CreateRepo() {
 func ExampleAPIClient_DeleteRepo() {
 
 	// Delete a repository called "test".
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ func ExampleAPIClient_DeleteRepo() {
 func ExampleAPIClient_ListRepo() {
 
 	// View the list of existing repositories.
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -93,7 +93,7 @@ func ExampleAPIClient_NewModifyFileClient() {
 	// This method enables you to group multiple "put file" operations into one
 	// request.
 
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -134,7 +134,7 @@ func ExampleAPIClient_PutFile_string() {
 	// string in the scripts and adds it to a file named "file" in the "test"
 	// repository.
 
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -170,7 +170,7 @@ func ExampleAPIClient_PutFile_file() {
 	// opens the file named "text.md" and then uses the PutFile method to add it
 	// to the repo "test@master".
 
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -207,7 +207,7 @@ func ExampleAPIClient_CreateBranch() {
 	// branch that will be used as head, and provenance. Provenance
 	// is an optional paramater and get be set to "nil" for nothing,
 	// to a commit ID or to a branch name.
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -246,7 +246,7 @@ func ExampleAPIClient_ListCommit() {
 	// In the example below, the "to" parameter is left blank, and the "from"
 	// parameter is set to "0", which means all commits.
 
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -297,7 +297,7 @@ func ExampleAPIClient_CreateBranch_fromcommit() {
 	// index [1] that adds "file2" in the repository "test" and will create
 	// a branch "new-branch" in which we will add "file4". "newbranch" will
 	// have "file1", "file2", and "file4", but will not have "file3".
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -350,7 +350,7 @@ func ExampleAPIClient_ListCommitF() {
 	// instead of returning all commits at once. Most of Pachyderm's
 	// "List" methods have a similar function.
 
-	c, err := NewFromAddress("127.0.0.1:30650")
+	c, err := NewFromURI("127.0.0.1:30650")
 	if err != nil {
 		panic(err)
 	}
@@ -401,7 +401,7 @@ func ExampleAPIClient_CreatePipeline() {
 	// to "/pfs/out" directory. Because no image is specified,
 	// Pachyderm will use the basic image. The input is defined as
 	// the repo "test" with the "/*" glob pattern.
-	c, err := NewFromAddress("192.168.64.2:30650")
+	c, err := NewFromURI("192.168.64.2:30650")
 	if err != nil {
 		panic(err)
 	}

--- a/src/client/transaction.go
+++ b/src/client/transaction.go
@@ -275,7 +275,7 @@ func (tb *TransactionBuilder) Close() error {
 // GetAddress should not exist on a TransactionBuilder because it doesn't represent
 // ownership of a connection to the API server, but it also doesn't return an error,
 // so we just passthrough to the parent client's implementation.
-func (tb *TransactionBuilder) GetAddress() string {
+func (tb *TransactionBuilder) GetAddress() *grpcutil.PachdAddress {
 	return tb.parent.GetAddress()
 }
 

--- a/src/internal/grpcutil/addr.go
+++ b/src/internal/grpcutil/addr.go
@@ -41,7 +41,7 @@ type PachdAddress struct {
 	Host string
 	// Port specifies the pachd port
 	Port uint16
-
+	// UnixSocket is set if the pachd address refers to a unix socket
 	UnixSocket string
 }
 
@@ -72,6 +72,8 @@ func ParsePachdAddress(value string) (*PachdAddress, error) {
 	}
 
 	switch {
+	case u.Path != "":
+		return nil, errors.New("pachd address should not include a path")
 	case u.User != nil:
 		return nil, errors.New("pachd address should not include login credentials")
 	case u.RawQuery != "":

--- a/src/internal/grpcutil/addr.go
+++ b/src/internal/grpcutil/addr.go
@@ -103,11 +103,17 @@ func (p *PachdAddress) Qualified() string {
 	if p.Secured {
 		return fmt.Sprintf("grpcs://%s:%d", p.Host, p.Port)
 	}
+	if p.UnixSocket != "" {
+		return p.UnixSocket
+	}
 	return fmt.Sprintf("grpc://%s:%d", p.Host, p.Port)
 }
 
-// Hostname returns the host:port combination of the pachd address, without
-// the scheme
-func (p *PachdAddress) Hostname() string {
-	return fmt.Sprintf("%s:%d", p.Host, p.Port)
+// Target returns a string suitable for calling grpc.Dial.
+// This may be a host:port pair for TCP connections, or a unix socket address.
+func (p *PachdAddress) Target() string {
+	if p.UnixSocket != "" {
+		return p.UnixSocket
+	}
+	return fmt.Sprintf("dns:///%s:%d", p.Host, p.Port)
 }

--- a/src/internal/grpcutil/addr.go
+++ b/src/internal/grpcutil/addr.go
@@ -41,6 +41,8 @@ type PachdAddress struct {
 	Host string
 	// Port specifies the pachd port
 	Port uint16
+
+	UnixSocket string
 }
 
 // ParsePachdAddress parses a string into a pachd address, or returns an error
@@ -63,6 +65,8 @@ func ParsePachdAddress(value string) (*PachdAddress, error) {
 
 	switch u.Scheme {
 	case "grpc", "grpcs", "http", "https":
+	case "unix":
+		return &PachdAddress{UnixSocket: value}, nil
 	default:
 		return nil, errors.Errorf("unrecognized scheme in pachd address: %s", u.Scheme)
 	}
@@ -74,8 +78,6 @@ func ParsePachdAddress(value string) (*PachdAddress, error) {
 		return nil, errors.New("pachd address should not include a query string")
 	case u.Fragment != "":
 		return nil, errors.New("pachd address should not include a fragment")
-	case u.Path != "":
-		return nil, errors.New("pachd address should not include a path")
 	}
 
 	port := uint16(DefaultPachdNodePort)

--- a/src/internal/grpcutil/addr_test.go
+++ b/src/internal/grpcutil/addr_test.go
@@ -17,6 +17,15 @@ func TestParsePachdAddress(t *testing.T) {
 	_, err = ParsePachdAddress("grpc://user:pass@pachyderm.com:80")
 	require.YesError(t, err)
 
+	_, err = ParsePachdAddress("grpc://pachyderm.com:80/")
+	require.YesError(t, err)
+
+	_, err = ParsePachdAddress("grpc://pachyderm.com:80/?foo")
+	require.YesError(t, err)
+
+	_, err = ParsePachdAddress("grpc://pachyderm.com:80/#foo")
+	require.YesError(t, err)
+
 	p, err := ParsePachdAddress("http://pachyderm.com:80")
 	require.NoError(t, err)
 	require.Equal(t, &PachdAddress{

--- a/src/internal/grpcutil/addr_test.go
+++ b/src/internal/grpcutil/addr_test.go
@@ -17,15 +17,6 @@ func TestParsePachdAddress(t *testing.T) {
 	_, err = ParsePachdAddress("grpc://user:pass@pachyderm.com:80")
 	require.YesError(t, err)
 
-	_, err = ParsePachdAddress("grpc://pachyderm.com:80/")
-	require.YesError(t, err)
-
-	_, err = ParsePachdAddress("grpc://pachyderm.com:80/?foo")
-	require.YesError(t, err)
-
-	_, err = ParsePachdAddress("grpc://pachyderm.com:80/#foo")
-	require.YesError(t, err)
-
 	p, err := ParsePachdAddress("http://pachyderm.com:80")
 	require.NoError(t, err)
 	require.Equal(t, &PachdAddress{
@@ -129,4 +120,14 @@ func TestPachdAddressHostname(t *testing.T) {
 		Port:    DefaultPachdNodePort,
 	}
 	require.Equal(t, "pachyderm.com:30650", p.Hostname())
+}
+
+func TestPachdAddressSocket(t *testing.T) {
+	p, err := ParsePachdAddress("unix:///tmp/socket")
+	require.NoError(t, err)
+	require.Equal(t, &PachdAddress{
+		Secured:    false,
+		UnixSocket: "unix:///tmp/socket",
+	}, p)
+
 }

--- a/src/internal/grpcutil/addr_test.go
+++ b/src/internal/grpcutil/addr_test.go
@@ -97,6 +97,13 @@ func TestParsePachdAddress(t *testing.T) {
 		Host:    "::1",
 		Port:    80,
 	}, p)
+
+	p, err = ParsePachdAddress("unix:///tmp/socket")
+	require.NoError(t, err)
+	require.Equal(t, &PachdAddress{
+		Secured:    false,
+		UnixSocket: "unix:///tmp/socket",
+	}, p)
 }
 
 func TestPachdAddressQualified(t *testing.T) {
@@ -113,6 +120,12 @@ func TestPachdAddressQualified(t *testing.T) {
 		Port:    DefaultPachdNodePort,
 	}
 	require.Equal(t, "grpcs://pachyderm.com:30650", p.Qualified())
+
+	p = &PachdAddress{
+		Secured:    false,
+		UnixSocket: "unix:///tmp/socket",
+	}
+	require.Equal(t, "unix:///tmp/socket", p.Qualified())
 }
 
 func TestPachdAddressHostname(t *testing.T) {
@@ -121,22 +134,19 @@ func TestPachdAddressHostname(t *testing.T) {
 		Host:    "pachyderm.com",
 		Port:    DefaultPachdNodePort,
 	}
-	require.Equal(t, "pachyderm.com:30650", p.Hostname())
+	require.Equal(t, "dns:///pachyderm.com:30650", p.Target())
 
 	p = &PachdAddress{
 		Secured: true,
 		Host:    "pachyderm.com",
 		Port:    DefaultPachdNodePort,
 	}
-	require.Equal(t, "pachyderm.com:30650", p.Hostname())
-}
+	require.Equal(t, "dns:///pachyderm.com:30650", p.Target())
 
-func TestPachdAddressSocket(t *testing.T) {
-	p, err := ParsePachdAddress("unix:///tmp/socket")
-	require.NoError(t, err)
-	require.Equal(t, &PachdAddress{
+	p = &PachdAddress{
 		Secured:    false,
 		UnixSocket: "unix:///tmp/socket",
-	}, p)
+	}
+	require.Equal(t, "unix:///tmp/socket", p.Target())
 
 }

--- a/src/internal/grpcutil/server.go
+++ b/src/internal/grpcutil/server.go
@@ -82,6 +82,15 @@ func NewServer(ctx context.Context, publicPortTLSAllowed bool, options ...grpc.S
 	}, nil
 }
 
+func (s *Server) ListenSocket(path string) error {
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	go s.Server.Serve(listener)
+	return nil
+}
+
 // ListenTCP causes the gRPC server to listen on a given TCP host and port
 func (s *Server) ListenTCP(host string, port uint16) (net.Listener, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))

--- a/src/internal/obj/integrationtests/deployment_test.go
+++ b/src/internal/obj/integrationtests/deployment_test.go
@@ -149,7 +149,7 @@ func getPachClient(t *testing.T, kubeClient *kube.Clientset, namespace string) *
 
 	// Connect to pachd
 	tu.WaitForPachdReady(t, namespace)
-	client, err := client.NewFromAddress(fmt.Sprintf("%s:%d", address, port), client.WithDialTimeout(100*time.Second))
+	client, err := client.NewFromURI(fmt.Sprintf("%s:%d", address, port), client.WithDialTimeout(100*time.Second))
 
 	// Some debugging info in case connecting fails - this will dump the pachd
 	// logs in case something went wrong there. In my experience, this has been

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -169,7 +169,7 @@ func (env *NonblockingServiceEnv) initPachClient() error {
 	// Initialize pach client
 	return backoff.Retry(func() error {
 		var err error
-		env.pachClient, err = client.NewFromAddress(env.pachAddress)
+		env.pachClient, err = client.NewFromURI(env.pachAddress)
 		if err != nil {
 			return errors.Wrapf(err, "failed to initialize pach client")
 		}

--- a/src/internal/testpachd/mock_env.go
+++ b/src/internal/testpachd/mock_env.go
@@ -49,7 +49,7 @@ func NewMockEnv(t testing.TB) *MockEnv {
 		return errorWait(ctx, mockEnv.MockPachd.Err())
 	})
 
-	mockEnv.PachClient, err = client.NewFromAddress(mockEnv.MockPachd.Addr.String())
+	mockEnv.PachClient, err = client.NewFromURI(mockEnv.MockPachd.Addr.String())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, mockEnv.PachClient.Close())

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"golang.org/x/oauth2"
@@ -199,23 +198,21 @@ func RewriteURL(t testing.TB, urlStr, host string) string {
 
 // DexHost returns the address to access the identity server during tests
 func DexHost(c *client.APIClient) string {
-	parts := strings.Split(c.GetAddress(), ":")
-	if parts[1] == "650" {
-		return parts[0] + ":658"
+	if c.GetAddress().Port == 650 {
+		return c.GetAddress().Host + ":658"
 	}
-	if parts[1] == "31650" {
-		return parts[0] + ":31658"
+	if c.GetAddress().Port == 31650 {
+		return c.GetAddress().Host + ":31658"
 	}
-	return parts[0] + ":30658"
+	return c.GetAddress().Host + ":30658"
 }
 
 func pachHost(c *client.APIClient) string {
-	parts := strings.Split(c.GetAddress(), ":")
-	if parts[1] == "650" {
-		return parts[0] + ":657"
+	if c.GetAddress().Port == 650 {
+		return c.GetAddress().Host + ":657"
 	}
-	if parts[1] == "31650" {
-		return parts[0] + ":31657"
+	if c.GetAddress().Port == 31650 {
+		return c.GetAddress().Host + ":31657"
 	}
-	return parts[0] + ":30657"
+	return c.GetAddress().Host + ":30657"
 }

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -437,7 +437,7 @@ func RunLocal() (retErr error) {
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
 		server, err := s3.Server(env.Config().S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
-			return client.NewFromAddress(fmt.Sprintf("localhost:%d", env.Config().PeerPort))
+			return client.NewFromURI(fmt.Sprintf("localhost:%d", env.Config().PeerPort))
 		})
 		if err != nil {
 			return err

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/keycache"
 	"github.com/pachyderm/pachyderm/v2/src/internal/license"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
@@ -146,22 +145,7 @@ func (a *apiServer) heartbeatToServer(ctx context.Context, licenseServer, id, se
 		return nil, err
 	}
 
-	pachdAddress, err := grpcutil.ParsePachdAddress(licenseServer)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not parse the active context's pachd address")
-	}
-
-	var options []client.Option
-	if pachdAddress.Secured {
-		options = append(options, client.WithSystemCAs)
-	}
-
-	var pachClient *client.APIClient
-	if pachdAddress.UnixSocket != "" {
-		pachClient, err = client.NewFromSocket(pachdAddress.UnixSocket)
-	} else {
-		pachClient, err = client.NewFromAddress(pachdAddress.Hostname(), options...)
-	}
+	pachClient, err := client.NewFromURI(licenseServer)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -156,7 +156,12 @@ func (a *apiServer) heartbeatToServer(ctx context.Context, licenseServer, id, se
 		options = append(options, client.WithSystemCAs)
 	}
 
-	pachClient, err := client.NewFromAddress(pachdAddress.Hostname(), options...)
+	var pachClient *client.APIClient
+	if pachdAddress.UnixSocket != "" {
+		pachClient, err = client.NewFromSocket(pachdAddress.UnixSocket)
+	} else {
+		pachClient, err = client.NewFromAddress(pachdAddress.Hostname(), options...)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/http/http.go
+++ b/src/server/http/http.go
@@ -153,7 +153,7 @@ func httpError(w http.ResponseWriter, err error) {
 func (s *server) getPachClient() *client.APIClient {
 	s.pachClientOnce.Do(func() {
 		var err error
-		s.pachClient, err = client.NewFromAddress(s.address)
+		s.pachClient, err = client.NewFromURI(s.address)
 		if err != nil {
 			panic(fmt.Sprintf("http server failed to initialize pach client: %v", err))
 		}

--- a/src/server/identity/server/api_server_test.go
+++ b/src/server/identity/server/api_server_test.go
@@ -4,11 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
@@ -178,7 +176,7 @@ func TestSetConfiguration(t *testing.T) {
 		)
 	}, backoff.NewTestingBackOff()))
 
-	resp, err := http.Get(fmt.Sprintf("http://%v/.well-known/openid-configuration", dexHost(adminClient)))
+	resp, err := http.Get(fmt.Sprintf("http://%v/.well-known/openid-configuration", tu.DexHost(adminClient)))
 	require.NoError(t, err)
 
 	var oidcConfig map[string]interface{}
@@ -275,12 +273,4 @@ func TestIDPConnectorCRUD(t *testing.T) {
 	listResp, err = adminClient.ListIDPConnectors(adminClient.Ctx(), &identity.ListIDPConnectorsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(listResp.Connectors))
-}
-
-func dexHost(c *client.APIClient) string {
-	parts := strings.Split(c.GetAddress(), ":")
-	if parts[1] == "650" {
-		return parts[0] + ":658"
-	}
-	return parts[0] + ":30658"
 }

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/keycache"
 	"github.com/pachyderm/pachyderm/v2/src/internal/license"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
@@ -174,23 +173,7 @@ func (a *apiServer) validateClusterConfig(ctx context.Context, address string) e
 		return errors.New("no address provided for cluster")
 	}
 
-	pachdAddress, err := grpcutil.ParsePachdAddress(address)
-	if err != nil {
-		return errors.Wrap(err, "could not parse the pachd address")
-	}
-
-	var options []client.Option
-	if pachdAddress.Secured {
-		options = append(options, client.WithSystemCAs)
-	}
-
-	// Attempt to connect to the pachd
-	var pachClient *client.APIClient
-	if pachdAddress.UnixSocket != "" {
-		pachClient, err = client.NewFromSocket(pachdAddress.UnixSocket)
-	} else {
-		pachClient, err = client.NewFromAddress(pachdAddress.Hostname(), options...)
-	}
+	pachClient, err := client.NewFromURI(address)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create client for %q", address)
 	}

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -185,7 +185,12 @@ func (a *apiServer) validateClusterConfig(ctx context.Context, address string) e
 	}
 
 	// Attempt to connect to the pachd
-	pachClient, err := client.NewFromAddress(pachdAddress.Hostname(), options...)
+	var pachClient *client.APIClient
+	if pachdAddress.UnixSocket != "" {
+		pachClient, err = client.NewFromSocket(pachdAddress.UnixSocket)
+	} else {
+		pachClient, err = client.NewFromAddress(pachdAddress.Hostname(), options...)
+	}
 	if err != nil {
 		return errors.Wrapf(err, "unable to create client for %q", address)
 	}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6605,9 +6605,7 @@ func TestHTTPAuth(t *testing.T) {
 	}
 	c := tu.GetPachClient(t)
 
-	clientAddr := c.GetAddress()
-	host, _, err := net.SplitHostPort(clientAddr)
-	require.NoError(t, err)
+	host := c.GetAddress().Host
 	port, ok := os.LookupEnv("PACHD_SERVICE_PORT_API_HTTP_PORT")
 	if !ok {
 		port = "30652" // default NodePort port for Pachd's HTTP API
@@ -6668,9 +6666,7 @@ func TestHTTPGetFile(t *testing.T) {
 	require.NoError(t, c.PutFile(dataRepo, commit1.ID, "giphy.gif", f, client.WithAppendPutFile()))
 	require.NoError(t, c.FinishCommit(dataRepo, commit1.ID))
 
-	clientAddr := c.GetAddress()
-	host, _, err := net.SplitHostPort(clientAddr)
-	require.NoError(t, err)
+	host := c.GetAddress().Host
 	port, ok := os.LookupEnv("PACHD_SERVICE_PORT_API_HTTP_PORT")
 	if !ok {
 		port = "30652" // default NodePort port for Pachd's HTTP API
@@ -6748,9 +6744,7 @@ func TestService(t *testing.T) {
 		// Hack: detect if running inside the cluster by looking for this env var
 		if _, ok := os.LookupEnv("KUBERNETES_PORT"); !ok {
 			// Outside cluster: Re-use external IP and external port defined above
-			clientAddr := c.GetAddress()
-			host, _, err := net.SplitHostPort(clientAddr)
-			require.NoError(t, err)
+			host := c.GetAddress().Host
 			return net.JoinHostPort(host, "31800")
 		}
 		// Get k8s service corresponding to pachyderm service above--must access
@@ -6813,9 +6807,7 @@ func TestService(t *testing.T) {
 		return nil
 	}, backoff.NewTestingBackOff()))
 
-	clientAddr := c.GetAddress()
-	host, _, err := net.SplitHostPort(clientAddr)
-	require.NoError(t, err)
+	host := c.GetAddress().Host
 	port, ok := os.LookupEnv("PACHD_SERVICE_PORT_API_HTTP_PORT")
 	if !ok {
 		port = "30652" // default NodePort port for Pachd's HTTP API
@@ -6910,9 +6902,7 @@ func TestServiceEnvVars(t *testing.T) {
 		// Hack: detect if running inside the cluster by looking for this env var
 		if _, ok := os.LookupEnv("KUBERNETES_PORT"); !ok {
 			// Outside cluster: Re-use external IP and external port defined above
-			clientAddr := c.GetAddress()
-			host, _, err := net.SplitHostPort(clientAddr)
-			require.NoError(t, err)
+			host := c.GetAddress().Host
 			return net.JoinHostPort(host, "31800")
 		}
 		// Get k8s service corresponding to pachyderm service above--must access

--- a/src/server/pps/server/githook/githook.go
+++ b/src/server/pps/server/githook/githook.go
@@ -61,7 +61,7 @@ func URLFromDomain(domain string) string {
 
 // RunGitHookServer starts the webhook server
 func RunGitHookServer(address string, etcdAddress string, etcdPrefix string) error {
-	c, err := client.NewFromAddress(address)
+	c, err := client.NewFromURI(address)
 	if err != nil {
 		return err
 	}

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -476,8 +476,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 		require.NoError(t, err)
 		time.Sleep(20 * time.Second)
 
-		host, _, err := net.SplitHostPort(c.GetAddress())
-		require.NoError(t, err)
+		host := c.GetAddress().Host
 		serviceAddr := net.JoinHostPort(host, "31800")
 
 		// Write a tar stream with a single file to


### PR DESCRIPTION
Rework how the client package handles creating connections:
- `NewFromAddress` is replaced by `NewFromURI`. `NewFromURI` accepts a fully-qualfiied (with scheme) URI, or just a `host:port` pair. If no scheme is specified, `grpc://` is assumed.
- Adds `NewFromPachdAddress`, which accepts an already-parsed `grpcutil.PachdAddress`. 
- `client.GetAddress()` returns a `grpcutil.PachdAddress` instead of a `host:port` string. This way we don't lose information about the scheme, and it avoids string munging trying to get the host and port out.