### PR TITLE
[Experiment] reset the k8s client transport when timeouts happen

### DIFF
--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
 )
 
 const bodyPrefixLength = 200
@@ -75,6 +77,7 @@ type loggingRoundTripper struct {
 
 // RoundTrip implements the http.RoundTripper interface for loggingRoundTripper
 func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, retErr error) {
+	requestID := uuid.New()
 	start := time.Now()
 
 	// Peek into req. body and log a prefix
@@ -86,6 +89,7 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, 
 				"method":           "Timeout",
 				"start":            start.Format(time.StampMicro),
 				"context-duration": time.Since(start).Seconds(),
+				"requestID":        requestID,
 			}).Debug()
 		}()
 	}
@@ -97,6 +101,7 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, 
 		"delay":       time.Since(start).Seconds(),
 		"http-method": req.Method,
 		"url":         req.URL.String(),
+		"requestID":   requestID,
 		"body":        bodyMsg(req.Body),
 	}).Debug()
 
@@ -110,6 +115,7 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, 
 			"duration":    time.Since(start),
 			"http-method": req.Method,
 			"url":         req.URL.String(),
+			"requestID":   requestID,
 			"err":         retErr,
 		})
 		if res != nil {

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -30,25 +30,23 @@ type bufReadCloser struct {
 	closefunc func() error
 }
 
-// Close implements the correspond method of io.Closer (and io.ReadCloser) for
-// bufReadCloser. It just passes the method call through to the wrapped
+// Close implements the corresponding method of io.Closer (and io.ReadCloser)
+// for bufReadCloser. It just passes the method call through to the wrapped
 // io.ReadCloser.
 func (b bufReadCloser) Close() error {
-	if b.closefunc != nil {
-		return b.closefunc()
-	}
+	return b.closefunc()
 }
 
 // newBufReadCloser wraps 'r' in a 'bufReadCloser', so that it can be peeked,
 // etc.
-func newBufReadCloser(r io.ReadCloser) bufReadCloser {
-	rc := bufReadCloser{
-		Reader: bufio.NewReaderSize(r, bodyPrefixLength),
+func newBufReadCloser(r io.ReadCloser) io.ReadCloser {
+	if r == nil {
+		return nil
 	}
-	if r != nil {
-		rc.closefunc = r.Close
+	return bufReadCloser{
+		Reader:    bufio.NewReaderSize(r, bodyPrefixLength),
+		closefunc: r.Close,
 	}
-	return rc
 }
 
 func bodyMsg(bodyPrefix []byte, err error) string {

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -17,7 +17,7 @@ import (
 )
 
 const bodyPrefixLength = 200
-const cancellationsBeforeReset = 30
+const cancellationsBeforeReset = 4
 
 // This is a copy of an internal interface used by k8s.io/client-go when using
 // a passed-in http.RoundTripper. We only need it in order to wrap client-go's

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -1,6 +1,7 @@
 package serviceenv
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -18,12 +19,14 @@ type loggingRoundTripper struct {
 // RoundTrip implements the http.RoundTripper interface for loggingRoundTripper
 func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, retErr error) {
 	logEntry := log.WithFields(map[string]interface{}{
+		"type":   "kube/APIServer request",
 		"method": req.Method,
 		"url":    req.URL.String(),
 	})
-	logEntry.Debug("kube/APIServer request")
+	logEntry.Debug()
 	defer func(start time.Time) {
 		fields := map[string]interface{}{
+			"type":     "kube/APIServer response",
 			"duration": time.Since(start),
 			"method":   req.Method,
 			"url":      req.URL.String(),
@@ -37,7 +40,7 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, 
 				if err != nil {
 					fields["body"] = string(bodytext)
 				} else {
-					fields["body"] = "error reading body: " + err.Error()
+					fields["body"] = fmt.Sprintf("error reading body: %v", err)
 				}
 			}
 		}

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -1,0 +1,55 @@
+package serviceenv
+
+import (
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// loggingRoundTripper is an internal implementation of http.RoundTripper with
+// which we wrap our kubernetes clients' own transport, so that we can log our
+// kubernetes requests and responses.
+type loggingRoundTripper struct {
+	underlying http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface for loggingRoundTripper
+func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, retErr error) {
+	logEntry := log.WithFields(map[string]interface{}{
+		"method": req.Method,
+		"url":    req.URL.String(),
+	})
+	logEntry.Debug("kube/APIServer request")
+	defer func(start time.Time) {
+		fields := map[string]interface{}{
+			"duration": time.Since(start),
+			"method":   req.Method,
+			"url":      req.URL.String(),
+			"status":   res.Status,
+			"err":      retErr,
+		}
+		if res.StatusCode >= 400 {
+			// error response -- log the error message
+			bodytext, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				fields["body"] = string(bodytext)
+			} else {
+				fields["body"] = "error reading body: " + err.Error()
+			}
+		}
+		logEntry := log.WithFields(fields)
+		logEntry.Debug("kube/APIServer response")
+	}(time.Now())
+	return t.underlying.RoundTrip(req)
+}
+
+// wrapWithLoggingTransport is k8s.io/client-go/transport.WrapperFunc that wraps
+// a pre-existing http.RoundTripper in loggingRoundTripper. We pass this to our
+// kubernetes client via rest.Config.WrapTransport to log our kubernetes RPCs
+func wrapWithLoggingTransport(rt http.RoundTripper) http.RoundTripper {
+	return &loggingRoundTripper{
+		underlying: rt,
+	}
+}

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -89,41 +89,43 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, 
 				"method":           "Timeout",
 				"start":            start.Format(time.StampMicro),
 				"context-duration": time.Since(start).Seconds(),
-				"requestID":        requestID,
+				"pach-request-id":  requestID,
 			}).Debug()
 		}()
 	}
 	req.Body = newBufReadCloser(req.Body)
 	log.WithFields(log.Fields{
-		"service":     "k8s.io/client-go",
-		"method":      "Request",
-		"start":       start.Format(time.StampMicro),
-		"delay":       time.Since(start).Seconds(),
-		"http-method": req.Method,
-		"url":         req.URL.String(),
-		"requestID":   requestID,
-		"body":        bodyMsg(req.Body),
+		"service":         "k8s.io/client-go",
+		"method":          "Request",
+		"start":           start.Format(time.StampMicro),
+		"delay":           time.Since(start).Seconds(),
+		"http-method":     req.Method,
+		"headers":         req.Header,
+		"url":             req.URL.String(),
+		"pach-request-id": requestID,
+		"body":            bodyMsg(req.Body),
 	}).Debug()
 
 	// Log response
 	defer func() {
 		le := log.WithFields(log.Fields{
-			"service":     "k8s.io/client-go",
-			"method":      "Response",
-			"start":       start.Format(time.StampMicro),
-			"now":         time.Now().Format(time.StampMicro),
-			"duration":    time.Since(start),
-			"http-method": req.Method,
-			"url":         req.URL.String(),
-			"requestID":   requestID,
-			"err":         retErr,
+			"service":         "k8s.io/client-go",
+			"method":          "Response",
+			"start":           start.Format(time.StampMicro),
+			"now":             time.Now().Format(time.StampMicro),
+			"duration":        time.Since(start),
+			"http-method":     req.Method,
+			"url":             req.URL.String(),
+			"pach-request-id": requestID,
+			"err":             retErr,
 		})
 		if res != nil {
 			// Peek into res. body and log a prefix
 			res.Body = newBufReadCloser(res.Body)
 			le = le.WithFields(log.Fields{
-				"status": res.Status,
-				"body":   bodyMsg(res.Body),
+				"status":  res.Status,
+				"headers": res.Header,
+				"body":    bodyMsg(res.Body),
 			})
 		}
 		le.Debug()

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -27,16 +27,18 @@ func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, 
 			"duration": time.Since(start),
 			"method":   req.Method,
 			"url":      req.URL.String(),
-			"status":   res.Status,
 			"err":      retErr,
 		}
-		if res.StatusCode >= 400 {
-			// error response -- log the error message
-			bodytext, err := ioutil.ReadAll(res.Body)
-			if err != nil {
-				fields["body"] = string(bodytext)
-			} else {
-				fields["body"] = "error reading body: " + err.Error()
+		if res != nil {
+			fields["status"] = res.Status
+			if res.StatusCode >= 400 {
+				// error response -- log the error message
+				bodytext, err := ioutil.ReadAll(res.Body)
+				if err != nil {
+					fields["body"] = string(bodytext)
+				} else {
+					fields["body"] = "error reading body: " + err.Error()
+				}
 			}
 		}
 		logEntry := log.WithFields(fields)

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -1,60 +1,143 @@
 package serviceenv
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
+const bodyPrefixLength = 200
+const cancellationsBeforeReset = 500
+
+// This is a copy of an internal interface used by k8s.io/client-go when using
+// a passed-in http.RoundTripper. We only need it in order to wrap client-go's
+// RoundTripper with logging
+type kubeRequestCanceler interface {
+	CancelRequest(*http.Request)
+}
+
+// bufReadCloser is very similar to a bufio.Reader, but it wraps a ReadCloser
+// (unlike bufio.Reader, which only wraps an io.Reader)
+type bufReadCloser struct {
+	*bufio.Reader
+	closefunc func() error
+}
+
+// Close implements the correspond method of io.Closer (and io.ReadCloser) for
+// bufReadCloser. It just passes the method call through to the wrapped
+// io.ReadCloser.
+func (b bufReadCloser) Close() error {
+	if b.closefunc != nil {
+		return b.closefunc()
+	}
+}
+
+// newBufReadCloser wraps 'r' in a 'bufReadCloser', so that it can be peeked,
+// etc.
+func newBufReadCloser(r io.ReadCloser) bufReadCloser {
+	rc := bufReadCloser{
+		Reader: bufio.NewReaderSize(r, bodyPrefixLength),
+	}
+	if r != nil {
+		rc.closefunc = r.Close
+	}
+	return rc
+}
+
+func bodyMsg(bodyPrefix []byte, err error) string {
+	bodyMsg := bytes.NewBuffer(bodyPrefix)
+	if err != nil && !errors.Is(err, io.EOF) {
+		bodyMsg.WriteString(fmt.Sprintf(" (error reading body: %v)", err))
+	}
+	return bodyMsg.String()
+}
+
 // loggingRoundTripper is an internal implementation of http.RoundTripper with
 // which we wrap our kubernetes clients' own transport, so that we can log our
 // kubernetes requests and responses.
 type loggingRoundTripper struct {
-	underlying http.RoundTripper
+	underlying      http.RoundTripper
+	cancellations   int
+	resetKubeClient func()
 }
 
 // RoundTrip implements the http.RoundTripper interface for loggingRoundTripper
 func (t *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, retErr error) {
-	logEntry := log.WithFields(map[string]interface{}{
-		"type":   "kube/APIServer request",
+	// Peek into req. body and log a prefix
+	req.Body = newBufReadCloser(req.Body)
+	log.WithFields(log.Fields{
+		"from":   "k8s.io/client-go",
 		"method": req.Method,
 		"url":    req.URL.String(),
-	})
-	logEntry.Debug()
+		"body":   bodyMsg(req.Body.(bufReadCloser).Peek(bodyPrefixLength)),
+	}).Debug()
+
+	// Log response
 	defer func(start time.Time) {
-		fields := map[string]interface{}{
-			"type":     "kube/APIServer response",
+		le := log.WithFields(log.Fields{
+			"from":     "k8s.io/client-go",
 			"duration": time.Since(start),
 			"method":   req.Method,
 			"url":      req.URL.String(),
 			"err":      retErr,
-		}
+		})
 		if res != nil {
-			fields["status"] = res.Status
-			if res.StatusCode >= 400 {
-				// error response -- log the error message
-				bodytext, err := ioutil.ReadAll(res.Body)
-				if err != nil {
-					fields["body"] = string(bodytext)
-				} else {
-					fields["body"] = fmt.Sprintf("error reading body: %v", err)
-				}
-			}
+			// Peek into res. body and log a prefix
+			res.Body = newBufReadCloser(res.Body)
+			le = le.WithFields(log.Fields{
+				"status": res.Status,
+				"body":   bodyMsg(res.Body.(bufReadCloser).Peek(bodyPrefixLength)),
+			})
 		}
-		logEntry := log.WithFields(fields)
-		logEntry.Debug("kube/APIServer response")
+		le.Debug()
 	}(time.Now())
 	return t.underlying.RoundTrip(req)
+}
+
+func (t *loggingRoundTripper) CancelRequest(req *http.Request) {
+	t.cancellations++
+	log.Debugf("%d/%d cancelletions before kubeClient is reset", t.cancellations, cancellationsBeforeReset)
+	if t.cancellations >= cancellationsBeforeReset {
+		t.resetKubeClient()
+		t.cancellations = 0
+	}
+	c, ok := t.underlying.(kubeRequestCanceler)
+	if !ok {
+		log.Errorf("loggingRoundTripper: underlying RoundTripper %T does not implement CancelRequest", t.underlying)
+		return
+	}
+
+	// Peek into req. body and log a prefix
+	req.Body = newBufReadCloser(req.Body)
+	log.WithFields(log.Fields{
+		"from":   "k8s.io/client-go",
+		"method": req.Method,
+		"url":    req.URL.String(),
+		"body":   bodyMsg(req.Body.(bufReadCloser).Peek(bodyPrefixLength)),
+	}).Debug()
+
+	// Print a stack trace, so we know where to look in the k8s client
+	debug.PrintStack()
+
+	// Cancel the underlying request
+	c.CancelRequest(req)
 }
 
 // wrapWithLoggingTransport is k8s.io/client-go/transport.WrapperFunc that wraps
 // a pre-existing http.RoundTripper in loggingRoundTripper. We pass this to our
 // kubernetes client via rest.Config.WrapTransport to log our kubernetes RPCs
-func wrapWithLoggingTransport(rt http.RoundTripper) http.RoundTripper {
-	return &loggingRoundTripper{
-		underlying: rt,
+func wrapWithLoggingTransport(resetKubeClient func()) func(rt http.RoundTripper) http.RoundTripper {
+	return func(rt http.RoundTripper) http.RoundTripper {
+		return &loggingRoundTripper{
+			resetKubeClient: resetKubeClient,
+			underlying:      rt,
+		}
 	}
 }

--- a/src/server/pkg/serviceenv/logging_transport.go
+++ b/src/server/pkg/serviceenv/logging_transport.go
@@ -14,7 +14,7 @@ import (
 )
 
 const bodyPrefixLength = 200
-const cancellationsBeforeReset = 500
+const cancellationsBeforeReset = 30
 
 // This is a copy of an internal interface used by k8s.io/client-go when using
 // a passed-in http.RoundTripper. We only need it in order to wrap client-go's

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -17,8 +18,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
 )
 
 // ServiceEnv is a struct containing connections to other services in the
@@ -163,6 +166,27 @@ func (env *ServiceEnv) initEtcdClient() error {
 	}, backoff.RetryEvery(time.Second).For(5*time.Minute))
 }
 
+func transportForConfig(config *transport.Config) (http.RoundTripper, error) {
+	tlsConfig, err := transport.TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	dial := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+
+	return utilnet.SetTransportDefaults(&http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConnsPerHost: 25,
+		DialContext:         dial,
+		DisableCompression:  false,
+	}), nil
+}
+
 func (env *ServiceEnv) initKubeClient() error {
 	return backoff.Retry(func() error {
 		// Get secure in-cluster config
@@ -183,11 +207,24 @@ func (env *ServiceEnv) initKubeClient() error {
 				},
 			}
 		}
+		tCfg, err := cfg.TransportConfig()
+		if err != nil {
+			fmt.Printf("%s\n", err)
+			return errors.Wrapf(err, "erorr getting transport config")
+		}
+		cfg.Transport, err = transportForConfig(tCfg)
+		if err != nil {
+			fmt.Printf("%s\n", err)
+			return errors.Wrapf(err, "erorr getting transport")
+		}
+		cfg.TLSClientConfig = rest.TLSClientConfig{}
+
 		cfg.WrapTransport = wrapWithLoggingTransport(env.RestartKubeClient)
 		env.kubeClient, err = kube.NewForConfig(cfg)
 		cfg.Timeout = 30 * time.Second
 		env.thirtySecondsKubeClient, err = kube.NewForConfig(cfg)
 		if err != nil {
+			fmt.Printf("%s\n", err)
 			return errors.Wrapf(err, "could not initialize kube client")
 		}
 		return nil

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -135,6 +135,10 @@ func (env *ServiceEnv) initPachClient() error {
 	}, backoff.RetryEvery(time.Second).For(5*time.Minute))
 }
 
+func (env *ServiceEnv) RestartKubeClient() {
+	env.kubeEg.Go(env.initKubeClient)
+}
+
 func (env *ServiceEnv) initEtcdClient() error {
 	// validate argument
 	if env.etcdAddress == "" {
@@ -179,7 +183,7 @@ func (env *ServiceEnv) initKubeClient() error {
 				},
 			}
 		}
-		cfg.WrapTransport = wrapWithLoggingTransport
+		cfg.WrapTransport = wrapWithLoggingTransport(env.RestartKubeClient)
 		env.kubeClient, err = kube.NewForConfig(cfg)
 		cfg.Timeout = 30 * time.Second
 		env.thirtySecondsKubeClient, err = kube.NewForConfig(cfg)

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -52,6 +52,12 @@ type ServiceEnv struct {
 	// kubeClient is a kubernetes client that, if initialized, is shared by all
 	// users of this environment
 	kubeClient *kube.Clientset
+	// thirtySecondsKubeClient is a kubernetes client that, if initialized, is
+	// shared by all users of this environment. Unlike kubeClient, it imposes a
+	// 30s timeout on all RPCs it sends
+	// TODO(msteffen): upgrade to latest vesion of k8s.io/client-go, which uses
+	// context passing to enforce timeouts, rather than startup options
+	thirtySecondsKubeClient *kube.Clientset
 	// kubeEg coordinates the initialization of kubeClient (see pachdEg)
 	kubeEg errgroup.Group
 
@@ -174,6 +180,8 @@ func (env *ServiceEnv) initKubeClient() error {
 			}
 		}
 		env.kubeClient, err = kube.NewForConfig(cfg)
+		cfg.Timeout = 30 * time.Second
+		env.thirtySecondsKubeClient, err = kube.NewForConfig(cfg)
 		if err != nil {
 			return errors.Wrapf(err, "could not initialize kube client")
 		}
@@ -209,7 +217,7 @@ func (env *ServiceEnv) GetEtcdClient() *etcd.Client {
 	return env.etcdClient
 }
 
-// GetKubeClient returns the already connected Kubernetes API client without
+// GetKubeClient returns the already-connected Kubernetes API client without
 // modification.
 func (env *ServiceEnv) GetKubeClient() *kube.Clientset {
 	if err := env.kubeEg.Wait(); err != nil {
@@ -219,6 +227,20 @@ func (env *ServiceEnv) GetKubeClient() *kube.Clientset {
 		panic("service env never connected to kubernetes")
 	}
 	return env.kubeClient
+}
+
+// Get30sKubeClient returns the already-connected thirtySecondsKubeClient
+// Kubernetes API client without modification (i.e. this is similar to
+// GetKubeClient(), but the client returned by this function times out all RPCs
+// after 30s).
+func (env *ServiceEnv) Get30sKubeClient() *kube.Clientset {
+	if err := env.kubeEg.Wait(); err != nil {
+		panic(err) // If env can't connect, there's no sensible way to recover
+	}
+	if env.thirtySecondsKubeClient == nil {
+		panic("service env never connected to kubernetes")
+	}
+	return env.thirtySecondsKubeClient
 }
 
 // GetLokiClient returns the loki client, it doesn't require blocking on a

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -179,6 +179,7 @@ func (env *ServiceEnv) initKubeClient() error {
 				},
 			}
 		}
+		cfg.WrapTransport = wrapWithLoggingTransport
 		env.kubeClient, err = kube.NewForConfig(cfg)
 		cfg.Timeout = 30 * time.Second
 		env.thirtySecondsKubeClient, err = kube.NewForConfig(cfg)

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -189,6 +189,7 @@ func transportForConfig(config *transport.Config) (http.RoundTripper, error) {
 
 func (env *ServiceEnv) initKubeClient() error {
 	return backoff.Retry(func() error {
+		log.Infof("Attempting to connect kube client")
 		// Get secure in-cluster config
 		var kubeAddr string
 		var ok bool
@@ -221,7 +222,7 @@ func (env *ServiceEnv) initKubeClient() error {
 
 		cfg.WrapTransport = wrapWithLoggingTransport(env.RestartKubeClient)
 		env.kubeClient, err = kube.NewForConfig(cfg)
-		cfg.Timeout = 30 * time.Second
+		cfg.Timeout = 15 * time.Second
 		env.thirtySecondsKubeClient, err = kube.NewForConfig(cfg)
 		if err != nil {
 			fmt.Printf("%s\n", err)

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -669,7 +669,7 @@ func (op *pipelineOp) scaleDownPipeline() (retErr error) {
 	}()
 
 	return op.updateRC(func(rc *v1.ReplicationController) bool {
-		if rc.Spec.Replicas != nil && *op.rc.Spec.Replicas == 0 {
+		if rc.Spec.Replicas == nil || *rc.Spec.Replicas == 0 {
 			return false // prior attempt succeeded
 		}
 		rc.Spec.Replicas = &zero


### PR DESCRIPTION
`client-go` tries really hard to reuse the same transport for every k8s client with the same TLS config, which means when we reset the client we're using the same connection pool (https://github.com/kubernetes/client-go/blob/v0.16.4/transport/cache.go#L30-L36). This should rebuild the http Transport from scratch and create new connections. If this works we might need to clean up the old transports.