### PR TITLE
[S3G] Parse commit_id from bucket name

### DIFF
--- a/src/server/pfs/s3/driver.go
+++ b/src/server/pfs/s3/driver.go
@@ -75,8 +75,11 @@ func (d *MasterDriver) listBuckets(pc *client.APIClient, r *http.Request, bucket
 func (d *MasterDriver) bucket(pc *client.APIClient, r *http.Request, name string) (*Bucket, error) {
 	var repo, branch, commit string
 	branch = "master"
-	parts := strings.SplitN(name, ".", 2)
-	if len(parts) == 2 {
+
+	parts := strings.SplitN(name, ".", 3)
+	if len(parts) == 3 {
+		commit, branch, repo = parts[0], parts[1], parts[2]
+	} else if len(parts) == 2 {
 		if uuid.IsUUIDWithoutDashes(parts[0]) {
 			commit = parts[0]
 		} else {

--- a/src/server/pfs/s3/driver.go
+++ b/src/server/pfs/s3/driver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/s2"
@@ -72,11 +73,15 @@ func (d *MasterDriver) listBuckets(pc *client.APIClient, r *http.Request, bucket
 }
 
 func (d *MasterDriver) bucket(pc *client.APIClient, r *http.Request, name string) (*Bucket, error) {
-	branch := "master"
-	var repo string
+	var repo, branch, commit string
+	branch = "master"
 	parts := strings.SplitN(name, ".", 2)
 	if len(parts) == 2 {
-		branch = parts[0]
+		if uuid.IsUUIDWithoutDashes(parts[0]) {
+			commit = parts[0]
+		} else {
+			branch = parts[0]
+		}
 		repo = parts[1]
 	} else {
 		repo = parts[0]
@@ -85,7 +90,7 @@ func (d *MasterDriver) bucket(pc *client.APIClient, r *http.Request, name string
 	return &Bucket{
 		Repo:   repo,
 		Branch: branch,
-		Commit: "",
+		Commit: commit,
 		Name:   name,
 	}, nil
 }


### PR DESCRIPTION
This PR allows S3 gateway clients to list objects by referencing a commit_id.

Resolves #6235

To-Do:

- [x] with respect to Global IDs, how should we disambiguate commits within the same repo that have the same Id but different branches? Something like `commit.branch.repo`?
- [ ] the 63 char limit imposed by S3 clients is out of our control, so we should think about supporting short commit_ids as part of the query?