### PR TITLE
Explicitly log when enterprise context is used

### DIFF
--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -58,7 +58,12 @@ func printRoleBinding(b *auth.RoleBinding) {
 
 func newClient(enterprise bool) (*client.APIClient, error) {
 	if enterprise {
-		return client.NewEnterpriseClientOnUserMachine("user")
+		c, err := client.NewEnterpriseClientOnUserMachine("user")
+		if err != nil {
+			return nil, err
+		}
+		fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+		return c, nil
 	}
 	return client.NewOnUserMachine("user")
 }

--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -16,7 +16,12 @@ import (
 
 func newClient(enterprise bool) (*client.APIClient, error) {
 	if enterprise {
-		return client.NewEnterpriseClientOnUserMachine("user")
+		c, err := client.NewEnterpriseClientOnUserMachine("user")
+		if err != nil {
+			return nil, err
+		}
+		fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+		return c, nil
 	}
 	return client.NewOnUserMachine("user")
 }

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -101,7 +101,7 @@ func TestGetAndUseRobotToken(t *testing.T) {
 		echo {{.token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
-		pachctl auth get-robot-token --enterprise -q {{.alice}} | pachctl auth use-auth-token --enterprise
+		pachctl auth get-robot-token --enterprise -q {{.alice}} | tail -1 | pachctl auth use-auth-token --enterprise
 		pachctl auth get-robot-token -q {{.bob}} | pachctl auth use-auth-token
 		pachctl auth whoami --enterprise | match {{.alice}}
 		pachctl auth whoami | match {{.bob}}

--- a/src/server/identity/cmds/cmds.go
+++ b/src/server/identity/cmds/cmds.go
@@ -64,6 +64,9 @@ func SetIdentityServerConfigCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 			req := &identity.SetIdentityServerConfigRequest{
 				Config: &identity.IdentityServerConfig{
 					Issuer: issuer,
@@ -87,6 +90,9 @@ func GetIdentityServerConfigCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 			resp, err := c.GetIdentityServerConfig(c.Ctx(), &identity.GetIdentityServerConfigRequest{})
 			if err != nil {
 				return grpcutil.ScrubGRPC(err)
@@ -110,6 +116,8 @@ func CreateIDPConnectorCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 			var rawConfigBytes []byte
 			if file == "-" {
 				var err error
@@ -159,6 +167,8 @@ func UpdateIDPConnectorCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+
 			var rawConfigBytes []byte
 			if file == "-" {
 				var err error
@@ -207,6 +217,7 @@ func GetIDPConnectorCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.GetIDPConnector(c.Ctx(), &identity.GetIDPConnectorRequest{Id: args[0]})
 			if err != nil {
@@ -237,6 +248,8 @@ func DeleteIDPConnectorCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.DeleteIDPConnector(c.Ctx(), &identity.DeleteIDPConnectorRequest{Id: args[0]})
 			return grpcutil.ScrubGRPC(err)
@@ -283,6 +296,7 @@ func CreateOIDCClientCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			req := &identity.CreateOIDCClientRequest{
 				Client: &identity.OIDCClient{
@@ -323,6 +337,7 @@ func DeleteOIDCClientCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.DeleteOIDCClient(c.Ctx(), &identity.DeleteOIDCClientRequest{Id: args[0]})
 			return grpcutil.ScrubGRPC(err)
@@ -343,6 +358,7 @@ func GetOIDCClientCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: args[0]})
 			if err != nil {
@@ -369,6 +385,7 @@ func UpdateOIDCClientCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			req := &identity.UpdateOIDCClientRequest{
 				Client: &identity.OIDCClient{
@@ -400,6 +417,7 @@ func ListOIDCClientsCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.ListOIDCClients(c.Ctx(), &identity.ListOIDCClientsRequest{})
 			if err != nil {

--- a/src/server/identity/cmds/cmds.go
+++ b/src/server/identity/cmds/cmds.go
@@ -53,6 +53,15 @@ func (c connectorConfig) toIDPConnector() (*identity.IDPConnector, error) {
 	}, nil
 }
 
+func newClient() (*client.APIClient, error) {
+	c, err := client.NewEnterpriseClientOnUserMachine("user")
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+	return c, nil
+}
+
 // SetIdentityServerConfigCmd returns a cobra.Command to configure the identity server
 func SetIdentityServerConfigCmd() *cobra.Command {
 	var issuer string
@@ -60,13 +69,12 @@ func SetIdentityServerConfigCmd() *cobra.Command {
 		Short: "Set the identity server config",
 		Long:  `Set the identity server config`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
 
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 			req := &identity.SetIdentityServerConfigRequest{
 				Config: &identity.IdentityServerConfig{
 					Issuer: issuer,
@@ -86,13 +94,12 @@ func GetIdentityServerConfigCmd() *cobra.Command {
 		Short: "Get the identity server config",
 		Long:  `Get the identity server config`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
 
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 			resp, err := c.GetIdentityServerConfig(c.Ctx(), &identity.GetIdentityServerConfigRequest{})
 			if err != nil {
 				return grpcutil.ScrubGRPC(err)
@@ -111,13 +118,12 @@ func CreateIDPConnectorCmd() *cobra.Command {
 		Short: "Create a new identity provider connector.",
 		Long:  `Create a new identity provider connector.`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
 
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 			var rawConfigBytes []byte
 			if file == "-" {
 				var err error
@@ -162,12 +168,11 @@ func UpdateIDPConnectorCmd() *cobra.Command {
 		Short: "Update an existing identity provider connector.",
 		Long:  `Update an existing identity provider connector. Only fields which are specified are updated.`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			var rawConfigBytes []byte
 			if file == "-" {
@@ -213,11 +218,10 @@ func GetIDPConnectorCmd() *cobra.Command {
 		Short: "Get the config for an identity provider connector.",
 		Long:  "Get the config for an identity provider connector.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.GetIDPConnector(c.Ctx(), &identity.GetIDPConnectorRequest{Id: args[0]})
 			if err != nil {
@@ -244,12 +248,11 @@ func DeleteIDPConnectorCmd() *cobra.Command {
 		Short: "Delete an identity provider connector",
 		Long:  "Delete an identity provider connector",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.DeleteIDPConnector(c.Ctx(), &identity.DeleteIDPConnectorRequest{Id: args[0]})
 			return grpcutil.ScrubGRPC(err)
@@ -264,7 +267,7 @@ func ListIDPConnectorsCmd() *cobra.Command {
 		Short: "List identity provider connectors",
 		Long:  `List identity provider connectors`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -291,12 +294,11 @@ func CreateOIDCClientCmd() *cobra.Command {
 		Short: "Create a new OIDC client.",
 		Long:  `Create a new OIDC client.`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			req := &identity.CreateOIDCClientRequest{
 				Client: &identity.OIDCClient{
@@ -332,12 +334,11 @@ func DeleteOIDCClientCmd() *cobra.Command {
 		Short: "Delete an OIDC client.",
 		Long:  `Delete an OIDC client.`,
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.DeleteOIDCClient(c.Ctx(), &identity.DeleteOIDCClientRequest{Id: args[0]})
 			return grpcutil.ScrubGRPC(err)
@@ -353,12 +354,11 @@ func GetOIDCClientCmd() *cobra.Command {
 		Short: "Get an OIDC client.",
 		Long:  `Get an OIDC client.`,
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: args[0]})
 			if err != nil {
@@ -380,12 +380,11 @@ func UpdateOIDCClientCmd() *cobra.Command {
 		Short: "Update an OIDC client.",
 		Long:  `Update an OIDC client.`,
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			req := &identity.UpdateOIDCClientRequest{
 				Client: &identity.OIDCClient{
@@ -412,12 +411,11 @@ func ListOIDCClientsCmd() *cobra.Command {
 		Short: "List OIDC clients.",
 		Long:  `List OIDC clients.`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.ListOIDCClients(c.Ctx(), &identity.ListOIDCClientsRequest{})
 			if err != nil {

--- a/src/server/license/cmds/cmds.go
+++ b/src/server/license/cmds/cmds.go
@@ -14,6 +14,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func newClient() (*client.APIClient, error) {
+	c, err := client.NewEnterpriseClientOnUserMachine("user")
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+	return c, nil
+}
+
 // ActivateCmd returns a cobra.Command to activate the license service
 func ActivateCmd() *cobra.Command {
 	activate := &cobra.Command{
@@ -26,12 +35,11 @@ func ActivateCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not read enterprise key")
 			}
 
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			// Activate the license server
 			req := &license.ActivateRequest{
@@ -55,12 +63,11 @@ func AddClusterCmd() *cobra.Command {
 		Short: "Register a new cluster with the license server.",
 		Long:  "Register a new cluster with the license server.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.License.AddCluster(c.Ctx(), &license.AddClusterRequest{
 				Id:      id,
@@ -89,12 +96,11 @@ func UpdateClusterCmd() *cobra.Command {
 		Short: "Update an existing cluster registered with the license server.",
 		Long:  "Update an existing cluster registered with the license server.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.License.UpdateCluster(c.Ctx(), &license.UpdateClusterRequest{
 				Id:                  id,
@@ -119,12 +125,11 @@ func DeleteClusterCmd() *cobra.Command {
 		Short: "Delete a cluster registered with the license server.",
 		Long:  "Delete a cluster registered with the license server.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.License.DeleteCluster(c.Ctx(), &license.DeleteClusterRequest{
 				Id: id,
@@ -142,12 +147,11 @@ func ListClustersCmd() *cobra.Command {
 		Short: "List clusters registered with the license server.",
 		Long:  "List clusters registered with the license server.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.License.ListClusters(c.Ctx(), &license.ListClustersRequest{})
 			if err != nil {
@@ -172,12 +176,11 @@ func DeleteAllCmd() *cobra.Command {
 		Short: "Delete all data from the license server",
 		Long:  "Delete all data from the license server",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			if _, err := c.License.DeleteAll(c.Ctx(), &license.DeleteAllRequest{}); err != nil {
 				return err
@@ -196,12 +199,11 @@ func GetStateCmd() *cobra.Command {
 		Short: "Get the configuration of the license service.",
 		Long:  "Get the configuration of the license service.",
 		Run: cmdutil.Run(func(args []string) error {
-			c, err := client.NewEnterpriseClientOnUserMachine("user")
+			c, err := newClient()
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
-			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.License.GetActivationCode(c.Ctx(), &license.GetActivationCodeRequest{})
 			if err != nil {

--- a/src/server/license/cmds/cmds.go
+++ b/src/server/license/cmds/cmds.go
@@ -31,6 +31,7 @@ func ActivateCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			// Activate the license server
 			req := &license.ActivateRequest{
@@ -58,6 +59,8 @@ func AddClusterCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.License.AddCluster(c.Ctx(), &license.AddClusterRequest{
 				Id:      id,
@@ -90,6 +93,8 @@ func UpdateClusterCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.License.UpdateCluster(c.Ctx(), &license.UpdateClusterRequest{
 				Id:                  id,
@@ -118,6 +123,8 @@ func DeleteClusterCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			_, err = c.License.DeleteCluster(c.Ctx(), &license.DeleteClusterRequest{
 				Id: id,
@@ -139,6 +146,8 @@ func ListClustersCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
+			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
 
 			resp, err := c.License.ListClusters(c.Ctx(), &license.ListClustersRequest{})
 			if err != nil {
@@ -168,6 +177,8 @@ func DeleteAllCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+
 			if _, err := c.License.DeleteAll(c.Ctx(), &license.DeleteAllRequest{}); err != nil {
 				return err
 			}
@@ -190,6 +201,8 @@ func GetStateCmd() *cobra.Command {
 				return errors.Wrapf(err, "could not connect")
 			}
 			defer c.Close()
+			fmt.Printf("Using enterprise context: %v\n", c.ClientContextName())
+
 			resp, err := c.License.GetActivationCode(c.Ctx(), &license.GetActivationCodeRequest{})
 			if err != nil {
 				return err


### PR DESCRIPTION
In the hackathon we've had confusion about what context the `pachctl idp` and `pachctl license` run against. Print the context name when running commands against the enterprise server to make it clear to end users.