### PR TITLE
[WIP] Removed nested watcher in S3 sidecar

### DIFF
--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -119,6 +119,8 @@ func (s *sidecarS3G) serveS3Instances() {
 
 func (s *sidecarS3G) createK8sServices() {
 	logrus.Infof("Launching sidecar s3 gateway master process")
+	// TODO: This is one gateway per pipeline, but can multiple jobs run per pipeline at once?
+	// Is there a risk of a new job seeing old data if the S3 gateway is slow to process events?
 	// createK8sServices goes through master election so that only one k8s service
 	// is created per pachyderm job running sidecar s3 gateway
 	backoff.RetryNotify(func() error {


### PR DESCRIPTION
This seems too simple - as the TODO comment says, the original comment is incorrect:

> 'watcher' will not see any job state updates after the first because job state updates don't update the pipelines index, so this establishes a watcher that will.

The pipelines index does see the writes to the the job state, so this seems to be a straightforward change to watch for the job to start, and then to wait for it to reach a terminal state. One invariant is that there's one job per pipeline, which I'm not 100% confident about?

