### PR TITLE
Filtering out localhost context in sync-contexts command

### DIFF
--- a/src/internal/auth/interceptor.go
+++ b/src/internal/auth/interceptor.go
@@ -112,7 +112,7 @@ var authHandlers = map[string]authHandler{
 	"/license_v2.API/DeleteAll":         authDisabledOr(clusterPermissions(auth.Permission_CLUSTER_DELETE_ALL)),
 	// Heartbeat relies on the shared secret generated at cluster registration-time
 	"/license_v2.API/Heartbeat":        unauthenticated,
-	"/license_v2.API/ListUserClusters": authenticated,
+	"/license_v2.API/ListUserClusters": authDisabledOr(authenticated),
 
 	//
 	// PFS API

--- a/src/internal/testutil/enterprise.go
+++ b/src/internal/testutil/enterprise.go
@@ -36,7 +36,7 @@ func ActivateEnterprise(t testing.TB, c *client.APIClient) {
 			Secret:           "localhost",
 			Address:          "grpc://localhost:650",
 			UserAddress:      "grpc://localhost:650",
-			EnterpriseServer: false,
+			EnterpriseServer: true,
 		})
 	if err != nil && !license.IsErrDuplicateClusterID(err) {
 		require.NoError(t, err)

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -311,6 +311,10 @@ func TestSyncContexts(t *testing.T) {
 		"clusterId", newClusterId,
 		"userAddress", "grpc://pachd.default:700",
 	).Run())
+
+	// make sure that the cluster with id = 'localhost' does not get synched.
+	// it's used by the License Server to identify itself
+	require.YesError(t, tu.BashCmd(`pachctl config list context | match localhost`).Run())
 }
 
 // Tests RegisterCluster command's derived argument values if not provided

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -312,8 +312,9 @@ func TestSyncContexts(t *testing.T) {
 		"userAddress", "grpc://pachd.default:700",
 	).Run())
 
-	// make sure that the cluster with id = 'localhost' does not get synched.
-	// it's used by the License Server to identify itself
+	// make sure that the cluster with id = 'localhost' does not get synched, which is
+	// self referencing context record for the enterprise server.
+	// it should be filtered on the criteria of being set as an enterprise server record
 	require.YesError(t, tu.BashCmd(`pachctl config list context | match localhost`).Run())
 }
 

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -383,7 +383,7 @@ func (a *apiServer) ListUserClusters(ctx context.Context, req *lc.ListUserCluste
 	a.LogReq(req)
 	defer func(start time.Time) { a.pachLogger.Log(req, resp, retErr, time.Since(start)) }(time.Now())
 	clusters := make([]*lc.UserClusterInfo, 0)
-	if err := a.env.GetDBClient().SelectContext(ctx, &clusters, `SELECT id, cluster_deployment_id, user_address, is_enterprise_server FROM license.clusters`); err != nil {
+	if err := a.env.GetDBClient().SelectContext(ctx, &clusters, `SELECT id, cluster_deployment_id, user_address, is_enterprise_server FROM license.clusters WHERE is_enterprise_server = false`); err != nil {
 		return nil, err
 	}
 	return &lc.ListUserClustersResponse{


### PR DESCRIPTION
It's a little unclear to me whether we want to provide some of the info in ListUserClusters in the ListClusters call. 

Does it make sense for us to filter the localhost record out of ListUserClusters not to confused the user synching contexts, but leave that record in `license list-clusters` for admins to see?