### PR TITLE
Support directories in join / group inputs without needing a trailing slash in the glob pattern

### DIFF
--- a/src/server/worker/datum/iterator.go
+++ b/src/server/worker/datum/iterator.go
@@ -53,8 +53,10 @@ func (pi *pfsIterator) Iterate(cb func(*Meta) error) error {
 	pattern := pi.input.Glob
 	return pi.pachClient.GlobFile(client.NewCommit(repo, branch, commit), pattern, func(fi *pfs.FileInfo) error {
 		g := glob.MustCompile(pi.input.Glob, '/')
-		joinOn := g.Replace(fi.File.Path, pi.input.JoinOn)
-		groupBy := g.Replace(fi.File.Path, pi.input.GroupBy)
+		// Remove the trailing slash to support glob replace on directory paths.
+		p := strings.TrimRight(fi.File.Path, "/")
+		joinOn := g.Replace(p, pi.input.JoinOn)
+		groupBy := g.Replace(p, pi.input.GroupBy)
 		return cb(&Meta{
 			Inputs: []*common.Input{
 				&common.Input{


### PR DESCRIPTION
This PR changes join and group inputs such that they can support directories without requiring a trailing slash in the glob. The trailing slash is trimmed from the paths before applying the glob replace which determines the value of the joinOn / groupBy field.