### PR TITLE
Remove self-RPCs from auth inteceptor

### DIFF
--- a/src/internal/auth/interceptor.go
+++ b/src/internal/auth/interceptor.go
@@ -251,14 +251,13 @@ type Interceptor struct {
 
 // InterceptUnary applies authentication rules to unary RPCs
 func (i *Interceptor) InterceptUnary(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	pachClient := i.env.GetPachClient(ctx)
 	a, ok := authHandlers[info.FullMethod]
 	if !ok {
 		logrus.Errorf("no auth function for %q\n", info.FullMethod)
 		return nil, fmt.Errorf("no auth function for %q, this is a bug", info.FullMethod)
 	}
 
-	username, err := a(pachClient, info.FullMethod)
+	username, err := a(ctx, i.env.AuthServer(), info.FullMethod)
 
 	if err != nil {
 		logrus.WithError(err).Errorf("denied unary call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
@@ -275,14 +274,13 @@ func (i *Interceptor) InterceptUnary(ctx context.Context, req interface{}, info 
 // InterceptStream applies authentication rules to streaming RPCs
 func (i *Interceptor) InterceptStream(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	ctx := stream.Context()
-	pachClient := i.env.GetPachClient(ctx)
 	a, ok := authHandlers[info.FullMethod]
 	if !ok {
 		logrus.Errorf("no auth function for %q\n", info.FullMethod)
 		return fmt.Errorf("no auth function for %q, this is a bug", info.FullMethod)
 	}
 
-	username, err := a(pachClient, info.FullMethod)
+	username, err := a(ctx, i.env.AuthServer(), info.FullMethod)
 
 	if err != nil {
 		logrus.WithError(err).Errorf("denied streaming call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -45,6 +45,7 @@ type ServiceEnv interface {
 	SetPpsServer(pps_server.APIServer)
 
 	Config() *Configuration
+	GetPachClient(ctx context.Context) *client.APIClient
 	GetEtcdClient() *etcd.Client
 	GetKubeClient() *kube.Clientset
 	GetLokiClient() (*loki.Client, error)

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	auth_server "github.com/pachyderm/pachyderm/v2/src/server/auth"
+	enterprise_server "github.com/pachyderm/pachyderm/v2/src/server/enterprise"
 	pfs_server "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	pps_server "github.com/pachyderm/pachyderm/v2/src/server/pps"
 
@@ -38,12 +39,12 @@ type ServiceEnv interface {
 	AuthServer() auth_server.APIServer
 	PfsServer() pfs_server.APIServer
 	PpsServer() pps_server.APIServer
+	EnterpriseServer() enterprise_server.APIServer
 	SetAuthServer(auth_server.APIServer)
 	SetPfsServer(pfs_server.APIServer)
 	SetPpsServer(pps_server.APIServer)
 
 	Config() *Configuration
-	GetPachClient(ctx context.Context) *client.APIClient
 	GetEtcdClient() *etcd.Client
 	GetKubeClient() *kube.Clientset
 	GetLokiClient() (*loki.Client, error)
@@ -111,9 +112,10 @@ type NonblockingServiceEnv struct {
 	// listenerEg coordinates the initialization of listener (see pachdEg)
 	listenerEg errgroup.Group
 
-	authServer auth_server.APIServer
-	ppsServer  pps_server.APIServer
-	pfsServer  pfs_server.APIServer
+	authServer       auth_server.APIServer
+	ppsServer        pps_server.APIServer
+	pfsServer        pfs_server.APIServer
+	enterpriseServer enterprise_server.APIServer
 
 	// ctx is the background context for the environment that will be canceled
 	// when the ServiceEnv is closed - this typically only happens for orderly
@@ -432,4 +434,14 @@ func (env *NonblockingServiceEnv) PfsServer() pfs_server.APIServer {
 // SetPfsServer registers a Pfs APIServer with this service env
 func (env *NonblockingServiceEnv) SetPfsServer(s pfs_server.APIServer) {
 	env.pfsServer = s
+}
+
+// EnterpriseServer returns the registered PFS APIServer
+func (env *NonblockingServiceEnv) EnterpriseServer() enterprise_server.APIServer {
+	return env.enterpriseServer
+}
+
+// SetEnterpriseServer registers a Enterprise APIServer with this service env
+func (env *NonblockingServiceEnv) SetEnterpriseServer(s enterprise_server.APIServer) {
+	env.enterpriseServer = s
 }

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	auth_server "github.com/pachyderm/pachyderm/v2/src/server/auth"
+	enterprise_server "github.com/pachyderm/pachyderm/v2/src/server/enterprise"
 	pfs_server "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	pps_server "github.com/pachyderm/pachyderm/v2/src/server/pps"
 
@@ -40,6 +41,9 @@ type TestServiceEnv struct {
 
 	// Pfs is the registered pfs APIServer
 	Pfs pfs_server.APIServer
+
+	// Enterprise is the registered pfs APIServer
+	Enterprise enterprise_server.APIServer
 
 	// Ready is a channel that blocks `GetPachClient` until it's closed.
 	// This avoids a race when we need to instantiate the server before
@@ -135,4 +139,14 @@ func (env *TestServiceEnv) SetPpsServer(s pps_server.APIServer) {
 // SetPfsServer returns the registered PFS APIServer
 func (env *TestServiceEnv) SetPfsServer(s pfs_server.APIServer) {
 	env.Pfs = s
+}
+
+// EnterpriseServer returns the registered Enterprise APIServer
+func (env *TestServiceEnv) EnterpriseServer() enterprise_server.APIServer {
+	return env.Enterprise
+}
+
+// SetEnterpriseServer returns the registered Enterprise APIServer
+func (env *TestServiceEnv) SetEnterpriseServer(s enterprise_server.APIServer) {
+	env.Enterprise = s
 }

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -254,9 +254,7 @@ func (a *apiServer) retrieveOrGeneratePPSToken() {
 }
 
 func (a *apiServer) getEnterpriseTokenState(ctx context.Context) (enterpriseclient.State, error) {
-	pachClient := a.env.GetPachClient(ctx)
-	resp, err := pachClient.Enterprise.GetState(pachClient.Ctx(),
-		&enterpriseclient.GetStateRequest{})
+	resp, err := a.env.EnterpriseServer().GetState(ctx, &enterpriseclient.GetStateRequest{})
 	if err != nil {
 		return 0, errors.Wrapf(grpcutil.ScrubGRPC(err), "could not get Enterprise status")
 	}
@@ -317,8 +315,6 @@ func (a *apiServer) hasClusterRole(ctx context.Context, username string, role st
 
 // Activate implements the protobuf auth.Activate RPC
 func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (resp *auth.ActivateResponse, retErr error) {
-	pachClient := a.env.GetPachClient(ctx)
-	ctx = pachClient.Ctx() // copy auth information
 	// We don't want to actually log the request/response since they contain
 	// credentials.
 	defer func(start time.Time) { a.LogResp(nil, nil, retErr, time.Since(start)) }(time.Now())

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -191,6 +191,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 				return err
 			}
 			eprsclient.RegisterAPIServer(externalServer.Server, enterpriseAPIServer)
+			env.SetEnterpriseServer(enterpriseAPIServer)
 			return nil
 		}); err != nil {
 			return err
@@ -291,6 +292,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 				return err
 			}
 			eprsclient.RegisterAPIServer(internalServer.Server, enterpriseAPIServer)
+			env.SetEnterpriseServer(enterpriseAPIServer)
 			return nil
 		}); err != nil {
 			return err
@@ -454,6 +456,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 			return err
 		}
 		eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
+		env.SetEnterpriseServer(enterpriseAPIServer)
 		return nil
 	}); err != nil {
 		return err
@@ -640,6 +643,7 @@ func doFullMode(config interface{}) (retErr error) {
 				return err
 			}
 			eprsclient.RegisterAPIServer(externalServer.Server, enterpriseAPIServer)
+			env.SetEnterpriseServer(enterpriseAPIServer)
 			return nil
 		}); err != nil {
 			return err
@@ -789,6 +793,7 @@ func doFullMode(config interface{}) (retErr error) {
 				return err
 			}
 			eprsclient.RegisterAPIServer(internalServer.Server, enterpriseAPIServer)
+			env.SetEnterpriseServer(enterpriseAPIServer)
 			return nil
 		}); err != nil {
 			return err

--- a/src/server/enterprise/iface.go
+++ b/src/server/enterprise/iface.go
@@ -1,0 +1,12 @@
+package enterprise
+
+import (
+	enterprise_client "github.com/pachyderm/pachyderm/v2/src/enterprise"
+)
+
+// APIServer is the internal interface for other services to call this one.
+// This includes all the public RPC methods and additional internal-only methods for use within pachd.
+// These methods *do not* check that a user is authorized unless otherwise noted.
+type APIServer interface {
+	enterprise_client.APIServer
+}

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -9,10 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/jmoiron/sqlx"
 
-	"github.com/pachyderm/pachyderm/v2/src/auth"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/server/pfs/pretty"
@@ -235,14 +232,6 @@ func (e ErrProvenanceOfSubvenance) Error() string {
 // 4. Commit provenance and commit subvenance are dual relations
 // If fix is true it will attempt to fix as many of these issues as it can.
 func (d *driver) fsck(ctx context.Context, fix bool, cb func(*pfs.FsckResponse) error) error {
-	// Check that the user is logged in (user doesn't need any access level to
-	// fsck, but they must be authenticated if auth is active)
-	if _, err := d.env.AuthServer().WhoAmI(ctx, &auth.WhoAmIRequest{}); err != nil {
-		if !auth.IsErrNotActivated(err) {
-			return errors.Wrapf(grpcutil.ScrubGRPC(err), "error authenticating (must log in to run fsck)")
-		}
-	}
-
 	onError := func(err error) error { return cb(&pfs.FsckResponse{Error: err.Error()}) }
 	onFix := func(fix string) error { return cb(&pfs.FsckResponse{Fix: fix}) }
 

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -237,8 +237,7 @@ func (e ErrProvenanceOfSubvenance) Error() string {
 func (d *driver) fsck(ctx context.Context, fix bool, cb func(*pfs.FsckResponse) error) error {
 	// Check that the user is logged in (user doesn't need any access level to
 	// fsck, but they must be authenticated if auth is active)
-	pachClient := d.env.GetPachClient(ctx)
-	if _, err := pachClient.WhoAmI(ctx, &auth.WhoAmIRequest{}); err != nil {
+	if _, err := d.env.AuthServer().WhoAmI(ctx, &auth.WhoAmIRequest{}); err != nil {
 		if !auth.IsErrNotActivated(err) {
 			return errors.Wrapf(grpcutil.ScrubGRPC(err), "error authenticating (must log in to run fsck)")
 		}

--- a/src/server/transaction/server/api_server.go
+++ b/src/server/transaction/server/api_server.go
@@ -31,7 +31,6 @@ func newAPIServer(
 		Logger: log.NewLogger("transaction.API", env.Logger()),
 		driver: d,
 	}
-	go func() { env.GetPachClient(context.Background()) }() // Begin dialing connection on startup
 	return s, nil
 }
 


### PR DESCRIPTION
Remove the self-RPCs in the auth interceptor and when checking enterprise license status. This should reduce latency.