### PR TITLE
[1.13.x] Fix collecting metrics with auth enabled

### DIFF
--- a/src/server/auth/iface.go
+++ b/src/server/auth/iface.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"github.com/pachyderm/pachyderm/src/client/auth"
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
+)
+
+// TransactionServer is an interface for the transactionally-supported
+// methods that can be called through the auth server.
+type TransactionServer interface {
+	AuthorizeInTransaction(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
+
+	GetScopeInTransaction(*txncontext.TransactionContext, *auth.GetScopeRequest) (*auth.GetScopeResponse, error)
+	SetScopeInTransaction(*txncontext.TransactionContext, *auth.SetScopeRequest) (*auth.SetScopeResponse, error)
+
+	GetACLInTransaction(*txncontext.TransactionContext, *auth.GetACLRequest) (*auth.GetACLResponse, error)
+	SetACLInTransaction(*txncontext.TransactionContext, *auth.SetACLRequest) (*auth.SetACLResponse, error)
+
+	GetAuthTokenInTransaction(*txncontext.TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error)
+	RevokeAuthTokenInTransaction(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
+
+	CheckIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Repo, auth.Scope) error
+}
+
+// APIServer represents an auth api server
+type APIServer interface {
+	auth.APIServer
+	TransactionServer
+}

--- a/src/server/auth/server/util.go
+++ b/src/server/auth/server/util.go
@@ -6,19 +6,19 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pkg/grpcutil"
-	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 )
 
 // CheckIsAuthorizedInTransaction is identicalto CheckIsAuthorized except that
 // it performs reads consistent with the latest state of the STM transaction.
-func CheckIsAuthorizedInTransaction(txnCtx *txnenv.TransactionContext, r *pfs.Repo, s auth.Scope) error {
+func (a *apiServer) CheckIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, r *pfs.Repo, s auth.Scope) error {
 	me, err := txnCtx.Client.WhoAmI(txnCtx.ClientContext, &auth.WhoAmIRequest{})
 	if auth.IsErrNotActivated(err) {
 		return nil
 	}
 
 	req := &auth.AuthorizeRequest{Repo: r.Name, Scope: s}
-	resp, err := txnCtx.Auth().AuthorizeInTransaction(txnCtx, req)
+	resp, err := a.AuthorizeInTransaction(txnCtx, req)
 	if err != nil {
 		return errors.Wrapf(grpcutil.ScrubGRPC(err), "error during authorization check for operation on \"%s\"", r.Name)
 	}

--- a/src/server/auth/testing/auth.go
+++ b/src/server/auth/testing/auth.go
@@ -4,7 +4,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/src/client/auth"
-	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 )
 
 // InactiveAPIServer (in the auth/testing package) is an implementation of the
@@ -55,7 +56,7 @@ func (a *InactiveAPIServer) Authorize(context.Context, *auth.AuthorizeRequest) (
 
 // AuthorizeInTransaction is the same as the Authorize RPC but for use inside a
 // running transaction.  It also returns a NotActivatedError.
-func (a *InactiveAPIServer) AuthorizeInTransaction(*txnenv.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error) {
+func (a *InactiveAPIServer) AuthorizeInTransaction(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -71,7 +72,7 @@ func (a *InactiveAPIServer) SetScope(context.Context, *auth.SetScopeRequest) (*a
 
 // SetScopeInTransaction is the same as the SetScope RPC but for use inside a
 // running transaction.  It also returns a NotActivatedError.
-func (a *InactiveAPIServer) SetScopeInTransaction(*txnenv.TransactionContext, *auth.SetScopeRequest) (*auth.SetScopeResponse, error) {
+func (a *InactiveAPIServer) SetScopeInTransaction(*txncontext.TransactionContext, *auth.SetScopeRequest) (*auth.SetScopeResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -82,7 +83,7 @@ func (a *InactiveAPIServer) GetScope(context.Context, *auth.GetScopeRequest) (*a
 
 // GetScopeInTransaction is the same as the GetScope RPC but for use inside a
 // running transaction.  It also returns a NotActivatedError.
-func (a *InactiveAPIServer) GetScopeInTransaction(*txnenv.TransactionContext, *auth.GetScopeRequest) (*auth.GetScopeResponse, error) {
+func (a *InactiveAPIServer) GetScopeInTransaction(*txncontext.TransactionContext, *auth.GetScopeRequest) (*auth.GetScopeResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -93,7 +94,7 @@ func (a *InactiveAPIServer) GetACL(context.Context, *auth.GetACLRequest) (*auth.
 
 // GetACLInTransaction is the same as the GetACL RPC but for use inside a
 // running transaction.  It also returns a NotActivatedError.
-func (a *InactiveAPIServer) GetACLInTransaction(*txnenv.TransactionContext, *auth.GetACLRequest) (*auth.GetACLResponse, error) {
+func (a *InactiveAPIServer) GetACLInTransaction(*txncontext.TransactionContext, *auth.GetACLRequest) (*auth.GetACLResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -104,7 +105,7 @@ func (a *InactiveAPIServer) SetACL(context.Context, *auth.SetACLRequest) (*auth.
 
 // SetACLInTransaction is the same as the SetACL RPC but for use inside a
 // running transaction.  It also returns a NotActivatedError.
-func (a *InactiveAPIServer) SetACLInTransaction(*txnenv.TransactionContext, *auth.SetACLRequest) (*auth.SetACLResponse, error) {
+func (a *InactiveAPIServer) SetACLInTransaction(*txncontext.TransactionContext, *auth.SetACLRequest) (*auth.SetACLResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -114,7 +115,7 @@ func (a *InactiveAPIServer) GetAuthToken(context.Context, *auth.GetAuthTokenRequ
 }
 
 // GetAuthTokenInTransaction is the same as GetAuthToken but for use inside a running transaction.
-func (a *InactiveAPIServer) GetAuthTokenInTransaction(*txnenv.TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error) {
+func (a *InactiveAPIServer) GetAuthTokenInTransaction(*txncontext.TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -134,7 +135,7 @@ func (a *InactiveAPIServer) RevokeAuthToken(context.Context, *auth.RevokeAuthTok
 }
 
 // RevokeAuthTokenInTransaction is the same as RevokeAuthToken but for use inside a running transaction
-func (a *InactiveAPIServer) RevokeAuthTokenInTransaction(*txnenv.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error) {
+func (a *InactiveAPIServer) RevokeAuthTokenInTransaction(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error) {
 	return nil, auth.ErrNotActivated
 }
 
@@ -181,4 +182,9 @@ func (a *InactiveAPIServer) ExtractAuthTokens(context.Context, *auth.ExtractAuth
 // RestoreAuthToken implements the RestoreAuthToken RPC, but just returns NotActivatedError
 func (a *InactiveAPIServer) RestoreAuthToken(context.Context, *auth.RestoreAuthTokenRequest) (*auth.RestoreAuthTokenResponse, error) {
 	return nil, auth.ErrNotActivated
+}
+
+// CheckIsAuthorizedInTransaction implements the internal transaction API
+func (a *InactiveAPIServer) CheckIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Repo, auth.Scope) error {
+	return auth.ErrNotActivated
 }

--- a/src/server/auth/testing/auth.go
+++ b/src/server/auth/testing/auth.go
@@ -186,5 +186,5 @@ func (a *InactiveAPIServer) RestoreAuthToken(context.Context, *auth.RestoreAuthT
 
 // CheckIsAuthorizedInTransaction implements the internal transaction API
 func (a *InactiveAPIServer) CheckIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Repo, auth.Scope) error {
-	return auth.ErrNotActivated
+	return nil
 }

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -186,6 +186,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 			return err
 		}
 		pfsclient.RegisterAPIServer(server.Server, pfsAPIServer)
+		env.SetPfsServer(pfsAPIServer)
 		return nil
 	}); err != nil {
 		return err
@@ -207,6 +208,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 			return err
 		}
 		ppsclient.RegisterAPIServer(server.Server, ppsAPIServer)
+		env.SetPpsServer(ppsAPIServer)
 		return nil
 	}); err != nil {
 		return err
@@ -250,6 +252,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 			return err
 		}
 		eprsclient.RegisterAPIServer(server.Server, enterpriseAPIServer)
+		env.SetEnterpriseServer(enterpriseAPIServer)
 		return nil
 	}); err != nil {
 		return err
@@ -566,6 +569,7 @@ func doFullMode(config interface{}) (retErr error) {
 				return err
 			}
 			pfsclient.RegisterAPIServer(internalServer.Server, pfsAPIServer)
+			env.SetPfsServer(pfsAPIServer)
 			return nil
 		}); err != nil {
 			return err
@@ -599,6 +603,7 @@ func doFullMode(config interface{}) (retErr error) {
 				return err
 			}
 			ppsclient.RegisterAPIServer(internalServer.Server, ppsAPIServer)
+			env.SetPpsServer(ppsAPIServer)
 			return nil
 		}); err != nil {
 			return err
@@ -642,6 +647,7 @@ func doFullMode(config interface{}) (retErr error) {
 				return err
 			}
 			eprsclient.RegisterAPIServer(internalServer.Server, enterpriseAPIServer)
+			env.SetEnterpriseServer(enterpriseAPIServer)
 			return nil
 		}); err != nil {
 			return err

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -27,11 +27,13 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/version"
 	"github.com/pachyderm/pachyderm/src/client/version/versionpb"
 	adminserver "github.com/pachyderm/pachyderm/src/server/admin/server"
+	auth_iface "github.com/pachyderm/pachyderm/src/server/auth"
 	authserver "github.com/pachyderm/pachyderm/src/server/auth/server"
 	debugserver "github.com/pachyderm/pachyderm/src/server/debug/server"
 	eprsserver "github.com/pachyderm/pachyderm/src/server/enterprise/server"
 	"github.com/pachyderm/pachyderm/src/server/health"
 	pach_http "github.com/pachyderm/pachyderm/src/server/http"
+	pfs_iface "github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pfs/s3"
 	pfs_server "github.com/pachyderm/pachyderm/src/server/pfs/server"
 	cache_pb "github.com/pachyderm/pachyderm/src/server/pkg/cache/groupcachepb"
@@ -46,6 +48,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
 	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
+	pps_iface "github.com/pachyderm/pachyderm/src/server/pps"
 	pps_server "github.com/pachyderm/pachyderm/src/server/pps/server"
 	"github.com/pachyderm/pachyderm/src/server/pps/server/githook"
 	txnserver "github.com/pachyderm/pachyderm/src/server/transaction/server"
@@ -171,7 +174,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 	if err != nil {
 		return err
 	}
-	var pfsAPIServer pfs_server.APIServer
+	var pfsAPIServer pfs_iface.APIServer
 	if err := logGRPCServerSetup("PFS API", func() error {
 		pfsAPIServer, err = pfs_server.NewAPIServer(
 			env,
@@ -191,7 +194,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 	}); err != nil {
 		return err
 	}
-	var ppsAPIServer pps_server.APIServer
+	var ppsAPIServer pps_iface.APIServer
 	if err := logGRPCServerSetup("PPS API", func() error {
 		ppsAPIServer, err = pps_server.NewSidecarAPIServer(
 			env,
@@ -213,7 +216,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 	}); err != nil {
 		return err
 	}
-	var authAPIServer authserver.APIServer
+	var authAPIServer auth_iface.APIServer
 	if err := logGRPCServerSetup("Auth API", func() error {
 		authAPIServer, err = authserver.NewAuthServer(
 			env,
@@ -226,6 +229,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 			return err
 		}
 		authclient.RegisterAPIServer(server.Server, authAPIServer)
+		env.SetAuthServer(authAPIServer)
 		return nil
 	}); err != nil {
 		return err
@@ -392,7 +396,7 @@ func doFullMode(config interface{}) (retErr error) {
 		if err != nil {
 			return err
 		}
-		var pfsAPIServer pfs_server.APIServer
+		var pfsAPIServer pfs_iface.APIServer
 		if err := logGRPCServerSetup("PFS API", func() error {
 			pfsAPIServer, err = pfs_server.NewAPIServer(env, txnEnv, path.Join(env.EtcdPrefix, env.PFSEtcdPrefix), treeCache, env.StorageRoot, memoryRequestBytes, blockAPIServer)
 			if err != nil {
@@ -403,7 +407,7 @@ func doFullMode(config interface{}) (retErr error) {
 		}); err != nil {
 			return err
 		}
-		var ppsAPIServer pps_server.APIServer
+		var ppsAPIServer pps_iface.APIServer
 		if err := logGRPCServerSetup("PPS API", func() error {
 			ppsAPIServer, err = pps_server.NewAPIServer(
 				env,
@@ -456,7 +460,7 @@ func doFullMode(config interface{}) (retErr error) {
 				}
 			}
 		}
-		var authAPIServer authserver.APIServer
+		var authAPIServer auth_iface.APIServer
 		if err := logGRPCServerSetup("Auth API", func() error {
 			authAPIServer, err = authserver.NewAuthServer(
 				env, txnEnv, path.Join(env.EtcdPrefix, env.AuthEtcdPrefix), true, requireNoncriticalServers)
@@ -554,7 +558,7 @@ func doFullMode(config interface{}) (retErr error) {
 		if err != nil {
 			return err
 		}
-		var pfsAPIServer pfs_server.APIServer
+		var pfsAPIServer pfs_iface.APIServer
 		if err := logGRPCServerSetup("PFS API", func() error {
 			pfsAPIServer, err = pfs_server.NewAPIServer(
 				env,
@@ -574,7 +578,7 @@ func doFullMode(config interface{}) (retErr error) {
 		}); err != nil {
 			return err
 		}
-		var ppsAPIServer pps_server.APIServer
+		var ppsAPIServer pps_iface.APIServer
 		if err := logGRPCServerSetup("PPS API", func() error {
 			ppsAPIServer, err = pps_server.NewAPIServer(
 				env,
@@ -608,7 +612,7 @@ func doFullMode(config interface{}) (retErr error) {
 		}); err != nil {
 			return err
 		}
-		var authAPIServer authserver.APIServer
+		var authAPIServer auth_iface.APIServer
 		if err := logGRPCServerSetup("Auth API", func() error {
 			authAPIServer, err = authserver.NewAuthServer(
 				env,
@@ -621,6 +625,7 @@ func doFullMode(config interface{}) (retErr error) {
 				return err
 			}
 			authclient.RegisterAPIServer(internalServer.Server, authAPIServer)
+			env.SetAuthServer(authAPIServer)
 			return nil
 		}); err != nil {
 			return err

--- a/src/server/pfs/iface.go
+++ b/src/server/pfs/iface.go
@@ -27,6 +27,8 @@ type TransactionServer interface {
 	DeleteBranchInTransaction(*txncontext.TransactionContext, *pfs_client.DeleteBranchRequest) error
 }
 
+// APIServer is the combination of the public RPC interface, the internal transaction interface and
+// other internal methods exposed by the PFS service
 type APIServer interface {
 	pfs_client.APIServer
 	TransactionServer

--- a/src/server/pfs/iface.go
+++ b/src/server/pfs/iface.go
@@ -1,9 +1,35 @@
 package pfs
 
 import (
-	pfs_client "github.com/pachyderm/pachyderm/v2/src/pfs"
+	"context"
+
+	pfs_client "github.com/pachyderm/pachyderm/src/client/pfs"
+	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 )
 
+// TransactionServer is an interface for the transactionally-supported
+// methods that can be called through the PFS server.
+type TransactionServer interface {
+	NewPropagater(col.STM) txncontext.PfsPropagater
+	NewPipelineFinisher(*txncontext.TransactionContext) txncontext.PipelineCommitFinisher
+
+	CreateRepoInTransaction(*txncontext.TransactionContext, *pfs_client.CreateRepoRequest) error
+	InspectRepoInTransaction(*txncontext.TransactionContext, *pfs_client.InspectRepoRequest) (*pfs_client.RepoInfo, error)
+	DeleteRepoInTransaction(*txncontext.TransactionContext, *pfs_client.DeleteRepoRequest) error
+
+	StartCommitInTransaction(*txncontext.TransactionContext, *pfs_client.StartCommitRequest, *pfs_client.Commit) (*pfs_client.Commit, error)
+	FinishCommitInTransaction(*txncontext.TransactionContext, *pfs_client.FinishCommitRequest) error
+	DeleteCommitInTransaction(*txncontext.TransactionContext, *pfs_client.DeleteCommitRequest) error
+
+	CreateBranchInTransaction(*txncontext.TransactionContext, *pfs_client.CreateBranchRequest) error
+	InspectBranchInTransaction(*txncontext.TransactionContext, *pfs_client.InspectBranchRequest) (*pfs_client.BranchInfo, error)
+	DeleteBranchInTransaction(*txncontext.TransactionContext, *pfs_client.DeleteBranchRequest) error
+}
+
 type APIServer interface {
-	ListRepoWithoutAuth(ctx context.Context) (*pfs.ListRepoResponse, error)
+	pfs_client.APIServer
+	TransactionServer
+
+	ListRepoNoAuth(context.Context, *pfs_client.ListRepoRequest) (*pfs_client.ListRepoResponse, error)
 }

--- a/src/server/pfs/iface.go
+++ b/src/server/pfs/iface.go
@@ -1,0 +1,9 @@
+package pfs
+
+import (
+	pfs_client "github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+type APIServer interface {
+	ListRepoWithoutAuth(ctx context.Context) (*pfs.ListRepoResponse, error)
+}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -117,6 +117,15 @@ func (a *apiServer) ListRepo(ctx context.Context, request *pfs.ListRepoRequest) 
 	return repoInfos, err
 }
 
+// ListRepoNoAuth is an internal API for collecting metrics (not an RPC) which doesn't check auth
+func (a *apiServer) ListRepoNoAuth(ctx context.Context, request *pfs.ListRepoRequest) (response *pfs.ListRepoResponse, retErr error) {
+	func() { a.Log(request, nil, nil, 0) }()
+	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
+
+	repoInfos, err := a.driver.listRepo(a.env.GetPachClient(ctx), false)
+	return repoInfos, err
+}
+
 // DeleteRepoInTransaction is identical to DeleteRepo except that it can run
 // inside an existing etcd STM transaction.  This is not an RPC.
 func (a *apiServer) DeleteRepoInTransaction(

--- a/src/server/pfs/server/api_server_v2.go
+++ b/src/server/pfs/server/api_server_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/storage/fileset"
 	"github.com/pachyderm/pachyderm/src/server/pkg/storage/metrics"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 	"golang.org/x/net/context"
 )
 
@@ -45,7 +46,7 @@ func newAPIServerV2(env *serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, e
 
 // DeleteRepoInTransaction is identical to DeleteRepo except that it can run
 // inside an existing etcd STM transaction.  This is not an RPC.
-func (a *apiServerV2) DeleteRepoInTransaction(txnCtx *txnenv.TransactionContext, request *pfs.DeleteRepoRequest) error {
+func (a *apiServerV2) DeleteRepoInTransaction(txnCtx *txncontext.TransactionContext, request *pfs.DeleteRepoRequest) error {
 	if request.All {
 		return a.driver.deleteAll(txnCtx)
 	}
@@ -54,7 +55,7 @@ func (a *apiServerV2) DeleteRepoInTransaction(txnCtx *txnenv.TransactionContext,
 
 // FinishCommitInTransaction is identical to FinishCommit except that it can run
 // inside an existing etcd STM transaction.  This is not an RPC.
-func (a *apiServerV2) FinishCommitInTransaction(txnCtx *txnenv.TransactionContext, request *pfs.FinishCommitRequest) error {
+func (a *apiServerV2) FinishCommitInTransaction(txnCtx *txncontext.TransactionContext, request *pfs.FinishCommitRequest) error {
 	return metrics.ReportRequest(func() error {
 		if request.Empty {
 			request.Description += pfs.EmptyStr
@@ -65,7 +66,7 @@ func (a *apiServerV2) FinishCommitInTransaction(txnCtx *txnenv.TransactionContex
 
 // DeleteCommitInTransaction is identical to DeleteCommit except that it can run
 // inside an existing etcd STM transaction.  This is not an RPC.
-func (a *apiServerV2) DeleteCommitInTransaction(txnCtx *txnenv.TransactionContext, request *pfs.DeleteCommitRequest) error {
+func (a *apiServerV2) DeleteCommitInTransaction(txnCtx *txncontext.TransactionContext, request *pfs.DeleteCommitRequest) error {
 	return a.driver.deleteCommit(txnCtx, request.Commit)
 }
 
@@ -147,7 +148,7 @@ func (a *apiServerV2) DeleteFile(ctx context.Context, request *pfs.DeleteFileReq
 
 // DeleteAll implements the protobuf pfs.DeleteAll RPC
 func (a *apiServerV2) DeleteAll(ctx context.Context, request *types.Empty) (response *types.Empty, retErr error) {
-	err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+	err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		return a.driver.deleteAll(txnCtx)
 	})
 	if err != nil {
@@ -309,7 +310,7 @@ func (a *apiServerV2) RenewTmpFileSet(ctx context.Context, req *pfs.RenewTmpFile
 // CreateRepoInTransaction is identical to CreateRepo except that it can run
 // inside an existing etcd STM transaction.  This is not an RPC.
 func (a *apiServerV2) CreateRepoInTransaction(
-	txnCtx *txnenv.TransactionContext,
+	txnCtx *txncontext.TransactionContext,
 	request *pfs.CreateRepoRequest,
 ) error {
 	if repo := request.GetRepo(); repo != nil && repo.Name == tmpRepo {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	"github.com/pachyderm/pachyderm/src/server/pkg/sql"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
 	"github.com/pachyderm/pachyderm/src/server/pkg/watch"
 
@@ -188,7 +189,7 @@ func newDriver(
 	return d, nil
 }
 
-func (d *driver) createRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, description string, update bool) error {
+func (d *driver) createRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, description string, update bool) error {
 	// Validate arguments
 	if repo == nil {
 		return errors.New("repo cannot be nil")
@@ -233,7 +234,7 @@ func (d *driver) createRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, d
 		// idempotent way to ensure that R exists. By permitting these calls when
 		// they don't actually change anything, even if the caller doesn't have
 		// WRITER access, we make the pattern more generally useful.
-		if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, repo, auth.Scope_WRITER); err != nil {
+		if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, repo, auth.Scope_WRITER); err != nil {
 			return errors.Wrapf(err, "could not update description of %q", repo)
 		}
 		existingRepoInfo.Description = description
@@ -243,7 +244,7 @@ func (d *driver) createRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, d
 		if authIsActivated {
 			// Create ACL for new repo. Make caller the sole owner. If the ACL already
 			// exists with a different owner, this will fail.
-			_, err := txnCtx.Auth().SetACLInTransaction(txnCtx, &auth.SetACLRequest{
+			_, err := d.env.AuthServer().SetACLInTransaction(txnCtx, &auth.SetACLRequest{
 				Repo: repo.Name,
 				Entries: []*auth.ACLEntry{{
 					Username: whoAmI.Username,
@@ -263,7 +264,7 @@ func (d *driver) createRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, d
 }
 
 func (d *driver) inspectRepo(
-	txnCtx *txnenv.TransactionContext,
+	txnCtx *txncontext.TransactionContext,
 	repo *pfs.Repo,
 	includeAuth bool,
 ) (*pfs.RepoInfo, error) {
@@ -548,7 +549,7 @@ func (d *driver) listRepo(pachClient *client.APIClient, includeAuth bool) (*pfs.
 	return result, nil
 }
 
-func (d *driver) deleteRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, force bool) error {
+func (d *driver) deleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, force bool) error {
 	// Validate arguments
 	if repo == nil {
 		return errors.New("repo cannot be nil")
@@ -574,7 +575,7 @@ func (d *driver) deleteRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, f
 	}
 
 	// Check if the caller is authorized to delete this repo
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, repo, auth.Scope_OWNER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, repo, auth.Scope_OWNER); err != nil {
 		return err
 	}
 
@@ -667,7 +668,7 @@ func (d *driver) deleteRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, f
 		return errors.Wrapf(err, "repos.Delete")
 	}
 
-	if _, err = txnCtx.Auth().SetACLInTransaction(txnCtx, &auth.SetACLRequest{
+	if _, err = d.env.AuthServer().SetACLInTransaction(txnCtx, &auth.SetACLRequest{
 		Repo: repo.Name, // NewACL is unset, so this will clear the acl for 'repo'
 	}); err != nil && !auth.IsErrNotActivated(err) {
 		return grpcutil.ScrubGRPC(err)
@@ -681,7 +682,7 @@ func (d *driver) deleteRepoSplitTransaction(ctx context.Context, repo *pfs.Repo,
 		return errors.New("repo cannot be nil")
 	}
 	// Tombstone repo.
-	if err := d.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+	if err := d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		return d.tombstoneRepo(txnCtx, repo, force)
 	}); err != nil {
 		return err
@@ -690,7 +691,7 @@ func (d *driver) deleteRepoSplitTransaction(ctx context.Context, repo *pfs.Repo,
 	commits := d.commits(repo.Name).ReadOnly(ctx)
 	ci := &pfs.CommitInfo{}
 	if err := commits.List(ci, col.DefaultOptions, func(ID string) error {
-		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 			commits := d.commits(repo.Name).ReadWrite(txnCtx.Stm)
 			if err := commits.Delete(ID); err != nil {
 				if col.IsErrNotFound(err) {
@@ -713,7 +714,7 @@ func (d *driver) deleteRepoSplitTransaction(ctx context.Context, repo *pfs.Repo,
 		return err
 	}
 	// Delete all branches / commits and repo.
-	return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+	return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		// Despite the fact that we already deleted each branch with
 		// tombstoneRepo, we also do branches.DeleteAll(), this insulates us
 		// against certain corruption situations where the RepoInfo doesn't
@@ -727,7 +728,7 @@ func (d *driver) deleteRepoSplitTransaction(ctx context.Context, repo *pfs.Repo,
 		if err := repos.Delete(repo.Name); err != nil && !col.IsErrNotFound(err) {
 			return err
 		}
-		if _, err := txnCtx.Auth().SetACLInTransaction(txnCtx, &auth.SetACLRequest{
+		if _, err := d.env.AuthServer().SetACLInTransaction(txnCtx, &auth.SetACLRequest{
 			Repo: repo.Name, // NewACL is unset, so this will clear the acl for 'repo'
 		}); err != nil && !auth.IsErrNotActivated(err) {
 			return grpcutil.ScrubGRPC(err)
@@ -736,7 +737,7 @@ func (d *driver) deleteRepoSplitTransaction(ctx context.Context, repo *pfs.Repo,
 	})
 }
 
-func (d *driver) tombstoneRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, force bool) error {
+func (d *driver) tombstoneRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, force bool) error {
 	// TODO(msteffen): Fix d.deleteAll() so that it doesn't need to delete and
 	// recreate the PPS spec repo, then uncomment this block to prevent users from
 	// deleting it and breaking their cluster
@@ -753,7 +754,7 @@ func (d *driver) tombstoneRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo
 			return err
 		}
 	}
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, repo, auth.Scope_OWNER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, repo, auth.Scope_OWNER); err != nil {
 		return err
 	}
 	repoInfo := &pfs.RepoInfo{}
@@ -786,7 +787,7 @@ func (d *driver) tombstoneRepo(txnCtx *txnenv.TransactionContext, repo *pfs.Repo
 	return nil
 }
 
-func (d *driver) updateCommitSubvenance(txnCtx *txnenv.TransactionContext, repo *pfs.Repo, prov *pfs.CommitProvenance) error {
+func (d *driver) updateCommitSubvenance(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, prov *pfs.CommitProvenance) error {
 	provCI := &pfs.CommitInfo{}
 	if err := d.commits(prov.Commit.Repo.Name).ReadWrite(txnCtx.Stm).Update(prov.Commit.ID, provCI, func() error {
 		subvTo := 0 // copy subvFrom to subvTo, excepting subv ranges to delete (so that they're overwritten)
@@ -807,7 +808,7 @@ func (d *driver) updateCommitSubvenance(txnCtx *txnenv.TransactionContext, repo 
 
 // ID can be passed in for transactions, which need to ensure the ID doesn't
 // change after the commit ID has been reported to a client.
-func (d *driver) startCommit(txnCtx *txnenv.TransactionContext, ID string, parent *pfs.Commit, branch string, provenance []*pfs.CommitProvenance, description string) (*pfs.Commit, error) {
+func (d *driver) startCommit(txnCtx *txncontext.TransactionContext, ID string, parent *pfs.Commit, branch string, provenance []*pfs.CommitProvenance, description string) (*pfs.Commit, error) {
 	return d.makeCommit(txnCtx, ID, parent, branch, nil, provenance, nil, nil, nil, nil, nil, description, time.Time{}, time.Time{}, 0)
 }
 
@@ -816,7 +817,7 @@ func (d *driver) buildCommit(ctx context.Context, ID string, parent *pfs.Commit,
 	tree *pfs.Object, trees []*pfs.Object, datums *pfs.Object,
 	started, finished time.Time, sizeBytes uint64) (*pfs.Commit, error) {
 	commit := &pfs.Commit{}
-	err := d.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+	err := d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
 		commit, err = d.makeCommit(txnCtx, ID, parent, branch, origin, provenance, tree, trees,
 			datums, nil, nil, "", started, finished, sizeBytes)
@@ -838,7 +839,7 @@ func (d *driver) buildCommit(ctx context.Context, ID string, parent *pfs.Commit,
 // - If only 'parent.ID' is set, and it contains a branch, then the new commit's
 //   parent will be the HEAD of that branch, but the branch will not be moved
 func (d *driver) makeCommit(
-	txnCtx *txnenv.TransactionContext,
+	txnCtx *txncontext.TransactionContext,
 	ID string,
 	parent *pfs.Commit,
 	branch string,
@@ -862,7 +863,7 @@ func (d *driver) makeCommit(
 		return nil, err
 	}
 	// Check that caller is authorized
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, parent.Repo, auth.Scope_WRITER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, parent.Repo, auth.Scope_WRITER); err != nil {
 		return nil, err
 	}
 
@@ -1212,7 +1213,7 @@ func (d *driver) makeCommit(
 	return newCommit, nil
 }
 
-func (d *driver) finishCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Commit, tree *pfs.Object, empty bool, description string) (retErr error) {
+func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs.Commit, tree *pfs.Object, empty bool, description string) (retErr error) {
 	// Validate arguments
 	if commit == nil {
 		return errors.New("commit cannot be nil")
@@ -1221,7 +1222,7 @@ func (d *driver) finishCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Com
 		return errors.New("commit repo cannot be nil")
 	}
 
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, commit.Repo, auth.Scope_WRITER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, commit.Repo, auth.Scope_WRITER); err != nil {
 		return err
 	}
 	commitInfo, err := d.resolveCommit(txnCtx.Stm, commit)
@@ -1303,8 +1304,8 @@ func (d *driver) finishCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Com
 	return nil
 }
 
-func (d *driver) finishOutputCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Commit, trees []*pfs.Object, datums *pfs.Object, size uint64) (retErr error) {
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, commit.Repo, auth.Scope_WRITER); err != nil {
+func (d *driver) finishOutputCommit(txnCtx *txncontext.TransactionContext, commit *pfs.Commit, trees []*pfs.Object, datums *pfs.Object, size uint64) (retErr error) {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, commit.Repo, auth.Scope_WRITER); err != nil {
 		return err
 	}
 	commitInfo, err := d.resolveCommit(txnCtx.Stm, commit)
@@ -1336,7 +1337,7 @@ func (d *driver) finishOutputCommit(txnCtx *txnenv.TransactionContext, commit *p
 	return nil
 }
 
-func (d *driver) updateProvenanceProgress(txnCtx *txnenv.TransactionContext, success bool, ci *pfs.CommitInfo) error {
+func (d *driver) updateProvenanceProgress(txnCtx *txncontext.TransactionContext, success bool, ci *pfs.CommitInfo) error {
 	if d.env.DisableCommitProgressCounter {
 		return nil
 	}
@@ -1814,7 +1815,7 @@ func (d *driver) listCommitF(pachClient *client.APIClient, repo *pfs.Repo,
 
 	// Make sure that the repo exists
 	if repo.Name != "" {
-		err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+		err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 			_, err := d.inspectRepo(txnCtx, repo, !includeAuth)
 			return err
 		})
@@ -2094,7 +2095,7 @@ func (d *driver) flushCommit(pachClient *client.APIClient, fromCommits []*pfs.Co
 	return nil
 }
 
-func (d *driver) deleteCommit(txnCtx *txnenv.TransactionContext, userCommit *pfs.Commit) error {
+func (d *driver) deleteCommit(txnCtx *txncontext.TransactionContext, userCommit *pfs.Commit) error {
 	// Validate arguments
 	if userCommit == nil {
 		return errors.New("commit cannot be nil")
@@ -2103,7 +2104,7 @@ func (d *driver) deleteCommit(txnCtx *txnenv.TransactionContext, userCommit *pfs
 		return errors.New("commit repo cannot be nil")
 	}
 
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, userCommit.Repo, auth.Scope_WRITER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, userCommit.Repo, auth.Scope_WRITER); err != nil {
 		return err
 	}
 	// Main txn: Delete all downstream commits, and update subvenance of upstream commits
@@ -2418,7 +2419,7 @@ func (d *driver) resolveCommitProvenance(stm col.STM, userCommitProvenance *pfs.
 //
 // This invariant is assumed to hold for all branches upstream of 'branch', but not
 // for 'branch' itself once 'b.Provenance' has been set.
-func (d *driver) createBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Branch, commit *pfs.Commit, provenance []*pfs.Branch, trigger *pfs.Trigger) error {
+func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs.Branch, commit *pfs.Commit, provenance []*pfs.Branch, trigger *pfs.Trigger) error {
 	// Validate arguments
 	if branch == nil {
 		return errors.New("branch cannot be nil")
@@ -2434,7 +2435,7 @@ func (d *driver) createBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Bra
 	}
 
 	var err error
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Scope_WRITER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Scope_WRITER); err != nil {
 		return err
 	}
 	// Validate request
@@ -2622,7 +2623,7 @@ func (d *driver) validateRepo(stm col.STM, repo *pfs.Repo) error {
 	return nil
 }
 
-func (d *driver) inspectBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Branch) (*pfs.BranchInfo, error) {
+func (d *driver) inspectBranch(txnCtx *txncontext.TransactionContext, branch *pfs.Branch) (*pfs.BranchInfo, error) {
 	// Validate arguments
 	if branch == nil {
 		return nil, errors.New("branch cannot be nil")
@@ -2657,7 +2658,7 @@ func (d *driver) listBranch(pachClient *client.APIClient, repo *pfs.Repo, revers
 
 	// Make sure that the repo exists
 	if repo.Name != "" {
-		err := d.txnEnv.WithReadContext(pachClient.Ctx(), func(txnCtx *txnenv.TransactionContext) error {
+		err := d.txnEnv.WithReadContext(pachClient.Ctx(), func(txnCtx *txncontext.TransactionContext) error {
 			_, err := d.inspectRepo(txnCtx, repo, !includeAuth)
 			return err
 		})
@@ -2698,7 +2699,7 @@ func (d *driver) listBranch(pachClient *client.APIClient, repo *pfs.Repo, revers
 	return result, nil
 }
 
-func (d *driver) deleteBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Branch, force bool) error {
+func (d *driver) deleteBranch(txnCtx *txncontext.TransactionContext, branch *pfs.Branch, force bool) error {
 	// Validate arguments
 	if branch == nil {
 		return errors.New("branch cannot be nil")
@@ -2707,7 +2708,7 @@ func (d *driver) deleteBranch(txnCtx *txnenv.TransactionContext, branch *pfs.Bra
 		return errors.New("branch repo cannot be nil")
 	}
 
-	if err := authserver.CheckIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Scope_WRITER); err != nil {
+	if err := d.env.AuthServer().CheckIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Scope_WRITER); err != nil {
 		return err
 	}
 
@@ -2824,7 +2825,7 @@ func (d *driver) putFiles(pachClient *client.APIClient, s *putFileServer) error 
 		// oneOff puts only work on branches, so we know branch != "". We pass
 		// a commit with no ID, that ID will be filled in with the head of
 		// branch (if it exists).
-		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 			_, err := d.makeCommit(txnCtx, "", client.NewCommit(repo, ""), branch, nil, nil, nil, nil, nil, putFilePaths, putFileRecords, "", time.Time{}, time.Time{}, 0)
 			return err
 		})
@@ -3264,7 +3265,7 @@ func (d *driver) copyFile(pachClient *client.APIClient, src *pfs.File, dst *pfs.
 	}
 	// dst is finished => all PutFileRecords are in 'records'--put in a new commit
 	if !dstIsOpenCommit {
-		return d.txnEnv.WithWriteContext(pachClient.Ctx(), func(txnCtx *txnenv.TransactionContext) error {
+		return d.txnEnv.WithWriteContext(pachClient.Ctx(), func(txnCtx *txncontext.TransactionContext) error {
 			_, err = d.makeCommit(txnCtx, "", client.NewCommit(dst.Commit.Repo.Name, ""), branch, nil, nil, nil, nil, nil, paths, records, "", time.Time{}, time.Time{}, 0)
 			return err
 		})
@@ -3273,7 +3274,7 @@ func (d *driver) copyFile(pachClient *client.APIClient, src *pfs.File, dst *pfs.
 }
 
 // getTreeForCommmit returns a HashTree that must be cleaned up after use
-func (d *driver) getTreeForCommit(txnCtx *txnenv.TransactionContext, commit *pfs.Commit) (hashtree.HashTree, error) {
+func (d *driver) getTreeForCommit(txnCtx *txncontext.TransactionContext, commit *pfs.Commit) (hashtree.HashTree, error) {
 	if commit == nil || commit.ID == "" {
 		return d.treeCache.GetOrAdd("nil", func() (hashtree.HashTree, error) {
 			return hashtree.NewDBHashTree(d.storageRoot)
@@ -3379,7 +3380,7 @@ func (d *driver) getTreeForFile(pachClient *client.APIClient, file *pfs.File) (h
 	}
 
 	var result hashtree.HashTree
-	err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+	err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		commitInfo, err := d.resolveCommit(txnCtx.Stm, file.Commit)
 		if err != nil {
 			return err
@@ -4125,7 +4126,7 @@ func (d *driver) deleteFile(pachClient *client.APIClient, file *pfs.File) error 
 		if branch == "" {
 			return pfsserver.ErrCommitFinished{file.Commit}
 		}
-		return d.txnEnv.WithWriteContext(pachClient.Ctx(), func(txnCtx *txnenv.TransactionContext) error {
+		return d.txnEnv.WithWriteContext(pachClient.Ctx(), func(txnCtx *txncontext.TransactionContext) error {
 			_, err := d.makeCommit(txnCtx, "", client.NewCommit(file.Commit.Repo.Name, ""), branch, nil, nil, nil, nil, nil, []string{file.Path}, []*pfs.PutFileRecords{&pfs.PutFileRecords{Tombstone: true}}, "", time.Time{}, time.Time{}, 0)
 			return err
 		})
@@ -4134,7 +4135,7 @@ func (d *driver) deleteFile(pachClient *client.APIClient, file *pfs.File) error 
 	return d.upsertPutFileRecords(pachClient, file, &pfs.PutFileRecords{Tombstone: true})
 }
 
-func (d *driver) deleteAll(txnCtx *txnenv.TransactionContext) error {
+func (d *driver) deleteAll(txnCtx *txncontext.TransactionContext) error {
 	// Note: d.listRepo() doesn't return the 'spec' repo, so it doesn't get
 	// deleted here. Instead, PPS is responsible for deleting and re-creating it
 	repoInfos, err := d.listRepo(txnCtx.Client, !includeAuth)

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -1,11 +1,12 @@
 package server
 
 import (
+	pfs_iface "github.com/pachyderm/pachyderm/src/server/pfs"
+
 	pfsclient "github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/hashtree"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
-	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
 )
 
 // Valid object storage backends
@@ -16,12 +17,6 @@ const (
 	MicrosoftBackendEnvVar = "MICROSOFT"
 	LocalBackendEnvVar     = "LOCAL"
 )
-
-// APIServer represents an api server.
-type APIServer interface {
-	pfsclient.APIServer
-	txnenv.PfsTransactionServer
-}
 
 // BlockAPIServer combines BlockAPIServer and ObjectAPIServer.
 type BlockAPIServer interface {
@@ -37,7 +32,7 @@ func NewAPIServer(
 	storageRoot string,
 	memoryRequest int64,
 	blockAPIServer BlockAPIServer,
-) (APIServer, error) {
+) (pfs_iface.APIServer, error) {
 	if env.StorageV2 {
 		a, err := newAPIServerV2(env, txnEnv, etcdPrefix, treeCache, storageRoot, memoryRequest)
 		if err != nil {

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/hashtree"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
+	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
 )
 
 // Valid object storage backends

--- a/src/server/pfs/server/testing.go
+++ b/src/server/pfs/server/testing.go
@@ -19,10 +19,12 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/version"
 	"github.com/pachyderm/pachyderm/src/client/version/versionpb"
 	authtesting "github.com/pachyderm/pachyderm/src/server/auth/testing"
+	pfs_iface "github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	"github.com/pachyderm/pachyderm/src/server/pkg/hashtree"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
 
 	"golang.org/x/net/context"
@@ -55,7 +57,7 @@ func generateRandomString(n int) string {
 func runServers(
 	t testing.TB,
 	port int32,
-	apiServer APIServer,
+	apiServer pfs_iface.APIServer,
 	blockAPIServer BlockAPIServer,
 ) {
 	server, err := grpcutil.NewServer(context.Background(), false)
@@ -128,7 +130,7 @@ func GetPachClient(t testing.TB, config *serviceenv.Configuration) *client.APICl
 	apiServer, err := newAPIServer(env, txnEnv, etcdPrefix, treeCache, "/tmp", 64*1024*1024, blockAPIServer)
 	require.NoError(t, err)
 
-	txnEnv.Initialize(env, nil, &authtesting.InactiveAPIServer{}, apiServer, txnenv.NewMockPpsTransactionServer())
+	txnEnv.Initialize(env, nil, &authtesting.InactiveAPIServer{}, apiServer, txncontext.NewMockPpsTransactionServer())
 
 	runServers(t, pfsPort, apiServer, blockAPIServer)
 	return env.GetPachClient(context.Background())

--- a/src/server/pfs/server/transaction_defer.go
+++ b/src/server/pfs/server/transaction_defer.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
-	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 )
 
 // Propagater is an object that is used to propagate PFS branches at the end of
@@ -20,7 +20,7 @@ type Propagater struct {
 	isNewCommit bool
 }
 
-func (a *apiServer) NewPropagater(stm col.STM) txnenv.PfsPropagater {
+func (a *apiServer) NewPropagater(stm col.STM) txncontext.PfsPropagater {
 	return &Propagater{
 		d:   a.driver,
 		stm: stm,
@@ -49,13 +49,13 @@ func (t *Propagater) Run() error {
 // The Run method is called at the end of any transaction
 type PipelineFinisher struct {
 	d      *driver
-	txnCtx *txnenv.TransactionContext
+	txnCtx *txncontext.TransactionContext
 
 	// pipeline output branches to finish commits on
 	branches []*pfs.Branch
 }
 
-func (a *apiServer) NewPipelineFinisher(txnCtx *txnenv.TransactionContext) txnenv.PipelineCommitFinisher {
+func (a *apiServer) NewPipelineFinisher(txnCtx *txncontext.TransactionContext) txncontext.PipelineCommitFinisher {
 	return &PipelineFinisher{
 		d:      a.driver,
 		txnCtx: txnCtx,

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -11,14 +11,14 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
-	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 )
 
 // triggerCommit is called when a commit is finished, it updates branches in
 // the repo if they trigger on the change and returns all branches which were
 // moved by this call.
 func (d *driver) triggerCommit(
-	txnCtx *txnenv.TransactionContext,
+	txnCtx *txncontext.TransactionContext,
 	commit *pfs.Commit,
 ) ([]*pfs.Branch, error) {
 	repos := d.repos.ReadWrite(txnCtx.Stm)
@@ -104,7 +104,7 @@ func (d *driver) triggerCommit(
 
 // isTriggered checks to see if a branch should be updated from oldHead to
 // newHead based on a trigger.
-func (d *driver) isTriggered(txnCtx *txnenv.TransactionContext, t *pfs.Trigger, oldHead, newHead *pfs.CommitInfo) (bool, error) {
+func (d *driver) isTriggered(txnCtx *txncontext.TransactionContext, t *pfs.Trigger, oldHead, newHead *pfs.CommitInfo) (bool, error) {
 	result := t.All
 	merge := func(cond bool) {
 		if t.All {
@@ -168,7 +168,7 @@ func (d *driver) isTriggered(txnCtx *txnenv.TransactionContext, t *pfs.Trigger, 
 }
 
 // validateTrigger returns an error if a trigger is invalid
-func (d *driver) validateTrigger(txnCtx *txnenv.TransactionContext, branch *pfs.Branch, trigger *pfs.Trigger) error {
+func (d *driver) validateTrigger(txnCtx *txncontext.TransactionContext, branch *pfs.Branch, trigger *pfs.Trigger) error {
 	if trigger == nil {
 		return nil
 	}

--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -254,7 +254,7 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 	metrics.EnterpriseFailures = enterprisemetrics.GetEnterpriseFailures()
 
 	// Pipeline info
-	resp, err := r.env.PpsServer().ListPipeline(ctx, &pps.ListPipelineRequest{AllowIncomplete: true})
+	resp, err := r.env.PpsServer().ListPipelineNoAuth(ctx, &pps.ListPipelineRequest{AllowIncomplete: true})
 	if err == nil {
 		metrics.Pipelines = int64(len(resp.PipelineInfo)) // Number of pipelines
 		for _, pi := range resp.PipelineInfo {
@@ -356,7 +356,7 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 		log.Errorf("Error getting pipeline metrics: %v", err)
 	}
 
-	ris, err := r.env.PfsServer().ListRepo(ctx, &pfs.ListRepoRequest{})
+	ris, err := r.env.PfsServer().ListRepoNoAuth(ctx, &pfs.ListRepoRequest{})
 	if err == nil {
 		var sz, mbranch uint64 = 0, 0
 		for _, ri := range ris.RepoInfo {

--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -375,5 +375,5 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 	} else {
 		log.Errorf("Error getting repo metrics: %v", err)
 	}
-	//log.Infof("Metrics logged: %v", metrics)
+	log.Infof("Metrics logged: %v", metrics)
 }

--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -375,5 +375,5 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 	} else {
 		log.Errorf("Error getting repo metrics: %v", err)
 	}
-	log.Infof("Metrics logged: %v", metrics)
+	//log.Infof("Metrics logged: %v", metrics)
 }

--- a/src/server/pkg/metrics/metrics.go
+++ b/src/server/pkg/metrics/metrics.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/enterprise"
+	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/config"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
 	"github.com/pachyderm/pachyderm/src/client/pps"
@@ -145,7 +145,7 @@ func (r *Reporter) reportClusterMetrics() {
 	for {
 		time.Sleep(reportingInterval)
 		metrics := &Metrics{}
-		internalMetrics(r.env.GetPachClient(context.Background()), metrics)
+		r.internalMetrics(metrics)
 		externalMetrics(r.env.GetKubeClient(), metrics)
 		metrics.ClusterID = r.clusterID
 		metrics.PodID = uuid.NewWithoutDashes()
@@ -240,19 +240,21 @@ func inputMetrics(input *pps.Input, metrics *Metrics) {
 	}
 }
 
-func internalMetrics(pachClient *client.APIClient, metrics *Metrics) {
+func (r *Reporter) internalMetrics(metrics *Metrics) {
 
 	// We should not return due to an error
 
+	ctx := context.Background()
+
 	// Activation code
-	enterpriseState, err := pachClient.Enterprise.GetState(pachClient.Ctx(), &enterprise.GetStateRequest{})
+	enterpriseState, err := r.env.EnterpriseServer().GetState(ctx, &enterprise.GetStateRequest{})
 	if err == nil {
 		metrics.ActivationCode = enterpriseState.ActivationCode
 	}
 	metrics.EnterpriseFailures = enterprisemetrics.GetEnterpriseFailures()
 
 	// Pipeline info
-	resp, err := pachClient.PpsAPIClient.ListPipeline(pachClient.Ctx(), &pps.ListPipelineRequest{AllowIncomplete: true})
+	resp, err := r.env.PpsServer().ListPipeline(ctx, &pps.ListPipelineRequest{AllowIncomplete: true})
 	if err == nil {
 		metrics.Pipelines = int64(len(resp.PipelineInfo)) // Number of pipelines
 		for _, pi := range resp.PipelineInfo {
@@ -354,10 +356,10 @@ func internalMetrics(pachClient *client.APIClient, metrics *Metrics) {
 		log.Errorf("Error getting pipeline metrics: %v", err)
 	}
 
-	ris, err := pachClient.ListRepo()
+	ris, err := r.env.PfsServer().ListRepo(ctx, &pfs.ListRepoRequest{})
 	if err == nil {
 		var sz, mbranch uint64 = 0, 0
-		for _, ri := range ris {
+		for _, ri := range ris.RepoInfo {
 			if (sz + ri.SizeBytes) < sz {
 				sz = 0xFFFFFFFFFFFFFFFF
 			} else {
@@ -367,7 +369,7 @@ func internalMetrics(pachClient *client.APIClient, metrics *Metrics) {
 				mbranch = uint64(len(ri.Branches))
 			}
 		}
-		metrics.Repos = int64(len(ris))
+		metrics.Repos = int64(len(ris.RepoInfo))
 		metrics.Bytes = sz
 		metrics.MaxBranches = mbranch
 	} else {

--- a/src/server/pkg/metrics/segment.go
+++ b/src/server/pkg/metrics/segment.go
@@ -7,7 +7,7 @@ import (
 	"github.com/segmentio/analytics-go"
 )
 
-const reportingInterval time.Duration = 10 * time.Second
+const reportingInterval time.Duration = 60 * time.Minute
 
 func newPersistentClient() *analytics.Client {
 	c := newSegmentClient()

--- a/src/server/pkg/metrics/segment.go
+++ b/src/server/pkg/metrics/segment.go
@@ -7,7 +7,7 @@ import (
 	"github.com/segmentio/analytics-go"
 )
 
-const reportingInterval time.Duration = 60 * time.Minute
+const reportingInterval time.Duration = 10 * time.Second
 
 func newPersistentClient() *analytics.Client {
 	c := newSegmentClient()

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/enterprise"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
+	"github.com/pachyderm/pachyderm/src/server/auth"
 	"github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 	"github.com/pachyderm/pachyderm/src/server/pps"
@@ -66,6 +67,7 @@ type ServiceEnv struct {
 	ppsServer        pps.APIServer
 	pfsServer        pfs.APIServer
 	enterpriseServer enterprise.APIServer
+	authServer       auth.APIServer
 }
 
 // InitPachOnlyEnv initializes this service environment. This dials a GRPC
@@ -265,4 +267,14 @@ func (env *ServiceEnv) EnterpriseServer() enterprise.APIServer {
 // SetEnterpriseServer registers a Enterprise APIServer with this service env
 func (env *ServiceEnv) SetEnterpriseServer(s enterprise.APIServer) {
 	env.enterpriseServer = s
+}
+
+// AuthServer returns the registered Auth APIServer
+func (env *ServiceEnv) AuthServer() auth.APIServer {
+	return env.authServer
+}
+
+// SetAuthServer registers a Auth APIServer with this service env
+func (env *ServiceEnv) SetAuthServer(s auth.APIServer) {
+	env.authServer = s
 }

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -9,7 +9,10 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/src/client"
+	"github.com/pachyderm/pachyderm/src/client/enterprise"
+	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
+	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
 
 	etcd "github.com/coreos/etcd/clientv3"
@@ -59,6 +62,10 @@ type ServiceEnv struct {
 	// of this environment, it doesn't require an initialization funcion, so
 	// there's no errgroup associated with it.
 	lokiClient *loki.Client
+
+	ppsServer        pps.APIServer
+	pfsServer        pfs.APIServer
+	enterpriseServer enterprise.APIServer
 }
 
 // InitPachOnlyEnv initializes this service environment. This dials a GRPC
@@ -228,4 +235,34 @@ func (env *ServiceEnv) GetLokiClient() (*loki.Client, error) {
 		return nil, errors.Errorf("loki not configured, is it running in the same namespace as pachd?")
 	}
 	return env.lokiClient, nil
+}
+
+// PpsServer returns the registered PPS APIServer
+func (env *ServiceEnv) PpsServer() pps.APIServer {
+	return env.ppsServer
+}
+
+// SetPpsServer registers a Pps APIServer with this service env
+func (env *ServiceEnv) SetPpsServer(s pps.APIServer) {
+	env.ppsServer = s
+}
+
+// PfsServer returns the registered PFS APIServer
+func (env *ServiceEnv) PfsServer() pfs.APIServer {
+	return env.pfsServer
+}
+
+// SetPfsServer registers a Pfs APIServer with this service env
+func (env *ServiceEnv) SetPfsServer(s pfs.APIServer) {
+	env.pfsServer = s
+}
+
+// EnterpriseServer returns the registered PFS APIServer
+func (env *ServiceEnv) EnterpriseServer() enterprise.APIServer {
+	return env.enterpriseServer
+}
+
+// SetEnterpriseServer registers a Enterprise APIServer with this service env
+func (env *ServiceEnv) SetEnterpriseServer(s enterprise.APIServer) {
+	env.enterpriseServer = s
 }

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -64,7 +64,7 @@ type ServiceEnv struct {
 	// there's no errgroup associated with it.
 	lokiClient *loki.Client
 
-	ppsServer        pps.APIServer
+	ppsServer        pps.InternalAPI
 	pfsServer        pfs.APIServer
 	enterpriseServer enterprise.APIServer
 	authServer       auth.APIServer
@@ -240,12 +240,12 @@ func (env *ServiceEnv) GetLokiClient() (*loki.Client, error) {
 }
 
 // PpsServer returns the registered PPS APIServer
-func (env *ServiceEnv) PpsServer() pps.APIServer {
+func (env *ServiceEnv) PpsServer() pps.InternalAPI {
 	return env.ppsServer
 }
 
 // SetPpsServer registers a Pps APIServer with this service env
-func (env *ServiceEnv) SetPpsServer(s pps.APIServer) {
+func (env *ServiceEnv) SetPpsServer(s pps.InternalAPI) {
 	env.ppsServer = s
 }
 

--- a/src/server/pkg/serviceenv/service_env.go
+++ b/src/server/pkg/serviceenv/service_env.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/pachyderm/pachyderm/src/client"
 	"github.com/pachyderm/pachyderm/src/client/enterprise"
-	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pkg/errors"
-	"github.com/pachyderm/pachyderm/src/client/pps"
+	"github.com/pachyderm/pachyderm/src/server/pfs"
 	"github.com/pachyderm/pachyderm/src/server/pkg/backoff"
+	"github.com/pachyderm/pachyderm/src/server/pps"
 
 	etcd "github.com/coreos/etcd/clientv3"
 	loki "github.com/grafana/loki/pkg/logcli/client"

--- a/src/server/pkg/transactionenv/env.go
+++ b/src/server/pkg/transactionenv/env.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/client/transaction"
+	auth_iface "github.com/pachyderm/pachyderm/src/server/auth"
 	pfs_iface "github.com/pachyderm/pachyderm/src/server/pfs"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
@@ -62,21 +63,6 @@ type TransactionServer interface {
 	) (*transaction.TransactionResponse, error)
 }
 
-// AuthTransactionServer is an interface for the transactionally-supported
-// methods that can be called through the auth server.
-type AuthTransactionServer interface {
-	AuthorizeInTransaction(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
-
-	GetScopeInTransaction(*txncontext.TransactionContext, *auth.GetScopeRequest) (*auth.GetScopeResponse, error)
-	SetScopeInTransaction(*txncontext.TransactionContext, *auth.SetScopeRequest) (*auth.SetScopeResponse, error)
-
-	GetACLInTransaction(*txncontext.TransactionContext, *auth.GetACLRequest) (*auth.GetACLResponse, error)
-	SetACLInTransaction(*txncontext.TransactionContext, *auth.SetACLRequest) (*auth.SetACLResponse, error)
-
-	GetAuthTokenInTransaction(*txncontext.TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error)
-	RevokeAuthTokenInTransaction(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
-}
-
 // TransactionEnv contains the APIServer instances for each subsystem that may
 // be involved in running transactions so that they can make calls to each other
 // without leaving the context of a transaction.  This is a separate object
@@ -84,7 +70,7 @@ type AuthTransactionServer interface {
 type TransactionEnv struct {
 	serviceEnv *serviceenv.ServiceEnv
 	txnServer  TransactionServer
-	authServer AuthTransactionServer
+	authServer auth_iface.TransactionServer
 	pfsServer  pfs_iface.TransactionServer
 	ppsServer  pps_iface.TransactionServer
 }
@@ -93,7 +79,7 @@ type TransactionEnv struct {
 func (env *TransactionEnv) Initialize(
 	serviceEnv *serviceenv.ServiceEnv,
 	txnServer TransactionServer,
-	authServer AuthTransactionServer,
+	authServer auth_iface.TransactionServer,
 	pfsServer pfs_iface.TransactionServer,
 	ppsServer pps_iface.TransactionServer,
 ) {

--- a/src/server/pkg/transactionenv/env.go
+++ b/src/server/pkg/transactionenv/env.go
@@ -10,8 +10,11 @@ import (
 	"github.com/pachyderm/pachyderm/src/client/pfs"
 	"github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/client/transaction"
+	pfs_iface "github.com/pachyderm/pachyderm/src/server/pfs"
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
+	pps_iface "github.com/pachyderm/pachyderm/src/server/pps"
 )
 
 // PfsWrites is an interface providing a wrapper for each operation that
@@ -49,80 +52,6 @@ type AuthWrites interface {
 	SetACL(*auth.SetACLRequest) (*auth.SetACLResponse, error)
 }
 
-// PfsPropagater is the interface that PFS implements to propagate commits at
-// the end of a transaction.  It is defined here to avoid a circular dependency.
-type PfsPropagater interface {
-	PropagateCommit(branch *pfs.Branch, isNewCommit bool) error
-	Run() error
-}
-
-// PipelineCommitFinisher is an interface to facilitate finishing pipeline commits
-// at the end of a transaction
-type PipelineCommitFinisher interface {
-	FinishPipelineCommits(branch *pfs.Branch) error
-	Run() error
-}
-
-// TransactionContext is a helper type to encapsulate the state for a given
-// set of operations being performed in the Pachyderm API.  When a new
-// transaction is started, a context will be created for it containing these
-// objects, which will be threaded through to every API call:
-//   ctx: the client context which initiated the operations being performed
-//   pachClient: the APIClient associated with the client context ctx
-//   stm: the object that controls transactionality with etcd.  This is to ensure
-//     that all reads and writes are consistent until changes are committed.
-//   txnEnv: a struct containing references to each API server, it can be used
-//     to make calls to other API servers (e.g. checking auth permissions)
-//   pfsDefer: an interface for ensuring certain PFS cleanup tasks are performed
-//     properly (and deduped) at the end of the transaction.
-type TransactionContext struct {
-	ClientContext  context.Context
-	Client         *client.APIClient
-	Stm            col.STM
-	pfsPropagater  PfsPropagater
-	commitFinisher PipelineCommitFinisher
-	txnEnv         *TransactionEnv
-}
-
-// Auth returns a reference to the Auth API Server so that transactionally-
-// supported methods can be called across the API boundary without using RPCs
-// (which will not maintain transactional guarantees)
-func (t *TransactionContext) Auth() AuthTransactionServer {
-	return t.txnEnv.authServer
-}
-
-// Pfs returns a reference to the PFS API Server so that transactionally-
-// supported methods can be called across the API boundary without using RPCs
-// (which will not maintain transactional guarantees)
-func (t *TransactionContext) Pfs() PfsTransactionServer {
-	return t.txnEnv.pfsServer
-}
-
-// PropagateCommit saves a branch to be propagated at the end of the transaction
-// (if all operations complete successfully).  This is used to batch together
-// propagations and dedupe downstream commits in PFS.
-func (t *TransactionContext) PropagateCommit(branch *pfs.Branch, isNewCommit bool) error {
-	return t.pfsPropagater.PropagateCommit(branch, isNewCommit)
-}
-
-func (t *TransactionContext) finish() error {
-	if t.commitFinisher != nil {
-		if err := t.commitFinisher.Run(); err != nil {
-			return err
-		}
-	}
-	return t.pfsPropagater.Run()
-}
-
-// FinishPipelineCommits saves a pipeline output branch to have its commits
-// finished at the end of the transaction
-func (t *TransactionContext) FinishPipelineCommits(branch *pfs.Branch) error {
-	if t.commitFinisher != nil {
-		return t.commitFinisher.FinishPipelineCommits(branch)
-	}
-	return nil
-}
-
 // TransactionServer is an interface used by other servers to append a request
 // to an existing transaction.
 type TransactionServer interface {
@@ -136,42 +65,16 @@ type TransactionServer interface {
 // AuthTransactionServer is an interface for the transactionally-supported
 // methods that can be called through the auth server.
 type AuthTransactionServer interface {
-	AuthorizeInTransaction(*TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
+	AuthorizeInTransaction(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
 
-	GetScopeInTransaction(*TransactionContext, *auth.GetScopeRequest) (*auth.GetScopeResponse, error)
-	SetScopeInTransaction(*TransactionContext, *auth.SetScopeRequest) (*auth.SetScopeResponse, error)
+	GetScopeInTransaction(*txncontext.TransactionContext, *auth.GetScopeRequest) (*auth.GetScopeResponse, error)
+	SetScopeInTransaction(*txncontext.TransactionContext, *auth.SetScopeRequest) (*auth.SetScopeResponse, error)
 
-	GetACLInTransaction(*TransactionContext, *auth.GetACLRequest) (*auth.GetACLResponse, error)
-	SetACLInTransaction(*TransactionContext, *auth.SetACLRequest) (*auth.SetACLResponse, error)
+	GetACLInTransaction(*txncontext.TransactionContext, *auth.GetACLRequest) (*auth.GetACLResponse, error)
+	SetACLInTransaction(*txncontext.TransactionContext, *auth.SetACLRequest) (*auth.SetACLResponse, error)
 
-	GetAuthTokenInTransaction(*TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error)
-	RevokeAuthTokenInTransaction(*TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
-}
-
-// PfsTransactionServer is an interface for the transactionally-supported
-// methods that can be called through the PFS server.
-type PfsTransactionServer interface {
-	NewPropagater(col.STM) PfsPropagater
-	NewPipelineFinisher(*TransactionContext) PipelineCommitFinisher
-
-	CreateRepoInTransaction(*TransactionContext, *pfs.CreateRepoRequest) error
-	InspectRepoInTransaction(*TransactionContext, *pfs.InspectRepoRequest) (*pfs.RepoInfo, error)
-	DeleteRepoInTransaction(*TransactionContext, *pfs.DeleteRepoRequest) error
-
-	StartCommitInTransaction(*TransactionContext, *pfs.StartCommitRequest, *pfs.Commit) (*pfs.Commit, error)
-	FinishCommitInTransaction(*TransactionContext, *pfs.FinishCommitRequest) error
-	DeleteCommitInTransaction(*TransactionContext, *pfs.DeleteCommitRequest) error
-
-	CreateBranchInTransaction(*TransactionContext, *pfs.CreateBranchRequest) error
-	InspectBranchInTransaction(*TransactionContext, *pfs.InspectBranchRequest) (*pfs.BranchInfo, error)
-	DeleteBranchInTransaction(*TransactionContext, *pfs.DeleteBranchRequest) error
-}
-
-// PpsTransactionServer is an interface for the transactionally-supported
-// methods that can be called through the PPS server.
-type PpsTransactionServer interface {
-	UpdateJobStateInTransaction(*TransactionContext, *pps.UpdateJobStateRequest) error
-	CreatePipelineInTransaction(*TransactionContext, *pps.CreatePipelineRequest, **pfs.Commit) error
+	GetAuthTokenInTransaction(*txncontext.TransactionContext, *auth.GetAuthTokenRequest) (*auth.GetAuthTokenResponse, error)
+	RevokeAuthTokenInTransaction(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
 }
 
 // TransactionEnv contains the APIServer instances for each subsystem that may
@@ -182,8 +85,8 @@ type TransactionEnv struct {
 	serviceEnv *serviceenv.ServiceEnv
 	txnServer  TransactionServer
 	authServer AuthTransactionServer
-	pfsServer  PfsTransactionServer
-	ppsServer  PpsTransactionServer
+	pfsServer  pfs_iface.TransactionServer
+	ppsServer  pps_iface.TransactionServer
 }
 
 // Initialize stores the references to APIServer instances in the TransactionEnv
@@ -191,8 +94,8 @@ func (env *TransactionEnv) Initialize(
 	serviceEnv *serviceenv.ServiceEnv,
 	txnServer TransactionServer,
 	authServer AuthTransactionServer,
-	pfsServer PfsTransactionServer,
-	ppsServer PpsTransactionServer,
+	pfsServer pfs_iface.TransactionServer,
+	ppsServer pps_iface.TransactionServer,
 ) {
 	env.serviceEnv = serviceEnv
 	env.txnServer = txnServer
@@ -218,70 +121,74 @@ type Transaction interface {
 }
 
 type directTransaction struct {
-	txnCtx *TransactionContext
+	txnCtx *txncontext.TransactionContext
+	txnEnv *TransactionEnv
 }
 
 // NewDirectTransaction is a helper function to instantiate a directTransaction
 // object.  It is exposed so that the transaction API server can run a direct
 // transaction even though there is an active transaction in the context (which
 // is why it cannot use `WithTransaction`).
-func NewDirectTransaction(txnCtx *TransactionContext) Transaction {
-	return &directTransaction{txnCtx: txnCtx}
+func NewDirectTransaction(txnEnv *TransactionEnv, txnCtx *txncontext.TransactionContext) Transaction {
+	return &directTransaction{
+		txnCtx: txnCtx,
+		txnEnv: txnEnv,
+	}
 }
 
 func (t *directTransaction) CreateRepo(original *pfs.CreateRepoRequest) error {
 	req := proto.Clone(original).(*pfs.CreateRepoRequest)
-	return t.txnCtx.txnEnv.pfsServer.CreateRepoInTransaction(t.txnCtx, req)
+	return t.txnEnv.pfsServer.CreateRepoInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) DeleteRepo(original *pfs.DeleteRepoRequest) error {
 	req := proto.Clone(original).(*pfs.DeleteRepoRequest)
-	return t.txnCtx.txnEnv.pfsServer.DeleteRepoInTransaction(t.txnCtx, req)
+	return t.txnEnv.pfsServer.DeleteRepoInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) StartCommit(original *pfs.StartCommitRequest, commit *pfs.Commit) (*pfs.Commit, error) {
 	req := proto.Clone(original).(*pfs.StartCommitRequest)
-	return t.txnCtx.txnEnv.pfsServer.StartCommitInTransaction(t.txnCtx, req, commit)
+	return t.txnEnv.pfsServer.StartCommitInTransaction(t.txnCtx, req, commit)
 }
 
 func (t *directTransaction) FinishCommit(original *pfs.FinishCommitRequest) error {
 	req := proto.Clone(original).(*pfs.FinishCommitRequest)
-	return t.txnCtx.txnEnv.pfsServer.FinishCommitInTransaction(t.txnCtx, req)
+	return t.txnEnv.pfsServer.FinishCommitInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) DeleteCommit(original *pfs.DeleteCommitRequest) error {
 	req := proto.Clone(original).(*pfs.DeleteCommitRequest)
-	return t.txnCtx.txnEnv.pfsServer.DeleteCommitInTransaction(t.txnCtx, req)
+	return t.txnEnv.pfsServer.DeleteCommitInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) CreateBranch(original *pfs.CreateBranchRequest) error {
 	req := proto.Clone(original).(*pfs.CreateBranchRequest)
-	return t.txnCtx.txnEnv.pfsServer.CreateBranchInTransaction(t.txnCtx, req)
+	return t.txnEnv.pfsServer.CreateBranchInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) DeleteBranch(original *pfs.DeleteBranchRequest) error {
 	req := proto.Clone(original).(*pfs.DeleteBranchRequest)
-	return t.txnCtx.txnEnv.pfsServer.DeleteBranchInTransaction(t.txnCtx, req)
+	return t.txnEnv.pfsServer.DeleteBranchInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) UpdateJobState(original *pps.UpdateJobStateRequest) error {
 	req := proto.Clone(original).(*pps.UpdateJobStateRequest)
-	return t.txnCtx.txnEnv.ppsServer.UpdateJobStateInTransaction(t.txnCtx, req)
+	return t.txnEnv.ppsServer.UpdateJobStateInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) SetScope(original *auth.SetScopeRequest) (*auth.SetScopeResponse, error) {
 	req := proto.Clone(original).(*auth.SetScopeRequest)
-	return t.txnCtx.txnEnv.authServer.SetScopeInTransaction(t.txnCtx, req)
+	return t.txnEnv.authServer.SetScopeInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) SetACL(original *auth.SetACLRequest) (*auth.SetACLResponse, error) {
 	req := proto.Clone(original).(*auth.SetACLRequest)
-	return t.txnCtx.txnEnv.authServer.SetACLInTransaction(t.txnCtx, req)
+	return t.txnEnv.authServer.SetACLInTransaction(t.txnCtx, req)
 }
 
 func (t *directTransaction) CreatePipeline(original *pps.CreatePipelineRequest, specCommit **pfs.Commit) error {
 	req := proto.Clone(original).(*pps.CreatePipelineRequest)
-	return t.txnCtx.txnEnv.ppsServer.CreatePipelineInTransaction(t.txnCtx, req, specCommit)
+	return t.txnEnv.ppsServer.CreatePipelineInTransaction(t.txnCtx, req, specCommit)
 }
 
 type appendTransaction struct {
@@ -371,54 +278,52 @@ func (env *TransactionEnv) WithTransaction(ctx context.Context, cb func(Transact
 		return cb(appendTxn)
 	}
 
-	return env.WithWriteContext(ctx, func(txnCtx *TransactionContext) error {
-		directTxn := NewDirectTransaction(txnCtx)
+	return env.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
+		directTxn := NewDirectTransaction(env, txnCtx)
 		return cb(directTxn)
 	})
 }
 
-// WithWriteContext will call the given callback with a TransactionContext
+// WithWriteContext will call the given callback with a txncontext.TransactionContext
 // which can be used to perform reads and writes on the current cluster state.
-func (env *TransactionEnv) WithWriteContext(ctx context.Context, cb func(*TransactionContext) error) error {
+func (env *TransactionEnv) WithWriteContext(ctx context.Context, cb func(*txncontext.TransactionContext) error) error {
 	_, err := col.NewSTM(ctx, env.serviceEnv.GetEtcdClient(), func(stm col.STM) error {
 		pachClient := env.serviceEnv.GetPachClient(ctx)
-		txnCtx := &TransactionContext{
+		txnCtx := &txncontext.TransactionContext{
 			Client:        pachClient,
 			ClientContext: pachClient.Ctx(),
 			Stm:           stm,
-			pfsPropagater: env.pfsServer.NewPropagater(stm),
-			txnEnv:        env,
+			PfsPropagater: env.pfsServer.NewPropagater(stm),
 		}
-		txnCtx.commitFinisher = env.pfsServer.NewPipelineFinisher(txnCtx)
+		txnCtx.CommitFinisher = env.pfsServer.NewPipelineFinisher(txnCtx)
 
 		err := cb(txnCtx)
 		if err != nil {
 			return err
 		}
-		return txnCtx.finish()
+		return txnCtx.Finish()
 	})
 	return err
 }
 
-// WithReadContext will call the given callback with a TransactionContext
+// WithReadContext will call the given callback with a txncontext.TransactionContext
 // which can be used to perform reads of the current cluster state. If the
 // transaction is used to perform any writes, they will be silently discarded.
-func (env *TransactionEnv) WithReadContext(ctx context.Context, cb func(*TransactionContext) error) error {
+func (env *TransactionEnv) WithReadContext(ctx context.Context, cb func(*txncontext.TransactionContext) error) error {
 	return col.NewDryrunSTM(ctx, env.serviceEnv.GetEtcdClient(), func(stm col.STM) error {
 		pachClient := env.serviceEnv.GetPachClient(ctx)
-		txnCtx := &TransactionContext{
+		txnCtx := &txncontext.TransactionContext{
 			Client:         pachClient,
 			ClientContext:  pachClient.Ctx(),
 			Stm:            stm,
-			pfsPropagater:  env.pfsServer.NewPropagater(stm),
-			commitFinisher: nil, // don't alter any pipeline commits in a read-only setting
-			txnEnv:         env,
+			PfsPropagater:  env.pfsServer.NewPropagater(stm),
+			CommitFinisher: nil, // don't alter any pipeline commits in a read-only setting
 		}
 
 		err := cb(txnCtx)
 		if err != nil {
 			return err
 		}
-		return txnCtx.finish()
+		return txnCtx.Finish()
 	})
 }

--- a/src/server/pkg/transactionenv/txncontext/context.go
+++ b/src/server/pkg/transactionenv/txncontext/context.go
@@ -1,0 +1,68 @@
+package txncontext
+
+import (
+	"context"
+
+	"github.com/pachyderm/pachyderm/src/client"
+	"github.com/pachyderm/pachyderm/src/client/pfs"
+	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
+)
+
+// PfsPropagater is the interface that PFS implements to propagate commits at
+// the end of a transaction.  It is defined here to avoid a circular dependency.
+type PfsPropagater interface {
+	PropagateCommit(branch *pfs.Branch, isNewCommit bool) error
+	Run() error
+}
+
+// PipelineCommitFinisher is an interface to facilitate finishing pipeline commits
+// at the end of a transaction
+type PipelineCommitFinisher interface {
+	FinishPipelineCommits(branch *pfs.Branch) error
+	Run() error
+}
+
+// TransactionContext is a helper type to encapsulate the state for a given
+// set of operations being performed in the Pachyderm API.  When a new
+// transaction is started, a context will be created for it containing these
+// objects, which will be threaded through to every API call:
+//   ctx: the client context which initiated the operations being performed
+//   pachClient: the APIClient associated with the client context ctx
+//   stm: the object that controls transactionality with etcd.  This is to ensure
+//     that all reads and writes are consistent until changes are committed.
+//   txnEnv: a struct containing references to each API server, it can be used
+//     to make calls to other API servers (e.g. checking auth permissions)
+//   pfsDefer: an interface for ensuring certain PFS cleanup tasks are performed
+//     properly (and deduped) at the end of the transaction.
+type TransactionContext struct {
+	ClientContext  context.Context
+	Client         *client.APIClient
+	Stm            col.STM
+	PfsPropagater  PfsPropagater
+	CommitFinisher PipelineCommitFinisher
+}
+
+// PropagateCommit saves a branch to be propagated at the end of the transaction
+// (if all operations complete successfully).  This is used to batch together
+// propagations and dedupe downstream commits in PFS.
+func (t *TransactionContext) PropagateCommit(branch *pfs.Branch, isNewCommit bool) error {
+	return t.PfsPropagater.PropagateCommit(branch, isNewCommit)
+}
+
+func (t *TransactionContext) Finish() error {
+	if t.CommitFinisher != nil {
+		if err := t.CommitFinisher.Run(); err != nil {
+			return err
+		}
+	}
+	return t.PfsPropagater.Run()
+}
+
+// FinishPipelineCommits saves a pipeline output branch to have its commits
+// finished at the end of the transaction
+func (t *TransactionContext) FinishPipelineCommits(branch *pfs.Branch) error {
+	if t.CommitFinisher != nil {
+		return t.CommitFinisher.FinishPipelineCommits(branch)
+	}
+	return nil
+}

--- a/src/server/pkg/transactionenv/txncontext/context.go
+++ b/src/server/pkg/transactionenv/txncontext/context.go
@@ -49,6 +49,7 @@ func (t *TransactionContext) PropagateCommit(branch *pfs.Branch, isNewCommit boo
 	return t.PfsPropagater.PropagateCommit(branch, isNewCommit)
 }
 
+// Finish runs the commit finisher and pfs propagator
 func (t *TransactionContext) Finish() error {
 	if t.CommitFinisher != nil {
 		if err := t.CommitFinisher.Run(); err != nil {

--- a/src/server/pkg/transactionenv/txncontext/testing.go
+++ b/src/server/pkg/transactionenv/txncontext/testing.go
@@ -1,4 +1,4 @@
-package transactionenv
+package txncontext
 
 import (
 	"github.com/pachyderm/pachyderm/src/client/auth"

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -1,0 +1,5 @@
+package pps
+
+import (
+	pfs_client "github.com/pachyderm/pachyderm/v2/src/pps"
+)

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -1,5 +1,23 @@
 package pps
 
 import (
-	pfs_client "github.com/pachyderm/pachyderm/v2/src/pps"
+	"context"
+
+	pfs_client "github.com/pachyderm/pachyderm/src/client/pfs"
+	pps_client "github.com/pachyderm/pachyderm/src/client/pps"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 )
+
+// TransactionServer is an interface for the transactionally-supported
+// methods that can be called through the PPS server.
+type TransactionServer interface {
+	UpdateJobStateInTransaction(*txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
+	CreatePipelineInTransaction(*txncontext.TransactionContext, *pps_client.CreatePipelineRequest, **pfs_client.Commit) error
+}
+
+type APIServer interface {
+	pps_client.APIServer
+	TransactionServer
+
+	ListPipelineNoAuth(context.Context, *pps_client.ListPipelineRequest) (*pps_client.PipelineInfos, error)
+}

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -15,9 +15,15 @@ type TransactionServer interface {
 	CreatePipelineInTransaction(*txncontext.TransactionContext, *pps_client.CreatePipelineRequest, **pfs_client.Commit) error
 }
 
-type APIServer interface {
-	pps_client.APIServer
+// InternalAPI is the set of non-RPC methods that are used internally within pachd
+type InternalAPI interface {
 	TransactionServer
 
 	ListPipelineNoAuth(context.Context, *pps_client.ListPipelineRequest) (*pps_client.PipelineInfos, error)
+}
+
+// APIServer is the set of all methods exposed by PPS
+type APIServer interface {
+	pps_client.APIServer
+	InternalAPI
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	"github.com/pachyderm/pachyderm/src/server/pkg/testutil"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
 	"github.com/pachyderm/pachyderm/src/server/pkg/watch"
 	"github.com/pachyderm/pachyderm/src/server/pkg/work"
@@ -196,7 +197,7 @@ func validateNames(names map[string]bool, input *pps.Input) error {
 	return nil
 }
 
-func (a *apiServer) validateInputInTransaction(txnCtx *txnenv.TransactionContext, pipelineName string, input *pps.Input) error {
+func (a *apiServer) validateInputInTransaction(txnCtx *txncontext.TransactionContext, pipelineName string, input *pps.Input) error {
 	if err := validateNames(make(map[string]bool), input); err != nil {
 		return err
 	}
@@ -235,7 +236,7 @@ func (a *apiServer) validateInputInTransaction(txnCtx *txnenv.TransactionContext
 						"'empty_files', as 's3' requires input data to be accessed via " +
 						"Pachyderm's S3 gateway rather than the file system")
 				}
-				if _, err := txnCtx.Pfs().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
+				if _, err := a.env.PfsServer().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
 					Repo: client.NewRepo(input.Pfs.Repo)}); err != nil {
 					return err
 				}
@@ -429,13 +430,13 @@ const (
 // authorizePipelineOp checks if the user indicated by 'ctx' is authorized
 // to perform 'operation' on the pipeline in 'info'
 func (a *apiServer) authorizePipelineOp(pachClient *client.APIClient, operation pipelineOperation, input *pps.Input, output string) error {
-	return a.txnEnv.WithReadContext(pachClient.Ctx(), func(txnCtx *txnenv.TransactionContext) error {
+	return a.txnEnv.WithReadContext(pachClient.Ctx(), func(txnCtx *txncontext.TransactionContext) error {
 		return a.authorizePipelineOpInTransaction(txnCtx, operation, input, output)
 	})
 }
 
 // authorizePipelineOpInTransaction is identical to authorizePipelineOp, but runs in the provided transaction
-func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionContext, operation pipelineOperation, input *pps.Input, output string) error {
+func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txncontext.TransactionContext, operation pipelineOperation, input *pps.Input, output string) error {
 	me, err := txnCtx.Client.WhoAmI(txnCtx.ClientContext, &auth.WhoAmIRequest{})
 	if auth.IsErrNotActivated(err) {
 		return nil // Auth isn't activated, skip authorization completely
@@ -463,7 +464,7 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 			}
 			done[repo] = struct{}{}
 			eg.Go(func() error {
-				resp, err := txnCtx.Auth().AuthorizeInTransaction(txnCtx, &auth.AuthorizeRequest{
+				resp, err := a.env.AuthServer().AuthorizeInTransaction(txnCtx, &auth.AuthorizeRequest{
 					Repo:  repo,
 					Scope: auth.Scope_READER,
 				})
@@ -495,7 +496,7 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 		var required auth.Scope
 		switch operation {
 		case pipelineOpCreate:
-			if _, err := txnCtx.Pfs().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
+			if _, err := a.env.PfsServer().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
 				Repo: &pfs.Repo{Name: output},
 			}); err == nil {
 				// the repo already exists, so we need the same permissions as update
@@ -508,7 +509,7 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 		case pipelineOpUpdate:
 			required = auth.Scope_WRITER
 		case pipelineOpDelete:
-			if _, err := txnCtx.Pfs().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
+			if _, err := a.env.PfsServer().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{
 				Repo: &pfs.Repo{Name: output},
 			}); isNotFoundErr(err) {
 				// special case: the pipeline output repo has been deleted (so the
@@ -520,7 +521,7 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txnenv.TransactionC
 			return errors.Errorf("internal error, unrecognized operation %v", operation)
 		}
 		if required != auth.Scope_NONE {
-			resp, err := txnCtx.Auth().AuthorizeInTransaction(txnCtx, &auth.AuthorizeRequest{
+			resp, err := a.env.AuthServer().AuthorizeInTransaction(txnCtx, &auth.AuthorizeRequest{
 				Repo:  output,
 				Scope: required,
 			})
@@ -552,7 +553,7 @@ func (a *apiServer) UpdateJobState(ctx context.Context, request *pps.UpdateJobSt
 	return &types.Empty{}, nil
 }
 
-func (a *apiServer) UpdateJobStateInTransaction(txnCtx *txnenv.TransactionContext, request *pps.UpdateJobStateRequest) error {
+func (a *apiServer) UpdateJobStateInTransaction(txnCtx *txncontext.TransactionContext, request *pps.UpdateJobStateRequest) error {
 	jobs := a.jobs.ReadWrite(txnCtx.Stm)
 
 	jobPtr := &pps.EtcdJobInfo{}
@@ -1939,7 +1940,7 @@ func (a *apiServer) validateEnterpriseChecks(ctx context.Context, pipelineInfo *
 	return nil
 }
 
-func (a *apiServer) validatePipelineInTransaction(txnCtx *txnenv.TransactionContext, pipelineInfo *pps.PipelineInfo) error {
+func (a *apiServer) validatePipelineInTransaction(txnCtx *txncontext.TransactionContext, pipelineInfo *pps.PipelineInfo) error {
 	if pipelineInfo.Pipeline == nil {
 		return errors.New("invalid pipeline spec: Pipeline field cannot be nil")
 	}
@@ -2097,7 +2098,7 @@ func (a *apiServer) sudo(pachClient *client.APIClient, f func(*client.APIClient)
 }
 
 // sudoTransaction is a convenience wrapper around sudo for api calls in a transaction
-func (a *apiServer) sudoTransaction(txnCtx *txnenv.TransactionContext, f func(*txnenv.TransactionContext) error) error {
+func (a *apiServer) sudoTransaction(txnCtx *txncontext.TransactionContext, f func(*txncontext.TransactionContext) error) error {
 	return a.sudo(txnCtx.Client, func(superUserClient *client.APIClient) error {
 		superCtx := *txnCtx
 		superCtx.Client = superUserClient
@@ -2140,12 +2141,12 @@ func (a *apiServer) makePipelineInfoCommitOnBranch(pachClient *client.APIClient,
 }
 
 func (a *apiServer) fixPipelineInputRepoACLs(ctx context.Context, pipelineInfo *pps.PipelineInfo, prevPipelineInfo *pps.PipelineInfo) error {
-	return a.txnEnv.WithWriteContext(ctx, func(txnCtx *txnenv.TransactionContext) error {
+	return a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		return a.fixPipelineInputRepoACLsInTransaction(txnCtx, pipelineInfo, prevPipelineInfo)
 	})
 }
 
-func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txnenv.TransactionContext, pipelineInfo *pps.PipelineInfo, prevPipelineInfo *pps.PipelineInfo) error {
+func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.TransactionContext, pipelineInfo *pps.PipelineInfo, prevPipelineInfo *pps.PipelineInfo) error {
 	add := make(map[string]struct{})
 	remove := make(map[string]struct{})
 	var pipelineName string
@@ -2214,8 +2215,8 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txnenv.Transac
 	for repo := range remove {
 		repo := repo
 		eg.Go(func() error {
-			return a.sudoTransaction(txnCtx, func(superTxnCtx *txnenv.TransactionContext) error {
-				_, err := superTxnCtx.Auth().SetScopeInTransaction(superTxnCtx, &auth.SetScopeRequest{
+			return a.sudoTransaction(txnCtx, func(superTxnCtx *txncontext.TransactionContext) error {
+				_, err := a.env.AuthServer().SetScopeInTransaction(superTxnCtx, &auth.SetScopeRequest{
 					Repo:     repo,
 					Username: auth.PipelinePrefix + pipelineName,
 					Scope:    auth.Scope_NONE,
@@ -2232,8 +2233,8 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txnenv.Transac
 	for repo := range add {
 		repo := repo
 		eg.Go(func() error {
-			return a.sudoTransaction(txnCtx, func(superTxnCtx *txnenv.TransactionContext) error {
-				_, err := superTxnCtx.Auth().SetScopeInTransaction(superTxnCtx, &auth.SetScopeRequest{
+			return a.sudoTransaction(txnCtx, func(superTxnCtx *txncontext.TransactionContext) error {
+				_, err := a.env.AuthServer().SetScopeInTransaction(superTxnCtx, &auth.SetScopeRequest{
 					Repo:     repo,
 					Username: auth.PipelinePrefix + pipelineName,
 					Scope:    auth.Scope_READER,
@@ -2245,8 +2246,8 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txnenv.Transac
 	// Add pipeline to its output repo's ACL as a WRITER if it's new
 	if prevPipelineInfo == nil {
 		eg.Go(func() error {
-			return a.sudoTransaction(txnCtx, func(superTxnCtx *txnenv.TransactionContext) error {
-				_, err := superTxnCtx.Auth().SetScopeInTransaction(superTxnCtx, &auth.SetScopeRequest{
+			return a.sudoTransaction(txnCtx, func(superTxnCtx *txncontext.TransactionContext) error {
+				_, err := a.env.AuthServer().SetScopeInTransaction(superTxnCtx, &auth.SetScopeRequest{
 					Repo:     pipelineName,
 					Username: auth.PipelinePrefix + pipelineName,
 					Scope:    auth.Scope_WRITER,
@@ -2342,7 +2343,7 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	return &types.Empty{}, nil
 }
 
-func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContext, request *pps.CreatePipelineRequest, prevSpecCommit **pfs.Commit) error {
+func (a *apiServer) CreatePipelineInTransaction(txnCtx *txncontext.TransactionContext, request *pps.CreatePipelineRequest, prevSpecCommit **pfs.Commit) error {
 	// Validate request
 	if err := a.validatePipelineRequest(request); err != nil {
 		return err
@@ -2397,7 +2398,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 	var visitErr error
 	pps.VisitInput(pipelineInfo.Input, func(input *pps.Input) {
 		if input.Cron != nil {
-			if err := txnCtx.Pfs().CreateRepoInTransaction(txnCtx,
+			if err := a.env.PfsServer().CreateRepoInTransaction(txnCtx,
 				&pfs.CreateRepoRequest{
 					Repo:        client.NewRepo(input.Cron.Repo),
 					Description: fmt.Sprintf("Cron tick repo for pipeline %s.", request.Pipeline.Name),
@@ -2406,7 +2407,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			}
 		}
 		if input.Git != nil {
-			if err := txnCtx.Pfs().CreateRepoInTransaction(txnCtx,
+			if err := a.env.PfsServer().CreateRepoInTransaction(txnCtx,
 				&pfs.CreateRepoRequest{
 					Repo:        client.NewRepo(input.Git.Name),
 					Description: fmt.Sprintf("Git input repo for pipeline %s.", request.Pipeline.Name),
@@ -2517,8 +2518,8 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			// we just created a new commit outside of the transaction, so our transaction reads won't see it
 			// to prevent errors, start and finish a commit in the transaction with the same ID
 			// this *will* cause an STM conflict, but will succeed on retry since specCommit already exists
-			if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
-				if _, err := superCtx.Pfs().StartCommitInTransaction(superCtx, &pfs.StartCommitRequest{
+			if err := a.sudoTransaction(txnCtx, func(superCtx *txncontext.TransactionContext) error {
+				if _, err := a.env.PfsServer().StartCommitInTransaction(superCtx, &pfs.StartCommitRequest{
 					Parent: client.NewCommit(ppsconsts.SpecRepo, ""),
 				}, specCommit); col.IsErrExists(err) {
 					// if a miracle occurs and we see the existing specCommit, that's fine, just continue
@@ -2526,7 +2527,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 				} else if err != nil {
 					return err
 				}
-				return superCtx.Pfs().FinishCommitInTransaction(superCtx, &pfs.FinishCommitRequest{
+				return a.env.PfsServer().FinishCommitInTransaction(superCtx, &pfs.FinishCommitRequest{
 					Commit: client.NewCommit(ppsconsts.SpecRepo, specCommit.ID),
 				})
 			}); err != nil {
@@ -2598,8 +2599,8 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			}
 
 			// move the spec branch for this pipeline to the new commit
-			if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
-				return superCtx.Pfs().CreateBranchInTransaction(superCtx, &pfs.CreateBranchRequest{
+			if err := a.sudoTransaction(txnCtx, func(superCtx *txncontext.TransactionContext) error {
+				return a.env.PfsServer().CreateBranchInTransaction(superCtx, &pfs.CreateBranchRequest{
 					Head:   specCommit,
 					Branch: client.NewBranch(ppsconsts.SpecRepo, pipelineInfo.Pipeline.Name),
 				})
@@ -2617,9 +2618,9 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			pipelinePtr.Parallelism = uint64(parallelism)
 
 			// Generate new pipeline auth token (added due to & add pipeline to the ACLs of input/output repos
-			if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
+			if err := a.sudoTransaction(txnCtx, func(superCtx *txncontext.TransactionContext) error {
 				oldAuthToken := pipelinePtr.AuthToken
-				tokenResp, err := superCtx.Auth().GetAuthTokenInTransaction(superCtx, &auth.GetAuthTokenRequest{
+				tokenResp, err := a.env.AuthServer().GetAuthTokenInTransaction(superCtx, &auth.GetAuthTokenRequest{
 					Subject: auth.PipelinePrefix + request.Pipeline.Name,
 					TTL:     -1,
 				})
@@ -2633,7 +2634,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 
 				// If getting a new auth token worked, we should revoke the old one
 				if oldAuthToken != "" {
-					_, err := superCtx.Auth().RevokeAuthTokenInTransaction(superCtx,
+					_, err := a.env.AuthServer().RevokeAuthTokenInTransaction(superCtx,
 						&auth.RevokeAuthTokenRequest{
 							Token: oldAuthToken,
 						})
@@ -2657,21 +2658,21 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			// don't branch the output/stats/marker commit chain from the old pipeline (re-use old branch HEAD)
 			// However it's valid to set request.Update == true even if no pipeline exists, so only
 			// set outputBranchHead if there's an old pipeline to update
-			_, err := txnCtx.Pfs().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{Branch: outputBranch})
+			_, err := a.env.PfsServer().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{Branch: outputBranch})
 			if err != nil && !isNotFoundErr(err) {
 				return err
 			} else if err == nil {
 				outputBranchHead = client.NewCommit(pipelineName, pipelineInfo.OutputBranch)
 			}
 
-			_, err = txnCtx.Pfs().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{Branch: statsBranch})
+			_, err = a.env.PfsServer().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{Branch: statsBranch})
 			if err != nil && !isNotFoundErr(err) {
 				return err
 			} else if err == nil {
 				statsBranchHead = client.NewCommit(pipelineName, "stats")
 			}
 
-			_, err = txnCtx.Pfs().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{Branch: markerBranch})
+			_, err = a.env.PfsServer().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{Branch: markerBranch})
 			if err != nil && !isNotFoundErr(err) {
 				return err
 			} else if err == nil {
@@ -2686,7 +2687,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 		}
 	} else {
 		// Create output repo, pipeline output, and stats
-		if err := txnCtx.Pfs().CreateRepoInTransaction(txnCtx,
+		if err := a.env.PfsServer().CreateRepoInTransaction(txnCtx,
 			&pfs.CreateRepoRequest{
 				Repo:        client.NewRepo(pipelineName),
 				Description: fmt.Sprintf("Output repo for pipeline %s.", request.Pipeline.Name),
@@ -2713,9 +2714,9 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			if commit, err = createOrValidateSpecCommit(); err != nil {
 				return err
 			}
-			if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
+			if err := a.sudoTransaction(txnCtx, func(superCtx *txncontext.TransactionContext) error {
 				// move the spec branch for this pipeline to the new commit
-				return superCtx.Pfs().CreateBranchInTransaction(superCtx, &pfs.CreateBranchRequest{
+				return a.env.PfsServer().CreateBranchInTransaction(superCtx, &pfs.CreateBranchRequest{
 					Head:   commit,
 					Branch: client.NewBranch(ppsconsts.SpecRepo, pipelineInfo.Pipeline.Name),
 				})
@@ -2734,8 +2735,8 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 
 		// Generate pipeline's auth token & add pipeline to the ACLs of input/output
 		// repos
-		if err := a.sudoTransaction(txnCtx, func(superCtx *txnenv.TransactionContext) error {
-			tokenResp, err := superCtx.Auth().GetAuthTokenInTransaction(superCtx, &auth.GetAuthTokenRequest{
+		if err := a.sudoTransaction(txnCtx, func(superCtx *txncontext.TransactionContext) error {
+			tokenResp, err := a.env.AuthServer().GetAuthTokenInTransaction(superCtx, &auth.GetAuthTokenRequest{
 				Subject: auth.PipelinePrefix + request.Pipeline.Name,
 				TTL:     -1,
 			})
@@ -2782,7 +2783,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 
 	// Create/update output branch (creating new output commit for the pipeline
 	// and restarting the pipeline)
-	if err := txnCtx.Pfs().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+	if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
 		Branch:     outputBranch,
 		Provenance: provenance,
 		Head:       outputBranchHead,
@@ -2795,7 +2796,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 			return
 		}
 		if input.Pfs != nil && input.Pfs.Trigger != nil {
-			_, err = txnCtx.Pfs().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{
+			_, err = a.env.PfsServer().InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{
 				Branch: client.NewBranch(input.Pfs.Repo, input.Pfs.Branch),
 			})
 
@@ -2806,7 +2807,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 				if err == nil {
 					prevHead = client.NewCommit(input.Pfs.Repo, input.Pfs.Branch)
 				}
-				visitErr = txnCtx.Pfs().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+				visitErr = a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
 					Branch:  client.NewBranch(input.Pfs.Repo, input.Pfs.Branch),
 					Head:    prevHead,
 					Trigger: input.Pfs.Trigger,
@@ -2818,7 +2819,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 		return errors.Wrapf(visitErr, "could not create/update trigger branch")
 	}
 	if pipelineInfo.EnableStats {
-		if err := txnCtx.Pfs().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+		if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
 			Branch:     client.NewBranch(pipelineName, "stats"),
 			Provenance: []*pfs.Branch{outputBranch},
 			Head:       statsBranchHead,
@@ -2827,7 +2828,7 @@ func (a *apiServer) CreatePipelineInTransaction(txnCtx *txnenv.TransactionContex
 		}
 	}
 	if pipelineInfo.Spout != nil && pipelineInfo.Spout.Marker != "" {
-		if err := txnCtx.Pfs().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+		if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
 			Branch: markerBranch,
 			Head:   markerBranchHead,
 		}); err != nil {
@@ -2928,7 +2929,7 @@ func (a *apiServer) InspectPipeline(ctx context.Context, request *pps.InspectPip
 // so they call this instead of making an RPC
 func (a *apiServer) inspectPipeline(pachClient *client.APIClient, name string) (*pps.PipelineInfo, error) {
 	var response *pps.PipelineInfo
-	if err := a.txnEnv.WithReadContext(pachClient.Ctx(), func(txnCtx *txnenv.TransactionContext) error {
+	if err := a.txnEnv.WithReadContext(pachClient.Ctx(), func(txnCtx *txncontext.TransactionContext) error {
 		var err error
 		response, err = a.inspectPipelineInTransaction(txnCtx, name)
 		return err
@@ -2938,7 +2939,7 @@ func (a *apiServer) inspectPipeline(pachClient *client.APIClient, name string) (
 	return response, nil
 }
 
-func (a *apiServer) inspectPipelineInTransaction(txnCtx *txnenv.TransactionContext, name string) (*pps.PipelineInfo, error) {
+func (a *apiServer) inspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, name string) (*pps.PipelineInfo, error) {
 	if _, err := checkLoggedIn(txnCtx.Client); err != nil {
 		return nil, err
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -3040,7 +3040,14 @@ func (a *apiServer) ListPipeline(ctx context.Context, request *pps.ListPipelineR
 	if err != nil {
 		return nil, err
 	}
+
+	return a.ListPipelineNoAuth(ctx, request)
+}
+
+// ListPipelineNoAuth is an internal  API for collecting metrics (not an RPC) which does not require an auth token
+func (a *apiServer) ListPipelineNoAuth(ctx context.Context, request *pps.ListPipelineRequest) (response *pps.PipelineInfos, retErr error) {
 	pipelineInfos := &pps.PipelineInfos{}
+	pachClient := a.env.GetPachClient(ctx)
 	if err := a.listPipeline(pachClient, request, func(pi *pps.PipelineInfo) error {
 		pipelineInfos.PipelineInfo = append(pipelineInfos.PipelineInfo, pi)
 		return nil

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	ppsclient "github.com/pachyderm/pachyderm/src/client/pps"
 	"github.com/pachyderm/pachyderm/src/server/pkg/log"
 	"github.com/pachyderm/pachyderm/src/server/pkg/metrics"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsdb"
@@ -78,7 +77,7 @@ func NewSidecarAPIServer(
 	workerGrpcPort uint16,
 	httpPort uint16,
 	peerPort uint16,
-) (APIServer, error) {
+) (pps_iface.APIServer, error) {
 	apiServer := &apiServer{
 		Logger:         log.NewLogger("pps.API"),
 		env:            env,

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -7,13 +7,8 @@ import (
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsdb"
 	"github.com/pachyderm/pachyderm/src/server/pkg/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	pps_iface "github.com/pachyderm/pachyderm/src/server/pps"
 )
-
-// APIServer represents a PPS API server
-type APIServer interface {
-	ppsclient.APIServer
-	txnenv.PpsTransactionServer
-}
 
 // NewAPIServer creates an APIServer.
 func NewAPIServer(
@@ -38,7 +33,7 @@ func NewAPIServer(
 	httpPort uint16,
 	peerPort uint16,
 	gcPercent int,
-) (APIServer, error) {
+) (pps_iface.APIServer, error) {
 	apiServer := &apiServer{
 		Logger:                log.NewLogger("pps.API"),
 		env:                   env,

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -22,7 +22,7 @@ import (
 	col "github.com/pachyderm/pachyderm/src/server/pkg/collection"
 	"github.com/pachyderm/pachyderm/src/server/pkg/obj"
 	"github.com/pachyderm/pachyderm/src/server/pkg/ppsutil"
-	txnenv "github.com/pachyderm/pachyderm/src/server/pkg/transactionenv"
+	"github.com/pachyderm/pachyderm/src/server/pkg/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/src/server/pkg/uuid"
 	"github.com/pachyderm/pachyderm/src/server/pkg/work"
 )
@@ -240,7 +240,7 @@ func mockBasicJob(t *testing.T, env *testEnv, pi *pps.PipelineInfo) (context.Con
 		}
 	}
 
-	env.MockPPSTransactionServer.UpdateJobStateInTransaction.Use(func(txnctx *txnenv.TransactionContext, request *pps.UpdateJobStateRequest) error {
+	env.MockPPSTransactionServer.UpdateJobStateInTransaction.Use(func(txnctx *txncontext.TransactionContext, request *pps.UpdateJobStateRequest) error {
 		updateJobState(request)
 		return nil
 	})


### PR DESCRIPTION
Make metrics work in 1.x by adding an unauthenticated internal interface for listing repos and pipelines. This isn't an RPC.

To add support for cross-service method calls that aren't RPCs, this PR applies the same refactor to 1.13 as we did in 2.x - create a new interface for each service in `src/server/<service>` which combines the RPC interface, transaction interface and a new internal interface for calls within pachd.

To avoid circular dependencies we need to split out the TransactionContext struct into it's own module. That makes up the bulk of the changes, just find-and-replacing.