### PR TITLE
Set WORKER_USES_ROOT to false by default

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -73,6 +73,8 @@ spec:
           {{- end }}
         - name: WORKER_IMAGE
           value: "{{ .Values.worker.image.repository }}:{{ default .Chart.AppVersion .Values.pachd.image.tag }}"
+        - name: WORKER_USES_ROOT
+          value: {{ .Values.worker.usesRoot }} | quote }}
         - name: IMAGE_PULL_SECRET
           value: {{ .Values.imagePullSecret | quote }}
         - name: WORKER_SIDECAR_IMAGE

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -553,6 +553,9 @@
                         },
                         "repository": {
                             "type": "string"
+                        },
+                        "usesRoot": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -337,6 +337,7 @@ worker:
     # name sets the name of the worker service account.  Analogous to
     # the --worker-service-account argument to pachctl deploy.
     name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
+  usesRoot: false
 
 postgresql:
   # Set to false if you are bringing your own PostgreSQL instance. PostgreSQL is a requirement for Pachyderm.

--- a/src/internal/deploy/assets/assets.go
+++ b/src/internal/deploy/assets/assets.go
@@ -550,6 +550,7 @@ func PachdDeployment(opts *AssetOpts, objectStoreBackend Backend, hostPath strin
 		{Name: "WORKER_IMAGE_PULL_POLICY", Value: "IfNotPresent"},
 		{Name: WorkerServiceAccountEnvVar, Value: opts.WorkerServiceAccountName},
 		{Name: "METRICS", Value: strconv.FormatBool(opts.Metrics)},
+		{Name: "WORKER_USES_ROOT", Value: strconv.FormatBool(opts.RunAsRoot)},
 		{Name: "LOG_LEVEL", Value: opts.LogLevel},
 		{
 			Name: "PACH_NAMESPACE",

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -79,7 +79,7 @@ type PachdSpecificConfiguration struct {
 	WorkerImagePullPolicy      string `env:"WORKER_IMAGE_PULL_POLICY,default="`
 	ImagePullSecret            string `env:"IMAGE_PULL_SECRET,default="`
 	MemoryRequest              string `env:"PACHD_MEMORY_REQUEST,default=1T"`
-	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=true"`
+	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=false"`
 	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY,default=false"`
 	// TODO: Merge this with the worker specific pod name (PPS_POD_NAME) into a global configuration pod name.
 	PachdPodName string `env:"PACHD_POD_NAME,required"`

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9620,7 +9620,11 @@ func TestNonrootPipeline(t *testing.T) {
 			Input:        client.NewPFSInput(dataRepo, "/*"),
 			OutputBranch: "",
 			Update:       false,
-			PodPatch:     `[{"op": "add",  "path": "/securityContext/runAsUser",  "value": 1000}]`,
+			PodPatch: `[
+				{"op": "add",  "path": "/securityContext",  "value": {}},
+				{"op": "add",  "path": "/securityContext/runAsUser",  "value": 1000}
+			]`,
+			Autoscaling: false,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
By default in 1.x we set a security context on all worker pods to force them to run as root, which breaks OpenShift and seems like overkill generally - we only _need_ to run as root for local deploys where we're using a hostpath. 

We'll need to expose this in the helm chart as well.