### PR TITLE
Adding 'E' marker to active enterprise context in 'pachctl config list context'

### DIFF
--- a/src/server/config/cmds_test.go
+++ b/src/server/config/cmds_test.go
@@ -159,16 +159,38 @@ func TestConfigListContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+
+	// Verify the * marker exists for the active-context when enterprise is disabled and the enterprise context isn't set
+	require.NoError(t, run(t, `
+		echo '{}' | pachctl config set context foo
+		echo '{}' | pachctl config set context bar
+		pachctl config set active-context bar
+		pachctl config list context | match "\*	bar"
+		pachctl config list context | match "	foo"
+	`))
+
+	require.NoError(t, tu.BashCmd(`
+		echo {{.license}} | pachctl enterprise activate
+		pachctl enterprise get-state | match ACTIVE
+		`,
+		"license", tu.GetTestEnterpriseCode(t),
+	).Run())
 
 	require.NoError(t, run(t, `
 		echo '{}' | pachctl config set context foo
 		echo '{}' | pachctl config set context bar
-		pachctl config list context | match -v "\*	bar"
-		pachctl config list context | match "	bar"
+		pachctl config set active-context bar
+		pachctl config list context | match "E\*	bar"
 		pachctl config list context | match "	foo"
 
-		pachctl config set active-context bar
+		pachctl config set active-enterprise-context foo
 		pachctl config list context | match "\*	bar"
-		pachctl config list context | match "	foo"
+		pachctl config list context | match "E	foo"
+
+		pachctl config set active-context foo
+		pachctl config list context | match "	bar"
+		pachctl config list context | match "E\*	foo"
 	`))
 }


### PR DESCRIPTION
This PR is a response to feature request: https://github.com/pachyderm/pachyderm/issues/6161