### PR TITLE
Block in object integration tests

### DIFF
--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -42,7 +42,8 @@ func NewDB(opts ...Option) (*sqlx.DB, error) {
 		opt(dbc)
 	}
 	fields := map[string]string{
-		"sslmode": "disable",
+		"sslmode":         "disable",
+		"connect_timeout": "30",
 	}
 	if dbc.host != "" {
 		fields["host"] = dbc.host

--- a/src/internal/obj/integrationtests/deployment_test.go
+++ b/src/internal/obj/integrationtests/deployment_test.go
@@ -245,6 +245,9 @@ func withManifest(t *testing.T, backend assets.Backend, secrets map[string][]byt
 	err = cmd.Run()
 	require.NoError(t, err)
 
+	// block until pachd deployment is ready - sometimes postgres isn't ready in time and the pachd pod restarts
+	require.NoError(t, tu.Cmd("kubectl", "wait", "--namespace", namespaceName, "--for=condition=available", "deployment/pachd", "--timeout", "2m").Run())
+
 	pachClient := getPachClient(t, kubeClient, namespaceName)
 	defer pachClient.Close()
 

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -118,10 +118,15 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	} else {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
+
+	log.Printf("Init with kube")
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	debug.SetGCPercent(env.Config().GCPercent)
+
+	log.Printf("Init Dex DB")
 	env.InitDexDB()
 
+	log.Printf("Apply migrations")
 	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
 	if err := migrations.ApplyMigrations(context.Background(), env.GetDBClient(), migrations.Env{}, clusterstate.DesiredClusterState); err != nil {
 		return err
@@ -133,6 +138,8 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}
+
+	log.Printf("Conifgure interceptor")
 
 	// Setup External Pachd GRPC Server.
 	authInterceptor := auth.NewInterceptor(env)

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -118,15 +118,10 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	} else {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
-
-	log.Printf("Init with kube")
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	debug.SetGCPercent(env.Config().GCPercent)
-
-	log.Printf("Init Dex DB")
 	env.InitDexDB()
 
-	log.Printf("Apply migrations")
 	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
 	if err := migrations.ApplyMigrations(context.Background(), env.GetDBClient(), migrations.Env{}, clusterstate.DesiredClusterState); err != nil {
 		return err
@@ -138,8 +133,6 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}
-
-	log.Printf("Conifgure interceptor")
 
 	// Setup External Pachd GRPC Server.
 	authInterceptor := auth.NewInterceptor(env)


### PR DESCRIPTION
Pachd was blocked waiting for postgres to come up, which can cause the object tests to fail. This adds a connect_timeout in the DSN so we retry the connection after 30 seconds, and a 2 minute timeout to wait before we connect to pachd.