### PR TITLE
pachctl deploy aws handles lack of credentials for S3 in enterprise deploy

### DIFF
--- a/src/internal/deploy/assets/assets.go
+++ b/src/internal/deploy/assets/assets.go
@@ -1056,7 +1056,7 @@ func WriteAmazonAssets(encoder serde.Encoder, opts *AssetOpts, region string, bu
 		return err
 	}
 	var secret map[string][]byte
-	if creds.ID != "" {
+	if creds != nil && creds.ID != "" {
 		secret = AmazonSecret(region, bucket, creds.ID, creds.Secret, creds.Token, cloudfrontDistro, "", advancedConfig)
 	}
 	return WriteSecret(encoder, secret, opts)

--- a/src/internal/deploy/cmds/cmds.go
+++ b/src/internal/deploy/cmds/cmds.go
@@ -639,7 +639,7 @@ If <object store backend> is \"s3\", then the arguments are:
 			// Require credentials to access S3 for pachd deployments.
 			// Enterprise server deployments don't require an S3 bucket, so they don't need credentials.
 			if creds == "" && !enterpriseServer {
-				return errors.Errorf("one of --credentials, or --iam-role needs to be provided")
+				return errors.Errorf("--credentials needs to be provided")
 			}
 
 			// populate 'amazonCreds' & validate


### PR DESCRIPTION
Resolves #6497 and #6499

pachctl deploy is deprecated in favour of the helm chart, but these were so simple to fix I just went ahead and did it.