### PR TITLE
Fix pq parsing error during nested queries in PostgresReadWriteCollection.GetByIndex

### DIFF
--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -192,11 +192,11 @@ func (c *postgresReadOnlyCollection) Get(key string, val proto.Message) error {
 	return errors.EnsureStack(proto.Unmarshal(result.Proto, val))
 }
 
-func (c *postgresCollection) getByIndex(ctx context.Context, q sqlx.ExtContext, index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error {
+func (c *postgresCollection) getByIndex(ctx context.Context, q sqlx.ExtContext, index *Index, indexVal string, val proto.Message, opts *Options, greedy bool, f func(string) error) error {
 	if err := c.validateIndex(index); err != nil {
 		return err
 	}
-	return c.list(ctx, map[string]string{indexFieldName(index): indexVal}, opts, q, func(m *model) error {
+	return c.list(ctx, map[string]string{indexFieldName(index): indexVal}, opts, greedy, q, func(m *model) error {
 		if err := proto.Unmarshal(m.Proto, val); err != nil {
 			return errors.EnsureStack(err)
 		}
@@ -205,11 +205,11 @@ func (c *postgresCollection) getByIndex(ctx context.Context, q sqlx.ExtContext, 
 }
 
 func (c *postgresReadOnlyCollection) GetByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error {
-	return c.getByIndex(c.ctx, c.db, index, indexVal, val, opts, f)
+	return c.getByIndex(c.ctx, c.db, index, indexVal, val, opts, false, f)
 }
 
 func (c *postgresReadWriteCollection) GetByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error {
-	return c.getByIndex(context.Background(), c.tx, index, indexVal, val, opts, f)
+	return c.getByIndex(context.Background(), c.tx, index, indexVal, val, opts, true, f)
 }
 
 func orderToSQL(order etcd.SortOrder) (string, error) {
@@ -238,8 +238,10 @@ func (c *postgresCollection) list(
 	ctx context.Context,
 	withFields map[string]string,
 	opts *Options,
+	greedy bool,
 	q sqlx.ExtContext,
-	f func(*model) error) error {
+	f func(*model) error,
+) error {
 	query := fmt.Sprintf("select key, createdat, updatedat, proto from collections.%s", c.table)
 
 	params := map[string]interface{}{}
@@ -268,6 +270,33 @@ func (c *postgresCollection) list(
 	}
 	defer rows.Close()
 
+	// greedy=true indicates that this may be run in a transaction, so we have to
+	// read the entire result set before returning control back to the user, or
+	// they could run a nested query which will break the pq parser.
+	if greedy {
+		results := []*model{}
+		for rows.Next() {
+			result := &model{}
+			if err := rows.StructScan(result); err != nil {
+				return c.mapSQLError(err, "")
+			}
+			results = append(results, result)
+		}
+		if err := rows.Close(); err != nil {
+			return c.mapSQLError(err, "")
+		}
+
+		for _, result := range results {
+			if err := f(result); err != nil {
+				if errors.Is(err, errutil.ErrBreak) {
+					return nil
+				}
+				return err
+			}
+		}
+		return nil
+	}
+
 	result := &model{}
 	for rows.Next() {
 		if err := rows.StructScan(result); err != nil {
@@ -286,7 +315,7 @@ func (c *postgresCollection) list(
 }
 
 func (c *postgresReadOnlyCollection) list(withFields map[string]string, opts *Options, f func(*model) error) error {
-	return c.postgresCollection.list(c.ctx, withFields, opts, c.db, f)
+	return c.postgresCollection.list(c.ctx, withFields, opts, false, c.db, f)
 }
 
 func (c *postgresReadOnlyCollection) List(val proto.Message, opts *Options, f func(string) error) error {

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -8,6 +8,7 @@ import (
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -21,6 +22,7 @@ func TestPostgresCollections(suite *testing.T) {
 		options := []dbutil.Option{
 			dbutil.WithHostPort(config.PostgresServiceHost, config.PostgresServicePort),
 			dbutil.WithDBName(config.PostgresDBName),
+			dbutil.WithMaxOpenConns(1), // All tests should be able to run on a single connection
 		}
 
 		db, err := dbutil.NewDB(options...)
@@ -63,6 +65,109 @@ func TestPostgresCollections(suite *testing.T) {
 
 	collectionTests(suite, newCollection)
 	watchTests(suite, newCollection)
+
+	// Postgres collections support getting multiple rows by a secondary index,
+	// although it requires loading the entire result set into memory to prevent
+	// multiple queries from using the transaction at once.  Consequently, it
+	// should only be used for small result sets.
+	suite.Run("ReadWriteGetByIndex", func(subsuite *testing.T) {
+		subsuite.Parallel()
+		emptyRead, emptyWriter := newCollection(context.Background(), subsuite)
+		defaultRead, defaultWriter := initCollection(subsuite, newCollection)
+
+		subsuite.Run("Empty", func(t *testing.T) {
+			t.Parallel()
+			err := emptyWriter(context.Background(), func(rw col.ReadWriteCollection) error {
+				pgrw := rw.(col.PostgresReadWriteCollection)
+				return pgrw.GetByIndex(TestSecondaryIndex, "foo", &col.TestItem{}, col.DefaultOptions(), func(string) error {
+					return errors.New("GetByIndex callback should not have been called for an empty collection")
+				})
+			})
+			require.NoError(t, err)
+			count, err := emptyRead(context.Background()).Count()
+			require.NoError(t, err)
+			require.Equal(t, int64(0), count)
+		})
+
+		subsuite.Run("Success", func(t *testing.T) {
+			t.Parallel()
+			keys := []string{}
+			err := defaultWriter(context.Background(), func(rw col.ReadWriteCollection) error {
+				testProto := &col.TestItem{}
+				pgrw := rw.(col.PostgresReadWriteCollection)
+				return pgrw.GetByIndex(TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
+					require.Equal(t, testProto.ID, key)
+					require.Equal(t, testProto.Value, originalValue)
+					keys = append(keys, key)
+					// Clear testProto.ID and testProto.Value just to make sure they get overwritten each time
+					testProto.ID = ""
+					testProto.Value = ""
+					return nil
+				})
+			})
+			require.NoError(t, err)
+			require.ElementsEqual(t, keys, idRange(0, defaultCollectionSize))
+			checkDefaultCollection(t, defaultRead, RowDiff{})
+		})
+
+		subsuite.Run("NoResults", func(t *testing.T) {
+			t.Parallel()
+			err := defaultWriter(context.Background(), func(rw col.ReadWriteCollection) error {
+				testProto := &col.TestItem{}
+				pgrw := rw.(col.PostgresReadWriteCollection)
+				return pgrw.GetByIndex(TestSecondaryIndex, changedValue, testProto, col.DefaultOptions(), func(string) error {
+					return errors.New("GetByIndex callback should not have been called for an index value with no rows")
+				})
+			})
+			require.NoError(t, err)
+			checkDefaultCollection(t, defaultRead, RowDiff{})
+		})
+
+		subsuite.Run("InvalidIndex", func(t *testing.T) {
+			t.Parallel()
+			err := defaultWriter(context.Background(), func(rw col.ReadWriteCollection) error {
+				pgrw := rw.(col.PostgresReadWriteCollection)
+				return pgrw.GetByIndex(&col.Index{}, "", &col.TestItem{}, col.DefaultOptions(), func(key string) error {
+					return errors.New("GetByIndex callback should not have been called when using an invalid index")
+				})
+			})
+			require.YesError(t, err)
+			require.Matches(t, "Unknown collection index", err.Error())
+			checkDefaultCollection(t, defaultRead, RowDiff{})
+		})
+
+		subsuite.Run("Nested", func(t *testing.T) {
+			t.Parallel()
+			outerKeys := []string{}
+			innerKeys := []string{}
+			innerID := makeID(3)
+			err := defaultWriter(context.Background(), func(rw col.ReadWriteCollection) error {
+				testProto := &col.TestItem{}
+				pgrw := rw.(col.PostgresReadWriteCollection)
+				return pgrw.GetByIndex(TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
+					outerKeys = append(outerKeys, testProto.ID)
+					if err := pgrw.Get(innerID, testProto); err != nil {
+						return err
+					}
+					innerKeys = append(innerKeys, testProto.ID)
+					// Clear testProto.ID and testProto.Value just to make sure they get overwritten each time
+					testProto.ID = ""
+					testProto.Value = ""
+					return nil
+				})
+			})
+			require.NoError(t, err)
+			require.ElementsEqual(t, idRange(0, defaultCollectionSize), outerKeys)
+
+			expectedInnerKeys := []string{}
+			for i := 0; i < defaultCollectionSize; i++ {
+				expectedInnerKeys = append(expectedInnerKeys, innerID)
+			}
+
+			require.ElementsEqual(t, expectedInnerKeys, innerKeys)
+			checkDefaultCollection(t, defaultRead, RowDiff{})
+		})
+	})
 
 	// TODO: postgres-specific collection tests:
 	// GetRevByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(int64) error) error

--- a/src/internal/dbutil/option.go
+++ b/src/internal/dbutil/option.go
@@ -25,3 +25,11 @@ func WithDBName(DBName string) Option {
 		dbc.name = DBName
 	}
 }
+
+// WithMaxOpenConns sets the maximum number of concurrent database connections
+// to be allocated before blocking new acquisitions.
+func WithMaxOpenConns(n int) Option {
+	return func(dbc *dbConfig) {
+		dbc.maxOpenConns = n
+	}
+}


### PR DESCRIPTION
In a transaction, we can't start the next query until the previous one has completed.  This changes `GetByIndex` to greedily read out the full result set on read-write collections before calling the user callback.  Also added `GetByIndex` tests for `PostgresReadWriteCollection`, including a test that reproduces this situation.  The symptom of this bug is an error that looks like `pq: unexpected Parse response 'C'`.