### PR TITLE
Don't transition a pipeline to failed during auth activation

### DIFF
--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -95,8 +95,6 @@ func TestSpoutPachctl(t *testing.T) {
 		}))
 	})
 	t.Run("SpoutAuthEnabledAfter", func(t *testing.T) {
-		// TODO(2.0 required): this test occasionally hangs (pipeline stuck in FAILURE)
-		t.Skip("skip flaky test")
 		tu.DeleteAll(t)
 		c := tu.GetPachClient(t)
 


### PR DESCRIPTION
During auth activation a pipeline won't have an auth token associated briefly, which can race with the PPS master recreating the RC. When this happens the pipeline would transition into the failure state, but we actually should retry.