### PR TITLE
Update Doc with behavior for creating a pipeline with an existing output repo

### DIFF
--- a/doc/docs/master/how-tos/pipeline-operations/create-pipeline.md
+++ b/doc/docs/master/how-tos/pipeline-operations/create-pipeline.md
@@ -93,35 +93,7 @@ To create a pipeline, complete the following steps:
 When you create a pipeline, Pachyderm automatically creates an eponymous output
 repository. However, if such a repo already exists, your pipeline will take
 over the master branch. The files that were stored in the repo before
-will not be in the `HEAD` of the branch. Instead, you might see new files
-created by the new pipeline or a message
-that the `the branch "master" has no head`. The
-contents of the output commit entirely depend on the pipeline code and the
-input repository. So if your new pipeline is different from the one that
-existed before, it will replace the old files with new ones or there will be
-no files until the new pipeline runs at least once. The old files are still
-available through the corresponding commit ID.
-
-If you want to completely replace an existing pipeline, you can do so by
-following the standard pipeline creation procedure, as described above. However,
-if instead, you want to merge the old files with the new files, you could
-do so by putting your old files in a separate Pachyderm branch or repo and
-creating a [union](../../../concepts/pipeline-concepts/datum/cross-union/#union-input)
-input that combines these two branches or repos.
-
-To access the old files, complete the following steps:
-
-1. View the list of all commits:
-
-    ```shell
-    pachctl list commit <repo>@<master>
-    ```
-
-1. Then, use the commit ID to access the old files:
-
-    ```shell
-    pachctl list file <repo>@<commit_ID>
-    ```
+will still be in the `HEAD` of the branch.
 
 !!! note "See Also:"
     - [Pipelines](../../../concepts/pipeline-concepts/pipeline/)


### PR DESCRIPTION
This follows from a discussion in Slack: https://pachyderm.slack.com/archives/C0163RX3YQZ/p1626740046167500

I deleted a paragraph that was attempting to explain how to recover from the previous behavior. 
Now if one creates a pipeline with the name of an already existing repo, any existing files remain in the head of the output repo’s master branch.

Let me know what you think @nadegepepin 