### PR TITLE
Replacing 'pachctl enterprise activate' with 'pachctl license activate'

### DIFF
--- a/doc/docs/master/enterprise/auth/enterprise-server/manage.md
+++ b/doc/docs/master/enterprise/auth/enterprise-server/manage.md
@@ -45,7 +45,7 @@ last_heartbeat: 2021-05-21 18:43:42.157027 +0000 UTC
 ### Update The Enterprise License
 To apply a new license and have it picked up by all clusters, run:
 ```shell
-$ pachctl license activate
+$ pachctl license activate --activate-only
 ```
 
 ### Unregister A Cluster

--- a/doc/docs/master/enterprise/auth/enterprise-server/manage.md
+++ b/doc/docs/master/enterprise/auth/enterprise-server/manage.md
@@ -45,7 +45,7 @@ last_heartbeat: 2021-05-21 18:43:42.157027 +0000 UTC
 ### Update The Enterprise License
 To apply a new license and have it picked up by all clusters, run:
 ```shell
-$ pachctl license activate --activate-only
+$ pachctl license activate --no-register
 ```
 
 ### Unregister A Cluster

--- a/doc/docs/master/enterprise/auth/enterprise-server/setup.md
+++ b/doc/docs/master/enterprise/auth/enterprise-server/setup.md
@@ -25,7 +25,7 @@ Proceed as usual:
 
 1. [Install your favorite version of `pachctl`](../../../../getting_started/local_installation/#install-pachctl).
 1. [Deploy Pachyderm](../../../getting_started/local_installation/#deploy-pachyderm): `pachctl deploy <local, google.....>`.
-1. [Activate your enterprise Key](../deployment/#activate-pachyderm-enterprise-edition): `pachctl enterprise activate`
+1. [Activate your enterprise Key](../deployment/#activate-pachyderm-enterprise-edition): `pachctl license activate`
 1. [Enable authentication](../index.md/#activate-user-access-management): `pachctl auth activate` 
 
 
@@ -62,7 +62,7 @@ Deploying a stand-alone enterprise server requires using the `--enterprise-serve
 
 - Use your enterprise key to activate your enterprise server: 
 	```shell
-	$ pachctl enterprise activate
+	$ pachctl license activate
 	```
 - Then enable Authentication at the Enterprise Server level:
 	```shell

--- a/doc/docs/master/enterprise/deployment.md
+++ b/doc/docs/master/enterprise/deployment.md
@@ -61,7 +61,7 @@ To activate the Pachyderm Enterprise Edition, complete the following steps::
 1. Activate the Enterprise Edition by running:
 
    ```shell
-   pachctl enterprise activate <activation-code>
+   pachctl license activate <activation-code>
    ```
 
    If this command does not return any error, then the activation was

--- a/doc/docs/master/reference/pachctl/pachctl_enterprise_activate.md
+++ b/doc/docs/master/reference/pachctl/pachctl_enterprise_activate.md
@@ -1,4 +1,4 @@
-## pachctl enterprise activate
+## pachctl license activate
 
 Activate the enterprise features of Pachyderm with an activation code
 
@@ -7,7 +7,7 @@ Activate the enterprise features of Pachyderm with an activation code
 Activate the enterprise features of Pachyderm with an activation code
 
 ```
-pachctl enterprise activate [flags]
+pachctl license activate [flags]
 ```
 
 ### Options

--- a/doc/docs/master/troubleshooting/pipeline_troubleshooting.md
+++ b/doc/docs/master/troubleshooting/pipeline_troubleshooting.md
@@ -34,7 +34,7 @@ That scenario is quite easy to troubleshoot:
 1. Additionally, your stderr and pipeline logs (`pachctl log -p <pipeline name> --master` or `pachctl log -p <pipeline name> --worker`) should contain one or both of those messages:
     - number of pipelines limit exceeded:
         ```
-        Pachyderm Community Edition requires an activation key to create more than 16 total pipelines (you have X).  Use the command `pachctl enterprise activate` to enter your key.
+        Pachyderm Community Edition requires an activation key to create more than 16 total pipelines (you have X).  Use the command `pachctl license activate` to enter your key.
 
         Pachyderm offers readily available activation keys for proofs-of-concept, startups, academic, nonprofit, or open-source projects. Tell us about your project to get one.
 
@@ -43,7 +43,7 @@ That scenario is quite easy to troubleshoot:
         ```
     - max number of workers exceeded:
         ```
-        This pipeline will only create a total of 8 workers (you specified X). Pachyderm Community Edition requires an activation key to create pipelines with constant parallelism greater than 8. Use the command `pachctl enterprise activate` to enter your key.
+        This pipeline will only create a total of 8 workers (you specified X). Pachyderm Community Edition requires an activation key to create pipelines with constant parallelism greater than 8. Use the command `pachctl license activate` to enter your key.
 
         Pachyderm offers readily available activation keys for proofs-of-concept, startups, academic, nonprofit, or open-source projects. Tell us about your project to get one.
 

--- a/etc/testing/test_tls.sh
+++ b/etc/testing/test_tls.sh
@@ -23,7 +23,7 @@ etc/deploy/gen_pachd_tls.sh "$hostport" ""
 etc/deploy/restart_with_tls.sh "$hostport" "${PWD}/pachd.pem" "${PWD}/pachd.key"
 
 set +x # Do not log our activation code when running this script in Travis
-echo "$ENT_ACT_CODE" | pachctl enterprise activate && echo
+echo "$ENT_ACT_CODE" | pachctl license activate && echo
 set -x
 
 # Make sure the pachyderm client can connect, write data, and create pipelines

--- a/src/server/config/cmds_test.go
+++ b/src/server/config/cmds_test.go
@@ -172,7 +172,7 @@ func TestConfigListContext(t *testing.T) {
 	`))
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		pachctl enterprise get-state | match ACTIVE
 		`,
 		"license", tu.GetTestEnterpriseCode(t),

--- a/src/server/enterprise/cmds/cmds_test.go
+++ b/src/server/enterprise/cmds/cmds_test.go
@@ -29,7 +29,7 @@ func TestManuallyJoinLicenseServer(t *testing.T) {
 	tu.DeleteAll(t)
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl license activate --activate-only
+		echo {{.license}} | pachctl license activate --no-register
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://localhost:653 --pachd-address grpc://localhost:653
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \

--- a/src/server/enterprise/cmds/cmds_test.go
+++ b/src/server/enterprise/cmds/cmds_test.go
@@ -16,7 +16,7 @@ func TestActivate(t *testing.T) {
 	defer tu.DeleteAll(t)
 	code := tu.GetTestEnterpriseCode(t)
 
-	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl enterprise activate`,
+	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate`,
 		"license", code).Run())
 
 	require.NoError(t, tu.BashCmd(`pachctl enterprise get-state | match ACTIVE`).Run())
@@ -29,7 +29,7 @@ func TestManuallyJoinLicenseServer(t *testing.T) {
 	tu.DeleteAll(t)
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl license activate
+		echo {{.license}} | pachctl license activate --activate-only
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://localhost:653 --pachd-address grpc://localhost:653
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -37,7 +37,7 @@ func TestRegisterPachd(t *testing.T) {
 	defer resetClusterState(t)
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
@@ -56,7 +56,7 @@ func TestRegisterAuthenticated(t *testing.T) {
 
 	cluster := tu.UniqueString("cluster")
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 
@@ -79,7 +79,7 @@ func TestEnterpriseRoleBindings(t *testing.T) {
 	defer resetClusterState(t)
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
@@ -100,7 +100,7 @@ func TestGetAndUseRobotToken(t *testing.T) {
 	defer resetClusterState(t)
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
@@ -124,7 +124,7 @@ func TestConfig(t *testing.T) {
 	defer resetClusterState(t)
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
@@ -165,7 +165,7 @@ func TestLoginEnterprise(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
@@ -210,7 +210,7 @@ func TestLoginPachd(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
@@ -253,7 +253,7 @@ func TestSyncContexts(t *testing.T) {
 
 	// register a new cluster
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650 --pachd-user-address grpc://pachd.default:655 --cluster-deployment-id {{.clusterId}} 
 		`,
@@ -335,7 +335,7 @@ func TestRegisterDefaultArgs(t *testing.T) {
 
 	// register a new cluster
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
 
@@ -362,7 +362,7 @@ func TestRegisterRollback(t *testing.T) {
 	id := tu.UniqueString("cluster")
 
 	require.NoError(t, tu.BashCmd(`
-		echo {{.license}} | pachctl enterprise activate
+		echo {{.license}} | pachctl license activate
 		`,
 		"license", tu.GetTestEnterpriseCode(t),
 	).Run())

--- a/src/server/license/cmds/cmds.go
+++ b/src/server/license/cmds/cmds.go
@@ -111,7 +111,7 @@ func ActivateCmd() *cobra.Command {
 
 		}),
 	}
-	activate.PersistentFlags().BoolVar(&onlyActivate, "activate-only", false, "Activate auth on the active enterprise context")
+	activate.PersistentFlags().BoolVar(&onlyActivate, "no-register", false, "Activate auth on the active enterprise context")
 	return cmdutil.CreateAlias(activate, "license activate")
 }
 

--- a/src/server/license/cmds/cmds_test.go
+++ b/src/server/license/cmds/cmds_test.go
@@ -16,7 +16,7 @@ func TestActivate(t *testing.T) {
 	defer tu.DeleteAll(t)
 	code := tu.GetTestEnterpriseCode(t)
 
-	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate`,
+	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate --activate-only`,
 		"license", code).Run())
 
 	require.NoError(t, tu.BashCmd(`pachctl license get-state | match ACTIVE`).Run())

--- a/src/server/license/cmds/cmds_test.go
+++ b/src/server/license/cmds/cmds_test.go
@@ -16,7 +16,7 @@ func TestActivate(t *testing.T) {
 	defer tu.DeleteAll(t)
 	code := tu.GetTestEnterpriseCode(t)
 
-	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate --activate-only`,
+	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate --no-register`,
 		"license", code).Run())
 
 	require.NoError(t, tu.BashCmd(`pachctl license get-state | match ACTIVE`).Run())


### PR DESCRIPTION
In most cases, a user will want to run `pachctl license activate` to setup the enterprise server's license, and enterprise services.

To achieve the special sub-case where a user ONLY wants to activate a new license, they can pass the `--no-register` flag