### PR TITLE
Split `pachctl config set-context` into two commands

### DIFF
--- a/src/server/config/cmds.go
+++ b/src/server/config/cmds.go
@@ -209,11 +209,10 @@ func Cmds() []*cobra.Command {
 	commands = append(commands, cmdutil.CreateAlias(getContext, "config get context"))
 
 	var overwrite bool
-	var kubeContextName string
 	setContext := &cobra.Command{
 		Use:   "{{alias}} <context>",
 		Short: "Set a context.",
-		Long:  "Set a context config from a given name and either JSON stdin, or a given kubernetes context.",
+		Long:  "Set a context config from a given name and a JSON configuration file on stdin",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
 			name := args[0]
 
@@ -229,47 +228,28 @@ func Cmds() []*cobra.Command {
 			}
 
 			var context config.Context
-			if kubeContextName != "" {
-				kubeConfig, err := config.RawKubeConfig()
-				if err != nil {
+			fmt.Println("Reading from stdin.")
+
+			var buf bytes.Buffer
+			var decoder *json.Decoder
+
+			contextReader := io.TeeReader(os.Stdin, &buf)
+			decoder = json.NewDecoder(contextReader)
+
+			if err := jsonpb.UnmarshalNext(decoder, &context); err != nil {
+				if errors.Is(err, io.EOF) {
+					return errors.New("unexpected EOF")
+				}
+				return errors.Wrapf(err, "malformed context")
+			}
+
+			pachdAddress, err := grpcutil.ParsePachdAddress(context.PachdAddress)
+			if err != nil {
+				if !errors.Is(err, grpcutil.ErrNoPachdAddress) {
 					return err
 				}
-
-				kubeContext := kubeConfig.Contexts[kubeContextName]
-				if kubeContext == nil {
-					return errors.Errorf("kubernetes context does not exist: %s", kubeContextName)
-				}
-
-				context = config.Context{
-					Source:      config.ContextSource_IMPORTED,
-					ClusterName: kubeContext.Cluster,
-					AuthInfo:    kubeContext.AuthInfo,
-					Namespace:   kubeContext.Namespace,
-				}
 			} else {
-				fmt.Println("Reading from stdin.")
-
-				var buf bytes.Buffer
-				var decoder *json.Decoder
-
-				contextReader := io.TeeReader(os.Stdin, &buf)
-				decoder = json.NewDecoder(contextReader)
-
-				if err := jsonpb.UnmarshalNext(decoder, &context); err != nil {
-					if errors.Is(err, io.EOF) {
-						return errors.New("unexpected EOF")
-					}
-					return errors.Wrapf(err, "malformed context")
-				}
-
-				pachdAddress, err := grpcutil.ParsePachdAddress(context.PachdAddress)
-				if err != nil {
-					if !errors.Is(err, grpcutil.ErrNoPachdAddress) {
-						return err
-					}
-				} else {
-					context.PachdAddress = pachdAddress.Qualified()
-				}
+				context.PachdAddress = pachdAddress.Qualified()
 			}
 
 			cfg.V2.Contexts[name] = &context
@@ -277,15 +257,75 @@ func Cmds() []*cobra.Command {
 		}),
 	}
 	setContext.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite a context if it already exists.")
-	setContext.Flags().StringVarP(&kubeContextName, "kubernetes", "k", "", "Import a given kubernetes context's values into the Pachyderm context.")
 	shell.RegisterCompletionFunc(setContext, contextCompletion)
 	commands = append(commands, cmdutil.CreateAlias(setContext, "config set context"))
+
+	var kubeContextName, namespace string
+	var enterprise bool
+	contextFromKube := &cobra.Command{
+		Use:   "{{alias}} <context>",
+		Short: "Import a kubernetes context as a Pachyderm context, and set the active Pachyderm context.",
+		Long:  "Import a kubernetes context as a Pachyderm context. By default the current kubernetes context is used.",
+		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
+			name := args[0]
+
+			cfg, err := config.Read(false, false)
+			if err != nil {
+				return err
+			}
+
+			if !overwrite {
+				if _, ok := cfg.V2.Contexts[name]; ok {
+					return errors.Errorf("context '%s' already exists, use `--overwrite` if you wish to replace it", args[0])
+				}
+			}
+
+			var context config.Context
+			kubeConfig, err := config.RawKubeConfig()
+			if err != nil {
+				return err
+			}
+
+			if kubeContextName == "" {
+				kubeContextName = kubeConfig.CurrentContext
+			}
+
+			kubeContext := kubeConfig.Contexts[kubeContextName]
+			if kubeContext == nil {
+				return errors.Errorf("kubernetes context does not exist: %s", kubeContextName)
+			}
+
+			if namespace == "" {
+				namespace = kubeContext.Namespace
+			}
+
+			context = config.Context{
+				Source:           config.ContextSource_IMPORTED,
+				ClusterName:      kubeContext.Cluster,
+				AuthInfo:         kubeContext.AuthInfo,
+				Namespace:        namespace,
+				EnterpriseServer: enterprise,
+			}
+
+			if enterprise {
+				cfg.V2.ActiveEnterpriseContext = name
+			} else {
+				cfg.V2.ActiveContext = name
+			}
+			cfg.V2.Contexts[name] = &context
+			return cfg.Write()
+		}),
+	}
+	contextFromKube.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "Overwrite a context if it already exists.")
+	contextFromKube.Flags().BoolVarP(&enterprise, "enterprise", "e", false, "Configure an enterprise server context.")
+	contextFromKube.Flags().StringVarP(&kubeContextName, "kubernetes", "k", "", "Specify the kubernetes context's values to import.")
+	contextFromKube.Flags().StringVarP(&namespace, "namespace", "n", "", "Specify a namespace where Pachyderm is deployed.")
+	commands = append(commands, cmdutil.CreateAlias(contextFromKube, "config import-kube"))
 
 	var pachdAddress string
 	var clusterName string
 	var authInfo string
 	var serverCAs string
-	var namespace string
 	var removeClusterDeploymentID bool
 	var updateContext *cobra.Command // standalone declaration so Run() can refer
 	updateContext = &cobra.Command{

--- a/src/server/config/cmds_test.go
+++ b/src/server/config/cmds_test.go
@@ -194,3 +194,21 @@ func TestConfigListContext(t *testing.T) {
 		pachctl config list context | match "E\*	foo"
 	`))
 }
+
+func TestImportKube(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	require.NoError(t, run(t, `
+		pachctl config import-kube imported
+		pachctl config get active-context | match 'imported'
+		pachctl config get context imported | match '"cluster_name": "minikube"'
+		pachctl config get context imported | match '"namespace": "default"'
+		pachctl config import-kube enterprise-kube --overwrite --namespace enterprise --enterprise
+		pachctl config get active-enterprise-context | match 'enterprise-kube'
+		pachctl config get context enterprise-kube | match '"cluster_name": "minikube"'
+		pachctl config get context enterprise-kube | match '"namespace": "enterprise"'
+
+	`))
+}


### PR DESCRIPTION
`pachctl config set-context` can accept a kube context name, but the usage is kind of obscure. When we eliminate `pachctl deploy local` we'll need a simple one-liner that creates a context based on the current kube context.

This PR introduces `pachctl config import-kube <pach context name>`, which creates a new Pach context from the current kube context. This also adds a `--namespace` flag, to support the case where we deploy into a context that isn't the default in the kube context, and `--enterprise` for deploying an enterprise server.

This should make the minikube helm deploy process as simple as `helm install && pachctl config import-kube`.