### PR TITLE
Upgrade to a more recent version of minikube

### DIFF
--- a/etc/kube/start-minikube.sh
+++ b/etc/kube/start-minikube.sh
@@ -3,7 +3,7 @@
 set -Eex
 
 # Parse flags
-VERSION=v1.13.0
+VERSION=v1.19.0
 minikube_args=(
   "--vm-driver=none"
   "--kubernetes-version=${VERSION}"

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -42,7 +42,7 @@ fi
 # To get the latest minikube version:
 # curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[].tag_name | sort -V | tail -n1
 if [ ! -f cached-deps/minikube ] ; then
-    MINIKUBE_VERSION=v1.13.1 # If changed, also do etc/kube/start-minikube.sh
+    MINIKUBE_VERSION=v1.19.0 # If changed, also do etc/kube/start-minikube.sh
     curl -L -o minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
         chmod +x ./minikube
         mv ./minikube cached-deps/minikube

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -5,7 +5,7 @@ set -Eex
 export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
 
 # Parse flags
-VERSION=v1.13.0
+VERSION=v1.19.0
 minikube_args=(
   "--vm-driver=docker"
   "--kubernetes-version=${VERSION}"


### PR DESCRIPTION
Our helm chart is set to 1.16+ (and it's probably time to move off 1.13 )