### PR TITLE
Don't override workdir when none is supplied

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ancestry"

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -332,7 +332,12 @@ func (d *driver) RunUserCode(
 	if d.uid != nil && d.gid != nil {
 		cmd.SysProcAttr = makeCmdCredentials(*d.uid, *d.gid)
 	}
-	cmd.Dir = filepath.Join(d.rootDir, d.pipelineInfo.Details.Transform.WorkingDir)
+
+	// By default PWD will be the working dir for the container, so we don't need to set Dir explicitly.
+	// If the pipeline or worker config explicitly sets the value, then override the container working dir.
+	if d.pipelineInfo.Details.Transform.WorkingDir != "" || d.rootDir != "/" {
+		cmd.Dir = filepath.Join(d.rootDir, d.pipelineInfo.Details.Transform.WorkingDir)
+	}
 	err := cmd.Start()
 	if err != nil {
 		return errors.EnsureStack(err)


### PR DESCRIPTION
Resolves https://github.com/pachyderm/pachyderm/issues/6425

Docker images have a WORKDIR, which is PWD when the container starts.  The Pachyderm pipeline spec also has an optional `working_dir` field which overrides the WORKDIR. Previously if the working_dir was empty, we would use the docker socket to inspect the image and set the working_dir to the image WORKDIR, and then set PWD for the user-specified command to that value.

Since we removed the docker socket, we no longer inspect the image and set `working_dir` when it's empty. This is fine, because PWD is already the WORKDIR for the image. We just need to not override it when `working_dir` is empty.

