### PR TITLE
Update Go for proto build image

### DIFF
--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.2
+FROM golang:1.16.1
 LABEL maintainer="msteffen@pachyderm.io"
 
 ENV GOPROXY https://proxy.golang.org
@@ -13,7 +13,9 @@ RUN unzip protoc.zip -d /
 RUN cp -r /include /bin
 
 RUN go get -u -v github.com/golang/protobuf/proto
-RUN go get -u -v github.com/gogo/protobuf/protoc-gen-gofast
+
+# if you modify the version of gogo/protobuf. you also need to update the path in run.sh
+RUN go get -u -v github.com/gogo/protobuf/protoc-gen-gofast@v1.3.2
 RUN mkdir -p ${GOPATH}/src/github.com/pachyderm/pachyderm
 RUN date +%s >/last_run_time
 

--- a/etc/proto/run.sh
+++ b/etc/proto/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -e
+set -ex
+
+export GOGO_PROTO_VERSION="v1.3.2"
 
 tar -C "${GOPATH}/src/github.com/pachyderm/pachyderm" -xf /dev/stdin
 
@@ -26,7 +28,7 @@ for i in $(find src -name "*.proto"); do \
         echo -e "\e[1;31mError:\e[0m missing \"go_package\" declaration in ${i}" >/dev/stderr
     fi
     protoc \
-        "-I${GOPATH}/src/github.com/gogo/protobuf" \
+        "-I${GOPATH}/pkg/mod/github.com/gogo/protobuf@${GOGO_PROTO_VERSION}" \
         -Isrc \
         --gogofast_out=plugins=grpc,\
 Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,\


### PR DESCRIPTION
In more recent Go versions `go get` installs modules to `$GOPATH/pkg/mod/` with the version,  instead of `$GOPATH/src`. Update the include flag for protoc to point to the new path.