### PR TITLE
Postgres: make tuneables configurable, monitor connection pool status, monitor transaction success

### DIFF
--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -25,6 +25,7 @@ cmds=(
   'kubectl get all --all-namespaces'
   'kubectl describe pod -l suite=pachyderm,app=pachd'
   'kubectl describe pod -l suite=pachyderm,app=etcd'
+  'curl -s http://$(minikube ip):30656/metrics'
   # Set --tail b/c by default 'kubectl logs' only outputs 10 lines if -l is set
   'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd'
   'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd --previous # if pachd restarted'

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/dexidp/dex v0.0.0-20201118094123-6ca0cbc85759
 	github.com/dexidp/dex/api/v2 v2.0.0
 	github.com/dlclark/regexp2 v1.2.0 // indirect
+	github.com/dlmiddlecote/sqlstats v1.0.2 // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
 github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/dlmiddlecote/sqlstats v1.0.2 h1:gSU11YN23D/iY50A2zVYwgXgy072khatTsIW6UPjUtI=
+github.com/dlmiddlecote/sqlstats v1.0.2/go.mod h1:0CWaIh/Th+z2aI6Q9Jpfg/o21zmGxWhbByHgQSCUQvY=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 h1:FwssHbCDJD025h+BchanCwE1Q8fyMgqDr2mOQAWOLGw=
@@ -763,6 +765,7 @@ github.com/mattn/go-shellwords v1.0.9/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLt
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=

--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -19,23 +20,37 @@ const (
 	DefaultDBName = "pgc"
 	// DefaultMaxOpenConns is the argument passed to SetMaxOpenConns
 	DefaultMaxOpenConns = 10
+	// DefaultMaxIdleConns is the default number of idle database connections to maintain.
+	DefaultMaxIdleConns = 2
+	// DefaultConnMaxLifetime is the default maximum amount of time a connection may be reused
+	// for.  Defaults to no maximum.
+	DefaultConnMaxLifetime = 0
+	// DefaultConnMaxIdleTime is the default maximum amount of time a connection may be idle.
+	// Defaults to no maximum.
+	DefaultConnMaxIdleTime = 0
 )
 
 type dbConfig struct {
-	host           string
-	port           int
-	user, password string
-	name           string
-	maxOpenConns   int
+	host            string
+	port            int
+	user, password  string
+	name            string
+	maxOpenConns    int
+	maxIdleConns    int
+	connMaxLifetime time.Duration
+	connMaxIdleTime time.Duration
 }
 
 func newConfig(opts ...Option) *dbConfig {
 	dbc := &dbConfig{
-		host:         DefaultHost,
-		port:         DefaultPort,
-		user:         DefaultUser,
-		name:         DefaultDBName,
-		maxOpenConns: DefaultMaxOpenConns,
+		host:            DefaultHost,
+		port:            DefaultPort,
+		user:            DefaultUser,
+		name:            DefaultDBName,
+		maxOpenConns:    DefaultMaxOpenConns,
+		maxIdleConns:    DefaultMaxIdleConns,
+		connMaxLifetime: DefaultConnMaxLifetime,
+		connMaxIdleTime: DefaultConnMaxIdleTime,
 	}
 	for _, opt := range opts {
 		opt(dbc)
@@ -89,6 +104,10 @@ func NewDB(opts ...Option) (*sqlx.DB, error) {
 	if dbc.maxOpenConns != 0 {
 		db.SetMaxOpenConns(dbc.maxOpenConns)
 	}
+	// Always set these; 0 does not mean "use the default", it means "use zero".
+	db.SetMaxIdleConns(dbc.maxIdleConns)
+	db.SetConnMaxLifetime(dbc.connMaxLifetime)
+	db.SetConnMaxIdleTime(dbc.connMaxIdleTime)
 	return db, nil
 }
 

--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -18,9 +18,12 @@ const (
 	DefaultUser = "postgres"
 	// DefaultDBName is the default DB name.
 	DefaultDBName = "pgc"
-	// DefaultMaxOpenConns is the argument passed to SetMaxOpenConns
+	// DefaultMaxOpenConns is the default maximum number of open connections; if you change
+	// this, also consider changing the default from the environment in
+	// serviceenv.GlobalConfiguration.
 	DefaultMaxOpenConns = 10
-	// DefaultMaxIdleConns is the default number of idle database connections to maintain.
+	// DefaultMaxIdleConns is the default number of idle database connections to maintain.  (2
+	// comes from the default in database/sql.go.)
 	DefaultMaxIdleConns = 2
 	// DefaultConnMaxLifetime is the default maximum amount of time a connection may be reused
 	// for.  Defaults to no maximum.

--- a/src/internal/dbutil/option.go
+++ b/src/internal/dbutil/option.go
@@ -1,5 +1,7 @@
 package dbutil
 
+import "time"
+
 // Option configures a DB.
 type Option func(*dbConfig)
 
@@ -31,5 +33,27 @@ func WithDBName(DBName string) Option {
 func WithMaxOpenConns(n int) Option {
 	return func(dbc *dbConfig) {
 		dbc.maxOpenConns = n
+	}
+}
+
+// WithMaxIdleConns sets the maximum number of idle database connections to keep available for
+// future queries.
+func WithMaxIdleConns(n int) Option {
+	return func(dbc *dbConfig) {
+		dbc.maxIdleConns = n
+	}
+}
+
+// WithConnMaxLifetime sets the maximum time a database connection may be reused for.
+func WithConnMaxLifetime(d time.Duration) Option {
+	return func(dbc *dbConfig) {
+		dbc.connMaxLifetime = d
+	}
+}
+
+// WithConnMaxIdleTime sets the maximum time a database connection may be idle for.
+func WithConnMaxIdleTime(d time.Duration) Option {
+	return func(dbc *dbConfig) {
+		dbc.connMaxIdleTime = d
 	}
 }

--- a/src/internal/dbutil/tx.go
+++ b/src/internal/dbutil/tx.go
@@ -9,7 +9,65 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
+)
+
+var (
+	txStartedMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "pachyderm",
+		Subsystem: "postgres",
+		Name:      "tx_start_count",
+		Help:      "Count of transactions that have been started.  One transaction may start many underlying database transactions, whose status is tracked separately.",
+	})
+	txFinishedMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pachyderm",
+		Subsystem: "postgres",
+		Name:      "tx_finish_count",
+		Help:      "Count of transactions that have finished, by outcome ('error', 'ok', etc.).",
+	}, []string{"outcome"})
+	txDurationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "pachyderm",
+		Subsystem: "postgres",
+		Name:      "tx_duration_seconds",
+		Help:      "Time taken for a transaction, by outcome ('error', 'ok', etc.).",
+		Buckets: []float64{
+			0.0001, // 100us
+			0.0005, // .5ms
+			0.001,  // 1ms
+			0.002,  // 2ms
+			0.005,  // 5ms
+			0.01,   // 10ms
+			0.02,   // 20ms
+			0.05,   // 50ms
+			0.1,    // 100ms
+			0.2,    // 200ms
+			0.5,    // 500ms
+			1,      // 1s
+			2,      // 2s
+			5,      // 5s
+			30,     // 30s
+			60,     // 60s
+			300,    // 5m
+			600,    // 10m
+			3600,   // 1h
+			86400,  // 1d
+		},
+	}, []string{"outcome"})
+
+	underlyingTxStartedMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "pachyderm",
+		Subsystem: "postgres",
+		Name:      "tx_underlying_start_count",
+		Help:      "Count of underlying database transactions that have been started.",
+	})
+	underlyingTxFinishMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pachyderm",
+		Subsystem: "postgres",
+		Name:      "tx_underlying_finish_count",
+		Help:      "Count of underlying database transactions that have finished, by outcome ('commit_ok', 'commit_failed', 'rollback_ok', 'rollback_failed', 'failed_start', etc.)",
+	}, []string{"outcome"})
 )
 
 type withTxConfig struct {
@@ -57,9 +115,13 @@ func WithTx(ctx context.Context, db *sqlx.DB, cb func(tx *sqlx.Tx) error, opts .
 	for _, opt := range opts {
 		opt(c)
 	}
-	return backoff.RetryUntilCancel(ctx, func() error {
+	start := time.Now()
+	txStartedMetric.Inc()
+	err := backoff.RetryUntilCancel(ctx, func() error {
+		underlyingTxStartedMetric.Inc()
 		tx, err := db.BeginTxx(ctx, &c.TxOptions)
 		if err != nil {
+			underlyingTxFinishMetric.WithLabelValues("failed_start").Inc()
 			return err
 		}
 		return tryTxFunc(tx, cb)
@@ -69,16 +131,37 @@ func WithTx(ctx context.Context, db *sqlx.DB, cb func(tx *sqlx.Tx) error, opts .
 		}
 		return err
 	})
+	duration := time.Since(start).Seconds()
+	if err != nil {
+		// Inspecting err could yield a better outcome type than "error", but some care is
+		// needed.  For example, `cb` could return "context deadline exceeded" because it
+		// creates a sub-context that expires, and that's a different error than 'commit'
+		// failing because the deadline expired during commit.
+		txFinishedMetric.WithLabelValues("error").Inc()
+		txDurationMetric.WithLabelValues("error").Observe(duration)
+		return err
+	}
+	txFinishedMetric.WithLabelValues("ok").Inc()
+	txDurationMetric.WithLabelValues("ok").Observe(duration)
+	return nil
 }
 
 func tryTxFunc(tx *sqlx.Tx, cb func(tx *sqlx.Tx) error) error {
 	if err := cb(tx); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
+			underlyingTxFinishMetric.WithLabelValues("rollback_failed").Inc()
 			logrus.Error(rbErr)
+			return err // The user error, not the rollback error.
 		}
+		underlyingTxFinishMetric.WithLabelValues("rollback_ok").Inc()
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		underlyingTxFinishMetric.WithLabelValues("commit_failed").Inc()
+		return err
+	}
+	underlyingTxFinishMetric.WithLabelValues("commit_ok").Inc()
+	return nil
 }
 
 func isTransactionError(err error) bool {

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -29,10 +29,10 @@ type GlobalConfiguration struct {
 	PostgresDBName                 string `env:"POSTGRES_DATABASE_NAME"`
 	PostgresUser                   string `env:"POSTGRES_USER,default=postgres"`
 	PostgresPassword               string `env:"POSTGRES_PASSWORD"`
-	PostgresMaxOpenConns           int    `env:"POSTGRES_MAX_OPEN_CONNS"`
-	PostgresMaxIdleConns           int    `env:"POSTGRES_MAX_IDLE_CONNS"`
-	PostgresConnMaxLifetimeSeconds int    `env:"POSTGRES_CONN_MAX_LIFETIME_SECONDS"`
-	PostgresConnMaxIdleSeconds     int    `env:"POSTGRES_CONN_MAX_IDLE_SECONDS"`
+	PostgresMaxOpenConns           int    `env:"POSTGRES_MAX_OPEN_CONNS,default=10"`
+	PostgresMaxIdleConns           int    `env:"POSTGRES_MAX_IDLE_CONNS,default=2"`
+	PostgresConnMaxLifetimeSeconds int    `env:"POSTGRES_CONN_MAX_LIFETIME_SECONDS,default=0"`
+	PostgresConnMaxIdleSeconds     int    `env:"POSTGRES_CONN_MAX_IDLE_SECONDS,default=0"`
 	PachdServiceHost               string `env:"PACHD_SERVICE_HOST"`
 	PachdServicePort               string `env:"PACHD_SERVICE_PORT"`
 

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -10,27 +10,31 @@ type Configuration struct {
 // GlobalConfiguration contains the global configuration.
 type GlobalConfiguration struct {
 	FeatureFlags
-	EtcdHost         string `env:"ETCD_SERVICE_HOST,required"`
-	EtcdPort         string `env:"ETCD_SERVICE_PORT,required"`
-	PPSWorkerPort    uint16 `env:"PPS_WORKER_GRPC_PORT,default=1080"`
-	Port             uint16 `env:"PORT,default=1650"`
-	PeerPort         uint16 `env:"PEER_PORT,default=1653"`
-	S3GatewayPort    uint16 `env:"S3GATEWAY_PORT,default=1600"`
-	PPSEtcdPrefix    string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
-	Namespace        string `env:"PACH_NAMESPACE,default=default"`
-	StorageRoot      string `env:"PACH_ROOT,default=/pach"`
-	GCPercent        int    `env:"GC_PERCENT,default=50"`
-	LokiHost         string `env:"LOKI_SERVICE_HOST"`
-	LokiPort         string `env:"LOKI_SERVICE_PORT"`
-	OidcPort         uint16 `env:"OIDC_PORT,default=1657"`
-	PostgresHost     string `env:"POSTGRES_HOST"`
-	PostgresPort     int    `env:"POSTGRES_PORT"`
-	PostgresSSL      string `env:"POSTGRES_SSL,default=disable"`
-	PostgresDBName   string `env:"POSTGRES_DATABASE_NAME"`
-	PostgresUser     string `env:"POSTGRES_USER,default=postgres"`
-	PostgresPassword string `env:"POSTGRES_PASSWORD"`
-	PachdServiceHost string `env:"PACHD_SERVICE_HOST"`
-	PachdServicePort string `env:"PACHD_SERVICE_PORT"`
+	EtcdHost                       string `env:"ETCD_SERVICE_HOST,required"`
+	EtcdPort                       string `env:"ETCD_SERVICE_PORT,required"`
+	PPSWorkerPort                  uint16 `env:"PPS_WORKER_GRPC_PORT,default=1080"`
+	Port                           uint16 `env:"PORT,default=1650"`
+	PeerPort                       uint16 `env:"PEER_PORT,default=1653"`
+	S3GatewayPort                  uint16 `env:"S3GATEWAY_PORT,default=1600"`
+	PPSEtcdPrefix                  string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
+	Namespace                      string `env:"PACH_NAMESPACE,default=default"`
+	StorageRoot                    string `env:"PACH_ROOT,default=/pach"`
+	GCPercent                      int    `env:"GC_PERCENT,default=50"`
+	LokiHost                       string `env:"LOKI_SERVICE_HOST"`
+	LokiPort                       string `env:"LOKI_SERVICE_PORT"`
+	OidcPort                       uint16 `env:"OIDC_PORT,default=1657"`
+	PostgresHost                   string `env:"POSTGRES_HOST"`
+	PostgresPort                   int    `env:"POSTGRES_PORT"`
+	PostgresSSL                    string `env:"POSTGRES_SSL,default=disable"`
+	PostgresDBName                 string `env:"POSTGRES_DATABASE_NAME"`
+	PostgresUser                   string `env:"POSTGRES_USER,default=postgres"`
+	PostgresPassword               string `env:"POSTGRES_PASSWORD"`
+	PostgresMaxOpenConns           int    `env:"POSTGRES_MAX_OPEN_CONNS"`
+	PostgresMaxIdleConns           int    `env:"POSTGRES_MAX_IDLE_CONNS"`
+	PostgresConnMaxLifetimeSeconds int    `env:"POSTGRES_CONN_MAX_LIFETIME_SECONDS"`
+	PostgresConnMaxIdleSeconds     int    `env:"POSTGRES_CONN_MAX_IDLE_SECONDS"`
+	PachdServiceHost               string `env:"PACHD_SERVICE_HOST"`
+	PachdServicePort               string `env:"PACHD_SERVICE_PORT"`
 
 	EtcdPrefix           string `env:"ETCD_PREFIX,default="`
 	DeploymentID         string `env:"CLUSTER_DEPLOYMENT_ID,default="`

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -271,6 +271,10 @@ func (env *NonblockingServiceEnv) initDBClient() error {
 			dbutil.WithHostPort(env.config.PostgresHost, env.config.PostgresPort),
 			dbutil.WithDBName(env.config.PostgresDBName),
 			dbutil.WithUserPassword(env.config.PostgresUser, env.config.PostgresPassword),
+			dbutil.WithMaxOpenConns(env.config.PostgresMaxOpenConns),
+			dbutil.WithMaxIdleConns(env.config.PostgresMaxIdleConns),
+			dbutil.WithConnMaxLifetime(time.Duration(env.config.PostgresConnMaxLifetimeSeconds)*time.Second),
+			dbutil.WithConnMaxIdleTime(time.Duration(env.config.PostgresConnMaxIdleSeconds)*time.Second),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This adds some code that helps with tuning Postgres.  All configurable connection pool parameters can be controlled through environment variables.  The defaults for a production pachd are now set in the GlobalConfiguration, but a comment points from `dbutil`'s constants there, so it shouldn't be confusing if you ever need to change them.  I also did some testing to ensure that the configuration actually takes effect.

I also added some monitoring that exports connection pool stats to Prometheus (list of metrics here: https://github.com/dlmiddlecote/sqlstats/blob/main/collector_115.go#L28).  When collected and hooked into Grafana, it looks something like:

![Capture](https://user-images.githubusercontent.com/2367/123874983-ecc07880-d906-11eb-95fe-1416e979ea34.PNG)

(I manually verified that these look reasonable during CI runs, and that we don't hit the error case where we try to add the metrics more than once.)

I also added some monitoring for transactions run through dbutil/WithTx.  The number of transactions started, finished (by outcome), and their latency is recorded.  The number of underlying database transactions started and finished are also recorded (exposing details such as whether the transaction committed or rolled back).  Note that we still have no visibility on queries like `env.WithDBClient().ExecContext(...)`; I think we would have to change the Postgres driver to `pgx` to have a good place to hook in there.

Finally, I made CI dump all prometheus metrics to the failure log if the tests fail -- may be helpful.  While developing this PR, I noticed a bug where I changed the connection limit to 0 instead of the default of 10, and that caused tests to fail.  I ran the job under SSH, probed the prometheus metrics, and noticed that the new DB metrics also said the limit was 0.  Suspicious!  I fixed the code that incorrectly changed the default, and all was well.  With the metrics dump, I would have saved 15 minutes ;)

This should let us keep an eye on our interactions with Postgres and easily tune it for optimal performance.