### PR TITLE
Fixing server_test.go#TestPanicOnNilArgs and removing Redundant auth validations on DeleteRepoInTransaction()

### DIFF
--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -1469,7 +1469,7 @@ func TestDeleteAll(t *testing.T) {
 	alice := robot(tu.UniqueString("alice"))
 	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
 
-	// alice creates a repo
+	// admin creates a repo
 	repo := tu.UniqueString(t.Name())
 	require.NoError(t, adminClient.CreateRepo(repo))
 
@@ -1493,6 +1493,37 @@ func TestDeleteAll(t *testing.T) {
 
 	// admin calls DeleteAll and succeeds
 	require.NoError(t, adminClient.DeleteAll())
+}
+
+// TestDeleteAllRepos tests that when you delete all repos,
+// only the repos you are authorized to delete are deleted
+func TestDeleteAllRepos(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+
+	alice := robot(tu.UniqueString("alice"))
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+
+	// admin creates a repo
+	adminRepo := tu.UniqueString(t.Name())
+	require.NoError(t, adminClient.CreateRepo(adminRepo))
+
+	// alice creates a repo
+	aliceRepo := tu.UniqueString(t.Name())
+	require.NoError(t, aliceClient.CreateRepo(aliceRepo))
+
+	// alice calls DeleteAll. It passes, but only deletes the repos she was authorized to delete
+	_, err := aliceClient.PfsAPIClient.DeleteRepo(aliceClient.Ctx(), &pfs.DeleteRepoRequest{All: true})
+	require.NoError(t, err)
+
+	listResp, err := aliceClient.ListRepo()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(listResp))
+	require.Equal(t, adminRepo, listResp[0].Repo.Name)
 }
 
 // TestListDatum tests that you must have READER access to all of job's

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5936,7 +5936,6 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("TestPanicOnNilArgs", func(t *testing.T) {
 		// TODO(2.0 required): Add validation to all PFS endpoints.
-		t.Skip("PFS endpoints are not fully validated in V2")
 		t.Parallel()
 		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
 		c := env.PachClient

--- a/src/server/pfs/server/val_server.go
+++ b/src/server/pfs/server/val_server.go
@@ -27,13 +27,8 @@ func newValidatedAPIServer(embeddedServer *apiServer, env serviceenv.ServiceEnv)
 // DeleteRepoInTransaction is identical to DeleteRepo except that it can run
 // inside an existing etcd STM transaction.  This is not an RPC.
 func (a *validatedAPIServer) DeleteRepoInTransaction(txnCtx *txncontext.TransactionContext, request *pfs.DeleteRepoRequest) error {
-	// TODO(2.0 required): How should auth be applied when using all?
-	if !request.All {
-		repo := request.Repo
-		// Check if the caller is authorized to delete this repo
-		if err := a.env.AuthServer().CheckRepoIsAuthorizedInTransaction(txnCtx, repo.Name, auth.Permission_REPO_DELETE); err != nil {
-			return err
-		}
+	if request.Repo == nil && !request.All {
+		return errors.New("either specify a repo to be deleted or request all repos to be deleted")
 	}
 	return a.apiServer.DeleteRepoInTransaction(txnCtx, request)
 }
@@ -149,6 +144,23 @@ func (a *validatedAPIServer) ClearCommit(ctx context.Context, req *pfs.ClearComm
 		return nil, err
 	}
 	return a.apiServer.ClearCommit(ctx, req)
+}
+
+func (a *validatedAPIServer) InspectCommit(ctx context.Context, req *pfs.InspectCommitRequest) (response *pfs.CommitInfo, retErr error) {
+	if req.Commit == nil {
+		return nil, errors.New("commit cannot be nil")
+	}
+	return a.apiServer.InspectCommit(ctx, req)
+}
+
+func (a *validatedAPIServer) GetFile(request *pfs.GetFileRequest, server pfs.API_GetFileServer) error {
+	if request.File == nil {
+		return errors.New("file cannot be nil")
+	}
+	if err := a.env.AuthServer().CheckRepoIsAuthorized(server.Context(), request.File.Commit.Branch.Repo.Name, auth.Permission_REPO_INSPECT_FILE); err != nil {
+		return err
+	}
+	return a.apiServer.GetFile(request, server)
 }
 
 func validateFile(file *pfs.File) error {


### PR DESCRIPTION
Included in this PR:
- Fixing Skipped test, `server_test.go#TestPanicOnNilArgs`
- Removing redundant auth validation in `val_server.go#DeleteRepoInTransaction`
- Adding Auth test to verify the Delete All Repos functionality