### PR TITLE
Add monitoring to the database connection after we're certain it works

### DIFF
--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -309,8 +309,8 @@ func (env *NonblockingServiceEnv) initDirectDBClient() error {
 	}, backoff.RetryEvery(time.Second).For(5*time.Minute)); err != nil {
 		return err
 	}
-	if err := prometheus.Register(sqlstats.NewStatsCollector("pg_bouncer", db.DB)); err != nil {
-		return fmt.Errorf("init stats collector for pg_bouncer: %w", err)
+	if err := prometheus.Register(sqlstats.NewStatsCollector("direct", env.directDBClient.DB)); err != nil {
+		return fmt.Errorf("init stats collector for direct db client: %w", err)
 	}
 	return nil
 }
@@ -334,8 +334,8 @@ func (env *NonblockingServiceEnv) initDBClient() error {
 	}, backoff.RetryEvery(time.Second).For(5*time.Minute)); err != nil {
 		return err
 	}
-	if err := prometheus.Register(sqlstats.NewStatsCollector("postgres", db.DB)); err != nil {
-		return fmt.Errorf("init stats collector for postgres: %w", err)
+	if err := prometheus.Register(sqlstats.NewStatsCollector("pg_bouncer", env.dbClient.DB)); err != nil {
+		return fmt.Errorf("init stats collector for pg_bouncer db client: %w", err)
 	}
 	return nil
 }

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -310,7 +310,7 @@ func (env *NonblockingServiceEnv) initDirectDBClient() error {
 		return err
 	}
 	if err := prometheus.Register(sqlstats.NewStatsCollector("direct", env.directDBClient.DB)); err != nil {
-		return fmt.Errorf("init stats collector for direct db client: %w", err)
+		log.WithError(err).Warning("problem registering stats collector for direct db client")
 	}
 	return nil
 }
@@ -335,7 +335,7 @@ func (env *NonblockingServiceEnv) initDBClient() error {
 		return err
 	}
 	if err := prometheus.Register(sqlstats.NewStatsCollector("pg_bouncer", env.dbClient.DB)); err != nil {
-		return fmt.Errorf("init stats collector for pg_bouncer db client: %w", err)
+		log.WithError(err).Warning("problem registering stats collector for pg_bouncer db client")
 	}
 	return nil
 }


### PR DESCRIPTION
If db.Ping fails, we end up calling `prometheus.Register(sqlstats.NewStatsCollector(db))` more than once, which fails the second time.  This prevents the case where we call it the second time; we add the monitoring after Ping succeeds, so no error can cause the code to run again and try to monitor a second db object with the same stats collector name.