### PR TITLE
Improve PFS collection error messages.

### DIFF
--- a/src/internal/collection/errors.go
+++ b/src/internal/collection/errors.go
@@ -10,8 +10,9 @@ import (
 // ErrNotFound indicates that a key was not found when it was expected to
 // exist.
 type ErrNotFound struct {
-	Type string
-	Key  string
+	Type          string
+	Key           string
+	customMessage string
 }
 
 func (err ErrNotFound) Is(other error) bool {
@@ -20,6 +21,9 @@ func (err ErrNotFound) Is(other error) bool {
 }
 
 func (err ErrNotFound) Error() string {
+	if err.customMessage != "" {
+		return err.customMessage
+	}
 	return fmt.Sprintf("%s %s not found", strings.TrimPrefix(err.Type, DefaultPrefix), err.Key)
 }
 
@@ -31,8 +35,9 @@ func IsErrNotFound(err error) bool {
 // ErrExists indicates that a key was found to exist when it was expected not
 // to.
 type ErrExists struct {
-	Type string
-	Key  string
+	Type          string
+	Key           string
+	customMessage string
 }
 
 func (err ErrExists) Is(other error) bool {
@@ -41,6 +46,9 @@ func (err ErrExists) Is(other error) bool {
 }
 
 func (err ErrExists) Error() string {
+	if err.customMessage != "" {
+		return err.customMessage
+	}
 	return fmt.Sprintf("%s %s already exists", strings.TrimPrefix(err.Type, DefaultPrefix), err.Key)
 }
 

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -59,15 +59,15 @@ func WithKeyGen(gen func(interface{}) (string, error)) Option {
 	}
 }
 
-func WithExistsMessage(convert func(interface{}) string) Option {
+func WithExistsMessage(format func(interface{}) string) Option {
 	return func(c *postgresCollection) {
-		c.exists = convert
+		c.exists = format
 	}
 }
 
-func WithNotFoundMessage(convert func(interface{}) string) Option {
+func WithNotFoundMessage(format func(interface{}) string) Option {
 	return func(c *postgresCollection) {
-		c.notFound = convert
+		c.notFound = format
 	}
 }
 

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -65,7 +65,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*sqlx.DB, col.Po
 	return func(ctx context.Context, t *testing.T) (ReadCallback, WriteCallback) {
 		db, listener := setup(ctx, t)
 
-		testCol := col.NewPostgresCollection("test_items", db, listener, &col.TestItem{}, []*col.Index{TestSecondaryIndex}, nil)
+		testCol := col.NewPostgresCollection("test_items", db, listener, &col.TestItem{}, []*col.Index{TestSecondaryIndex})
 		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *sqlx.Tx) error {
 			return col.SetupPostgresCollections(ctx, sqlTx, testCol)
 		}))

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -72,16 +72,16 @@ type Index struct {
 // ReadWriteCollection is a collection interface that supports read,write and delete
 // operations.
 type ReadWriteCollection interface {
-	Get(key string, val proto.Message) error
-	Put(key string, val proto.Message) error
+	Get(key interface{}, val proto.Message) error
+	Put(key interface{}, val proto.Message) error
 	// Update reads the current value associated with 'key', calls 'f' to update
 	// the value, and writes the new value back to the collection. 'key' must be
 	// present in the collection, or a 'Not Found' error is returned
-	Update(key string, val proto.Message, f func() error) error
+	Update(key interface{}, val proto.Message, f func() error) error
 	// Upsert is like Update but 'key' is not required to be present
-	Upsert(key string, val proto.Message, f func() error) error
-	Create(key string, val proto.Message) error
-	Delete(key string) error
+	Upsert(key interface{}, val proto.Message, f func() error) error
+	Create(key interface{}, val proto.Message) error
+	Delete(key interface{}) error
 	DeleteAll() error
 }
 
@@ -97,11 +97,6 @@ type PostgresReadWriteCollection interface {
 	// exactly one row is not found.
 	// TODO: decide if we should merge this with GetByIndex and use an `Options`.
 	GetUniqueByIndex(index *Index, indexVal string, val proto.Message) error
-
-	// Unsupported operations - only here during migration so we can compile
-	// TODO: remove these before merging into master
-	TTL(key string) (int64, error)
-	PutTTL(key string, val proto.Message, ttl int64) error
 }
 
 type EtcdReadWriteCollection interface {
@@ -122,15 +117,15 @@ type EtcdReadWriteCollection interface {
 
 // ReadOnlyCollection is a collection interface that only supports read ops.
 type ReadOnlyCollection interface {
-	Get(key string, val proto.Message) error
+	Get(key interface{}, val proto.Message) error
 	GetByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
 	List(val proto.Message, opts *Options, f func(string) error) error
 	ListRev(val proto.Message, opts *Options, f func(string, int64) error) error
 	Count() (int64, error)
 	Watch(opts ...watch.Option) (watch.Watcher, error)
 	WatchF(f func(*watch.Event) error, opts ...watch.Option) error
-	WatchOne(key string, opts ...watch.Option) (watch.Watcher, error)
-	WatchOneF(key string, f func(*watch.Event) error, opts ...watch.Option) error
+	WatchOne(key interface{}, opts ...watch.Option) (watch.Watcher, error)
+	WatchOneF(key interface{}, f func(*watch.Event) error, opts ...watch.Option) error
 	WatchByIndex(index *Index, val string, opts ...watch.Option) (watch.Watcher, error)
 	WatchByIndexF(index *Index, val string, f func(*watch.Event) error, opts ...watch.Option) error
 }
@@ -139,10 +134,6 @@ type PostgresReadOnlyCollection interface {
 	ReadOnlyCollection
 
 	GetRevByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string, int64) error) error
-
-	// Unsupported operation - only here during migration so we can compile
-	// TODO: remove this before merging into master
-	TTL(key string) (int64, error)
 }
 
 type EtcdReadOnlyCollection interface {

--- a/src/internal/ppsdb/ppsdb.go
+++ b/src/internal/ppsdb/ppsdb.go
@@ -27,7 +27,6 @@ func Pipelines(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollectio
 		listener,
 		&pps.PipelineInfo{},
 		nil,
-		nil,
 	)
 }
 
@@ -70,7 +69,6 @@ func Jobs(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
 		listener,
 		&pps.JobInfo{},
 		jobsIndexes,
-		nil,
 	)
 }
 
@@ -79,7 +77,7 @@ func Jobs(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
 // querying.
 func AllCollections() []col.PostgresCollection {
 	return []col.PostgresCollection{
-		col.NewPostgresCollection(pipelinesCollectionName, nil, nil, nil, pipelinesIndexes, nil),
-		col.NewPostgresCollection(jobsCollectionName, nil, nil, nil, jobsIndexes, nil),
+		col.NewPostgresCollection(pipelinesCollectionName, nil, nil, nil, pipelinesIndexes),
+		col.NewPostgresCollection(jobsCollectionName, nil, nil, nil, jobsIndexes),
 	}
 }

--- a/src/internal/transactiondb/transactiondb.go
+++ b/src/internal/transactiondb/transactiondb.go
@@ -23,7 +23,6 @@ func Transactions(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollec
 		listener,
 		&transaction.TransactionInfo{},
 		transactionsIndexes,
-		nil,
 	)
 }
 
@@ -32,6 +31,6 @@ func Transactions(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollec
 // querying.
 func AllCollections() []col.PostgresCollection {
 	return []col.PostgresCollection{
-		col.NewPostgresCollection(transactionsCollectionName, nil, nil, nil, transactionsIndexes, nil),
+		col.NewPostgresCollection(transactionsCollectionName, nil, nil, nil, transactionsIndexes),
 	}
 }

--- a/src/server/auth/server/authdb.go
+++ b/src/server/auth/server/authdb.go
@@ -23,7 +23,6 @@ func authConfigCollection(db *sqlx.DB, listener col.PostgresListener) col.Postgr
 		listener,
 		&auth.OIDCConfig{},
 		nil,
-		nil,
 	)
 }
 
@@ -36,7 +35,6 @@ func roleBindingsCollection(db *sqlx.DB, listener col.PostgresListener) col.Post
 		listener,
 		&auth.RoleBinding{},
 		roleBindingsIndexes,
-		nil,
 	)
 }
 
@@ -49,7 +47,6 @@ func membersCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresC
 		listener,
 		&auth.Groups{},
 		membersIndexes,
-		nil,
 	)
 }
 
@@ -62,7 +59,6 @@ func groupsCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCo
 		listener,
 		&auth.Users{},
 		groupsIndexes,
-		nil,
 	)
 }
 
@@ -71,9 +67,9 @@ func groupsCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCo
 // querying.
 func AllCollections() []col.PostgresCollection {
 	return []col.PostgresCollection{
-		col.NewPostgresCollection(authConfigCollectionName, nil, nil, nil, authConfigIndexes, nil),
-		col.NewPostgresCollection(roleBindingsCollectionName, nil, nil, nil, roleBindingsIndexes, nil),
-		col.NewPostgresCollection(membersCollectionName, nil, nil, nil, membersIndexes, nil),
-		col.NewPostgresCollection(groupsCollectionName, nil, nil, nil, groupsIndexes, nil),
+		col.NewPostgresCollection(authConfigCollectionName, nil, nil, nil, authConfigIndexes),
+		col.NewPostgresCollection(roleBindingsCollectionName, nil, nil, nil, roleBindingsIndexes),
+		col.NewPostgresCollection(membersCollectionName, nil, nil, nil, membersIndexes),
+		col.NewPostgresCollection(groupsCollectionName, nil, nil, nil, groupsIndexes),
 	}
 }

--- a/src/server/license/server/col.go
+++ b/src/server/license/server/col.go
@@ -20,7 +20,6 @@ func licenseCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresC
 		listener,
 		&ec.LicenseRecord{},
 		licenseIndexes,
-		nil,
 	)
 }
 

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -26,9 +26,14 @@ type ErrRepoExists struct {
 	Repo *pfs.Repo
 }
 
-// ErrRepoDeleted represents a repo-deleted error.
-type ErrRepoDeleted struct {
-	Repo *pfs.Repo
+// ErrBranchNotFound represents a branch-not-found error.
+type ErrBranchNotFound struct {
+	Branch *pfs.Branch
+}
+
+// ErrBranchExists represents a branch-exists error.
+type ErrBranchExists struct {
+	Branch *pfs.Branch
 }
 
 // ErrCommitNotFound represents a commit-not-found error.
@@ -118,8 +123,12 @@ func (e ErrRepoExists) Error() string {
 	return fmt.Sprintf("repo %v already exists", e.Repo)
 }
 
-func (e ErrRepoDeleted) Error() string {
-	return fmt.Sprintf("repo %v was deleted", e.Repo)
+func (e ErrBranchNotFound) Error() string {
+	return fmt.Sprintf("branch %q not found in repo %v", e.Branch.Name, e.Branch.Repo)
+}
+
+func (e ErrBranchExists) Error() string {
+	return fmt.Sprintf("branch %q already exists in repo %v", e.Branch.Name, e.Branch.Repo)
 }
 
 func (e ErrCommitNotFound) Error() string {
@@ -178,7 +187,7 @@ var (
 	commitErrorRe             = regexp.MustCompile("commit [^ ]+ in repo [^ ]+ finished with an error")
 	repoNotFoundRe            = regexp.MustCompile(`repos [a-zA-Z0-9.\-_]{1,255} not found`)
 	repoExistsRe              = regexp.MustCompile(`repo ?[a-zA-Z0-9.\-_]{1,255} already exists`)
-	branchNotFoundRe          = regexp.MustCompile(`branches [a-zA-Z0-9.\-_@]{1,255} not found`)
+	branchNotFoundRe          = regexp.MustCompile(`branch [^ ]+ not found in repo [^ ]+`)
 	fileNotFoundRe            = regexp.MustCompile(`file .+ not found`)
 	outputCommitNotFinishedRe = regexp.MustCompile("output commit .+ not finished")
 	commitNotFinishedRe       = regexp.MustCompile("commit .+ not finished")

--- a/src/server/pfs/pfs_test.go
+++ b/src/server/pfs/pfs_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestErrorMatching(t *testing.T) {
 	c := client.NewCommit("foo", "bar", "")
-	require.True(t, IsCommitNotFoundErr(ErrCommitNotFound{c}))
+	require.True(t, IsCommitNotFoundErr(ErrCommitNotFound{Commit: c}))
 	require.False(t, IsCommitNotFoundErr(ErrCommitDeleted{c}))
 	require.False(t, IsCommitNotFoundErr(ErrCommitFinished{c}))
 
-	require.False(t, IsCommitDeletedErr(ErrCommitNotFound{c}))
+	require.False(t, IsCommitDeletedErr(ErrCommitNotFound{Commit: c}))
 	require.True(t, IsCommitDeletedErr(ErrCommitDeleted{c}))
 	require.False(t, IsCommitDeletedErr(ErrCommitFinished{c}))
 
-	require.False(t, IsCommitFinishedErr(ErrCommitNotFound{c}))
+	require.False(t, IsCommitFinishedErr(ErrCommitNotFound{Commit: c}))
 	require.False(t, IsCommitFinishedErr(ErrCommitDeleted{c}))
 	require.True(t, IsCommitFinishedErr(ErrCommitFinished{c}))
 }

--- a/src/server/pfs/pfs_test.go
+++ b/src/server/pfs/pfs_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestErrorMatching(t *testing.T) {
 	c := client.NewCommit("foo", "bar", "")
-	require.True(t, IsCommitNotFoundErr(ErrCommitNotFound{Commit: c}))
+	require.True(t, IsCommitNotFoundErr(ErrCommitNotFound{c}))
 	require.False(t, IsCommitNotFoundErr(ErrCommitDeleted{c}))
 	require.False(t, IsCommitNotFoundErr(ErrCommitFinished{c}))
 
-	require.False(t, IsCommitDeletedErr(ErrCommitNotFound{Commit: c}))
+	require.False(t, IsCommitDeletedErr(ErrCommitNotFound{c}))
 	require.True(t, IsCommitDeletedErr(ErrCommitDeleted{c}))
 	require.False(t, IsCommitDeletedErr(ErrCommitFinished{c}))
 
-	require.False(t, IsCommitFinishedErr(ErrCommitNotFound{Commit: c}))
+	require.False(t, IsCommitFinishedErr(ErrCommitNotFound{c}))
 	require.False(t, IsCommitFinishedErr(ErrCommitDeleted{c}))
 	require.True(t, IsCommitFinishedErr(ErrCommitFinished{c}))
 }

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -174,7 +174,7 @@ func (d *driver) createRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 	// proceed with ACL creation (avoids awkward "access denied" error when
 	// calling "createRepo" on a repo that already exists)
 	var existingRepoInfo pfs.RepoInfo
-	err = repos.Get(pfsdb.RepoKey(repo), &existingRepoInfo)
+	err = repos.Get(repo, &existingRepoInfo)
 	if err != nil && !col.IsErrNotFound(err) {
 		return errors.Wrapf(err, "error checking whether %q exists", repo)
 	} else if err == nil {
@@ -202,12 +202,12 @@ func (d *driver) createRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 			return errors.Wrapf(err, "could not update description of %q", repo)
 		}
 		existingRepoInfo.Description = description
-		return repos.Put(pfsdb.RepoKey(repo), &existingRepoInfo)
+		return repos.Put(repo, &existingRepoInfo)
 	} else {
 		// if this is a system repo, make sure the corresponding user repo already exists
 		if repo.Type != pfs.UserRepoType {
 			baseRepo := client.NewRepo(repo.Name)
-			err = repos.Get(pfsdb.RepoKey(baseRepo), &existingRepoInfo)
+			err = repos.Get(baseRepo, &existingRepoInfo)
 			if err != nil && col.IsErrNotFound(err) {
 				return errors.Errorf("cannot create a system repo without a corresponding 'user' repo")
 			} else if err != nil {
@@ -230,7 +230,7 @@ func (d *driver) createRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 				return errors.Wrapf(grpcutil.ScrubGRPC(err), "could not create role binding for new repo %q", repo)
 			}
 		}
-		return repos.Create(pfsdb.RepoKey(repo), &pfs.RepoInfo{
+		return repos.Create(repo, &pfs.RepoInfo{
 			Repo:        repo,
 			Created:     txnCtx.Timestamp,
 			Description: description,
@@ -244,7 +244,7 @@ func (d *driver) inspectRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Re
 		return nil, errors.New("repo cannot be nil")
 	}
 	repoInfo := &pfs.RepoInfo{}
-	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(pfsdb.RepoKey(repo), repoInfo); err != nil {
+	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(repo, repoInfo); err != nil {
 		return nil, err
 	}
 	if includeAuth {
@@ -334,7 +334,7 @@ func (d *driver) deleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 	// proceed with auth check (avoids awkward "access denied" error when calling
 	// "deleteRepo" on a repo that's already gone)
 	var repoInfo pfs.RepoInfo
-	err := repos.Get(pfsdb.RepoKey(repo), &repoInfo)
+	err := repos.Get(repo, &repoInfo)
 	if err != nil {
 		if !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "error checking whether %q exists", repo)
@@ -412,7 +412,7 @@ func (d *driver) deleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 	if err := d.commits.ReadWrite(txnCtx.SqlTx).DeleteByIndex(pfsdb.CommitsRepoIndex, pfsdb.RepoKey(repo)); err != nil {
 		return err
 	}
-	if err := repos.Delete(pfsdb.RepoKey(repo)); err != nil && !col.IsErrNotFound(err) {
+	if err := repos.Delete(repo); err != nil && !col.IsErrNotFound(err) {
 		return errors.Wrapf(err, "repos.Delete")
 	}
 
@@ -462,7 +462,7 @@ func (d *driver) startCommit(
 
 	// Check if repo exists and load it in case we need to add a new branch
 	repoInfo := &pfs.RepoInfo{}
-	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(pfsdb.RepoKey(branch.Repo), repoInfo); err != nil {
+	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(branch.Repo, repoInfo); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, pfsserver.ErrRepoNotFound{Repo: branch.Repo}
 		}
@@ -472,11 +472,11 @@ func (d *driver) startCommit(
 	// update 'branch' (which must always be set) and set parent.ID (if 'parent'
 	// was not set)
 	branchInfo := &pfs.BranchInfo{}
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Upsert(pfsdb.BranchKey(branch), branchInfo, func() error {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Upsert(branch, branchInfo, func() error {
 		if branchInfo.Branch == nil {
 			// New branch, update the RepoInfo
 			add(&repoInfo.Branches, branch)
-			if err := d.repos.ReadWrite(txnCtx.SqlTx).Put(pfsdb.RepoKey(repoInfo.Repo), repoInfo); err != nil {
+			if err := d.repos.ReadWrite(txnCtx.SqlTx).Put(repoInfo.Repo, repoInfo); err != nil {
 				return err
 			}
 			branchInfo.Branch = branch
@@ -530,7 +530,7 @@ func (d *driver) startCommit(
 		newCommitInfo.ParentCommit = parentCommitInfo.Commit
 		parentCommitInfo.ChildCommits = append(parentCommitInfo.ChildCommits, newCommit)
 
-		if err := d.commits.ReadWrite(txnCtx.SqlTx).Put(pfsdb.CommitKey(parentCommitInfo.Commit), parentCommitInfo); err != nil {
+		if err := d.commits.ReadWrite(txnCtx.SqlTx).Put(parentCommitInfo.Commit, parentCommitInfo); err != nil {
 			// Note: error is emitted if parent.ID is a missing/invalid branch OR a
 			// missing/invalid commit ID
 			return nil, errors.Wrapf(err, "could not resolve parent commit %s", parent)
@@ -538,7 +538,7 @@ func (d *driver) startCommit(
 	}
 
 	// Finally, create the commit
-	if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(pfsdb.CommitKey(newCommit), newCommitInfo); err != nil {
+	if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(newCommit, newCommitInfo); err != nil {
 		if col.IsErrExists(err) {
 			return nil, errors.EnsureStack(pfsserver.ErrInconsistentCommit{Commit: newCommit, Branch: newCommit.Branch})
 		}
@@ -580,7 +580,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 	}
 	commitInfo.Finishing = txnCtx.Timestamp
 	commitInfo.Error = commitError
-	return d.commits.ReadWrite(txnCtx.SqlTx).Put(pfsdb.CommitKey(commitInfo.Commit), commitInfo)
+	return d.commits.ReadWrite(txnCtx.SqlTx).Put(commitInfo.Commit, commitInfo)
 }
 
 // resolveAlias finds the first ancestor of the source commit which is not an alias (possibly source itself)
@@ -617,20 +617,20 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 	// doing a 'run pipeline' with explicit provenance (to make off-head commits
 	// in the branch).
 	branchInfo := &pfs.BranchInfo{}
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(branch), branchInfo); err != nil {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, branchInfo); err != nil {
 		return nil, err
 	}
 
 	// Check if the alias already exists
 	commitInfo := &pfs.CommitInfo{}
-	if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(pfsdb.CommitKey(commit), commitInfo); err != nil {
+	if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(commit, commitInfo); err != nil {
 		if !col.IsErrNotFound(err) {
 			return nil, err
 		}
 		// No commit already exists, create a new one
 		// First load the parent commit and update it to point to the child
 		parentCommitInfo := &pfs.CommitInfo{}
-		if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(parent), parentCommitInfo, func() error {
+		if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(parent, parentCommitInfo, func() error {
 			parentCommitInfo.ChildCommits = append(parentCommitInfo.ChildCommits, commit)
 			return nil
 		}); err != nil {
@@ -656,7 +656,7 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 			}
 			commitInfo.Error = parentCommitInfo.Error
 		}
-		if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(pfsdb.CommitKey(commitInfo.Commit), commitInfo); err != nil {
+		if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(commitInfo.Commit, commitInfo); err != nil {
 			return nil, err
 		}
 	} else {
@@ -676,7 +676,7 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 
 	// Update the branch head
 	branchInfo.Head = commit
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Put(pfsdb.BranchKey(branch), branchInfo); err != nil {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Put(branch, branchInfo); err != nil {
 		return nil, err
 	}
 
@@ -685,13 +685,13 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 
 func (d *driver) repoSize(ctx context.Context, repo *pfs.Repo) (int64, error) {
 	repoInfo := new(pfs.RepoInfo)
-	if err := d.repos.ReadOnly(ctx).Get(pfsdb.RepoKey(repo), repoInfo); err != nil {
+	if err := d.repos.ReadOnly(ctx).Get(repo, repoInfo); err != nil {
 		return 0, err
 	}
 	for _, branch := range repoInfo.Branches {
 		if branch.Name == "master" {
 			branchInfo := &pfs.BranchInfo{}
-			if err := d.branches.ReadOnly(ctx).Get(pfsdb.BranchKey(branch), branchInfo); err != nil {
+			if err := d.branches.ReadOnly(ctx).Get(branch, branchInfo); err != nil {
 				return 0, err
 			}
 			ci, err := d.getCommit(ctx, branchInfo.Head)
@@ -731,7 +731,7 @@ func (d *driver) propagateBranches(txnCtx *txncontext.TransactionContext, branch
 			return branchInfo, nil
 		}
 		branchInfo := &pfs.BranchInfo{}
-		if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(branch), branchInfo); err != nil {
+		if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, branchInfo); err != nil {
 			return nil, err
 		}
 		branchInfoCache[pfsdb.BranchKey(branch)] = branchInfo
@@ -829,7 +829,7 @@ func (d *driver) propagateBranches(txnCtx *txncontext.TransactionContext, branch
 			subvBI.Head = newCommit
 			if newCommitInfo.ParentCommit != nil {
 				parentCommitInfo := &pfs.CommitInfo{}
-				if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(newCommitInfo.ParentCommit), parentCommitInfo, func() error {
+				if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(newCommitInfo.ParentCommit, parentCommitInfo, func() error {
 					parentCommitInfo.ChildCommits = append(parentCommitInfo.ChildCommits, newCommit)
 					return nil
 				}); err != nil {
@@ -837,15 +837,12 @@ func (d *driver) propagateBranches(txnCtx *txncontext.TransactionContext, branch
 				}
 			}
 
-			if err := d.branches.ReadWrite(txnCtx.SqlTx).Put(pfsdb.BranchKey(subvBI.Branch), subvBI); err != nil {
+			if err := d.branches.ReadWrite(txnCtx.SqlTx).Put(subvBI.Branch, subvBI); err != nil {
 				return err
 			}
 
 			// finally create open 'commit'
-			if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(
-				pfsdb.CommitKey(newCommit),
-				newCommitInfo,
-			); err != nil && col.IsErrExists(err) {
+			if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(newCommit, newCommitInfo); err != nil && col.IsErrExists(err) {
 				return errors.EnsureStack(pfsserver.ErrInconsistentCommit{
 					Commit: newCommit,
 					Branch: newCommit.Branch,
@@ -908,7 +905,7 @@ func (d *driver) inspectCommit(ctx context.Context, commit *pfs.Commit, wait pfs
 			}
 		case pfs.CommitState_FINISHED:
 			// Watch the CommitInfo until the commit has been finished
-			if err := d.commits.ReadOnly(ctx).WatchOneF(pfsdb.CommitKey(commit), func(ev *watch.Event) error {
+			if err := d.commits.ReadOnly(ctx).WatchOneF(commit, func(ev *watch.Event) error {
 				if ev.Type == watch.EventDelete {
 					return pfsserver.ErrCommitDeleted{Commit: commit}
 				}
@@ -972,7 +969,7 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 	if commit.ID == "" {
 		// If commit.ID is unspecified, get it from the branch head
 		branchInfo := &pfs.BranchInfo{}
-		if err := d.branches.ReadWrite(sqlTx).Get(pfsdb.BranchKey(commit.Branch), branchInfo); err != nil {
+		if err := d.branches.ReadWrite(sqlTx).Get(commit.Branch, branchInfo); err != nil {
 			return nil, err
 		}
 		commit.ID = branchInfo.Head.ID
@@ -998,7 +995,7 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 			if commit == nil {
 				return nil, pfsserver.ErrCommitNotFound{Commit: userCommit}
 			}
-			if err := d.commits.ReadWrite(sqlTx).Get(pfsdb.CommitKey(commit), commitInfo); err != nil {
+			if err := d.commits.ReadWrite(sqlTx).Get(commit, commitInfo); err != nil {
 				if col.IsErrNotFound(err) {
 					if i == 0 {
 						return nil, pfsserver.ErrCommitNotFound{Commit: userCommit}
@@ -1019,7 +1016,7 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 				}
 				return nil, pfsserver.ErrCommitNotFound{Commit: userCommit}
 			}
-			if err := d.commits.ReadWrite(sqlTx).Get(pfsdb.CommitKey(commit), &cis[i%len(cis)]); err != nil {
+			if err := d.commits.ReadWrite(sqlTx).Get(commit, &cis[i%len(cis)]); err != nil {
 				if col.IsErrNotFound(err) {
 					if i == 0 {
 						return nil, pfsserver.ErrCommitNotFound{Commit: userCommit}
@@ -1100,7 +1097,7 @@ func (d *driver) listCommit(
 
 	// Make sure that the repo exists
 	if repo.Name != "" {
-		if err := d.repos.ReadOnly(ctx).Get(pfsdb.RepoKey(repo), &pfs.RepoInfo{}); err != nil {
+		if err := d.repos.ReadOnly(ctx).Get(repo, &pfs.RepoInfo{}); err != nil {
 			if col.IsErrNotFound(err) {
 				return pfsserver.ErrRepoNotFound{Repo: repo}
 			}
@@ -1201,7 +1198,7 @@ func (d *driver) listCommit(
 		cursor := to
 		for number != 0 && cursor != nil && (from == nil || cursor.ID != from.ID) {
 			commitInfo := &pfs.CommitInfo{}
-			if err := d.commits.ReadOnly(ctx).Get(pfsdb.CommitKey(cursor), commitInfo); err != nil {
+			if err := d.commits.ReadOnly(ctx).Get(cursor, commitInfo); err != nil {
 				return err
 			}
 			if passesCommitOriginFilter(commitInfo, all, originKind) {
@@ -1356,7 +1353,7 @@ func (d *driver) squashCommitSet(txnCtx *txncontext.TransactionContext, commitse
 	affectedBranches := []*pfs.Branch{}
 	for _, commitInfo := range commitInfos {
 		deleted[pfsdb.CommitKey(commitInfo.Commit)] = commitInfo
-		if err := d.commits.ReadWrite(txnCtx.SqlTx).Delete(pfsdb.CommitKey(commitInfo.Commit)); err != nil {
+		if err := d.commits.ReadWrite(txnCtx.SqlTx).Delete(commitInfo.Commit); err != nil {
 			return err
 		}
 
@@ -1367,7 +1364,7 @@ func (d *driver) squashCommitSet(txnCtx *txncontext.TransactionContext, commitse
 
 		// Update the commit's branch's branchInfo in case this was the head of the branch
 		branchInfo := &pfs.BranchInfo{}
-		if err := d.branches.ReadWrite(txnCtx.SqlTx).Update(pfsdb.BranchKey(commitInfo.Commit.Branch), branchInfo, func() error {
+		if err := d.branches.ReadWrite(txnCtx.SqlTx).Update(commitInfo.Commit.Branch, branchInfo, func() error {
 			if branchInfo.Head.ID == commitInfo.Commit.ID {
 				if commitInfo.ParentCommit == nil || !proto.Equal(commitInfo.ParentCommit.Branch, commitInfo.Commit.Branch) {
 					// Create a new empty commit for the branch head
@@ -1433,7 +1430,7 @@ func (d *driver) squashCommitSet(txnCtx *txncontext.TransactionContext, commitse
 		parent := oldestCommitInfo.ParentCommit
 		for _, commit := range liveChildren {
 			commitInfo := &pfs.CommitInfo{}
-			if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(commit), commitInfo, func() error {
+			if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(commit, commitInfo, func() error {
 				commitInfo.ParentCommit = parent
 				return nil
 			}); err != nil {
@@ -1442,7 +1439,7 @@ func (d *driver) squashCommitSet(txnCtx *txncontext.TransactionContext, commitse
 		}
 		if parent != nil {
 			commitInfo := &pfs.CommitInfo{}
-			if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(parent), commitInfo, func() error {
+			if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(parent, commitInfo, func() error {
 				// Add existing live commits in commitInfo.ChildCommits to the
 				// live children above oldestCommitInfo, then put them all in
 				// 'parent'
@@ -1580,7 +1577,7 @@ func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 
 	// Retrieve (and create, if necessary) the current version of this branch
 	branchInfo := &pfs.BranchInfo{}
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Upsert(pfsdb.BranchKey(branch), branchInfo, func() error {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Upsert(branch, branchInfo, func() error {
 		branchInfo.Branch = branch
 		branchInfo.DirectProvenance = nil
 		for _, provBranch := range provenance {
@@ -1646,7 +1643,7 @@ func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 	toUpdate := []*pfs.BranchInfo{branchInfo}
 	for _, subvBranch := range branchInfo.Subvenance {
 		subvBranchInfo := &pfs.BranchInfo{}
-		if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(subvBranch), subvBranchInfo); err != nil {
+		if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(subvBranch, subvBranchInfo); err != nil {
 			return err
 		}
 		toUpdate = append(toUpdate, subvBranchInfo)
@@ -1665,7 +1662,7 @@ func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 				return err
 			}
 			provBranchInfo := &pfs.BranchInfo{}
-			if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(provBranch), provBranchInfo); err != nil {
+			if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(provBranch, provBranchInfo); err != nil {
 				return errors.Wrapf(err, "error getting prov branch")
 			}
 			for _, provBranch := range provBranchInfo.Provenance {
@@ -1676,7 +1673,7 @@ func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 				}
 			}
 		}
-		if err := d.branches.ReadWrite(txnCtx.SqlTx).Put(pfsdb.BranchKey(branchInfo.Branch), branchInfo); err != nil {
+		if err := d.branches.ReadWrite(txnCtx.SqlTx).Put(branchInfo.Branch, branchInfo); err != nil {
 			return err
 		}
 		// Update Subvenance of 'branchInfo's Provenance (incl. all Subvenance)
@@ -1684,7 +1681,7 @@ func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 			if !has(&branchInfo.Provenance, oldProvBranch) {
 				// Provenance was deleted, so we delete ourselves from their subvenance
 				oldProvBranchInfo := &pfs.BranchInfo{}
-				if err := d.branches.ReadWrite(txnCtx.SqlTx).Update(pfsdb.BranchKey(oldProvBranch), oldProvBranchInfo, func() error {
+				if err := d.branches.ReadWrite(txnCtx.SqlTx).Update(oldProvBranch, oldProvBranchInfo, func() error {
 					del(&oldProvBranchInfo.Subvenance, branchInfo.Branch)
 					return nil
 				}); err != nil {
@@ -1696,7 +1693,7 @@ func (d *driver) createBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 
 	// Add the new branch to the repo info
 	repoInfo := &pfs.RepoInfo{}
-	if err := d.repos.ReadWrite(txnCtx.SqlTx).Update(pfsdb.RepoKey(branch.Repo), repoInfo, func() error {
+	if err := d.repos.ReadWrite(txnCtx.SqlTx).Update(branch.Repo, repoInfo, func() error {
 		add(&repoInfo.Branches, branch)
 		return nil
 	}); err != nil {
@@ -1735,7 +1732,7 @@ func (d *driver) inspectBranch(txnCtx *txncontext.TransactionContext, branch *pf
 	}
 
 	result := &pfs.BranchInfo{}
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(branch), result); err != nil {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -1753,7 +1750,7 @@ func (d *driver) listBranch(ctx context.Context, repo *pfs.Repo, reverse bool, c
 
 	// Make sure that the repo exists
 	if repo.Name != "" {
-		if err := d.repos.ReadOnly(ctx).Get(pfsdb.RepoKey(repo), &pfs.RepoInfo{}); err != nil {
+		if err := d.repos.ReadOnly(ctx).Get(repo, &pfs.RepoInfo{}); err != nil {
 			if col.IsErrNotFound(err) {
 				return pfsserver.ErrRepoNotFound{Repo: repo}
 			}
@@ -1819,7 +1816,7 @@ func (d *driver) deleteBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 	}
 
 	branchInfo := &pfs.BranchInfo{}
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(branch), branchInfo); err != nil {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, branchInfo); err != nil {
 		if !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "branches.Get")
 		}
@@ -1835,7 +1832,7 @@ func (d *driver) deleteBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 		// For provenant branches, remove this branch from subvenance
 		for _, provBranch := range branchInfo.Provenance {
 			provBranchInfo := &pfs.BranchInfo{}
-			if err := d.branches.ReadWrite(txnCtx.SqlTx).Update(pfsdb.BranchKey(provBranch), provBranchInfo, func() error {
+			if err := d.branches.ReadWrite(txnCtx.SqlTx).Update(provBranch, provBranchInfo, func() error {
 				del(&provBranchInfo.Subvenance, branch)
 				return nil
 			}); err != nil && !errutil.IsNotFoundError(err) {
@@ -1846,7 +1843,7 @@ func (d *driver) deleteBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 		// For subvenant branches, recalculate provenance
 		for _, subvBranch := range branchInfo.Subvenance {
 			subvBranchInfo := &pfs.BranchInfo{}
-			if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(subvBranch), subvBranchInfo); err != nil {
+			if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(subvBranch, subvBranchInfo); err != nil {
 				return err
 			}
 			del(&subvBranchInfo.DirectProvenance, branch)
@@ -1855,12 +1852,12 @@ func (d *driver) deleteBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 			}
 		}
 
-		if err := d.branches.ReadWrite(txnCtx.SqlTx).Delete(pfsdb.BranchKey(branch)); err != nil {
+		if err := d.branches.ReadWrite(txnCtx.SqlTx).Delete(branch); err != nil {
 			return errors.Wrapf(err, "branches.Delete")
 		}
 	}
 	repoInfo := &pfs.RepoInfo{}
-	if err := d.repos.ReadWrite(txnCtx.SqlTx).Update(pfsdb.RepoKey(branch.Repo), repoInfo, func() error {
+	if err := d.repos.ReadWrite(txnCtx.SqlTx).Update(branch.Repo, repoInfo, func() error {
 		del(&repoInfo.Branches, branch)
 		return nil
 	}); err != nil {
@@ -1877,7 +1874,7 @@ func (d *driver) addBranchProvenance(txnCtx *txncontext.TransactionContext, bran
 	}
 	add(&branchInfo.Provenance, provBranch)
 	provBranchInfo := &pfs.BranchInfo{}
-	if err := d.branches.ReadWrite(txnCtx.SqlTx).Upsert(pfsdb.BranchKey(provBranch), provBranchInfo, func() error {
+	if err := d.branches.ReadWrite(txnCtx.SqlTx).Upsert(provBranch, provBranchInfo, func() error {
 		if provBranchInfo.Branch == nil {
 			// We are creating this branch for the first time, set the Branch and Head
 			provBranchInfo.Branch = provBranch
@@ -1894,7 +1891,7 @@ func (d *driver) addBranchProvenance(txnCtx *txncontext.TransactionContext, bran
 		return err
 	}
 	repoInfo := &pfs.RepoInfo{}
-	return d.repos.ReadWrite(txnCtx.SqlTx).Update(pfsdb.RepoKey(provBranch.Repo), repoInfo, func() error {
+	return d.repos.ReadWrite(txnCtx.SqlTx).Update(provBranch.Repo, repoInfo, func() error {
 		add(&repoInfo.Branches, provBranch)
 		return nil
 	})
@@ -1943,7 +1940,7 @@ func (d *driver) makeEmptyCommit(txnCtx *txncontext.TransactionContext, branchIn
 		commitInfo.Finished = txnCtx.Timestamp
 		commitInfo.Details = &pfs.CommitInfo_Details{}
 	}
-	if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(pfsdb.CommitKey(commit), commitInfo); err != nil {
+	if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(commit, commitInfo); err != nil {
 		return nil, err
 	}
 	return commit, nil

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -290,7 +290,7 @@ func (d *driver) fsck(ctx context.Context, fix bool, cb func(*pfs.FsckResponse) 
 				// We've observed users getting ErrExists from this create,
 				// which doesn't make a lot of sense, but we insulate against
 				// it anyways so it doesn't prevent the command from working.
-				if err := d.commits.ReadWrite(sqlTx).Create(pfsdb.CommitKey(ci.Commit), ci); err != nil && !col.IsErrExists(err) {
+				if err := d.commits.ReadWrite(sqlTx).Create(ci.Commit, ci); err != nil && !col.IsErrExists(err) {
 					return err
 				}
 			}

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5863,6 +5863,31 @@ func TestPFS(suite *testing.T) {
 		require.YesError(t, err)
 		require.True(t, errutil.IsNotFoundError(err))
 	})
+	suite.Run("ErrorMessages", func(t *testing.T) {
+		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		// don't show user .user suffix
+		_, err := env.PachClient.InspectRepo("test")
+		require.YesError(t, err)
+		require.True(t, errutil.IsNotFoundError(err))
+		require.False(t, strings.Contains(err.Error(), pfs.UserRepoType))
+
+		require.NoError(t, env.PachClient.CreateRepo("test"))
+
+		err = env.PachClient.CreateRepo("test")
+		require.YesError(t, err)
+		require.True(t, errutil.IsAlreadyExistError(err))
+		require.False(t, strings.Contains(err.Error(), pfs.UserRepoType))
+
+		_, err = env.PachClient.InspectBranch("test", "branch")
+		require.YesError(t, err)
+		require.True(t, errutil.IsNotFoundError(err))
+		require.False(t, strings.Contains(err.Error(), pfs.UserRepoType))
+
+		_, err = env.PachClient.InspectCommit("test", "branch", uuid.NewWithoutDashes())
+		require.YesError(t, err)
+		require.True(t, errutil.IsNotFoundError(err))
+		require.False(t, strings.Contains(err.Error(), pfs.UserRepoType))
+	})
 }
 
 var (

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/ancestry"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
@@ -22,11 +21,11 @@ func (d *driver) triggerCommit(
 	commit *pfs.Commit,
 ) error {
 	repoInfo := &pfs.RepoInfo{}
-	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(pfsdb.RepoKey(commit.Branch.Repo), repoInfo); err != nil {
+	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(commit.Branch.Repo, repoInfo); err != nil {
 		return err
 	}
 	commitInfo := &pfs.CommitInfo{}
-	if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(pfsdb.CommitKey(commit), commitInfo); err != nil {
+	if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(commit, commitInfo); err != nil {
 		return err
 	}
 
@@ -41,7 +40,7 @@ func (d *driver) triggerCommit(
 		}
 
 		bi := &pfs.BranchInfo{}
-		if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(pfsdb.BranchKey(branch), bi); err != nil {
+		if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, bi); err != nil {
 			return nil, err
 		}
 
@@ -54,7 +53,7 @@ func (d *driver) triggerCommit(
 
 			if newHead != nil {
 				oldHead := &pfs.CommitInfo{}
-				if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(pfsdb.CommitKey(bi.Head), oldHead); err != nil {
+				if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(bi.Head, oldHead); err != nil {
 					return nil, err
 				}
 


### PR DESCRIPTION
Suppress `.user` suffix by changing the underlying keys to match the
pretty-printed string forms, and rephrase so the plural/collection name
is more natural.