### PR TITLE
[1.13.x] - Add configuration for PPS master dlock

### DIFF
--- a/src/server/pfs/server/master_v2.go
+++ b/src/server/pfs/server/master_v2.go
@@ -17,7 +17,7 @@ const (
 
 func (d *driverV2) master(env *serviceenv.ServiceEnv) {
 	ctx := context.Background()
-	masterLock := dlock.NewDLock(d.etcdClient, path.Join(d.prefix, masterLockPath))
+	masterLock := dlock.NewDLock(d.etcdClient, path.Join(d.prefix, masterLockPath), 15)
 	err := backoff.RetryNotify(func() error {
 		masterCtx, err := masterLock.Lock(ctx)
 		if err != nil {

--- a/src/server/pkg/serviceenv/config.go
+++ b/src/server/pkg/serviceenv/config.go
@@ -70,7 +70,8 @@ type PachdSpecificConfiguration struct {
 	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY",default=false"`
 	MetricsEndpoint            string `env:"METRICS_ENDPOINT",default="`
 	// TODO: Merge this with the worker specific pod name (PPS_POD_NAME) into a global configuration pod name.
-	PachdPodName string `env:"PACHD_POD_NAME,required"`
+	PachdPodName                string `env:"PACHD_POD_NAME,required"`
+	PPSMasterLockTimeoutSeconds int    `env:"PPS_MASTER_LOCK_TIMEOUT_SECONDS",default=15`
 }
 
 // StorageConfiguration contains the storage configuration.

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -89,7 +89,7 @@ func (a *apiServer) master() {
 		eventCh:                make(chan *pipelineEvent, 1), // avoid thrashing
 	}
 
-	masterLock := dlock.NewDLock(a.env.GetEtcdClient(), path.Join(a.etcdPrefix, masterLockPath))
+	masterLock := dlock.NewDLock(a.env.GetEtcdClient(), path.Join(a.etcdPrefix, masterLockPath), a.env.PPSMasterLockTimeoutSeconds)
 	backoff.RetryNotify(func() error {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -139,7 +139,7 @@ func (s *sidecarS3G) createK8sServices() {
 			path.Join(s.apiServer.etcdPrefix,
 				s3gSidecarLockPath,
 				s.pipelineInfo.Pipeline.Name,
-				s.pipelineInfo.Salt))
+				s.pipelineInfo.Salt), 15)
 		ctx, err := masterLock.Lock(s.pachClient.Ctx())
 		if err != nil {
 			// retry obtaining lock

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -163,7 +163,7 @@ func (w *Worker) master(etcdClient *etcd.Client, etcdPrefix string) {
 	pipelineInfo := w.driver.PipelineInfo()
 	logger := logs.NewMasterLogger(pipelineInfo)
 	lockPath := path.Join(etcdPrefix, masterLockPath, pipelineInfo.Pipeline.Name, pipelineInfo.Salt)
-	masterLock := dlock.NewDLock(etcdClient, lockPath)
+	masterLock := dlock.NewDLock(etcdClient, lockPath, 15)
 
 	b := backoff.NewInfiniteBackOff()
 	// Setting a high backoff so that when this master fails, the other


### PR DESCRIPTION
We've run into a few scenarios where pachd, under heavy load, will fail to meet the 15s deadline to heartbeat to etcd. This causes the PPS master to lose the lock, which triggers shutting down and restarting the watchers.

This code path isn't well-tested and it's been the source of several bugs. Right now as a workaround we can ask customers to allocate more resources and hopefully reduce the pause, but there's also value in this timeout being field-configurable as a way to unblock customers.

This PR doesn't make all the dlocks configurable, just the PPS master, just to keep the number of options manageable. The other processes that acquire a lock haven't had a similar history of issues in production.