### PR TITLE
Fix context cancel race in new version of GetFile

### DIFF
--- a/src/internal/storage/fileset/dir_inserter.go
+++ b/src/internal/storage/fileset/dir_inserter.go
@@ -68,11 +68,11 @@ func (d dirFile) Index() *index.Index {
 	}
 }
 
-func (d dirFile) Content(w io.Writer) error {
+func (d dirFile) Content(_ context.Context, _ io.Writer) error {
 	return nil
 }
 
-func (d dirFile) Hash() ([]byte, error) {
+func (d dirFile) Hash(_ context.Context) ([]byte, error) {
 	// TODO: It may make sense to move the generation of directory metadata (size / hash) into the directory inserter.
 	panic("we should not be using the Hash function for dirFile, this is a bug")
 }

--- a/src/internal/storage/fileset/fileset.go
+++ b/src/internal/storage/fileset/fileset.go
@@ -102,9 +102,9 @@ type File interface {
 	// Index returns the index for the file.
 	Index() *index.Index
 	// Content writes the content of the file.
-	Content(w io.Writer) error
+	Content(ctx context.Context, w io.Writer) error
 	// Hash returns the hash of the file.
-	Hash() ([]byte, error)
+	Hash(ctx context.Context) ([]byte, error)
 }
 
 var _ File = &MergeFileReader{}

--- a/src/internal/storage/fileset/fileset_test.go
+++ b/src/internal/storage/fileset/fileset_test.go
@@ -47,7 +47,7 @@ func checkFile(t *testing.T, f File, tf *testFile) {
 	r, w := io.Pipe()
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		return f.Content(w)
+		return f.Content(context.Background(), w)
 	})
 	eg.Go(func() (retErr error) {
 		defer func() {
@@ -225,7 +225,7 @@ func TestStableHash(t *testing.T) {
 			}
 			found = true
 			var err error
-			hash, err = f.Hash()
+			hash, err = f.Hash(ctx)
 			return err
 		}), msg)
 		if !found {

--- a/src/internal/storage/fileset/merge.go
+++ b/src/internal/storage/fileset/merge.go
@@ -60,7 +60,7 @@ func (mr *MergeReader) iterate(ctx context.Context, cb func(File) error) error {
 			return nil
 		}
 		if len(fss) == 1 {
-			return cb(newFileReader(ctx, mr.chunks, fss[0].file.Index()))
+			return cb(newFileReader(mr.chunks, fss[0].file.Index()))
 		}
 		var dataRefs []*chunk.DataRef
 		for _, fs := range fss {
@@ -69,7 +69,7 @@ func (mr *MergeReader) iterate(ctx context.Context, cb func(File) error) error {
 		}
 		mergeIdx := fss[0].file.Index()
 		mergeIdx.File.DataRefs = dataRefs
-		return cb(newMergeFileReader(ctx, mr.chunks, mergeIdx))
+		return cb(newMergeFileReader(mr.chunks, mergeIdx))
 
 	})
 }
@@ -84,20 +84,18 @@ func (mr *MergeReader) iterateDeletive(ctx context.Context, cb func(File) error)
 	pq := stream.NewPriorityQueue(ss, compare)
 	return pq.Iterate(func(ss []stream.Stream) error {
 		fs := ss[0].(*fileStream)
-		return cb(newFileReader(ctx, mr.chunks, fs.file.Index()))
+		return cb(newFileReader(mr.chunks, fs.file.Index()))
 	})
 }
 
 // MergeFileReader is an abstraction for reading a merged file.
 type MergeFileReader struct {
-	ctx    context.Context
 	chunks *chunk.Storage
 	idx    *index.Index
 }
 
-func newMergeFileReader(ctx context.Context, chunks *chunk.Storage, idx *index.Index) *MergeFileReader {
+func newMergeFileReader(chunks *chunk.Storage, idx *index.Index) *MergeFileReader {
 	return &MergeFileReader{
-		ctx:    ctx,
 		chunks: chunks,
 		idx:    idx,
 	}
@@ -111,15 +109,15 @@ func (mfr *MergeFileReader) Index() *index.Index {
 }
 
 // Content returns the content of the merged file.
-func (mfr *MergeFileReader) Content(w io.Writer) error {
-	r := mfr.chunks.NewReader(mfr.ctx, mfr.idx.File.DataRefs)
+func (mfr *MergeFileReader) Content(ctx context.Context, w io.Writer) error {
+	r := mfr.chunks.NewReader(ctx, mfr.idx.File.DataRefs)
 	return r.Get(w)
 }
 
 // Hash returns the hash of the file.
-func (mfr *MergeFileReader) Hash() ([]byte, error) {
+func (mfr *MergeFileReader) Hash(ctx context.Context) ([]byte, error) {
 	var resolvedDataRefs []*chunk.DataRef
-	cw := mfr.chunks.NewWriter(mfr.ctx, "resolve-writer", func(annotations []*chunk.Annotation) error {
+	cw := mfr.chunks.NewWriter(ctx, "resolve-writer", func(annotations []*chunk.Annotation) error {
 		if annotations[0].NextDataRef != nil {
 			resolvedDataRefs = append(resolvedDataRefs, annotations[0].NextDataRef)
 		}

--- a/src/internal/storage/fileset/reader.go
+++ b/src/internal/storage/fileset/reader.go
@@ -41,25 +41,23 @@ func (r *Reader) Iterate(ctx context.Context, cb func(File) error, deletive ...b
 	if len(deletive) > 0 && deletive[0] {
 		ir := index.NewReader(r.chunks, prim.Deletive, r.indexOpts...)
 		return ir.Iterate(ctx, func(idx *index.Index) error {
-			return cb(newFileReader(ctx, r.chunks, idx))
+			return cb(newFileReader(r.chunks, idx))
 		})
 	}
 	ir := index.NewReader(r.chunks, prim.Additive, r.indexOpts...)
 	return ir.Iterate(ctx, func(idx *index.Index) error {
-		return cb(newFileReader(ctx, r.chunks, idx))
+		return cb(newFileReader(r.chunks, idx))
 	})
 }
 
 // FileReader is an abstraction for reading a file.
 type FileReader struct {
-	ctx    context.Context
 	chunks *chunk.Storage
 	idx    *index.Index
 }
 
-func newFileReader(ctx context.Context, chunks *chunk.Storage, idx *index.Index) *FileReader {
+func newFileReader(chunks *chunk.Storage, idx *index.Index) *FileReader {
 	return &FileReader{
-		ctx:    ctx,
 		chunks: chunks,
 		idx:    proto.Clone(idx).(*index.Index),
 	}
@@ -73,12 +71,12 @@ func (fr *FileReader) Index() *index.Index {
 }
 
 // Content writes the content of the file.
-func (fr *FileReader) Content(w io.Writer) error {
-	r := fr.chunks.NewReader(fr.ctx, fr.idx.File.DataRefs)
+func (fr *FileReader) Content(ctx context.Context, w io.Writer) error {
+	r := fr.chunks.NewReader(ctx, fr.idx.File.DataRefs)
 	return r.Get(w)
 }
 
 // Hash returns the hash of the file.
-func (fr *FileReader) Hash() ([]byte, error) {
+func (fr *FileReader) Hash(_ context.Context) ([]byte, error) {
 	return hashDataRefs(fr.idx.File.DataRefs)
 }

--- a/src/internal/storage/fileset/transforms.go
+++ b/src/internal/storage/fileset/transforms.go
@@ -81,10 +81,10 @@ func (im *indexMap) Index() *index.Index {
 	return im.idx
 }
 
-func (im *indexMap) Content(w io.Writer) error {
-	return im.inner.Content(w)
+func (im *indexMap) Content(ctx context.Context, w io.Writer) error {
+	return im.inner.Content(ctx, w)
 }
 
-func (im *indexMap) Hash() ([]byte, error) {
-	return im.inner.Hash()
+func (im *indexMap) Hash(ctx context.Context) ([]byte, error) {
+	return im.inner.Hash(ctx)
 }

--- a/src/internal/storage/fileset/util.go
+++ b/src/internal/storage/fileset/util.go
@@ -40,13 +40,13 @@ func CopyFiles(ctx context.Context, w *Writer, fs FileSet, deletive ...bool) err
 }
 
 // WriteTarEntry writes an tar entry for f to w
-func WriteTarEntry(w io.Writer, f File) error {
+func WriteTarEntry(ctx context.Context, w io.Writer, f File) error {
 	idx := f.Index()
 	tw := tar.NewWriter(w)
 	if err := tw.WriteHeader(tarutil.NewHeader(idx.Path, index.SizeBytes(idx))); err != nil {
 		return err
 	}
-	if err := f.Content(tw); err != nil {
+	if err := f.Content(ctx, tw); err != nil {
 		return err
 	}
 	return tw.Flush()
@@ -56,7 +56,7 @@ func WriteTarEntry(w io.Writer, f File) error {
 // It will contain an entry for each File in fs
 func WriteTarStream(ctx context.Context, w io.Writer, fs FileSet) error {
 	if err := fs.Iterate(ctx, func(f File) error {
-		return WriteTarEntry(w, f)
+		return WriteTarEntry(ctx, w, f)
 	}); err != nil {
 		return err
 	}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -536,7 +536,7 @@ func (a *apiServer) GetFile(request *pfs.GetFileRequest, server pfs.API_GetFileS
 			return getFileURL(ctx, request.URL, src)
 		}
 		if err := grpcutil.WithStreamingBytesWriter(server, func(w io.Writer) error {
-			return file.Content(w)
+			return file.Content(ctx, w)
 		}); err != nil {
 			return 0, err
 		}
@@ -560,7 +560,7 @@ func getFileURL(ctx context.Context, URL string, src Source) (int64, error) {
 			return nil
 		}
 		if err := miscutil.WithPipe(func(w io.Writer) error {
-			return file.Content(w)
+			return file.Content(ctx, w)
 		}, func(r io.Reader) error {
 			return objClient.Put(ctx, filepath.Join(parsedURL.Object, fi.File.Path), r)
 		}); err != nil {
@@ -599,7 +599,7 @@ func getFileTar(ctx context.Context, w io.Writer, src Source) error {
 	// 	},
 	// }
 	if err := src.Iterate(ctx, func(fi *pfs.FileInfo, file fileset.File) error {
-		return fileset.WriteTarEntry(w, file)
+		return fileset.WriteTarEntry(ctx, w, file)
 	}); err != nil {
 		return err
 	}

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -149,7 +149,7 @@ func (s *source) computeRegularFileInfo(ctx context.Context, f fileset.File) (*p
 		SizeBytes: index.SizeBytes(f.Index()),
 	}
 	var err error
-	fi.Hash, err = f.Hash()
+	fi.Hash, err = f.Hash(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes a race condition in the new version of GetFile. The basic problem was that an abstraction (`fileset.File`) was being used outside of the callback based iteration that it was created in. This was a problem because the context used by `fileset.File` was the one associated with the iteration. Once the iteration is completed, the context is canceled and attempting to get the content would return context canceled. The change I made was to remove the internal context from the implementations of `fileset.File` and require the appropriate context to be passed into the functions that need a context.