### PR TITLE
Fix an issue with the file set renewer usage in the unordered writer

### DIFF
--- a/src/internal/storage/fileset/unordered_writer.go
+++ b/src/internal/storage/fileset/unordered_writer.go
@@ -115,7 +115,7 @@ func (uw *UnorderedWriter) withWriter(cb func(*Writer) error) error {
 	}
 	uw.ids = append(uw.ids, *id)
 	if uw.renewer != nil {
-		uw.renewer.Add(id.TrackerID())
+		uw.renewer.Add(id.HexString())
 	}
 	// Reset fileset buffer.
 	uw.buffer = NewBuffer()

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -26,9 +26,9 @@ const (
 	// BranchHeader is the header for branches.
 	BranchHeader = "BRANCH\tHEAD\tTRIGGER\t\n"
 	// FileHeader is the header for files.
-	FileHeader = "NAME\tTAG\tTYPE\tSIZE\t\n"
+	FileHeader = "NAME\tTYPE\tSIZE\t\n"
 	// FileHeaderWithCommit is the header for files that includes a commit field.
-	FileHeaderWithCommit = "COMMIT\tNAME\tTAG\tTYPE\tCOMMITTED\tSIZE\t\n"
+	FileHeaderWithCommit = "COMMIT\tNAME\tTYPE\tCOMMITTED\tSIZE\t\n"
 	// DiffFileHeader is the header for files produced by diff file.
 	DiffFileHeader = "OP\t" + FileHeader
 )

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -290,6 +290,9 @@ func (reg *registry) processJobRunning(pj *pendingJob) error {
 			return reg.processDatums(ctx, pj, master, dit)
 		})
 	}); err != nil {
+		if errors.Is(err, errutil.ErrBreak) {
+			return nil
+		}
 		return err
 	}
 	if pj.ji.Details.Egress != nil {
@@ -394,7 +397,10 @@ func (reg *registry) processDatums(ctx context.Context, pj *pendingJob, master *
 		return err
 	}
 	if stats.FailedID != "" {
-		return reg.failJob(pj, fmt.Sprintf("datum %v failed", stats.FailedID))
+		if err := reg.failJob(pj, fmt.Sprintf("datum %v failed", stats.FailedID)); err != nil {
+			return err
+		}
+		return errutil.ErrBreak
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes an issue with the file set renewer usage in the unordered writer. The identifier being used in the renewer add call was the tracker id rather than the file set id which resulted with renewal failing and canceling the renewal context. This error was obscured by the fact that the error is not within the main control flow, so the error that is seen is a context cancel. Logging will be added in another PR (https://github.com/pachyderm/pachyderm/pull/6664) to make these types of issues more obvious. Also, this PR removes the tag header column from the file info pretty printing (this was missed in a prior PR) and makes a change to ensure we don't attempt to succeed a job after a datum failure.

Fixes https://github.com/pachyderm/pachyderm/issues/6615