### PR TITLE
Change some inspect pipelines to collection checks.

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1446,7 +1446,7 @@ func (a *apiServer) validateV2Features(request *pps.CreatePipelineRequest) (*pps
 func (a *apiServer) validateEnterpriseChecks(ctx context.Context, pipelineInfo *pps.PipelineInfo) error {
 	pachClient := a.env.GetPachClient(ctx)
 	pipelines := a.pipelines.ReadOnly(ctx)
-	if err := pipelines.Get(pipelineInfo.Pipeline.Name, &pps.PipelineInfo{}); err == nil {
+	if err := pipelines.Get(pipelineInfo.Pipeline.Name, &pps.StoredPipelineInfo{}); err == nil {
 		// Pipeline already exists so we allow people to update it even if
 		// they're over the limits.
 		return nil
@@ -1977,7 +1977,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 	update := false
 	if request.Update {
 		// check if the pipeline already exists, meaning this is a real update
-		if err := a.pipelines.ReadWrite(txnCtx.SqlTx).Get(request.Pipeline.Name, &pps.PipelineInfo{}); err == nil {
+		if err := a.pipelines.ReadWrite(txnCtx.SqlTx).Get(request.Pipeline.Name, &pps.StoredPipelineInfo{}); err == nil {
 			update = true
 		} else if !col.IsErrNotFound(err) {
 			return err

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1445,10 +1445,13 @@ func (a *apiServer) validateV2Features(request *pps.CreatePipelineRequest) (*pps
 
 func (a *apiServer) validateEnterpriseChecks(ctx context.Context, pipelineInfo *pps.PipelineInfo) error {
 	pachClient := a.env.GetPachClient(ctx)
-	if _, err := pachClient.InspectPipeline(pipelineInfo.Pipeline.Name); err == nil {
+	pipelines := a.pipelines.ReadOnly(ctx)
+	if err := pipelines.Get(pipelineInfo.Pipeline.Name, &pps.PipelineInfo{}); err == nil {
 		// Pipeline already exists so we allow people to update it even if
 		// they're over the limits.
 		return nil
+	} else if !col.IsErrNotFound(err) {
+		return err
 	}
 	resp, err := pachClient.Enterprise.GetState(pachClient.Ctx(),
 		&enterpriseclient.GetStateRequest{})
@@ -1459,14 +1462,14 @@ func (a *apiServer) validateEnterpriseChecks(ctx context.Context, pipelineInfo *
 		// Enterprise is enabled so anything goes.
 		return nil
 	}
-	pipelines, err := a.pipelines.ReadOnly(ctx).Count()
+	pipelineCount, err := pipelines.Count()
 	if err != nil {
 		return err
 	}
-	if pipelines >= enterpriselimits.Pipelines {
+	if pipelineCount >= enterpriselimits.Pipelines {
 		enterprisemetrics.IncEnterpriseFailures()
 		return errors.Errorf("%s requires an activation key to create more than %d total pipelines (you have %d). %s\n\n%s",
-			enterprisetext.OpenSourceProduct, enterpriselimits.Pipelines, pipelines, enterprisetext.ActivateCTA, enterprisetext.RegisterCTA)
+			enterprisetext.OpenSourceProduct, enterpriselimits.Pipelines, pipelineCount, enterprisetext.ActivateCTA, enterprisetext.RegisterCTA)
 	}
 	if pipelineInfo.ParallelismSpec != nil && pipelineInfo.ParallelismSpec.Constant > enterpriselimits.Parallelism {
 		enterprisemetrics.IncEnterpriseFailures()
@@ -1973,9 +1976,11 @@ func (a *apiServer) CreatePipelineInTransaction(
 	}
 	update := false
 	if request.Update {
-		// inspect the pipeline to see if this is a real update
-		if _, err := a.inspectPipelineInTransaction(txnCtx, request.Pipeline.Name); err == nil {
+		// check if the pipeline already exists, meaning this is a real update
+		if err := a.pipelines.ReadWrite(txnCtx.SqlTx).Get(request.Pipeline.Name, &pps.PipelineInfo{}); err == nil {
 			update = true
+		} else if !col.IsErrNotFound(err) {
+			return err
 		}
 	}
 	var (


### PR DESCRIPTION
Both of these seem like cases where we don't really care about the extra
information and work inspect pipeline does, and which might give
confusing errors with broken cluster states.

One is also a gRPC unnecessarily.