### PR TITLE
Maintain crashing monitor in CRASHING state.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4727,7 +4727,6 @@ func TestPipelineCrashing(t *testing.T) {
 		if pi.State != pps.PipelineState_PIPELINE_RUNNING {
 			return errors.Errorf("pipeline in wrong state: %s", pi.State.String())
 		}
-		require.True(t, pi.Reason != "")
 		return nil
 	}, backoff.NewTestingBackOff()))
 }

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -769,7 +769,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		EOF
 		`).Run())
 
-	require.NoErrorWithinT(t, 10*time.Second, func() error {
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
 		| match 'name: my-pipeline' \
@@ -782,7 +782,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		kubectl uncordon minikube
 	`).Run())
 
-	require.NoErrorWithinT(t, 10*time.Second, func() error {
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
 		| match 'name: my-pipeline' \

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -777,7 +777,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		`).Run()
 	})
 
-	// prevent new pods from being scheduled
+	// allow new pods to be scheduled
 	require.NoError(t, tu.BashCmd(`
 		kubectl uncordon minikube
 	`).Run())

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -772,8 +772,8 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
-		| match 'name: my-pipeline' \
-		| match 'crashing'
+		| match my-pipeline \
+		| match crashing
 		`).Run()
 	})
 
@@ -785,8 +785,8 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
-		| match 'name: my-pipeline' \
-		| match 'running'
+		| match my-pipeline \
+		| match running
 		`).Run()
 	})
 }

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -231,8 +231,8 @@ func (op *pipelineOp) run() error {
 			return op.setPipelineState(pps.PipelineState_PIPELINE_PAUSED, "")
 		}
 		// start a monitor to poll k8s and update us when it goes into a running state
-		op.startCrashingPipelineMonitor()
 		op.startPipelineMonitor()
+		op.startCrashingPipelineMonitor()
 		// Surprisingly, scaleUpPipeline() is necessary, in case a pipelines is
 		// quickly transitioned to CRASHING after coming out of STANDBY. Because the
 		// pipeline controller reads the current state of the pipeline after each

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -410,7 +410,6 @@ func (op *pipelineOp) createPipelineResources() error {
 // updates the the pipeline state.
 // Note: this is called by every run through step(), so must be idempotent
 func (op *pipelineOp) startPipelineMonitor() {
-	op.stopCrashingPipelineMonitor()
 	op.m.startMonitor(op.pipelineInfo)
 	op.pipelineInfo.Details.WorkerRc = op.rc.ObjectMeta.Name
 }


### PR DESCRIPTION
Fixes #6513 
Need to figure out a way to test this, would have to delay a pod's startup/make it stop crashing without updating the pipeline. 