### PR TITLE
Ignore file not found error during egress.

### DIFF
--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -483,7 +483,9 @@ func deserializeDatumSet(any *types.Any) (*DatumSet, error) {
 
 func (reg *registry) processJobEgressing(pj *pendingJob) error {
 	url := pj.ji.Details.Egress.URL
-	if err := pj.driver.PachClient().GetFileURL(pj.commitInfo.Commit, "/", url); err != nil {
+	err := pj.driver.PachClient().GetFileURL(pj.commitInfo.Commit, "/", url)
+	// file not found means the commit is empty, nothing to egress
+	if err != nil && !pfsserver.IsFileNotFoundErr(err) {
 		return err
 	}
 	return reg.succeedJob(pj)

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -294,6 +294,17 @@ func TestTransformPipeline(suite *testing.T) {
 		}
 	})
 
+	suite.Run("TestJobSuccessEgressEmpty", func(t *testing.T) {
+		t.Parallel()
+		_, bucket := testutil.NewObjectClient(t)
+		pi := defaultPipelineInfo()
+		pi.Details.Input.Pfs.Glob = "/"
+		pi.Details.Egress = &pps.Egress{URL: fmt.Sprintf("local://%s/", bucket)}
+		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+
+		testJobSuccess(t, env, pi, nil)
+	})
+
 	suite.Run("TestJobFailedDatum", func(t *testing.T) {
 		t.Parallel()
 		pi := defaultPipelineInfo()


### PR DESCRIPTION
This error just indicates an empty commit.