### PR TITLE
Switch S3 tests to use MFC instead of RPC per file

### DIFF
--- a/src/server/pfs/s3/master_test.go
+++ b/src/server/pfs/s3/master_test.go
@@ -330,7 +330,7 @@ func masterListObjectsPaginated(t *testing.T, pachClient *client.APIClient, mini
 	commit, err := pachClient.StartCommit(repo, "master")
 	require.NoError(t, err)
 
-	pachClient.WithModifyFileClient(commit, func(mf client.ModifyFile) error {
+	require.NoError(t, pachClient.WithModifyFileClient(commit, func(mf client.ModifyFile) error {
 		for i := 0; i <= 1000; i++ {
 			putListFileTestObject(t, mf, "", i)
 		}
@@ -339,12 +339,12 @@ func masterListObjectsPaginated(t *testing.T, pachClient *client.APIClient, mini
 			putListFileTestObject(t, mf, "dir/", i)
 		}
 		return nil
-	})
+	}))
 
-	pachClient.WithModifyFileClient(client.NewCommit(repo, "branch", ""), func(mf client.ModifyFile) error {
+	require.NoError(t, pachClient.WithModifyFileClient(client.NewCommit(repo, "branch", ""), func(mf client.ModifyFile) error {
 		putListFileTestObject(t, mf, "", 1001)
 		return nil
-	})
+	}))
 
 	require.NoError(t, pachClient.FinishCommit(repo, commit.Branch.Name, commit.ID))
 
@@ -406,17 +406,17 @@ func masterListObjectsRecursive(t *testing.T, pachClient *client.APIClient, mini
 	require.NoError(t, pachClient.CreateBranch(repo, "branch", "", "", nil))
 	require.NoError(t, pachClient.CreateBranch(repo, "emptybranch", "", "", nil))
 
-	pachClient.WithModifyFileClient(client.NewCommit(repo, "master", ""), func(mf client.ModifyFile) error {
+	require.NoError(t, pachClient.WithModifyFileClient(client.NewCommit(repo, "master", ""), func(mf client.ModifyFile) error {
 		putListFileTestObject(t, mf, "", 0)
 		putListFileTestObject(t, mf, "rootdir/", 1)
 		putListFileTestObject(t, mf, "rootdir/subdir/", 2)
 		return nil
-	})
+	}))
 
-	pachClient.WithModifyFileClient(client.NewCommit(repo, "branch", ""), func(mf client.ModifyFile) error {
+	require.NoError(t, pachClient.WithModifyFileClient(client.NewCommit(repo, "branch", ""), func(mf client.ModifyFile) error {
 		putListFileTestObject(t, mf, "", 3)
 		return nil
-	})
+	}))
 	endTime := time.Now().Add(time.Duration(5) * time.Minute)
 
 	// Request that will list all files in master

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -17,7 +17,6 @@ import (
 	minio "github.com/minio/minio-go/v6"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
 func getObject(t *testing.T, minioClient *minio.Client, bucket, file string) (string, error) {
@@ -83,10 +82,9 @@ func checkListObjects(t *testing.T, ch <-chan minio.ObjectInfo, startTime *time.
 	}
 }
 
-func putListFileTestObject(t *testing.T, pachClient *client.APIClient, commit *pfs.Commit, dir string, i int) {
+func putListFileTestObject(t *testing.T, mf client.ModifyFile, dir string, i int) {
 	t.Helper()
-	require.NoError(t, pachClient.PutFile(
-		commit,
+	require.NoError(t, mf.PutFile(
 		fmt.Sprintf("%s%d", dir, i),
 		strings.NewReader(fmt.Sprintf("%d\n", i)),
 	))

--- a/src/server/pfs/s3/worker_test.go
+++ b/src/server/pfs/s3/worker_test.go
@@ -240,19 +240,19 @@ func TestWorkerDriver(t *testing.T) {
 	inputMasterCommit, err := pachClient.StartCommit(inputRepo, "master")
 	require.NoError(t, err)
 
-	pachClient.WithModifyFileClient(inputMasterCommit, func(mf client.ModifyFile) error {
+	require.NoError(t, pachClient.WithModifyFileClient(inputMasterCommit, func(mf client.ModifyFile) error {
 		putListFileTestObject(t, mf, "", 0)
 		putListFileTestObject(t, mf, "rootdir/", 1)
 		putListFileTestObject(t, mf, "rootdir/subdir/", 2)
 		return nil
-	})
+	}))
 	require.NoError(t, pachClient.FinishCommit(inputRepo, inputMasterCommit.Branch.Name, inputMasterCommit.ID))
 
 	// create a develop branch on the input repo
 	inputDevelopCommit, err := pachClient.StartCommit(inputRepo, "develop")
 	require.NoError(t, err)
 
-	pachClient.WithModifyFileClient(inputDevelopCommit, func(mf client.ModifyFile) error {
+	require.NoError(t, pachClient.WithModifyFileClient(inputDevelopCommit, func(mf client.ModifyFile) error {
 		for i := 0; i <= 100; i++ {
 			putListFileTestObject(t, mf, "", i)
 		}
@@ -260,7 +260,7 @@ func TestWorkerDriver(t *testing.T) {
 			putListFileTestObject(t, mf, "dir/", i)
 		}
 		return nil
-	})
+	}))
 	require.NoError(t, pachClient.FinishCommit(inputRepo, inputDevelopCommit.Branch.Name, inputDevelopCommit.ID))
 
 	// create the output branch

--- a/src/server/pfs/s3/worker_test.go
+++ b/src/server/pfs/s3/worker_test.go
@@ -239,20 +239,28 @@ func TestWorkerDriver(t *testing.T) {
 	// create a master branch on the input repo
 	inputMasterCommit, err := pachClient.StartCommit(inputRepo, "master")
 	require.NoError(t, err)
-	putListFileTestObject(t, pachClient, inputMasterCommit, "", 0)
-	putListFileTestObject(t, pachClient, inputMasterCommit, "rootdir/", 1)
-	putListFileTestObject(t, pachClient, inputMasterCommit, "rootdir/subdir/", 2)
+
+	pachClient.WithModifyFileClient(inputMasterCommit, func(mf client.ModifyFile) error {
+		putListFileTestObject(t, mf, "", 0)
+		putListFileTestObject(t, mf, "rootdir/", 1)
+		putListFileTestObject(t, mf, "rootdir/subdir/", 2)
+		return nil
+	})
 	require.NoError(t, pachClient.FinishCommit(inputRepo, inputMasterCommit.Branch.Name, inputMasterCommit.ID))
 
 	// create a develop branch on the input repo
 	inputDevelopCommit, err := pachClient.StartCommit(inputRepo, "develop")
 	require.NoError(t, err)
-	for i := 0; i <= 100; i++ {
-		putListFileTestObject(t, pachClient, inputDevelopCommit, "", i)
-	}
-	for i := 0; i < 10; i++ {
-		putListFileTestObject(t, pachClient, inputDevelopCommit, "dir/", i)
-	}
+
+	pachClient.WithModifyFileClient(inputDevelopCommit, func(mf client.ModifyFile) error {
+		for i := 0; i <= 100; i++ {
+			putListFileTestObject(t, mf, "", i)
+		}
+		for i := 0; i < 10; i++ {
+			putListFileTestObject(t, mf, "dir/", i)
+		}
+		return nil
+	})
 	require.NoError(t, pachClient.FinishCommit(inputRepo, inputDevelopCommit.Branch.Name, inputDevelopCommit.ID))
 
 	// create the output branch


### PR DESCRIPTION
`TestMasterDriver/master/ListObjectsPaginated` was one of our slowest tests, according to Circle, at 2.5 minutes. This PR switches it from doing 1000 serial RPCs to put files, to using a ModifyFileClient and streaming the updates. Testing locally this whole package takes 5 seconds with this change.