### PR TITLE
Fix the listener proxy in Hub

### DIFF
--- a/src/internal/deploy/assets/assets.go
+++ b/src/internal/deploy/assets/assets.go
@@ -766,7 +766,7 @@ func PachdPeerService(opts *AssetOpts) *v1.Service {
 				{
 					Port:       30653,
 					Name:       "api-grpc-peer-port",
-					TargetPort: intstr.FromInt(653), // also set in cmd/pachd/main.go
+					TargetPort: intstr.FromInt(1653), // also set in cmd/pachd/main.go
 				},
 			},
 		},

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -312,7 +312,7 @@ func (env *NonblockingServiceEnv) newProxyClient() (proxy.APIClient, error) {
 	var servicePachClient *client.APIClient
 	if err := backoff.Retry(func() error {
 		var err error
-		servicePachClient, err = client.NewFromURI(net.JoinHostPort(env.config.PachdServiceHost, env.config.PachdServicePort))
+		servicePachClient, err = client.NewInCluster()
 		return err
 	}, backoff.RetryEvery(time.Second).For(5*time.Minute)); err != nil {
 		return nil, errors.Wrapf(err, "failed to initialize service pach client")

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -681,6 +681,12 @@ func doFullMode(config interface{}) (retErr error) {
 		}); err != nil {
 			return err
 		}
+		if err := logGRPCServerSetup("Proxy API", func() error {
+			proxyclient.RegisterAPIServer(externalServer.Server, proxyserver.NewAPIServer(env))
+			return nil
+		}); err != nil {
+			return err
+		}
 		txnEnv.Initialize(env, transactionAPIServer)
 		if _, err := externalServer.ListenTCP("", env.Config().Port); err != nil {
 			return err

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -681,12 +681,6 @@ func doFullMode(config interface{}) (retErr error) {
 		}); err != nil {
 			return err
 		}
-		if err := logGRPCServerSetup("Proxy API", func() error {
-			proxyclient.RegisterAPIServer(externalServer.Server, proxyserver.NewAPIServer(env))
-			return nil
-		}); err != nil {
-			return err
-		}
 		txnEnv.Initialize(env, transactionAPIServer)
 		if _, err := externalServer.ListenTCP("", env.Config().Port); err != nil {
 			return err
@@ -812,6 +806,12 @@ func doFullMode(config interface{}) (retErr error) {
 		}
 		if err := logGRPCServerSetup("Admin API", func() error {
 			adminclient.RegisterAPIServer(internalServer.Server, adminserver.NewAPIServer(env))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := logGRPCServerSetup("Proxy API", func() error {
+			proxyclient.RegisterAPIServer(internalServer.Server, proxyserver.NewAPIServer(env))
 			return nil
 		}); err != nil {
 			return err


### PR DESCRIPTION
This PR changes the listener proxy to go through the peer pachd service rather than the normal pachd service.