### PR TITLE
Fix a few places that are referencing the wrong commit state

### DIFF
--- a/src/internal/pfssync/sync.go
+++ b/src/internal/pfssync/sync.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -100,16 +98,7 @@ func (d *downloader) downloadInfo(storageRoot string, file *pfs.File, config *do
 		if fi.FileType == pfs.FileType_DIR {
 			return nil
 		}
-		basePath := fi.File.Path
-		if file.Path != "/" {
-			// TODO: Remove right trim when PFS dirs are not encoded with a trailing slash.
-			var err error
-			basePath, err = filepath.Rel(path.Dir(strings.TrimRight(file.Path, "/")), fi.File.Path)
-			if err != nil {
-				return errors.EnsureStack(err)
-			}
-		}
-		fullPath := path.Join(storageRoot, basePath)
+		fullPath := path.Join(storageRoot, fi.File.Path)
 		if err := os.MkdirAll(path.Dir(fullPath), 0700); err != nil {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -54,7 +54,7 @@ func (s *source) Iterate(ctx context.Context, cb func(*pfs.FileInfo, fileset.Fil
 		fi := &pfs.FileInfo{
 			File:      file,
 			FileType:  pfs.FileType_FILE,
-			Committed: s.commitInfo.Finished,
+			Committed: s.commitInfo.Finishing,
 		}
 		if fileset.IsDir(idx.Path) {
 			fi.FileType = pfs.FileType_DIR

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -115,14 +115,14 @@ func (d *driver) isTriggered(txnCtx *txncontext.TransactionContext, t *pfs.Trigg
 			return false, errors.EnsureStack(err)
 		}
 		var oldTime, newTime time.Time
-		if oldHead != nil && oldHead.Finished != nil {
-			oldTime, err = types.TimestampFromProto(oldHead.Finished)
+		if oldHead != nil && oldHead.Finishing != nil {
+			oldTime, err = types.TimestampFromProto(oldHead.Finishing)
 			if err != nil {
 				return false, errors.EnsureStack(err)
 			}
 		}
-		if newHead.Finished != nil {
-			newTime, err = types.TimestampFromProto(newHead.Finished)
+		if newHead.Finishing != nil {
+			newTime, err = types.TimestampFromProto(newHead.Finishing)
 			if err != nil {
 				return false, errors.EnsureStack(err)
 			}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2059,7 +2059,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 			Commit: client.NewSystemRepo(pipelineName, pfs.SpecRepoType).NewCommit("master", ""),
 		}); err != nil {
 			return err
-		} else if ci.Finished == nil {
+		} else if ci.Finishing == nil {
 			return errors.Errorf("the HEAD commit of this pipeline's spec branch " +
 				"is open. Either another CreatePipeline call is running or a previous " +
 				"call crashed. If you're sure no other CreatePipeline commands are " +
@@ -2919,7 +2919,7 @@ func (a *apiServer) propagateJobs(txnCtx *txncontext.TransactionContext) error {
 
 	for _, commitInfo := range commitInfos {
 		// Skip alias commits and any commits which have already been finished
-		if commitInfo.Origin.Kind == pfs.OriginKind_ALIAS || commitInfo.Finished != nil {
+		if commitInfo.Origin.Kind == pfs.OriginKind_ALIAS || commitInfo.Finishing != nil {
 			continue
 		}
 

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -253,7 +253,7 @@ func (m *ppsMaster) monitorPipeline(ctx context.Context, pipelineInfo *pps.Pipel
 						if !ok {
 							return nil // subscribeCommit exited, nothing left to do
 						}
-						if ci.Finished != nil {
+						if ci.Finishing != nil {
 							continue
 						}
 						childSpan, ctx = extended.AddSpanToAnyPipelineTrace(oldCtx,
@@ -424,7 +424,7 @@ func (m *ppsMaster) makeCronCommits(ctx context.Context, in *pps.Input) error {
 	commitInfo, err := pachClient.InspectCommit(in.Cron.Repo, "master", "")
 	if err != nil {
 		return err
-	} else if commitInfo != nil && commitInfo.Finished == nil {
+	} else if commitInfo != nil && commitInfo.Finishing == nil {
 		// and if there is, delete it
 		if err = pachClient.SquashCommitSet(commitInfo.Commit.ID); err != nil {
 			return err

--- a/src/server/worker/pipeline/transform/pending_job.go
+++ b/src/server/worker/pipeline/transform/pending_job.go
@@ -101,7 +101,7 @@ func (pj *pendingJob) load() error {
 			return err
 		}
 		if ci.Error == "" {
-			if ci.Finished != nil {
+			if ci.Finishing != nil {
 				pj.parentDit = datum.NewCommitIterator(pachClient, pj.parentMetaCommit)
 			} else {
 				parentJi, err := pachClient.InspectJob(pj.ji.Job.Pipeline.Name, pj.parentMetaCommit.ID, true)


### PR DESCRIPTION
This PR fixes a few places that are referencing the wrong commit state (finishing vs finished) and changes lazy / empty download to use full paths (the semantics of 1.x) rather than relative.