### PR TITLE
Pachd uses unprivileged ports

### DIFF
--- a/Dockerfile.pachd
+++ b/Dockerfile.pachd
@@ -16,4 +16,6 @@ COPY dex-assets /dex-assets
 COPY --from=pachyderm_build /tmp/to-copy /
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+USER 1000:1000
+
 ENTRYPOINT ["/pachd"]

--- a/Dockerfile.pachd
+++ b/Dockerfile.pachd
@@ -16,6 +16,4 @@ COPY dex-assets /dex-assets
 COPY --from=pachyderm_build /tmp/to-copy /
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-USER 1000:1000
-
 ENTRYPOINT ["/pachd"]

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -438,9 +438,9 @@ func portForwarder(context *config.Context) (*PortForwarder, uint16, error) {
 
 	var port uint16
 	if context.EnterpriseServer {
-		port, err = fw.RunForEnterpriseServer(0, 650)
+		port, err = fw.RunForEnterpriseServer(0, 1650)
 	} else {
-		port, err = fw.RunForDaemon(0, 650)
+		port, err = fw.RunForDaemon(0, 1650)
 	}
 
 	if err != nil {

--- a/src/client/portforwarder.go
+++ b/src/client/portforwarder.go
@@ -189,13 +189,13 @@ func (f *PortForwarder) RunForDashWebSocket(localPort uint16) (uint16, error) {
 }
 
 // RunForPFS creates a port forwarder for PFS over HTTP.
-func (f *PortForwarder) RunForPFS(localPort uint16) (uint16, error) {
-	return f.Run("pachd", localPort, 30652)
+func (f *PortForwarder) RunForPFS(localPort, remotePort uint16) (uint16, error) {
+	return f.Run("pachd", localPort, remotePort)
 }
 
 // RunForS3Gateway creates a port forwarder for the s3gateway.
-func (f *PortForwarder) RunForS3Gateway(localPort uint16) (uint16, error) {
-	return f.Run("pachd", localPort, 600)
+func (f *PortForwarder) RunForS3Gateway(localPort, remotePort uint16) (uint16, error) {
+	return f.Run("pachd", localPort, remotePort)
 }
 
 // RunForIDE creates a port forwarder for the IDE

--- a/src/internal/deploy/assets/assets.go
+++ b/src/internal/deploy/assets/assets.go
@@ -86,7 +86,7 @@ var (
 	IAMAnnotation = "iam.amazonaws.com/role"
 
 	// OidcPort is the port where OIDC ID Providers can send auth assertions
-	OidcPort = int32(657)
+	OidcPort = int32(1657)
 )
 
 // Backend is the type used to enumerate what system provides object storage or
@@ -508,16 +508,16 @@ func imagePullSecrets(opts *AssetOpts) []v1.LocalObjectReference {
 func PachdDeployment(opts *AssetOpts, objectStoreBackend Backend, hostPath string) *apps.Deployment {
 	// set port defaults
 	if opts.PachdPort == 0 {
-		opts.PachdPort = 650
+		opts.PachdPort = 1650
 	}
 	if opts.TracePort == 0 {
-		opts.TracePort = 651
+		opts.TracePort = 1651
 	}
 	if opts.HTTPPort == 0 {
-		opts.HTTPPort = 652
+		opts.HTTPPort = 1652
 	}
 	if opts.PeerPort == 0 {
-		opts.PeerPort = 653
+		opts.PeerPort = 1653
 	}
 	mem := resource.MustParse(opts.PachdNonCacheMemRequest)
 	cpu := resource.MustParse(opts.PachdCPURequest)
@@ -737,41 +737,41 @@ func PachdService(opts *AssetOpts) *v1.Service {
 				// NOTE: do not put any new ports before `api-grpc-port`, as
 				// it'll change k8s SERVICE_PORT env var values
 				{
-					Port:     650, // also set in cmd/pachd/main.go
+					Port:     1650, // also set in cmd/pachd/main.go
 					Name:     "api-grpc-port",
 					NodePort: 30650,
 				},
 				{
-					Port:     651, // also set in cmd/pachd/main.go
+					Port:     1651, // also set in cmd/pachd/main.go
 					Name:     "trace-port",
 					NodePort: 30651,
 				},
 				{
-					Port:     652, // also set in cmd/pachd/main.go
+					Port:     1652, // also set in cmd/pachd/main.go
 					Name:     "api-http-port",
 					NodePort: 30652,
 				},
 				{
 					Port:     OidcPort,
 					Name:     "oidc-port",
-					NodePort: 30000 + OidcPort,
+					NodePort: 30657,
 				},
 				{
-					Port:     658,
+					Port:     1658,
 					Name:     "identity-port",
 					NodePort: 30658,
 				},
 				{
-					Port:     600, // also set in cmd/pachd/main.go
+					Port:     1600, // also set in cmd/pachd/main.go
 					Name:     "s3gateway-port",
 					NodePort: 30600,
 				},
 				{
-					Port:       656,
+					Port:       1656,
 					Name:       "prometheus-metrics",
 					NodePort:   30656,
 					Protocol:   v1.ProtocolTCP,
-					TargetPort: intstr.FromInt(656),
+					TargetPort: intstr.FromInt(1656),
 				},
 			},
 		},

--- a/src/internal/deploy/assets/enterprise.go
+++ b/src/internal/deploy/assets/enterprise.go
@@ -29,31 +29,31 @@ func EnterpriseService(opts *AssetOpts) *v1.Service {
 				// NOTE: do not put any new ports before `api-grpc-port`, as
 				// it'll change k8s SERVICE_PORT env var values
 				{
-					Port:     650, // also set in cmd/pachd/main.go
+					Port:     1650, // also set in cmd/pachd/main.go
 					Name:     "api-grpc-port",
 					NodePort: 31650,
 				},
 				{
-					Port:     651, // also set in cmd/pachd/main.go
+					Port:     1651, // also set in cmd/pachd/main.go
 					Name:     "trace-port",
 					NodePort: 31651,
 				},
 				{
 					Port:     OidcPort,
 					Name:     "oidc-port",
-					NodePort: 31000 + OidcPort,
+					NodePort: 31657,
 				},
 				{
-					Port:     658,
+					Port:     1658,
 					Name:     "identity-port",
 					NodePort: 31658,
 				},
 				{
-					Port:       656,
+					Port:       1656,
 					Name:       "prometheus-metrics",
 					NodePort:   31656,
 					Protocol:   v1.ProtocolTCP,
-					TargetPort: intstr.FromInt(656),
+					TargetPort: intstr.FromInt(1656),
 				},
 			},
 		},

--- a/src/internal/deploy/cmds/ide.go
+++ b/src/internal/deploy/cmds/ide.go
@@ -207,7 +207,7 @@ func createDeployIDECmd() *cobra.Command {
 	deployIDE.Flags().StringVar(&hubImage, "hub-image", "", "Image for IDE hub. By default this value is automatically derived.")
 	deployIDE.Flags().StringVar(&userImage, "user-image", "", "Image for IDE user environments. By default this value is automatically derived.")
 	deployIDE.Flags().StringVar(&clientID, "client-id", "ide", "The OIDC client ID for the IDE.")
-	deployIDE.Flags().StringVar(&internalIDAddr, "internal-id-server", "http://pachd:658", "The web address where the identity server can be reached from within the cluster.")
+	deployIDE.Flags().StringVar(&internalIDAddr, "internal-id-server", "http://pachd:1658", "The web address where the identity server can be reached from within the cluster.")
 	deployIDE.Flags().StringVar(&idAddr, "id-server", "http://localhost:30658", "The web address where the identity server can be reached from the client machine.")
 	deployIDE.Flags().StringVar(&ideAddr, "ide-address", "http://localhost:30659", "The web address where the IDE can be reached from the client machine.")
 

--- a/src/internal/grpcutil/addr.go
+++ b/src/internal/grpcutil/addr.go
@@ -16,7 +16,7 @@ const (
 
 	// DefaultPachdPort is the pachd kubernetes service's default
 	// Port (often used with Pachyderm ELBs)
-	DefaultPachdPort = 650
+	DefaultPachdPort = 1650
 )
 
 var (

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -12,18 +12,18 @@ type GlobalConfiguration struct {
 	FeatureFlags
 	EtcdHost            string `env:"ETCD_SERVICE_HOST,required"`
 	EtcdPort            string `env:"ETCD_SERVICE_PORT,required"`
-	PPSWorkerPort       uint16 `env:"PPS_WORKER_GRPC_PORT,default=80"`
-	Port                uint16 `env:"PORT,default=650"`
-	HTTPPort            uint16 `env:"HTTP_PORT,default=652"`
-	PeerPort            uint16 `env:"PEER_PORT,default=653"`
-	S3GatewayPort       uint16 `env:"S3GATEWAY_PORT,default=600"`
+	PPSWorkerPort       uint16 `env:"PPS_WORKER_GRPC_PORT,default=1080"`
+	Port                uint16 `env:"PORT,default=1650"`
+	HTTPPort            uint16 `env:"HTTP_PORT,default=1652"`
+	PeerPort            uint16 `env:"PEER_PORT,default=1653"`
+	S3GatewayPort       uint16 `env:"S3GATEWAY_PORT,default=1600"`
 	PPSEtcdPrefix       string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
 	Namespace           string `env:"PACH_NAMESPACE,default=default"`
 	StorageRoot         string `env:"PACH_ROOT,default=/pach"`
 	GCPercent           int    `env:"GC_PERCENT,default=50"`
 	LokiHost            string `env:"LOKI_SERVICE_HOST"`
 	LokiPort            string `env:"LOKI_SERVICE_PORT"`
-	OidcPort            uint16 `env:"OIDC_PORT,default=657"`
+	OidcPort            uint16 `env:"OIDC_PORT,default=1657"`
 	PostgresServiceHost string `env:"POSTGRES_SERVICE_HOST"`
 	PostgresServicePort int    `env:"POSTGRES_SERVICE_PORT"`
 	PostgresServiceSSL  string `env:"POSTGRES_SERVICE_SSL,default=disable"`

--- a/src/internal/testutil/enterprise.go
+++ b/src/internal/testutil/enterprise.go
@@ -34,8 +34,8 @@ func ActivateEnterprise(t testing.TB, c *client.APIClient) {
 		&license.AddClusterRequest{
 			Id:               "localhost",
 			Secret:           "localhost",
-			Address:          "grpc://localhost:650",
-			UserAddress:      "grpc://localhost:650",
+			Address:          "grpc://localhost:1650",
+			UserAddress:      "grpc://localhost:1650",
 			EnterpriseServer: true,
 		})
 	if err != nil && !license.IsErrDuplicateClusterID(err) {
@@ -46,7 +46,7 @@ func ActivateEnterprise(t testing.TB, c *client.APIClient) {
 		&enterprise.ActivateRequest{
 			Id:            "localhost",
 			Secret:        "localhost",
-			LicenseServer: "grpc://localhost:650",
+			LicenseServer: "grpc://localhost:1650",
 		})
 	require.NoError(t, err)
 }

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -26,7 +26,7 @@ func OIDCOIDCConfig() *auth.OIDCConfig {
 		Issuer:          "http://localhost:30658/",
 		ClientID:        "pachyderm",
 		ClientSecret:    "notsecret",
-		RedirectURI:     "http://pachd:657/authorization-code/callback",
+		RedirectURI:     "http://pachd:1657/authorization-code/callback",
 		LocalhostIssuer: true,
 		Scopes:          auth.DefaultOIDCScopes,
 	}
@@ -70,7 +70,7 @@ func ConfigureOIDCProvider(t *testing.T) error {
 		Client: &identity.OIDCClient{
 			Id:           "testapp",
 			Name:         "testapp",
-			RedirectUris: []string{"http://test.example.com:657/authorization-code/callback"},
+			RedirectUris: []string{"http://test.example.com:1657/authorization-code/callback"},
 			Secret:       "test",
 		},
 	})
@@ -80,7 +80,7 @@ func ConfigureOIDCProvider(t *testing.T) error {
 		Client: &identity.OIDCClient{
 			Id:           "pachyderm",
 			Name:         "pachyderm",
-			RedirectUris: []string{"http://pachd:657/authorization-code/callback"},
+			RedirectUris: []string{"http://pachd:1657/authorization-code/callback"},
 			Secret:       "notsecret",
 			TrustedPeers: []string{"testapp"},
 		},
@@ -142,7 +142,7 @@ func GetOIDCTokenForTrustedApp(t testing.TB) string {
 	oauthConfig := oauth2.Config{
 		ClientID:     "testapp",
 		ClientSecret: "test",
-		RedirectURL:  "http://test.example.com:657/authorization-code/callback",
+		RedirectURL:  "http://test.example.com:1657/authorization-code/callback",
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  RewriteURL(t, "http://pachd:30658/auth", DexHost(testClient)),
 			TokenURL: RewriteURL(t, "http://pachd:30658/token", DexHost(testClient)),
@@ -198,8 +198,8 @@ func RewriteURL(t testing.TB, urlStr, host string) string {
 
 // DexHost returns the address to access the identity server during tests
 func DexHost(c *client.APIClient) string {
-	if c.GetAddress().Port == 650 {
-		return c.GetAddress().Host + ":658"
+	if c.GetAddress().Port == 1650 {
+		return c.GetAddress().Host + ":1658"
 	}
 	if c.GetAddress().Port == 31650 {
 		return c.GetAddress().Host + ":31658"
@@ -208,8 +208,8 @@ func DexHost(c *client.APIClient) string {
 }
 
 func pachHost(c *client.APIClient) string {
-	if c.GetAddress().Port == 650 {
-		return c.GetAddress().Host + ":657"
+	if c.GetAddress().Port == 1650 {
+		return c.GetAddress().Host + ":1657"
 	}
 	if c.GetAddress().Port == 31650 {
 		return c.GetAddress().Host + ":31657"

--- a/src/internal/testutil/pach_client.go
+++ b/src/internal/testutil/pach_client.go
@@ -19,7 +19,7 @@ var (
 func GetPachClient(t testing.TB) *client.APIClient {
 	clientOnce.Do(func() {
 		var err error
-		if _, ok := os.LookupEnv("PACHD_PORT_650_TCP_ADDR"); ok {
+		if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
 			pachClient, err = client.NewInCluster()
 		} else {
 			pachClient, err = client.NewForTest()

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -289,14 +289,14 @@ func TestConfig(t *testing.T) {
             "issuer": "http://localhost:30658/",
             "localhost_issuer": true,
             "client_id": "localhost",
-            "redirect_uri": "http://localhost:650"
+            "redirect_uri": "http://localhost:1650"
         }
 EOF
 		pachctl auth get-config \
 		  | match '"issuer": "http://localhost:30658/"' \
 		  | match '"localhost_issuer": true' \
 		  | match '"client_id": "localhost"' \
-		  | match '"redirect_uri": "http://localhost:650"' \
+		  | match '"redirect_uri": "http://localhost:1650"' \
 		  | match '}'
 		`).Run())
 
@@ -305,7 +305,7 @@ EOF
 		  | match 'issuer: http://localhost:30658/' \
 		  | match 'localhost_issuer: true' \
 		  | match 'client_id: localhost' \
-		  | match 'redirect_uri: http://localhost:650' \
+		  | match 'redirect_uri: http://localhost:1650' \
 		`).Run())
 }
 

--- a/src/server/auth/server/http_client.go
+++ b/src/server/auth/server/http_client.go
@@ -7,7 +7,7 @@ import (
 )
 
 // localhostIdentityServer is the URL we can reach the embedded identity server at
-const localhostIdentityServer = "http://localhost:658/"
+const localhostIdentityServer = "http://localhost:1658/"
 
 // RewriteRoundTripper replaces the expected hostname with a new hostname.
 // If a scheme is specified it's also replaced.

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -567,7 +567,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 		})
 	rootClient.Enterprise.Activate(rootClient.Ctx(),
 		&enterprise.ActivateRequest{
-			LicenseServer: "localhost:650",
+			LicenseServer: "localhost:1650",
 			Id:            "localhost",
 			Secret:        "localhost",
 		})

--- a/src/server/auth/server/testing/config_test.go
+++ b/src/server/auth/server/testing/config_test.go
@@ -32,7 +32,7 @@ func TestSetGetConfigBasic(t *testing.T) {
 		Issuer:          "http://localhost:30658/",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
-		RedirectURI:     "http://pachd:657/authorization-code/test",
+		RedirectURI:     "http://pachd:1657/authorization-code/test",
 		LocalhostIssuer: true,
 	}
 	_, err := adminClient.SetConfiguration(adminClient.Ctx(),
@@ -58,20 +58,20 @@ func TestIssuerNotLocalhost(t *testing.T) {
 
 	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
 
-	// set the issuer to locahost:658 so we don't need to set LocalhostIssuer = true
+	// set the issuer to locahost:1658 so we don't need to set LocalhostIssuer = true
 	_, err := adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
 		Config: &identity.IdentityServerConfig{
-			Issuer: "http://localhost:658/",
+			Issuer: "http://localhost:1658/",
 		},
 	})
 	require.NoError(t, err)
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
-		Issuer:          "http://localhost:658/",
+		Issuer:          "http://localhost:1658/",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
-		RedirectURI:     "http://pachd:657/authorization-code/test",
+		RedirectURI:     "http://pachd:1657/authorization-code/test",
 		LocalhostIssuer: false,
 	}
 	_, err = adminClient.SetConfiguration(adminClient.Ctx(),
@@ -110,7 +110,7 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 		Issuer:          "http://localhost:30658/",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
-		RedirectURI:     "http://pachd:657/authorization-code/test",
+		RedirectURI:     "http://pachd:1657/authorization-code/test",
 		LocalhostIssuer: true,
 	}
 	_, err = aliceClient.SetConfiguration(aliceClient.Ctx(),
@@ -169,7 +169,7 @@ func TestConfigRestartAuth(t *testing.T) {
 		Issuer:          "http://localhost:30658/",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
-		RedirectURI:     "http://pachd:657/authorization-code/test",
+		RedirectURI:     "http://pachd:1657/authorization-code/test",
 		LocalhostIssuer: true,
 	}
 	_, err := adminClient.SetConfiguration(adminClient.Ctx(),
@@ -255,7 +255,7 @@ func TestSetGetNilConfig(t *testing.T) {
 		Issuer:          "http://localhost:30658/",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
-		RedirectURI:     "http://pachd:657/authorization-code/test",
+		RedirectURI:     "http://pachd:1657/authorization-code/test",
 		LocalhostIssuer: true,
 	}
 	_, err := adminClient.SetConfiguration(adminClient.Ctx(),

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -544,7 +544,9 @@ This resets the cluster to its initial state.`,
 	var uiPort uint16
 	var uiWebsocketPort uint16
 	var pfsPort uint16
+	var remotePfsPort uint16
 	var s3gatewayPort uint16
+	var remoteS3gatewayPort uint16
 	var dexPort uint16
 	var remoteDexPort uint16
 	var idePort, remoteIDEPort uint16
@@ -620,7 +622,7 @@ This resets the cluster to its initial state.`,
 			}
 
 			fmt.Println("Forwarding the PFS port...")
-			port, err = fw.RunForPFS(pfsPort)
+			port, err = fw.RunForPFS(pfsPort, remotePfsPort)
 			if err != nil {
 				fmt.Printf("port forwarding failed: %v\n", err)
 			} else {
@@ -630,7 +632,7 @@ This resets the cluster to its initial state.`,
 			}
 
 			fmt.Println("Forwarding the s3gateway port...")
-			port, err = fw.RunForS3Gateway(s3gatewayPort)
+			port, err = fw.RunForS3Gateway(s3gatewayPort, remoteS3gatewayPort)
 			if err != nil {
 				fmt.Printf("port forwarding failed: %v\n", err)
 			} else {
@@ -693,15 +695,17 @@ This resets the cluster to its initial state.`,
 		}),
 	}
 	portForward.Flags().Uint16VarP(&port, "port", "p", 30650, "The local port to bind pachd to.")
-	portForward.Flags().Uint16Var(&remotePort, "remote-port", 650, "The remote port that pachd is bound to in the cluster.")
+	portForward.Flags().Uint16Var(&remotePort, "remote-port", 1650, "The remote port that pachd is bound to in the cluster.")
 	portForward.Flags().Uint16Var(&oidcPort, "oidc-port", 30657, "The local port to bind pachd's OIDC callback to.")
-	portForward.Flags().Uint16Var(&remoteOidcPort, "remote-oidc-port", 657, "The remote port that OIDC callback is bound to in the cluster.")
+	portForward.Flags().Uint16Var(&remoteOidcPort, "remote-oidc-port", 1657, "The remote port that OIDC callback is bound to in the cluster.")
 	portForward.Flags().Uint16VarP(&uiPort, "ui-port", "u", 30080, "The local port to bind Pachyderm's dash service to.")
 	portForward.Flags().Uint16VarP(&uiWebsocketPort, "proxy-port", "x", 30081, "The local port to bind Pachyderm's dash proxy service to.")
 	portForward.Flags().Uint16VarP(&pfsPort, "pfs-port", "f", 30652, "The local port to bind PFS over HTTP to.")
+	portForward.Flags().Uint16Var(&remotePfsPort, "remote-pfs-port", 30652, "The remote port PFS over HTTP is bound to.")
 	portForward.Flags().Uint16VarP(&s3gatewayPort, "s3gateway-port", "s", 30600, "The local port to bind the s3gateway to.")
+	portForward.Flags().Uint16Var(&remoteS3gatewayPort, "remote-s3gateway-port", 1600, "The remote port that the s3 gateway is bound to.")
 	portForward.Flags().Uint16Var(&dexPort, "dex-port", 30658, "The local port to bind the identity service to.")
-	portForward.Flags().Uint16Var(&remoteDexPort, "remote-dex-port", 658, "The local port to bind the identity service to.")
+	portForward.Flags().Uint16Var(&remoteDexPort, "remote-dex-port", 1658, "The local port to bind the identity service to.")
 	portForward.Flags().Uint16Var(&idePort, "ide-port", 30659, "The local port to bind the IDE service to.")
 	portForward.Flags().Uint16Var(&remoteIDEPort, "remote-ide-port", 8000, "The local port to bind the IDE service to.")
 	portForward.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace Pachyderm is deployed in.")

--- a/src/server/enterprise/cmds/cmds_test.go
+++ b/src/server/enterprise/cmds/cmds_test.go
@@ -30,7 +30,7 @@ func TestManuallyJoinLicenseServer(t *testing.T) {
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate --no-register
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://localhost:653 --pachd-address grpc://localhost:653
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://localhost:1653 --pachd-address grpc://localhost:1653
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
 		  | match 'id: {{.id}}' \

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -61,7 +61,7 @@ func TestGetState(t *testing.T) {
 		&enterprise.ActivateRequest{
 			Id:            "localhost",
 			Secret:        "localhost",
-			LicenseServer: "grpc://localhost:650",
+			LicenseServer: "grpc://localhost:1650",
 		})
 	require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestGetActivationCode(t *testing.T) {
 		&enterprise.ActivateRequest{
 			Id:            "localhost",
 			Secret:        "localhost",
-			LicenseServer: "grpc://localhost:650",
+			LicenseServer: "grpc://localhost:1650",
 		})
 	require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestHeartbeatDeleted(t *testing.T) {
 		&lc.AddClusterRequest{
 			Id:      "localhost",
 			Secret:  "localhost",
-			Address: "grpc://localhost:650",
+			Address: "grpc://localhost:1650",
 		})
 	require.NoError(t, err)
 

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -38,7 +38,7 @@ func TestRegisterPachd(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
 		  | match 'id: {{.id}}' \
@@ -57,8 +57,8 @@ func TestRegisterAuthenticated(t *testing.T) {
 	cluster := tu.UniqueString("cluster")
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
@@ -80,8 +80,8 @@ func TestEnterpriseRoleBindings(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth set enterprise clusterAdmin robot:test1
 		pachctl auth get enterprise | match robot:test1
@@ -101,8 +101,8 @@ func TestGetAndUseRobotToken(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth get-robot-token --enterprise -q {{.alice}} | tail -1 | pachctl auth use-auth-token --enterprise
 		pachctl auth get-robot-token -q {{.bob}} | pachctl auth use-auth-token
@@ -125,8 +125,8 @@ func TestConfig(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:650 --pachd-address pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:1650 --pachd-address pachd.default:1650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 			`,
 		"id", tu.UniqueString("cluster"),
@@ -138,20 +138,20 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		pachctl auth set-config --enterprise <<EOF
 {
-	"issuer": "http://pach-enterprise.enterprise:658",
+	"issuer": "http://pach-enterprise.enterprise:1658",
         "localhost_issuer": true,
 	"client_id": localhost,
-	"redirect_uri": "http://pach-enterprise.enterprise:650"
+	"redirect_uri": "http://pach-enterprise.enterprise:1650"
 }
 EOF
 	`).Run())
 
 	require.NoError(t, tu.BashCmd(`
 		pachctl auth get-config --enterprise \
-		  | match '"issuer": "http://pach-enterprise.enterprise:658"' \
+		  | match '"issuer": "http://pach-enterprise.enterprise:1658"' \
 		  | match '"localhost_issuer": true' \
 		  | match '"client_id": "localhost"' \
-		  | match '"redirect_uri": "http://pach-enterprise.enterprise:650"'
+		  | match '"redirect_uri": "http://pach-enterprise.enterprise:1650"'
 		`,
 	).Run())
 }
@@ -166,8 +166,8 @@ func TestLoginEnterprise(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
@@ -211,8 +211,8 @@ func TestLoginPachd(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
@@ -254,8 +254,8 @@ func TestSyncContexts(t *testing.T) {
 	// register a new cluster
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650 --pachd-user-address grpc://pachd.default:655 --cluster-deployment-id {{.clusterId}} 
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650 --pachd-user-address grpc://pachd.default:1655 --cluster-deployment-id {{.clusterId}} 
 		`,
 		"id", id,
 		"token", tu.RootToken,
@@ -275,7 +275,7 @@ func TestSyncContexts(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		pachctl enterprise sync-contexts
 		pachctl config list context | match {{.id}}
-		pachctl config get context {{.id}} | match "\"pachd_address\": \"grpc://pachd.default:655\"" 
+		pachctl config get context {{.id}} | match "\"pachd_address\": \"grpc://pachd.default:1655\"" 
 		pachctl config get context {{.id}} | match "\"cluster_deployment_id\": \"{{.clusterId}}\""
 		pachctl config get context {{.id}} | match "\"source\": \"IMPORTED\","
 		`,
@@ -341,8 +341,8 @@ func TestRegisterDefaultArgs(t *testing.T) {
 	// register a new cluster
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 
 		pachctl enterprise sync-contexts
 
@@ -375,7 +375,7 @@ func TestRegisterRollback(t *testing.T) {
 	// passing an unreachable enterprise-server-address to the `enterprise register` command
 	// causes it to fail, and rollback cluster record creation
 	require.YesError(t, tu.BashCmd(`
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc:/bad-address:650 --pachd-address grpc://pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc:/bad-address:1650 --pachd-address grpc://pachd.default:1650
 		`,
 		"id", id,
 	).Run())
@@ -389,7 +389,7 @@ func TestRegisterRollback(t *testing.T) {
 	).Run())
 
 	require.NoError(t, tu.BashCmd(`
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:650 --pachd-address grpc://pachd.default:650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
 		`,
 		"id", id,
 	).Run())

--- a/src/server/identity/server/api_server.go
+++ b/src/server/identity/server/api_server.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	dexHTTPPort = ":658"
+	dexHTTPPort = ":1658"
 
 	configKey = 1
 )

--- a/src/server/license/cmds/cmds.go
+++ b/src/server/license/cmds/cmds.go
@@ -68,8 +68,8 @@ func ActivateCmd() *cobra.Command {
 			resp, err := c.License.AddCluster(c.Ctx(),
 				&license.AddClusterRequest{
 					Id:                  "localhost",
-					Address:             "grpc://localhost:653",
-					UserAddress:         "grpc://localhost:653",
+					Address:             "grpc://localhost:1653",
+					UserAddress:         "grpc://localhost:1653",
 					ClusterDeploymentId: clusterInfo.DeploymentID,
 					EnterpriseServer:    true,
 				})
@@ -82,7 +82,7 @@ func ActivateCmd() *cobra.Command {
 				&enterprise.ActivateRequest{
 					Id:            "localhost",
 					Secret:        resp.Secret,
-					LicenseServer: "grpc://localhost:653",
+					LicenseServer: "grpc://localhost:1653",
 				})
 			if err != nil {
 				return errors.Wrapf(err, "could not activate the enterprise service")

--- a/src/server/license/cmds/cmds_test.go
+++ b/src/server/license/cmds/cmds_test.go
@@ -30,19 +30,19 @@ func TestClusterCRUD(t *testing.T) {
 	tu.ActivateEnterprise(t, tu.GetPachClient(t))
 	defer tu.DeleteAll(t)
 	require.NoError(t, tu.BashCmd(`
-		pachctl license add-cluster --id {{.id}} --address grpc://localhost:653
+		pachctl license add-cluster --id {{.id}} --address grpc://localhost:1653
 		pachctl license list-clusters \
                   | match 'id: {{.id}}' \
-                  | match 'address: grpc://localhost:653' \
+                  | match 'address: grpc://localhost:1653' \
                   | match 'id: localhost' \
-                  | match 'address: grpc://localhost:650'
-		pachctl license update-cluster --id {{.id}} --address grpc://127.0.0.1:650
+                  | match 'address: grpc://localhost:1650'
+		pachctl license update-cluster --id {{.id}} --address grpc://127.0.0.1:1650
 		pachctl license list-clusters \
-                  | match 'address: grpc://127.0.0.1:650' \
-                  | match 'address: grpc://localhost:650'
+                  | match 'address: grpc://127.0.0.1:1650' \
+                  | match 'address: grpc://localhost:1650'
 		pachctl license delete-cluster --id {{.id}}
 		pachctl license list-clusters \
-		  | match -v 'address: grpc://127.0.0.1:650' \
+		  | match -v 'address: grpc://127.0.0.1:1650' \
 		  | match -v 'id: {{.id}}'
 		`,
 		"id", tu.UniqueString("cluster"),

--- a/src/server/license/server/license_test.go
+++ b/src/server/license/server/license_test.go
@@ -158,7 +158,7 @@ func TestClusterCRUD(t *testing.T) {
 	// Add a new cluster
 	newCluster, err := client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
 		Id:                  "new",
-		Address:             "grpc://localhost:650",
+		Address:             "grpc://localhost:1650",
 		UserAddress:         "grpc://localhost:999",
 		ClusterDeploymentId: "some-deployment-id",
 		EnterpriseServer:    false,
@@ -170,11 +170,11 @@ func TestClusterCRUD(t *testing.T) {
 	expectedStatuses := map[string]*license.ClusterStatus{
 		"localhost": {
 			Id:      "localhost",
-			Address: "grpc://localhost:650",
+			Address: "grpc://localhost:1650",
 		},
 		"new": {
 			Id:      "new",
-			Address: "grpc://localhost:650",
+			Address: "grpc://localhost:1650",
 		},
 	}
 
@@ -216,13 +216,13 @@ func TestClusterCRUD(t *testing.T) {
 	// Update the cluster
 	_, err = client.License.UpdateCluster(client.Ctx(), &license.UpdateClusterRequest{
 		Id:                  "new",
-		Address:             "localhost:653",
+		Address:             "localhost:1653",
 		UserAddress:         "localhost:1000",
 		ClusterDeploymentId: "another-deployment-id",
 	})
 	require.NoError(t, err)
 
-	expectedStatuses["new"].Address = "localhost:653"
+	expectedStatuses["new"].Address = "localhost:1653"
 
 	expectedUserClusters["new"].Address = "localhost:1000"
 	expectedUserClusters["new"].ClusterDeploymentId = "another-deployment-id"
@@ -312,7 +312,7 @@ func TestAddClusterNoLicense(t *testing.T) {
 	client := tu.GetPachClient(t)
 	_, err := client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
 		Id:      "new",
-		Address: "grpc://localhost:650",
+		Address: "grpc://localhost:1650",
 	})
 	require.YesError(t, err)
 	require.Matches(t, "enterprise license is not valid", err.Error())
@@ -428,7 +428,7 @@ func TestListUserClusters(t *testing.T) {
 
 	_, err = client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
 		Id:                  "new",
-		Address:             "grpc://localhost:650",
+		Address:             "grpc://localhost:1650",
 		UserAddress:         "grpc://localhost:999",
 		ClusterDeploymentId: "some-deployment-id",
 		EnterpriseServer:    false,

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -473,7 +473,7 @@ func TestS3SkippedDatums(t *testing.T) {
 					fmt.Sprintf(
 						// access background repo via regular s3g (not S3_ENDPOINT, which
 						// can only access inputs)
-						"aws --endpoint=http://pachd.%s:600 s3 cp s3://master.%s/round /tmp/bg",
+						"aws --endpoint=http://pachd.%s:1600 s3 cp s3://master.%s/round /tmp/bg",
 						Namespace, background,
 					),
 					"aws --endpoint=${S3_ENDPOINT} s3 cp s3://s3g_in/file /tmp/s3in",
@@ -630,7 +630,7 @@ func TestS3SkippedDatums(t *testing.T) {
 					fmt.Sprintf(
 						// access background repo via regular s3g (not S3_ENDPOINT, which
 						// can only access inputs)
-						"aws --endpoint=http://pachd.%s:600 s3 cp s3://master.%s/round /tmp/bg",
+						"aws --endpoint=http://pachd.%s:1600 s3 cp s3://master.%s/round /tmp/bg",
 						Namespace, background,
 					),
 					"cat /pfs/in/* >/tmp/pfsin",

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -639,7 +639,7 @@ func (a *apiServer) createWorkerPachctlSecret(ctx context.Context, ptr *pps.Stor
 		return errors.Wrapf(err, "error getting the active context")
 	}
 	context.SessionToken = ptr.AuthToken
-	context.PachdAddress = "localhost:653"
+	context.PachdAddress = "localhost:1653"
 
 	rawConfig, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Update all the default ports in pachd to be > 1000, so the pod doesn't need to run as root. Originally this was also going to run pachd as a non-root user by default, but accessing the hostpath requires root access, so local deploys don't work :/

There's also a bigger project here to reduce the number of places where we define these ports.