### PR TITLE
Fix an issue with transactional create pipeline

### DIFF
--- a/src/internal/transactionenv/refresh.go
+++ b/src/internal/transactionenv/refresh.go
@@ -38,11 +38,11 @@ type basicPutFile struct {
 }
 
 func (b basicPutFile) Hash() [16]byte {
-	hasher := md5.New()
-	hasher.Write([]byte(b.path))
-	hasher.Write([]byte{0})
-	hasher.Write(b.data)
-	return md5.Sum(nil)
+	buf := &bytes.Buffer{}
+	buf.Write([]byte(b.path))
+	buf.Write([]byte{0})
+	buf.Write(b.data)
+	return md5.Sum(buf.Bytes())
 }
 
 type refresher struct {

--- a/src/internal/transactionenv/refresh.go
+++ b/src/internal/transactionenv/refresh.go
@@ -84,7 +84,7 @@ func (env *TransactionEnv) withRefreshLoop(ctx context.Context, txnCtx *txnconte
 			pipelineCache: map[string]*pps.PipelineInfo{},
 		}
 	}
-	txnCtx.FilesetManager = r
+	txnCtx.FileSetManager = r
 	for {
 		r.refresh(ctx)
 		if err := cb(txnCtx); err == nil || !isErrTransactionConflict(err) {

--- a/src/internal/transactionenv/refresh.go
+++ b/src/internal/transactionenv/refresh.go
@@ -76,7 +76,7 @@ func (env *TransactionEnv) NewRefresher(info *transaction.TransactionInfo) *refr
 	return out
 }
 
-func (env *TransactionEnv) withRefreshLoop(ctx context.Context, r *refresher, cb func(txncontext.FilesetManager) error) error {
+func (env *TransactionEnv) withRefreshLoop(ctx context.Context, txnCtx *txncontext.TransactionContext, r *refresher, cb func(*txncontext.TransactionContext) error) error {
 	if r == nil {
 		r = &refresher{
 			env:           env.serviceEnv,
@@ -84,9 +84,10 @@ func (env *TransactionEnv) withRefreshLoop(ctx context.Context, r *refresher, cb
 			pipelineCache: map[string]*pps.PipelineInfo{},
 		}
 	}
+	txnCtx.FilesetManager = r
 	for {
 		r.refresh(ctx)
-		if err := cb(r); err == nil || !isErrTransactionConflict(err) {
+		if err := cb(txnCtx); err == nil || !isErrTransactionConflict(err) {
 			return err
 		}
 	}

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -32,14 +32,14 @@ type TransactionContext struct {
 	PpsJobStopper  PpsJobStopper
 	PpsJobFinisher PpsJobFinisher
 
-	FilesetManager FilesetManager
+	FileSetManager FileSetManager
 }
 
 type identifier interface {
 	WhoAmI(context.Context, *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 }
 
-func New(ctx context.Context, authServer identifier, m FilesetManager) (*TransactionContext, error) {
+func New(ctx context.Context, authServer identifier, m FileSetManager) (*TransactionContext, error) {
 	var username string
 	// check auth once now so that we can refer to it later
 	if authServer != nil {
@@ -54,7 +54,7 @@ func New(ctx context.Context, authServer identifier, m FilesetManager) (*Transac
 		CommitSetID:    uuid.NewWithoutDashes(),
 		Timestamp:      types.TimestampNow(),
 		username:       username,
-		FilesetManager: m,
+		FileSetManager: m,
 	}, nil
 }
 
@@ -142,7 +142,7 @@ type PpsJobFinisher interface {
 	Run() error
 }
 
-type FilesetManager interface {
+type FileSetManager interface {
 	CreateFileset(path string, data []byte) (string, error)
 	LatestPipelineInfo(*TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
 }

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -2,6 +2,7 @@ package txncontext
 
 import (
 	"context"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/jmoiron/sqlx"
@@ -17,6 +18,7 @@ import (
 // transaction is started, a context will be created for it containing these
 // objects, which will be threaded through to every API call:
 type TransactionContext struct {
+	start    time.Time
 	username string
 	// SqlTx is the ongoing database transaction.
 	SqlTx *sqlx.Tx
@@ -39,7 +41,7 @@ type identifier interface {
 	WhoAmI(context.Context, *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 }
 
-func New(ctx context.Context, sqlTx *sqlx.Tx, authServer identifier, m FilesetManager) (*TransactionContext, error) {
+func New(ctx context.Context, sqlTx *sqlx.Tx, authServer identifier, m FilesetManager, start time.Time) (*TransactionContext, error) {
 	var username string
 	// check auth once now so that we can refer to it later
 	if authServer != nil {
@@ -50,6 +52,7 @@ func New(ctx context.Context, sqlTx *sqlx.Tx, authServer identifier, m FilesetMa
 		}
 	}
 	return &TransactionContext{
+		start:          start,
 		SqlTx:          sqlTx,
 		CommitSetID:    uuid.NewWithoutDashes(),
 		Timestamp:      types.TimestampNow(),
@@ -63,6 +66,10 @@ func (t *TransactionContext) WhoAmI() (*auth.WhoAmIResponse, error) {
 		return nil, auth.ErrNotActivated
 	}
 	return &auth.WhoAmIResponse{Username: t.username}, nil
+}
+
+func (t *TransactionContext) Now() time.Time {
+	return t.start
 }
 
 // PropagateJobs notifies PPS that there are new commits in the transaction's

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9265,7 +9265,7 @@ func TestUpdateMultiplePipelinesInTransaction(t *testing.T) {
 			[]string{"bash"},
 			[]string{
 				fmt.Sprintf("cat /pfs/%s/foo >> /pfs/out/foo", input),
-				fmt.Sprintf("echo '%s' >> /pfs/out/foo", suffix),
+				fmt.Sprintf("echo -n '%s' >> /pfs/out/foo", suffix),
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1787,7 +1787,7 @@ func (a *apiServer) initializePipelineInfo(txnCtx *txncontext.TransactionContext
 
 	// Reprocess overrides the salt in the request
 	if request.Salt == "" || request.Reprocess {
-		request.Salt = uuid.NewWithoutDashes()
+		request.Salt = txnCtx.CommitSetID
 	}
 
 	pipelineInfo := &pps.PipelineInfo{
@@ -1800,7 +1800,7 @@ func (a *apiServer) initializePipelineInfo(txnCtx *txncontext.TransactionContext
 			Input:                 request.Input,
 			OutputBranch:          request.OutputBranch,
 			Egress:                request.Egress,
-			CreatedAt:             now(txnCtx),
+			CreatedAt:             txnCtx.Timestamp,
 			ResourceRequests:      request.ResourceRequests,
 			ResourceLimits:        request.ResourceLimits,
 			SidecarResourceLimits: request.SidecarResourceLimits,

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1453,8 +1453,8 @@ func (s podSlice) Less(i, j int) bool {
 	return s[i].ObjectMeta.Name < s[j].ObjectMeta.Name
 }
 
-func now() *types.Timestamp {
-	t, err := types.TimestampProto(time.Now())
+func now(txnCtx *txncontext.TransactionContext) *types.Timestamp {
+	t, err := types.TimestampProto(txnCtx.Now())
 	if err != nil {
 		panic(err)
 	}
@@ -1780,7 +1780,7 @@ func (a *apiServer) CreatePipeline(ctx context.Context, request *pps.CreatePipel
 	return &types.Empty{}, nil
 }
 
-func (a *apiServer) initializePipelineInfo(request *pps.CreatePipelineRequest, oldPipelineInfo *pps.PipelineInfo) (*pps.PipelineInfo, error) {
+func (a *apiServer) initializePipelineInfo(txnCtx *txncontext.TransactionContext, request *pps.CreatePipelineRequest, oldPipelineInfo *pps.PipelineInfo) (*pps.PipelineInfo, error) {
 	if err := a.validatePipelineRequest(request); err != nil {
 		return nil, err
 	}
@@ -1800,7 +1800,7 @@ func (a *apiServer) initializePipelineInfo(request *pps.CreatePipelineRequest, o
 			Input:                 request.Input,
 			OutputBranch:          request.OutputBranch,
 			Egress:                request.Egress,
-			CreatedAt:             now(),
+			CreatedAt:             now(txnCtx),
 			ResourceRequests:      request.ResourceRequests,
 			ResourceLimits:        request.ResourceLimits,
 			SidecarResourceLimits: request.SidecarResourceLimits,
@@ -1859,7 +1859,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 	}
 	pipelineName := request.Pipeline.Name
 
-	newPipelineInfo, err := a.initializePipelineInfo(request, oldPipelineInfo)
+	newPipelineInfo, err := a.initializePipelineInfo(txnCtx, request, oldPipelineInfo)
 	if err != nil {
 		return err
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1453,14 +1453,6 @@ func (s podSlice) Less(i, j int) bool {
 	return s[i].ObjectMeta.Name < s[j].ObjectMeta.Name
 }
 
-func now(txnCtx *txncontext.TransactionContext) *types.Timestamp {
-	t, err := types.TimestampProto(txnCtx.Now())
-	if err != nil {
-		panic(err)
-	}
-	return t
-}
-
 func (a *apiServer) validatePipelineRequest(request *pps.CreatePipelineRequest) error {
 	if request.Pipeline == nil {
 		return errors.New("invalid pipeline spec: request.Pipeline cannot be nil")
@@ -1853,7 +1845,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 	specFileSetID *string,
 	prevPipelineVersion *uint64,
 ) error {
-	oldPipelineInfo, err := txnCtx.FilesetManager.LatestPipelineInfo(txnCtx, request.Pipeline)
+	oldPipelineInfo, err := txnCtx.FileSetManager.LatestPipelineInfo(txnCtx, request.Pipeline)
 	if err != nil {
 		return err
 	}
@@ -1868,7 +1860,7 @@ func (a *apiServer) CreatePipelineInTransaction(
 	if err != nil {
 		return err
 	}
-	if *specFileSetID, err = txnCtx.FilesetManager.CreateFileset(ppsconsts.SpecFile, data); err != nil {
+	if *specFileSetID, err = txnCtx.FileSetManager.CreateFileset(ppsconsts.SpecFile, data); err != nil {
 		return err
 	}
 
@@ -2604,7 +2596,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 	}
 
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		pipelineInfo, err := txnCtx.FilesetManager.LatestPipelineInfo(txnCtx, request.Pipeline)
+		pipelineInfo, err := txnCtx.FileSetManager.LatestPipelineInfo(txnCtx, request.Pipeline)
 		if err != nil {
 			return err
 		}
@@ -2651,7 +2643,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 	}
 
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		pipelineInfo, err := txnCtx.FilesetManager.LatestPipelineInfo(txnCtx, request.Pipeline)
+		pipelineInfo, err := txnCtx.FileSetManager.LatestPipelineInfo(txnCtx, request.Pipeline)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fixes an issue that occurs when creating pipelines in a transaction where the pipelines all have the same spec file (https://github.com/pachyderm/pachyderm/issues/6713). The issue appears to be because a hash is computed for the spec file sets created in the transaction, but this hash doesn't actually use the disambiguating data (path + data) because the sum isn't actually called on the hasher, but rather the sum exposed by the hashing package (md5). This would cause all of the file sets to have the same hash, so the first spec file set would get used for the rest of the pipelines that get created.