### PR TITLE
Remove snaps from build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,11 @@ jobs:
       - checkout
       - restore_cache:
          keys:
-         - pach-build-dependencies-{{ checksum "etc/testing/circle/install.sh" }}
-         - pach-build-dependencies-
+         - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
+         - pach-build-dependencies-v2-
       - run: etc/testing/circle/install.sh 
       - save_cache:
-         key: pach-build-dependencies-{{ checksum "etc/testing/circle/install.sh" }}
+         key: pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
          paths:
          - cached-deps/
       - run: etc/testing/circle/start-minikube.sh 

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -5,8 +5,6 @@ set -ex
 mkdir -p cached-deps
 
 # Install deps
-sudo snap install --classic goreleaser
-sudo snap install jq
 sudo apt update -y
 sudo apt-get install -y -qq \
   silversearcher-ag \
@@ -73,4 +71,17 @@ if [ ! -f cached-deps/helm ]; then
   curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
       | tar xzf - linux-amd64/helm
       mv ./linux-amd64/helm cached-deps/helm
+fi
+
+# Install goreleaser 
+if [ ! -f cached-deps/goreleaser ]; then
+  GORELEASER_VERSION=0.169.0
+  curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
+      | tar xzf - -C cached-deps goreleaser
+fi
+
+# Install jq
+if [ ! -f cached-deps/jq ]; then
+  JQ_VERSION=1.6
+  curl -L https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 > cached-deps/jq
 fi


### PR DESCRIPTION
Installing snaps is sometimes really slow in CI (10m) versus about 30s to just curl jq and goreleaser.