### PR TITLE
Add cache to fileset index layer that enables binary searching on index chunks

### DIFF
--- a/src/internal/storage/fileset/index/cache.go
+++ b/src/internal/storage/fileset/index/cache.go
@@ -1,0 +1,106 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sort"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
+)
+
+type Cache interface {
+	Get(ctx context.Context, chunkRef *chunk.DataRef, filter *pathFilter, w io.Writer) error
+}
+
+type cache struct {
+	storage *chunk.Storage
+	cache   *simplelru.LRU
+	mu      sync.Mutex
+}
+
+func NewCache(storage *chunk.Storage, size int) Cache {
+	lruCache, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		panic(err)
+	}
+	return &cache{
+		storage: storage,
+		cache:   lruCache,
+	}
+}
+
+func (c *cache) Get(ctx context.Context, chunkRef *chunk.DataRef, filter *pathFilter, w io.Writer) error {
+	c.mu.Lock()
+	v, ok := c.cache.Get(string(chunkRef.Ref.Id))
+	c.mu.Unlock()
+	if ok {
+		return get(v.(*cachedChunk), filter, w)
+	}
+	cr := c.storage.NewReader(ctx, []*chunk.DataRef{chunkRef})
+	buf := &bytes.Buffer{}
+	if err := cr.Get(buf); err != nil {
+		return err
+	}
+	cachedChunk, err := c.computeCachedChunk(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.cache.Add(string(chunkRef.Ref.Id), cachedChunk)
+	c.mu.Unlock()
+	return get(cachedChunk, filter, w)
+}
+
+type cachedChunk struct {
+	data        []byte
+	pathOffsets []*pathOffset
+}
+
+type pathOffset struct {
+	lower, upper string
+	offset       int
+}
+
+func (c *cache) computeCachedChunk(data []byte) (*cachedChunk, error) {
+	br := bytes.NewReader(data)
+	pbr := pbutil.NewReader(br)
+	var pathOffsets []*pathOffset
+	for {
+		pathOffset := &pathOffset{
+			offset: len(data) - br.Len(),
+		}
+		idx := &Index{}
+		if err := pbr.Read(idx); err != nil {
+			break
+		}
+		pathOffset.lower = idx.Path
+		if idx.Range != nil {
+			pathOffset.upper = idx.Range.LastPath
+		}
+		pathOffsets = append(pathOffsets, pathOffset)
+	}
+	return &cachedChunk{
+		data:        data,
+		pathOffsets: pathOffsets,
+	}, nil
+}
+
+func get(cachedChunk *cachedChunk, filter *pathFilter, w io.Writer) error {
+	if len(cachedChunk.pathOffsets) == 0 {
+		_, err := w.Write(cachedChunk.data)
+		return err
+	}
+	i := sort.Search(len(cachedChunk.pathOffsets), func(i int) bool {
+		return atStart(cachedChunk.pathOffsets[i].lower, filter) || atStart(cachedChunk.pathOffsets[i].upper, filter)
+	})
+	if i >= len(cachedChunk.pathOffsets) {
+		_, err := w.Write(cachedChunk.data[cachedChunk.pathOffsets[i-1].offset:])
+		return err
+	}
+	_, err := w.Write(cachedChunk.data[cachedChunk.pathOffsets[i].offset:])
+	return err
+}

--- a/src/internal/storage/fileset/index/index_test.go
+++ b/src/internal/storage/fileset/index/index_test.go
@@ -25,8 +25,8 @@ func write(tb testing.TB, chunks *chunk.Storage, fileNames []string) *Index {
 	return topIdx
 }
 
-func actualFiles(tb testing.TB, topIdx *Index, chunks *chunk.Storage, opts ...Option) []string {
-	ir := NewReader(chunks, topIdx, opts...)
+func actualFiles(tb testing.TB, chunks *chunk.Storage, cache Cache, topIdx *Index, opts ...Option) []string {
+	ir := NewReader(chunks, cache, topIdx, opts...)
 	result := []string{}
 	require.NoError(tb, ir.Iterate(context.Background(), func(idx *Index) error {
 		result = append(result, idx.Path)
@@ -56,60 +56,61 @@ func Check(t *testing.T, permString string) {
 	db := testutil.NewTestDB(t)
 	tr := track.NewTestTracker(t, db)
 	_, chunks := chunk.NewTestStorage(t, db, tr)
+	cache := NewCache(chunks, 10)
 	fileNames := Generate(permString)
 	averageBits = 12
 	topIdx := write(t, chunks, fileNames)
 	t.Run("Full", func(t *testing.T) {
 		expected := fileNames
-		actual := actualFiles(t, topIdx, chunks)
+		actual := actualFiles(t, chunks, cache, topIdx)
 		require.Equal(t, expected, actual)
 	})
 	t.Run("FirstFile", func(t *testing.T) {
 		prefix := fileNames[0]
 		expected := []string{prefix}
-		actual := actualFiles(t, topIdx, chunks, WithPrefix(prefix))
+		actual := actualFiles(t, chunks, cache, topIdx, WithPrefix(prefix))
 		require.Equal(t, expected, actual)
-		actual = actualFiles(t, topIdx, chunks, WithRange(pathRange(expected)))
+		actual = actualFiles(t, chunks, cache, topIdx, WithRange(pathRange(expected)))
 		require.Equal(t, expected, actual)
 	})
 	t.Run("FirstRange", func(t *testing.T) {
 		prefix := string(fileNames[0][0])
 		expected := expectedFiles(fileNames, prefix)
-		actual := actualFiles(t, topIdx, chunks, WithPrefix(prefix))
+		actual := actualFiles(t, chunks, cache, topIdx, WithPrefix(prefix))
 		require.Equal(t, expected, actual)
-		actual = actualFiles(t, topIdx, chunks, WithRange(pathRange(expected)))
+		actual = actualFiles(t, chunks, cache, topIdx, WithRange(pathRange(expected)))
 		require.Equal(t, expected, actual)
 	})
 	t.Run("MiddleFile", func(t *testing.T) {
 		prefix := fileNames[len(fileNames)/2]
 		expected := []string{prefix}
-		actual := actualFiles(t, topIdx, chunks, WithPrefix(prefix))
+		actual := actualFiles(t, chunks, cache, topIdx, WithPrefix(prefix))
 		require.Equal(t, expected, actual)
-		actual = actualFiles(t, topIdx, chunks, WithRange(pathRange(expected)))
+		actual = actualFiles(t, chunks, cache, topIdx, WithRange(pathRange(expected)))
 		require.Equal(t, expected, actual)
 	})
 	t.Run("MiddleRange", func(t *testing.T) {
 		prefix := string(fileNames[len(fileNames)/2][0])
 		expected := expectedFiles(fileNames, prefix)
-		actual := actualFiles(t, topIdx, chunks, WithPrefix(prefix))
+		actual := actualFiles(t, chunks, cache, topIdx, WithPrefix(prefix))
 		require.Equal(t, expected, actual)
-		actual = actualFiles(t, topIdx, chunks, WithRange(pathRange(expected)))
+		actual = actualFiles(t, chunks, cache, topIdx, WithRange(pathRange(expected)))
 		require.Equal(t, expected, actual)
 	})
 	t.Run("LastFile", func(t *testing.T) {
 		prefix := fileNames[len(fileNames)-1]
 		expected := []string{prefix}
-		actual := actualFiles(t, topIdx, chunks, WithPrefix(prefix))
+		actual := actualFiles(t, chunks, cache, topIdx, WithPrefix(prefix))
 		require.Equal(t, expected, actual)
-		actual = actualFiles(t, topIdx, chunks, WithRange(pathRange(expected)))
+		actual = actualFiles(t, chunks, cache, topIdx, WithRange(pathRange(expected)))
 		require.Equal(t, expected, actual)
 	})
 	t.Run("LastRange", func(t *testing.T) {
 		prefix := string(fileNames[len(fileNames)-1][0])
 		expected := expectedFiles(fileNames, prefix)
-		actual := actualFiles(t, topIdx, chunks, WithPrefix(prefix))
+		actual := actualFiles(t, chunks, cache, topIdx, WithPrefix(prefix))
 		require.Equal(t, expected, actual)
-		actual = actualFiles(t, topIdx, chunks, WithRange(pathRange(expected)))
+		actual = actualFiles(t, chunks, cache, topIdx, WithRange(pathRange(expected)))
 		require.Equal(t, expected, actual)
 	})
 }


### PR DESCRIPTION
This PR adds a cache to the fileset index layer that enables binary searching on index chunks. Index chunks store serialized index protos and are subject to the same min / avg / max configuration of normal file content chunks. This means that index chunks can have a lot of index protos packed into them (i.e. the current default chunk avg is 8MB, which would be a lot of index protos). A linear scan through these protos is a significant amount of overhead for point queries (we had a similar problem in 1.x with output repos that we "addressed" by just making the chunks smaller). To address this, I added a caching layer to the indexing layer that stores sorted path offsets in memory for a set of cached index chunks, which allows us to perform a binary search on the indexes in the chunk when a cache hit occurs. There might be some opportunity for improving this later by either exposing arbitrary metadata to associate with chunks cached in the chunk storage layer so that we don't need a separate cache for this and potentially just storing the index entries rather than offsets that are used to select the right byte offset to feed into the normal index reader.