### PR TITLE
Use UID 1000 in the worker binary

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -9,3 +9,5 @@ WORKDIR /app
 COPY worker . 
 COPY worker_init init
 COPY pachctl .
+
+USER 1000


### PR DESCRIPTION
I really have not done much investigation into what was preventing this from working before; I just tried adding the relevant line in the dockerfile.

In particular:
- Volume mounts? AFAICT the only way to change the owner/permissions associated with mounts in kubernetes is with security contexts, and I know the init container needs to mount at least `/pach-bin` to work (to copy the worker binary there, so the user container can run it). Doesn't this mean that user 1000 shouldn't be able to copy the worker binary into `/pach-bin` and therefore that nothing works?
- Worker service port? There were issues setting this previously, and I didn't change anything in this PR
- This just changes the UID in the init container, but wouldn't it be necessary to change the default UID of user pipelines? That sounds completely insane though, and I'd expect this to break every pipeline.

I guess CI runs though?