### PR TITLE
[1.13.x] Pipeline operations ignore errors in revoking auth tokens

### DIFF
--- a/src/client/auth/auth.go
+++ b/src/client/auth/auth.go
@@ -87,6 +87,9 @@ var (
 	// ErrExpiredToken is returned by the Auth API if a restored token expired in
 	// the past.
 	ErrExpiredToken = status.Error(codes.Internal, "token expiration is in the past")
+
+	// ErrRevokeUnknownToken is returned by the Auth API if a token to be revoked doesn't exist
+	ErrRevokeUnknownToken = status.Error(codes.Internal, "token has expired or is already revoked")
 )
 
 // IsErrNotActivated checks if an error is a ErrNotActivated
@@ -97,6 +100,16 @@ func IsErrNotActivated(err error) bool {
 	// TODO(msteffen) This is unstructured because we have no way to propagate
 	// structured errors across GRPC boundaries. Fix
 	return strings.Contains(err.Error(), status.Convert(ErrNotActivated).Message())
+}
+
+// IsErrRevokeUnknownToken checks if an error is a ErrRevokeUnknownToken
+func IsErrRevokeUnknownToken(err error) bool {
+	if err == nil {
+		return false
+	}
+	// TODO(msteffen) This is unstructured because we have no way to propagate
+	// structured errors across GRPC boundaries. Fix
+	return strings.Contains(err.Error(), status.Convert(ErrRevokeUnknownToken).Message())
 }
 
 // IsErrPartiallyActivated checks if an error is a ErrPartiallyActivated

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -2233,9 +2233,10 @@ func (a *apiServer) RevokeAuthTokenInTransaction(txnCtx *txnenv.TransactionConte
 	tokens := a.tokens.ReadWrite(txnCtx.Stm)
 	var tokenInfo auth.TokenInfo
 	if err := tokens.Get(auth.HashToken(req.Token), &tokenInfo); err != nil {
-		if !col.IsErrNotFound(err) {
-			return nil, err
+		if col.IsErrNotFound(err) {
+			return nil, auth.ErrRevokeUnknownToken
 		}
+		return nil, err
 	}
 	if !isAdmin && tokenInfo.Subject != callerInfo.Subject {
 		return nil, &auth.ErrNotAuthorized{


### PR DESCRIPTION
Jimmy reported this issue with a hub cluster:

```
$ pachctl delete pipeline raw_data
error revoking old auth token:  pachyderm/1.7.0/pachyderm_auth/tokens/faa0c5df1d27cedaa87fa55e417e295c019f1ba6603afda83b7832fa8d59b3f6 not found
```

In 1.13 revoking auth tokens and updating the pipeline isn't atomic, so it's possible for a pipeline to end up with an invalid token in etcd. If the pipeline's token is invalid it throws an error when updating or deleting.

In 2.x we do this all in one DB transaction (revoke the token,  generate the new one, add it to the pipeline spec) so it's not an issue.