### PR TITLE
Updating S3 Gateway to work with V2

### DIFF
--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -99,7 +99,7 @@ case "${BUCKET}" in
     bucket_num="${BUCKET#PPS}"
     test_bucket "./src/server" test-pps "${bucket_num}" "${PPS_BUCKETS}"
     if [[ "${bucket_num}" -eq "${PPS_BUCKETS}" ]]; then
-      go test -v -count=1 ./src/server/pps/server -timeout 300s
+      go test -v -count=1 ./src/server/pps/server -timeout 420s
     fi
     ;;
   AUTH)

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"crypto/md5"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/jmoiron/sqlx"
@@ -433,7 +435,10 @@ func ContainsS3Inputs(in *pps.Input) bool {
 // sidecar server) and the worker (which passes the endpoint to the user code)
 // need to know it.
 func SidecarS3GatewayService(pipeline, commitSetId string) string {
-	return fmt.Sprintf("s3-%v-%v", strings.ToLower(pipeline), commitSetId)
+	hash := md5.New()
+	hash.Write([]byte(pipeline))
+	hash.Write([]byte(commitSetId))
+	return "s3-" + pfs.EncodeHash(hash.Sum(nil))
 }
 
 // ErrorState returns true if s is an error state for a pipeline, that is, a

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -433,7 +433,7 @@ func ContainsS3Inputs(in *pps.Input) bool {
 // sidecar server) and the worker (which passes the endpoint to the user code)
 // need to know it.
 func SidecarS3GatewayService(jobID string) string {
-	return "s3-" + jobID
+	return "s3-" + strings.Replace(strings.ToLower(jobID), "@", "-", 1)
 }
 
 // ErrorState returns true if s is an error state for a pipeline, that is, a

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -432,8 +432,8 @@ func ContainsS3Inputs(in *pps.Input) bool {
 // is in ppsutil because both PPS (which creates the service, in the s3 gateway
 // sidecar server) and the worker (which passes the endpoint to the user code)
 // need to know it.
-func SidecarS3GatewayService(jobID string) string {
-	return "s3-" + strings.Replace(strings.ToLower(jobID), "@", "-", 1)
+func SidecarS3GatewayService(pipeline, commitSetId string) string {
+	return fmt.Sprintf("s3-%v-%v", strings.ToLower(pipeline), commitSetId)
 }
 
 // ErrorState returns true if s is an error state for a pipeline, that is, a

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -8,7 +8,9 @@ import (
 	"path"
 	"runtime/debug"
 	"runtime/pprof"
+	"sync"
 
+	"github.com/gorilla/mux"
 	adminclient "github.com/pachyderm/pachyderm/v2/src/admin"
 	authclient "github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -386,9 +388,11 @@ func RunLocal() (retErr error) {
 		return internalServer.Wait()
 	})
 	go waitForError("S3 Server", errChan, requireNoncriticalServers, func() error {
-		server, err := s3.Server(env.Config().S3GatewayPort, s3.NewMasterDriver(), func() (*client.APIClient, error) {
+		router := s3.Router(s3.NewMasterDriver(), func() (*client.APIClient, error) {
 			return client.NewFromURI(fmt.Sprintf("localhost:%d", env.Config().PeerPort))
 		})
+		server := s3.Server(env.Config().S3GatewayPort, router, map[string]*mux.Router{}, &sync.Mutex{})
+
 		if err != nil {
 			return err
 		}

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -8,9 +8,7 @@ import (
 	"path"
 	"runtime/debug"
 	"runtime/pprof"
-	"sync"
 
-	"github.com/gorilla/mux"
 	adminclient "github.com/pachyderm/pachyderm/v2/src/admin"
 	authclient "github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -391,7 +389,7 @@ func RunLocal() (retErr error) {
 		router := s3.Router(s3.NewMasterDriver(), func() (*client.APIClient, error) {
 			return client.NewFromURI(fmt.Sprintf("localhost:%d", env.Config().PeerPort))
 		})
-		server := s3.Server(env.Config().S3GatewayPort, router, map[string]*mux.Router{}, &sync.Mutex{})
+		server := s3.Server(env.Config().S3GatewayPort, router)
 
 		if err != nil {
 			return err
@@ -399,7 +397,7 @@ func RunLocal() (retErr error) {
 		certPath, keyPath, err := tls.GetCertPaths()
 		if err != nil {
 			log.Warnf("s3gateway TLS disabled: %v", err)
-			return server.ListenAndServe()
+			return server.HttpServer.ListenAndServe()
 		}
 		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
 		// Read TLS cert and key
@@ -407,8 +405,8 @@ func RunLocal() (retErr error) {
 		if err != nil {
 			return errors.Wrapf(err, "couldn't load TLS cert for s3gateway: %v", err)
 		}
-		server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
-		return server.ListenAndServeTLS(certPath, keyPath)
+		server.HttpServer.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
+		return server.HttpServer.ListenAndServeTLS(certPath, keyPath)
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
 		http.Handle("/metrics", promhttp.Handler())

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -397,7 +397,7 @@ func RunLocal() (retErr error) {
 		certPath, keyPath, err := tls.GetCertPaths()
 		if err != nil {
 			log.Warnf("s3gateway TLS disabled: %v", err)
-			return server.HttpServer.ListenAndServe()
+			return server.ListenAndServe()
 		}
 		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
 		// Read TLS cert and key
@@ -405,8 +405,8 @@ func RunLocal() (retErr error) {
 		if err != nil {
 			return errors.Wrapf(err, "couldn't load TLS cert for s3gateway: %v", err)
 		}
-		server.HttpServer.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
-		return server.HttpServer.ListenAndServeTLS(certPath, keyPath)
+		server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
+		return server.ListenAndServeTLS(certPath, keyPath)
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
 		http.Handle("/metrics", promhttp.Handler())

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -849,7 +849,7 @@ func doFullMode(config interface{}) (retErr error) {
 		certPath, keyPath, err := tls.GetCertPaths()
 		if err != nil {
 			log.Warnf("s3gateway TLS disabled: %v", err)
-			return server.HttpServer.ListenAndServe()
+			return server.ListenAndServe()
 		}
 		cLoader := tls.NewCertLoader(certPath, keyPath, tls.CertCheckFrequency)
 		// Read TLS cert and key
@@ -857,8 +857,8 @@ func doFullMode(config interface{}) (retErr error) {
 		if err != nil {
 			return errors.Wrapf(err, "couldn't load TLS cert for s3gateway: %v", err)
 		}
-		server.HttpServer.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
-		return server.HttpServer.ListenAndServeTLS(certPath, keyPath)
+		server.TLSConfig = &gotls.Config{GetCertificate: cLoader.GetCertificate}
+		return server.ListenAndServeTLS(certPath, keyPath)
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
 		http.Handle("/metrics", promhttp.Handler())

--- a/src/server/pfs/s3/s3.go
+++ b/src/server/pfs/s3/s3.go
@@ -120,7 +120,7 @@ func Router(driver Driver, clientFactory ClientFactory) *mux.Router {
 // to configure handlers (mux.Routers) corresponding to different request URI hostnames.
 // This way one http Server can respond differently and accordingly to each specific job.
 type S3Server struct {
-	HttpServer  *http.Server
+	*http.Server
 	routerMap   map[string]*mux.Router
 	routersLock sync.RWMutex
 }
@@ -151,7 +151,7 @@ func Server(port uint16, defaultRouter *mux.Router) *S3Server {
 		"source": "s3gateway",
 	})
 	s3Server := S3Server{routerMap: make(map[string]*mux.Router)}
-	s3Server.HttpServer = &http.Server{
+	s3Server.Server = &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		ReadTimeout:  requestTimeout,
 		WriteTimeout: requestTimeout,

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -137,7 +137,7 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 	require.NoError(t, err)
 
 	go func() {
-		server.HttpServer.Serve(listener)
+		server.Serve(listener)
 	}()
 
 	port := listener.Addr().(*net.TCPAddr).Port
@@ -149,5 +149,5 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 		runner(t, pachClient, minioClient)
 	})
 
-	require.NoError(t, server.HttpServer.Shutdown(context.Background()))
+	require.NoError(t, server.Shutdown(context.Background()))
 }

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -11,11 +11,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/gorilla/mux"
 	minio "github.com/minio/minio-go/v6"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
@@ -134,12 +132,12 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 	router := Router(driver, func() (*client.APIClient, error) {
 		return pachClient.WithCtx(context.Background()), nil
 	})
-	server := Server(0, router, map[string]*mux.Router{}, &sync.Mutex{})
+	server := Server(0, router)
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 
 	go func() {
-		server.Serve(listener)
+		server.HttpServer.Serve(listener)
 	}()
 
 	port := listener.Addr().(*net.TCPAddr).Port
@@ -151,5 +149,5 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 		runner(t, pachClient, minioClient)
 	})
 
-	require.NoError(t, server.Shutdown(context.Background()))
+	require.NoError(t, server.HttpServer.Shutdown(context.Background()))
 }

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -203,10 +203,6 @@ func (s *s3InstanceCreatingJobHandler) OnCreate(ctx context.Context, jobInfo *pp
 		}
 	}
 	driver := s3.NewWorkerDriver(inputBuckets, outputBucket)
-	// TODO(msteffen) always serve on the same port for now (there shouldn't be
-	// more than one job in s.servers). When parallel jobs are implemented, the
-	// servers in s.servers won't actually serve anymore, and instead parent
-	// server will forward requests based on the request hostname
 	router := s3.Router(driver, func() (*client.APIClient, error) {
 		return s.s.apiServer.env.GetPachClient(s.s.pachClient.Ctx()), nil // clones s.pachClient
 	})

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -211,7 +211,7 @@ func TestS3Input(t *testing.T) {
 		svcs, err := k.CoreV1().Services(Namespace).List(metav1.ListOptions{})
 		require.NoError(t, err)
 		for _, s := range svcs.Items {
-			if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jobInfo.Job.ID) {
+			if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jobInfo.Job.Pipeline.Name, jobInfo.Job.ID) {
 				return errors.Errorf("service %q should be cleaned up by sidecar after job", s.ObjectMeta.Name)
 			}
 		}
@@ -345,7 +345,7 @@ func TestS3Output(t *testing.T) {
 		svcs, err := k.CoreV1().Services(Namespace).List(metav1.ListOptions{})
 		require.NoError(t, err)
 		for _, s := range svcs.Items {
-			if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jobInfo.Job.ID) {
+			if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jobInfo.Job.Pipeline.Name, jobInfo.Job.ID) {
 				return errors.Errorf("service %q should be cleaned up by sidecar after job", s.ObjectMeta.Name)
 			}
 		}
@@ -431,7 +431,7 @@ func TestFullS3(t *testing.T) {
 		svcs, err := k.CoreV1().Services(Namespace).List(metav1.ListOptions{})
 		require.NoError(t, err)
 		for _, s := range svcs.Items {
-			if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jobInfo.Job.ID) {
+			if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jobInfo.Job.Pipeline.Name, jobInfo.Job.ID) {
 				return errors.Errorf("service %q should be cleaned up by sidecar after job", s.ObjectMeta.Name)
 			}
 		}
@@ -579,7 +579,7 @@ func TestS3SkippedDatums(t *testing.T) {
 				svcs, err := k.CoreV1().Services(Namespace).List(metav1.ListOptions{})
 				require.NoError(t, err)
 				for _, s := range svcs.Items {
-					if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jis[j].Job.ID) {
+					if s.ObjectMeta.Name == ppsutil.SidecarS3GatewayService(jis[j].Job.Pipeline.Name, jis[j].Job.ID) {
 						return errors.Errorf("service %q should be cleaned up by sidecar after job", s.ObjectMeta.Name)
 					}
 				}

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -230,7 +230,7 @@ func TestS3Chain(t *testing.T) {
 	require.NoError(t, c.CreateRepo(dataRepo))
 	dataCommit := client.NewCommit(dataRepo, "master", "")
 
-	numPipelines := 10
+	numPipelines := 5
 	pipelines := make([]string, numPipelines)
 	for i := 0; i < numPipelines; i++ {
 		pipelines[i] = tu.UniqueString(t.Name())
@@ -728,7 +728,7 @@ func TestS3SkippedDatums(t *testing.T) {
 		pipelineCommit := client.NewCommit(pipeline, "master", "")
 		// Add files to 'repo'. Old files in 'repo' should be reprocessed in every
 		// job, changing the 'background' field in the output
-		for i := 1; i < 7; i++ {
+		for i := 1; i <= 5; i++ {
 			// Increment "/round" in 'background'
 			iS := strconv.Itoa(i)
 			bgc, err := c.StartCommit(background, "master")

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -664,7 +664,7 @@ func TestS3SkippedDatums(t *testing.T) {
 		pipelineCommit := client.NewCommit(pipeline, "master", "")
 		// Add files to 'repo'. Old files in 'repo' should be reprocessed in every
 		// job, changing the 'background' field in the output
-		for i := 1; i < 10; i++ {
+		for i := 1; i < 7; i++ {
 			// Increment "/round" in 'background'
 			iS := strconv.Itoa(i)
 			bgc, err := c.StartCommit(background, "master")

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -519,7 +519,7 @@ func (d *driver) UserCodeEnv(
 			result = append(
 				result,
 				fmt.Sprintf("S3_ENDPOINT=http://%s.%s:%s",
-					ppsutil.SidecarS3GatewayService(jobID),
+					ppsutil.SidecarS3GatewayService(fmt.Sprintf("%v@%v", outputCommit.Branch.Repo.Name, jobID)),
 					d.Namespace(),
 					os.Getenv("S3GATEWAY_PORT"),
 				),

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -519,7 +519,7 @@ func (d *driver) UserCodeEnv(
 			result = append(
 				result,
 				fmt.Sprintf("S3_ENDPOINT=http://%s.%s:%s",
-					ppsutil.SidecarS3GatewayService(fmt.Sprintf("%v@%v", outputCommit.Branch.Repo.Name, jobID)),
+					ppsutil.SidecarS3GatewayService(outputCommit.Branch.Repo.Name, jobID),
 					d.Namespace(),
 					os.Getenv("S3GATEWAY_PORT"),
 				),

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -49,7 +49,7 @@ func Worker(driver driver.Driver, logger logs.TaggedLogger, subtask *work.Task, 
 
 func checkS3Gateway(driver driver.Driver, logger logs.TaggedLogger) error {
 	return backoff.RetryNotify(func() error {
-		jobDomain := ppsutil.SidecarS3GatewayService(fmt.Sprintf("%v@%v", driver.PipelineInfo().Pipeline.Name, logger.JobID()))
+		jobDomain := ppsutil.SidecarS3GatewayService(driver.PipelineInfo().Pipeline.Name, logger.JobID())
 		endpoint := fmt.Sprintf("http://%s:%s/", jobDomain, os.Getenv("S3GATEWAY_PORT"))
 		_, err := (&http.Client{Timeout: 5 * time.Second}).Get(endpoint)
 		logger.Logf("checking s3 gateway service for job %q: %v", logger.JobID(), err)

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -31,7 +31,7 @@ func Worker(driver driver.Driver, logger logs.TaggedLogger, subtask *work.Task, 
 		return err
 	}
 	return status.withJob(datumSet.JobID, func() error {
-		logger = logger.WithJob(fmt.Sprintf("%v@%v", driver.PipelineInfo().Pipeline.Name, datumSet.JobID))
+		logger = logger.WithJob(datumSet.JobID)
 		if err := logger.LogStep("datum task", func() error {
 			if ppsutil.ContainsS3Inputs(driver.PipelineInfo().Details.Input) || driver.PipelineInfo().Details.S3Out {
 				if err := checkS3Gateway(driver, logger); err != nil {
@@ -49,7 +49,8 @@ func Worker(driver driver.Driver, logger logs.TaggedLogger, subtask *work.Task, 
 
 func checkS3Gateway(driver driver.Driver, logger logs.TaggedLogger) error {
 	return backoff.RetryNotify(func() error {
-		endpoint := fmt.Sprintf("http://%s:%s/", ppsutil.SidecarS3GatewayService(logger.JobID()), os.Getenv("S3GATEWAY_PORT"))
+		jobDomain := ppsutil.SidecarS3GatewayService(fmt.Sprintf("%v@%v", driver.PipelineInfo().Pipeline.Name, logger.JobID()))
+		endpoint := fmt.Sprintf("http://%s:%s/", jobDomain, os.Getenv("S3GATEWAY_PORT"))
 		_, err := (&http.Client{Timeout: 5 * time.Second}).Get(endpoint)
 		logger.Logf("checking s3 gateway service for job %q: %v", logger.JobID(), err)
 		return err

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -31,7 +31,7 @@ func Worker(driver driver.Driver, logger logs.TaggedLogger, subtask *work.Task, 
 		return err
 	}
 	return status.withJob(datumSet.JobID, func() error {
-		logger = logger.WithJob(datumSet.JobID)
+		logger = logger.WithJob(fmt.Sprintf("%v@%v", driver.PipelineInfo().Pipeline.Name, datumSet.JobID))
 		if err := logger.LogStep("datum task", func() error {
 			if ppsutil.ContainsS3Inputs(driver.PipelineInfo().Details.Input) || driver.PipelineInfo().Details.S3Out {
 				if err := checkS3Gateway(driver, logger); err != nil {


### PR DESCRIPTION
Changes:

1) Now that it's possible for multiple Pipeline Jobs to exist at the same time, we cannot represent each S3G endpoint as its own Server with its own port. Instead we now keep a mapping of mux router objects that are used by the server to serve the corresponding s3 endpoints

2) S3_ENDPOINT usr container environment variable now resolves to a Global-ID compatible Job ID (pipeline@id).
- ex. http://s3-pipeline-id:1600