### PR TITLE
Fixes TestLokiLogs.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4016,7 +4016,6 @@ func TestManyLogs(t *testing.T) {
 
 func TestLokiLogs(t *testing.T) {
 	// TODO(2.0 required): This test is taking too long to complete due to slow pipelines
-	t.Skip("Skipping flaky test")
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -4063,6 +4062,8 @@ func TestLokiLogs(t *testing.T) {
 		return nil
 	})
 
+	time.Sleep(5 * time.Second)
+
 	iter := c.GetLogsLoki("", pjis[0].PipelineJob.ID, nil, "", false, false, 0)
 	foundFoos := 0
 	for iter.Next() {
@@ -4072,9 +4073,6 @@ func TestLokiLogs(t *testing.T) {
 	}
 	require.NoError(t, iter.Err())
 	require.Equal(t, numFiles, foundFoos, "didn't receive enough log lines containing foo")
-
-	// Sleep for a 30 seconds give us some spacing to test from parameter.
-	time.Sleep(time.Second * 30)
 }
 
 func TestAllDatumsAreProcessed(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4015,7 +4015,6 @@ func TestManyLogs(t *testing.T) {
 }
 
 func TestLokiLogs(t *testing.T) {
-	// TODO(2.0 required): This test is taking too long to complete due to slow pipelines
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}


### PR DESCRIPTION
This fixes the Loki Logs test, the issue seemed to be that after receiving all of the logs in follow mode not all of the logs were returned from a non-follow request. I'm guessing that there's a bit of a lag between when Loki returns them and when they get indexed. Unfortunately the best way to fix it seemed to be a sleep, I tried doing it with a `NoErrorUntil` and that proved to be much less stable. In local testing this version of the code succeeded every time I ran it.