### PR TITLE
Add cleaning to source path in pachctl put file

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1435,12 +1435,8 @@ Objects are a low-level resource and should not be accessed directly by most use
 }
 
 func putFileHelper(mf client.ModifyFile, path, source string, recursive, appendFile bool) (retErr error) {
-	// Resolve the path, then trim any prefixed '../' to avoid sending bad paths
-	// to the server, and convert to unix path in case we're on windows.
+	// Resolve the path and convert to unix path in case we're on windows.
 	path = filepath.ToSlash(filepath.Clean(path))
-	for strings.HasPrefix(path, "../") {
-		path = strings.TrimPrefix(path, "../")
-	}
 	var opts []client.PutFileOption
 	if appendFile {
 		opts = append(opts, client.WithAppendPutFile())
@@ -1457,6 +1453,8 @@ func putFileHelper(mf client.ModifyFile, path, source string, recursive, appendF
 		defer stdin.Finish()
 		return mf.PutFile(path, stdin, opts...)
 	}
+	// Resolve the source and convert to unix path in case we're on windows.
+	source = filepath.ToSlash(filepath.Clean(source))
 	if recursive {
 		return filepath.Walk(source, func(filePath string, info os.FileInfo, err error) error {
 			// file doesn't exist


### PR DESCRIPTION
This PR fixes an issue caused by not cleaning the source path when using pachctl put file identified here: https://github.com/pachyderm/pachyderm/issues/6344. Not cleaning the source path results with us not trimming the source prefix when creating the put file requests in a recursive put file. Also, I removed the trimming of a relative prefix for the destination path. I think it is better for us to just return the error that the server will return since relative paths are invalid in 2.0.