### PR TITLE
Add commit sizes to InspectCommit

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -150,25 +150,24 @@ func TestRepoSize(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(commitInfos))
 
-	// TODO(2.0 required): fix commit sizes
-	// // check data repo size
-	// repoInfo, err := c.InspectRepo(dataRepo)
-	// require.NoError(t, err)
-	// require.Equal(t, uint64(6), repoInfo.SizeBytes)
+	// check data repo size
+	repoInfo, err := c.InspectRepo(dataRepo)
+	require.NoError(t, err)
+	require.Equal(t, uint64(6), repoInfo.SizeBytes)
 
-	// // check pipeline repo size
-	// repoInfo, err = c.InspectRepo(pipeline)
-	// require.NoError(t, err)
-	// require.Equal(t, uint64(6), repoInfo.SizeBytes)
+	// check pipeline repo size
+	repoInfo, err = c.InspectRepo(pipeline)
+	require.NoError(t, err)
+	require.Equal(t, uint64(6), repoInfo.SizeBytes)
 
-	// // ensure size is updated when we delete a commit
-	// require.NoError(t, c.SquashCommit(dataRepo, commit1.Branch.Name, commit1.ID))
-	// repoInfo, err = c.InspectRepo(dataRepo)
-	// require.NoError(t, err)
-	// require.Equal(t, uint64(3), repoInfo.SizeBytes)
-	// repoInfo, err = c.InspectRepo(pipeline)
-	// require.NoError(t, err)
-	// require.Equal(t, uint64(3), repoInfo.SizeBytes)
+	// ensure size is updated when we delete a commit
+	require.NoError(t, c.SquashCommit(dataRepo, commit1.Branch.Name, commit1.ID))
+	repoInfo, err = c.InspectRepo(dataRepo)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), repoInfo.SizeBytes)
+	repoInfo, err = c.InspectRepo(pipeline)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), repoInfo.SizeBytes)
 }
 
 func TestPFSPipeline(t *testing.T) {

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -108,6 +108,11 @@ func (a *apiServer) InspectRepo(ctx context.Context, request *pfs.InspectRepoReq
 	if err != nil {
 		return nil, err
 	}
+	size, err := a.driver.getRepoSize(ctx, info.Repo)
+	if err != nil {
+		return nil, err
+	}
+	info.SizeBytes = uint64(size)
 	return info, nil
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -866,7 +866,6 @@ func (d *driver) writeFinishedCommit(sqlTx *sqlx.Tx, commit *pfs.Commit, commitI
 }
 
 func (d *driver) getRepoSize(ctx context.Context, repo *pfs.Repo) (int64, error) {
-	// update the repo size if this is the head of master
 	repoInfo := new(pfs.RepoInfo)
 	if err := d.repos.ReadOnly(ctx).Get(pfsdb.RepoKey(repo), repoInfo); err != nil {
 		return 0, err

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -256,16 +256,10 @@ func (d *driver) inspectRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, 
 	if repo == nil {
 		return nil, errors.New("repo cannot be nil")
 	}
-
 	result := &pfs.RepoInfo{}
 	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(pfsdb.RepoKey(repo), result); err != nil {
 		return nil, err
 	}
-	size, err := d.getRepoSize(txnCtx.ClientContext, repo)
-	if err != nil {
-		return nil, err
-	}
-	result.SizeBytes = uint64(size)
 	if includeAuth {
 		permissions, roles, err := d.getPermissions(txnCtx.ClientContext, repo)
 		if err != nil {

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -490,3 +490,12 @@ func (d *driver) getOrComputeTotal(ctx context.Context, commit *pfs.Commit) (*fi
 	}
 	return d.commitStore.GetTotalFileset(ctx, commit)
 }
+
+// sizeOfCommit gets the size of a commit.
+func (d *driver) sizeOfCommit(ctx context.Context, commit *pfs.Commit) (int64, error) {
+	fsid, err := d.getFileset(ctx, commit)
+	if err != nil {
+		return 0, err
+	}
+	return d.storage.SizeOf(ctx, *fsid)
+}

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -612,8 +612,7 @@ func TestPFS(suite *testing.T) {
 
 		require.Equal(t, commit, commitInfo.Commit)
 		require.NotNil(t, commitInfo.Finished)
-		// TODO (2.0 required)
-		// require.Equal(t, len(fileContent), int(commitInfo.SizeBytes))
+		require.Equal(t, len(fileContent), int(commitInfo.SizeBytes))
 		require.True(t, started.Before(tStarted))
 		require.True(t, finished.After(tFinished))
 	})
@@ -2260,18 +2259,17 @@ func TestPFS(suite *testing.T) {
 
 		require.NoError(t, env.PachClient.FinishCommit(repo, commit.Branch.Name, commit.ID))
 
-		_, err = env.PachClient.InspectRepo(repo)
+		info, err := env.PachClient.InspectRepo(repo)
 		require.NoError(t, err)
 
-		// TODO (2.0 required)
-		// require.Equal(t, int(info.SizeBytes), totalSize)
+		require.Equal(t, totalSize, int(info.SizeBytes))
 
-		// infos, err := env.PachClient.ListRepo()
-		// require.NoError(t, err)
-		// require.Equal(t, 1, len(infos))
-		// info = infos[0]
+		infos, err := env.PachClient.ListRepo()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(infos))
+		info = infos[0]
 
-		// require.Equal(t, int(info.SizeBytes), totalSize)
+		require.Equal(t, totalSize, int(info.SizeBytes))
 	})
 
 	suite.Run("Create", func(t *testing.T) {


### PR DESCRIPTION
- Commit sizes were temporarily removed when compaction was moved to read time.  This adds them back and re-enables the checks in the tests.
- Repo size is retrieved from the commit at read time rather than stored with the repo info in the repo collection.