### PR TITLE
Fix commit count value in test.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10383,7 +10383,7 @@ func TestUpdateMultiplePipelinesInTransaction(t *testing.T) {
 	require.NoError(t, err)
 	commits, err := c.ListCommitByRepo(repoB)
 	require.NoError(t, err)
-	require.Equal(t, 4, len(commits))
+	require.Equal(t, 2, len(commits))
 
 	pipelineJobInfos, err := c.ListPipelineJob(pipelineB, nil, nil, -1, false)
 	require.NoError(t, err)


### PR DESCRIPTION
This is a result of the meta repo change, which moves stats commits out of
the output repo. I'm not sure how this didn't fail in #6186.