### PR TITLE
Lockout users when Enterprise License expires, except Non-Admin and Pipeline users 

### DIFF
--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -14,12 +14,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/enterprise"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/pachyderm/pachyderm/v2/src/license"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 
@@ -2718,4 +2721,68 @@ func TestDeleteExpiredAuthTokens(t *testing.T) {
 	require.Equal(t, 2, len(postDeleteTokens), "only the two unexpired tokens should be returned.")
 	require.True(t, contains(postDeleteTokens, auth.HashToken(noExpirationResp.Token)), "robot token without expiration should be extracted")
 	require.True(t, contains(postDeleteTokens, auth.HashToken(slowExpirationResp.Token)), "robot token without expiration should be extracted")
+}
+
+func TestExpiredClusterLocksOutUsers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+
+	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+
+	alice := tu.UniqueString("robot:alice")
+	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+
+	repo := tu.UniqueString("TestRotateAuthToken")
+	require.NoError(t, aliceClient.CreateRepo(repo))
+
+	// Admin can list repos
+	repoInfo, err := adminClient.ListRepo()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(repoInfo))
+
+	// Alice can list repos
+	repoInfo, err = aliceClient.ListRepo()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(repoInfo))
+
+	// set Enterprise Token value to have expired
+	ts := &types.Timestamp{Seconds: time.Now().Unix() - 100}
+	resp, err := adminClient.License.Activate(adminClient.Ctx(),
+		&license.ActivateRequest{
+			ActivationCode: tu.GetTestEnterpriseCode(t),
+			Expires:        ts,
+		})
+	require.NoError(t, err)
+	require.True(t, resp.GetInfo().Expires.Seconds == ts.Seconds)
+
+	// Heartbeat forces Enterprise Service to refresh it's view of the LicenseRecord
+	_, err = adminClient.Enterprise.Heartbeat(adminClient.Ctx(), &enterprise.HeartbeatRequest{})
+	require.NoError(t, err)
+
+	// verify Alice can no longer operate on the system
+	_, err = aliceClient.ListRepo()
+	require.YesError(t, err)
+	require.True(t, strings.Contains(err.Error(), "Pachyderm Enterprise is not active"))
+
+	// verify that admin can still complete an operation (ex. ListRepo)
+	repoInfo, err = adminClient.ListRepo()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(repoInfo))
+
+	// admin grants alice cluster admin role
+	_, err = adminClient.AuthAPIClient.ModifyRoleBinding(adminClient.Ctx(),
+		&auth.ModifyRoleBindingRequest{
+			Principal: alice,
+			Roles:     []string{auth.ClusterAdminRole},
+			Resource:  &auth.Resource{Type: auth.ResourceType_CLUSTER},
+		})
+	require.NoError(t, err)
+
+	// verify that the Alice can now operate on cluster again
+	repoInfo, err = aliceClient.ListRepo()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(repoInfo))
 }

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -107,5 +107,26 @@ func TestCannotAuthenticateWithExpiredLicense(t *testing.T) {
 	require.YesError(t, err)
 	require.True(t, strings.Contains(err.Error(), "Pachyderm Enterprise is not active"))
 
+	// give test user the Cluster Admin Role
+	// admin grants alice cluster admin role
+	_, err = adminClient.AuthAPIClient.ModifyRoleBinding(adminClient.Ctx(),
+		&auth.ModifyRoleBindingRequest{
+			Principal: user(tu.DexMockConnectorEmail),
+			Roles:     []string{auth.ClusterAdminRole},
+			Resource:  &auth.Resource{Type: auth.ResourceType_CLUSTER},
+		})
+	require.NoError(t, err)
+
+	// try to authenticate again
+	authResp, err := testClient.Authenticate(testClient.Ctx(),
+		&auth.AuthenticateRequest{OIDCState: loginInfo.State})
+	require.NoError(t, err)
+	testClient.SetAuthToken(authResp.PachToken)
+
+	// Check that testClient authenticated as the right user
+	whoAmIResp, err := testClient.WhoAmI(testClient.Ctx(), &auth.WhoAmIRequest{})
+	require.NoError(t, err)
+	require.Equal(t, user(tu.DexMockConnectorEmail), whoAmIResp.Username)
+
 	tu.DeleteAll(t)
 }

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -1,11 +1,16 @@
 package server
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/enterprise"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/pachyderm/pachyderm/v2/src/license"
 )
 
 // TestOIDCAuthCodeFlow tests that we can configure an OIDC provider and do the
@@ -59,6 +64,48 @@ func TestOIDCTrustedApp(t *testing.T) {
 	whoAmIResp, err := testClient.WhoAmI(testClient.Ctx(), &auth.WhoAmIRequest{})
 	require.NoError(t, err)
 	require.Equal(t, user(tu.DexMockConnectorEmail), whoAmIResp.Username)
+
+	tu.DeleteAll(t)
+}
+
+// TestCannotAuthenticateWithExpiredLicense tests that we cannot login when the
+// enterprise license is expired. We test this through the configured OIDC provider
+// and do the auth code flow.
+func TestCannotAuthenticateWithExpiredLicense(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	tu.DeleteAll(t)
+	tu.ConfigureOIDCProvider(t)
+	defer tu.DeleteAll(t)
+
+	testClient := tu.GetUnauthenticatedPachClient(t)
+	loginInfo, err := testClient.GetOIDCLogin(testClient.Ctx(), &auth.GetOIDCLoginRequest{})
+	require.NoError(t, err)
+
+	tu.DoOAuthExchange(t, testClient, testClient, loginInfo.LoginURL)
+
+	// Expire Enterprise License
+	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	// set Enterprise Token value to have expired
+	ts := &types.Timestamp{Seconds: time.Now().Unix() - 100}
+	resp, err := adminClient.License.Activate(adminClient.Ctx(),
+		&license.ActivateRequest{
+			ActivationCode: tu.GetTestEnterpriseCode(t),
+			Expires:        ts,
+		})
+	require.NoError(t, err)
+	require.True(t, resp.GetInfo().Expires.Seconds == ts.Seconds)
+
+	// Heartbeat forces Enterprise Service to refresh it's view of the LicenseRecord
+	_, err = adminClient.Enterprise.Heartbeat(adminClient.Ctx(), &enterprise.HeartbeatRequest{})
+	require.NoError(t, err)
+
+	// Verify failure to authenticate with the OIDC Login Info
+	_, err = testClient.Authenticate(testClient.Ctx(),
+		&auth.AuthenticateRequest{OIDCState: loginInfo.State})
+	require.YesError(t, err)
+	require.True(t, strings.Contains(err.Error(), "Pachyderm Enterprise is not active"))
 
 	tu.DeleteAll(t)
 }

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -450,6 +450,18 @@ func doSidecarMode(config interface{}) (retErr error) {
 	}); err != nil {
 		return err
 	}
+	var enterpriseAPIServer eprsclient.APIServer
+	if err := logGRPCServerSetup("Enterprise API", func() error {
+		enterpriseAPIServer, err = eprsserver.NewEnterpriseServer(
+			env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+		if err != nil {
+			return err
+		}
+		eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
+		return nil
+	}); err != nil {
+		return err
+	}
 	var transactionAPIServer txnserver.APIServer
 	if err := logGRPCServerSetup("Transaction API", func() error {
 		transactionAPIServer, err = txnserver.NewAPIServer(


### PR DESCRIPTION
Desired Behavior:
When the Enterprise License expires all users are locked out (cannot authenticate), with the exception of 
- the Root User
- any user with the ClusterAdmin Role
- the PPS Master User
- any Pipeline

Implementation Line Items:
1.) Returning Enterprise Service to Side-car
2.) Adding a check for expired Cluster Admin.
