### PR TITLE
Refactor PPS to not pass pach clients around

### DIFF
--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -67,11 +67,12 @@ func (m *ppsMaster) startMonitor(pipelineInfo *pps.PipelineInfo, ptr *pps.Stored
 	defer m.monitorCancelsMu.Unlock()
 	if _, ok := m.monitorCancels[pipeline]; !ok {
 		m.monitorCancels[pipeline] = m.startMonitorThread(
-			"monitorPipeline for "+pipeline, func(pachClient *client.APIClient) {
+			"monitorPipeline for "+pipeline, func(ctx context.Context) {
 				// monitorPipeline needs auth privileges to call subscribeCommit and
 				// blockCommit
+				pachClient := m.a.env.GetPachClient(ctx)
 				pachClient.SetAuthToken(ptr.AuthToken)
-				m.monitorPipeline(pachClient, pipelineInfo)
+				m.monitorPipeline(pachClient.Ctx(), pipelineInfo)
 			})
 	}
 }
@@ -100,8 +101,8 @@ func (m *ppsMaster) startCrashingMonitor(parallelism uint64, pipelineInfo *pps.P
 	if _, ok := m.crashingMonitorCancels[pipeline]; !ok {
 		m.crashingMonitorCancels[pipeline] = m.startMonitorThread(
 			"monitorCrashingPipeline for "+pipeline,
-			func(pachClient *client.APIClient) {
-				m.monitorCrashingPipeline(pachClient, parallelism, pipelineInfo)
+			func(ctx context.Context) {
+				m.monitorCrashingPipeline(ctx, parallelism, pipelineInfo)
 			})
 	}
 }
@@ -154,11 +155,11 @@ func (m *ppsMaster) cancelAllMonitorsAndCrashingMonitors() {
 // and startPipelinePoller (in poller.go). It doesn't manipulate any of
 // APIServer's fields, just wrapps the passed function in a goroutine, and
 // returns a cancel() fn to cancel it and block until it returns.
-func (m *ppsMaster) startMonitorThread(name string, f func(pachClient *client.APIClient)) func() {
-	ctx, cancel := context.WithCancel(m.masterClient.Ctx())
+func (m *ppsMaster) startMonitorThread(name string, f func(ctx context.Context)) func() {
+	ctx, cancel := context.WithCancel(m.masterCtx)
 	done := make(chan struct{})
 	go func() {
-		f(m.a.env.GetPachClient(ctx))
+		f(ctx)
 		close(done)
 	}()
 	return func() {
@@ -174,7 +175,7 @@ func (m *ppsMaster) startMonitorThread(name string, f func(pachClient *client.AP
 	}
 }
 
-func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) {
+func (m *ppsMaster) monitorPipeline(ctx context.Context, pipelineInfo *pps.PipelineInfo) {
 	pipeline := pipelineInfo.Pipeline.Name
 	log.Printf("PPS master: monitoring pipeline %q", pipeline)
 	var eg errgroup.Group
@@ -182,9 +183,9 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 		if in.Cron != nil {
 			eg.Go(func() error {
 				return backoff.RetryNotify(func() error {
-					return m.makeCronCommits(pachClient, in)
+					return m.makeCronCommits(ctx, in)
 				}, backoff.NewInfiniteBackOff(),
-					backoff.NotifyCtx(pachClient.Ctx(), "cron for "+in.Cron.Name))
+					backoff.NotifyCtx(ctx, "cron for "+in.Cron.Name))
 			})
 		}
 	})
@@ -195,6 +196,7 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 		eg.Go(func() error {
 			defer close(ciChan)
 			return backoff.RetryNotify(func() error {
+				pachClient := m.a.env.GetPachClient(ctx)
 				return pachClient.SubscribeCommit(pipeline, "",
 					client.NewCommitProvenance(ppsconsts.SpecRepo, pipeline, pipelineInfo.SpecCommit.ID),
 					"", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
@@ -202,15 +204,14 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 						return nil
 					})
 			}, backoff.NewInfiniteBackOff(),
-				backoff.NotifyCtx(pachClient.Ctx(), "SubscribeCommit for "+pipeline))
+				backoff.NotifyCtx(ctx, "SubscribeCommit for "+pipeline))
 		})
 		eg.Go(func() error {
 			return backoff.RetryNotify(func() error {
 				var (
-					oldCtx        = pachClient.Ctx()
-					oldPachClient = pachClient
-					childSpan     opentracing.Span
-					ctx           context.Context
+					oldCtx    = ctx
+					childSpan opentracing.Span
+					ctx       context.Context
 				)
 				defer func() {
 					// childSpan is overwritten so wrap in a lambda for late binding
@@ -220,10 +221,7 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 				childSpan, ctx = extended.AddSpanToAnyPipelineTrace(oldCtx,
 					m.a.env.GetEtcdClient(), pipeline,
 					"/pps.Master/MonitorPipeline/Begin")
-				if childSpan != nil {
-					pachClient = oldPachClient.WithCtx(ctx)
-				}
-				if err := m.a.transitionPipelineState(pachClient.Ctx(),
+				if err := m.a.transitionPipelineState(ctx,
 					pipeline,
 					[]pps.PipelineState{
 						pps.PipelineState_PIPELINE_RUNNING,
@@ -260,11 +258,8 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 							m.a.env.GetEtcdClient(), pipeline,
 							"/pps.Master/MonitorPipeline/SpinUp",
 							"commit", ci.Commit.ID)
-						if childSpan != nil {
-							pachClient = oldPachClient.WithCtx(ctx)
-						}
 
-						if err := m.a.transitionPipelineState(pachClient.Ctx(),
+						if err := m.a.transitionPipelineState(ctx,
 							pipeline,
 							[]pps.PipelineState{pps.PipelineState_PIPELINE_STANDBY},
 							pps.PipelineState_PIPELINE_RUNNING, ""); err != nil {
@@ -282,6 +277,7 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 						for {
 							// Wait for the commit to be finished before blocking on the
 							// job because the job may not exist yet.
+							pachClient := m.a.env.GetPachClient(ctx)
 							if _, err := pachClient.BlockCommit(ci.Commit.Branch.Repo.Name, ci.Commit.Branch.Name, ci.Commit.ID); err != nil {
 								return err
 							}
@@ -300,15 +296,12 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 									m.a.env.GetEtcdClient(), pipeline,
 									"/pps.Master/MonitorPipeline/WatchNext",
 									"commit", ci.Commit.ID)
-								if childSpan != nil {
-									pachClient = oldPachClient.WithCtx(ctx)
-								}
 							default:
 								break running
 							}
 						}
 
-						if err := m.a.transitionPipelineState(pachClient.Ctx(),
+						if err := m.a.transitionPipelineState(ctx,
 							pipeline,
 							[]pps.PipelineState{
 								pps.PipelineState_PIPELINE_RUNNING,
@@ -325,12 +318,12 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 							}
 							return err
 						}
-					case <-pachClient.Ctx().Done():
-						return pachClient.Ctx().Err()
+					case <-ctx.Done():
+						return ctx.Err()
 					}
 				}
 			}, backoff.NewInfiniteBackOff(),
-				backoff.NotifyCtx(pachClient.Ctx(), "monitorPipeline for "+pipeline))
+				backoff.NotifyCtx(ctx, "monitorPipeline for "+pipeline))
 		})
 	}
 	if err := eg.Wait(); err != nil {
@@ -338,9 +331,9 @@ func (m *ppsMaster) monitorPipeline(pachClient *client.APIClient, pipelineInfo *
 	}
 }
 
-func (m *ppsMaster) monitorCrashingPipeline(pachClient *client.APIClient, parallelism uint64, pipelineInfo *pps.PipelineInfo) {
+func (m *ppsMaster) monitorCrashingPipeline(ctx context.Context, parallelism uint64, pipelineInfo *pps.PipelineInfo) {
 	pipeline := pipelineInfo.Pipeline.Name
-	ctx, cancelInner := context.WithCancel(pachClient.Ctx())
+	ctx, cancelInner := context.WithCancel(ctx)
 	if parallelism == 0 {
 		parallelism = 1
 	}
@@ -371,11 +364,12 @@ func (m *ppsMaster) monitorCrashingPipeline(pachClient *client.APIClient, parall
 
 // makeCronCommits makes commits to a single cron input's repo. It's
 // a helper function called by monitorPipeline.
-func (m *ppsMaster) makeCronCommits(pachClient *client.APIClient, in *pps.Input) error {
+func (m *ppsMaster) makeCronCommits(ctx context.Context, in *pps.Input) error {
 	schedule, err := cron.ParseStandard(in.Cron.Spec)
 	if err != nil {
 		return err // Shouldn't happen, as the input is validated in CreatePipeline
 	}
+	pachClient := m.a.env.GetPachClient(ctx)
 	// make sure there isn't an unfinished commit on the branch
 	commitInfo, err := pachClient.InspectCommit(in.Cron.Repo, "master", "")
 	if err != nil && !pfsserver.IsNoHeadErr(err) {
@@ -387,7 +381,7 @@ func (m *ppsMaster) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 		}
 	}
 
-	latestTime, err := getLatestCronTime(pachClient, in)
+	latestTime, err := m.getLatestCronTime(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -398,8 +392,8 @@ func (m *ppsMaster) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 		// and wait until then to make the next commit
 		select {
 		case <-time.After(time.Until(next)):
-		case <-pachClient.Ctx().Done():
-			return pachClient.Ctx().Err()
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 		if err != nil {
 			return err
@@ -437,8 +431,9 @@ func (m *ppsMaster) makeCronCommits(pachClient *client.APIClient, in *pps.Input)
 // 'in's most recently executed cron tick was and returns it (or, if no cron
 // ticks are in 'in's cron repo, it retuns the 'Start' time set in 'in.Cron'
 // (typically set by 'pachctl extract')
-func getLatestCronTime(pachClient *client.APIClient, in *pps.Input) (time.Time, error) {
+func (m *ppsMaster) getLatestCronTime(ctx context.Context, in *pps.Input) (time.Time, error) {
 	var latestTime time.Time
+	pachClient := m.a.env.GetPachClient(ctx)
 	files, err := pachClient.ListFileAll(in.Cron.Repo, "master", "", "")
 	if err != nil && !pfsserver.IsNoHeadErr(err) {
 		return latestTime, err

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -49,7 +49,7 @@ type pipelineOp struct {
 	m *ppsMaster
 	// a pachyderm client wrapping this operation's context (child of the PPS
 	// master's context, and cancelled at the end of step())
-	opClient     *client.APIClient
+	ctx          context.Context
 	ptr          *pps.StoredPipelineInfo
 	pipelineInfo *pps.PipelineInfo
 	rc           *v1.ReplicationController
@@ -70,10 +70,10 @@ func (m *ppsMaster) step(pipeline string, keyVer, keyRev int64) (retErr error) {
 	log.Infof("PPS master: processing event for %q", pipeline)
 
 	// Initialize op ctx (cancelled at the end of step(), to avoid leaking
-	// resources). op.opClient wraps opCtx, whereas masterClient is passed by the
+	// resources), whereas masterClient is passed by the
 	// PPS master and used in case a monitor needs to be spawned for 'pipeline',
 	// whose lifetime is tied to the master rather than this op.
-	opCtx, cancel := context.WithCancel(m.masterClient.Ctx())
+	opCtx, cancel := context.WithCancel(m.masterCtx)
 	defer cancel()
 
 	// Handle tracing
@@ -89,7 +89,7 @@ func (m *ppsMaster) step(pipeline string, keyVer, keyRev int64) (retErr error) {
 	}()
 
 	// Retrieve pipelineInfo from the spec repo
-	op, err := m.newPipelineOp(m.masterClient.WithCtx(opCtx), pipeline)
+	op, err := m.newPipelineOp(opCtx, pipeline)
 	if err != nil {
 		// fail immediately without retry
 		return stepError{
@@ -108,19 +108,19 @@ func (m *ppsMaster) step(pipeline string, keyVer, keyRev int64) (retErr error) {
 	return op.run()
 }
 
-func (m *ppsMaster) newPipelineOp(opClient *client.APIClient, pipeline string) (*pipelineOp, error) {
+func (m *ppsMaster) newPipelineOp(ctx context.Context, pipeline string) (*pipelineOp, error) {
 	op := &pipelineOp{
-		m:        m,
-		opClient: opClient,
-		ptr:      &pps.StoredPipelineInfo{},
+		m:   m,
+		ctx: ctx,
+		ptr: &pps.StoredPipelineInfo{},
 	}
 	// get latest StoredPipelineInfo (events can pile up, so that the current state
 	// doesn't match the event being processed)
-	if err := m.a.pipelines.ReadOnly(opClient.Ctx()).Get(pipeline, op.ptr); err != nil {
+	if err := m.a.pipelines.ReadOnly(ctx).Get(pipeline, op.ptr); err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve etcd pipeline info for %q", pipeline)
 	}
 	// Update trace with any new pipeline info from getPipelineInfo()
-	tracing.TagAnySpan(opClient.Ctx(),
+	tracing.TagAnySpan(ctx,
 		"current-state", op.ptr.State.String(),
 		"spec-commit", pretty.CompactPrintCommitSafe(op.ptr.SpecCommit))
 	// set op.pipelineInfo
@@ -236,7 +236,7 @@ func (op *pipelineOp) run() error {
 // should be one of the first calls made on 'op', as most other methods (e.g.
 // getRC, though not failPipeline) assume that op.pipelineInfo is set.
 func (op *pipelineOp) getPipelineInfo() error {
-	err := op.m.a.sudo(op.opClient, func(superUserClient *client.APIClient) error {
+	err := op.m.a.sudo(op.ctx, func(superUserClient *client.APIClient) error {
 		var err error
 		op.pipelineInfo, err = ppsutil.GetPipelineInfo(superUserClient, op.ptr)
 		return err
@@ -260,7 +260,7 @@ func (op *pipelineOp) getPipelineInfo() error {
 // redundant), and then returns an error to the caller to indicate that the
 // caller shouldn't continue with other operations
 func (op *pipelineOp) getRC(expectation rcExpectation) (retErr error) {
-	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
+	span, _ := tracing.AddSpanToAnyExisting(op.ctx,
 		"/pps.Master/GetRC", "pipeline", op.ptr.Pipeline.Name)
 	defer func(span opentracing.Span) {
 		tracing.TagAnySpan(span, "err", fmt.Sprintf("%v", retErr))
@@ -377,7 +377,7 @@ func (op *pipelineOp) rcIsFresh() bool {
 // setPipelineState set's op's state in etcd to 'state'. This will trigger an
 // etcd watch event and cause step() to eventually run again.
 func (op *pipelineOp) setPipelineState(state pps.PipelineState, reason string) error {
-	if err := op.m.a.setPipelineState(op.opClient.Ctx(),
+	if err := op.m.a.setPipelineState(op.ctx,
 		op.ptr.Pipeline.Name, state, reason); err != nil {
 		// don't bother failing if we can't set the state
 		return stepError{
@@ -392,7 +392,7 @@ func (op *pipelineOp) setPipelineState(state pps.PipelineState, reason string) e
 // createPipelineResources creates the RC and any services for op's pipeline.
 func (op *pipelineOp) createPipelineResources() error {
 	log.Infof("PPS master: creating resources for pipeline %q", op.ptr.Pipeline.Name)
-	if err := op.m.a.createWorkerSvcAndRc(op.opClient.Ctx(), op.ptr, op.pipelineInfo); err != nil {
+	if err := op.m.a.createWorkerSvcAndRc(op.ctx, op.ptr, op.pipelineInfo); err != nil {
 		if errors.As(err, &noValidOptionsErr{}) {
 			// these errors indicate invalid pipelineInfo, don't retry
 			return stepError{
@@ -441,16 +441,14 @@ func (op *pipelineOp) stopCrashingPipelineMonitor() {
 func (op *pipelineOp) finishPipelineOutputCommits() (retErr error) {
 	log.Infof("PPS master: finishing output commits for pipeline %q", op.ptr.Pipeline.Name)
 
-	var pachClient *client.APIClient
-	if span, _ctx := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
+	pachClient := op.m.a.env.GetPachClient(op.ctx)
+	if span, _ctx := tracing.AddSpanToAnyExisting(op.ctx,
 		"/pps.Master/FinishPipelineOutputCommits", "pipeline", op.ptr.Pipeline.Name); span != nil {
-		pachClient = op.opClient.WithCtx(_ctx) // copy span back into pachClient
+		pachClient = pachClient.WithCtx(_ctx) // copy span back into pachClient
 		defer func() {
 			tracing.TagAnySpan(span, "err", fmt.Sprintf("%v", retErr))
 			tracing.FinishAnySpan(span)
 		}()
-	} else {
-		pachClient = op.opClient
 	}
 	pachClient.SetAuthToken(op.ptr.AuthToken)
 
@@ -499,7 +497,7 @@ func (op *pipelineOp) updateRC(update func(rc *v1.ReplicationController)) error 
 // configured number of workers.
 func (op *pipelineOp) scaleUpPipeline() (retErr error) {
 	log.Infof("PPS master: scaling up workers for %q", op.ptr.Pipeline.Name)
-	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
+	span, _ := tracing.AddSpanToAnyExisting(op.ctx,
 		"/pps.Master/ScaleUpPipeline", "pipeline", op.ptr.Pipeline.Name)
 	defer func() {
 		if retErr != nil {
@@ -530,7 +528,7 @@ func (op *pipelineOp) scaleUpPipeline() (retErr error) {
 // configured number of workers.
 func (op *pipelineOp) scaleDownPipeline() (retErr error) {
 	log.Infof("PPS master: scaling down workers for %q", op.ptr.Pipeline.Name)
-	span, _ := tracing.AddSpanToAnyExisting(op.opClient.Ctx(),
+	span, _ := tracing.AddSpanToAnyExisting(op.ctx,
 		"/pps.Master/ScaleDownPipeline", "pipeline", op.ptr.Pipeline.Name)
 	defer func() {
 		if retErr != nil {

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -60,7 +60,7 @@ func (a *apiServer) ServeSidecarS3G() {
 	if err := backoff.RetryNotify(func() error {
 		retryCtx, retryCancel := context.WithCancel(context.Background())
 		defer retryCancel()
-		if err := a.sudo(s.pachClient.WithCtx(retryCtx), func(superUserClient *client.APIClient) error {
+		if err := a.sudo(retryCtx, func(superUserClient *client.APIClient) error {
 			buf := bytes.Buffer{}
 			if err := superUserClient.GetFile(ppsconsts.SpecRepo, "", specCommit, ppsconsts.SpecFile, &buf); err != nil {
 				return errors.Wrapf(err, "could not read existing PipelineInfo from PFS")


### PR DESCRIPTION
Follow up to https://github.com/pachyderm/pachyderm/pull/6140 but for PPS.

Eliminates internal methods that accept pach client in favour of passing around a ctx and creating a client only where needed. The next step is to replace these RPCs with internal method calls.