### PR TITLE
Switch s3 sidecar pipeline detail fetch back to gRPC

### DIFF
--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -103,6 +103,7 @@ case "${BUCKET}" in
     bucket_num="${BUCKET#PPS}"
     test_bucket "./src/server" test-pps "${bucket_num}" "${PPS_BUCKETS}"
     if [[ "${bucket_num}" -eq "${PPS_BUCKETS}" ]]; then
+      export PACH_TEST_WITH_AUTH=1
       go test -v -count=1 ./src/server/pps/server -timeout 420s
     fi
     ;;
@@ -115,7 +116,7 @@ case "${BUCKET}" in
     make test-enterprise
     # Launch a stand-alone enterprise server in a separate namespace
     make launch-enterprise
-    echo "{\"pachd_address\": \"grpc://${VM_IP}:${ENTERPRISE_PORT}\", \"source\": 2}" | pachctl config set context "enterprise" --overwrite 
+    echo "{\"pachd_address\": \"grpc://${VM_IP}:${ENTERPRISE_PORT}\", \"source\": 2}" | pachctl config set context "enterprise" --overwrite
     pachctl config set active-enterprise-context enterprise
     make test-enterprise-integration
     ;;

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
-	"github.com/pachyderm/pachyderm/v2/src/internal"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dlock"
@@ -67,7 +66,7 @@ func (a *apiServer) ServeSidecarS3G() {
 		// auth is off)
 		s.pachClient.SetAuthToken(s.pipelineInfo.AuthToken)
 
-		if err := internal.GetPipelineDetails(s.pachClient.Ctx(), a.env.PfsServer(), s.pipelineInfo); err != nil {
+		if err := ppsutil.GetPipelineDetails(s.pachClient, s.pipelineInfo); err != nil {
 			return errors.Wrapf(err, "sidecar s3 gateway: could not get pipeline details")
 		}
 		return nil

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -62,6 +62,7 @@ func TestS3PipelineErrors(t *testing.T) {
 	}
 
 	c, _ := initPachClient(t)
+	defer c.DeleteAll()
 
 	repo1, repo2 := tu.UniqueString(t.Name()+"_data"), tu.UniqueString(t.Name()+"_data")
 	require.NoError(t, c.CreateRepo(repo1))
@@ -136,6 +137,7 @@ func TestS3Input(t *testing.T) {
 	}
 
 	c, userToken := initPachClient(t)
+	defer c.DeleteAll()
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -226,6 +228,7 @@ func TestS3Chain(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	c, userToken := initPachClient(t)
+	defer c.DeleteAll()
 
 	dataRepo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -290,6 +293,7 @@ func TestNamespaceInEndpoint(t *testing.T) {
 	}
 
 	c, _ := initPachClient(t)
+	defer c.DeleteAll()
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -339,6 +343,7 @@ func TestS3Output(t *testing.T) {
 	}
 
 	c, userToken := initPachClient(t)
+	defer c.DeleteAll()
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -424,6 +429,7 @@ func TestFullS3(t *testing.T) {
 	}
 
 	c, userToken := initPachClient(t)
+	defer c.DeleteAll()
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -511,6 +517,7 @@ func TestS3SkippedDatums(t *testing.T) {
 	name := t.Name()
 
 	c, userToken := initPachClient(t)
+	defer c.DeleteAll()
 
 	t.Run("S3Inputs", func(t *testing.T) {
 		// TODO(2.0 optional): Duplicate file paths from different datums no longer allowed.

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -25,8 +25,6 @@ import (
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
-	"golang.org/x/net/context"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -241,7 +239,7 @@ func TestS3Chain(t *testing.T) {
 		if i > 0 {
 			input = pipelines[i-1]
 		}
-		_, err := c.PpsAPIClient.CreatePipeline(context.Background(),
+		_, err := c.PpsAPIClient.CreatePipeline(c.Ctx(),
 			&pps.CreatePipelineRequest{
 				Pipeline: client.NewPipeline(pipelines[i]),
 				Transform: &pps.Transform{

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -50,8 +50,7 @@ func initPachClient(t testing.TB) (*client.APIClient, string) {
 		require.NoError(t, c.DeleteAll())
 		return c, ""
 	}
-	rootClient := tu.GetAuthenticatedPachClient(t, tu.RootToken)
-	require.NoError(t, rootClient.DeleteAll())
+	tu.ActivateAuth(t)
 	c := tu.GetAuthenticatedPachClient(t, tu.UniqueString("user-"))
 	return c, c.AuthToken()
 }
@@ -62,7 +61,7 @@ func TestS3PipelineErrors(t *testing.T) {
 	}
 
 	c, _ := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	repo1, repo2 := tu.UniqueString(t.Name()+"_data"), tu.UniqueString(t.Name()+"_data")
 	require.NoError(t, c.CreateRepo(repo1))
@@ -137,7 +136,7 @@ func TestS3Input(t *testing.T) {
 	}
 
 	c, userToken := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -228,7 +227,7 @@ func TestS3Chain(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	c, userToken := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	dataRepo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -293,7 +292,7 @@ func TestNamespaceInEndpoint(t *testing.T) {
 	}
 
 	c, _ := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -343,7 +342,7 @@ func TestS3Output(t *testing.T) {
 	}
 
 	c, userToken := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -429,7 +428,7 @@ func TestFullS3(t *testing.T) {
 	}
 
 	c, userToken := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	repo := tu.UniqueString(t.Name() + "_data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -517,7 +516,7 @@ func TestS3SkippedDatums(t *testing.T) {
 	name := t.Name()
 
 	c, userToken := initPachClient(t)
-	defer c.DeleteAll()
+	defer tu.DeleteAll(t)
 
 	t.Run("S3Inputs", func(t *testing.T) {
 		// TODO(2.0 optional): Duplicate file paths from different datums no longer allowed.


### PR DESCRIPTION
Also run s3 tests with auth enabled by default.