### PR TITLE
[1.13.x] - Recreate eventCh when master restarts

### DIFF
--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -86,7 +86,6 @@ func (a *apiServer) master() {
 		a:                      a,
 		monitorCancels:         make(map[string]func()),
 		crashingMonitorCancels: make(map[string]func()),
-		eventCh:                make(chan *pipelineEvent, 1), // avoid thrashing
 	}
 
 	masterLock := dlock.NewDLock(a.env.GetEtcdClient(), path.Join(a.etcdPrefix, masterLockPath))
@@ -121,6 +120,7 @@ func (a *apiServer) setPipelineCrashing(ctx context.Context, pipelineName string
 func (m *ppsMaster) run() {
 	// close m.eventCh after all cancels have returned and therefore all pollers
 	// (which are what write to m.eventCh) have exited
+	m.eventCh = make(chan *pipelineEvent, 1)
 	defer close(m.eventCh)
 	defer m.cancelAllMonitorsAndCrashingMonitors()
 	// start pollers in the background--cancel functions ensure poll/monitor


### PR DESCRIPTION
We used to close `m.eventCh` in a defer in `run`, but we call `run` in an infinite loop. The first time the PPS master loses the etcd lock it would shut everything down, close the channel, and then re-acquire the lock and try to start them, only to have them send their events on a closed channel.