### PR TITLE
Make CI PPS test bucketing regex more specific

### DIFF
--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -44,7 +44,7 @@ function test_bucket {
     tests=( $(go test -v  "${package}" -list ".*" | grep -v '^ok' | grep -v '^Benchmark') )
     # Add anchors for the regex so we don't run collateral tests
     tests=( "${tests[@]/#/^}" )
-    tests=( "${tests[@]/%/$}" )
+    tests=( "${tests[@]/%/\$\$}" )
     total_tests="${#tests[@]}"
     # Determine the offset and length of the sub-array of tests we want to run
     # The last bucket may have a few extra tests, to accommodate rounding

--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -54,7 +54,7 @@ function test_bucket {
         "bucket_size+=bucket_num < num_buckets ? 0 : total_tests%num_buckets"
     test_regex="$(IFS=\|; echo "${tests[*]:start:bucket_size}")"
     echo "Running ${bucket_size} tests of ${total_tests} total tests"
-    make RUN="-run=\"${test_regex}\"" "${target}"
+    make RUN="-run='${test_regex}'" "${target}"
     set -x
 }
 

--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -42,6 +42,9 @@ function test_bucket {
     echo "Running bucket $bucket_num of $num_buckets"
     # shellcheck disable=SC2207
     tests=( $(go test -v  "${package}" -list ".*" | grep -v '^ok' | grep -v '^Benchmark') )
+    # Add anchors for the regex so we don't run collateral tests
+    tests=( "${tests[@]/#/^}" )
+    tests=( "${tests[@]/%/$}" )
     total_tests="${#tests[@]}"
     # Determine the offset and length of the sub-array of tests we want to run
     # The last bucket may have a few extra tests, to accommodate rounding

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -59,6 +59,9 @@ function test_bucket {
     echo "Running bucket $bucket_num of $num_buckets"
     # shellcheck disable=SC2207
     tests=( $(go test -v  "${package}" -list ".*" | grep -v '^ok' | grep -v '^Benchmark') )
+    # Add anchors for the regex so we don't run collateral tests
+    tests=( "${tests[@]/#/^}" )
+    tests=( "${tests[@]/%/$}" )
     total_tests="${#tests[@]}"
     # Determine the offset and length of the sub-array of tests we want to run
     # The last bucket may have a few extra tests, to accommodate rounding

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -61,7 +61,7 @@ function test_bucket {
     tests=( $(go test -v  "${package}" -list ".*" | grep -v '^ok' | grep -v '^Benchmark') )
     # Add anchors for the regex so we don't run collateral tests
     tests=( "${tests[@]/#/^}" )
-    tests=( "${tests[@]/%/$}" )
+    tests=( "${tests[@]/%/\$\$}" )
     total_tests="${#tests[@]}"
     # Determine the offset and length of the sub-array of tests we want to run
     # The last bucket may have a few extra tests, to accommodate rounding

--- a/etc/testing/circle_tests_inner.sh
+++ b/etc/testing/circle_tests_inner.sh
@@ -71,7 +71,7 @@ function test_bucket {
         "bucket_size+=bucket_num < num_buckets ? 0 : total_tests%num_buckets"
     test_regex="$(IFS=\|; echo "${tests[*]:start:bucket_size}")"
     echo "Running ${bucket_size} tests of ${total_tests} total tests"
-    make RUN="-run=\"${test_regex}\"" "${target}"
+    make RUN="-run='${test_regex}'" "${target}"
 }
 
 # Clean cached test results


### PR DESCRIPTION
The current regex does not account for test names which are substrings of other test names, so some tests may end up running multiple times in different buckets.  Fix this by anchoring the test name regexes with `^testname$`.