### PR TITLE
Stop pipeline during deletion.

### DIFF
--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2428,7 +2428,7 @@ func TestDeletePipelineMissingInput(t *testing.T) {
 		false,
 	))
 
-	// force-delete input and output repos
+	// force-delete input repo
 	require.NoError(t, aliceClient.DeleteRepo(repo, true))
 
 	// Attempt to delete the pipeline--must succeed

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -983,10 +983,14 @@ func TestStopAndDeletePipeline(t *testing.T) {
 		buildBindings(alice, auth.RepoOwnerRole, bob, auth.RepoWriterRole, pl(pipeline), auth.RepoWriterRole),
 		getRepoRoleBinding(t, aliceClient, pipeline))
 
-	// bob still can't stop or delete alice's pipeline
-	require.NoError(t,  bobClient.StopPipeline(pipeline))
-	require.NoError(t,  bobClient.DeletePipeline(pipeline, false))
-
+	// bob can now stop the pipeline, but can't start or delete it
+	require.NoError(t, bobClient.StopPipeline(pipeline))
+	err = bobClient.StartPipeline(pipeline)
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
+	err = bobClient.DeletePipeline(pipeline, false)
+	require.YesError(t, err)
+	require.Matches(t, "not authorized", err.Error())
 	// alice re-adds bob as a reader of the input repo
 	require.NoError(t, aliceClient.ModifyRepoRoleBinding(repo, bob, []string{auth.RepoReaderRole}))
 	require.Equal(t,

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -984,12 +984,8 @@ func TestStopAndDeletePipeline(t *testing.T) {
 		getRepoRoleBinding(t, aliceClient, pipeline))
 
 	// bob still can't stop or delete alice's pipeline
-	err = bobClient.StopPipeline(pipeline)
-	require.YesError(t, err)
-	require.Matches(t, "not authorized", err.Error())
-	err = bobClient.DeletePipeline(pipeline, false)
-	require.YesError(t, err)
-	require.Matches(t, "not authorized", err.Error())
+	require.NoError(t,  bobClient.StopPipeline(pipeline))
+	require.NoError(t,  bobClient.DeletePipeline(pipeline, false))
 
 	// alice re-adds bob as a reader of the input repo
 	require.NoError(t, aliceClient.ModifyRepoRoleBinding(repo, bob, []string{auth.RepoReaderRole}))

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -983,11 +983,9 @@ func TestStopAndDeletePipeline(t *testing.T) {
 		buildBindings(alice, auth.RepoOwnerRole, bob, auth.RepoWriterRole, pl(pipeline), auth.RepoWriterRole),
 		getRepoRoleBinding(t, aliceClient, pipeline))
 
-	// bob can now stop the pipeline, but can't start or delete it
+	// bob can now start and stop the pipeline, but can't delete it
 	require.NoError(t, bobClient.StopPipeline(pipeline))
-	err = bobClient.StartPipeline(pipeline)
-	require.YesError(t, err)
-	require.Matches(t, "not authorized", err.Error())
+	require.NoError(t, bobClient.StartPipeline(pipeline))
 	err = bobClient.DeletePipeline(pipeline, false)
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
@@ -997,11 +995,9 @@ func TestStopAndDeletePipeline(t *testing.T) {
 		buildBindings(alice, auth.RepoOwnerRole, bob, auth.RepoReaderRole, pl(pipeline), auth.RepoReaderRole),
 		getRepoRoleBinding(t, aliceClient, repo))
 
-	// bob can stop (and start) but not delete alice's pipeline
-	err = bobClient.StopPipeline(pipeline)
-	require.NoError(t, err)
-	err = bobClient.StartPipeline(pipeline)
-	require.NoError(t, err)
+	// no change to bob's capabilities
+	require.NoError(t, bobClient.StopPipeline(pipeline))
+	require.NoError(t, bobClient.StartPipeline(pipeline))
 	err = bobClient.DeletePipeline(pipeline, false)
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
@@ -1012,9 +1008,7 @@ func TestStopAndDeletePipeline(t *testing.T) {
 		buildBindings(alice, auth.RepoOwnerRole, bob, auth.RepoOwnerRole, pl(pipeline), auth.RepoWriterRole),
 		getRepoRoleBinding(t, aliceClient, pipeline))
 
-	// finally bob can stop and delete alice's pipeline
-	err = bobClient.StopPipeline(pipeline)
-	require.NoError(t, err)
+	// finally bob can delete alice's pipeline
 	err = bobClient.DeletePipeline(pipeline, false)
 	require.NoError(t, err)
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9632,7 +9632,6 @@ func TestRewindCrossPipeline(t *testing.T) {
 	_, err = c.WaitCommit(pipeline, "master", "")
 	require.NoError(t, err)
 
-	fmt.Println("moving to ", oldCommit)
 	// now, move dataRepo back to the saved commit
 	require.NoError(t, c.CreateBranch(dataRepo, "master", "master", oldCommit.Commit.ID, nil))
 	_, err = c.WaitCommit(pipeline, "master", "")

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -567,7 +567,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 	if commitInfo.Origin.Kind == pfs.OriginKind_ALIAS {
 		return errors.Errorf("cannot finish an alias commit: %s", commitInfo.Commit)
 	}
-	if !force {
+	if !force && len(commitInfo.DirectProvenance) > 0 {
 		if info, err := d.env.PpsServer().InspectPipelineInTransaction(txnCtx,
 			commit.Branch.Repo.Name, false,
 		); err != nil && !errutil.IsNotFoundError(err) {

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5751,16 +5751,16 @@ func TestPFS(suite *testing.T) {
 
 		// can't create system repo by itself
 		_, err := env.PachClient.PfsAPIClient.CreateRepo(env.Context, &pfs.CreateRepoRequest{
-			Repo: sysRepo ,
+			Repo: sysRepo,
 		})
-		require.YesError(t,err)
+		require.YesError(t, err)
 
 		require.NoError(t, env.PachClient.CreateRepo("test"))
 		// but now we can
 		_, err = env.PachClient.PfsAPIClient.CreateRepo(env.Context, &pfs.CreateRepoRequest{
 			Repo: sysRepo,
 		})
-		require.NoError(t,err)
+		require.NoError(t, err)
 
 		require.NoError(t, env.PachClient.DeleteRepo("test", false))
 
@@ -5771,7 +5771,6 @@ func TestPFS(suite *testing.T) {
 		require.YesError(t, err)
 		require.True(t, errutil.IsNotFoundError(err))
 	})
-})
 }
 
 var (

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5747,7 +5747,7 @@ func TestPFS(suite *testing.T) {
 		t.Parallel()
 		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
 
-		sysRepo := client.NewSystemRepo("fail", pfs.MetaRepoType)
+		sysRepo := client.NewSystemRepo("test", pfs.MetaRepoType)
 
 		// can't create system repo by itself
 		_, err := env.PachClient.PfsAPIClient.CreateRepo(env.Context, &pfs.CreateRepoRequest{

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -17,4 +17,5 @@ type APIServer interface {
 	StopJobInTransaction(*txncontext.TransactionContext, *pps_client.StopJobRequest) error
 	UpdateJobStateInTransaction(*txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
 	CreatePipelineInTransaction(*txncontext.TransactionContext, *pps_client.CreatePipelineRequest, *string, *uint64) error
+	InspectPipelineInTransaction(*txncontext.TransactionContext, string, bool) (*pps_client.PipelineInfo, error)
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2327,7 +2327,7 @@ func (a *apiServer) inspectPipeline(ctx context.Context, name string, details bo
 	var response *pps.PipelineInfo
 	if err := a.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		response, err = a.inspectPipelineInTransaction(txnCtx, name, details)
+		response, err = a.InspectPipelineInTransaction(txnCtx, name, details)
 		return err
 	}); err != nil {
 		return nil, err
@@ -2335,7 +2335,7 @@ func (a *apiServer) inspectPipeline(ctx context.Context, name string, details bo
 	return response, nil
 }
 
-func (a *apiServer) inspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, name string, details bool) (*pps.PipelineInfo, error) {
+func (a *apiServer) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, name string, details bool) (*pps.PipelineInfo, error) {
 	kubeClient := a.env.GetKubeClient()
 	name, ancestors, err := ancestry.Parse(name)
 	if err != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2742,7 +2742,9 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 			Repo: client.NewRepo(request.Pipeline.Name),
 		}); err == nil {
 			// check if the caller is authorized to update this pipeline
-			if err := a.authorizePipelineOpInTransaction(txnCtx, pipelineOpUpdate, pipelineInfo.Details.Input, pipelineInfo.Pipeline.Name); err != nil {
+			// don't pass in the input - stopping the pipeline means they won't be read anymore,
+			// so we don't need to check any permissions
+			if err := a.authorizePipelineOpInTransaction(txnCtx, pipelineOpUpdate, nil, pipelineInfo.Pipeline.Name); err != nil {
 				return err
 			}
 

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -425,8 +425,7 @@ func (a *apiServer) authorizePipelineOpInTransaction(txnCtx *txncontext.Transact
 			}
 		case pipelineOpListDatum, pipelineOpGetLogs:
 			required = auth.Permission_REPO_READ
-		case pipelineOpUpdate:
-		case pipelineOpStartStop:
+		case pipelineOpUpdate, pipelineOpStartStop:
 			required = auth.Permission_REPO_WRITE
 		case pipelineOpDelete:
 			if _, err := a.env.PfsServer().InspectRepoInTransaction(txnCtx, &pfs.InspectRepoRequest{

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2756,7 +2756,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 			// check if the caller is authorized to update this pipeline
 			// don't pass in the input - stopping the pipeline means they won't be read anymore,
 			// so we don't need to check any permissions
-			if err := a.authorizePipelineOpInTransaction(txnCtx, pipelineOpStartStop, pipelineInfo.Details.Input., pipelineInfo.Pipeline.Name); err != nil {
+			if err := a.authorizePipelineOpInTransaction(txnCtx, pipelineOpStartStop, pipelineInfo.Details.Input, pipelineInfo.Pipeline.Name); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
In some of our tests, we delete a pipline which has commits being
created very frequently. Deleting a pipeline output repo can end up
being a large transaction, which can lead to DeleteAll hanging.