### PR TITLE
Switch main deploy methods to use helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,14 +171,14 @@ clean-launch-kube:
 
 launch: install check-kubectl
 	$(eval STARTTIME := $(shell date +%s))
-	$(PACHCTL) deploy local --dry-run | kubectl $(KUBECTLFLAGS) apply -f -
+	helm install pachyderm etc/helm/pachyderm --set deployTarget=LOCAL
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
 launch-dev: check-kubectl check-kubectl-connection install
 	$(eval STARTTIME := $(shell date +%s))
-	$(PACHCTL) deploy local --no-guaranteed -d --dry-run $(LAUNCH_DEV_ARGS) | kubectl $(KUBECTLFLAGS) apply -f -
+	helm install pachyderm etc/helm/pachyderm --set deployTarget=LOCAL,pachd.image.tag=local
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
@@ -186,22 +186,18 @@ launch-dev: check-kubectl check-kubectl-connection install
 launch-enterprise: check-kubectl check-kubectl-connection install
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	$(PACHCTL) deploy local --no-guaranteed -d --enterprise-server --namespace enterprise  --pachd-memory-request 128M --postgres-memory-request 128M --etcd-memory-request 128M --pachd-cpu-request 100m --postgres-cpu-request 100m --etcd-cpu-request 100m --dry-run $(LAUNCH_DEV_ARGS) | kubectl $(KUBECTLFLAGS) apply -f -
+	helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
 clean-launch: check-kubectl install
-	yes | $(PACHCTL) undeploy
+	yes | helm delete pachyderm
+	kubectl delete pvc -l suite=pachyderm
 
 clean-launch-dev: check-kubectl install
-	yes | $(PACHCTL) undeploy
-
-full-clean-launch: check-kubectl
-	kubectl $(KUBECTLFLAGS) delete --ignore-not-found job -l suite=pachyderm
-	kubectl $(KUBECTLFLAGS) delete --ignore-not-found all -l suite=pachyderm
-	kubectl $(KUBECTLFLAGS) delete --ignore-not-found serviceaccount -l suite=pachyderm
-	kubectl $(KUBECTLFLAGS) delete --ignore-not-found secret -l suite=pachyderm
+	yes | helm delete pachyderm
+	kubectl delete pvc -l suite=pachyderm
 
 test-proto-static:
 	./etc/proto/test_no_changes.sh || echo "Protos need to be recompiled; run 'DOCKER_BUILD_FLAGS=--no-cache make proto'."
@@ -339,9 +335,6 @@ logs: check-kubectl
 follow-logs: check-kubectl
 	kubectl $(KUBECTLFLAGS) get pod -l app=pachd | sed '1d' | cut -f1 -d ' ' | xargs -n 1 -I pod sh -c 'echo pod && kubectl $(KUBECTLFLAGS) logs -f pod'
 
-google-cluster-manifest:
-	@$(PACHCTL) deploy --dry-run google $(BUCKET_NAME) $(STORAGE_NAME) $(STORAGE_SIZE)
-
 google-cluster:
 	gcloud container clusters create $(CLUSTER_NAME) --scopes storage-rw --machine-type $(CLUSTER_MACHINE_TYPE) --num-nodes $(CLUSTER_SIZE)
 	gcloud config set container/cluster $(CLUSTER_NAME)
@@ -356,9 +349,6 @@ clean-google-cluster:
 	gcloud compute firewall-rules delete pachd
 	gsutil -m rm -r gs://$(BUCKET_NAME)
 	gcloud compute disks delete $(STORAGE_NAME)
-
-amazon-cluster-manifest: install
-	@$(PACHCTL) deploy --dry-run amazon $(BUCKET_NAME) $(AWS_ID) $(AWS_KEY) $(AWS_TOKEN) $(AWS_REGION) $(STORAGE_NAME) $(STORAGE_SIZE)
 
 amazon-cluster:
 	aws s3api create-bucket --bucket $(BUCKET_NAME) --region $(AWS_REGION)
@@ -380,9 +370,6 @@ amazon-clean:
 	N|n) echo "The amazon clean process has been cancelled by user!";break;; \
 	*) echo "input parameter error, please input again ";continue;;esac; \
         fi;done;
-
-microsoft-cluster-manifest:
-	@$(PACHCTL) deploy --dry-run microsoft $(CONTAINER_NAME) $(AZURE_STORAGE_NAME) $(AZURE_STORAGE_KEY) $(VHD_URI) $(STORAGE_SIZE)
 
 microsoft-cluster:
 	azure group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION)
@@ -436,7 +423,6 @@ check-buckets:
 	launch-dev \
 	clean-launch \
 	clean-launch-dev \
-	full-clean-launch \
 	test-proto-static \
 	test-deploy-manifests \
 	regenerate-test-deploy-manifests \

--- a/Makefile
+++ b/Makefile
@@ -191,13 +191,17 @@ launch-enterprise: check-kubectl check-kubectl-connection install
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
-clean-launch: check-kubectl install
-	yes | helm delete pachyderm
+clean-launch: check-kubectl
+	helm delete pachyderm || true
+	helm delete enterprise || true
 	kubectl delete pvc -l suite=pachyderm
+	kubectl delete pvc -l suite=pachyderm -n enterprise
 
-clean-launch-dev: check-kubectl install
-	yes | helm delete pachyderm
+clean-launch-dev: check-kubectl
+	helm delete pachyderm || true
+	helm delete enterprise || true
 	kubectl delete pvc -l suite=pachyderm
+	kubectl delete pvc -l suite=pachyderm -n enterprise
 
 test-proto-static:
 	./etc/proto/test_no_changes.sh || echo "Protos need to be recompiled; run 'DOCKER_BUILD_FLAGS=--no-cache make proto'."

--- a/Makefile
+++ b/Makefile
@@ -194,12 +194,10 @@ launch-enterprise: check-kubectl check-kubectl-connection install
 clean-launch: check-kubectl
 	helm delete pachyderm || true
 	helm delete enterprise || true
-	kubectl delete pvc -l suite=pachyderm
-	kubectl delete pvc -l suite=pachyderm -n enterprise
-
-clean-launch-dev: check-kubectl
-	helm delete pachyderm || true
-	helm delete enterprise || true
+	# These resources were not cleaned up by the old pachctl undeploy
+	kubectl delete roles.rbac.authorization.k8s.io,rolebindings.rbac.authorization.k8s.io -l suite=pachyderm
+	kubectl delete clusterroles.rbac.authorization.k8s.io,clusterrolebindings.rbac.authorization.k8s.io -l suite=pachyderm
+	# Helm won't clean statefulset PVCs by design
 	kubectl delete pvc -l suite=pachyderm
 	kubectl delete pvc -l suite=pachyderm -n enterprise
 
@@ -216,7 +214,7 @@ proto: docker-build-proto
 	./etc/proto/build.sh
 
 # Run all the tests. Note! This is no longer the test entrypoint for travis
-test: clean-launch-dev launch-dev lint enterprise-code-checkin-test docker-build test-pfs-server test-cmds test-libs test-auth test-identity test-license test-enterprise test-worker test-admin test-pps
+test: clean-launch launch-dev lint enterprise-code-checkin-test docker-build test-pfs-server test-cmds test-libs test-auth test-identity test-license test-enterprise test-worker test-admin test-pps
 
 enterprise-code-checkin-test:
 	@which ag || { printf "'ag' not found. Run:\n  sudo apt-get install -y silversearcher-ag\n  brew install the_silver_searcher\nto install it\n\n"; exit 1; }
@@ -426,7 +424,6 @@ check-buckets:
 	launch \
 	launch-dev \
 	clean-launch \
-	clean-launch-dev \
 	test-proto-static \
 	test-deploy-manifests \
 	regenerate-test-deploy-manifests \

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ launch: install check-kubectl
 
 launch-dev: check-kubectl check-kubectl-connection install
 	$(eval STARTTIME := $(shell date +%s))
-	helm install pachyderm etc/helm/pachyderm --set deployTarget=LOCAL,pachd.image.tag=local
+	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -145,7 +145,7 @@ spec:
         - containerPort: 1658
           name: identity-port
           protocol: TCP
-        - containerPort: 1656 #Confirm for 2.0
+        - containerPort: 1656
           name: prom-metrics
           protocol: TCP
         readinessProbe:

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -2,6 +2,8 @@ deployTarget: LOCAL
 dash:
   enabled: false
 pachd:
+  service:
+    type: NodePort
   image:
     tag: local
   storage:

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -3,7 +3,7 @@ dash:
   enabled: false
 pachd:
   image:
-    tag: LOCAL
+    tag: local
   storage:
     local:
       requireRoot: false

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -1,0 +1,10 @@
+deployTarget: LOCAL
+dash:
+  enabled: false
+pachd:
+  image:
+    tag: LOCAL
+  storage:
+    local:
+      requireRoot: false
+      hostPath: /tmp/pachyderm

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -10,6 +10,8 @@ pachd:
     local:
       requireRoot: false
       hostPath: /tmp/pachyderm/
+  metrics:
+    enabled: false
 postgresql:
   service:
     type: NodePort

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -24,3 +24,5 @@ etcd:
     requests:
       cpu: 250m
       memory: 512M
+worker:
+  usesRoot: true

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -19,3 +19,8 @@ pachd:
 postgresql:
   service:
     type: NodePort
+etcd:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512M

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -13,9 +13,6 @@ pachd:
   metrics:
     enabled: false
   resources:
-    limits:
-      cpu: 250m
-      memory: 512M
     requests:
       cpu: 250m
       memory: 512M

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -12,6 +12,13 @@ pachd:
       hostPath: /tmp/pachyderm/
   metrics:
     enabled: false
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512M
+    requests:
+      cpu: 250m
+      memory: 512M
 postgresql:
   service:
     type: NodePort

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -10,3 +10,6 @@ pachd:
     local:
       requireRoot: false
       hostPath: /tmp/pachyderm
+postgresql:
+  service:
+    type: NodePort

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -9,7 +9,7 @@ pachd:
   storage:
     local:
       requireRoot: false
-      hostPath: /tmp/pachyderm
+      hostPath: /tmp/pachyderm/
 postgresql:
   service:
     type: NodePort

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/env.sh"
 # so we explicitly create the host path on the host machine and chmod it so we can write to it. 
 minikube ssh 'mkdir -p /tmp/pachyderm/pachd && chmod -R 777 /tmp/pachyderm'
 
-helm install pachyderm ../../helm/pachyderm -f helm-values.yaml
+helm install pachyderm etc/helm/pachyderm -f helm-values.yaml
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/env.sh"
 # so we explicitly create the host path on the host machine and chmod it so we can write to it. 
 minikube ssh 'mkdir -p /tmp/pachyderm/pachd && chmod -R 777 /tmp/pachyderm'
 
-helm install pachyderm etc/helm/pachyderm -f helm-values.yaml
+helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/env.sh"
 # so we explicitly create the host path on the host machine and chmod it so we can write to it. 
 minikube ssh 'mkdir -p /tmp/pachyderm/pachd && chmod -R 777 /tmp/pachyderm'
 
-pachctl deploy local --no-guaranteed -d --dry-run --rootless --host-path /tmp/pachyderm | kubectl apply -f -
+helm install pachyderm ../../helm/pachyderm -f helm-values.yaml
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 


### PR DESCRIPTION
make launch differences:
- No longer sets CPU / Mem Requests for pachd
- Is no longer nodeport by default
- Always assigns random hostpath
- Uses statefulset instead of deployment

