### PR TITLE
Add Tracker Renewal Tests.

### DIFF
--- a/src/internal/storage/fileset/option.go
+++ b/src/internal/storage/fileset/option.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
-	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
+	"golang.org/x/sync/semaphore"
 )
 
 // StorageOption configures a storage.
@@ -49,7 +49,7 @@ type UnorderedWriterOption func(*UnorderedWriter)
 
 // WithRenewal configures the UnorderedWriter to renew subfileset paths
 // with the provided renewer.
-func WithRenewal(ttl time.Duration, r *renew.StringSet) UnorderedWriterOption {
+func WithRenewal(ttl time.Duration, r *Renewer) UnorderedWriterOption {
 	return func(uw *UnorderedWriter) {
 		uw.ttl = ttl
 		uw.renewer = r

--- a/src/internal/storage/fileset/option.go
+++ b/src/internal/storage/fileset/option.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
-	"golang.org/x/sync/semaphore"
 )
 
 // StorageOption configures a storage.

--- a/src/internal/storage/fileset/renewer.go
+++ b/src/internal/storage/fileset/renewer.go
@@ -17,7 +17,7 @@ type Renewer struct {
 func newRenewer(ctx context.Context, tracker track.Tracker, ttl time.Duration) *Renewer {
 	return &Renewer{
 		r: renew.NewStringSet(ctx, ttl, func(ctx context.Context, id string, ttl time.Duration) error {
-			_, err := tracker.SetTTLPrefix(ctx, id, ttl)
+			_, err := tracker.SetTTL(ctx, id, ttl)
 			return err
 		}),
 	}

--- a/src/internal/storage/fileset/renewer.go
+++ b/src/internal/storage/fileset/renewer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
 
-// Renewer renews filesets by ID
+// Renewer renews file sets by ID
 // It is a renew.StringSet wrapped for type safety
 type Renewer struct {
 	r *renew.StringSet

--- a/src/internal/storage/fileset/renewer.go
+++ b/src/internal/storage/fileset/renewer.go
@@ -1,0 +1,40 @@
+package fileset
+
+import (
+	"context"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
+)
+
+// Renewer renews filesets by ID
+// It is a renew.StringSet wrapped for type safety
+type Renewer struct {
+	r *renew.StringSet
+}
+
+func newRenewer(ctx context.Context, tracker track.Tracker, ttl time.Duration) *Renewer {
+	return &Renewer{
+		r: renew.NewStringSet(ctx, ttl, func(ctx context.Context, id string, ttl time.Duration) error {
+			_, err := tracker.SetTTLPrefix(ctx, id, ttl)
+			return err
+		}),
+	}
+}
+
+func (r *Renewer) Add(id ID) {
+	r.r.Add(id.TrackerID())
+}
+
+func (r *Renewer) Remove(id ID) {
+	r.r.Remove(id.TrackerID())
+}
+
+func (r *Renewer) Context() context.Context {
+	return r.r.Context()
+}
+
+func (r *Renewer) Close() error {
+	return r.r.Close()
+}

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -245,7 +245,7 @@ func (s *Storage) Drop(ctx context.Context, id ID) error {
 // SetTTL sets the time-to-live for the fileset at id
 func (s *Storage) SetTTL(ctx context.Context, id ID, ttl time.Duration) (time.Time, error) {
 	oid := id.TrackerID()
-	return s.tracker.SetTTLPrefix(ctx, oid, ttl)
+	return s.tracker.SetTTL(ctx, oid, ttl)
 }
 
 // SizeUpperBound returns an upper bound for the size of the data in the file set in bytes.

--- a/src/internal/storage/fileset/unordered_writer.go
+++ b/src/internal/storage/fileset/unordered_writer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
-	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
 )
 
 // UnorderedWriter allows writing Files, unordered by path, into multiple ordered filesets.
@@ -19,7 +18,7 @@ type UnorderedWriter struct {
 	buffer                     *Buffer
 	subFileSet                 int64
 	ttl                        time.Duration
-	renewer                    *renew.StringSet
+	renewer                    *Renewer
 	ids                        []ID
 	getParentID                func() (*ID, error)
 	validator                  func(string) error
@@ -115,7 +114,7 @@ func (uw *UnorderedWriter) withWriter(cb func(*Writer) error) error {
 	}
 	uw.ids = append(uw.ids, *id)
 	if uw.renewer != nil {
-		uw.renewer.Add(id.HexString())
+		uw.renewer.Add(*id)
 	}
 	// Reset fileset buffer.
 	uw.buffer = NewBuffer()

--- a/src/internal/storage/renew/renewer.go
+++ b/src/internal/storage/renew/renewer.go
@@ -34,9 +34,9 @@ func NewRenewer(ctx context.Context, ttl time.Duration, renewFunc Func) *Renewer
 		done:   make(chan struct{}),
 	}
 	go func() {
+		defer close(r.done)
+		defer r.cancel()
 		r.err = r.renewLoop(ctx)
-		r.cancel()
-		close(r.done)
 	}()
 	return r
 }

--- a/src/internal/storage/renew/renewer.go
+++ b/src/internal/storage/renew/renewer.go
@@ -39,7 +39,7 @@ func NewRenewer(ctx context.Context, ttl time.Duration, renewFunc Func) *Renewer
 		defer close(r.done)
 		defer r.cancel()
 		err := r.renewLoop(ctx)
-		if errors.Is(err, ctx.Err()) {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			err = nil
 		}
 		r.err = err

--- a/src/internal/storage/renew/renewer.go
+++ b/src/internal/storage/renew/renewer.go
@@ -68,11 +68,8 @@ func (r *Renewer) renewLoop(ctx context.Context) (retErr error) {
 			defer cf()
 			return r.renewFunc(ctx, r.ttl)
 		}(); err != nil {
-			// if the context errored, then exit, otherwise log it and keep going.
-			if errors.Is(err, ctx.Err()) {
-				return err
-			}
 			logrus.Errorf("error during renewal: %v", err)
+			return err
 		}
 		select {
 		case <-ticker.C:

--- a/src/internal/storage/renew/renewer.go
+++ b/src/internal/storage/renew/renewer.go
@@ -38,7 +38,11 @@ func NewRenewer(ctx context.Context, ttl time.Duration, renewFunc Func) *Renewer
 	go func() {
 		defer close(r.done)
 		defer r.cancel()
-		r.err = r.renewLoop(ctx)
+		err := r.renewLoop(ctx)
+		if errors.Is(err, ctx.Err()) {
+			err = nil
+		}
+		r.err = err
 	}()
 	return r
 }

--- a/src/internal/storage/track/postgres_tracker.go
+++ b/src/internal/storage/track/postgres_tracker.go
@@ -138,7 +138,7 @@ func (t *postgresTracker) SetTTLPrefix(ctx context.Context, prefix string, ttl t
 			WHERE str_id LIKE $1 || '%'
 			RETURNING expires_at
 		)
-		SELECT COUNT(*) as count, COALESCE(MIN(expires_at), CURRENT_TIMESTAMP) as expires_at FROM rows
+		SELECT COUNT(*) as count, COALESCE(MIN(expires_at), CURRENT_TIMESTAMP + $2 * interval '1 microsecond') as expires_at FROM rows
 		`, prefix, ttl.Microseconds())
 	if err != nil {
 		return time.Time{}, 0, err

--- a/src/internal/storage/track/postgres_tracker.go
+++ b/src/internal/storage/track/postgres_tracker.go
@@ -180,7 +180,7 @@ func (t *postgresTracker) DeleteTx(tx *sqlx.Tx, id string) error {
 		WITH target AS (
 			SELECT int_id FROM storage.tracker_objects WHERE str_id = $1
 		)
-		SELECT count(distinct from_id) FROM storage.tracker_refs WHERE to_id IN (SELECT int_id FROM TARGET)
+		SELECT count(distinct from_id) FROM storage.tracker_refs WHERE to_id IN (SELECT int_id FROM target)
 	`, id); err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (t *postgresTracker) DeleteTx(tx *sqlx.Tx, id string) error {
 		WITH target AS (
 			SELECT int_id FROM storage.tracker_objects WHERE str_id = $1
 		)
-		DELETE FROM storage.tracker_refs WHERE from_id IN (SELECT int_id FROM TARGET)
+		DELETE FROM storage.tracker_refs WHERE from_id IN (SELECT int_id FROM target)
 	`, id)
 	if err != nil {
 		return err

--- a/src/internal/storage/track/renewer.go
+++ b/src/internal/storage/track/renewer.go
@@ -59,7 +59,7 @@ func NewRenewer(tracker Tracker, name string, ttl time.Duration) *Renewer {
 // Add adds an object to the set of objects being renewed.
 func (r *Renewer) Add(ctx context.Context, id string) error {
 	n := r.nextInt()
-	id2 := fmt.Sprintf("%s/%d", r.id, n)
+	id2 := fmt.Sprintf("%s/%04d", r.id, n)
 	// create an object whos sole purpose is to reference id, and to have a structured name
 	// which can be renewed in bulk by prefix
 	return Create(ctx, r.tracker, id2, []string{id}, r.ttl)

--- a/src/internal/storage/track/renewer.go
+++ b/src/internal/storage/track/renewer.go
@@ -78,6 +78,7 @@ func (r *Renewer) Close() (retErr error) {
 	if err != nil {
 		return err
 	}
+	// TODO: try to check this earlier. beware of the race when incrementing r.n and creating a new entry.
 	if n != r.n {
 		return errors.Errorf("renewer prefix has wrong count HAVE: %d WANT: %d", n, r.n)
 	}

--- a/src/internal/storage/track/renewer.go
+++ b/src/internal/storage/track/renewer.go
@@ -40,7 +40,7 @@ type Renewer struct {
 // NewRenewer returns a renewer renewing objects in tracker with ttl
 func NewRenewer(tracker Tracker, name string, ttl time.Duration) *Renewer {
 	if ttl == 0 {
-		panic("must provide non-zero TTL for track.Rewnewer")
+		panic("must provide non-zero TTL for track.Renewer")
 	}
 	if name == "" {
 		panic("must provide non-empty name for track.Renewer")

--- a/src/internal/storage/track/renewer.go
+++ b/src/internal/storage/track/renewer.go
@@ -38,6 +38,12 @@ type Renewer struct {
 
 // NewRenewer returns a renewer renewing objects in tracker with ttl
 func NewRenewer(tracker Tracker, name string, ttl time.Duration) *Renewer {
+	if ttl == 0 {
+		panic("must provide non-zero TTL for track.Rewnewer")
+	}
+	if name == "" {
+		panic("must provide non-empty name for track.Renewer")
+	}
 	r := &Renewer{
 		id:      TmpTrackerPrefix + name + "-" + uuid.NewWithoutDashes(),
 		tracker: tracker,

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -177,6 +177,9 @@ func TestTracker(t *testing.T, newTracker func(testing.TB) Tracker) {
 				// get rid of "expire"
 				require.Equal(t, 1, runGC(t, tracker))
 
+				// should be no-op
+				require.Equal(t, 0, runGC(t, tracker))
+
 				// get rid of "keep"
 				_, err = tracker.SetTTLPrefix(ctx, "keep", ExpireNow)
 				require.NoError(t, err)

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -18,8 +18,6 @@ var (
 	ErrDifferentObjectExists = errors.Errorf("a different object exists at that id")
 	// ErrDanglingRef the operation would create a dangling reference
 	ErrDanglingRef = errors.Errorf("the operation would create a dangling reference")
-	// ErrTombstone cannot create object because it is marked as a tombstone
-	ErrTombstone = errors.Errorf("cannot create object because it is marked as a tombstone")
 	// ErrSelfReference object cannot reference itself
 	ErrSelfReference = errors.Errorf("object cannot reference itself")
 )
@@ -60,7 +58,7 @@ type Tracker interface {
 	// If the id doesn't exist, no error is returned
 	DeleteTx(tx *sqlx.Tx, id string) error
 
-	// IterateDeletable calls cb with all the objects objects which are no longer referenced and have expired or are tombstoned
+	// IterateDeletable calls cb with all the objects objects which are no longer referenced and have expired
 	IterateDeletable(ctx context.Context, cb func(id string) error) error
 }
 

--- a/src/internal/storage/track/util.go
+++ b/src/internal/storage/track/util.go
@@ -24,6 +24,13 @@ func Delete(ctx context.Context, tr Tracker, id string) error {
 
 // Drop sets the object at id to expire now
 func Drop(ctx context.Context, tr Tracker, id string) error {
-	_, err := tr.SetTTLPrefix(ctx, id, ExpireNow)
+	_, err := tr.SetTTL(ctx, id, ExpireNow)
 	return err
+}
+
+// DropPrefix sets all objects with prefix to expire now.
+// It returns the number of objects affected or an error.
+func DropPrefix(ctx context.Context, tr Tracker, prefix string) (int, error) {
+	_, n, err := tr.SetTTLPrefix(ctx, prefix, ExpireNow)
+	return n, err
 }


### PR DESCRIPTION
The important fix here is the that we no longer return `sql.ErrNoRows` when renewing an empty prefix.  There are also some tests to make sure that expiration works correctly, but they did not find any bugs.