### PR TITLE
License service stores enterprise license in postgres collection

### DIFF
--- a/src/internal/clusterstate/current.go
+++ b/src/internal/clusterstate/current.go
@@ -16,6 +16,7 @@ import (
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
 	"github.com/pachyderm/pachyderm/v2/src/server/identity"
 	"github.com/pachyderm/pachyderm/v2/src/server/license"
+	licenseserver "github.com/pachyderm/pachyderm/v2/src/server/license/server"
 	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs/server"
 )
 
@@ -88,4 +89,9 @@ var DesiredClusterState migrations.State = migrations.InitialState().
 	}).
 	Apply("identity config token lifetime", func(ctx context.Context, env migrations.Env) error {
 		return identity.AddTokenExpiryConfig(ctx, env.Tx)
+	}).
+	Apply("create license collection", func(ctx context.Context, env migrations.Env) error {
+		collections := []col.PostgresCollection{}
+		collections = append(collections, licenseserver.AllCollections()...)
+		return col.SetupPostgresCollections(ctx, env.Tx, collections...)
 	})

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -210,8 +210,7 @@ func RunLocal() (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("License API", func() error {
-			licenseAPIServer, err := licenseserver.New(
-				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+			licenseAPIServer, err := licenseserver.New(env)
 			if err != nil {
 				return err
 			}

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -170,8 +170,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		}
 
 		if err := logGRPCServerSetup("License API", func() error {
-			licenseAPIServer, err := licenseserver.New(
-				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+			licenseAPIServer, err := licenseserver.New(env)
 			if err != nil {
 				return err
 			}
@@ -264,8 +263,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 		}
 
 		if err := logGRPCServerSetup("License API", func() error {
-			licenseAPIServer, err := licenseserver.New(
-				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+			licenseAPIServer, err := licenseserver.New(env)
 			if err != nil {
 				return err
 			}
@@ -643,8 +641,7 @@ func doFullMode(config interface{}) (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("License API", func() error {
-			licenseAPIServer, err := licenseserver.New(
-				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+			licenseAPIServer, err := licenseserver.New(env)
 			if err != nil {
 				return err
 			}
@@ -771,8 +768,7 @@ func doFullMode(config interface{}) (retErr error) {
 			return err
 		}
 		if err := logGRPCServerSetup("License API", func() error {
-			licenseAPIServer, err := licenseserver.New(
-				env, path.Join(env.Config().EtcdPrefix, env.Config().EnterpriseEtcdPrefix))
+			licenseAPIServer, err := licenseserver.New(env)
 			if err != nil {
 				return err
 			}

--- a/src/server/license/server/col.go
+++ b/src/server/license/server/col.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"github.com/jmoiron/sqlx"
+
+	ec "github.com/pachyderm/pachyderm/v2/src/enterprise"
+	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+)
+
+const (
+	licenseCollectionName = "license"
+)
+
+var licenseIndexes = []*col.Index{}
+
+func licenseCollection(db *sqlx.DB, listener *col.PostgresListener) col.PostgresCollection {
+	return col.NewPostgresCollection(
+		licenseCollectionName,
+		db,
+		listener,
+		&ec.LicenseRecord{},
+		licenseIndexes,
+		nil,
+	)
+}
+
+func AllCollections() []col.PostgresCollection {
+	return []col.PostgresCollection{
+		licenseCollection(nil, nil),
+	}
+}


### PR DESCRIPTION
In the move from etcd to postgres it looks like the license server's record of the user's current enterprise license didn't get moved to postgres.