### PR TITLE
PPS worker performance improvements

### DIFF
--- a/src/internal/tarutil/option.go
+++ b/src/internal/tarutil/option.go
@@ -11,11 +11,3 @@ func WithHeaderCallback(cb func(*tar.Header) error) ExportOption {
 		ec.headerCallback = cb
 	}
 }
-
-// WithSymlink configures the export call to execute the callback for each symlink encountered.
-// The callback that is passed into the callback should be executed if the symlinked file should be written to the tar stream.
-func WithSymlinkCallback(cb func(string, string, func() error) error) ExportOption {
-	return func(ec *exportConfig) {
-		ec.symlinkCallback = cb
-	}
-}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -712,9 +712,15 @@ func (a *apiServer) Fsck(request *pfs.FsckRequest, fsckServer pfs.API_FsckServer
 }
 
 // CreateFileset implements the pfs.CreateFileset RPC
-func (a *apiServer) CreateFileset(server pfs.API_CreateFilesetServer) error {
+func (a *apiServer) CreateFileset(server pfs.API_CreateFilesetServer) (retErr error) {
+	request, err := server.Recv()
+	func() { a.Log(request, nil, nil, 0) }()
+	defer func(start time.Time) { a.Log(request, nil, retErr, time.Since(start)) }(time.Now())
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
 	fsID, err := a.driver.createFileset(server.Context(), func(uw *fileset.UnorderedWriter) error {
-		_, err := a.modifyFile(server.Context(), uw, server, nil)
+		_, err := a.modifyFile(server.Context(), uw, server, request)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
This PR contains a couple small changes to improve the performance of the PPS workers:
- Improves the performance of skipping by writing meta files directly to the fileset stream, rather than going through the local filesystem (the per file overhead needs to be kept really low for this to be acceptable).
- We now convert the output to a tar stream on the fly, rather than buffering the output into a tar file on the local filesystem.
- Refactors the handling of symlinks out of the tarutil package.