### PR TITLE
Fix the module cache key to ignore the branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,12 @@ jobs:
       # This also avoids accumulating old versions of modules over time.
       - restore_cache:
          keys:
-         - pach-go-mod-cache-v1-{{ .Branch }}-{{ checksum "go.sum" }}
+         - pach-go-mod-cache-v2-{{ checksum "go.sum" }}
       - run: etc/testing/circle/build.sh 
       - run: etc/testing/circle/launch.sh 
       - run: etc/testing/circle/run_tests.sh 
       - save_cache:
-         key: pach-go-mod-cache-v1-{{ .Branch }}-{{ checksum "go.sum" }}
+         key: pach-go-mod-cache-v2-{{ checksum "go.sum" }}
          paths:
          - /home/circleci/.go_workspace/pkg/mod
       - save_cache:


### PR DESCRIPTION
Don't include the branch in the module cache, if the go.sum matches it's fine 🤕 