### PR TITLE
Remove non-greedy postgres list behavior.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -5880,7 +5880,6 @@ func TestCronPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	t.Skip("TODO: This tests passes when run in isolation, but is flaky and often hangs.")
 	c := tu.GetPachClient(t)
 	require.NoError(t, c.DeleteAll())
 	t.Run("SimpleCron", func(t *testing.T) {


### PR DESCRIPTION
Even in the read only case, row iteration takes up a connection as long
as the row is open. Any nested query will require another, making it
possible to deadlock if all connections are waiting on outer queries.
List pipeline was particularly egregious here because it opened up to
twenty subqueries.