### PR TITLE
[Parallel Tests] - Add optional filter label to worker pods

### DIFF
--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -19,6 +19,7 @@ type GlobalConfiguration struct {
 	S3GatewayPort       uint16 `env:"S3GATEWAY_PORT,default=600"`
 	PPSEtcdPrefix       string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
 	Namespace           string `env:"PACH_NAMESPACE,default=default"`
+	PipelineLabel       string `env:"PACH_WORKER_LABEL"`
 	StorageRoot         string `env:"PACH_ROOT,default=/pach"`
 	CacheRoot           string `env:"PACH_CACHE_ROOT,default=/pach-cache"`
 	GCPercent           int    `env:"GC_PERCENT,default=50"`

--- a/src/server/pps/server/poller.go
+++ b/src/server/pps/server/poller.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -91,8 +92,12 @@ func (m *ppsMaster) pollPipelines(pollClient *client.APIClient) {
 			// then we might delete the RC for brand-new pipeline 'foo'). Even if we
 			// do delete a live pipeline's RC, it'll be fixed in the next cycle)
 			kc := m.a.env.GetKubeClient().CoreV1().ReplicationControllers(m.a.env.Config().Namespace)
+			labelSelector := "suite=pachyderm"
+			if m.a.env.Config().PipelineLabel != "" {
+				labelSelector = fmt.Sprintf("%v,pipelineFilter=%v", labelSelector, m.a.env.Config().PipelineLabel)
+			}
 			rcs, err := kc.List(metav1.ListOptions{
-				LabelSelector: "suite=pachyderm,pipelineName",
+				LabelSelector: labelSelector,
 			})
 			if err != nil {
 				// No sensible error recovery here (e.g .if we can't reach k8s). We'll
@@ -174,13 +179,16 @@ func (m *ppsMaster) pollPipelines(pollClient *client.APIClient) {
 func (m *ppsMaster) pollPipelinePods(pollClient *client.APIClient) {
 	ctx := pollClient.Ctx()
 	if err := backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error {
+		selector := map[string]string{
+			"component": "worker",
+		}
+		if m.a.env.Config().PipelineLabel != "" {
+			selector["pipelineFilter"] = m.a.env.Config().PipelineLabel
+		}
 		kubePipelineWatch, err := m.a.env.GetKubeClient().CoreV1().Pods(m.a.namespace).Watch(
 			metav1.ListOptions{
-				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
-					map[string]string{
-						"component": "worker",
-					})),
-				Watch: true,
+				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(selector)),
+				Watch:         true,
 			})
 		if err != nil {
 			return errors.Wrap(err, "failed to watch kubernetes pods")

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	pipelineNameLabel         = "pipelineName"
+	pipelineFilterLabel       = "pipelineFilter"
 	pachVersionAnnotation     = "version"
 	specCommitAnnotation      = "specCommit"
 	hashedAuthTokenAnnotation = "authTokenHash"
@@ -485,6 +486,9 @@ func (a *apiServer) getWorkerOptions(ptr *pps.EtcdPipelineInfo, pipelineInfo *pp
 	rcName := ppsutil.PipelineRcName(pipelineName, pipelineVersion)
 	labels := labels(rcName)
 	labels[pipelineNameLabel] = pipelineName
+	if a.env.Config().PipelineLabel != "" {
+		labels[pipelineFilterLabel] = a.env.Config().PipelineLabel
+	}
 	userImage := transform.Image
 	if userImage == "" {
 		userImage = DefaultUserImage


### PR DESCRIPTION
Right now pachd assumes every worker pod in a namespace belongs to it. I started looking at supporting multiple pachds using multiple namespaces, but it gets hairy to handle exposing the etcd and postgres services to the sidecars in every namespace. Debugging is also a pain.

This is an alternate approach where pachds can attach a label to their worker pods, and only care about pods with their label. This allows us to run pipelines from multiple pachds in a single namespace without them clobbering each other.