### PR TITLE
Make auth token duration configurable

### DIFF
--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -38,6 +38,9 @@ type GlobalConfiguration struct {
 	Metrics              bool   `env:"METRICS,default=true"`
 	MetricsEndpoint      string `env:"METRICS_ENDPOINT,default="`
 
+	// SessionDurationMinutes it how long auth tokens are valid for, defaults to 30 days (30 * 24 * 60)
+	SessionDurationMinutes int `env:"SESSION_DURATION_MINUTES,default=43200"`
+
 	IdentityServerDatabase string `env:"IDENTITY_SERVER_DATABASE,default=dex"`
 	IdentityServerUser     string `env:"IDENTITY_SERVER_USER,default=postgres"`
 	IdentityServerPassword string `env:"IDENTITY_SERVER_PASSWORD"`


### PR DESCRIPTION
Users have requested the ability to set the auth token duration shorter than 30 days for compliance reasons.

This is half of the solution to https://github.com/pachyderm/pachyderm/issues/5799, the other half is reducing the expiration on access tokens in dex. 