### PR TITLE
local.sh: update ports, add correct RBAC rules, allow "kind" 

### DIFF
--- a/etc/testing/local.sh
+++ b/etc/testing/local.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
-set -euo pipefail
+set -xeuo pipefail
+
+# Run pachd locally like:
+# CGO_ENABLED=0 go build ./src/server/cmd/pachd
+# ./etc/testing/local.sh ./pachd
+#
+# If you use kind instead of minikube, you will have to override some configuration:
+#
+# LOCAL_PACH_CONTEXT=kind-kind LOCAL_PACH_APISERVER_HOST=127.0.0.1 LOCAL_PACH_APISERVER_PORT=46407 \
+# ./etc/testing/local.sh ./pachd
+#
+# The truly motiviated engineer would teach pachd to read ~/.kube/config (testutil already does this
+# if KUBERNETES_SERVICE_HOST is unset), or at least `jq` the host and port out of `kubectl config
+# view -o json`.
 
 forward() {
   NAME=$1
@@ -8,22 +21,102 @@ forward() {
   if [ -f /tmp/pach/port-forwards/$NAME.pid ]; then
     kill $(cat /tmp/pach/port-forwards/$NAME.pid) || true
   fi
-  
+
   kubectl port-forward service/$NAME $PORT --address 127.0.0.1 >/dev/null 2>&1 &
   PID=$!
-  
+
   mkdir -p /tmp/pach/port-forwards
   echo $PID > /tmp/pach/port-forwards/$NAME.pid
 }
 
 # make sure we're testing against minikube
-kubectl config use-context minikube
+kubectl config use-context ${LOCAL_PACH_CONTEXT:-'minikube'}
+
+# TODO(jonathan): We should be able to make the helm chart generate this for us.
+# add rbac rules
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    labels:
+        app: ""
+        suite: pachyderm
+    name: pachyderm
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app: ""
+        suite: pachyderm
+    name: pachyderm
+    namespace: default
+rules:
+    - apiGroups:
+          - ""
+      resources:
+          - nodes
+          - pods
+          - pods/log
+          - endpoints
+      verbs:
+          - get
+          - list
+          - watch
+    - apiGroups:
+          - ""
+      resources:
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - services
+      verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+    - apiGroups:
+          - ""
+      resources:
+          - secrets
+      verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    labels:
+        app: ""
+        suite: pachyderm
+    name: pachyderm
+    namespace: default
+roleRef:
+    apiGroup: ""
+    kind: ClusterRole
+    name: pachyderm
+subjects:
+    - kind: ServiceAccount
+      name: pachyderm
+      namespace: default
+EOF
 
 # port-forward postgres and etcd
 forward postgres 32228:5432
 forward etcd 2379
 
-echo '{"pachd_address": "grpc://localhost:650", "source": 2}' | pachctl config set context "local" --overwrite && pachctl config set active-context "local"
+echo '{"pachd_address": "grpc://localhost:1650", "source": 2}' | pachctl config set context "local" --overwrite && pachctl config set active-context "local"
+
+export LOCAL_TEST=true
+export PACHD_POD_NAME=fake-pachd
 
 export ETCD_SERVICE_HOST="127.0.0.1"
 export ETCD_SERVICE_PORT=2379
@@ -40,13 +133,11 @@ export STORAGE_HOST_PATH=/tmp/pach/storage
 export PACH_CACHE_ROOT=/tmp/pach/cache
 
 # connect to the k8s API in minikube
-export KUBERNETES_PORT_443_TCP_ADDR=$(minikube ip)
-export KUBERNETES_PORT=8443
+export KUBERNETES_PORT_443_TCP_ADDR=${LOCAL_PACH_APISERVER_HOST:-$(minikube ip)}
+export KUBERNETES_PORT=${LOCAL_PACH_APISERVER_PORT:-'8443'}
 
 # mount the bearer token for the default k8s service account
 export KUBERNETES_BEARER_TOKEN_FILE=/tmp/pach/kubernetes-default-token
-kubectl get -n kube-system -o json secret $(kubectl -n kube-system get secrets  | grep 'default-token' | awk '{print $1}') | jq -r '.data.token' | base64 -D > $KUBERNETES_BEARER_TOKEN_FILE
-
-export LOCAL_TEST=true
+kubectl get -n default -o json secret $(kubectl -n default get secrets  | grep 'pachyderm-token' | awk '{print $1}') | jq -r '.data.token | @base64d' > $KUBERNETES_BEARER_TOKEN_FILE
 
 $@


### PR DESCRIPTION
I remembered that this existed today, and it's been very helpful.  I tweaked a few things to make it potentially work for more people, mostly me.  (The base64 command burned me again; MacOS's version wants different flags than Linux's -- so I just did the transform in jq instead.)

I also added the RBAC rules; the default service account in kube-system didn't have the necessary permissions.  I extracted a minimal manifest out of the currently-checked-in helm chart and that works for me.  Putting a heredoc in the script is distasteful... we can replace this with something that convinces helm to apply the correct manifests, but that is a bigger change and will do it later ;)