### PR TITLE
Fix broken worker pachClient auth in postgres integration branch

### DIFF
--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -12,7 +12,9 @@ import (
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
 
 	etcd "github.com/coreos/etcd/clientv3"
 	dex_storage "github.com/dexidp/dex/storage"
@@ -182,11 +184,24 @@ func (env *NonblockingServiceEnv) initPachClient() error {
 	}
 	// Initialize pach client
 	return backoff.Retry(func() error {
-		var err error
-		env.pachClient, err = client.NewFromURI(env.pachAddress)
+		pachClient, err := client.NewFromURI(env.pachAddress)
 		if err != nil {
 			return errors.Wrapf(err, "failed to initialize pach client")
 		}
+		if config := env.Config().WorkerSpecificConfiguration; config != nil {
+			// This is running in a pipeline, load the auth token from the
+			// PipelineInfo and set the client auth.
+			// Add a timeout in case fetching the StoredPipelineInfo hangs
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			pipelines := ppsdb.Pipelines(env.GetDBClient(), env.GetPostgresListener())
+			storedPipelineInfo := &pps.StoredPipelineInfo{}
+			if err := pipelines.ReadOnly(ctx).Get(config.PPSPipelineName, storedPipelineInfo); err != nil {
+				return err
+			}
+			pachClient.SetAuthToken(storedPipelineInfo.AuthToken)
+		}
+		env.pachClient = pachClient
 		return nil
 	}, backoff.RetryEvery(time.Second).For(5*time.Minute))
 }

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -59,7 +59,6 @@ func getPipelineInfo(pachClient *client.APIClient, env serviceenv.ServiceEnv) (*
 	if err := pipelines.ReadOnly(ctx).Get(env.Config().PPSPipelineName, pipelinePtr); err != nil {
 		return nil, err
 	}
-	pachClient.SetAuthToken(pipelinePtr.AuthToken)
 	// Notice we use the SpecCommitID from our env, not from etcd. This is
 	// because the value in etcd might get updated while the worker pod is
 	// being created and we don't want to run the transform of one version of
@@ -75,7 +74,7 @@ func do(config interface{}) error {
 
 	// Construct a client that connects to the sidecar.
 	pachClient := env.GetPachClient(context.Background())
-	pipelineInfo, err := getPipelineInfo(pachClient, env) // get pipeline creds for pachClient
+	pipelineInfo, err := getPipelineInfo(pachClient, env)
 	if err != nil {
 		return errors.Wrapf(err, "error getting pipelineInfo")
 	}

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -95,7 +95,6 @@ func do(config interface{}) error {
 
 	workerserver.RegisterWorkerServer(server.Server, workerInstance.APIServer)
 	versionpb.RegisterAPIServer(server.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
-	// TODO: why do we pass down the pachClient here?  shouldn't we let it use the one from env that will inherit credentials from any RPCs?
 	debugclient.RegisterDebugServer(server.Server, debugserver.NewDebugServer(env, env.Config().PodName, pachClient))
 
 	// Put our IP address into etcd, so pachd can discover us

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -99,6 +99,7 @@ type Driver interface {
 type driver struct {
 	env             serviceenv.ServiceEnv
 	ctx             context.Context
+	pachClient      *client.APIClient
 	pipelineInfo    *pps.PipelineInfo
 	activeDataMutex *sync.Mutex
 
@@ -125,6 +126,7 @@ type driver struct {
 // enterprise features are activated (for exporting stats).
 func NewDriver(
 	env serviceenv.ServiceEnv,
+	pachClient *client.APIClient,
 	pipelineInfo *pps.PipelineInfo,
 	rootPath string,
 ) (Driver, error) {
@@ -137,6 +139,7 @@ func NewDriver(
 	result := &driver{
 		env:             env,
 		ctx:             env.Context(),
+		pachClient:      pachClient,
 		pipelineInfo:    pipelineInfo,
 		activeDataMutex: &sync.Mutex{},
 		jobs:            jobs,
@@ -293,7 +296,7 @@ func (d *driver) InputDir() string {
 }
 
 func (d *driver) PachClient() *client.APIClient {
-	return d.env.GetPachClient(d.ctx)
+	return d.pachClient
 }
 
 func (d *driver) NewSQLTx(cb func(*sqlx.Tx) error) error {

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -129,6 +129,7 @@ func newTestEnv(t *testing.T, dbConfig serviceenv.ConfigOption, pipelineInfo *pp
 	workerDir := filepath.Join(realEnv.Directory, "worker")
 	driver, err := driver.NewDriver(
 		realEnv.ServiceEnv,
+		realEnv.PachClient,
 		pipelineInfo,
 		workerDir,
 	)

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dlock"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -46,6 +47,7 @@ type Worker struct {
 //  4. a driver that provides common functionality between the above components
 func NewWorker(
 	env serviceenv.ServiceEnv,
+	pachClient *client.APIClient,
 	pipelineInfo *pps.PipelineInfo,
 	rootPath string,
 ) (*Worker, error) {
@@ -58,6 +60,7 @@ func NewWorker(
 
 	driver, err := driver.NewDriver(
 		env,
+		pachClient,
 		pipelineInfo,
 		rootPath,
 	)


### PR DESCRIPTION
I had changed the worker driver to get its PachClient straight from the `ServiceEnv`.  This has made a lot of tests very angry and has been widely regarded as a bad move.  Revert it so that the credentialed client in `worker/main.go` is passed down and reused in the driver.