### PR TITLE
[Parallel Tests] -  Add Logger to serviceenv

### DIFF
--- a/src/internal/cache/server/server.go
+++ b/src/internal/cache/server/server.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/golang/groupcache/groupcachepb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cache/groupcachepb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/shard"
 
 	"github.com/golang/groupcache"
@@ -23,9 +24,9 @@ type CacheServer interface {
 }
 
 // NewCacheServer creates a new CacheServer.
-func NewCacheServer(router shard.Router, shards uint64) CacheServer {
+func NewCacheServer(env serviceenv.ServiceEnv, router shard.Router, shards uint64) CacheServer {
 	server := &groupCacheServer{
-		Logger:      log.NewLogger("CacheServer"),
+		Logger:      log.NewLogger("CacheServer", env.Logger()),
 		router:      router,
 		localShards: make(map[uint64]bool),
 		shards:      shards,

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -40,17 +40,16 @@ type logger struct {
 }
 
 // NewLogger creates a new logger
-func NewLogger(service string) Logger {
-	return newLogger(service, true)
+func NewLogger(service string, l *logrus.Logger) Logger {
+	return newLogger(service, true, l)
 }
 
 // NewLocalLogger creates a new logger for local testing (which does not report prometheus metrics)
-func NewLocalLogger(service string) Logger {
-	return newLogger(service, false)
+func NewLocalLogger(service string, l *logrus.Logger) Logger {
+	return newLogger(service, false, l)
 }
 
-func newLogger(service string, exportStats bool) Logger {
-	l := logrus.StandardLogger()
+func newLogger(service string, exportStats bool, l *logrus.Logger) Logger {
 	l.Formatter = FormatterFunc(Pretty)
 	newLogger := &logger{
 		l.WithFields(logrus.Fields{"service": service}),

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -38,6 +38,7 @@ type ServiceEnv interface {
 	GetDBClient() *sqlx.DB
 	ClusterID() string
 	Context() context.Context
+	Logger() *log.Logger
 	Close() error
 }
 
@@ -318,6 +319,10 @@ func (env *NonblockingServiceEnv) ClusterID() string {
 
 func (env *NonblockingServiceEnv) Context() context.Context {
 	return env.ctx
+}
+
+func (env *NonblockingServiceEnv) Logger() *log.Logger {
+	return log.StandardLogger()
 }
 
 func (env *NonblockingServiceEnv) Close() error {

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -8,6 +8,7 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	loki "github.com/grafana/loki/pkg/logcli/client"
 	"github.com/jmoiron/sqlx"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	kube "k8s.io/client-go/kubernetes"
 )
@@ -21,6 +22,7 @@ type TestServiceEnv struct {
 	KubeClient    *kube.Clientset
 	LokiClient    *loki.Client
 	DBClient      *sqlx.DB
+	Log           *log.Logger
 	Ctx           context.Context
 }
 
@@ -50,6 +52,10 @@ func (s *TestServiceEnv) Context() context.Context {
 
 func (s *TestServiceEnv) ClusterID() string {
 	return "testing"
+}
+
+func (s *TestServiceEnv) Logger() *log.Logger {
+	return s.Log
 }
 
 func (s *TestServiceEnv) Close() error {

--- a/src/server/admin/server/server.go
+++ b/src/server/admin/server/server.go
@@ -14,7 +14,7 @@ type APIServer interface {
 // NewAPIServer returns a new admin.APIServer
 func NewAPIServer(env serviceenv.ServiceEnv) APIServer {
 	return &apiServer{
-		Logger: log.NewLogger("admin.API"),
+		Logger: log.NewLogger("admin.API", env.Logger()),
 		clusterInfo: &admin.ClusterInfo{
 			ID:           env.ClusterID(),
 			DeploymentID: env.Config().DeploymentID,

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -158,7 +158,7 @@ func NewAuthServer(
 	s := &apiServer{
 		env:        env,
 		txnEnv:     txnEnv,
-		pachLogger: log.NewLogger("auth.API"),
+		pachLogger: log.NewLogger("auth.API", env.Logger()),
 		members: col.NewCollection(
 			env.GetEtcdClient(),
 			path.Join(etcdPrefix, membersPrefix),

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -64,7 +64,7 @@ func NewEnterpriseServer(env serviceenv.ServiceEnv, etcdPrefix string) (ec.APISe
 	)
 
 	s := &apiServer{
-		pachLogger:           log.NewLogger("enterprise.API"),
+		pachLogger:           log.NewLogger("enterprise.API", env.Logger()),
 		env:                  env,
 		enterpriseTokenCache: keycache.NewCache(enterpriseTokenCol, enterpriseTokenKey, defaultEnterpriseRecord),
 		enterpriseTokenCol:   enterpriseTokenCol,

--- a/src/server/identity/server/api_server.go
+++ b/src/server/identity/server/api_server.go
@@ -49,7 +49,7 @@ func (a *apiServer) LogResp(request interface{}, response interface{}, err error
 func NewIdentityServer(env serviceenv.ServiceEnv, storage dex_storage.Storage, public bool) identity.APIServer {
 	server := &apiServer{
 		env:        env,
-		pachLogger: log.NewLogger("identity.API"),
+		pachLogger: log.NewLogger("identity.API", env.Logger()),
 		api:        newDexAPI(storage),
 	}
 

--- a/src/server/identity/server/dex_web_test.go
+++ b/src/server/identity/server/dex_web_test.go
@@ -21,7 +21,10 @@ import (
 )
 
 func getTestEnv(t *testing.T) serviceenv.ServiceEnv {
-	env := &serviceenv.TestServiceEnv{DBClient: testutil.NewTestDB(t)}
+	env := &serviceenv.TestServiceEnv{
+		DBClient: testutil.NewTestDB(t),
+		Log:      logrus.New(),
+	}
 	require.NoError(t, migrations.ApplyMigrations(context.Background(), env.GetDBClient(), migrations.Env{}, clusterstate.DesiredClusterState))
 	require.NoError(t, migrations.BlockUntil(context.Background(), env.GetDBClient(), clusterstate.DesiredClusterState))
 	return env

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -57,7 +57,7 @@ func New(env serviceenv.ServiceEnv, etcdPrefix string) (lc.APIServer, error) {
 	)
 
 	s := &apiServer{
-		pachLogger:           log.NewLogger("license.API"),
+		pachLogger:           log.NewLogger("license.API", env.Logger()),
 		env:                  env,
 		enterpriseTokenCache: keycache.NewCache(enterpriseToken, licenseRecordKey, defaultRecord),
 		enterpriseToken:      enterpriseToken,

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -47,7 +47,7 @@ func newAPIServer(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcd
 		return nil, err
 	}
 	s := &apiServer{
-		Logger: log.NewLogger("pfs.API"),
+		Logger: log.NewLogger("pfs.API", env.Logger()),
 		driver: d,
 		env:    env,
 		txnEnv: txnEnv,

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -25,7 +25,7 @@ func NewAPIServer(
 ) (APIServer, error) {
 	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PPSEtcdPrefix)
 	apiServer := &apiServer{
-		Logger:                log.NewLogger("pps.API"),
+		Logger:                log.NewLogger("pps.API", env.Logger()),
 		env:                   env,
 		txnEnv:                txnEnv,
 		etcdPrefix:            etcdPrefix,
@@ -70,7 +70,7 @@ func NewSidecarAPIServer(
 	peerPort uint16,
 ) (APIServer, error) {
 	apiServer := &apiServer{
-		Logger:         log.NewLogger("pps.API"),
+		Logger:         log.NewLogger("pps.API", env.Logger()),
 		env:            env,
 		txnEnv:         txnEnv,
 		etcdPrefix:     etcdPrefix,

--- a/src/server/transaction/server/api_server.go
+++ b/src/server/transaction/server/api_server.go
@@ -31,7 +31,7 @@ func newAPIServer(
 		return nil, err
 	}
 	s := &apiServer{
-		Logger: log.NewLogger("transaction.API"),
+		Logger: log.NewLogger("transaction.API", env.Logger()),
 		driver: d,
 		env:    env,
 	}


### PR DESCRIPTION
Make it possible to redirect (most) logs to a file by injecting a logger from serviceenv.