### PR TITLE
Change worker_uses_root env var to follow pachd.storage.local.requireRoot

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -73,8 +73,10 @@ spec:
           {{- end }}
         - name: WORKER_IMAGE
           value: "{{ .Values.worker.image.repository }}:{{ default .Chart.AppVersion .Values.pachd.image.tag }}"
+        {{- if and (eq .Values.deployTarget "LOCAL") .Values.pachd.storage.local.requireRoot }}
         - name: WORKER_USES_ROOT
-          value: {{ .Values.worker.usesRoot | quote }}
+          value: "True"
+        {{- end }}
         - name: IMAGE_PULL_SECRET
           value: {{ .Values.imagePullSecret | quote }}
         - name: WORKER_SIDECAR_IMAGE

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -553,9 +553,6 @@
                         },
                         "repository": {
                             "type": "string"
-                        },
-                        "usesRoot": {
-                            "type": "boolean"
                         }
                     }
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -338,7 +338,6 @@ worker:
     # name sets the name of the worker service account.  Analogous to
     # the --worker-service-account argument to pachctl deploy.
     name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
-  usesRoot: false
 
 postgresql:
   # Set to false if you are bringing your own PostgreSQL instance. PostgreSQL is a requirement for Pachyderm.


### PR DESCRIPTION
Since root is required locally to write to `hostPath` synchronize both pach and workers to use the same value.

Fixes issue where local workloads would not work by default and required `usesRoot` to be set to true manually