### PR TITLE
Bump go version for CI to 1.16

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   timeout: 5m
+  skip-dirs:
+    - cached-deps
 linters:
   disable:
     - errcheck

--- a/etc/testing/circle/build.sh
+++ b/etc/testing/circle/build.sh
@@ -5,6 +5,9 @@ set -ex
 source "$(dirname "$0")/env.sh"
 
 eval $(minikube docker-env)
+
+go version
+
 make install
 VERSION=$(pachctl version --client-only)
 git config user.email "donotreply@pachyderm.com"

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -85,3 +85,6 @@ if [ ! -f cached-deps/jq ]; then
   JQ_VERSION=1.6
   curl -L https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 > cached-deps/jq
 fi
+
+sudo rm -rf /usr/local/go
+curl -L https://golang.org/dl/go1.16.6.linux-amd64.tar.gz | sudo tar xzf - -C /usr/local/


### PR DESCRIPTION
The CircleCI VM comes with Go 1.15, but we want to upgrade dependencies and write code that depends on a newer version. Install 1.16.6 explicitly in CI instead.