### PR TITLE
Remove alias to dbutil.WithTx

### DIFF
--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -120,20 +120,10 @@ func (c *postgresCollection) ReadWrite(tx *sqlx.Tx) PostgresReadWriteCollection 
 	return &postgresReadWriteCollection{c, tx}
 }
 
-type ErrTransactionConflict = dbutil.ErrTransactionConflict
-
-// NewSQLTx starts a transaction on the given DB, passes it to the callback, and
-// finishes the transaction afterwards. If the callback was successful, the
-// transaction is committed. If any errors occur, the transaction is rolled
-// back.  This will reattempt the transaction forever.
-func NewSQLTx(ctx context.Context, db *sqlx.DB, apply func(*sqlx.Tx) error) error {
-	return dbutil.WithTx(ctx, db, apply)
-}
-
 // NewDryrunSQLTx is identical to NewSQLTx except it will always roll back the
 // transaction instead of committing it.
 func NewDryrunSQLTx(ctx context.Context, db *sqlx.DB, apply func(*sqlx.Tx) error) error {
-	err := NewSQLTx(ctx, db, func(tx *sqlx.Tx) error {
+	err := dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
 		if err := apply(tx); err != nil {
 			return err
 		}

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -75,7 +75,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*sqlx.DB, col.Po
 		}
 
 		writeCallback := func(ctx context.Context, f func(col.ReadWriteCollection) error) error {
-			return col.NewSQLTx(ctx, db, func(tx *sqlx.Tx) error {
+			return dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
 				return f(testCol.ReadWrite(tx))
 			})
 		}

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsconsts"
@@ -201,7 +202,7 @@ func logSetPipelineState(pipeline string, from []pps.PipelineState, to pps.Pipel
 // exclusively?) called by the PPS master
 func SetPipelineState(ctx context.Context, db *sqlx.DB, pipelinesCollection col.PostgresCollection, pipeline string, from []pps.PipelineState, to pps.PipelineState, reason string) (retErr error) {
 	logSetPipelineState(pipeline, from, to, reason)
-	err := col.NewSQLTx(ctx, db, func(sqlTx *sqlx.Tx) error {
+	err := dbutil.WithTx(ctx, db, func(sqlTx *sqlx.Tx) error {
 		pipelines := pipelinesCollection.ReadWrite(sqlTx)
 		pipelineInfo := &pps.PipelineInfo{}
 		if err := pipelines.Get(pipeline, pipelineInfo); err != nil {

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -297,7 +298,7 @@ func (env *TransactionEnv) WithTransaction(ctx context.Context, cb func(Transact
 // WithWriteContext will call the given callback with a txncontext.TransactionContext
 // which can be used to perform reads and writes on the current cluster state.
 func (env *TransactionEnv) WithWriteContext(ctx context.Context, cb func(*txncontext.TransactionContext) error) error {
-	return col.NewSQLTx(ctx, env.serviceEnv.GetDBClient(), func(sqlTx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, env.serviceEnv.GetDBClient(), func(sqlTx *sqlx.Tx) error {
 		txnCtx := &txncontext.TransactionContext{
 			ClientContext: ctx,
 			SqlTx:         sqlTx,

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
@@ -285,7 +286,7 @@ func (d *driver) fsck(ctx context.Context, fix bool, cb func(*pfs.FsckResponse) 
 	// TODO(global ids): is there any verification we can do for commitsets?
 
 	if fix {
-		return col.NewSQLTx(ctx, d.env.GetDBClient(), func(sqlTx *sqlx.Tx) error {
+		return dbutil.WithTx(ctx, d.env.GetDBClient(), func(sqlTx *sqlx.Tx) error {
 			for _, ci := range newCommitInfos {
 				// We've observed users getting ErrExists from this create,
 				// which doesn't make a lot of sense, but we insulate against

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ancestry"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
@@ -1990,7 +1991,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 		}
 
 		// The transaction cannot continue because it cannot see the fileset - abort and retry
-		return &col.ErrTransactionConflict{}
+		return &dbutil.ErrTransactionConflict{}
 	}
 
 	// Verify that all input repos exist (create cron and git repos if necessary)
@@ -2684,7 +2685,7 @@ func (a *apiServer) deletePipeline(ctx context.Context, request *pps.DeletePipel
 	}
 
 	// Delete PipelineInfo
-	if err := col.NewSQLTx(ctx, a.env.GetDBClient(), func(sqlTx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, a.env.GetDBClient(), func(sqlTx *sqlx.Tx) error {
 		return a.pipelines.ReadWrite(sqlTx).Delete(request.Pipeline.Name)
 	}); err != nil {
 		return errors.Wrapf(err, "collection.Delete")
@@ -2760,7 +2761,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 		return a.pipelines.ReadWrite(txnCtx.SqlTx).Update(pipelineInfo.Pipeline.Name, newPipelineInfo, func() error {
 			if newPipelineInfo.Version != pipelineInfo.Version {
 				// If the pipeline has changed, restart the transaction and try again
-				return col.ErrTransactionConflict{}
+				return dbutil.ErrTransactionConflict{}
 			}
 			newPipelineInfo.Stopped = false
 			return nil
@@ -2818,7 +2819,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 			if err := a.pipelines.ReadWrite(txnCtx.SqlTx).Update(pipelineInfo.Pipeline.Name, newPipelineInfo, func() error {
 				if newPipelineInfo.Version != pipelineInfo.Version {
 					// If the pipeline has changed, restart the transaction and try again
-					return col.ErrTransactionConflict{}
+					return dbutil.ErrTransactionConflict{}
 				}
 				newPipelineInfo.Stopped = true
 				return nil

--- a/src/server/transaction/server/api_server.go
+++ b/src/server/transaction/server/api_server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/net/context"
 
-	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
@@ -89,7 +89,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *transaction.DeleteAl
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
 
-	if err := col.NewSQLTx(ctx, a.driver.db, func(sqlTx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, a.driver.db, func(sqlTx *sqlx.Tx) error {
 		return a.driver.deleteAll(ctx, sqlTx, nil)
 	}); err != nil {
 		return nil, err

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -79,7 +80,7 @@ func (d *driver) startTransaction(ctx context.Context) (*transaction.Transaction
 		Started:  now(),
 	}
 
-	if err := col.NewSQLTx(ctx, d.db, func(sqlTx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, d.db, func(sqlTx *sqlx.Tx) error {
 		return d.transactions.ReadWrite(sqlTx).Put(
 			info.Transaction.ID,
 			info,
@@ -288,7 +289,7 @@ func (d *driver) updateTransaction(
 		if err == nil {
 			// only persist the transaction if we succeeded, otherwise just update localInfo
 			var storedInfo transaction.TransactionInfo
-			if err = col.NewSQLTx(ctx, d.db, func(sqlTx *sqlx.Tx) error {
+			if err = dbutil.WithTx(ctx, d.db, func(sqlTx *sqlx.Tx) error {
 				// Update the existing transaction with the new requests/responses
 				return d.transactions.ReadWrite(sqlTx).Update(txn.ID, &storedInfo, func() error {
 					if storedInfo.Version != localInfo.Version {

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/exec"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
@@ -301,7 +302,7 @@ func (d *driver) PachClient() *client.APIClient {
 }
 
 func (d *driver) NewSQLTx(cb func(*sqlx.Tx) error) error {
-	return col.NewSQLTx(d.ctx, d.env.GetDBClient(), cb)
+	return dbutil.WithTx(d.ctx, d.env.GetDBClient(), cb)
 }
 
 func (d *driver) RunUserCode(


### PR DESCRIPTION
Makes it easier to identify places that perform a transaction.  This was already an alias, so it made sense to just do the rename.