### PR TITLE
Remove pattern of passing pach client in PFS

### DIFF
--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -52,7 +52,6 @@ func newAPIServer(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcd
 		env:    env,
 		txnEnv: txnEnv,
 	}
-	go func() { s.env.GetPachClient(context.Background()) }() // Begin dialing connection on startup
 	return s, nil
 }
 
@@ -116,7 +115,7 @@ func (a *apiServer) InspectRepo(ctx context.Context, request *pfs.InspectRepoReq
 func (a *apiServer) ListRepo(ctx context.Context, request *pfs.ListRepoRequest) (response *pfs.ListRepoResponse, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	repoInfos, err := a.driver.listRepo(a.env.GetPachClient(ctx), true)
+	repoInfos, err := a.driver.listRepo(ctx, true)
 	return repoInfos, err
 }
 
@@ -202,7 +201,7 @@ func (a *apiServer) InspectCommitInTransaction(txnCtx *txnenv.TransactionContext
 func (a *apiServer) InspectCommit(ctx context.Context, request *pfs.InspectCommitRequest) (response *pfs.CommitInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	return a.driver.inspectCommit(a.env.GetPachClient(ctx), request.Commit, request.BlockState)
+	return a.driver.inspectCommit(ctx, request.Commit, request.BlockState)
 }
 
 // ListCommit implements the protobuf pfs.ListCommit RPC
@@ -212,7 +211,7 @@ func (a *apiServer) ListCommit(request *pfs.ListCommitRequest, respServer pfs.AP
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("stream containing %d commits", sent), retErr, time.Since(start))
 	}(time.Now())
-	return a.driver.listCommit(a.env.GetPachClient(respServer.Context()), request.Repo, request.To, request.From, request.Number, request.Reverse, func(ci *pfs.CommitInfo) error {
+	return a.driver.listCommit(respServer.Context(), request.Repo, request.To, request.From, request.Number, request.Reverse, func(ci *pfs.CommitInfo) error {
 		sent++
 		return respServer.Send(ci)
 	})
@@ -240,21 +239,21 @@ func (a *apiServer) SquashCommit(ctx context.Context, request *pfs.SquashCommitR
 func (a *apiServer) FlushCommit(request *pfs.FlushCommitRequest, stream pfs.API_FlushCommitServer) (retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	return a.driver.flushCommit(a.env.GetPachClient(stream.Context()), request.Commits, request.ToRepos, stream.Send)
+	return a.driver.flushCommit(stream.Context(), request.Commits, request.ToRepos, stream.Send)
 }
 
 // SubscribeCommit implements the protobuf pfs.SubscribeCommit RPC
 func (a *apiServer) SubscribeCommit(request *pfs.SubscribeCommitRequest, stream pfs.API_SubscribeCommitServer) (retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	return a.driver.subscribeCommit(a.env.GetPachClient(stream.Context()), request.Repo, request.Branch, request.Prov, request.From, request.State, stream.Send)
+	return a.driver.subscribeCommit(stream.Context(), request.Repo, request.Branch, request.Prov, request.From, request.State, stream.Send)
 }
 
 // ClearCommit deletes all data in the commit.
 func (a *apiServer) ClearCommit(ctx context.Context, request *pfs.ClearCommitRequest) (_ *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
-	return &types.Empty{}, a.driver.clearCommit(a.env.GetPachClient(ctx), request.Commit)
+	return &types.Empty{}, a.driver.clearCommit(ctx, request.Commit)
 }
 
 // CreateBranchInTransaction is identical to CreateBranch except that it can run
@@ -298,7 +297,7 @@ func (a *apiServer) InspectBranchInTransaction(txnCtx *txnenv.TransactionContext
 func (a *apiServer) ListBranch(ctx context.Context, request *pfs.ListBranchRequest) (response *pfs.BranchInfos, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	branches, err := a.driver.listBranch(a.env.GetPachClient(ctx), request.Repo, request.Reverse)
+	branches, err := a.driver.listBranch(ctx, request.Repo, request.Reverse)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +323,6 @@ func (a *apiServer) DeleteBranch(ctx context.Context, request *pfs.DeleteBranchR
 }
 
 func (a *apiServer) ModifyFile(server pfs.API_ModifyFileServer) (retErr error) {
-	pachClient := a.env.GetPachClient(server.Context())
 	request, err := server.Recv()
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
@@ -333,7 +331,7 @@ func (a *apiServer) ModifyFile(server pfs.API_ModifyFileServer) (retErr error) {
 			return 0, err
 		}
 		var bytesRead int64
-		if err := a.driver.modifyFile(pachClient, request.Commit, func(uw *fileset.UnorderedWriter) error {
+		if err := a.driver.modifyFile(server.Context(), request.Commit, func(uw *fileset.UnorderedWriter) error {
 			var err error
 			bytesRead, err = a.modifyFile(server.Context(), uw, server, request)
 			return err
@@ -349,7 +347,6 @@ type modifyFileSource interface {
 }
 
 func (a *apiServer) modifyFile(ctx context.Context, uw *fileset.UnorderedWriter, server modifyFileSource, req *pfs.ModifyFileRequest) (int64, error) {
-	pachClient := a.env.GetPachClient(ctx)
 	var bytesRead int64
 	for {
 		// TODO Validation.
@@ -376,7 +373,7 @@ func (a *apiServer) modifyFile(ctx context.Context, uw *fileset.UnorderedWriter,
 				}
 			case *pfs.ModifyFileRequest_CopyFile:
 				cf := mod.CopyFile
-				if err := a.driver.copyFile(pachClient, uw, cf.Dst, cf.Src, cf.Append, cf.Tag); err != nil {
+				if err := a.driver.copyFile(ctx, uw, cf.Dst, cf.Src, cf.Append, cf.Tag); err != nil {
 					return bytesRead, err
 				}
 			}
@@ -532,7 +529,7 @@ func (a *apiServer) GetFile(request *pfs.GetFileRequest, server pfs.API_GetFileS
 	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
 	return metrics.ReportRequestWithThroughput(func() (int64, error) {
 		ctx := server.Context()
-		src, err := a.driver.getFile(a.env.GetPachClient(ctx), request.File)
+		src, err := a.driver.getFile(ctx, request.File)
 		if err != nil {
 			return 0, err
 		}
@@ -618,7 +615,7 @@ func getFileTar(ctx context.Context, w io.Writer, src Source) error {
 func (a *apiServer) InspectFile(ctx context.Context, request *pfs.InspectFileRequest) (response *pfs.FileInfo, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	return a.driver.inspectFile(a.env.GetPachClient(ctx), request.File)
+	return a.driver.inspectFile(ctx, request.File)
 }
 
 // ListFile implements the protobuf pfs.ListFile RPC
@@ -628,7 +625,7 @@ func (a *apiServer) ListFile(request *pfs.ListFileRequest, server pfs.API_ListFi
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("response stream with %d objects", sent), retErr, time.Since(start))
 	}(time.Now())
-	return a.driver.listFile(a.env.GetPachClient(server.Context()), request.File, request.Full, func(fi *pfs.FileInfo) error {
+	return a.driver.listFile(server.Context(), request.File, request.Full, func(fi *pfs.FileInfo) error {
 		sent++
 		return server.Send(fi)
 	})
@@ -641,7 +638,7 @@ func (a *apiServer) WalkFile(request *pfs.WalkFileRequest, server pfs.API_WalkFi
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("response stream with %d objects", sent), retErr, time.Since(start))
 	}(time.Now())
-	return a.driver.walkFile(a.env.GetPachClient(server.Context()), request.File, func(fi *pfs.FileInfo) error {
+	return a.driver.walkFile(server.Context(), request.File, func(fi *pfs.FileInfo) error {
 		sent++
 		return server.Send(fi)
 	})
@@ -654,7 +651,7 @@ func (a *apiServer) GlobFile(request *pfs.GlobFileRequest, respServer pfs.API_Gl
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("response stream with %d objects", sent), retErr, time.Since(start))
 	}(time.Now())
-	return a.driver.globFile(a.env.GetPachClient(respServer.Context()), request.Commit, request.Pattern, func(fi *pfs.FileInfo) error {
+	return a.driver.globFile(respServer.Context(), request.Commit, request.Pattern, func(fi *pfs.FileInfo) error {
 		sent++
 		return respServer.Send(fi)
 	})
@@ -667,7 +664,7 @@ func (a *apiServer) DiffFile(request *pfs.DiffFileRequest, server pfs.API_DiffFi
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("response stream with %d objects", sent), retErr, time.Since(start))
 	}(time.Now())
-	return a.driver.diffFile(a.env.GetPachClient(server.Context()), request.OldFile, request.NewFile, func(oldFi, newFi *pfs.FileInfo) error {
+	return a.driver.diffFile(server.Context(), request.OldFile, request.NewFile, func(oldFi, newFi *pfs.FileInfo) error {
 		sent++
 		return server.Send(&pfs.DiffFileResponse{
 			OldFile: oldFi,
@@ -696,7 +693,7 @@ func (a *apiServer) Fsck(request *pfs.FsckRequest, fsckServer pfs.API_FsckServer
 	defer func(start time.Time) {
 		a.Log(request, fmt.Sprintf("stream containing %d messages", sent), retErr, time.Since(start))
 	}(time.Now())
-	if err := a.driver.fsck(a.env.GetPachClient(fsckServer.Context()), request.Fix, func(resp *pfs.FsckResponse) error {
+	if err := a.driver.fsck(fsckServer.Context(), request.Fix, func(resp *pfs.FsckResponse) error {
 		sent++
 		return fsckServer.Send(resp)
 	}); err != nil {
@@ -720,7 +717,7 @@ func (a *apiServer) CreateFileset(server pfs.API_CreateFilesetServer) error {
 }
 
 func (a *apiServer) GetFileset(ctx context.Context, req *pfs.GetFilesetRequest) (*pfs.CreateFilesetResponse, error) {
-	filesetID, err := a.driver.getFileset(a.env.GetPachClient(ctx), req.Commit)
+	filesetID, err := a.driver.getFileset(ctx, req.Commit)
 	if err != nil {
 		return nil, err
 	}
@@ -730,12 +727,11 @@ func (a *apiServer) GetFileset(ctx context.Context, req *pfs.GetFilesetRequest) 
 }
 
 func (a *apiServer) AddFileset(ctx context.Context, req *pfs.AddFilesetRequest) (*types.Empty, error) {
-	pachClient := a.env.GetPachClient(ctx)
 	fsid, err := fileset.ParseID(req.FilesetId)
 	if err != nil {
 		return nil, err
 	}
-	if err := a.driver.addFileset(pachClient, req.Commit, *fsid); err != nil {
+	if err := a.driver.addFileset(ctx, req.Commit, *fsid); err != nil {
 		return nil, err
 	}
 	return &types.Empty{}, nil

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -21,8 +21,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (d *driver) modifyFile(pachClient *client.APIClient, commit *pfs.Commit, cb func(*fileset.UnorderedWriter) error) error {
-	ctx := pachClient.Ctx()
+func (d *driver) modifyFile(ctx context.Context, commit *pfs.Commit, cb func(*fileset.UnorderedWriter) error) error {
 	// Store the originally-requested parameters because they will be overwritten by inspectCommit
 	repo := commit.Branch.Repo.Name
 	branch := commit.Branch.Name
@@ -31,7 +30,7 @@ func (d *driver) modifyFile(pachClient *client.APIClient, commit *pfs.Commit, cb
 		branch = commitID
 		commitID = ""
 	}
-	commitInfo, err := d.inspectCommit(pachClient, commit, pfs.CommitState_STARTED)
+	commitInfo, err := d.inspectCommit(ctx, commit, pfs.CommitState_STARTED)
 	if err != nil {
 		if (!isNotFoundErr(err) && !isNoHeadErr(err)) || branch == "" {
 			return err
@@ -46,7 +45,7 @@ func (d *driver) modifyFile(pachClient *client.APIClient, commit *pfs.Commit, cb
 		}
 		var opts []fileset.UnorderedWriterOption
 		if commitInfo.ParentCommit != nil {
-			parentFilesetID, err := d.getFileset(pachClient, commitInfo.ParentCommit)
+			parentFilesetID, err := d.getFileset(ctx, commitInfo.ParentCommit)
 			if err != nil {
 				return err
 			}
@@ -54,11 +53,11 @@ func (d *driver) modifyFile(pachClient *client.APIClient, commit *pfs.Commit, cb
 		}
 		return d.oneOffModifyFile(ctx, repo, branch, cb, opts...)
 	}
-	filesetID, err := d.getFileset(pachClient, commitInfo.Commit)
+	filesetID, err := d.getFileset(ctx, commitInfo.Commit)
 	if err != nil {
 		return err
 	}
-	return d.withCommitUnorderedWriter(pachClient, commitInfo.Commit, cb, fileset.WithParentID(filesetID))
+	return d.withCommitUnorderedWriter(ctx, commitInfo.Commit, cb, fileset.WithParentID(filesetID))
 }
 
 // TODO: Cleanup after failure?
@@ -68,7 +67,7 @@ func (d *driver) oneOffModifyFile(ctx context.Context, repo, branch string, cb f
 		if err != nil {
 			return err
 		}
-		if err := d.withCommitUnorderedWriter(txnCtx.Client, commit, cb, opts...); err != nil {
+		if err := d.withCommitUnorderedWriter(ctx, commit, cb, opts...); err != nil {
 			return err
 		}
 		return d.finishCommit(txnCtx, commit, "")
@@ -76,8 +75,8 @@ func (d *driver) oneOffModifyFile(ctx context.Context, repo, branch string, cb f
 }
 
 // withCommitWriter calls cb with an unordered writer. All data written to cb is added to the commit, or an error is returned.
-func (d *driver) withCommitUnorderedWriter(pachClient *client.APIClient, commit *pfs.Commit, cb func(*fileset.UnorderedWriter) error, opts ...fileset.UnorderedWriterOption) (retErr error) {
-	return d.storage.WithRenewer(pachClient.Ctx(), defaultTTL, func(ctx context.Context, renewer *renew.StringSet) error {
+func (d *driver) withCommitUnorderedWriter(ctx context.Context, commit *pfs.Commit, cb func(*fileset.UnorderedWriter) error, opts ...fileset.UnorderedWriterOption) (retErr error) {
+	return d.storage.WithRenewer(ctx, defaultTTL, func(ctx context.Context, renewer *renew.StringSet) error {
 		id, err := d.withUnorderedWriter(ctx, renewer, false, cb, opts...)
 		if err != nil {
 			return err
@@ -116,39 +115,39 @@ func (d *driver) getDefaultTag() string {
 	return fmt.Sprintf("%012d", time.Now().UnixNano())
 }
 
-func (d *driver) openCommit(pachClient *client.APIClient, commit *pfs.Commit, opts ...index.Option) (*pfs.CommitInfo, fileset.FileSet, error) {
+func (d *driver) openCommit(ctx context.Context, commit *pfs.Commit, opts ...index.Option) (*pfs.CommitInfo, fileset.FileSet, error) {
 	if commit.Branch.Repo.Name == fileSetsRepo {
 		fsid, err := fileset.ParseID(commit.ID)
 		if err != nil {
 			return nil, nil, err
 		}
-		fs, err := d.storage.Open(pachClient.Ctx(), []fileset.ID{*fsid}, opts...)
+		fs, err := d.storage.Open(ctx, []fileset.ID{*fsid}, opts...)
 		if err != nil {
 			return nil, nil, err
 		}
 		return &pfs.CommitInfo{Commit: commit}, fs, nil
 	}
+	pachClient := d.env.GetPachClient(ctx)
 	if err := authserver.CheckRepoIsAuthorized(pachClient, commit.Branch.Repo.Name, auth.Permission_REPO_READ); err != nil {
 		return nil, nil, err
 	}
-	commitInfo, err := d.inspectCommit(pachClient, commit, pfs.CommitState_STARTED)
+	commitInfo, err := d.inspectCommit(ctx, commit, pfs.CommitState_STARTED)
 	if err != nil {
 		return nil, nil, err
 	}
-	id, err := d.getFileset(pachClient, commitInfo.Commit)
+	id, err := d.getFileset(ctx, commitInfo.Commit)
 	if err != nil {
 		return nil, nil, err
 	}
-	fs, err := d.storage.Open(pachClient.Ctx(), []fileset.ID{*id}, opts...)
+	fs, err := d.storage.Open(ctx, []fileset.ID{*id}, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
 	return commitInfo, fs, nil
 }
 
-func (d *driver) copyFile(pachClient *client.APIClient, uw *fileset.UnorderedWriter, dst string, src *pfs.File, appendFile bool, tag string) (retErr error) {
-	ctx := pachClient.Ctx()
-	srcCommitInfo, err := d.inspectCommit(pachClient, src.Commit, pfs.CommitState_STARTED)
+func (d *driver) copyFile(ctx context.Context, uw *fileset.UnorderedWriter, dst string, src *pfs.File, appendFile bool, tag string) (retErr error) {
+	srcCommitInfo, err := d.inspectCommit(ctx, src.Commit, pfs.CommitState_STARTED)
 	if err != nil {
 		return err
 	}
@@ -162,7 +161,7 @@ func (d *driver) copyFile(pachClient *client.APIClient, uw *fileset.UnorderedWri
 		}
 		return path.Join(dstPath, relPath)
 	}
-	_, fs, err := d.openCommit(pachClient, srcCommit, index.WithPrefix(srcPath))
+	_, fs, err := d.openCommit(ctx, srcCommit, index.WithPrefix(srcPath))
 	if err != nil {
 		return err
 	}
@@ -177,10 +176,10 @@ func (d *driver) copyFile(pachClient *client.APIClient, uw *fileset.UnorderedWri
 	return uw.Copy(ctx, fs, appendFile, tag)
 }
 
-func (d *driver) getFile(pachClient *client.APIClient, file *pfs.File) (Source, error) {
+func (d *driver) getFile(ctx context.Context, file *pfs.File) (Source, error) {
 	commit := file.Commit
 	glob := cleanPath(file.Path)
-	commitInfo, fs, err := d.openCommit(pachClient, commit, index.WithPrefix(globLiteralPrefix(glob)))
+	commitInfo, fs, err := d.openCommit(ctx, commit, index.WithPrefix(globLiteralPrefix(glob)))
 	if err != nil {
 		return nil, err
 	}
@@ -199,13 +198,12 @@ func (d *driver) getFile(pachClient *client.APIClient, file *pfs.File) (Source, 
 	return NewErrOnEmpty(s, &pfsserver.ErrFileNotFound{File: file}), nil
 }
 
-func (d *driver) inspectFile(pachClient *client.APIClient, file *pfs.File) (*pfs.FileInfo, error) {
-	ctx := pachClient.Ctx()
+func (d *driver) inspectFile(ctx context.Context, file *pfs.File) (*pfs.FileInfo, error) {
 	p := cleanPath(file.Path)
 	if p == "/" {
 		p = ""
 	}
-	commitInfo, fs, err := d.openCommit(pachClient, file.Commit, index.WithPrefix(p))
+	commitInfo, fs, err := d.openCommit(ctx, file.Commit, index.WithPrefix(p))
 	if err != nil {
 		return nil, err
 	}
@@ -232,10 +230,9 @@ func (d *driver) inspectFile(pachClient *client.APIClient, file *pfs.File) (*pfs
 	return ret, nil
 }
 
-func (d *driver) listFile(pachClient *client.APIClient, file *pfs.File, full bool, cb func(*pfs.FileInfo) error) error {
-	ctx := pachClient.Ctx()
+func (d *driver) listFile(ctx context.Context, file *pfs.File, full bool, cb func(*pfs.FileInfo) error) error {
 	name := cleanPath(file.Path)
-	commitInfo, fs, err := d.openCommit(pachClient, file.Commit, index.WithPrefix(name))
+	commitInfo, fs, err := d.openCommit(ctx, file.Commit, index.WithPrefix(name))
 	if err != nil {
 		return err
 	}
@@ -265,13 +262,12 @@ func (d *driver) listFile(pachClient *client.APIClient, file *pfs.File, full boo
 	})
 }
 
-func (d *driver) walkFile(pachClient *client.APIClient, file *pfs.File, cb func(*pfs.FileInfo) error) (retErr error) {
-	ctx := pachClient.Ctx()
+func (d *driver) walkFile(ctx context.Context, file *pfs.File, cb func(*pfs.FileInfo) error) (retErr error) {
 	p := cleanPath(file.Path)
 	if p == "/" {
 		p = ""
 	}
-	commitInfo, fs, err := d.openCommit(pachClient, file.Commit, index.WithPrefix(p))
+	commitInfo, fs, err := d.openCommit(ctx, file.Commit, index.WithPrefix(p))
 	if err != nil {
 		return err
 	}
@@ -289,10 +285,9 @@ func (d *driver) walkFile(pachClient *client.APIClient, file *pfs.File, cb func(
 	})
 }
 
-func (d *driver) globFile(pachClient *client.APIClient, commit *pfs.Commit, glob string, cb func(*pfs.FileInfo) error) error {
-	ctx := pachClient.Ctx()
+func (d *driver) globFile(ctx context.Context, commit *pfs.Commit, glob string, cb func(*pfs.FileInfo) error) error {
 	glob = cleanPath(glob)
-	commitInfo, fs, err := d.openCommit(pachClient, commit, index.WithPrefix(globLiteralPrefix(glob)))
+	commitInfo, fs, err := d.openCommit(ctx, commit, index.WithPrefix(globLiteralPrefix(glob)))
 	if err != nil {
 		return err
 	}
@@ -317,7 +312,7 @@ func (d *driver) globFile(pachClient *client.APIClient, commit *pfs.Commit, glob
 	})
 }
 
-func (d *driver) diffFile(pachClient *client.APIClient, oldFile, newFile *pfs.File, cb func(oldFi, newFi *pfs.FileInfo) error) error {
+func (d *driver) diffFile(ctx context.Context, oldFile, newFile *pfs.File, cb func(oldFi, newFi *pfs.FileInfo) error) error {
 	// TODO: move validation to the Validating API Server
 	// Validation
 	if newFile == nil {
@@ -332,6 +327,7 @@ func (d *driver) diffFile(pachClient *client.APIClient, oldFile, newFile *pfs.Fi
 	if newFile.Commit.Branch.Repo == nil {
 		return errors.New("file commit repo cannot be nil")
 	}
+	pachClient := d.env.GetPachClient(ctx)
 	// Do READER authorization check for both newFile and oldFile
 	if oldFile != nil && oldFile.Commit != nil {
 		if err := authserver.CheckRepoIsAuthorized(pachClient, oldFile.Commit.Branch.Repo.Name, auth.Permission_REPO_READ); err != nil {
@@ -343,7 +339,7 @@ func (d *driver) diffFile(pachClient *client.APIClient, oldFile, newFile *pfs.Fi
 			return err
 		}
 	}
-	newCommitInfo, err := d.inspectCommit(pachClient, newFile.Commit, pfs.CommitState_STARTED)
+	newCommitInfo, err := d.inspectCommit(ctx, newFile.Commit, pfs.CommitState_STARTED)
 	if err != nil {
 		return err
 	}
@@ -365,7 +361,7 @@ func (d *driver) diffFile(pachClient *client.APIClient, oldFile, newFile *pfs.Fi
 	}
 	var old Source = emptySource{}
 	if oldCommit != nil {
-		oldCommitInfo, fs, err := d.openCommit(pachClient, oldCommit, index.WithPrefix(oldName))
+		oldCommitInfo, fs, err := d.openCommit(ctx, oldCommit, index.WithPrefix(oldName))
 		if err != nil {
 			return err
 		}
@@ -379,7 +375,7 @@ func (d *driver) diffFile(pachClient *client.APIClient, oldFile, newFile *pfs.Fi
 		}
 		old = NewSource(d.storage, oldCommitInfo, fs, opts...)
 	}
-	newCommitInfo, fs, err := d.openCommit(pachClient, newCommit, index.WithPrefix(newName))
+	newCommitInfo, fs, err := d.openCommit(ctx, newCommit, index.WithPrefix(newName))
 	if err != nil {
 		return err
 	}
@@ -393,7 +389,7 @@ func (d *driver) diffFile(pachClient *client.APIClient, oldFile, newFile *pfs.Fi
 	}
 	new := NewSource(d.storage, newCommitInfo, fs, opts...)
 	diff := NewDiffer(old, new)
-	return diff.Iterate(pachClient.Ctx(), cb)
+	return diff.Iterate(ctx, cb)
 }
 
 // createFileset creates a new temporary fileset and returns it.
@@ -420,45 +416,44 @@ func (d *driver) renewFileset(ctx context.Context, id fileset.ID, ttl time.Durat
 	return err
 }
 
-func (d *driver) addFileset(pachClient *client.APIClient, commit *pfs.Commit, filesetID fileset.ID) error {
-	commitInfo, err := d.inspectCommit(pachClient, commit, pfs.CommitState_STARTED)
+func (d *driver) addFileset(ctx context.Context, commit *pfs.Commit, filesetID fileset.ID) error {
+	commitInfo, err := d.inspectCommit(ctx, commit, pfs.CommitState_STARTED)
 	if err != nil {
 		return err
 	}
 	if commitInfo.Finished != nil {
 		return pfsserver.ErrCommitFinished{commitInfo.Commit}
 	}
-	return d.commitStore.AddFileset(pachClient.Ctx(), commitInfo.Commit, filesetID)
+	return d.commitStore.AddFileset(ctx, commitInfo.Commit, filesetID)
 }
 
-func (d *driver) getFileset(pachClient *client.APIClient, commit *pfs.Commit) (*fileset.ID, error) {
-	commitInfo, err := d.getCommit(pachClient, commit)
+func (d *driver) getFileset(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
+	commitInfo, err := d.getCommit(ctx, commit)
 	if err != nil {
 		return nil, err
 	}
 	if commitInfo.Finished != nil {
-		return d.getOrComputeTotal(pachClient, commitInfo.Commit)
+		return d.getOrComputeTotal(ctx, commitInfo.Commit)
 	}
 	var ids []fileset.ID
 	if commitInfo.ParentCommit != nil {
 		// ¯\_(ツ)_/¯
-		parentId, err := d.getFileset(pachClient, commitInfo.ParentCommit)
+		parentId, err := d.getFileset(ctx, commitInfo.ParentCommit)
 		if err != nil {
 			return nil, err
 		}
 		ids = append(ids, *parentId)
 	}
-	id, err := d.commitStore.GetDiffFileset(pachClient.Ctx(), commitInfo.Commit)
+	id, err := d.commitStore.GetDiffFileset(ctx, commitInfo.Commit)
 	if err != nil {
 		return nil, err
 	}
 	ids = append(ids, *id)
-	return d.storage.Compose(pachClient.Ctx(), ids, defaultTTL)
+	return d.storage.Compose(ctx, ids, defaultTTL)
 }
 
-func (d *driver) getOrComputeTotal(pachClient *client.APIClient, commit *pfs.Commit) (*fileset.ID, error) {
-	ctx := pachClient.Ctx()
-	commitInfo, err := d.getCommit(pachClient, commit)
+func (d *driver) getOrComputeTotal(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
+	commitInfo, err := d.getCommit(ctx, commit)
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +474,7 @@ func (d *driver) getOrComputeTotal(pachClient *client.APIClient, commit *pfs.Com
 	}
 	var inputs []fileset.ID
 	if commitInfo.ParentCommit != nil {
-		parentDiff, err := d.getOrComputeTotal(pachClient, commitInfo.ParentCommit)
+		parentDiff, err := d.getOrComputeTotal(ctx, commitInfo.ParentCommit)
 		if err != nil {
 			return nil, err
 		}

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -1,13 +1,13 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
@@ -230,16 +230,15 @@ func (e ErrProvenanceOfSubvenance) Error() string {
 // 3. Commit provenance is transitive
 // 4. Commit provenance and commit subvenance are dual relations
 // If fix is true it will attempt to fix as many of these issues as it can.
-func (d *driver) fsck(pachClient *client.APIClient, fix bool, cb func(*pfs.FsckResponse) error) error {
+func (d *driver) fsck(ctx context.Context, fix bool, cb func(*pfs.FsckResponse) error) error {
 	// Check that the user is logged in (user doesn't need any access level to
 	// fsck, but they must be authenticated if auth is active)
-	if _, err := pachClient.WhoAmI(pachClient.Ctx(), &auth.WhoAmIRequest{}); err != nil {
+	pachClient := d.env.GetPachClient(ctx)
+	if _, err := pachClient.WhoAmI(ctx, &auth.WhoAmIRequest{}); err != nil {
 		if !auth.IsErrNotActivated(err) {
 			return errors.Wrapf(grpcutil.ScrubGRPC(err), "error authenticating (must log in to run fsck)")
 		}
 	}
-
-	ctx := pachClient.Ctx()
 
 	repos := d.repos.ReadOnly(ctx)
 

--- a/src/server/pfs/server/transaction_defer.go
+++ b/src/server/pfs/server/transaction_defer.go
@@ -76,7 +76,7 @@ func (f *PipelineFinisher) FinishPipelineCommits(branch *pfs.Branch) error {
 func (f *PipelineFinisher) Run() error {
 	for _, branch := range f.branches {
 		if err := f.d.listCommit(
-			f.txnCtx.Client,
+			f.txnCtx.ClientContext,
 			branch.Repo,
 			client.NewCommit(branch.Repo.Name, branch.Name, ""), // to
 			nil,   // from

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -152,7 +152,7 @@ func (d *driver) isTriggered(txnCtx *txnenv.TransactionContext, t *pfs.Trigger, 
 			commits++
 			if ci.ParentCommit != nil && (oldHead == nil || oldHead.Commit.ID != ci.ParentCommit.ID) {
 				var err error
-				ci, err = d.inspectCommit(txnCtx.Client, ci.ParentCommit, pfs.CommitState_STARTED)
+				ci, err = d.inspectCommit(txnCtx.ClientContext, ci.ParentCommit, pfs.CommitState_STARTED)
 				if err != nil {
 					return false, err
 				}
@@ -182,7 +182,7 @@ func (d *driver) validateTrigger(txnCtx *txnenv.TransactionContext, branch *pfs.
 	if trigger.Commits < 0 {
 		return errors.Errorf("can't trigger on a negative number of commits")
 	}
-	bis, err := d.listBranch(txnCtx.Client, branch.Repo, false)
+	bis, err := d.listBranch(txnCtx.ClientContext, branch.Repo, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In several places in the codebase we pass a pach client around, to propagate a context for calls within a single service. This eliminates this pattern in PFS. This is a first step to make it clearer where we're actually making cross-service calls (and consequently creating nested transactions) so we can migrate those to method calls that propagate a transaction.