### PR TITLE
Run load tests against a Hub workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - run: cd helmchart && cr index -o pachyderm -r helmchart -c https://pachyderm.github.io/helmchart --package-path ../.cr-release-packages --push
   hub:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - run: etc/testing/circle/run_hub_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       image: ubuntu-2004:202101-01
     steps:
       - checkout
-      - setup_remote_docker
+      # - setup_remote_docker
       - run: |
           echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run: etc/testing/circle/run_hub_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,13 +120,10 @@ jobs:
       - run: cd helmchart && cr index -o pachyderm -r helmchart -c https://pachyderm.github.io/helmchart --package-path ../.cr-release-packages --push
   hub:
     resource_class: large
-    # docker:
-    #   - image: circleci/golang:1.16
     machine:
       image: ubuntu-2004:202101-01
     steps:
       - checkout
-      # - setup_remote_docker
       - run: |
           echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run: etc/testing/circle/run_hub_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,10 @@ jobs:
       - run: cd helmchart && cr index -o pachyderm -r helmchart -c https://pachyderm.github.io/helmchart --package-path ../.cr-release-packages --push
   hub:
     resource_class: large
-    docker:
-      - image: circleci/golang:1.16
+    # docker:
+    #   - image: circleci/golang:1.16
+    machine:
+      image: ubuntu-2004:202101-01
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
       - run: cr upload -o pachyderm -r helmchart --skip-existing
       - run: cd helmchart && cr index -o pachyderm -r helmchart -c https://pachyderm.github.io/helmchart --package-path ../.cr-release-packages --push
   hub:
+    resource_class: large
     docker:
       - image: circleci/golang:1.16
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,15 +34,15 @@ jobs:
          keys:
          - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
          - pach-build-dependencies-v2-
-      - run: etc/testing/circle/install.sh 
+      - run: etc/testing/circle/install.sh
       - save_cache:
          key: pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
          paths:
          - cached-deps/
-      - run: etc/testing/circle/start-minikube.sh 
+      - run: etc/testing/circle/start-minikube.sh
       - run: etc/testing/circle/launch-loki.sh
 
-      # The build cache will grow indefinitely, so we rotate the cache once a week. 
+      # The build cache will grow indefinitely, so we rotate the cache once a week.
       # This ensures the time to restore the cache isn't longer than the speedup in compilation.
       - run: "echo $(($(date +%s)/604800)) > current_week"
       - restore_cache:
@@ -55,9 +55,9 @@ jobs:
       - restore_cache:
          keys:
          - pach-go-mod-cache-v2-{{ checksum "go.sum" }}
-      - run: etc/testing/circle/build.sh 
+      - run: etc/testing/circle/build.sh
       - when: #Save cache in only one bucket, after build and before running tests, this ensures build cache is saved even when tests fail
-          condition: 
+          condition:
             equal: [MISC, <<parameters.bucket>> ]
           steps:
             - save_cache:
@@ -68,9 +68,9 @@ jobs:
                 key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
                 paths:
                   - /home/circleci/.gocache
-      - run: etc/testing/circle/launch.sh 
-      - run: etc/testing/circle/run_tests.sh 
-      - run: etc/testing/circle/upload_stats.sh 
+      - run: etc/testing/circle/launch.sh
+      - run: etc/testing/circle/run_tests.sh
+      - run: etc/testing/circle/upload_stats.sh
       - run:
           name: Dump debugging info in case of failure
           when: on_fail
@@ -110,7 +110,7 @@ jobs:
       - run: git config --global user.name buildbot
       - run:
           name: Clone Pachyderm
-          command: git clone -b ${CIRCLE_TAG} --depth 1 https://github.com/pachyderm/pachyderm.git pachyderm 
+          command: git clone -b ${CIRCLE_TAG} --depth 1 https://github.com/pachyderm/pachyderm.git pachyderm
       - run:
           # the helmchart git repo hosts the helm repository (gh-pages) Chart releaser only supports https clone, not ssh
           name: Clone Helmchart
@@ -118,6 +118,12 @@ jobs:
       - run: cr package pachyderm/etc/helm/pachyderm
       - run: cr upload -o pachyderm -r helmchart --skip-existing
       - run: cd helmchart && cr index -o pachyderm -r helmchart -c https://pachyderm.github.io/helmchart --package-path ../.cr-release-packages --push
+  hub:
+    docker:
+      - image: circleci/golang:1.15
+    steps:
+      - checkout
+      - run: etc/testing/circle/run-hub-tests.sh
 workflows:
   circleci:
     jobs:
@@ -154,3 +160,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  hub_live_tests:
+    jobs:
+      - hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,8 @@ jobs:
       - image: circleci/golang:1.16
     steps:
       - checkout
+      - setup_remote_docker:
+        version: 19.03.13
       - run: etc/testing/circle/run_hub_tests.sh
 workflows:
   circleci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - image: circleci/golang:1.15
     steps:
       - checkout
-      - run: etc/testing/circle/run-hub-tests.sh
+      - run: etc/testing/circle/run_hub_tests.sh
 workflows:
   circleci:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,7 @@ jobs:
       - image: circleci/golang:1.16
     steps:
       - checkout
-      - setup_remote_docker:
-        version: 19.03.13
+      - setup_remote_docker
       - run: etc/testing/circle/run_hub_tests.sh
 workflows:
   circleci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run: |
+          echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run: etc/testing/circle/run_hub_tests.sh
 workflows:
   circleci:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ release:
 	@make release-pachctl
 	@echo "Release $(VERSION) completed"
 
-release-helper: release-docker-images docker-push
+release-helper: release-docker-images docker-push-release
 
 release-docker-images:
 	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --skip-publish --rm-dist -f goreleaser/docker.yml
@@ -118,10 +118,12 @@ docker-tag:
 	docker tag pachyderm/pachctl pachyderm/pachctl:$(VERSION)
 
 docker-push: docker-tag
-	$(SKIP) docker push pachyderm/etcd:v3.3.5
 	$(SKIP) docker push pachyderm/pachd:$(VERSION)
 	$(SKIP) docker push pachyderm/worker:$(VERSION)
 	$(SKIP) docker push pachyderm/pachctl:$(VERSION)
+
+docker-push-release: docker-push
+	$(SKIP) docker push pachyderm/etcd:v3.3.5
 
 check-kubectl:
 	@# check that kubectl is installed
@@ -229,7 +231,7 @@ enterprise-code-checkin-test:
 test-pfs-server:
 	./etc/testing/pfs_server.sh $(TIMEOUT) $(TESTFLAGS)
 
-test-pps: launch-stats docker-build-spout-test 
+test-pps: launch-stats docker-build-spout-test
 	@# Use the count flag to disable test caching for this test suite.
 	PROM_PORT=$$(kubectl --namespace=monitoring get svc/prometheus -o json | jq -r .spec.ports[0].nodePort) \
 	  go test -v -count=1 ./src/server -parallel 1 -timeout $(TIMEOUT) $(RUN) $(TESTFLAGS)
@@ -265,7 +267,7 @@ test-s3gateway-integration:
 	fi
 	$(INTEGRATION_SCRIPT_PATH) http://localhost:30600 --access-key=none --secret-key=none
 
-test-s3gateway-unit: 
+test-s3gateway-unit:
 	go test -v -count=1 ./src/server/pfs/s3 -timeout $(TIMEOUT) $(TESTFLAGS)
 
 test-fuse:
@@ -311,7 +313,7 @@ clean-launch-kafka:
 launch-kafka:
 	kubectl apply -f etc/kubernetes-kafka -R
 	kubectl wait --for=condition=ready pod -l app=kafka --timeout=5m
-	
+
 clean-launch-stats:
 	kubectl delete --filename etc/kubernetes-prometheus -R
 
@@ -411,6 +413,7 @@ check-buckets:
 	docker-build-test-entrypoint \
 	docker-tag \
 	docker-push \
+	docker-push-release \
 	check-buckets \
 	check-kubectl \
 	check-kubectl-connection \

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -32,7 +32,7 @@ make install
 export VERSION=$(pachctl version --client-only)
 
 # build docker images
-DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot --skip-publish --rm-dist -f goreleaser/docker.yml
+goreleaser release -p 1 --snapshot --skip-publish --rm-dist -f goreleaser/docker.yml
 docker tag pachyderm/pachd pachyderm/pachd:$VERSION
 docker tag pachyderm/worker pachyderm/worker:$VERSION
 docker tag pachyderm/pachctl pachyderm/pachctl:$VERSION

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 mkdir -p $HOME/go/bin
 export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+export GOPATH=$HOME/go
 
 # Install go.
 sudo rm -rf /usr/local/go
@@ -24,18 +25,12 @@ curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER
 
 # Build pachctl.
 make install
+pachctl version --client-only
 
-# set up version for docker builds
+# Set version for docker builds.
 export VERSION=$(pachctl version --client-only)
 
-# build docker images
-# goreleaser release -p 1 --snapshot --skip-publish --rm-dist -f goreleaser/docker.yml
-# docker tag pachyderm/pachd pachyderm/pachd:$VERSION
-# docker tag pachyderm/worker pachyderm/worker:$VERSION
-# docker tag pachyderm/pachctl pachyderm/pachctl:$VERSION
-# docker push pachyderm/pachd:$VERSION
-# docker push pachyderm/worker:$VERSION
-# docker push pachyderm/pachctl:$VERSION
+# Build and push docker images.
 make docker-build
 make docker-push
 

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -41,7 +41,7 @@ docker push pachyderm/worker:$VERSION
 docker push pachyderm/pachctl:$VERSION
 
 # create a workspace
-hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION --expiration 2h
+hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION --expiration 2h --description $CIRCLE_BUILD_URL --prefix "ci-"
 
 # print versions for debugging
 pachctl version

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -2,7 +2,26 @@
 
 set -euxo pipefail
 
+# install hubcli
 wget https://github.com/pachyderm/hubcli/releases/download/v0.0.1-beta.1/hubcli
 chmod a+x hubcli
-./hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json
+
+# install pachctl and friends
+make install
+VERSION=$(pachctl version --client-only)
+git config user.email "donotreply@pachyderm.com"
+git config user.name "anonymous"
+git tag -f -am "Circle CI test v$VERSION" v"$VERSION"
+
+# push a docker image
+make docker-build
+
+# create a workspace
+./hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION
+
+# run tests against hub
+pachctl run pfs-load-test
+pachctl run pps-load-test
+
+# delete the workspace
 ./hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op delete-workspace --loglevel trace --infofile workspace.json

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -6,6 +6,13 @@ set -euxo pipefail
 wget https://github.com/pachyderm/hubcli/releases/download/v0.0.1-beta.1/hubcli
 chmod a+x hubcli
 
+# install goreleaser
+mkdir cached-deps
+GORELEASER_VERSION=0.169.0
+curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
+    | tar xzf - -C cached-deps goreleaser
+
+
 # install pachctl and friends
 make install
 VERSION=$(pachctl version --client-only)

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -43,6 +43,9 @@ docker push pachyderm/pachctl:$VERSION
 # create a workspace
 hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION --expiration 2h
 
+# print versions for debugging
+pachctl version
+
 # run tests against hub
 pachctl run pfs-load-test
 pachctl run pps-load-test

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -8,10 +8,10 @@ chmod a+x hubcli
 
 # install goreleaser
 mkdir cached-deps
+export PATH=$PATH:$(pwd)/cached-deps
 GORELEASER_VERSION=0.169.0
 curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
     | tar xzf - -C cached-deps goreleaser
-
 
 # install pachctl and friends
 make install

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -41,7 +41,7 @@ docker push pachyderm/worker:$VERSION
 docker push pachyderm/pachctl:$VERSION
 
 # create a workspace
-hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION
+hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION --expiration 2h
 
 # run tests against hub
 pachctl run pfs-load-test

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+wget https://github.com/pachyderm/hubcli/releases/download/v0.0.1-beta.1/hubcli
+chmod a+x hubcli
+./hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json
+./hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op delete-workspace --loglevel trace --infofile workspace.json

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -3,7 +3,12 @@
 set -euxo pipefail
 
 mkdir -p $HOME/go/bin
-export PATH=$PATH:$HOME/go/bin
+export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+
+# Install go.
+sudo rm -rf /usr/local/go
+curl -L https://golang.org/dl/go1.16.6.linux-amd64.tar.gz | sudo tar xzf - -C /usr/local/
+go version
 
 # install hubcli
 pushd $HOME/go/bin
@@ -12,43 +17,39 @@ wget https://github.com/pachyderm/hubcli/releases/download/0.0.2/hubcli
 chmod a+x hubcli
 popd
 
-# install goreleaser
+# Install goreleaser.
 GORELEASER_VERSION=0.169.0
 curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
     | tar xzf - -C $HOME/go/bin goreleaser
 
-# TODO: upgrade go here (as per install.sh)
-
-# setup environment for build
-export VERSION_ADDITIONAL="-$(git log --pretty=format:%H | head -n 1)"
-export CLIENT_ADDITIONAL_VERSION="github.com/pachyderm/pachyderm/v2/src/version.AdditionalVersion=${VERSION_ADDITIONAL}"
-export GC_FLAGS="all=-trimpath=${PWD}"
-export LD_FLAGS="-X ${CLIENT_ADDITIONAL_VERSION}"
-
-# build pachctl
+# Build pachctl.
 make install
 
 # set up version for docker builds
 export VERSION=$(pachctl version --client-only)
 
 # build docker images
-goreleaser release -p 1 --snapshot --skip-publish --rm-dist -f goreleaser/docker.yml
-docker tag pachyderm/pachd pachyderm/pachd:$VERSION
-docker tag pachyderm/worker pachyderm/worker:$VERSION
-docker tag pachyderm/pachctl pachyderm/pachctl:$VERSION
-docker push pachyderm/pachd:$VERSION
-docker push pachyderm/worker:$VERSION
-docker push pachyderm/pachctl:$VERSION
+# goreleaser release -p 1 --snapshot --skip-publish --rm-dist -f goreleaser/docker.yml
+# docker tag pachyderm/pachd pachyderm/pachd:$VERSION
+# docker tag pachyderm/worker pachyderm/worker:$VERSION
+# docker tag pachyderm/pachctl pachyderm/pachctl:$VERSION
+# docker push pachyderm/pachd:$VERSION
+# docker push pachyderm/worker:$VERSION
+# docker push pachyderm/pachctl:$VERSION
+make docker-build
+make docker-push
 
-# create a workspace
+# Create a workspace running the image we just built.
 hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION --expiration 2h --description $CIRCLE_BUILD_URL --prefix "ci-"
 
-# print versions for debugging
+# Print client and server versions, for debugging.
 pachctl version
 
-# run tests against hub
+# Run load tests.
 pachctl run pfs-load-test
 pachctl run pps-load-test
 
-# delete the workspace
+# Delete the workspace.  We don't do this in a "trap ... exit" statement so that you can log into
+# the workspace and debug it if the load tests fail.  Hub will automatically clean up the workspace
+# at its expiration time set above.
 hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op delete-workspace --loglevel trace --infofile workspace.json

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 mkdir -p $HOME/go/bin
+export PATH=$PATH:$HOME/go/bin
 
 # install hubcli
 pushd $HOME/go/bin


### PR DESCRIPTION
This adds a CI job that builds pachd, starts that on Hub, and runs the pfs and pps load tests.

I worry a little about pushing to pachyderm/pachd (etc.) from CI, since it seems easy for a bug to overwrite an existing tag and cause a massive outage across the fleet.  So we should do something about that.