### PR TITLE
`pachctl put file` strips directory from target path

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -952,7 +952,8 @@ $ {{alias}} repo@branch -i http://host/path`,
 						if source == "-" {
 							return errors.Errorf("must specify filename when reading data from stdin")
 						}
-						if err := putFileHelper(mf, joinPaths("", source), source, recursive, appendFile); err != nil {
+						target := filepath.Base(source)
+						if err := putFileHelper(mf, joinPaths("", target), source, recursive, appendFile); err != nil {
 							return err
 						}
 					} else if len(sources) == 1 {
@@ -964,7 +965,8 @@ $ {{alias}} repo@branch -i http://host/path`,
 					} else {
 						// We have multiple sources and the user has specified a path,
 						// we use that path as a prefix for the filepaths.
-						if err := putFileHelper(mf, joinPaths(file.Path, source), source, recursive, appendFile); err != nil {
+						target := filepath.Base(source)
+						if err := putFileHelper(mf, joinPaths(file.Path, target), source, recursive, appendFile); err != nil {
 							return err
 						}
 					}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -838,6 +838,7 @@ from commits with 'get file'.`,
 	var appendFile bool
 	var compress bool
 	var enableProgress bool
+	var fullPath bool
 	putFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>[:<path/to/file>]",
 		Short: "Put a file into the filesystem.",
@@ -952,7 +953,10 @@ $ {{alias}} repo@branch -i http://host/path`,
 						if source == "-" {
 							return errors.Errorf("must specify filename when reading data from stdin")
 						}
-						target := filepath.Base(source)
+						target := source
+						if !fullPath {
+							target = filepath.Base(source)
+						}
 						if err := putFileHelper(mf, joinPaths("", target), source, recursive, appendFile); err != nil {
 							return err
 						}
@@ -965,7 +969,10 @@ $ {{alias}} repo@branch -i http://host/path`,
 					} else {
 						// We have multiple sources and the user has specified a path,
 						// we use that path as a prefix for the filepaths.
-						target := filepath.Base(source)
+						target := source
+						if !fullPath {
+							target = filepath.Base(source)
+						}
 						if err := putFileHelper(mf, joinPaths(file.Path, target), source, recursive, appendFile); err != nil {
 							return err
 						}
@@ -982,6 +989,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 	putFile.Flags().IntVarP(&parallelism, "parallelism", "p", DefaultParallelism, "The maximum number of files that can be uploaded in parallel.")
 	putFile.Flags().BoolVarP(&appendFile, "append", "a", false, "Append to the existing content of the file, either from previous commits or previous calls to 'put file' within this commit.")
 	putFile.Flags().BoolVar(&enableProgress, "progress", isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()), "Print progress bars.")
+	putFile.Flags().BoolVar(&fullPath, "full-path", false, "If true, use the entire path provided to -f as the target filename in PFS. By default only the base of the path is used.")
 	shell.RegisterCompletionFunc(putFile,
 		func(flag, text string, maxCompletions int64) ([]prompt.Suggest, shell.CacheFunc) {
 			if flag == "-f" || flag == "--file" || flag == "-i" || flag == "input-file" {


### PR DESCRIPTION
One common frustration with `pachctl put file` is that by default the target file name is PFS is the entire relative path.

For example, in 1.x:
```
> pachctl put file training@master -f examples/ml/iris/data/iris.csv
> pachctl list file training@master
NAME                            TAG     TYPE SIZE
/examples/ml/iris/data/iris.csv default file 4.444KiB
```

This makes our examples clumsy because users have to cd to the correct directory to run commands (or provide the target path, which our examples don't do).

This PR proposes to make `pachctl put file` consider only the base of the path provided by the user. Examples:

Putting a single or multiple files uses their names, but not the path:
```
> pachctl put file training@example1 -f examples/ml/iris/data/iris.csv
> pachctl list file training@example1
NAME      TAG     TYPE SIZE
/iris.csv default file 4.444KiB
```

Putting multiple files at a specified path puts them in a subdirectory:
```
> pachctl put file training@example2:/test -f examples/ml/iris/data/test/1.csv -f examples/ml/iris/data/test/2.csv
> pachctl list file training@example2:/test
NAME        TAG     TYPE SIZE
/test/1.csv default file 16B
/test/2.csv default file 96B
```

Recursive copies the containing directory:
```
> pachctl put file training@example3: -r -f examples/ml/iris/data
> pachctl list file training@example3:/data
NAME           TAG     TYPE SIZE
/data/iris.csv default file 4.444KiB
/data/test/            dir  112B
```
