### PR TITLE
roles: add GET_PACHD_LOGS permission to debugger role

### DIFF
--- a/src/server/auth/server/roles.go
+++ b/src/server/auth/server/roles.go
@@ -111,6 +111,7 @@ func init() {
 		ResourceTypes: []auth.ResourceType{auth.ResourceType_CLUSTER},
 		Permissions: []auth.Permission{
 			auth.Permission_CLUSTER_DEBUG_DUMP,
+			auth.Permission_CLUSTER_GET_PACHD_LOGS,
 		},
 	})
 


### PR DESCRIPTION
A debug dump returns the logs anyway, so this doesn't escalate the capabilities the user has.