### PR TITLE
stop allowing clone failures in testfaster pool builds

### DIFF
--- a/.testfaster.yml
+++ b/.testfaster.yml
@@ -56,12 +56,14 @@ base:
     RUN mkdir /root/project
     WORKDIR /root/project
     # Warm up go mod cache and go build cache we set CIRCLE_BRANCH so that
-    # Makefile uses cacheable build params (version).  Also cache the go deps
-    # the linter uses (we don't really care if the linter passes)
+    # Makefile uses cacheable build params (version).
     RUN git clone https://github.com/pachyderm/pachyderm && \
         cd pachyderm && \
         git checkout bb4c26d7c838e61cff5b99c56f44662eea920c6b && \
-        CIRCLE_BRANCH=1 make install && \
+        CIRCLE_BRANCH=1 make install
+    # Also cache the go deps the linter uses (we don't really care if the
+    # linter passes)
+    RUN cd pachyderm && \
         PATH="/root/go/bin:${PATH}" etc/testing/lint.sh || true
     RUN wget -nv https://github.com/instrumenta/kubeval/releases/download/0.15.0/kubeval-linux-amd64.tar.gz && \
         tar xf kubeval-linux-amd64.tar.gz && \


### PR DESCRIPTION
Due to networking issues I'm investigating, sometimes `git clone` fails in Testfaster. Currently the failure is hidden by the `|| true` which was intended to hide lint failures, but ended up hiding `git clone` failures as well.

Split out cloning the repo from getting the go deps for the linter, so that we can apply the `|| true` to only one part. This way, if cloning the pachyderm repo fails, at least we fail the pool build rather than letting it proceed only to fail mysteriously later, like [this](https://pachyderm.slack.com/archives/CDWDPKPMY/p1620066432086700).