### PR TITLE
Fix additional help topics in base `pachctl` command

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -931,7 +931,7 @@ Commands by Action:{{range actions}}{{if .IsAvailableCommand}}
 Other Commands:{{range other}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
-Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .Name .NamePadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}


### PR DESCRIPTION
It looks like this was written against an old API that no longer works.  I will also backport this to 1.13.x when merged, as it looks like it was broken there as well (with slightly different outcomes).

Fixes #6599 