### PR TITLE
Ensure /tmp, /pach-cache exist in the pachd image

### DIFF
--- a/Dockerfile.pachd
+++ b/Dockerfile.pachd
@@ -11,4 +11,5 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go-bindata -o src/server/cmd/worker/assets/assets.go -pkg assets /etc/ssl/certs/... && \
     CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o pachd "src/server/cmd/pachd/main.go" && \
-    CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o worker "src/server/cmd/worker/main.go"
+    CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o worker "src/server/cmd/worker/main.go" && \
+    mkdir -p /tmp/to-copy/tmp /tmp/to-copy/pach-cache && chmod -R 777 /tmp/to-copy

--- a/etc/pachd/Dockerfile
+++ b/etc/pachd/Dockerfile
@@ -6,6 +6,7 @@ LABEL name="Pachyderm" \
       vendor="Pachyderm"
 
 COPY --from=pachyderm_build /licenses /
+COPY --from=pachyderm_build /tmp/to-copy /
 
 COPY --from=pachyderm_build /app/pachd /pachd
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -141,7 +141,7 @@ func newDriver(
 		return nil, err
 	}
 	if env.StorageDiskCacheSize > 0 {
-		diskCache, err := obj.NewLocalClient(filepath.Join(os.TempDir(), "pfs-cache", uuid.NewWithoutDashes()))
+		diskCache, err := obj.NewLocalClient(filepath.Join(env.CacheRoot, "pfs-cache", uuid.NewWithoutDashes()))
 		if err != nil {
 			return nil, err
 		}

--- a/src/server/pkg/serviceenv/option.go
+++ b/src/server/pkg/serviceenv/option.go
@@ -1,15 +1,12 @@
 package serviceenv
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 	"github.com/pachyderm/pachyderm/src/server/pkg/storage/chunk"
 	"github.com/pachyderm/pachyderm/src/server/pkg/storage/fileset"
 )
-
-var localDiskCachePath = filepath.Join(os.TempDir(), "pfs-cache")
 
 // ChunkStorageOptions returns the chunk storage options for the service environment.
 func (env *ServiceEnv) ChunkStorageOptions() ([]chunk.StorageOption, error) {
@@ -18,7 +15,7 @@ func (env *ServiceEnv) ChunkStorageOptions() ([]chunk.StorageOption, error) {
 		opts = append(opts, chunk.WithMaxConcurrentObjects(0, env.StorageUploadConcurrencyLimit))
 	}
 	if env.StorageDiskCacheSize > 0 {
-		diskCache, err := obj.NewLocalClient(localDiskCachePath)
+		diskCache, err := obj.NewLocalClient(filepath.Join(env.CacheRoot, "pfs-cache"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We still create directories under `os.TempDir()` in `withTmpFile`, which is used for legacy spouts as well as debug dumps. I imagine there's little harm in moving these under the same directory, but I wonder if @actgardner's suggestion [here](https://github.com/pachyderm/pachyderm/issues/6058#issuecomment-832107649) starts to make more sense.