### PR TITLE
Rewrites Local Object Client

### DIFF
--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -20,7 +20,8 @@ sudo apt-get install -y -qq \
 
 ## Install Go
 wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz 
-sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 
 # Install fuse
 sudo modprobe fuse

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -18,11 +18,6 @@ sudo apt-get install -y -qq \
   shellcheck \
   docker-ce-cli
 
-## Install Go
-wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz 
-sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
-
 # Install fuse
 sudo modprobe fuse
 sudo chmod 666 /dev/fuse

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -19,8 +19,8 @@ sudo apt-get install -y -qq \
   docker-ce-cli
 
 ## Install Go
-wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz 
-rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz 
+sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 
 # Install fuse
 sudo modprobe fuse

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -18,6 +18,10 @@ sudo apt-get install -y -qq \
   shellcheck \
   docker-ce-cli
 
+## Install Go
+wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz 
+rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
+
 # Install fuse
 sudo modprobe fuse
 sudo chmod 666 /dev/fuse

--- a/src/internal/obj/monkey_client.go
+++ b/src/internal/obj/monkey_client.go
@@ -86,3 +86,7 @@ func (c *monkeyClient) Exists(ctx context.Context, path string) (bool, error) {
 	}
 	return c.c.Exists(ctx, path)
 }
+
+func (c *monkeyClient) BucketURL() string {
+	return c.c.(interface{ BucketURL() string }).BucketURL()
+}

--- a/src/internal/obj/uniform_client.go
+++ b/src/internal/obj/uniform_client.go
@@ -68,3 +68,7 @@ func (uc *uniformClient) Exists(ctx context.Context, p string) (_ bool, retErr e
 	}
 	return exists, err
 }
+
+func (uc *uniformClient) BucketURL() string {
+	return uc.c.(interface{ BucketURL() string }).BucketURL()
+}

--- a/src/internal/testutil/obj.go
+++ b/src/internal/testutil/obj.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
@@ -13,5 +12,5 @@ func NewObjectClient(t testing.TB) (obj.Client, string) {
 	dir := t.TempDir()
 	objC, err := obj.NewLocalClient(dir)
 	require.NoError(t, err)
-	return objC, strings.ReplaceAll(strings.Trim(dir, "/"), "/", ".")
+	return objC, objC.(interface{ BucketURL() string }).BucketURL()
 }

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4535,9 +4535,10 @@ func TestPFS(suite *testing.T) {
 			require.NoError(t, env.PachClient.PutFile(commit, path, strings.NewReader(path)))
 		}
 		check := func() {
-			objC, bucket := tu.NewObjectClient(t)
+			objC, _ := tu.NewObjectClient(t)
 			for _, path := range paths {
-				url := fmt.Sprintf("local://%s/", bucket)
+				getURL := objC.(interface{ BucketURL() string })
+				url := getURL.BucketURL()
 				require.NoError(t, env.PachClient.GetFileURL(commit, path, url))
 			}
 			for _, path := range paths {

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4535,11 +4535,9 @@ func TestPFS(suite *testing.T) {
 			require.NoError(t, env.PachClient.PutFile(commit, path, strings.NewReader(path)))
 		}
 		check := func() {
-			objC, _ := tu.NewObjectClient(t)
+			objC, bucketURL := tu.NewObjectClient(t)
 			for _, path := range paths {
-				getURL := objC.(interface{ BucketURL() string })
-				url := getURL.BucketURL()
-				require.NoError(t, env.PachClient.GetFileURL(commit, path, url))
+				require.NoError(t, env.PachClient.GetFileURL(commit, path, bucketURL))
 			}
 			for _, path := range paths {
 				buf := &bytes.Buffer{}


### PR DESCRIPTION
Rewrites the local object client to fix a few issues:
- It was impossible to have an object at a path containing a slash, and any other object at a path having the first path as a prefix.  This is now fixed by base64 encoding the paths.
- Concurrent access to the store had the possibility to return partially written files.  This is fixed by writing to a staging area under a UUID and then renaming the completed file into it's final place.

The staging area is cleared during client initialization.  So "turn it off and on again" will be an available strategy for troubleshooting.