### PR TITLE
[Parallel Tests] -  Keycache has context that can be cancelled

### DIFF
--- a/src/internal/keycache/cache.go
+++ b/src/internal/keycache/cache.go
@@ -1,12 +1,11 @@
 package keycache
 
 import (
+	"context"
+	"fmt"
 	"sync/atomic"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
-	logrus "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
@@ -17,6 +16,7 @@ import (
 // Cache watches a key in etcd and caches the value in an atomic value
 // This is useful for frequently read but infrequently updated values
 type Cache struct {
+	ctx          context.Context
 	c            col.Collection
 	defaultValue proto.Message
 	key          string
@@ -24,11 +24,12 @@ type Cache struct {
 }
 
 // NewCache returns a cache for the given key in the etcd collection
-func NewCache(c col.Collection, key string, defaultValue proto.Message) *Cache {
+func NewCache(ctx context.Context, c col.Collection, key string, defaultValue proto.Message) *Cache {
 	value := &atomic.Value{}
 	value.Store(defaultValue)
 	return &Cache{
 		c:            c,
+		ctx:          ctx,
 		value:        value,
 		key:          key,
 		defaultValue: defaultValue,
@@ -44,32 +45,33 @@ func (c *Cache) Watch() {
 		}
 		defer watcher.Close()
 		for {
-			ev, ok := <-watcher.Watch()
-			if !ok {
-				return errors.New("watch closed unexpectedly")
-			}
+			select {
+			case <-c.ctx.Done():
+				return errors.New("done")
+			case ev, ok := <-watcher.Watch():
+				if !ok {
+					return errors.New("watch closed unexpectedly")
+				}
 
-			if ev.Type == watch.EventError {
-				return ev.Err
-			}
+				if ev.Type == watch.EventError {
+					return ev.Err
+				}
 
-			if string(ev.Key) == c.key {
-				switch ev.Type {
-				case watch.EventPut:
-					val := proto.Clone(c.defaultValue)
-					if err := proto.Unmarshal(ev.Value, val); err != nil {
-						return err
+				if string(ev.Key) == c.key {
+					switch ev.Type {
+					case watch.EventPut:
+						val := proto.Clone(c.defaultValue)
+						if err := proto.Unmarshal(ev.Value, val); err != nil {
+							return err
+						}
+						c.value.Store(val)
+					case watch.EventDelete:
+						c.value.Store(c.defaultValue)
 					}
-					c.value.Store(val)
-				case watch.EventDelete:
-					c.value.Store(c.defaultValue)
 				}
 			}
 		}
-	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
-		logrus.Printf("error from watcher for %v: %v; retrying in %v", c.key, err, d)
-		return nil
-	})
+	}, backoff.NewInfiniteBackOff(), backoff.NotifyCtx(c.ctx, fmt.Sprintf("watcher for %v", c.key)))
 }
 
 // Load retrieves the current cached value

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -196,8 +196,8 @@ func NewAuthServer(
 	}
 
 	if watchesEnabled {
-		s.configCache = keycache.NewCache(authConfig, configKey, &DefaultOIDCConfig)
-		s.clusterRoleBindingCache = keycache.NewCache(roleBindings, clusterRoleBindingKey, &auth.RoleBinding{})
+		s.configCache = keycache.NewCache(env.Context(), authConfig, configKey, &DefaultOIDCConfig)
+		s.clusterRoleBindingCache = keycache.NewCache(env.Context(), roleBindings, clusterRoleBindingKey, &auth.RoleBinding{})
 
 		// Watch for new auth config options
 		go s.configCache.Watch()

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -66,7 +66,7 @@ func NewEnterpriseServer(env serviceenv.ServiceEnv, etcdPrefix string) (ec.APISe
 	s := &apiServer{
 		pachLogger:           log.NewLogger("enterprise.API"),
 		env:                  env,
-		enterpriseTokenCache: keycache.NewCache(enterpriseTokenCol, enterpriseTokenKey, defaultEnterpriseRecord),
+		enterpriseTokenCache: keycache.NewCache(env.Context(), enterpriseTokenCol, enterpriseTokenKey, defaultEnterpriseRecord),
 		enterpriseTokenCol:   enterpriseTokenCol,
 		configCol:            col.NewCollection(env.GetEtcdClient(), etcdPrefix, nil, &ec.EnterpriseConfig{}, nil, nil),
 	}

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -59,7 +59,7 @@ func New(env serviceenv.ServiceEnv, etcdPrefix string) (lc.APIServer, error) {
 	s := &apiServer{
 		pachLogger:           log.NewLogger("license.API"),
 		env:                  env,
-		enterpriseTokenCache: keycache.NewCache(enterpriseToken, licenseRecordKey, defaultRecord),
+		enterpriseTokenCache: keycache.NewCache(env.Context(), enterpriseToken, licenseRecordKey, defaultRecord),
 		enterpriseToken:      enterpriseToken,
 	}
 	go s.enterpriseTokenCache.Watch()


### PR DESCRIPTION
Thread the service env context through the keycache so we can cancel the watches.