### PR TITLE
Add the ability to send profiles to Google Cloud Profiler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pachyderm/pachyderm/v2
 go 1.16
 
 require (
+	cloud.google.com/go v0.49.0 // indirect
 	cloud.google.com/go/storage v1.3.0
 	github.com/Azure/azure-sdk-for-go v36.1.0+incompatible
 	github.com/aws/aws-lambda-go v1.13.3
@@ -18,7 +19,7 @@ require (
 	github.com/dexidp/dex v0.0.0-20201118094123-6ca0cbc85759
 	github.com/dexidp/dex/api/v2 v2.0.0
 	github.com/dlclark/regexp2 v1.2.0 // indirect
-	github.com/dlmiddlecote/sqlstats v1.0.2 // indirect
+	github.com/dlmiddlecote/sqlstats v1.0.2
 	github.com/docker/go-units v0.4.0
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pachyderm/pachyderm/v2
 go 1.16
 
 require (
-	cloud.google.com/go v0.49.0 // indirect
+	cloud.google.com/go v0.49.0
 	cloud.google.com/go/storage v1.3.0
 	github.com/Azure/azure-sdk-for-go v36.1.0+incompatible
 	github.com/aws/aws-lambda-go v1.13.3
@@ -13,7 +13,6 @@ require (
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/coreos/etcd v3.3.13+incompatible
-	github.com/coreos/go-etcd v2.0.0+incompatible
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/dexidp/dex v0.0.0-20201118094123-6ca0cbc85759

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,7 @@ github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPg
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/pprof v0.0.0-20190723021845-34ac40c74b70 h1:XTnP8fJpa4Kvpw2qARB4KS9izqxPS0Sd92cDlY3uk+w=
 github.com/google/pprof v0.0.0-20190723021845-34ac40c74b70/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/go.sum
+++ b/go.sum
@@ -214,7 +214,6 @@ github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkE
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/go-etcd v2.0.0+incompatible h1:bXhRBIXoTm9BYHS3gE0TtQuyNZyeEMux2sDi4oo5YOo=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
@@ -482,6 +481,7 @@ github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9/go.mod h1:cIg4er
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/src/internal/profileutil/profileutil.go
+++ b/src/internal/profileutil/profileutil.go
@@ -14,21 +14,26 @@ import (
 // https://cloud.google.com/profiler/docs
 //
 // Service is the name of this binary (pachd, worker, etc.).
-func StartCloudProfiler(service string, config *serviceenv.Configuration) error {
+//
+// If there is a problem starting the cloud profiler, it logs a message but we continue.
+func StartCloudProfiler(service string, config *serviceenv.Configuration) {
 	if config == nil {
 		log.Warn("nil configuration passed to StartCloudProfiler; profiling not enabled")
-		return nil
+		return
 	}
 	p := config.GoogleCloudProfilerProject
 	if p == "" {
-		return nil
+		return
 	}
-	log.Debugf("enabling google cloud profiler; sending profiles to project %q", p)
-	return profiler.Start(profiler.Config{
+	log.Infof("enabling google cloud profiler; sending profiles to project %q", p)
+	err := profiler.Start(profiler.Config{
 		Service:        service,
 		ServiceVersion: version.PrettyPrintVersion(version.Version),
 		MutexProfiling: true,
 		DebugLogging:   false,
 		ProjectID:      p,
 	})
+	if err != nil {
+		log.WithError(err).Error("failed to start cloud profiler; profiling not enabled")
+	}
 }

--- a/src/internal/profileutil/profileutil.go
+++ b/src/internal/profileutil/profileutil.go
@@ -1,0 +1,34 @@
+// Profileutil contains functionality to export performance information to external systems.
+package profileutil
+
+import (
+	"cloud.google.com/go/profiler"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/version"
+	log "github.com/sirupsen/logrus"
+)
+
+// StartCloudProfiler enables Google Cloud Profiler and begins exporting profiles, if
+// GoogleCloudProfilerProject is set in the provided configuration.  Configuration information is
+// read from the instance's GCE metadata server, so this requires running on GCP.  Docs:
+// https://cloud.google.com/profiler/docs
+//
+// Service is the name of this binary (pachd, worker, etc.).
+func StartCloudProfiler(service string, config *serviceenv.Configuration) error {
+	if config == nil {
+		log.Warn("nil configuration passed to StartCloudProfiler; profiling not enabled")
+		return nil
+	}
+	p := config.GoogleCloudProfilerProject
+	if p == "" {
+		return nil
+	}
+	log.Debugf("enabling google cloud profiler; sending profiles to project %q", p)
+	return profiler.Start(profiler.Config{
+		Service:        service,
+		ServiceVersion: version.PrettyPrintVersion(version.Version),
+		MutexProfiling: true,
+		DebugLogging:   false,
+		ProjectID:      p,
+	})
+}

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -60,10 +60,11 @@ type GlobalConfiguration struct {
 	PPSPipelineName string `env:"PPS_PIPELINE_NAME"`
 
 	// If set to the name of a GCP project, enable GCP-specific continuous profiling and send
-	// profiles that project: https://cloud.google.com/profiler/docs.  Requires that pachd have
-	// google application credentials (through environment variables or workload identity), and
-	// that the service account associated with the credentials has 'cloudprofiler.agent' on the
-	// target project.
+	// profiles to that project: https://cloud.google.com/profiler/docs.  Requires that pachd
+	// has google application credentials (through environment variables or workload identity),
+	// and that the service account associated with the credentials has 'cloudprofiler.agent' on
+	// the target project.  If set on a pachd pod, propagates to workers and sidecars (which
+	// also need permission).
 	GoogleCloudProfilerProject string `env:"GOOGLE_CLOUD_PROFILER_PROJECT"`
 }
 

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -58,6 +58,13 @@ type GlobalConfiguration struct {
 	PPSSpecCommitID string `env:"PPS_SPEC_COMMIT"`
 	// The name of the pipeline that this worker belongs to
 	PPSPipelineName string `env:"PPS_PIPELINE_NAME"`
+
+	// If set to the name of a GCP project, enable GCP-specific continuous profiling and send
+	// profiles that project: https://cloud.google.com/profiler/docs.  Requires that pachd have
+	// google application credentials (through environment variables or workload identity), and
+	// that the service account associated with the credentials has 'cloudprofiler.agent' on the
+	// target project.
+	GoogleCloudProfilerProject string `env:"GOOGLE_CLOUD_PROFILER_PROJECT"`
 }
 
 // PachdFullConfiguration contains the full pachd configuration.

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -25,6 +25,7 @@ import (
 	logutil "github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/profileutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tls"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
@@ -118,6 +119,9 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
+	if err := profileutil.StartCloudProfiler("pachyderm-pachd-enterprise", env.Config()); err != nil {
+		return errors.Wrapf(err, "error starting cloud profiler")
+	}
 	debug.SetGCPercent(env.Config().GCPercent)
 	env.InitDexDB()
 
@@ -370,6 +374,9 @@ func doSidecarMode(config interface{}) (retErr error) {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
+	if err := profileutil.StartCloudProfiler("pachyderm-pachd-sidecar", env.Config()); err != nil {
+		return errors.Wrapf(err, "error starting cloud profiler")
+	}
 	debug.SetGCPercent(env.Config().GCPercent)
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
@@ -524,6 +531,9 @@ func doFullMode(config interface{}) (retErr error) {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
+	if err := profileutil.StartCloudProfiler("pachyderm-pachd-full", env.Config()); err != nil {
+		return errors.Wrapf(err, "error starting cloud profiler")
+	}
 	debug.SetGCPercent(env.Config().GCPercent)
 	env.InitDexDB()
 	if env.Config().EtcdPrefix == "" {

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -119,9 +119,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
-	if err := profileutil.StartCloudProfiler("pachyderm-pachd-enterprise", env.Config()); err != nil {
-		return errors.Wrapf(err, "error starting cloud profiler")
-	}
+	profileutil.StartCloudProfiler("pachyderm-pachd-enterprise", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
 	env.InitDexDB()
 
@@ -374,9 +372,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
-	if err := profileutil.StartCloudProfiler("pachyderm-pachd-sidecar", env.Config()); err != nil {
-		return errors.Wrapf(err, "error starting cloud profiler")
-	}
+	profileutil.StartCloudProfiler("pachyderm-pachd-sidecar", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
@@ -531,9 +527,7 @@ func doFullMode(config interface{}) (retErr error) {
 		log.Printf("no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
-	if err := profileutil.StartCloudProfiler("pachyderm-pachd-full", env.Config()); err != nil {
-		return errors.Wrapf(err, "error starting cloud profiler")
-	}
+	profileutil.StartCloudProfiler("pachyderm-pachd-full", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
 	env.InitDexDB()
 	if env.Config().EtcdPrefix == "" {

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -14,6 +14,7 @@ import (
 	logutil "github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/profileutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
@@ -64,6 +65,11 @@ func do(config interface{}) error {
 	// must run InstallJaegerTracer before InitWithKube/pach client initialization
 	tracing.InstallJaegerTracerFromEnv()
 	env := serviceenv.InitServiceEnv(serviceenv.NewConfiguration(config))
+
+	// Enable cloud profilers if the configuration allows.
+	if err := profileutil.StartCloudProfiler("pachyderm-worker", env.Config()); err != nil {
+		return errors.Wrapf(err, "error starting cloud profiler")
+	}
 
 	// Construct a client that connects to the sidecar.
 	pachClient := env.GetPachClient(context.Background())

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -67,9 +67,7 @@ func do(config interface{}) error {
 	env := serviceenv.InitServiceEnv(serviceenv.NewConfiguration(config))
 
 	// Enable cloud profilers if the configuration allows.
-	if err := profileutil.StartCloudProfiler("pachyderm-worker", env.Config()); err != nil {
-		return errors.Wrapf(err, "error starting cloud profiler")
-	}
+	profileutil.StartCloudProfiler("pachyderm-worker", env.Config())
 
 	// Construct a client that connects to the sidecar.
 	pachClient := env.GetPachClient(context.Background())

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -201,6 +201,10 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 		sidecarEnv = append(sidecarEnv, v1.EnvVar{Name: "LOKI_LOGGING", Value: "true"})
 		workerEnv = append(workerEnv, v1.EnvVar{Name: "LOKI_LOGGING", Value: "true"})
 	}
+	if p := a.env.Config().GoogleCloudProfilerProject; p != "" {
+		sidecarEnv = append(sidecarEnv, v1.EnvVar{Name: "GOOGLE_CLOUD_PROFILER_PROJECT", Value: p})
+		workerEnv = append(workerEnv, v1.EnvVar{Name: "GOOGLE_CLOUD_PROFILER_PROJECT", Value: p})
+	}
 
 	// This only happens in local deployment.  We want the workers to be
 	// able to read from/write to the hostpath volume as well.


### PR DESCRIPTION
This would allow GCP customers (like Hub) to continuously monitor the performance of pachyderm and identify hotspots in actual production loads.  We use it for Hub itself and it's found a lot of issues (like a goroutine leak in the sentry client library).

![Capture](https://user-images.githubusercontent.com/2367/124704281-d051ac80-dec1-11eb-829e-066951021fd0.PNG)

Doc note: if a customer were to enable this, they'd need to also enable "cloud profiling" through GCP at: https://console.cloud.google.com/apis/library/cloudprofiler.googleapis.com?project=<their gcp project name>
