### PR TITLE
Fix `pachctl diff file` error: 'pattern contains path separator'

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1565,10 +1565,11 @@ func joinPaths(prefix, filePath string) string {
 }
 
 func dlFile(pachClient *client.APIClient, f *pfs.File) (_ string, retErr error) {
-	if err := os.MkdirAll(filepath.Join(os.TempDir(), filepath.Dir(f.Path)), 0777); err != nil {
+	tempDir := filepath.Join(os.TempDir(), filepath.Dir(f.Path))
+	if err := os.MkdirAll(tempDir, 0777); err != nil {
 		return "", err
 	}
-	file, err := ioutil.TempFile("", f.Path+"_")
+	file, err := ioutil.TempFile(tempDir, filepath.Base(f.Path+"_"))
 	if err != nil {
 		return "", err
 	}

--- a/src/server/pfs/cmds/cmds_test.go
+++ b/src/server/pfs/cmds/cmds_test.go
@@ -104,3 +104,21 @@ func TestMountParsing(t *testing.T) {
 		require.Equal(t, ro, opts[repo])
 	}
 }
+
+func TestDiffFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	require.NoError(t, tu.BashCmd(`
+		pachctl create repo {{.repo}}
+
+		echo "foo" | pachctl put file {{.repo}}@master:/data
+
+		echo "bar" | pachctl put file {{.repo}}@master:/data
+
+		pachctl diff file {{.repo}}@master:/data {{.repo}}@master^:/data \
+			| match -- '-foo'
+		`,
+		"repo", tu.UniqueString("TestDiffFile-repo"),
+	).Run())
+}


### PR DESCRIPTION
Addressing issue: https://github.com/pachyderm/pachyderm/issues/6364

I assume that this error was introduced when we updated to a more recent version of the `filepath` module