### PR TITLE
Prevent ListPipeline from holding an open query.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9717,6 +9717,53 @@ func TestExpiredFileset(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestListPipelineError(t testing.TB) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
+
+	dataRepo := tu.UniqueString(t.Name())
+	require.NoError(t, c.CreateRepo(dataRepo))
+
+	bad := tu.UniqueString("bad")
+	base := tu.UniqueString("pipeline")
+
+	for i := 0; i < 15; i++ {
+		name := fmt.Sprintf("%s-%d", base, i)
+		if i == 0 {
+			name = bad
+		}
+		require.NoError(t, c.CreatePipeline(
+			name,
+			"",
+			[]string{"bash"},
+			[]string{"echo test"},
+			nil,
+			client.NewPFSInput(dataRepo, "/"),
+			"master",
+			false,
+		))
+	}
+
+	// delete the first pipeline's spec repo, which will cause getting details to error
+	require.NoError(t, c.DeleteRepo(bad, true))
+
+	_, err := c.InspectPipeline(bad, true)
+	require.YesError(t, err)
+
+	// listing without details should be fine
+	_, err = c.ListPipeline(false)
+	require.NoError(t, err)
+
+	// but requesting details will fail, make sure it's due to the missing spec file
+	_, err = c.ListPipeline(true)
+	require.YesError(t, err)
+	require.Matches(t, "spec file", err.Error())
+}
+
 func monitorReplicas(t testing.TB, pipeline string, n int) {
 	c := tu.GetPachClient(t)
 	kc := tu.GetKubeClient(t)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9717,7 +9717,7 @@ func TestExpiredFileset(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestListPipelineError(t testing.TB) {
+func TestListPipelineError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2410,8 +2410,9 @@ func (a *apiServer) listPipeline(ctx context.Context, request *pps.ListPipelineR
 	// spin up goroutines to get the PFS info
 	limiter := limit.New(5)
 	for i := range infos {
+		i := i
 		limiter.Acquire()
-		chain.CreateTask(func(ctx context.Context, serial func(func() error) error) error {
+		if err := chain.CreateTask(func(ctx context.Context, serial func(func() error) error) error {
 			defer limiter.Release()
 			if request.Details {
 				if err := ppsutil.GetPipelineDetails(a.env.GetPachClient(ctx), infos[i]); err != nil {
@@ -2424,7 +2425,9 @@ func (a *apiServer) listPipeline(ctx context.Context, request *pps.ListPipelineR
 				}
 				return nil
 			})
-		})
+		}); err != nil {
+			return err
+		}
 	}
 	return chain.Wait()
 }


### PR DESCRIPTION
ListPipeline sent pipeline infos on a channel to have their details
fetched and possibly be sent to the grpc caller. This kept the list
pipeline SQL query open for a potentially long time, and had issues
around managing the channel when errors were encountered. A smaller
issue was that pipelines were returned in a random order.

Instead, fetch all pipeline infos at once from the database. Pipeline
info objects should be relatively small, so it's unlikely that this
will cause memory issues anytime soon. In addition, we canprocess all
infos in order after their details are fetched.