### PR TITLE
Revert "Save cache after build and before tests (#6540)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ jobs:
          keys:
          - pach-go-mod-cache-v2-{{ checksum "go.sum" }}
       - run: etc/testing/circle/build.sh 
-      - when: #Save cache in only one bucket, after build and before running tests, this ensures build cache is saved even when tests fail
+      - run: etc/testing/circle/launch.sh 
+      - run: etc/testing/circle/run_tests.sh 
+      - when:
           condition: 
             equal: [MISC, <<parameters.bucket>> ]
           steps:
@@ -65,11 +67,9 @@ jobs:
                 paths:
                   - /home/circleci/.go_workspace/pkg/mod
             - save_cache:
-                key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
+                key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}-{{ .BuildNum }}
                 paths:
                   - /home/circleci/.gocache
-      - run: etc/testing/circle/launch.sh 
-      - run: etc/testing/circle/run_tests.sh 
       - run: etc/testing/circle/upload_stats.sh 
       - run:
           name: Dump debugging info in case of failure


### PR DESCRIPTION
This reverts commit 28a586e0a216da418f2b7ea52dd5d674c9f1919b.

I am not sure why this change caused a higher failure rate on CI for PPS4 bucket. For now I am going to revert this.