### PR TITLE
Fix metrics pipeline details

### DIFF
--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -251,7 +251,7 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 
 	// Pipeline info
 	if err := func() error {
-		lpClient, err := r.env.GetPachClient(ctx).PpsAPIClient.ListPipeline(ctx, &pps.ListPipelineRequest{Details: true})
+		lpClient, err := r.env.GetPachClient(ctx).PpsAPIClient.ListPipeline(ctx, &pps.ListPipelineRequest{Details: false})
 		if err != nil {
 			return err
 		}

--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -251,7 +251,7 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 
 	// Pipeline info
 	if err := func() error {
-		lpClient, err := r.env.GetPachClient(ctx).PpsAPIClient.ListPipeline(ctx, &pps.ListPipelineRequest{Details: false})
+		lpClient, err := r.env.GetPachClient(ctx).PpsAPIClient.ListPipeline(ctx, &pps.ListPipelineRequest{Details: true})
 		if err != nil {
 			return err
 		}
@@ -261,18 +261,6 @@ func (r *Reporter) internalMetrics(metrics *Metrics) {
 		}
 		metrics.Pipelines = int64(len(pipelineInfos)) // Number of pipelines
 		for _, pi := range pipelineInfos {
-			if pi.Details.ParallelismSpec != nil {
-				if metrics.MaxParallelism < pi.Details.ParallelismSpec.Constant {
-					metrics.MaxParallelism = pi.Details.ParallelismSpec.Constant
-				}
-				if metrics.MinParallelism > pi.Details.ParallelismSpec.Constant {
-					metrics.MinParallelism = pi.Details.ParallelismSpec.Constant
-				}
-				metrics.NumParallelism++
-			}
-			if pi.Details.Egress != nil {
-				metrics.CfgEgress++
-			}
 			if pi.JobCounts != nil {
 				var cnt int64 = 0
 				for _, c := range pi.JobCounts {


### PR DESCRIPTION
The list pipeline call in the metrics collection was not collecting the details which was causing a panic when attempting to access the details field. Also, the place where the details field was being accessed is a duplicate of what is captured in a block that protects against the details field being nil. We need to invest some time in making metrics collection unit testable, or at least add some tests that will hit the metrics collection code path to avoid these issues.

Fixes: #6543