### PR TITLE
Fix launch dev

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "launch-dev",
       "type": "shell",
-      "command": "eval $(minikube docker-env --shell bash); make clean-launch; LAUNCH_DEV_ARGS='pachd.clusterDeploymentID=dev' make launch-dev",
+      "command": "eval $(minikube docker-env --shell bash); make clean-launch; make launch-dev",
       "problemMatcher": []
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ launch: install check-kubectl
 
 launch-dev: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
-	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml --set $(LAUNCH_DEV_ARGS)
+	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"


### PR DESCRIPTION
Currently `make launch-dev` with no args fails with 

```
Error: flag needs an argument: --set
```

Looks like from the changes here: https://github.com/pachyderm/pachyderm/pull/6590/files 

Setting `clusterDeploymentId: dev` is now done in the values file referenced, so we don't need to set it via the command line. 

I've also removed it from the vscode tasks file. @Tryneus `make launch-dev` doesn't do a docker build, should we add a `make docker-build` to the `launch-dev` vs code task?