### PR TITLE
Groups don't have a double colon when synced from an IDP

### DIFF
--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -337,7 +337,7 @@ func (a *apiServer) validateIDToken(ctx context.Context, rawIDToken string) (*oi
 func (a *apiServer) syncGroupMembership(ctx context.Context, claims *IDTokenClaims) error {
 	groups := make([]string, len(claims.Groups))
 	for i, g := range claims.Groups {
-		groups[i] = fmt.Sprintf("%s:%s", auth.GroupPrefix, g)
+		groups[i] = fmt.Sprintf("%s%s", auth.GroupPrefix, g)
 	}
 	// Sync group membership based on the groups claim, if any
 	return a.setGroupsForUserInternal(ctx, auth.UserPrefix+claims.Email, groups)


### PR DESCRIPTION
We noticed in documenting the auth integrations that synced groups have the form `group::<name>`, which is a mistake. This removes the second colon.

We don't have a good test for syncing groups from third-party IDPs - I'll add an item to the backlog, we could either run against a real Auth0 instance or PR a change to Dex to put Kilgore Trout in a group.