### PR TITLE
Redact secrets in logs

### DIFF
--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1324,6 +1324,9 @@ func (a *apiServer) checkCanonicalSubject(subject string) error {
 // GetConfiguration implements the protobuf auth.GetConfiguration RPC.
 func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigurationRequest) (resp *auth.GetConfigurationResponse, retErr error) {
 	removeSecret := func(r *auth.GetConfigurationResponse) *auth.GetConfigurationResponse {
+		if r.Configuration == nil {
+			return r
+		}
 		copyResp := proto.Clone(r).(*auth.GetConfigurationResponse)
 		copyResp.Configuration.ClientSecret = ""
 		return copyResp
@@ -1348,6 +1351,9 @@ func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigura
 // SetConfiguration implements the protobuf auth.SetConfiguration RPC
 func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigurationRequest) (resp *auth.SetConfigurationResponse, retErr error) {
 	removeSecret := func(r *auth.SetConfigurationRequest) *auth.SetConfigurationRequest {
+		if r.Configuration == nil {
+			return r
+		}
 		copyReq := proto.Clone(r).(*auth.SetConfigurationRequest)
 		copyReq.Configuration.ClientSecret = ""
 		return copyReq

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1323,8 +1323,13 @@ func (a *apiServer) checkCanonicalSubject(subject string) error {
 
 // GetConfiguration implements the protobuf auth.GetConfiguration RPC.
 func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigurationRequest) (resp *auth.GetConfigurationResponse, retErr error) {
+	removeSecret := func(r *auth.GetConfigurationResponse) *auth.GetConfigurationResponse {
+		copyResp := proto.Clone(r).(*auth.GetConfigurationResponse)
+		copyResp.Configuration.ClientSecret = ""
+		return copyResp
+	}
 	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.LogResp(req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
 
 	if !a.watchesEnabled {
 		return nil, errors.New("watches are not enabled, unable to get current config")
@@ -1342,8 +1347,13 @@ func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigura
 
 // SetConfiguration implements the protobuf auth.SetConfiguration RPC
 func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigurationRequest) (resp *auth.SetConfigurationResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	removeSecret := func(r *auth.SetConfigurationRequest) *auth.SetConfigurationRequest {
+		copyReq := proto.Clone(r).(*auth.SetConfigurationRequest)
+		copyReq.Configuration.ClientSecret = ""
+		return copyReq
+	}
+	a.LogReq(removeSecret(req))
+	defer func(start time.Time) { a.LogResp(removeSecret(req), resp, retErr, time.Since(start)) }(time.Now())
 
 	if !a.watchesEnabled {
 		return nil, errors.New("watches are not enabled, unable to set config")

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -171,8 +171,15 @@ func (a *apiServer) Heartbeat(ctx context.Context, req *ec.HeartbeatRequest) (re
 
 // Activate implements the Activate RPC
 func (a *apiServer) Activate(ctx context.Context, req *ec.ActivateRequest) (resp *ec.ActivateResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.pachLogger.Log(req, resp, retErr, time.Since(start)) }(time.Now())
+	// Redact the secret from the request when logging
+	removeSecret := func(r *ec.ActivateRequest) *ec.ActivateRequest {
+		copyReq := proto.Clone(r).(*ec.ActivateRequest)
+		copyReq.Secret = ""
+		return copyReq
+	}
+
+	a.LogReq(removeSecret(req))
+	defer func(start time.Time) { a.pachLogger.Log(removeSecret(req), resp, retErr, time.Since(start)) }(time.Now())
 
 	// Try to heartbeat before persisting the configuration
 	heartbeatResp, err := a.heartbeatToServer(ctx, req.LicenseServer, req.Id, req.Secret)
@@ -247,8 +254,15 @@ func (a *apiServer) GetState(ctx context.Context, req *ec.GetStateRequest) (resp
 
 // GetActivationCode returns the current state of the cluster's Pachyderm Enterprise key (ACTIVE, EXPIRED, or NONE), including the enterprise activation code
 func (a *apiServer) GetActivationCode(ctx context.Context, req *ec.GetActivationCodeRequest) (resp *ec.GetActivationCodeResponse, retErr error) {
+	// Redact the activation code from the response
+	removeSecret := func(r *ec.GetActivationCodeResponse) *ec.GetActivationCodeResponse {
+		copyResp := proto.Clone(r).(*ec.GetActivationCodeResponse)
+		copyResp.ActivationCode = ""
+		return copyResp
+	}
+
 	a.LogReq(req)
-	defer func(start time.Time) { a.pachLogger.Log(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.pachLogger.Log(req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
 	return a.getEnterpriseRecord()
 }
 

--- a/src/server/identity/server/api_server.go
+++ b/src/server/identity/server/api_server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	logrus "github.com/sirupsen/logrus"
 
 	"github.com/pachyderm/pachyderm/v2/src/identity"
@@ -92,8 +93,14 @@ func (a *apiServer) GetIdentityServerConfig(ctx context.Context, req *identity.G
 }
 
 func (a *apiServer) CreateIDPConnector(ctx context.Context, req *identity.CreateIDPConnectorRequest) (resp *identity.CreateIDPConnectorResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	removeJSONConfig := func(r *identity.CreateIDPConnectorRequest) *identity.CreateIDPConnectorRequest {
+		copyReq := proto.Clone(r).(*identity.CreateIDPConnectorRequest)
+		copyReq.Connector.JsonConfig = ""
+		return copyReq
+	}
+
+	a.LogReq(removeJSONConfig(req))
+	defer func(start time.Time) { a.LogResp(removeJSONConfig(req), resp, retErr, time.Since(start)) }(time.Now())
 
 	if err := a.api.createConnector(req); err != nil {
 		return nil, err
@@ -102,8 +109,14 @@ func (a *apiServer) CreateIDPConnector(ctx context.Context, req *identity.Create
 }
 
 func (a *apiServer) GetIDPConnector(ctx context.Context, req *identity.GetIDPConnectorRequest) (resp *identity.GetIDPConnectorResponse, retErr error) {
+	removeJSONConfig := func(r *identity.GetIDPConnectorResponse) *identity.GetIDPConnectorResponse {
+		copyResp := proto.Clone(r).(*identity.GetIDPConnectorResponse)
+		copyResp.Connector.JsonConfig = ""
+		return copyResp
+	}
+
 	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.LogResp(req, removeJSONConfig(resp), retErr, time.Since(start)) }(time.Now())
 
 	c, err := a.api.getConnector(req.Id)
 	if err != nil {
@@ -116,8 +129,14 @@ func (a *apiServer) GetIDPConnector(ctx context.Context, req *identity.GetIDPCon
 }
 
 func (a *apiServer) UpdateIDPConnector(ctx context.Context, req *identity.UpdateIDPConnectorRequest) (resp *identity.UpdateIDPConnectorResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	removeJSONConfig := func(r *identity.UpdateIDPConnectorRequest) *identity.UpdateIDPConnectorRequest {
+		copyReq := proto.Clone(r).(*identity.UpdateIDPConnectorRequest)
+		copyReq.Connector.JsonConfig = ""
+		return copyReq
+	}
+
+	a.LogReq(removeJSONConfig(req))
+	defer func(start time.Time) { a.LogResp(removeJSONConfig(req), resp, retErr, time.Since(start)) }(time.Now())
 
 	if err := a.api.updateConnector(req); err != nil {
 		return nil, err
@@ -127,8 +146,16 @@ func (a *apiServer) UpdateIDPConnector(ctx context.Context, req *identity.Update
 }
 
 func (a *apiServer) ListIDPConnectors(ctx context.Context, req *identity.ListIDPConnectorsRequest) (resp *identity.ListIDPConnectorsResponse, retErr error) {
+	removeJSONConfig := func(r *identity.ListIDPConnectorsResponse) *identity.ListIDPConnectorsResponse {
+		copyResp := proto.Clone(r).(*identity.ListIDPConnectorsResponse)
+		for _, c := range copyResp.Connectors {
+			c.JsonConfig = ""
+		}
+		return copyResp
+	}
+
 	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.LogResp(req, removeJSONConfig(resp), retErr, time.Since(start)) }(time.Now())
 
 	connectors, err := a.api.listConnectors()
 	if err != nil {
@@ -150,8 +177,14 @@ func (a *apiServer) DeleteIDPConnector(ctx context.Context, req *identity.Delete
 }
 
 func (a *apiServer) CreateOIDCClient(ctx context.Context, req *identity.CreateOIDCClientRequest) (resp *identity.CreateOIDCClientResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	removeSecret := func(r *identity.CreateOIDCClientRequest) *identity.CreateOIDCClientRequest {
+		copyReq := proto.Clone(r).(*identity.CreateOIDCClientRequest)
+		copyReq.Client.Secret = ""
+		return copyReq
+	}
+
+	a.LogReq(removeSecret(req))
+	defer func(start time.Time) { a.LogResp(removeSecret(req), nil, retErr, time.Since(start)) }(time.Now())
 
 	client, err := a.api.createClient(ctx, req)
 	if err != nil {
@@ -164,8 +197,13 @@ func (a *apiServer) CreateOIDCClient(ctx context.Context, req *identity.CreateOI
 }
 
 func (a *apiServer) UpdateOIDCClient(ctx context.Context, req *identity.UpdateOIDCClientRequest) (resp *identity.UpdateOIDCClientResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	removeSecret := func(r *identity.UpdateOIDCClientRequest) *identity.UpdateOIDCClientRequest {
+		copyReq := proto.Clone(r).(*identity.UpdateOIDCClientRequest)
+		copyReq.Client.Secret = ""
+		return copyReq
+	}
+	a.LogReq(removeSecret(req))
+	defer func(start time.Time) { a.LogResp(removeSecret(req), nil, retErr, time.Since(start)) }(time.Now())
 
 	if err := a.api.updateClient(ctx, req); err != nil {
 		return nil, err
@@ -175,8 +213,13 @@ func (a *apiServer) UpdateOIDCClient(ctx context.Context, req *identity.UpdateOI
 }
 
 func (a *apiServer) GetOIDCClient(ctx context.Context, req *identity.GetOIDCClientRequest) (resp *identity.GetOIDCClientResponse, retErr error) {
+	removeSecret := func(r *identity.GetOIDCClientResponse) *identity.GetOIDCClientResponse {
+		copyResp := proto.Clone(r).(*identity.GetOIDCClientResponse)
+		copyResp.Client.Secret = ""
+		return copyResp
+	}
 	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.LogResp(req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
 
 	client, err := a.api.getClient(req.Id)
 	if err != nil {
@@ -187,8 +230,15 @@ func (a *apiServer) GetOIDCClient(ctx context.Context, req *identity.GetOIDCClie
 }
 
 func (a *apiServer) ListOIDCClients(ctx context.Context, req *identity.ListOIDCClientsRequest) (resp *identity.ListOIDCClientsResponse, retErr error) {
+	removeSecret := func(r *identity.ListOIDCClientsResponse) *identity.ListOIDCClientsResponse {
+		copyResp := proto.Clone(r).(*identity.ListOIDCClientsResponse)
+		for _, c := range copyResp.Clients {
+			c.Secret = ""
+		}
+		return copyResp
+	}
 	a.LogReq(req)
-	defer func(start time.Time) { a.LogResp(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.LogResp(req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
 
 	clients, err := a.api.listClients()
 	if err != nil {

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -123,8 +123,15 @@ func (a *apiServer) Activate(ctx context.Context, req *lc.ActivateRequest) (resp
 
 // GetActivationCode returns the current state of the cluster's Pachyderm Enterprise key (ACTIVE, EXPIRED, or NONE), including the enterprise activation code
 func (a *apiServer) GetActivationCode(ctx context.Context, req *lc.GetActivationCodeRequest) (resp *lc.GetActivationCodeResponse, retErr error) {
+	// Redact the activation code from the response
+	removeSecret := func(r *lc.GetActivationCodeResponse) *lc.GetActivationCodeResponse {
+		copyResp := proto.Clone(r).(*lc.GetActivationCodeResponse)
+		copyResp.ActivationCode = ""
+		return copyResp
+	}
+
 	a.LogReq(req)
-	defer func(start time.Time) { a.pachLogger.Log(req, resp, retErr, time.Since(start)) }(time.Now())
+	defer func(start time.Time) { a.pachLogger.Log(req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
 
 	return a.getLicenseRecord()
 }
@@ -190,8 +197,14 @@ func (a *apiServer) validateClusterConfig(ctx context.Context, address string) e
 // AddCluster registers a new pachd with this license server. Each pachd is configured with a shared secret
 // which is used to authenticate to the license server when heartbeating.
 func (a *apiServer) AddCluster(ctx context.Context, req *lc.AddClusterRequest) (resp *lc.AddClusterResponse, retErr error) {
-	a.LogReq(req)
-	defer func(start time.Time) { a.pachLogger.Log(req, nil, retErr, time.Since(start)) }(time.Now())
+	// Redact the secret from the request
+	removeSecret := func(r *lc.AddClusterRequest) *lc.AddClusterRequest {
+		copyReq := proto.Clone(r).(*lc.AddClusterRequest)
+		copyReq.Secret = ""
+		return copyReq
+	}
+	a.LogReq(removeSecret(req))
+	defer func(start time.Time) { a.pachLogger.Log(removeSecret(req), nil, retErr, time.Since(start)) }(time.Now())
 
 	// Make sure we have an active license
 	if err := a.checkLicenseState(); err != nil {


### PR DESCRIPTION
- auth`GetConfiguration` and `SetConfiguration` logged the client_secret
- enterprise `Activate` logged the shared secret, and `GetState` logged the license
- license `Activate` and `GetState` logged the license
- identity server IDP operations logged the connector config, which can include secrets
- identity server OIDC client operations logged the client secret