### PR TITLE
Fix a few issues in the collection package

### DIFF
--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -35,7 +35,6 @@ var (
 )
 
 func TestEtcdCollections(suite *testing.T) {
-	suite.Parallel()
 	etcdEnv := testetcd.NewEnv(suite)
 	newCollection := func(ctx context.Context, t *testing.T) (ReadCallback, WriteCallback) {
 		prefix := testutil.UniqueString("test-etcd-collections-")

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -384,7 +384,10 @@ func (c *postgresReadOnlyCollection) Count() (int64, error) {
 func (c *postgresReadOnlyCollection) Watch(opts ...watch.Option) (watch.Watcher, error) {
 	options := watch.SumOptions(opts...)
 
-	watcher := newPostgresWatcher(c.db, c.listener, c.tableWatchChannel(), c.template, nil, nil, options)
+	watcher, err := newPostgresWatcher(c.db, c.listener, c.tableWatchChannel(), c.template, nil, nil, options)
+	if err != nil {
+		return nil, err
+	}
 
 	go func() {
 		// Do a list of the collection to get the initial state
@@ -431,7 +434,10 @@ func (c *postgresReadOnlyCollection) WatchF(f func(*watch.Event) error, opts ...
 func (c *postgresReadOnlyCollection) WatchOne(key string, opts ...watch.Option) (watch.Watcher, error) {
 	options := watch.SumOptions(opts...)
 
-	watcher := newPostgresWatcher(c.db, c.listener, c.indexWatchChannel("key", key), c.template, nil, nil, options)
+	watcher, err := newPostgresWatcher(c.db, c.listener, c.indexWatchChannel("key", key), c.template, nil, nil, options)
+	if err != nil {
+		return nil, err
+	}
 
 	go func() {
 		// Load the initial state of the row
@@ -478,7 +484,10 @@ func (c *postgresReadOnlyCollection) WatchByIndex(index *Index, indexVal string,
 	options := watch.SumOptions(opts...)
 
 	channelName := c.indexWatchChannel(indexFieldName(index), indexVal)
-	watcher := newPostgresWatcher(c.db, c.listener, channelName, c.template, nil, nil, options)
+	watcher, err := newPostgresWatcher(c.db, c.listener, channelName, c.template, nil, nil, options)
+	if err != nil {
+		return nil, err
+	}
 
 	go func() {
 		// Do a list of the collection to get the initial state

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -490,6 +490,7 @@ func watchTests(
 		watchOneTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, key string) watch.Watcher {
 			watcher, err := reader(ctx).WatchOne(key)
 			require.NoError(t, err)
+			t.Cleanup(watcher.Close)
 			return watcher
 		})
 	})
@@ -675,6 +676,7 @@ func watchTests(
 		watchByIndexTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, value string) watch.Watcher {
 			watcher, err := reader(ctx).WatchByIndex(TestSecondaryIndex, value)
 			require.NoError(t, err)
+			t.Cleanup(watcher.Close)
 			return watcher
 		})
 	})
@@ -719,6 +721,7 @@ func watchTests(
 		watchByIndexTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, value string) watch.Watcher {
 			watcher, err := reader(ctx).WatchByIndex(TestSecondaryIndex, value)
 			require.NoError(t, err)
+			t.Cleanup(watcher.Close)
 			return watcher
 		})
 	})


### PR DESCRIPTION
This PR fixes a few issues in the collection package.

The fixes were:
- Ensuring that registration errors are propagated back to the client (the watcher setup was dropping the error returned during registration).
- Ensuring that all of the watchers are closed in the tests (a subset of the watcher tests were not closing the watcher upon completion).
- Ensuring that we exit the watcher forwarding goroutine when the watcher is closed or the context is canceled. There were two places were we would block on a send to the watcher channel that may never be read by the client.
- Making the top level tests serial, while keeping the subtests parallel. The etcd interrupt after initial test seems to incur a variable delay (past the 5 second timeout) when more tests are running in a parallel group through go test. Making the top level tests serial and fixing the watcher leak seem to address the issue, but we may want to look into this more later.


I also changed the proxy test to just run the watcher tests. The collection tests don't go through the proxy.