### PR TITLE
Fix concurrent transaction usage when authorizing in pps

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -423,7 +423,6 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 		// Check that the user is authorized to read all input repos, and write to the
 		// output repo (which the pipeline needs to be able to do on the user's
 		// behalf)
-		var eg errgroup.Group
 		done := make(map[string]struct{}) // don't double-authorize repos
 		pps.VisitInput(input, func(in *pps.Input) {
 			var repo string
@@ -438,14 +437,9 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 				return
 			}
 			done[repo] = struct{}{}
-			eg.Go(func() error {
-				if err := authServer.CheckRepoIsAuthorizedInTransaction(txnCtx, repo, auth.Permission_REPO_READ); err != nil {
-					return err
-				}
-				return nil
-			})
+			err = authServer.CheckRepoIsAuthorizedInTransaction(txnCtx, repo, auth.Permission_REPO_READ)
 		})
-		if err := eg.Wait(); err != nil {
+		if err != nil {
 			return err
 		}
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -424,9 +424,13 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 		// output repo (which the pipeline needs to be able to do on the user's
 		// behalf)
 		done := make(map[string]struct{}) // don't double-authorize repos
+		err = nil
 		pps.VisitInput(input, func(in *pps.Input) {
-			var repo string
+			if err != nil {
+				return
+			}
 
+			var repo string
 			if in.Pfs != nil {
 				repo = in.Pfs.Repo
 			} else {


### PR DESCRIPTION
Found another place where we use a sqlx.Tx in an unsafe manner.  We may need some sort of locking in the future to ensure this doesn't crop up again.