### PR TITLE
(Breaking change) Setup global object for postgres information

### DIFF
--- a/etc/helm/examples/enterprise-dev.yaml
+++ b/etc/helm/examples/enterprise-dev.yaml
@@ -9,6 +9,4 @@ enterpriseServer:
     tag: local
 pachd:
   enabled: false
-pgbouncer:
-  enabled: true
 

--- a/etc/helm/examples/hub-values.yaml
+++ b/etc/helm/examples/hub-values.yaml
@@ -3,6 +3,14 @@
 
 deployTarget: GOOGLE
 
+global:
+  postgresql:
+    postgresqlHost: "cloudsql-auth-proxy.default.svc.cluster.local."
+    postgresqlPort: "5432"
+    postgresqlSSL: "disable"
+    postgresqlUsername: "postgres"
+    postgresqlPassword: "Example-Password"
+
 dash:
   enabled: true
   image:
@@ -31,12 +39,6 @@ ingress:
   host: "dash.test"
 
 pachd:
-  postgresql:
-    host: "cloudsql-auth-proxy.default.svc.cluster.local."
-    port: "5432"
-    ssl: "disable"
-    user: "postgres"
-    password: "Example-Password"
   goMaxProcs: 3
   # image.tag is configured per workspace.
   lokiLogging: true

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -38,17 +38,17 @@ spec:
         - --mode=enterprise
         env:
         - name: POSTGRES_HOST
-          value: postgres
+          value: {{ required "postgresql host required" .Values.global.postgresql.postgresqlHost | quote }}
         - name: POSTGRES_PORT
-          value: "5432"
+          value: {{ required "postgresql port required" .Values.global.postgresql.postgresqlPort | quote }}
         - name: PG_BOUNCER_HOST
-          value: pg-bouncer
+          value: pg-bouncer # Must match pgbouncer service name
         - name: PG_BOUNCER_PORT
-          value: "5432"
+          value: "5432" # Must match pgbouncer service port
         - name: POSTGRES_DATABASE
-          value: pachyderm
+          value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
         - name: POSTGRES_USER
-          value: pachyderm
+          value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
         - name: CLUSTER_DEPLOYMENT_ID
           value: {{ default (randAlphaNum 32) .Values.enterpriseServer.clusterDeploymentID | quote }}
         image: "{{ .Values.enterpriseServer.image.repository }}:{{ default .Chart.AppVersion .Values.enterpriseServer.image.tag }}"

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -43,30 +43,22 @@ spec:
       - command:
         - /pachd
         env:
-        {{- if .Values.pachd.postgresql.host }}
         - name: POSTGRES_HOST
-          value: {{ .Values.pachd.postgresql.host | quote}}
-        {{- end }}
-        {{- if .Values.pachd.postgresql.port }}
+          value: {{ required "postgresql host required" .Values.global.postgresql.postgresqlHost | quote }}
         - name: POSTGRES_PORT
-          value:  {{ .Values.pachd.postgresql.port | quote}}
-        {{- end }}
-        {{- if .Values.pachd.postgresql.user }}
+          value:  {{ required "postgresql port required" .Values.global.postgresql.postgresqlPort | quote }}
         - name: POSTGRES_USER
-          value: {{ .Values.pachd.postgresql.user | quote}}
-        {{- end }}
-        {{- if .Values.pachd.postgresql.database }}
+          value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
         - name: POSTGRES_DATABASE
-          value: {{ .Values.pachd.postgresql.database | quote }}
-        {{- end }}
-        {{- if .Values.pachd.postgresql.ssl }}
+          value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
+        {{- if .Values.global.postgresql.ssl }}
         - name: POSTGRES_SSL
-          value: {{ .Values.pachd.postgresql.ssl | quote }}
+          value: {{ .Values.global.postgresql.ssl | quote }}
         {{- end }}
         - name: PG_BOUNCER_HOST
-          value: pg-bouncer
+          value: pg-bouncer # Must match pgbouncer service name
         - name: PG_BOUNCER_PORT
-          value: "5432"
+          value: "5432" # Must match pbouncer service port
         - name: LOKI_LOGGING
           value: {{ .Values.pachd.lokiLogging | quote}}
         - name: PACH_ROOT

--- a/etc/helm/pachyderm/templates/pachd/storage-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/storage-secret.yaml
@@ -44,8 +44,8 @@ data:
   MICROSOFT_ID: {{ .Values.pachd.storage.microsoft.id | toString | b64enc | quote }}
   MICROSOFT_SECRET: {{ .Values.pachd.storage.microsoft.secret | toString | b64enc | quote }}
   {{- end }}
-  {{- if  .Values.pachd.postgresql.password }}
-  POSTGRES_PASSWORD: {{ .Values.pachd.postgresql.password | toString | b64enc | quote }}
-  IDENTITY_SERVER_PASSWORD: {{ .Values.pachd.postgresql.password | toString | b64enc | quote }}
+  {{- if .Values.global.postgresql.postgresqlPassword }}
+  POSTGRES_PASSWORD: {{ .Values.global.postgresql.postgresqlPassword | toString | b64enc | quote }}
+  IDENTITY_SERVER_PASSWORD: {{ .Values.global.postgresql.postgresqlPassword | toString | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -2,7 +2,6 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.pgbouncer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,11 +28,11 @@ spec:
       containers:
       - env:
         - name: DB_USER
-          value: pachyderm
+          value: {{ .Values.global.postgresql.postgresqlUsername }}
         - name: DB_PASSWORD
-          value: elephantastic
+          value: {{ .Values.global.postgresql.postgresqlPassword }}
         - name: DB_HOST
-          value: postgres
+          value: {{ .Values.global.postgresql.postgresqlHost }}
         - name: AUTH_TYPE
           value: trust
         - name: MAX_CLIENT_CONN
@@ -48,5 +47,3 @@ spec:
           requests:
             cpu: 250m
             memory: 256M
-      #serviceAccountName: pachyderm
-{{- end }}

--- a/etc/helm/pachyderm/templates/pgbouncer/service.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/service.yaml
@@ -2,7 +2,6 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.pgbouncer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,4 +21,3 @@ spec:
     app: pg-bouncer
     suite: pachyderm
   type: {{ .Values.pgbouncer.service.type }}
-{{- end }}

--- a/etc/helm/pachyderm/templates/postgresql/configmap.yaml
+++ b/etc/helm/pachyderm/templates/postgresql/configmap.yaml
@@ -12,7 +12,7 @@ data:
 
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
         CREATE DATABASE dex;
-        GRANT ALL PRIVILEGES ON DATABASE dex TO pachyderm;
+        GRANT ALL PRIVILEGES ON DATABASE dex TO "$POSTGRES_USER";
     EOSQL
 kind: ConfigMap
 metadata:

--- a/etc/helm/pachyderm/templates/postgresql/statefulset.yaml
+++ b/etc/helm/pachyderm/templates/postgresql/statefulset.yaml
@@ -33,9 +33,9 @@ spec:
       containers:
       - env:
         - name: POSTGRES_DB
-          value: pachyderm
+          value: {{ .Values.global.postgresql.postgresqlDatabase | quote }}
         - name: POSTGRES_USER
-          value: pachyderm
+          value: {{ .Values.global.postgresql.postgresqlUsername | quote }}
         - name: POSTGRES_HOST_AUTH_METHOD
           # TODO: Remove trust as auth method
           value: trust

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -239,6 +239,34 @@
                 }
             }
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "postgresql": {
+                    "type": "object",
+                    "properties": {
+                        "postgresqlDatabase": {
+                            "type": "string"
+                        },
+                        "postgresqlHost": {
+                            "type": "string"
+                        },
+                        "postgresqlPassword": {
+                            "type": "string"
+                        },
+                        "postgresqlPort": {
+                            "type": "string"
+                        },
+                        "postgresqlSSL": {
+                            "type": "string"
+                        },
+                        "postgresqlUsername": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "imagePullSecret": {
             "type": "string"
         },
@@ -346,29 +374,6 @@
                 },
                 "podLabels": {
                     "type": "object"
-                },
-                "postgresql": {
-                    "type": "object",
-                    "properties": {
-                        "database": {
-                            "type": "string"
-                        },
-                        "host": {
-                            "type": "string"
-                        },
-                        "password": {
-                            "type": "string"
-                        },
-                        "port": {
-                            "type": "string"
-                        },
-                        "ssl": {
-                            "type": "string"
-                        },
-                        "user": {
-                            "type": "string"
-                        }
-                    }
                 },
                 "ppsWorkerGRPCPort": {
                     "type": "integer"
@@ -560,9 +565,6 @@
         "pgbouncer": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
                 "resources": {
                     "type": "object"
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -12,6 +12,17 @@ imagePullSecret: ""
 # MINIO, MICROSOFT, CUSTOM or LOCAL.
 deployTarget: ""
 
+global:
+  postgresql:
+    postgresqlUsername: "pachyderm"
+    postgresqlPassword: "elephantastic"
+    postgresqlDatabase: "pachyderm"
+    # The postgresql database host to connect to. Defaults to built in postgres service
+    postgresqlHost: "postgres"
+    # The postgresql database port to connect to. Defaults to built in postgres service
+    postgresqlPort: "5432"
+    postgresqlSSL: "disable"
+
 dash:
   # enabled controls whether the dash manifests are created or not.
   enabled: false
@@ -162,17 +173,10 @@ pachd:
     #requests:
     #  cpu: "1"
     #  memory: "2G"
+
   # requireCriticalServersOnly only requires the critical pachd
   # servers to startup and run without errors.  It is analogous to the
   # --require-critical-servers-only argument to pachctl deploy.
-  postgresql:
-    host: "postgres"
-    port: "5432"
-    ssl: "disable"
-    user: "pachyderm"
-    password: ""
-    database: "pachyderm"
-
   requireCriticalServersOnly: false
   # If enabled, External service creates a service which is safe to
   # be exposed externally
@@ -340,7 +344,6 @@ worker:
     name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
 
 pgbouncer:
-  enabled: true
   service:
     type: ClusterIP
   resources: {}

--- a/etc/helm/test/hub_test.go
+++ b/etc/helm/test/hub_test.go
@@ -4,7 +4,6 @@
 package helmtest
 
 import (
-	"log"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -45,7 +44,6 @@ func TestHub(t *testing.T) {
 	for _, object := range objects {
 		switch object := object.(type) {
 		case *v1beta1.Ingress:
-			log.Println("ingress", object.String())
 			for _, rule := range object.Spec.Rules {
 				if rule.Host == "dash.test" {
 					checks["ingress"] = true

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -118,6 +118,12 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 	}, {
 		Name:  client.PPSPipelineNameEnv,
 		Value: pipelineInfo.Pipeline.Name,
+	}, {
+		Name:  "POSTGRES_PORT",
+		Value: "",
+	}, {
+		Name:  "POSTGRES_HOST",
+		Value: "",
 	},
 		// These are set explicitly below to prevent kubernetes from setting them to the service host and port.
 		{

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -118,12 +118,6 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 	}, {
 		Name:  client.PPSPipelineNameEnv,
 		Value: pipelineInfo.Pipeline.Name,
-	}, {
-		Name:  "POSTGRES_PORT",
-		Value: "",
-	}, {
-		Name:  "POSTGRES_HOST",
-		Value: "",
 	},
 		// These are set explicitly below to prevent kubernetes from setting them to the service host and port.
 		{


### PR DESCRIPTION
Since postgres information is referenced in multiple places, setup a global object.

This PR also removes the ability to disable pgbouncer (it's always required)

Get rid of spurious log statement in hub tests