### PR TITLE
Fix some problems with multipart uploads.

### DIFF
--- a/etc/kube/start-minikube.sh
+++ b/etc/kube/start-minikube.sh
@@ -3,7 +3,7 @@
 set -Eex
 
 # Parse flags
-VERSION=v1.14.0
+VERSION=v1.13.0
 minikube_args=(
   "--vm-driver=none"
   "--kubernetes-version=${VERSION}"

--- a/etc/kube/start-minikube.sh
+++ b/etc/kube/start-minikube.sh
@@ -3,7 +3,7 @@
 set -Eex
 
 # Parse flags
-VERSION=v1.13.0
+VERSION=v1.14.0
 minikube_args=(
   "--vm-driver=none"
   "--kubernetes-version=${VERSION}"

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -6,7 +6,7 @@ PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
 export PATH
 
 # Parse flags
-VERSION=v1.13.0
+VERSION=v1.14.0
 minikube_args=(
   "--vm-driver=docker"
   "--kubernetes-version=${VERSION}"

--- a/src/server/pfs/s3/multipart.go
+++ b/src/server/pfs/s3/multipart.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/src/client"
@@ -179,9 +180,11 @@ func (c *controller) InitMultipart(r *http.Request, bucketName, key string) (str
 	return uploadID, nil
 }
 
-func (c *controller) AbortMultipart(r *http.Request, bucketName, key, uploadID string) error {
-	c.logger.Debugf("AbortMultipart: bucketName=%+v, key=%+v, uploadID=%+v", bucketName, key, uploadID)
-
+func (c *controller) AbortMultipart(r *http.Request, bucketName, key, uploadID string) (retErr error) {
+	c.logger.Infof("AbortMultipart: bucketName=%+v, key=%+v, uploadID=%+v", bucketName, key, uploadID)
+	defer func(start time.Time) {
+		c.logger.Infof("AbortMultipart: duration=%v, error=%v", time.Since(start), retErr)
+	}(time.Now())
 	pc, err := c.requestClient(r)
 	if err != nil {
 		return err
@@ -209,9 +212,11 @@ func (c *controller) AbortMultipart(r *http.Request, bucketName, key, uploadID s
 	return nil
 }
 
-func (c *controller) CompleteMultipart(r *http.Request, bucketName, key, uploadID string, parts []*s2.Part) (*s2.CompleteMultipartResult, error) {
+func (c *controller) CompleteMultipart(r *http.Request, bucketName, key, uploadID string, parts []*s2.Part) (res *s2.CompleteMultipartResult, retErr error) {
 	c.logger.Debugf("CompleteMultipart: bucketName=%+v, key=%+v, uploadID=%+v, parts=%+v", bucketName, key, uploadID, parts)
-
+	defer func(start time.Time) {
+		c.logger.Infof("CompleteMultipart: duration=%v, result=%+v, error=%v", time.Since(start), res, retErr)
+	}(time.Now())
 	pc, err := c.requestClient(r)
 	if err != nil {
 		return nil, err
@@ -241,19 +246,9 @@ func (c *controller) CompleteMultipart(r *http.Request, bucketName, key, uploadI
 		return nil, err
 	}
 
-	// check if the destination file already exists, and if so, delete it
-	_, err = pc.InspectFile(bucket.Repo, bucket.Commit, key)
-	if err != nil && !pfsServer.IsFileNotFoundErr(err) && !pfsServer.IsNoHeadErr(err) {
-		return nil, err
-	} else if err == nil {
-		err = pc.DeleteFile(bucket.Repo, bucket.Commit, key)
-		if err != nil {
-			if errutil.IsWriteToOutputBranchError(err) {
-				return nil, writeToOutputBranchError(r)
-			}
-			return nil, err
-		}
-	}
+	// S3 "supports" concurrent complete calls on the same upload ID.
+	// Write to a random file ID in our directory to avoid conflict
+	dstPath := uuid.NewWithoutDashes()
 
 	for i, part := range parts {
 		srcPath := chunkPath(bucket.Repo, bucket.Commit, key, uploadID, part.PartNumber)
@@ -280,17 +275,20 @@ func (c *controller) CompleteMultipart(r *http.Request, bucketName, key, uploadI
 			return nil, s2.EntityTooSmallError(r)
 		}
 
-		err = pc.CopyFile(c.repo, "master", srcPath, bucket.Repo, bucket.Commit, key, false)
-		if err != nil {
-			if errutil.IsWriteToOutputBranchError(err) {
-				return nil, writeToOutputBranchError(r)
-			}
+		if err := pc.CopyFile(c.repo, "master", srcPath, c.repo, "master", dstPath, false); err != nil {
 			return nil, err
 		}
 	}
 
-	err = pc.DeleteFile(c.repo, "master", parentDirPath(bucket.Repo, bucket.Commit, key, uploadID))
-	if err != nil {
+	// overwrite file, for "last write wins" behavior
+	if err := pc.CopyFile(c.repo, "master", dstPath, bucket.Repo, bucket.Commit, key, true); err != nil {
+		if errutil.IsWriteToOutputBranchError(err) {
+			return nil, writeToOutputBranchError(r)
+		}
+		return nil, err
+	}
+
+	if err := pc.DeleteFile(c.repo, "master", parentDirPath(bucket.Repo, bucket.Commit, key, uploadID)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes two large issues with our s3 multipart upload support. The
first impacts correctness: previously, the file parts were put into
destination directory piece by piece, in separate commits, which could
trigger downstream jobs with partial states. Instead, we now build the
file incrementally in a uniquely named file in the multipart repo and
copy it into the destination in one go.

The second is a bit more nebulous. I have observed the aws cli client
making multiple concurrent CompleteMultipartUpload requests. The AWS
documentation isn't clear on this case, but the client seems like it
expects subsequent calls to succeed until one of them has finished. In
our system, this will just cause identical jobs, so I have attempted to
accommodate this behavior.