### PR TITLE
Remove docker socket from worker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,6 @@ docker-gpu: docker-build-gpu docker-push-gpu
 
 docker-gpu-dev: docker-build-gpu docker-push-gpu-dev
 
-docker-build-test-entrypoint:
-	docker build $(DOCKER_BUILD_FLAGS) -t pachyderm_entrypoint etc/testing/entrypoint
-
 docker-tag:
 	docker tag pachyderm/pachd pachyderm/pachd:$(VERSION)
 	docker tag pachyderm/worker pachyderm/worker:$(VERSION)
@@ -241,7 +238,7 @@ test-pfs-storage: test-postgres
 	go test -count=1 ./src/internal/storage/... -timeout $(TIMEOUT) $(TESTFLAGS)
 	go test -count=1 ./src/internal/migrations/... $(TESTFLAGS)
 
-test-pps: launch-stats docker-build-spout-test docker-build-test-entrypoint
+test-pps: launch-stats docker-build-spout-test 
 	@# Use the count flag to disable test caching for this test suite.
 	PROM_PORT=$$(kubectl --namespace=monitoring get svc/prometheus -o json | jq -r .spec.ports[0].nodePort) \
 	  go test -v -count=1 ./src/server -parallel 1 -timeout $(TIMEOUT) $(RUN) $(TESTFLAGS)

--- a/etc/testing/entrypoint/Dockerfile
+++ b/etc/testing/entrypoint/Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:20.04
-# Fix timezone issue
-ENV TZ=UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN useradd -ms /bin/bash test
-ENTRYPOINT ["cp", "/pfs/in/file", "/pfs/out/file"]

--- a/go.mod
+++ b/go.mod
@@ -95,10 +95,6 @@ require (
 	sigs.k8s.io/yaml v1.1.0
 )
 
-// Docker library versioning is not straightforward, see https://github.com/moby/moby/issues/39302
-// For the moment, the windows build requires a fix that has not been tagged with an official release
-replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.20191213113251-3452f136aa68
-
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
 
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190718183610-8e956561bbf5

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,13 @@ github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4Kfc
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v1.4.2-0.20191213113251-3452f136aa68 h1:ilBPbVMnqewShBNvTSuiiSu6DoGkIECLKOUb5txDX9A=
-github.com/docker/docker v1.4.2-0.20191213113251-3452f136aa68/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.7.3-0.20190103212154-2b7e084dc98b/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.7.3-0.20190309235953-33c3200e0d16/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.7.3-0.20190817195342-4760db040282/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce h1:KXS1Jg+ddGcWA8e1N7cupxaHHZhit5rB9tfDU+mfjyY=
+github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/src/internal/deploy/assets/assets.go
+++ b/src/internal/deploy/assets/assets.go
@@ -211,8 +211,8 @@ type AssetOpts struct {
 	// Namespace is the kubernetes namespace to deploy to.
 	Namespace string
 
-	// NoExposeDockerSocket if true prevents pipelines from accessing the docker socket.
-	NoExposeDockerSocket bool
+	// ExposeDockerSocket allows worker pipelines to access the docker socket.
+	ExposeDockerSocket bool
 
 	// If set, the files indictated by 'TLS.ServerCert' and 'TLS.ServerKey' are
 	// placed into a Kubernetes secret and used by pachd nodes to authenticate
@@ -593,7 +593,7 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend Backend, hostPath strin
 		{Name: "METRICS", Value: strconv.FormatBool(opts.Metrics)},
 		{Name: "LOG_LEVEL", Value: opts.LogLevel},
 		{Name: "IAM_ROLE", Value: opts.IAMRole},
-		{Name: "NO_EXPOSE_DOCKER_SOCKET", Value: strconv.FormatBool(opts.NoExposeDockerSocket)},
+		{Name: "EXPOSE_DOCKER_SOCKET", Value: strconv.FormatBool(opts.ExposeDockerSocket)},
 		{
 			Name: "PACH_NAMESPACE",
 			ValueFrom: &v1.EnvVarSource{

--- a/src/internal/deploy/assets/assets.go
+++ b/src/internal/deploy/assets/assets.go
@@ -211,9 +211,6 @@ type AssetOpts struct {
 	// Namespace is the kubernetes namespace to deploy to.
 	Namespace string
 
-	// ExposeDockerSocket allows worker pipelines to access the docker socket.
-	ExposeDockerSocket bool
-
 	// If set, the files indictated by 'TLS.ServerCert' and 'TLS.ServerKey' are
 	// placed into a Kubernetes secret and used by pachd nodes to authenticate
 	// during TLS
@@ -593,7 +590,6 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend Backend, hostPath strin
 		{Name: "METRICS", Value: strconv.FormatBool(opts.Metrics)},
 		{Name: "LOG_LEVEL", Value: opts.LogLevel},
 		{Name: "IAM_ROLE", Value: opts.IAMRole},
-		{Name: "EXPOSE_DOCKER_SOCKET", Value: strconv.FormatBool(opts.ExposeDockerSocket)},
 		{
 			Name: "PACH_NAMESPACE",
 			ValueFrom: &v1.EnvVarSource{

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -253,7 +253,7 @@ func standardDeployCmds() []*cobra.Command {
 	var imagePullSecret string
 	var localRoles bool
 	var logLevel string
-	var noExposeDockerSocket bool
+	var exposeDockerSocket bool
 	var noGuaranteed bool
 	var noRBAC bool
 	var pachdCPURequest string
@@ -281,7 +281,7 @@ func standardDeployCmds() []*cobra.Command {
 		cmd.Flags().BoolVar(&noRBAC, "no-rbac", false, "Don't deploy RBAC roles for Pachyderm. (for k8s versions prior to 1.8)")
 		cmd.Flags().BoolVar(&localRoles, "local-roles", false, "Use namespace-local roles instead of cluster roles. Ignored if --no-rbac is set.")
 		cmd.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace to deploy Pachyderm to.")
-		cmd.Flags().BoolVar(&noExposeDockerSocket, "no-expose-docker-socket", false, "Don't expose the Docker socket to worker containers. This limits the privileges of workers which prevents them from automatically setting the container's working dir and user.")
+		cmd.Flags().BoolVar(&exposeDockerSocket, "expose-docker-socket", false, "Expose the Docker socket to worker containers. This requires root privileges for workers, but allows them to automatically set the working dir and user.")
 		cmd.Flags().StringVar(&tlsCertKey, "tls", "", "string of the form \"<cert path>,<key path>\" of the signed TLS certificate and private key that Pachd should use for TLS authentication (enables TLS-encrypted communication with Pachd)")
 		cmd.Flags().IntVar(&uploadConcurrencyLimit, "upload-concurrency-limit", assets.DefaultUploadConcurrencyLimit, "The maximum number of concurrent object storage uploads per Pachd instance.")
 		cmd.Flags().IntVar(&putFileConcurrencyLimit, "put-file-concurrency-limit", assets.DefaultPutFileConcurrencyLimit, "The maximum number of files to upload or fetch from remote sources (HTTP, blob storage) using PutFile concurrently.")
@@ -395,7 +395,7 @@ func standardDeployCmds() []*cobra.Command {
 			NoRBAC:                     noRBAC,
 			LocalRoles:                 localRoles,
 			Namespace:                  namespace,
-			NoExposeDockerSocket:       noExposeDockerSocket,
+			ExposeDockerSocket:         exposeDockerSocket,
 			ClusterDeploymentID:        clusterDeploymentID,
 			RequireCriticalServersOnly: requireCriticalServersOnly,
 			WorkerServiceAccountName:   workerServiceAccountName,

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -253,7 +253,6 @@ func standardDeployCmds() []*cobra.Command {
 	var imagePullSecret string
 	var localRoles bool
 	var logLevel string
-	var exposeDockerSocket bool
 	var noGuaranteed bool
 	var noRBAC bool
 	var pachdCPURequest string
@@ -281,7 +280,6 @@ func standardDeployCmds() []*cobra.Command {
 		cmd.Flags().BoolVar(&noRBAC, "no-rbac", false, "Don't deploy RBAC roles for Pachyderm. (for k8s versions prior to 1.8)")
 		cmd.Flags().BoolVar(&localRoles, "local-roles", false, "Use namespace-local roles instead of cluster roles. Ignored if --no-rbac is set.")
 		cmd.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace to deploy Pachyderm to.")
-		cmd.Flags().BoolVar(&exposeDockerSocket, "expose-docker-socket", false, "Expose the Docker socket to worker containers. This requires root privileges for workers, but allows them to automatically set the working dir and user.")
 		cmd.Flags().StringVar(&tlsCertKey, "tls", "", "string of the form \"<cert path>,<key path>\" of the signed TLS certificate and private key that Pachd should use for TLS authentication (enables TLS-encrypted communication with Pachd)")
 		cmd.Flags().IntVar(&uploadConcurrencyLimit, "upload-concurrency-limit", assets.DefaultUploadConcurrencyLimit, "The maximum number of concurrent object storage uploads per Pachd instance.")
 		cmd.Flags().IntVar(&putFileConcurrencyLimit, "put-file-concurrency-limit", assets.DefaultPutFileConcurrencyLimit, "The maximum number of files to upload or fetch from remote sources (HTTP, blob storage) using PutFile concurrently.")
@@ -395,7 +393,6 @@ func standardDeployCmds() []*cobra.Command {
 			NoRBAC:                     noRBAC,
 			LocalRoles:                 localRoles,
 			Namespace:                  namespace,
-			ExposeDockerSocket:         exposeDockerSocket,
 			ClusterDeploymentID:        clusterDeploymentID,
 			RequireCriticalServersOnly: requireCriticalServersOnly,
 			WorkerServiceAccountName:   workerServiceAccountName,

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -71,7 +71,6 @@ type PachdSpecificConfiguration struct {
 	WorkerImagePullPolicy      string `env:"WORKER_IMAGE_PULL_POLICY,default="`
 	IAMRole                    string `env:"IAM_ROLE,default="`
 	ImagePullSecret            string `env:"IMAGE_PULL_SECRET,default="`
-	ExposeDockerSocket         bool   `env:"EXPOSE_DOCKER_SOCKET,default=false"`
 	MemoryRequest              string `env:"PACHD_MEMORY_REQUEST,default=1T"`
 	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=true"`
 	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY,default=false"`

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -71,7 +71,7 @@ type PachdSpecificConfiguration struct {
 	WorkerImagePullPolicy      string `env:"WORKER_IMAGE_PULL_POLICY,default="`
 	IAMRole                    string `env:"IAM_ROLE,default="`
 	ImagePullSecret            string `env:"IMAGE_PULL_SECRET,default="`
-	NoExposeDockerSocket       bool   `env:"NO_EXPOSE_DOCKER_SOCKET,default=false"`
+	ExposeDockerSocket         bool   `env:"EXPOSE_DOCKER_SOCKET,default=false"`
 	MemoryRequest              string `env:"PACHD_MEMORY_REQUEST,default=1T"`
 	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=true"`
 	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY,default=false"`

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9836,9 +9836,16 @@ func TestListDeletedDatums(t *testing.T) {
 }
 
 // TestNonrootPipeline tests that a pipeline can work when it's running as a UID that's not 0 (root).
+// This test doesn't work in a typical local deployment because the storage sidecar needs to
+// run as root to access the host path where the chunks are stored (at /pach).
 func TestNonrootPipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
+	}
+
+	// Only run this test in CI since we can control the permissions on the hostpath
+	if os.Getenv("CIRCLE_REPOSITORY_URL") == "" {
+		t.Skip("Skipping non-root test because hostpath permissions can't be verified")
 	}
 
 	c := tu.GetPachClient(t)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6959,7 +6959,7 @@ func TestListDatumDuringJob(t *testing.T) {
 	require.Equal(t, 0, len(dis))
 
 	// test job progress by waiting until some datums are returned, and verify that it's not all of them
-	require.NoErrorWithinT(t, 30*time.Second, func() error {
+	require.NoErrorWithinT(t, 60*time.Second, func() error {
 		return backoff.Retry(func() error {
 			dis, err = c.ListDatumAll(jobInfo.Job.Pipeline.Name, jobInfo.Job.ID)
 			if err != nil {
@@ -9774,7 +9774,6 @@ func TestNonrootPipeline(t *testing.T) {
 		&pps.CreatePipelineRequest{
 			Pipeline: client.NewPipeline(pipeline),
 			Transform: &pps.Transform{
-				Image: "ubuntu:20.04",
 				Cmd:   []string{"bash"},
 				Stdin: []string{fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo)},
 			},
@@ -9795,11 +9794,9 @@ func TestNonrootPipeline(t *testing.T) {
 	require.NoError(t, err)
 	// The commitset should have a commit in: data, spec, pipeline, meta
 	require.Equal(t, 4, len(commitInfos))
-	// First two are not deterministically ordered
+	// Just verify the user commit was produced
 	require.Equal(t, pipeline, commitInfos[2].Commit.Branch.Repo.Name)
 	require.Equal(t, pfs.UserRepoType, commitInfos[2].Commit.Branch.Repo.Type)
-	require.Equal(t, pipeline, commitInfos[3].Commit.Branch.Repo.Name)
-	require.Equal(t, pfs.MetaRepoType, commitInfos[3].Commit.Branch.Repo.Type)
 
 	var buf bytes.Buffer
 	require.NoError(t, c.GetFile(commitInfos[2].Commit, "file", &buf))

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9878,6 +9878,7 @@ func TestNonrootPipeline(t *testing.T) {
 			PodPatch:     `[{"op": "add",  "path": "/securityContext/runAsUser",  "value": 1000}]`,
 		},
 	)
+	require.NoError(t, err)
 
 	commitInfo, err := c.InspectCommit(pipeline, "master", "")
 	require.NoError(t, err)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -101,7 +101,7 @@ type apiServer struct {
 	storageHostPath       string
 	iamRole               string
 	imagePullSecret       string
-	noExposeDockerSocket  bool
+	exposeDockerSocket    bool
 	reporter              *metrics.Reporter
 	workerUsesRoot        bool
 	workerGrpcPort        uint16

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -101,7 +101,6 @@ type apiServer struct {
 	storageHostPath       string
 	iamRole               string
 	imagePullSecret       string
-	exposeDockerSocket    bool
 	reporter              *metrics.Reporter
 	workerUsesRoot        bool
 	workerGrpcPort        uint16

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -32,7 +32,6 @@ func NewAPIServer(
 		storageHostPath:       env.Config().StorageHostPath,
 		iamRole:               env.Config().IAMRole,
 		imagePullSecret:       env.Config().ImagePullSecret,
-		exposeDockerSocket:    env.Config().ExposeDockerSocket,
 		reporter:              reporter,
 		workerUsesRoot:        env.Config().WorkerUsesRoot,
 		pipelines:             ppsdb.Pipelines(env.GetDBClient(), env.GetPostgresListener()),

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -32,7 +32,7 @@ func NewAPIServer(
 		storageHostPath:       env.Config().StorageHostPath,
 		iamRole:               env.Config().IAMRole,
 		imagePullSecret:       env.Config().ImagePullSecret,
-		noExposeDockerSocket:  env.Config().NoExposeDockerSocket,
+		exposeDockerSocket:    env.Config().ExposeDockerSocket,
 		reporter:              reporter,
 		workerUsesRoot:        env.Config().WorkerUsesRoot,
 		pipelines:             ppsdb.Pipelines(env.GetDBClient(), env.GetPostgresListener()),

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -279,20 +279,7 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 			ContainerPort: options.s3GatewayPort,
 		})
 	}
-	if a.exposeDockerSocket {
-		options.volumes = append(options.volumes, v1.Volume{
-			Name: "docker",
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
-					Path: "/var/run/docker.sock",
-				},
-			},
-		})
-		userVolumeMounts = append(userVolumeMounts, v1.VolumeMount{
-			Name:      "docker",
-			MountPath: "/var/run/docker.sock",
-		})
-	}
+
 	zeroVal := int64(0)
 	workerImage := a.workerImage
 	var securityContext *v1.PodSecurityContext

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -279,7 +279,7 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 			ContainerPort: options.s3GatewayPort,
 		})
 	}
-	if !a.noExposeDockerSocket {
+	if a.exposeDockerSocket {
 		options.volumes = append(options.volumes, v1.Volume{
 			Name: "docker",
 			VolumeSource: v1.VolumeSource{

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -61,6 +61,12 @@ func NewWorker(
 		return nil, err
 	}
 
+	if pipelineInfo.Transform.Image != "" && pipelineInfo.Transform.Cmd == nil {
+		ppsutil.FailPipeline(env.Context(), env.GetDBClient(), driver.Pipelines(),
+			pipelineInfo.Pipeline.Name,
+			"nothing to run: no transform.cmd")
+	}
+
 	worker := &Worker{
 		driver: driver,
 		status: &transform.Status{},


### PR DESCRIPTION
Switch `NoExposeDockerSocket` to `ExposeDockerSocket` everywhere, and make it false by default.

This also adds an integration test that checks whether we can run an un-privileged pipeline. It only runs in CI, until we get rid of the hostpath for local deploys in favour of minio. 