### PR TITLE
Fix addresses for `pachctl enterprise register`

### DIFF
--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -157,7 +157,11 @@ func RegisterCmd() *cobra.Command {
 			}
 
 			if pachdAddr == "" {
-				pachdAddr = ec.GetAddress().Qualified()
+				pachdAddr = c.GetAddress().Qualified()
+			}
+
+			if enterpriseAddr == "" {
+				enterpriseAddr = ec.GetAddress().Qualified()
 			}
 
 			if clusterId == "" {


### PR DESCRIPTION
There are three addresses involved in registering a pachd with the enterprise server:
- `pachdUsrAddr` is the address for the client contexts to reach the pachd. This should default to the active context address.
- `pachdAddr` is the address for the enterprise server to reach the pachd. This should default to the active context address.
- `enterpriseAddr` is the address for the pachd to reach the enterprise server. This should default to the active enterprise context address.

We noticed this in the hackathon because `enterpriseAddr` wasn't automatically set.