### PR TITLE
CI performance improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,15 +43,22 @@ jobs:
       - run: etc/testing/circle/launch-loki.sh
       - restore_cache:
          keys:
-         - pach-go-cache-{{ .Branch }}
-         - pach-go-cache-
+         - pach-go-build-cache-{{ .Branch }}
+         - pach-go-build-cache
+      - restore_cache:
+         keys:
+         - pach-go-mod-cache-{{ .Branch }}
+         - pach-go-mod-cache
       - run: etc/testing/circle/build.sh 
       - run: etc/testing/circle/launch.sh 
       - run: etc/testing/circle/run_tests.sh 
       - save_cache:
-         key: pach-go-cache-{{ .Branch }}
+         key: pach-go-mod-cache-{{ .Branch }}
          paths:
          - /home/circleci/.go_workspace/pkg/mod
+      - save_cache:
+         key: pach-go-build-cache-{{ .Branch }}
+         paths:
          - /home/circleci/.gocache
       - run: etc/testing/circle/upload_stats.sh 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,23 +41,29 @@ jobs:
          - cached-deps/
       - run: etc/testing/circle/start-minikube.sh 
       - run: etc/testing/circle/launch-loki.sh
+
+      # The build cache will grow indefinitely, so we rotate the cache once a week. 
+      # This ensures the time to restore the cache isn't longer than the speedup in compilation.
+      - run: "echo $(($(date +%s)/604800)) > current_week"
       - restore_cache:
          keys:
-         - pach-go-build-cache-{{ .Branch }}
-         - pach-go-build-cache
+         - pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
+         - pach-go-build-cache-v1-master-{{ checksum "current_week" }}
+
+      # Only restore the module cache based on an exact match for go.sum.
+      # This also avoids accumulating old versions of modules over time.
       - restore_cache:
          keys:
-         - pach-go-mod-cache-{{ .Branch }}
-         - pach-go-mod-cache
+         - pach-go-mod-cache-v1-{{ .Branch }}-{{ checksum "go.sum" }}
       - run: etc/testing/circle/build.sh 
       - run: etc/testing/circle/launch.sh 
       - run: etc/testing/circle/run_tests.sh 
       - save_cache:
-         key: pach-go-mod-cache-{{ .Branch }}
+         key: pach-go-mod-cache-v1-{{ .Branch }}-{{ checksum "go.sum" }}
          paths:
          - /home/circleci/.go_workspace/pkg/mod
       - save_cache:
-         key: pach-go-build-cache-{{ .Branch }}
+         key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}-{{ .BuildNum }}
          paths:
          - /home/circleci/.gocache
       - run: etc/testing/circle/upload_stats.sh 
@@ -77,17 +83,17 @@ workflows:
           matrix:
             parameters:
               bucket:
-              #- MISC
+              - MISC
               # If you want to update the number of PPS buckets, you'll neet to
               # update the value of PPS_BUCKETS above
-              #- AUTH
+              - AUTH
               - ENTERPRISE
-              #- PFS
-              #- PPS1
-              #- PPS2
-              #- PPS3
-              #- PPS4
-              # - PPS5
-              #- PPS6
-              #- EXAMPLES
-              #- OBJECT
+              - PFS
+              - PPS1
+              - PPS2
+              - PPS3
+              - PPS4
+              - PPS5
+              - PPS6
+              - EXAMPLES
+              - OBJECT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,17 +69,17 @@ workflows:
           matrix:
             parameters:
               bucket:
-              - MISC
+              #- MISC
               # If you want to update the number of PPS buckets, you'll neet to
               # update the value of PPS_BUCKETS above
-              - AUTH
+              #- AUTH
               - ENTERPRISE
-              - PFS
-              - PPS1
-              - PPS2
-              - PPS3
-              - PPS4
-              - PPS5
-              - PPS6
-              - EXAMPLES
-              - OBJECT
+              #- PFS
+              #- PPS1
+              #- PPS2
+              #- PPS3
+              #- PPS4
+              # - PPS5
+              #- PPS6
+              #- EXAMPLES
+              #- OBJECT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
          paths:
          - cached-deps/
       - run: etc/testing/circle/start-minikube.sh 
+      - run: etc/testing/circle/launch-loki.sh
       - restore_cache:
          keys:
          - pach-go-cache-{{ .Branch }}

--- a/etc/testing/circle/launch-loki.sh
+++ b/etc/testing/circle/launch-loki.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+source "$(dirname "$0")/env.sh"
+
+# Deploy Loki but don't block until it's deployed - we'll check later
+helm repo remove loki || true
+helm repo add loki https://grafana.github.io/loki/charts
+helm repo update
+helm upgrade --install loki loki/loki-stack

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -4,8 +4,6 @@ set -ex
 
 source "$(dirname "$0")/env.sh"
 
-make launch-loki
-
 # Normally `pachctl deploy local` adds a PodSecurityContext to run as root,
 # because we can't guarantee the hostpath will be writable by our normal UID (1000).
 # We want to run as UID 1000 in CI because that's more reflective of real life,
@@ -15,5 +13,8 @@ minikube ssh 'mkdir -p /tmp/pachyderm/pachd && chmod -R 777 /tmp/pachyderm'
 pachctl deploy local --no-guaranteed -d --dry-run --rootless --host-path /tmp/pachyderm | kubectl apply -f -
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
+
+# Wait for loki to be deployed
+kubectl wait --for=condition=ready pod -l release=loki --timeout=5m
 
 pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"


### PR DESCRIPTION
This has two fixes to improve CI performance:

Some latency hiding for the Loki deploy. We used to deploy Loki and then sit idly while k8s pulls the images, etc. This deploys the helm chart and then goes away to do the pachd build, and comes back to check on the progress later.

Recompute the cache more often. Right now the cache key doesn't change between runs, so the cache would get staler and staler for 30 days until it expired. This PR keys the module cache on the go.sum checksum, and accumulates the build cache for a week before rotating it.