### PR TITLE
pacherr: remove IsRetryable

### DIFF
--- a/src/internal/errutil/errutil.go
+++ b/src/internal/errutil/errutil.go
@@ -1,6 +1,8 @@
 package errutil
 
 import (
+	"errors"
+	"net"
 	"strings"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
@@ -55,4 +57,10 @@ func IsInvalidPathError(err error) bool {
 	}
 	return strings.Contains(err.Error(), "only printable ASCII characters allowed") ||
 		strings.Contains(err.Error(), "not allowed in path")
+}
+
+// IsNetRetryable returns true if the error is a temporary network error.
+func IsNetRetryable(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Temporary()
 }

--- a/src/internal/obj/amazon_client.go
+++ b/src/internal/obj/amazon_client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -221,7 +220,7 @@ func (c *amazonClient) Get(ctx context.Context, name string, w io.Writer) (retEr
 				tracing.FinishAnySpan(span, "err", retErr)
 			}()
 			resp, connErr = http.DefaultClient.Do(req)
-			if connErr != nil && isNetRetryable(connErr) {
+			if connErr != nil && pacherr.IsNetRetryable(connErr) {
 				return connErr
 			}
 			return nil
@@ -315,9 +314,4 @@ func (c *amazonClient) transformError(err error, objectPath string) error {
 		return pacherr.WrapTransient(err, minWait)
 	}
 	return err
-}
-
-func isNetRetryable(err error) bool {
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Temporary()
 }

--- a/src/internal/obj/amazon_client.go
+++ b/src/internal/obj/amazon_client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	log "github.com/sirupsen/logrus"
@@ -220,7 +221,7 @@ func (c *amazonClient) Get(ctx context.Context, name string, w io.Writer) (retEr
 				tracing.FinishAnySpan(span, "err", retErr)
 			}()
 			resp, connErr = http.DefaultClient.Do(req)
-			if connErr != nil && pacherr.IsNetRetryable(connErr) {
+			if connErr != nil && errutil.IsNetRetryable(connErr) {
 				return connErr
 			}
 			return nil

--- a/src/internal/pacherr/transient.go
+++ b/src/internal/pacherr/transient.go
@@ -1,8 +1,6 @@
 package pacherr
 
 import (
-	"errors"
-	"net"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -32,9 +30,4 @@ func (e *TransientError) Unwrap() error {
 func (e *TransientError) GRPCStatus() *status.Status {
 	// TODO: not sure if codes.Unavailable is appropriate here
 	return status.New(codes.Unavailable, e.Error())
-}
-
-func IsNetRetryable(err error) bool {
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Temporary()
 }

--- a/src/internal/pacherr/transient.go
+++ b/src/internal/pacherr/transient.go
@@ -34,8 +34,7 @@ func (e *TransientError) GRPCStatus() *status.Status {
 	return status.New(codes.Unavailable, e.Error())
 }
 
-func isNetRetryable(err error) bool {
+func IsNetRetryable(err error) bool {
 	var netErr net.Error
-	// nolint:govet
 	return errors.As(err, &netErr) && netErr.Temporary()
 }

--- a/src/internal/pacherr/transient.go
+++ b/src/internal/pacherr/transient.go
@@ -34,12 +34,6 @@ func (e *TransientError) GRPCStatus() *status.Status {
 	return status.New(codes.Unavailable, e.Error())
 }
 
-func IsRetryable(err error) bool {
-	var target TransientError
-	// nolint:govet
-	return errors.As(err, &target) || isNetRetryable(err)
-}
-
 func isNetRetryable(err error) bool {
 	var netErr net.Error
 	// nolint:govet


### PR DESCRIPTION
`go vet` says it's invalid, and we don't call it from anywhere.

This had the side effect of making lint fail because the `isNetRetryable` became unused.  That function was copied over to amazon_client at some point and is used there correctly, so I moved the function to `errutil` and made it public.  (It's actually unclear to me if it should live in `pacherr` or `errutil`.  I moved it to `errutil` because it doesn't have anything to do with the code in `pacherr`.)