### PR TITLE
Fix miscutil.WithPipe not returning errors.

### DIFF
--- a/src/internal/miscutil/miscutil.go
+++ b/src/internal/miscutil/miscutil.go
@@ -19,7 +19,7 @@ func WithPipe(wcb func(w io.Writer) error, rcb func(r io.Reader) error) error {
 	eg.Go(func() error {
 		err := rcb(pr)
 		pr.CloseWithError(err)
-		return pr.Close()
+		return err
 	})
 	return eg.Wait()
 }

--- a/src/internal/miscutil/miscutil.go
+++ b/src/internal/miscutil/miscutil.go
@@ -12,15 +12,13 @@ func WithPipe(wcb func(w io.Writer) error, rcb func(r io.Reader) error) error {
 	pr, pw := io.Pipe()
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		if err := wcb(pw); err != nil {
-			return pw.CloseWithError(err)
-		}
-		return pw.Close()
+		err := wcb(pw)
+		pw.CloseWithError(err)
+		return err
 	})
 	eg.Go(func() error {
-		if err := rcb(pr); err != nil {
-			return pr.CloseWithError(err)
-		}
+		err := rcb(pr)
+		pr.CloseWithError(err)
 		return pr.Close()
 	})
 	return eg.Wait()

--- a/src/internal/obj/google_client.go
+++ b/src/internal/obj/google_client.go
@@ -120,7 +120,7 @@ func (c *googleClient) transformError(err error, objectPath string) error {
 		return err
 	}
 
-	var googleErr googleapi.Error
+	googleErr := &googleapi.Error{}
 	if !errors.As(err, &googleErr) {
 		return err
 	}

--- a/src/internal/pacherr/common.go
+++ b/src/internal/pacherr/common.go
@@ -16,23 +16,23 @@ type ErrNotExist struct {
 }
 
 func NewNotExist(collection, id string) error {
-	return &ErrNotExist{
+	return ErrNotExist{
 		Collection: collection,
 		ID:         id,
 	}
 }
 
-func (e *ErrNotExist) Error() string {
+func (e ErrNotExist) Error() string {
 	return fmt.Sprintf("%s does not contain item: (%s)", e.Collection, e.ID)
 }
 
-func (e *ErrNotExist) GRPCStatus() *status.Status {
+func (e ErrNotExist) GRPCStatus() *status.Status {
 	return status.New(codes.NotFound, e.Error())
 }
 
 func IsNotExist(err error) bool {
-	target := &ErrNotExist{}
-	return errors.As(err, target) || os.IsNotExist(err)
+	target := ErrNotExist{}
+	return errors.As(err, &target) || os.IsNotExist(err)
 }
 
 type ErrExists struct {
@@ -47,17 +47,17 @@ func NewExists(collection, id string) error {
 	}
 }
 
-func (e *ErrExists) Error() string {
+func (e ErrExists) Error() string {
 	return fmt.Sprintf("%s already contains an item: (%s)", e.Collection, e.ID)
 }
 
-func (e *ErrExists) GRPCStatus() *status.Status {
+func (e ErrExists) GRPCStatus() *status.Status {
 	return status.New(codes.AlreadyExists, e.Error())
 }
 
 func IsExists(err error) bool {
-	target := &ErrExists{}
-	return errors.As(err, target)
+	target := ErrExists{}
+	return errors.As(err, &target)
 }
 
 var (

--- a/src/internal/storage/chunk/client.go
+++ b/src/internal/storage/chunk/client.go
@@ -99,7 +99,7 @@ func (c *trackedClient) Create(ctx context.Context, md Metadata, chunkData []byt
 	if err := c.store.Put(ctx, key, chunkData); err != nil {
 		return nil, err
 	}
-	_, err := c.db.Exec(`
+	_, err := c.db.ExecContext(ctx, `
 	UPDATE storage.chunk_objects
 	SET uploaded = TRUE
 	WHERE chunk_id = $1 AND gen = $2

--- a/src/internal/storage/chunk/transform.go
+++ b/src/internal/storage/chunk/transform.go
@@ -46,7 +46,7 @@ func Create(ctx context.Context, opts CreateOptions, ptext []byte, createFunc fu
 }
 
 // Get calls getFunc to retrieve a chunk, then verifies, decrypts, and decompresses the data.
-// Uncompressed plaintext is written to w.
+// cb is called with the uncompressed plaintext
 func Get(ctx context.Context, client Client, cache kv.GetPut, ref *Ref, cb kv.ValueCallback) error {
 	if err := getFromCache(ctx, cache, ref, cb); err == nil {
 		return nil
@@ -190,7 +190,7 @@ func cryptoXOR(key, dst, src []byte) {
 func verifyData(id ID, x []byte) error {
 	actualHash := Hash(x)
 	if !bytes.Equal(actualHash[:], id) {
-		return errors.Errorf("bad chunk. HAVE: %x WANT: %x", actualHash, id)
+		return errors.Errorf("bad chunk. HAVE: %v WANT: %v", actualHash, id)
 	}
 	return nil
 }

--- a/src/internal/storage/kv/kv.go
+++ b/src/internal/storage/kv/kv.go
@@ -10,7 +10,7 @@ type ValueCallback = func([]byte) error
 // GetPut supports the basic Get and Put operations
 type GetPut interface {
 	// Get looks up the value that corresponds to key and calls cb once if the key exists
-	// if the key does not exist ErrKeyNotFound is returned
+	// if the key does not exist then a pacherr.ErrNotExist is returned
 	Get(ctx context.Context, key []byte, cb ValueCallback) error
 	// Put creates an entry mapping key to value, overwriting any previous mapping.
 	Put(ctx context.Context, key, value []byte) error

--- a/src/internal/storage/kv/memcache.go
+++ b/src/internal/storage/kv/memcache.go
@@ -42,9 +42,10 @@ func (mc *memoryCache) Get(ctx context.Context, key []byte, cb ValueCallback) er
 }
 
 func (mc *memoryCache) Delete(ctx context.Context, key []byte) error {
+	k := string(key)
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
-	mc.cache.Remove(key)
+	mc.cache.Remove(k)
 	return nil
 }
 

--- a/src/internal/storage/kv/obj_adapter.go
+++ b/src/internal/storage/kv/obj_adapter.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
 )
 
 type objectAdapter struct {
@@ -34,9 +33,6 @@ func (s *objectAdapter) Put(ctx context.Context, key, value []byte) (retErr erro
 func (s *objectAdapter) Get(ctx context.Context, key []byte, cb ValueCallback) (retErr error) {
 	return s.withBuffer(func(buf *bytes.Buffer) error {
 		if err := s.objC.Get(ctx, string(key), buf); err != nil {
-			if pacherr.IsNotExist(err) {
-				err = pacherr.NewNotExist("kv", string(key))
-			}
 			return err
 		}
 		return cb(buf.Bytes())

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -91,6 +91,14 @@ func newDriver(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcdPre
 	if err != nil {
 		return nil, err
 	}
+	// test object storage.
+	if err := func() error {
+		ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cf()
+		return obj.TestStorage(ctx, objClient)
+	}(); err != nil {
+		return nil, err
+	}
 	repos := pfsdb.Repos(env.GetDBClient(), env.GetPostgresListener())
 	commits := pfsdb.Commits(env.GetDBClient(), env.GetPostgresListener())
 	branches := pfsdb.Branches(env.GetDBClient(), env.GetPostgresListener())

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -93,7 +93,7 @@ func newDriver(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, etcdPre
 	}
 	// test object storage.
 	if err := func() error {
-		ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cf := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cf()
 		return obj.TestStorage(ctx, objClient)
 	}(); err != nil {

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -486,8 +486,8 @@ func (d *driver) commitSizeUpperBound(ctx context.Context, commit *pfs.Commit) (
 	return d.storage.SizeUpperBound(ctx, *fsid)
 }
 
-func newFileNotFound(commitID string, path string) *pacherr.ErrNotExist {
-	return &pacherr.ErrNotExist{
+func newFileNotFound(commitID string, path string) pacherr.ErrNotExist {
+	return pacherr.ErrNotExist{
 		Collection: "commit/" + commitID,
 		ID:         path,
 	}


### PR DESCRIPTION
miscutil.WithPipe was not returning errors because CloseWithError always returns nil, and that was being passed to the errgroup.  So errgroup.Wait always returned nil, even in the case of failure.