### PR TITLE
Re-enable spout auth test

### DIFF
--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -37,9 +37,6 @@ func TestSpoutPachctl(t *testing.T) {
 		defer tu.DeleteAll(t)
 		c := tu.GetAuthenticatedPachClient(t, auth.RootUser)
 
-		dataRepo := tu.UniqueString("TestSpoutAuth_data")
-		require.NoError(t, c.CreateRepo(dataRepo))
-
 		// create a spout pipeline
 		pipeline := tu.UniqueString("pipelinespoutauth")
 		_, err := c.PpsAPIClient.CreatePipeline(
@@ -98,13 +95,8 @@ func TestSpoutPachctl(t *testing.T) {
 		}))
 	})
 	t.Run("SpoutAuthEnabledAfter", func(t *testing.T) {
-		// TODO(2.0 required): The pipeline is still in the running state after auth is activated
-		t.Skip("pipeline is still running after activating auth")
 		tu.DeleteAll(t)
 		c := tu.GetPachClient(t)
-
-		dataRepo := tu.UniqueString("TestSpoutAuthEnabledAfter_data")
-		require.NoError(t, c.CreateRepo(dataRepo))
 
 		// create a spout pipeline
 		pipeline := tu.UniqueString("pipelinespoutauthenabledafter")
@@ -142,46 +134,15 @@ func TestSpoutPachctl(t *testing.T) {
 			})
 		}))
 
-		// now let's authenticate, and make sure the spout fails due to a lack of authorization
+		// activate auth, which will generate a new PPS token for the pipeline and trigger
+		// the RC to be recreated
 		c = tu.GetAuthenticatedPachClient(t, auth.RootUser)
 		defer tu.DeleteAll(t)
-
-		require.NoErrorWithinTRetry(t, 10*time.Second, func() error {
-			pipelineInfo, err := c.InspectPipeline(pipeline, false)
-			if err != nil {
-				return err
-			}
-			if pipelineInfo.State != pps.PipelineState_PIPELINE_FAILURE {
-				return errors.Errorf("incorrect pipeline state, expected %s, got %s", pps.PipelineState_PIPELINE_FAILURE, pipelineInfo.State)
-			}
-			return nil
-		})
 
 		// make sure we can delete commits
 		commitInfo, err := c.InspectCommit(pipeline, "master", "")
 		require.NoError(t, err)
 		require.NoError(t, c.SquashCommitSet(commitInfo.Commit.ID))
-
-		// now let's update the pipeline and make sure it works again
-		_, err = c.PpsAPIClient.CreatePipeline(
-			c.Ctx(),
-			&pps.CreatePipelineRequest{
-				Pipeline: client.NewPipeline(pipeline),
-				Transform: &pps.Transform{
-					Cmd: []string{"/bin/sh"},
-					Stdin: []string{
-						"while [ : ]",
-						"do",
-						"sleep 2",
-						"date > date",
-						basicPutFile("./date*"),
-						"done"},
-				},
-				Update:    true,
-				Reprocess: true,         // to ensure subscribe commit will only read commits since the update
-				Spout:     &pps.Spout{}, // this needs to be non-nil to make it a spout
-			})
-		require.NoError(t, err)
 
 		// get 6 successive commits
 		countBreakFunc = newCountBreakFunc(6)
@@ -199,13 +160,19 @@ func TestSpoutPachctl(t *testing.T) {
 			})
 		}))
 
-		// finally, let's make sure that the provenance is in a consistent state after running the spout test
+		// make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
 				return errors.New(resp.Error)
 			}
 			return nil
 		}))
+
+		// Make sure the pipeline is still running
+		pipelineInfo, err := c.InspectPipeline(pipeline, false)
+		require.NoError(t, err)
+
+		require.Equal(t, pps.PipelineState_PIPELINE_RUNNING, pipelineInfo.State)
 	})
 
 	testSpout(t, true)
@@ -227,9 +194,6 @@ func testSpout(t *testing.T, usePachctl bool) {
 	}
 
 	t.Run("SpoutBasic", func(t *testing.T) {
-		dataRepo := tu.UniqueString("TestSpoutBasic_data")
-		require.NoError(t, c.CreateRepo(dataRepo))
-
 		// create a spout pipeline
 		pipeline := tu.UniqueString("pipelinespoutbasic")
 		_, err := c.PpsAPIClient.CreatePipeline(
@@ -320,9 +284,6 @@ func testSpout(t *testing.T, usePachctl bool) {
 	})
 
 	t.Run("SpoutOverwrite", func(t *testing.T) {
-		dataRepo := tu.UniqueString("TestSpoutOverwrite_data")
-		require.NoError(t, c.CreateRepo(dataRepo))
-
 		pipeline := tu.UniqueString("pipelinespoutoverwrite")
 		_, err := c.PpsAPIClient.CreatePipeline(
 			c.Ctx(),
@@ -379,9 +340,6 @@ func testSpout(t *testing.T, usePachctl bool) {
 	})
 
 	t.Run("SpoutProvenance", func(t *testing.T) {
-		dataRepo := tu.UniqueString("TestSpoutProvenance_data")
-		require.NoError(t, c.CreateRepo(dataRepo))
-
 		// create a pipeline
 		pipeline := tu.UniqueString("pipelinespoutprovenance")
 		_, err := c.PpsAPIClient.CreatePipeline(


### PR DESCRIPTION
In 1.x we had a test that created a spout without auth, and then activated auth, and the pipeline would get stuck until you updated the spec. This seems like a bug we turned into a test. 

Update the test to activate auth and expect the spout to stay in a running state without raising an error, since activating auth should restart the pipeline.