### PR TITLE
Change pachctl stop job and wait job to accept job or subjob id

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "launch-dev",
       "type": "shell",
-      "command": "eval $(minikube docker-env --shell bash); yes | pachctl undeploy; LAUNCH_DEV_ARGS='--cluster-deployment-id=dev' make launch-dev",
+      "command": "eval $(minikube docker-env --shell bash); make clean-launch; LAUNCH_DEV_ARGS='pachd.clusterDeploymentID=dev' make launch-dev",
       "problemMatcher": []
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -176,14 +176,14 @@ launch: install check-kubectl
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
-launch-dev: check-kubectl check-kubectl-connection install
+launch-dev: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
-	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml
+	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml --set $(LAUNCH_DEV_ARGS)
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
-launch-enterprise: check-kubectl check-kubectl-connection install
+launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
 	helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml

--- a/src/internal/uuid/uuid.go
+++ b/src/internal/uuid/uuid.go
@@ -42,4 +42,4 @@ func IsUUIDWithoutDashes(s string) bool {
 // Because we use UUIDv4, the 13th character is a '4'.
 // Moreover, a UUID can only contain "hexadecimal" characters,
 // lowercase here.
-var uuidWithoutDashesRegexp = regexp.MustCompile("[0-9a-f]{12}4[0-9a-f]{19}")
+var uuidWithoutDashesRegexp = regexp.MustCompile("^[0-9a-f]{12}4[0-9a-f]{19}$")

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/ansiterm"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pretty"
 	pfsclient "github.com/pachyderm/pachyderm/v2/src/pfs"
 	ppsclient "github.com/pachyderm/pachyderm/v2/src/pps"
@@ -80,10 +81,9 @@ func PrintJobSetInfo(w io.Writer, jobSetInfo *ppsclient.JobSetInfo, fullTimestam
 	var created *types.Timestamp
 	var modified *types.Timestamp
 	for _, job := range jobSetInfo.Jobs {
-		switch job.State {
-		case ppsclient.JobState_JOB_SUCCESS:
+		if job.State == ppsclient.JobState_JOB_SUCCESS {
 			success++
-		case ppsclient.JobState_JOB_FAILURE:
+		} else if ppsutil.IsTerminal(job.State) {
 			failure++
 		}
 

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -168,6 +168,8 @@ func (d *driver) runTransaction(txnCtx *txncontext.TransactionContext, info *tra
 			err = directTxn.DeleteBranch(request.DeleteBranch)
 		} else if request.UpdateJobState != nil {
 			err = directTxn.UpdateJobState(request.UpdateJobState)
+		} else if request.StopJob != nil {
+			err = directTxn.StopJob(request.StopJob)
 		} else if request.DeleteAll != nil {
 			// TODO: extend this to delete everything through PFS, PPS, Auth and
 			// update the client DeleteAll call to use only this, then remove unused


### PR DESCRIPTION
Following #6567, the 'jobset' concept has been renamed to a 'job', so it would make sense for `stop job` and `wait job` to accept a top-level job object (not constrained by a pipeline).  This changes those commands to accept both formats and do the right thing in either case.  To have `wait job` not have a polymorphic output, it now always outputs a table (instead of the details view it had previously).  There are a few other tangentially-related bug fixes (see comments).