### PR TITLE
Give meta repos the same provenance as output repos.

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2209,7 +2209,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 		}
 		if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
 			Branch:     statsBranch,
-			Provenance: []*pfs.Branch{outputBranch},
+			Provenance: provenance, // same provenance as output branch
 		}); err != nil {
 			return errors.Wrapf(err, "could not create/update meta branch")
 		}
@@ -2713,6 +2713,13 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 		}); err != nil {
 			return err
 		}
+		// restore same provenance to meta repo
+		if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+			Branch:     client.NewSystemRepo(pipelineInfo.Pipeline.Name, pfs.MetaRepoType).NewBranch(pipelineInfo.OutputBranch),
+			Provenance: provenance,
+		}); err != nil {
+			return err
+		}
 
 		storedPipelineInfo := &pps.StoredPipelineInfo{}
 		return a.pipelines.ReadWrite(txnCtx.SqlTx).Update(pipelineInfo.Pipeline.Name, storedPipelineInfo, func() error {
@@ -2751,9 +2758,15 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 			return err
 		}
 
-		// Remove branch provenance to prevent new output commits from being created
+		// Remove branch provenance to prevent new output and meta commits from being created
 		if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
 			Branch:     client.NewBranch(pipelineInfo.Pipeline.Name, pipelineInfo.OutputBranch),
+			Provenance: nil,
+		}); err != nil {
+			return err
+		}
+		if err := a.env.PfsServer().CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+			Branch:     client.NewSystemRepo(pipelineInfo.Pipeline.Name, pfs.MetaRepoType).NewBranch(pipelineInfo.OutputBranch),
 			Provenance: nil,
 		}); err != nil {
 			return err


### PR DESCRIPTION
This is motivated at least in part by our use of meta repos as a place
to store information during a job.