### PR TITLE
Create default empty branch head commits

### DIFF
--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -648,7 +648,7 @@ func (n *loopbackNode) commit(repo string) (string, error) {
 	defer n.root().mu.Unlock()
 	// You can access branches that don't exist, which allows you to create
 	// branches through the fuse mount.
-	if errutil.IsNotFoundError(err) || bi.Head == nil {
+	if errutil.IsNotFoundError(err) {
 		n.root().commits[repo] = ""
 		return "", nil
 	}

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -285,7 +285,7 @@ func IsCommitOnOutputBranchErr(err error) bool {
 }
 
 // IsParentNotFinishedErr returns true if the err is due to an attempt to
-// start a commit on an output branch.
+// start a commit in an input branch while the parent commit is still open.
 func IsParentNotFinishedErr(err error) bool {
 	if err == nil {
 		return false

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -35,12 +35,6 @@ type ErrCommitNotFound struct {
 	Commit *pfs.Commit
 }
 
-// ErrNoHead represents an error encountered because a branch has no head (e.g.
-// inspectCommit(master) when 'master' has no commits)
-type ErrNoHead struct {
-	Branch *pfs.Branch
-}
-
 // ErrCommitExists represents an error where the commit already exists.
 type ErrCommitExists struct {
 	Commit *pfs.Commit
@@ -115,11 +109,6 @@ func (e ErrCommitNotFound) Error() string {
 	return fmt.Sprintf("commit %v not found in repo %v", e.Commit.ID, pretty.CompactPrintRepo(e.Commit.Branch.Repo))
 }
 
-func (e ErrNoHead) Error() string {
-	// the dashboard is matching on this message in stats. Please open an issue on the dash before changing this
-	return fmt.Sprintf("the branch \"%s\" has no head (create one with 'start commit')", e.Branch.Name)
-}
-
 func (e ErrCommitExists) Error() string {
 	return fmt.Sprintf("commit %v already exists in repo %v", e.Commit.ID, pretty.CompactPrintRepo(e.Commit.Branch.Repo))
 }
@@ -164,7 +153,6 @@ var (
 	repoExistsRe              = regexp.MustCompile(`repo ?[a-zA-Z0-9.\-_]{1,255} already exists`)
 	branchNotFoundRe          = regexp.MustCompile(`branches [a-zA-Z0-9.\-_@]{1,255} not found`)
 	fileNotFoundRe            = regexp.MustCompile(`file .+ not found`)
-	hasNoHeadRe               = regexp.MustCompile(`the branch .+ has no head \(create one with 'start commit'\)`)
 	outputCommitNotFinishedRe = regexp.MustCompile("output commit .+ not finished")
 	commitNotFinishedRe       = regexp.MustCompile("commit .+ not finished")
 	ambiguousCommitRe         = regexp.MustCompile("commit .+ is ambiguous")
@@ -233,15 +221,6 @@ func IsFileNotFoundErr(err error) bool {
 		return false
 	}
 	return fileNotFoundRe.MatchString(err.Error())
-}
-
-// IsNoHeadErr returns true if the err is due to an operation that cannot be
-// performed on a headless branch
-func IsNoHeadErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	return hasNoHeadRe.MatchString(err.Error())
 }
 
 // IsOutputCommitNotFinishedErr returns true if the err is due to an operation

--- a/src/server/pfs/s3/bucket.go
+++ b/src/server/pfs/s3/bucket.go
@@ -219,22 +219,20 @@ func (c *controller) DeleteBucket(r *http.Request, bucketName string) error {
 		return maybeNotFoundError(r, err)
 	}
 
-	if branchInfo.Head != nil {
-		hasFiles := false
-		err = pc.WalkFile(branchInfo.Head, "", func(fileInfo *pfsClient.FileInfo) error {
-			if fileInfo.FileType == pfsClient.FileType_FILE {
-				hasFiles = true
-				return errutil.ErrBreak
-			}
-			return nil
-		})
-		if err != nil {
-			return s2.InternalError(r, err)
+	hasFiles := false
+	err = pc.WalkFile(branchInfo.Head, "", func(fileInfo *pfsClient.FileInfo) error {
+		if fileInfo.FileType == pfsClient.FileType_FILE {
+			hasFiles = true
+			return errutil.ErrBreak
 		}
+		return nil
+	})
+	if err != nil {
+		return s2.InternalError(r, err)
+	}
 
-		if hasFiles {
-			return s2.BucketNotEmptyError(r)
-		}
+	if hasFiles {
+		return s2.BucketNotEmptyError(r)
 	}
 
 	err = pc.DeleteBranch(bucket.Repo, bucket.Branch, false)

--- a/src/server/pfs/s3/driver.go
+++ b/src/server/pfs/s3/driver.go
@@ -91,13 +91,13 @@ func (d *MasterDriver) bucket(pc *client.APIClient, r *http.Request, name string
 }
 
 func (d *MasterDriver) bucketCapabilities(pc *client.APIClient, r *http.Request, bucket *Bucket) (bucketCapabilities, error) {
-	branchInfo, err := pc.InspectBranch(bucket.Repo, bucket.Branch)
+	_, err := pc.InspectBranch(bucket.Repo, bucket.Branch)
 	if err != nil {
 		return bucketCapabilities{}, maybeNotFoundError(r, err)
 	}
 
 	return bucketCapabilities{
-		readable:         branchInfo.Head != nil,
+		readable:         true,
 		writable:         true,
 		historicVersions: true,
 	}, nil

--- a/src/server/pfs/s3/multipart.go
+++ b/src/server/pfs/s3/multipart.go
@@ -246,7 +246,7 @@ func (c *controller) CompleteMultipart(r *http.Request, bucketName, key, uploadI
 
 	// check if the destination file already exists, and if so, delete it
 	_, err = pc.InspectFile(client.NewCommit(bucket.Repo, bucket.Branch, bucket.Commit), key)
-	if err != nil && !pfsServer.IsFileNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
+	if err != nil && !pfsServer.IsFileNotFoundErr(err) {
 		return nil, err
 	} else if err == nil {
 		err = pc.DeleteFile(client.NewCommit(bucket.Repo, bucket.Branch, bucket.Commit), key)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -787,10 +787,6 @@ func (d *driver) propagateBranches(txnCtx *txncontext.TransactionContext, branch
 			if err != nil {
 				return err
 			}
-			//if provOfSubvBI.Branch.Repo.Type == pfs.SpecRepoType {
-			//	// A spec repo doesn't contribute datums so ignore it?
-			//	continue
-			//}
 			if provOfSubvBI.Head.ID != subvBI.Head.ID {
 				needsCommit = true
 				break

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -29,7 +29,7 @@ func (d *driver) modifyFile(ctx context.Context, commit *pfs.Commit, cb func(*fi
 	}
 	commitInfo, err := d.inspectCommit(ctx, commit, pfs.CommitState_STARTED)
 	if err != nil {
-		if (!isNotFoundErr(err) && !isNoHeadErr(err)) || branch.Name == "" {
+		if !isNotFoundErr(err) || branch.Name == "" {
 			return err
 		}
 		return d.oneOffModifyFile(ctx, branch, cb)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -260,6 +260,7 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.CreateRepo("in"))
 		require.NoError(t, env.PachClient.CreateRepo("out"))
 		require.NoError(t, env.PachClient.CreateBranch("out", "master", "", "", []*pfs.Branch{client.NewBranch("in", "master")}))
+		require.NoError(t, env.PachClient.FinishCommit("out", "master", ""))
 		require.NoError(t, env.PachClient.PutFile(client.NewCommit("in", "master", ""), "foo", strings.NewReader("foo")))
 		outRepo := client.NewRepo("out")
 		cis, err := env.PachClient.ListCommit(outRepo, nil, nil, 0)
@@ -3353,6 +3354,7 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.CreateRepo("C"))
 		require.NoError(t, env.PachClient.CreateRepo("D"))
 		require.NoError(t, env.PachClient.CreateBranch("C", "master", "", "", []*pfs.Branch{client.NewBranch("A", "master"), client.NewBranch("B", "master")}))
+		require.NoError(t, env.PachClient.FinishCommit("C", "master", ""))
 		_, err := env.PachClient.StartCommit("A", "master")
 		require.NoError(t, err)
 		require.NoError(t, env.PachClient.FinishCommit("A", "master", ""))
@@ -3663,7 +3665,6 @@ func TestPFS(suite *testing.T) {
 		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
-		require.NoError(t, env.PachClient.CreateBranch("A", "master", "", "", nil))
 		commit, err := env.PachClient.StartCommit("A", "master")
 		require.NoError(t, err)
 		env.PachClient.FinishCommit("A", commit.Branch.Name, commit.ID)
@@ -3675,7 +3676,7 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.FinishCommit("A", commit2.Branch.Name, commit2.ID))
 
 		aRepo := client.NewRepo("A")
-		commitInfos, err := env.PachClient.ListCommit(aRepo, aRepo.NewCommit("master2", ""), nil, 0)
+		commitInfos, err := env.PachClient.ListCommit(aRepo, nil, nil, 0)
 		require.NoError(t, err)
 		commits := []*pfs.Commit{}
 		for _, ci := range commitInfos {
@@ -4033,7 +4034,9 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.CreateRepo("C"))
 
 		require.NoError(t, env.PachClient.CreateBranch("B", "master", "", "", []*pfs.Branch{client.NewBranch("A", "master")}))
+		require.NoError(t, env.PachClient.FinishCommit("B", "master", ""))
 		require.NoError(t, env.PachClient.CreateBranch("C", "master", "", "", []*pfs.Branch{client.NewBranch("B", "master")}))
+		require.NoError(t, env.PachClient.FinishCommit("C", "master", ""))
 
 		ctx, cancel := context.WithCancel(env.PachClient.Ctx())
 		defer cancel()

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -52,12 +52,9 @@ func (d *driver) triggerCommit(
 			}
 
 			if newHead != nil {
-				var oldHead *pfs.CommitInfo
-				if bi.Head != nil {
-					oldHead = &pfs.CommitInfo{}
-					if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(pfsdb.CommitKey(bi.Head), oldHead); err != nil {
-						return nil, err
-					}
+				oldHead := &pfs.CommitInfo{}
+				if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(pfsdb.CommitKey(bi.Head), oldHead); err != nil {
+					return nil, err
 				}
 
 				triggered, err := d.isTriggered(txnCtx, bi.Trigger, oldHead, newHead)

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -137,7 +137,7 @@ func (d *driver) isTriggered(txnCtx *txncontext.TransactionContext, t *pfs.Trigg
 		var commits int64
 		for commits < t.Commits {
 			commits++
-			if ci.ParentCommit != nil && (oldHead == nil || oldHead.Commit.ID != ci.ParentCommit.ID) {
+			if ci.ParentCommit != nil && oldHead.Commit.ID != ci.ParentCommit.ID {
 				var err error
 				ci, err = d.inspectCommit(txnCtx.ClientContext, ci.ParentCommit, pfs.CommitState_STARTED)
 				if err != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2960,9 +2960,6 @@ func (a *apiServer) RunPipeline(ctx context.Context, request *pps.RunPipelineReq
 	if err != nil {
 		return nil, err
 	}
-	if branchInfo.Head == nil {
-		return nil, errors.Errorf("run pipeline needs a pipeline with existing data to run\nnew commits will trigger the pipeline automatically, so this only needs to be used if you need to run the pipeline on an old version of the data, or to rerun an job")
-	}
 
 	// include the branch and its provenance in the branch provenance map
 	branchProvMap := make(map[string]bool)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -3103,7 +3103,7 @@ func (a *apiServer) RunCron(ctx context.Context, request *pps.RunCronRequest) (r
 			if cron.Overwrite {
 				// get rid of any files, so the new file "overwrites" previous runs
 				err = mf.DeleteFile("/")
-				if err != nil && !isNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
+				if err != nil && !isNotFoundErr(err) {
 					return errors.Wrapf(err, "delete error")
 				}
 			}


### PR DESCRIPTION
This simplifies a lot of handling in PFS if we can assume that there is always a branch head.  In CreateBranch and SquashCommit, we ensure that a branch head always exists.