### PR TITLE
Add golanglint-ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,5 @@
 run:
   timeout: 5m
+linters:
+  disable:
+    - errcheck

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -16,7 +16,8 @@ sudo apt-get install -y -qq \
   pkg-config \
   fuse \
   conntrack \
-  pv
+  pv \
+  shellcheck
 
 # Install fuse
 sudo modprobe fuse

--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -63,7 +63,7 @@ go clean -testcache
 
 case "${BUCKET}" in
  MISC)
-    #make lint
+    make lint
     make check-buckets
     make enterprise-code-checkin-test
     make test-cmds

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,27 +18,8 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-# Update golint once a day, or if it isn't installed
-if [ -z "$(find "$(command -v golint)" -mtime -1 2>/dev/null)" ]; then
-  go get -u golang.org/x/lint/golint
-fi
-
-find "./src" \
-  \( -path "*.pb.go" -o -path "*internal/tar*" "${skip_paths[@]}" \) -prune -o -name '*.go' -print0 \
-| xargs -P32 -n 1 golint -set_exit_status 
-
-files=$(gofmt -l "${GIT_REPO_DIR}/src" || true)
-if [[ -n "${files}" ]]; then
-    echo Files not passing gofmt:
-    tr ' ' '\n'  <<< "$files"
-    exit 1
-fi
-
-# Update staticcheck once a day, or if it isn't installed
-if [ -z "$(find "$(command -v staticcheck)" -mtime -1 2>/dev/null)" ]; then
-  go get -u honnef.co/go/tools/cmd/staticcheck
-fi
-staticcheck "${GIT_REPO_DIR}/..."
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.40.1
+golangci-lint run --timeout 10m
 
 # shellcheck disable=SC2046
 find . \

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -19,7 +19,7 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
 done
 
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.40.1
-golangci-lint run --timeout 10m
+./bin/golangci-lint run --timeout 10m
 
 # shellcheck disable=SC2046
 find . \

--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -44,14 +44,12 @@ func mainError(err error) {
 }
 
 const (
-	cannotParseErr                     = "cannot parse"
-	cannotSetBothRequiredAndDefaultErr = "cannot set both required and default"
-	duplicateRestrictToKeyErr          = "duplicate restrict to key"
-	envKeyNotSetWhenRequiredErr        = "env key not set when required"
-	expectedPointerErr                 = "expected pointer"
-	expectedStructErr                  = "expected struct"
-	fieldTypeNotAllowedErr             = "field type not allowed"
-	invalidTagErr                      = "invalid tag, must be KEY,{required},{default=DEFAULT_VALUE}"
+	cannotParseErr              = "cannot parse"
+	envKeyNotSetWhenRequiredErr = "env key not set when required"
+	expectedPointerErr          = "expected pointer"
+	expectedStructErr           = "expected struct"
+	fieldTypeNotAllowedErr      = "field type not allowed"
+	invalidTagErr               = "invalid tag, must be KEY,{required},{default=DEFAULT_VALUE}"
 )
 
 func populate(object interface{}, decoders []Decoder) error {

--- a/src/internal/grpcutil/buffer.go
+++ b/src/internal/grpcutil/buffer.go
@@ -25,7 +25,7 @@ func (b *BufPool) GetBuffer() []byte {
 
 // PutBuffer returns the buffer to the pool.
 func (b *BufPool) PutBuffer(buf []byte) {
-	b.Put(buf) //lint:ignore SA6002 []byte is sufficiently pointer-like for our purposes
+	b.Put(buf) //nolint:staticcheck // []byte is sufficiently pointer-like for our purposes
 }
 
 // bufPool is a pool of buffers that are sized for grpc connections

--- a/src/internal/obj/microsoft_client.go
+++ b/src/internal/obj/microsoft_client.go
@@ -167,8 +167,7 @@ func (w *microsoftWriter) writeBlock(block []byte) (retErr error) {
 
 	w.eg.Go(func() error {
 		defer w.limiter.Release()
-		//lint:ignore SA6002 []byte is sufficiently pointer-like for our purposes
-		defer bufPool.Put(block[:cap(block)])
+		defer bufPool.Put(block[:cap(block)]) //nolint:staticcheck // []byte is sufficiently pointer-like for our purposes
 		if err := w.blob.PutBlock(blockID, block, nil); err != nil {
 			w.err = err
 			return err

--- a/src/internal/pacherr/transient.go
+++ b/src/internal/pacherr/transient.go
@@ -36,10 +36,12 @@ func (e *TransientError) GRPCStatus() *status.Status {
 
 func IsRetryable(err error) bool {
 	var target TransientError
+	// nolint:govet
 	return errors.As(err, &target) || isNetRetryable(err)
 }
 
 func isNetRetryable(err error) bool {
 	var netErr net.Error
+	// nolint:govet
 	return errors.As(err, &netErr) && netErr.Temporary()
 }

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -352,7 +352,7 @@ func IsTerminal(state pps.JobState) bool {
 // UpdateJobState performs the operations involved with a job state transition.
 func UpdateJobState(pipelines col.ReadWriteCollection, jobs col.ReadWriteCollection, jobPtr *pps.StoredJobInfo, state pps.JobState, reason string) error {
 	if IsTerminal(jobPtr.State) {
-		return ppsServer.ErrJobFinished{jobPtr.Job}
+		return ppsServer.ErrJobFinished{Job: jobPtr.Job}
 	}
 
 	// Update pipeline

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -68,8 +68,8 @@ type PachdSpecificConfiguration struct {
 	MemoryRequest              string `env:"PACHD_MEMORY_REQUEST,default=1T"`
 	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=true"`
 	DeploymentID               string `env:"CLUSTER_DEPLOYMENT_ID,default="`
-	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY",default="false"`
-	MetricsEndpoint            string `env:"METRICS_ENDPOINT",default=""`
+	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY,default=false"`
+	MetricsEndpoint            string `env:"METRICS_ENDPOINT,default="`
 	// TODO: Merge this with the worker specific pod name (PPS_POD_NAME) into a global configuration pod name.
 	PachdPodName string `env:"PACHD_POD_NAME,required"`
 

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -68,8 +68,8 @@ type PachdSpecificConfiguration struct {
 	MemoryRequest              string `env:"PACHD_MEMORY_REQUEST,default=1T"`
 	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=true"`
 	DeploymentID               string `env:"CLUSTER_DEPLOYMENT_ID,default="`
-	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY",default=false"`
-	MetricsEndpoint            string `env:"METRICS_ENDPOINT",default="`
+	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY",default="false"`
+	MetricsEndpoint            string `env:"METRICS_ENDPOINT",default=""`
 	// TODO: Merge this with the worker specific pod name (PPS_POD_NAME) into a global configuration pod name.
 	PachdPodName string `env:"PACHD_POD_NAME,required"`
 

--- a/src/internal/sql/sql.go
+++ b/src/internal/sql/sql.go
@@ -81,5 +81,4 @@ func (r *PGDumpReader) readFooter() error {
 			return err
 		}
 	}
-	return nil
 }

--- a/src/internal/storage/chunk/chunk_test.go
+++ b/src/internal/storage/chunk/chunk_test.go
@@ -130,7 +130,7 @@ func BenchmarkRollingHash(b *testing.B) {
 		hash.Write(initialWindow)
 		for _, bt := range data {
 			hash.Roll(bt)
-			//lint:ignore SA9003 benchmark is simulating exact usecase
+			// nolint:staticcheck // benchmark is simulating exact usecase
 			if hash.Sum64()&splitMask == 0 {
 			}
 		}

--- a/src/internal/storage/fileset/fileset_test.go
+++ b/src/internal/storage/fileset/fileset_test.go
@@ -21,10 +21,8 @@ import (
 )
 
 const (
-	max         = 20 * units.MB
-	maxTags     = 10
-	testPath    = "test"
-	scratchPath = "scratch"
+	max     = 20 * units.MB
+	maxTags = 10
 )
 
 type testFile struct {
@@ -81,7 +79,6 @@ func TestWriteThenRead(t *testing.T) {
 	fileNames := index.Generate("abc")
 	files := []*testFile{}
 	for _, fileName := range fileNames {
-		var files []*testFile
 		for _, tagInt := range random.Perm(maxTags) {
 			tag := fmt.Sprintf("%08x", tagInt)
 			data := randutil.Bytes(random, random.Intn(max))

--- a/src/internal/storage/fileset/index/util.go
+++ b/src/internal/storage/fileset/index/util.go
@@ -65,11 +65,3 @@ func SizeBytes(idx *Index) int64 {
 	}
 	return size
 }
-
-func newDataRef(chunkRef *chunk.Ref, offset, size int64) *chunk.DataRef {
-	return &chunk.DataRef{
-		Ref:         chunkRef,
-		OffsetBytes: offset,
-		SizeBytes:   size,
-	}
-}

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -497,7 +497,9 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 	var roleBinding auth.RoleBinding
 	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(resourceKey(resource), &roleBinding); err != nil {
 		if col.IsErrNotFound(err) {
-			return nil, &auth.ErrNoRoleBinding{*resource}
+			return nil, &auth.ErrNoRoleBinding{
+				Resource: *resource,
+			}
 		}
 		return nil, errors.Wrapf(err, "error getting role bindings for %s \"%s\"", resource.Type, resource.Name)
 	}
@@ -777,7 +779,9 @@ func (a *apiServer) setUserRoleBindingInTransaction(txnCtx *txncontext.Transacti
 	var bindings auth.RoleBinding
 	if err := roleBindings.Get(key, &bindings); err != nil {
 		if col.IsErrNotFound(err) {
-			return &auth.ErrNoRoleBinding{*resource}
+			return &auth.ErrNoRoleBinding{
+				Resource: *resource,
+			}
 		}
 		return err
 	}

--- a/src/server/debug/cmds/cmds.go
+++ b/src/server/debug/cmds/cmds.go
@@ -122,13 +122,13 @@ func createFilter(pachd bool, pipeline, worker string) (*debug.Filter, error) {
 		if f != nil {
 			return nil, errors.Errorf("only one debug filter allowed")
 		}
-		f = &debug.Filter{Filter: &debug.Filter_Pipeline{&pps.Pipeline{Name: pipeline}}}
+		f = &debug.Filter{Filter: &debug.Filter_Pipeline{Pipeline: &pps.Pipeline{Name: pipeline}}}
 	}
 	if worker != "" {
 		if f != nil {
 			return nil, errors.Errorf("only one debug filter allowed")
 		}
-		f = &debug.Filter{Filter: &debug.Filter_Worker{&debug.Worker{Pod: worker}}}
+		f = &debug.Filter{Filter: &debug.Filter_Worker{Worker: &debug.Worker{Pod: worker}}}
 	}
 	return f, nil
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10159,7 +10159,7 @@ func TestTrigger(t *testing.T) {
 		require.NoError(t, c.GetFile(pipelineCommit1, fmt.Sprintf("file%d", i), &buf))
 		require.Equal(t, strings.Repeat("a", fileBytes), buf.String())
 	}
-	cis, err = c.ListCommit(client.NewRepo(pipeline1), client.NewCommit(pipeline1, "master", ""), nil, 0)
+	_, err = c.ListCommit(client.NewRepo(pipeline1), client.NewCommit(pipeline1, "master", ""), nil, 0)
 	require.NoError(t, err)
 	// Another 10 100 byte files = 2K, so the last file should trigger both pipelines.
 	for i := numFiles; i < 2*numFiles; i++ {
@@ -10504,36 +10504,4 @@ func TestSystemRepoDependence(t *testing.T) {
 	// spec repo should have been deleted
 	require.YesError(t, err)
 	require.True(t, errutil.IsNotFoundError(grpcutil.ScrubGRPC(err)))
-}
-
-//lint:ignore U1000 false positive from staticcheck
-func restartAll(t *testing.T) {
-	k := tu.GetKubeClient(t)
-	podsInterface := k.CoreV1().Pods(v1.NamespaceDefault)
-	podList, err := podsInterface.List(
-		metav1.ListOptions{
-			LabelSelector: "suite=pachyderm",
-		})
-	require.NoError(t, err)
-	for _, pod := range podList.Items {
-		require.NoError(t, podsInterface.Delete(pod.Name, &metav1.DeleteOptions{
-			GracePeriodSeconds: new(int64),
-		}))
-	}
-	tu.WaitForPachdReady(t, v1.NamespaceDefault)
-}
-
-//lint:ignore U1000 false positive from staticcheck
-func restartOne(t *testing.T) {
-	k := tu.GetKubeClient(t)
-	podsInterface := k.CoreV1().Pods(v1.NamespaceDefault)
-	podList, err := podsInterface.List(
-		metav1.ListOptions{
-			LabelSelector: "app=pachd",
-		})
-	require.NoError(t, err)
-	require.NoError(t, podsInterface.Delete(
-		podList.Items[rand.Intn(len(podList.Items))].Name,
-		&metav1.DeleteOptions{GracePeriodSeconds: new(int64)}))
-	tu.WaitForPachdReady(t, v1.NamespaceDefault)
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"

--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -412,7 +412,7 @@ func (n *loopbackNode) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.A
 		return fs.ToErrno(err)
 	}
 
-	var err error = nil
+	var err error
 	st := syscall.Stat_t{}
 	err = syscall.Lstat(p, &st)
 	if err != nil {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1266,7 +1266,7 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 			if err := d.commits.ReadWrite(sqlTx).Get(pfsdb.CommitKey(commit), &cis[i%len(cis)]); err != nil {
 				if col.IsErrNotFound(err) {
 					if i == 0 {
-						return nil, pfsserver.ErrCommitNotFound{userCommit}
+						return nil, pfsserver.ErrCommitNotFound{Commit: userCommit}
 					}
 					return nil, pfsserver.ErrParentCommitNotFound{Commit: commit}
 				}

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -38,7 +38,7 @@ func (d *driver) modifyFile(ctx context.Context, commit *pfs.Commit, cb func(*fi
 		// The commit is already finished - if the commit was explicitly specified,
 		// error out, otherwise we can make a child commit since this is the branch head.
 		if commitID != "" {
-			return pfsserver.ErrCommitFinished{commitInfo.Commit}
+			return pfsserver.ErrCommitFinished{Commit: commitInfo.Commit}
 		}
 		var opts []fileset.UnorderedWriterOption
 		if commitInfo.ParentCommit != nil {

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -412,7 +412,7 @@ func (d *driver) addFileset(txnCtx *txncontext.TransactionContext, commit *pfs.C
 		return err
 	}
 	if commitInfo.Finished != nil {
-		return pfsserver.ErrCommitFinished{commitInfo.Commit}
+		return pfsserver.ErrCommitFinished{Commit: commitInfo.Commit}
 	}
 	return d.commitStore.AddFilesetTx(txnCtx.SqlTx, commitInfo.Commit, filesetID)
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -525,7 +525,7 @@ func (a *apiServer) CreateJob(ctx context.Context, request *pps.CreateJobRequest
 			return err
 		}
 		if commitInfo.Finished != nil {
-			return pfsServer.ErrCommitFinished{commitInfo.Commit}
+			return pfsServer.ErrCommitFinished{Commit: commitInfo.Commit}
 		}
 		if request.Stats == nil {
 			request.Stats = &pps.ProcessStats{}
@@ -2878,7 +2878,6 @@ func (a *apiServer) RunPipeline(ctx context.Context, request *pps.RunPipelineReq
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
 
 	pachClient := a.env.GetPachClient(ctx)
-	ctx = ctx // pachClient will propagate auth info
 	pfsClient := pachClient.PfsAPIClient
 	ppsClient := pachClient.PpsAPIClient
 
@@ -3194,7 +3193,6 @@ func (a *apiServer) ListSecret(ctx context.Context, in *types.Empty) (response *
 func (a *apiServer) DeleteAll(ctx context.Context, request *types.Empty) (response *types.Empty, retErr error) {
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
-	ctx = ctx // pachClient will propagate auth info
 
 	if _, err := a.DeletePipeline(ctx, &pps.DeletePipelineRequest{All: true, Force: true}); err != nil {
 		return nil, err

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -498,7 +498,7 @@ func (a *apiServer) UpdateJobStateInTransaction(txnCtx *txncontext.TransactionCo
 		return err
 	}
 	if ppsutil.IsTerminal(jobPtr.State) {
-		return ppsServer.ErrJobFinished{jobPtr.Job}
+		return ppsServer.ErrJobFinished{Job: jobPtr.Job}
 	}
 
 	jobPtr.Restart = request.Restart

--- a/src/server/transaction/pretty/pretty.go
+++ b/src/server/transaction/pretty/pretty.go
@@ -73,7 +73,7 @@ func sprintDeleteRepo(request *pfs.DeleteRepoRequest) string {
 }
 
 func sprintStartCommit(request *pfs.StartCommitRequest, response *transaction.TransactionResponse) string {
-	commit := "unknown"
+	var commit string
 	if response == nil || response.Commit == nil {
 		commit = "ERROR (unknown response type)"
 	} else {


### PR DESCRIPTION
Re-enable linting in CI and clean up a few pieces of unused code that are detected. golanglint-ci is a meta-linter which runs govet a few other checks by default (https://golangci-lint.run/usage/linters/). This is a mostly stock config, except `errcheck` is currently disabled because we have an alarming number of unchecked errors to work through. 

This removes golint - which is deprecated and "is not, and will never be, trustworthy enough for its suggestions to be enforced automatically, for example as part of a build process" (https://github.com/golang/lint#purpose). It is no longer necessary to write a godoc comment for every public field, struct and method.