### PR TITLE
Adds bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ _tmp
 /etc/testing/s3gateway/s3-tests
 /etc/testing/s3gateway/*.txt
 /etc/testing/deploy-manifests/test
+bin/**
 
 .bucket
 .cluster_name


### PR DESCRIPTION
`make lint` installs a binary to `bin`, which should be ignored by git if we are using it that way.