### PR TITLE
Allow VisitInput to bubble up an error.

### DIFF
--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -437,13 +437,15 @@ func GetStatsCommit(commitInfo *pfs.CommitInfo) *pfs.Commit {
 // ContainsS3Inputs returns 'true' if 'in' is or contains any PFS inputs with
 // 'S3' set to true. Any pipelines with s3 inputs lj
 func ContainsS3Inputs(in *pps.Input) bool {
-	foundErr := pps.VisitInput(in, func(in *pps.Input) error {
+	var found bool
+	pps.VisitInput(in, func(in *pps.Input) error {
 		if in.Pfs != nil && in.Pfs.S3 {
+			found = true
 			return errutil.ErrBreak
 		}
 		return nil
 	})
-	return foundErr != nil
+	return found
 }
 
 // SidecarS3GatewayService returns the name of the kubernetes service created

--- a/src/pps/util.go
+++ b/src/pps/util.go
@@ -32,28 +32,26 @@ func init() {
 }
 
 // VisitInput visits each input recursively in ascending order (root last)
-func VisitInput(input *Input, f func(*Input)) {
+func VisitInput(input *Input, f func(*Input) error) error {
+	var source []*Input
 	switch {
 	case input == nil:
-		return // Spouts may have nil input
+		return nil // Spouts may have nil input
 	case input.Cross != nil:
-		for _, input := range input.Cross {
-			VisitInput(input, f)
-		}
+		source = input.Cross
 	case input.Join != nil:
-		for _, input := range input.Join {
-			VisitInput(input, f)
-		}
+		source = input.Join
 	case input.Group != nil:
-		for _, input := range input.Group {
-			VisitInput(input, f)
-		}
+		source = input.Group
 	case input.Union != nil:
-		for _, input := range input.Union {
-			VisitInput(input, f)
+		source = input.Union
+	}
+	for _, input := range source {
+		if err := VisitInput(input, f); err != nil {
+			return err
 		}
 	}
-	f(input)
+	return f(input)
 }
 
 // InputName computes the name of an Input.
@@ -85,7 +83,7 @@ func InputName(input *Input) string {
 
 // SortInput sorts an Input.
 func SortInput(input *Input) {
-	VisitInput(input, func(input *Input) {
+	VisitInput(input, func(input *Input) error {
 		SortInputs := func(inputs []*Input) {
 			sort.SliceStable(inputs, func(i, j int) bool { return InputName(inputs[i]) < InputName(inputs[j]) })
 		}
@@ -99,13 +97,14 @@ func SortInput(input *Input) {
 		case input.Union != nil:
 			SortInputs(input.Union)
 		}
+		return nil
 	})
 }
 
 // InputBranches returns the branches in an Input.
 func InputBranches(input *Input) []*pfs.Branch {
 	var result []*pfs.Branch
-	VisitInput(input, func(input *Input) {
+	VisitInput(input, func(input *Input) error {
 		if input.Pfs != nil {
 			result = append(result, &pfs.Branch{
 				Repo: &pfs.Repo{
@@ -133,6 +132,7 @@ func InputBranches(input *Input) []*pfs.Branch {
 				Name: input.Git.Branch,
 			})
 		}
+		return nil
 	})
 	return result
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -8340,17 +8340,15 @@ func TestSquashCommitRunsJob(t *testing.T) {
 			if len(pipelineJobInfos) != 1 {
 				return errors.Errorf("Expected one job, but got %d: %v", len(pipelineJobInfos), pipelineJobInfos)
 			}
-			pps.VisitInput(pipelineJobInfos[0].Input, func(input *pps.Input) {
+			return pps.VisitInput(pipelineJobInfos[0].Input, func(input *pps.Input) error {
 				if input.Pfs == nil {
-					err = errors.Errorf("expected a single PFS input, but got: %v", pipelineJobInfos[0].Input)
-					return
+					return errors.Errorf("expected a single PFS input, but got: %v", pipelineJobInfos[0].Input)
 				}
 				if input.Pfs.Commit != commit2.ID {
-					err = errors.Errorf("expected job to process %s, but instead processed: %s", commit2.ID, pipelineJobInfos[0].Input)
-					return
+					return errors.Errorf("expected job to process %s, but instead processed: %s", commit2.ID, pipelineJobInfos[0].Input)
 				}
+				return nil
 			})
-			return err
 		}, backoff.NewTestingBackOff())
 	})
 
@@ -8369,17 +8367,15 @@ func TestSquashCommitRunsJob(t *testing.T) {
 			if len(pipelineJobInfos) != 1 {
 				return errors.Errorf("Expected one job, but got %d: %v", len(pipelineJobInfos), pipelineJobInfos)
 			}
-			pps.VisitInput(pipelineJobInfos[0].Input, func(input *pps.Input) {
+			return pps.VisitInput(pipelineJobInfos[0].Input, func(input *pps.Input) error {
 				if input.Pfs == nil {
-					err = errors.Errorf("expected a single PFS input, but got: %v", pipelineJobInfos[0].Input)
-					return
+					return errors.Errorf("expected a single PFS input, but got: %v", pipelineJobInfos[0].Input)
 				}
 				if input.Pfs.Commit != commit1.ID {
-					err = errors.Errorf("expected job to process %s, but instead processed: %s", commit1.ID, pipelineJobInfos[0].Input)
-					return
+					return errors.Errorf("expected job to process %s, but instead processed: %s", commit1.ID, pipelineJobInfos[0].Input)
 				}
+				return nil
 			})
-			return err
 		}, backoff.NewTestingBackOff())
 	})
 
@@ -8983,10 +8979,11 @@ func TestDeferredCross(t *testing.T) {
 	headCommit, err := c.InspectCommit(dataSet, "master", "")
 	require.NoError(t, err)
 
-	pps.VisitInput(pipelineJobInfo.Input, func(i *pps.Input) {
+	pps.VisitInput(pipelineJobInfo.Input, func(i *pps.Input) error {
 		if i.Pfs != nil && i.Pfs.Repo == dataSet {
 			require.Equal(t, i.Pfs.Commit, headCommit.Commit.ID)
 		}
+		return nil
 	})
 }
 

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -1047,14 +1047,13 @@ func pipelineHelper(reprocess bool, build bool, pushImages bool, registry, usern
 			if request.Transform.Build.Language != "" && request.Transform.Build.Image != "" {
 				return errors.New("cannot specify both a build `language` and `image`")
 			}
-			var err error
-			ppsclient.VisitInput(request.Input, func(input *ppsclient.Input) {
+			if err := ppsclient.VisitInput(request.Input, func(input *ppsclient.Input) error {
 				inputName := ppsclient.InputName(input)
 				if inputName == "build" || inputName == "source" {
-					err = errors.New("build step-enabled pipelines cannot have inputs with the name 'build' or 'source', as they are reserved for build assets")
+					return errors.New("build step-enabled pipelines cannot have inputs with the name 'build' or 'source', as they are reserved for build assets")
 				}
-			})
-			if err != nil {
+				return nil
+			}); err != nil {
 				return err
 			}
 			pipelineParentPath, _ := filepath.Split(pipelinePath)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2463,12 +2463,15 @@ func (a *apiServer) inspectPipelineInTransaction(txnCtx *txncontext.TransactionC
 			pipelineInfo.Service.IP = service.Spec.ClusterIP
 		}
 	}
-	if hasGitInput := pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) error {
+	var hasGitInput bool
+	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) error {
 		if input.Git != nil {
+			hasGitInput = true
 			return errutil.ErrBreak
 		}
 		return nil
-	}); hasGitInput != nil {
+	})
+	if hasGitInput {
 		pipelineInfo.GithookURL = "pending"
 		svc, err := getGithookService(kubeClient, a.namespace)
 		if err != nil {

--- a/src/server/pps/server/githook/githook.go
+++ b/src/server/pps/server/githook/githook.go
@@ -108,12 +108,13 @@ func (s *gitHookServer) findMatchingPipelineInputs(payload github.PushPayload) (
 		return nil, nil, err
 	}
 	for _, pipelineInfo := range pipelines {
-		pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {
+		pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) error {
 			if input.Git != nil {
 				if input.Git.URL == payload.Repository.CloneURL && matchingBranch(input.Git.Branch, payloadBranch) {
 					inputs = append(inputs, input.Git)
 				}
 			}
+			return nil
 		})
 	}
 	if len(inputs) == 0 {

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -179,7 +179,7 @@ func (m *ppsMaster) monitorPipeline(ctx context.Context, pipelineInfo *pps.Pipel
 	pipeline := pipelineInfo.Pipeline.Name
 	log.Printf("PPS master: monitoring pipeline %q", pipeline)
 	var eg errgroup.Group
-	pps.VisitInput(pipelineInfo.Input, func(in *pps.Input) {
+	pps.VisitInput(pipelineInfo.Input, func(in *pps.Input) error {
 		if in.Cron != nil {
 			eg.Go(func() error {
 				return backoff.RetryNotify(func() error {
@@ -188,6 +188,7 @@ func (m *ppsMaster) monitorPipeline(ctx context.Context, pipelineInfo *pps.Pipel
 					backoff.NotifyCtx(ctx, "cron for "+in.Cron.Name))
 			})
 		}
+		return nil
 	})
 	if pipelineInfo.Standby {
 		// Capacity 1 gives us a bit of buffer so we don't needlessly go into

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -186,7 +186,7 @@ func (s *s3InstanceCreatingJobHandler) OnCreate(ctx context.Context, pipelineJob
 
 	// Initialize new S3 gateway
 	var inputBuckets []*s3.Bucket
-	pps.VisitInput(pipelineJobInfo.Input, func(in *pps.Input) {
+	pps.VisitInput(pipelineJobInfo.Input, func(in *pps.Input) error {
 		if in.Pfs != nil && in.Pfs.S3 {
 			inputBuckets = append(inputBuckets, &s3.Bucket{
 				Repo:   in.Pfs.Repo,
@@ -195,6 +195,7 @@ func (s *s3InstanceCreatingJobHandler) OnCreate(ctx context.Context, pipelineJob
 				Name:   in.Pfs.Name,
 			})
 		}
+		return nil
 	})
 	var outputBucket *s3.Bucket
 	if s.s.pipelineInfo.S3Out {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -794,12 +794,15 @@ func (a *apiServer) createWorkerSvcAndRc(ctx context.Context, ptr *pps.StoredPip
 		}
 	}
 
-	if hasGitErr := pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) error {
+	var hasGitInput bool
+	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) error {
 		if input.Git != nil {
+			hasGitInput = true
 			return errutil.ErrBreak
 		}
 		return nil
-	}); hasGitErr != nil {
+	})
+	if hasGitInput {
 		return a.checkOrDeployGithookService()
 	}
 	return nil

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/deploy/assets"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
@@ -793,17 +794,13 @@ func (a *apiServer) createWorkerSvcAndRc(ctx context.Context, ptr *pps.StoredPip
 		}
 	}
 
-	// True if the pipeline has a git input
-	var hasGitInput bool
-	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {
+	if hasGitErr := pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) error {
 		if input.Git != nil {
-			hasGitInput = true
+			return errutil.ErrBreak
 		}
-	})
-	if hasGitInput {
-		if err := a.checkOrDeployGithookService(); err != nil {
-			return err
-		}
+		return nil
+	}); hasGitErr != nil {
+		return a.checkOrDeployGithookService()
 	}
 	return nil
 }


### PR DESCRIPTION
This caused a problem in create pipeline where continuing past an error
in a transaction led to an expected postgres error code. This
functionality is hacked on in variously awkward ways across our
codebase, anyway, so probably worth doing.