### PR TITLE
[S3G] Support commit.repo bucket name

### DIFF
--- a/src/server/pfs/s3/master_test.go
+++ b/src/server/pfs/s3/master_test.go
@@ -332,7 +332,8 @@ func masterListObjectsPaginated(t *testing.T, pachClient *client.APIClient, mini
 	// `LastModified` date is correct. A few minutes are subtracted/added to
 	// each to tolerate the node time not being the same as the host time.
 	startTime := time.Now().Add(time.Duration(-5) * time.Minute)
-	repo := tu.UniqueString("testlistobjectspaginated")
+	//
+	repo := tu.UniqueString("testLOP")
 	require.NoError(t, pachClient.CreateRepo(repo))
 	commit, err := pachClient.StartCommit(repo, "master")
 	require.NoError(t, err)
@@ -353,6 +354,18 @@ func masterListObjectsPaginated(t *testing.T, pachClient *client.APIClient, mini
 		expectedFiles = append(expectedFiles, fmt.Sprintf("%d", i))
 	}
 	checkListObjects(t, ch, &startTime, &endTime, expectedFiles, []string{"dir/"})
+
+	// Query by commit.repo
+	ch = minioClient.ListObjects(fmt.Sprintf("%s.%s", commit.ID, repo), "", false, make(chan struct{}))
+	checkListObjects(t, ch, &startTime, &endTime, expectedFiles, []string{"dir/"})
+
+	// Query by commit.branch.repo
+	ch = minioClient.ListObjects(fmt.Sprintf("%s.%s.%s", commit.ID, "master", repo), "", false, make(chan struct{}))
+	checkListObjects(t, ch, &startTime, &endTime, expectedFiles, []string{"dir/"})
+
+	// Query a different branch other than master
+	ch = minioClient.ListObjects(fmt.Sprintf("%s.%s", "branch", repo), "", false, make(chan struct{}))
+	checkListObjects(t, ch, &startTime, &endTime, []string{"1001"}, []string{})
 
 	// Request that will list all files in master starting with 1
 	ch = minioClient.ListObjects(fmt.Sprintf("master.%s", repo), "1", false, make(chan struct{}))

--- a/src/server/pfs/s3/master_test.go
+++ b/src/server/pfs/s3/master_test.go
@@ -332,7 +332,8 @@ func masterListObjectsPaginated(t *testing.T, pachClient *client.APIClient, mini
 	// `LastModified` date is correct. A few minutes are subtracted/added to
 	// each to tolerate the node time not being the same as the host time.
 	startTime := time.Now().Add(time.Duration(-5) * time.Minute)
-	//
+	// S3 client limits bucket name to 63 chars, and our commit_ids are 32 chars,
+	// leaving us with 31 free chars to use
 	repo := tu.UniqueString("testLOP")
 	require.NoError(t, pachClient.CreateRepo(repo))
 	commit, err := pachClient.StartCommit(repo, "master")


### PR DESCRIPTION
Previously merged a similar update in `master` https://github.com/pachyderm/pachyderm/pull/6271
This is just to achieve the same functionality in the 1.13.x branch.

Resolves #6235