### PR TITLE
Adding --enterprise flag to 'pachctl enterprise get-state' & 'pachctl version'

### DIFF
--- a/src/server/enterprise/cmds/cmds.go
+++ b/src/server/enterprise/cmds/cmds.go
@@ -223,13 +223,14 @@ func RegisterCmd() *cobra.Command {
 // publicly-accessible to accessible only by the owner, who can subsequently add
 // users
 func GetStateCmd() *cobra.Command {
+	var isEnterprise bool
 	getState := &cobra.Command{
 		Short: "Check whether the Pachyderm cluster has enterprise features " +
 			"activated",
 		Long: "Check whether the Pachyderm cluster has enterprise features " +
 			"activated",
 		Run: cmdutil.Run(func(args []string) error {
-			c, err := client.NewOnUserMachine("user")
+			c, err := newClient(isEnterprise)
 			if err != nil {
 				return errors.Wrapf(err, "could not connect")
 			}
@@ -252,6 +253,7 @@ func GetStateCmd() *cobra.Command {
 			return nil
 		}),
 	}
+	getState.PersistentFlags().BoolVar(&isEnterprise, "enterprise", false, "Activate auth on the active enterprise context")
 	return cmdutil.CreateAlias(getState, "enterprise get-state")
 }
 


### PR DESCRIPTION
Adding an enterprise flag to both these commands allows for a more ergonomic retrieval of version and license information from the enterprise server.