### PR TITLE
Fix listing of jobsets after a squash, and `list job` with --pipeline without --expand flag

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1053,7 +1053,7 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 		}
 	}
 
-	// Traverse commits' parents until you've reached the right/ancestor
+	// Traverse commits' parents until you've reached the right ancestor
 	commitInfo := &pfs.CommitInfo{}
 	if ancestryLength >= 0 {
 		for i := 0; i <= ancestryLength; i++ {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1053,7 +1053,7 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 		}
 	}
 
-	// Traverse commits' parents until you've reached the right ancestor
+	// Traverse commits' parents until you've reached the right/ancestor
 	commitInfo := &pfs.CommitInfo{}
 	if ancestryLength >= 0 {
 		for i := 0; i <= ancestryLength; i++ {


### PR DESCRIPTION
The `pps.ListJobSet` and `pps.InspectJobSet` RPCs would list the commits in the job to leverage PFS's topological sort before converting into `pps.JobInfo`s.  This doesn't work if the commitset has been squashed, as that will return a 'not found' error.  This PR changes it to recognize the 'not found' error and to do a normal list of the jobs in the jobset without any ordering.

In addition, `pachctl list job` would error if `--pipeline` was specified, but `--expand` was not.  Since `--pipeline` obviously implies `--expand`, this PR reorganizes the checks to allow this.