### PR TITLE
ListPipeline omits details when a user doesn't have access

### DIFF
--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -269,39 +269,6 @@ func JobInput(pipelineInfo *pps.PipelineInfo, outputCommit *pfs.Commit) *pps.Inp
 	return jobInput
 }
 
-// PipelineReqFromInfo converts a PipelineInfo into a CreatePipelineRequest.
-func PipelineReqFromInfo(pipelineInfo *pps.PipelineInfo) *pps.CreatePipelineRequest {
-	return &pps.CreatePipelineRequest{
-		Pipeline:              pipelineInfo.Pipeline,
-		Transform:             pipelineInfo.Details.Transform,
-		ParallelismSpec:       pipelineInfo.Details.ParallelismSpec,
-		Egress:                pipelineInfo.Details.Egress,
-		OutputBranch:          pipelineInfo.Details.OutputBranch,
-		ResourceRequests:      pipelineInfo.Details.ResourceRequests,
-		ResourceLimits:        pipelineInfo.Details.ResourceLimits,
-		SidecarResourceLimits: pipelineInfo.Details.SidecarResourceLimits,
-		Input:                 pipelineInfo.Details.Input,
-		Description:           pipelineInfo.Details.Description,
-		CacheSize:             pipelineInfo.Details.CacheSize,
-		MaxQueueSize:          pipelineInfo.Details.MaxQueueSize,
-		Service:               pipelineInfo.Details.Service,
-		DatumSetSpec:          pipelineInfo.Details.DatumSetSpec,
-		DatumTimeout:          pipelineInfo.Details.DatumTimeout,
-		JobTimeout:            pipelineInfo.Details.JobTimeout,
-		Salt:                  pipelineInfo.Details.Salt,
-		PodSpec:               pipelineInfo.Details.PodSpec,
-		PodPatch:              pipelineInfo.Details.PodPatch,
-		Spout:                 pipelineInfo.Details.Spout,
-		SchedulingSpec:        pipelineInfo.Details.SchedulingSpec,
-		DatumTries:            pipelineInfo.Details.DatumTries,
-		Standby:               pipelineInfo.Details.Standby,
-		S3Out:                 pipelineInfo.Details.S3Out,
-		Metadata:              pipelineInfo.Details.Metadata,
-		ReprocessSpec:         pipelineInfo.Details.ReprocessSpec,
-		Autoscaling:           pipelineInfo.Details.Autoscaling,
-	}
-}
-
 // IsTerminal returns 'true' if 'state' indicates that the job is done (i.e.
 // the state will not change later: SUCCESS, FAILURE, KILLED) and 'false'
 // otherwise.

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -544,19 +544,34 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", infoAfter.AuthToken)
 
-	// And also check for a listPipeline
+	// Check that an unprivileged user can list pipelines without details
 	pipelineInfos, err := aliceClient.ListPipeline(false)
 	require.NoError(t, err)
+	require.Equal(t, 2, len(pipelineInfos))
 	for _, pipelineInfo := range pipelineInfos {
 		require.Equal(t, "", pipelineInfo.AuthToken)
 	}
-	// TODO(2.0 required): this call errors if it uses aliceClient (maybe skip
-	// pipelines we don't have read access on?)
-	// pipelineInfos, err = aliceClient.ListPipeline(true)
-	pipelineInfos, err = bobClient.ListPipeline(true)
+
+	// Check that an unprivileged user can list pipelines with details,
+	// but the details are skipped
+	pipelineInfos, err = aliceClient.ListPipeline(true)
 	require.NoError(t, err)
+	require.Equal(t, 2, len(pipelineInfos))
 	for _, pipelineInfo := range pipelineInfos {
 		require.Equal(t, "", pipelineInfo.AuthToken)
+		if pipelineInfo.Pipeline.Name == goodPipeline {
+			require.Nil(t, pipelineInfo.Details)
+		} else {
+			require.NotNil(t, pipelineInfo.Details)
+		}
+	}
+
+	pipelineInfos, err = bobClient.ListPipeline(true)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(pipelineInfos))
+	for _, pipelineInfo := range pipelineInfos {
+		require.Equal(t, "", pipelineInfo.AuthToken)
+		require.NotNil(t, pipelineInfo.Details)
 	}
 
 	// Make sure the updated pipeline runs successfully

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -693,16 +693,13 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	inspectPipeline.Flags().AddFlagSet(fullTimestampsFlags)
 	commands = append(commands, cmdutil.CreateAlias(inspectPipeline, "inspect pipeline"))
 
-	var spec bool
 	listPipeline := &cobra.Command{
 		Use:   "{{alias}} [<pipeline>]",
 		Short: "Return info about all pipelines.",
 		Long:  "Return info about all pipelines.",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(args []string) error {
 			// validate flags
-			if raw && spec {
-				return errors.Errorf("cannot set both --raw and --spec")
-			} else if !raw && !spec && output != "" {
+			if !raw && output != "" {
 				cmdutil.ErrorAndExit("cannot set --output (-o) without --raw or --spec")
 			}
 			history, err := cmdutil.ParseHistory(history)
@@ -746,14 +743,6 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 					}
 				}
 				return nil
-			} else if spec {
-				e := encoder(output)
-				for _, pipelineInfo := range pipelineInfos {
-					if err := e.EncodeProto(ppsutil.PipelineReqFromInfo(pipelineInfo)); err != nil {
-						return err
-					}
-				}
-				return nil
 			}
 			for _, pi := range pipelineInfos {
 				if ppsutil.ErrorState(pi.State) {
@@ -768,7 +757,6 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			return writer.Flush()
 		}),
 	}
-	listPipeline.Flags().BoolVarP(&spec, "spec", "s", false, "Output 'create pipeline' compatibility specs.")
 	listPipeline.Flags().AddFlagSet(outputFlags)
 	listPipeline.Flags().AddFlagSet(fullTimestampsFlags)
 	listPipeline.Flags().StringVar(&history, "history", "none", "Return revision history for pipelines.")

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2449,7 +2449,10 @@ func (a *apiServer) listPipeline(ctx context.Context, request *pps.ListPipelineR
 				pachClient := a.env.GetPachClient(ctx)
 				if request.Details {
 					if err := ppsutil.GetPipelineDetails(pachClient, info); err != nil {
-						return err
+						// If the user doesn't have permission to access the spec commit, don't send the details
+						if !auth.IsErrNotAuthorized(err) {
+							return err
+						}
 					}
 				}
 				if err := func() error {


### PR DESCRIPTION
When a user does `ListPipeline` and requests details, we attempt to deserialize the spec commit for every pipeline into the response. A user may not have permissions to view every spec commit - previously this caused ListCommit to fail. Instead, this PR omits the details from a pipeline entry when the user doesn't have access. This shouldn't have much user-facing impact since `pachctl list pipeline` doesn't request the details or display any information from them.

This also removes the `--spec` flag for `pachctl list pipeline`, because (presumably for performance reasons) `pachctl list pipeline` no longer requests the spec commits for every pipeline, which meant the command was useless and stack-traced.