### PR TITLE
Run pachd as non-root user by default and make local deploy use PSP

### DIFF
--- a/Dockerfile.pachd
+++ b/Dockerfile.pachd
@@ -16,4 +16,6 @@ COPY dex-assets /dex-assets
 COPY --from=pachyderm_build /tmp/to-copy /
 COPY --from=pachyderm_build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+USER 1000
+
 ENTRYPOINT ["/pachd"]

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -6,11 +6,14 @@ source "$(dirname "$0")/env.sh"
 
 make launch-loki
 
-for i in $(seq 3); do
-    make clean-launch-dev || true # may be nothing to delete
-    make launch-dev && break
-    (( i < 3 )) # false if this is the last loop (causes exit)
-    sleep 10
-done
+# Normally `pachctl deploy local` adds a PodSecurityContext to run as root,
+# because we can't guarantee the hostpath will be writable by our normal UID (1000).
+# We want to run as UID 1000 in CI because that's more reflective of real life,
+# so we explicitly create the host path on the host machine and chmod it so we can write to it. 
+minikube ssh 'mkdir -p /tmp/pachyderm/pachd && chmod -R 777 /tmp/pachyderm'
+
+pachctl deploy local --no-guaranteed -d --dry-run --rootless --host-path /tmp/pachyderm | kubectl apply -f -
+
+kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 
 pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -482,6 +482,7 @@ func standardDeployCmds() []*cobra.Command {
 
 	var dev bool
 	var hostPath string
+	var rootless bool
 	deployLocal := &cobra.Command{
 		Short:  "Deploy a single-node Pachyderm cluster with local metadata storage.",
 		Long:   "Deploy a single-node Pachyderm cluster with local metadata storage.",
@@ -509,6 +510,10 @@ func standardDeployCmds() []*cobra.Command {
 					opts.PostgresOpts.Port = dbutil.DefaultPort
 					opts.EtcdOpts.Port = etcdNodePort
 				}
+			}
+
+			if !rootless {
+				opts.RunAsRoot = true
 			}
 
 			// Put the enterprise server backing data in a different path,
@@ -541,6 +546,7 @@ func standardDeployCmds() []*cobra.Command {
 	appendGlobalFlags(deployLocal)
 	appendContextFlags(deployLocal)
 	deployLocal.Flags().StringVar(&hostPath, "host-path", "/var/pachyderm", "Location on the host machine where PFS metadata will be stored.")
+	deployLocal.Flags().BoolVar(&rootless, "rootless", false, "Run as the default image user (UID 1000) instead of root")
 	deployLocal.Flags().BoolVarP(&dev, "dev", "d", false, "Deploy pachd with local version tags, disable metrics, expose Pachyderm's object/block API, and use an insecure authentication mechanism (do not set on any cluster with sensitive data)")
 	commands = append(commands, cmdutil.CreateAlias(deployLocal, "deploy local"))
 

--- a/src/internal/obj/integrationtests/deployment_test.go
+++ b/src/internal/obj/integrationtests/deployment_test.go
@@ -222,6 +222,7 @@ func withManifest(t *testing.T, backend assets.Backend, secrets map[string][]byt
 		WorkerServiceAccountName:   assets.DefaultWorkerServiceAccountName,
 		NoDash:                     true,
 		LocalRoles:                 true,
+		RunAsRoot:                  true,
 	}
 
 	manifest := makeManifest(t, backend, secrets, opts)


### PR DESCRIPTION
Under normal circumstances pachd doesn't need to run as root. This PR makes the pachd docker image rootless by setting the UID to 1000. 

`pachctl deploy local` is a special case, because we use a host path mounted at `/pach` to store the data. We can't trust that the path will exist (with the right permissions) on the host machine, so we need to run as root in that specific case. However, all our testing is done with local deploys, and we want to run most of our tests as a non-root user.

The solution I'm proposing here is:
- the dockerfile runs as UID 1000 by default
- `pachctl deploy local` uses a pod security context to run as root by default, with a `--rootless` option to not use the PSC.
- in local development we'll use the PSC
- in CI we'll use the `--rootless` flag to make sure the entire test suite works when we don't have root (which should be the typical case in 99% of deployments - nobody should be using a hostpath in production!). This requires a little extra work to set up the directory on the host with the right permissions.

We'll need to add the PSC to the helm chart to maintain parity for local deploys as well.