### PR TITLE
Request pipeline details for metrics.

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -31,6 +31,10 @@ const (
 	// string (with this prefix) is a logical Pachyderm robot user.
 	RobotPrefix = "robot:"
 
+	// InternalPrefix indicates that this Subject is internal to Pachyderm itself,
+	// created to run a background task
+	InternalPrefix = "internal:"
+
 	// PipelinePrefix indicates that this Subject is a PPS pipeline. Any string
 	// (with this prefix) is a logical PPS pipeline (even though the pipeline may
 	// not exist).

--- a/src/internal/internal.go
+++ b/src/internal/internal.go
@@ -1,0 +1,98 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/gogo/protobuf/types"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/ppsconsts"
+	"github.com/pachyderm/pachyderm/v2/src/internal/tarutil"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
+)
+
+type fakeStream struct {
+	ctx context.Context
+}
+
+func (f fakeStream) SetHeader(metadata.MD) error  { return nil }
+func (f fakeStream) SendHeader(metadata.MD) error { return nil }
+func (f fakeStream) SetTrailer(metadata.MD)       {}
+func (f fakeStream) Context() context.Context     { return f.ctx }
+func (f fakeStream) SendMsg(_ interface{}) error  { return nil }
+func (f fakeStream) RecvMsg(_ interface{}) error  { return nil }
+
+func (f *fakeStream) SetContext(ctx context.Context) { f.ctx = ctx }
+
+type repoLister struct {
+	fakeStream
+	list []*pfs.RepoInfo
+}
+
+func (l *repoLister) Send(info *pfs.RepoInfo) error {
+	l.list = append(l.list, info)
+	return nil
+}
+
+func ListRepo(ctx context.Context, server pfs.APIServer, req *pfs.ListRepoRequest) ([]*pfs.RepoInfo, error) {
+	var lister repoLister
+	lister.SetContext(ctx)
+	if err := server.ListRepo(req, &lister); err != nil {
+		return nil, err
+	}
+	return lister.list, nil
+}
+
+type pipelineLister struct {
+	fakeStream
+	list []*pps.PipelineInfo
+}
+
+func (l *pipelineLister) Send(info *pps.PipelineInfo) error {
+	l.list = append(l.list, info)
+	return nil
+}
+
+func ListPipeline(ctx context.Context, server pps.APIServer, req *pps.ListPipelineRequest) ([]*pps.PipelineInfo, error) {
+	var lister pipelineLister
+	lister.SetContext(ctx)
+	if err := server.ListPipeline(req, &lister); err != nil {
+		return nil, err
+	}
+	return lister.list, nil
+}
+
+type fileGetter struct {
+	fakeStream
+	buffer bytes.Buffer
+}
+
+func (g *fileGetter) Send(bytes *types.BytesValue) error {
+	_, err := g.buffer.Write(bytes.Value)
+	return err // always nil
+}
+
+func GetPipelineDetails(ctx context.Context, apiServer pfs.APIServer, info *pps.PipelineInfo) error {
+	var getter fileGetter
+	getter.SetContext(ctx)
+	if err := apiServer.GetFileTAR(&pfs.GetFileRequest{File: info.SpecCommit.NewFile(ppsconsts.SpecFile)}, &getter); err != nil {
+		return err
+	}
+	var file bytes.Buffer
+	if err := tarutil.Iterate(&getter.buffer, func(f tarutil.File) error {
+		return f.Content(&file)
+	}); err != nil {
+		return err
+	}
+
+	loadedPipelineInfo := &pps.PipelineInfo{}
+	if err := loadedPipelineInfo.Unmarshal(file.Bytes()); err != nil {
+		return errors.Wrapf(err, "could not unmarshal PipelineInfo bytes from PFS")
+	}
+	info.Version = loadedPipelineInfo.Version
+	info.Details = loadedPipelineInfo.Details
+	return nil
+}

--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
-	"github.com/pachyderm/pachyderm/v2/src/internal/clientsdk"
+	"github.com/pachyderm/pachyderm/v2/src/internal"
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -251,11 +251,7 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 
 	// Pipeline info
 	if err := func() error {
-		lpClient, err := r.env.GetPachClient(ctx).PpsAPIClient.ListPipeline(ctx, &pps.ListPipelineRequest{Details: false})
-		if err != nil {
-			return err
-		}
-		pipelineInfos, err := clientsdk.ListPipelineInfo(lpClient)
+		pipelineInfos, err := internal.ListPipeline(ctx, r.env.PpsServer(), &pps.ListPipelineRequest{Details: true})
 		if err != nil {
 			return err
 		}
@@ -354,11 +350,7 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 	}
 
 	if err := func() error {
-		rClient, err := r.env.GetPachClient(ctx).PfsAPIClient.ListRepo(ctx, &pfs.ListRepoRequest{})
-		if err != nil {
-			return err
-		}
-		repoInfos, err := clientsdk.ListRepoInfo(rClient)
+		repoInfos, err := internal.ListRepo(ctx, r.env.PfsServer(), &pfs.ListRepoRequest{Type: pfs.UserRepoType})
 		if err != nil {
 			return err
 		}

--- a/src/internal/middleware/auth/handler.go
+++ b/src/internal/middleware/auth/handler.go
@@ -79,11 +79,11 @@ func setWhoAmI(ctx context.Context, username string) context.Context {
 	return context.WithValue(ctx, whoAmIResultKey, username)
 }
 
-// AsInternalUser gives a context's a cached whoami username of form internal:<name>. It also
-// strips away existing incoming metadata to add an empty auth token. As a result, this context will
-// not be able to make additional gRPCs
+// AsInternalUser should never be used during user requests, only internal background jobs.
+// It gives a context a cached whoami username of form internal:<name>. It also overwrites
+// any existing metadata. As a result, this context may not be able to make additional gRPCs.
 func AsInternalUser(ctx context.Context, username string) context.Context {
-	emptyToken := metadata.New(map[string]string{auth.ContextTokenKey: ""})
-	ctx = metadata.NewIncomingContext(ctx, emptyToken)
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{})
+	ctx = metadata.NewOutgoingContext(ctx, metadata.MD{})
 	return context.WithValue(ctx, whoAmIResultKey, auth.InternalPrefix+strings.TrimPrefix(username, auth.InternalPrefix))
 }

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -119,8 +119,6 @@ func GetLimitsResourceList(limits *pps.ResourceSpec) (*v1.ResourceList, error) {
 func GetPipelineDetails(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo) error {
 	// ensure we are authorized to read the pipeline's spec commit, but don't propagate that back out
 	pachClient = pachClient.WithCtx(pachClient.Ctx())
-	pachClient.SetAuthToken(pipelineInfo.AuthToken)
-
 	buf := bytes.Buffer{}
 	if err := pachClient.GetFile(pipelineInfo.SpecCommit, ppsconsts.SpecFile, &buf); err != nil {
 		return errors.Wrapf(err, "could not retrieve pipeline spec file from PFS for pipeline '%s'", pipelineInfo.Pipeline.Name)

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1215,16 +1215,17 @@ func (a *apiServer) getAuthenticatedUser(ctx context.Context) (*auth.TokenInfo, 
 		return nil, err
 	}
 
-	token, err := auth.GetAuthToken(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// try to lookup pre-computed subject
 	if subject := internalauth.GetWhoAmI(ctx); subject != "" {
 		return &auth.TokenInfo{
 			Subject: subject,
 		}, nil
+	}
+
+	// otherwise, we need a token
+	token, err := auth.GetAuthToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	tokenInfo, lookupErr := a.lookupAuthTokenInfo(ctx, auth.HashToken(token))

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	internalauth "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing/extended"
@@ -33,6 +34,8 @@ const (
 	noRCExpected
 	rcExpected
 )
+
+const controllerUsername = "pipeline-controller"
 
 func max(is ...int) int {
 	if len(is) == 0 {
@@ -120,7 +123,7 @@ func (m *ppsMaster) step(pipeline string, keyVer, keyRev int64) (retErr error) {
 func (m *ppsMaster) newPipelineOp(ctx context.Context, pipeline string) (*pipelineOp, error) {
 	op := &pipelineOp{
 		m:            m,
-		ctx:          ctx,
+		ctx:          internalauth.AsInternalUser(ctx, controllerUsername),
 		pipelineInfo: &pps.PipelineInfo{},
 	}
 	// get latest PipelineInfo (events can pile up, so that the current state

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dlock"
@@ -66,7 +67,7 @@ func (a *apiServer) ServeSidecarS3G() {
 		// auth is off)
 		s.pachClient.SetAuthToken(s.pipelineInfo.AuthToken)
 
-		if err := ppsutil.GetPipelineDetails(s.pachClient, s.pipelineInfo); err != nil {
+		if err := internal.GetPipelineDetails(s.pachClient.Ctx(), a.env.PfsServer(), s.pipelineInfo); err != nil {
 			return errors.Wrapf(err, "sidecar s3 gateway: could not get pipeline details")
 		}
 		return nil


### PR DESCRIPTION
Fix #6485 

I guess we don't support the old "allow incomplete" behavior from before, which would have allowed retrieving whatever details we could rather than all or nothing.