### PR TITLE
Package `dockertestenv` provides a test environment with external dependencies provided by docker.

### DIFF
--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -15,7 +15,8 @@ sudo apt-get install -y -qq \
   fuse \
   conntrack \
   pv \
-  shellcheck
+  shellcheck \
+  docker-ce-cli
 
 # Install fuse
 sudo modprobe fuse

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/proxy"
 )
 
@@ -52,7 +52,7 @@ func TestPostgresCollections(suite *testing.T) {
 // TODO: Add test for filling up watcher buffer.
 func TestPostgresCollectionsProxy(suite *testing.T) {
 	watchTests(suite, newCollectionFunc(func(_ context.Context, t *testing.T) (*sqlx.DB, col.PostgresListener) {
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		listener := client.NewProxyPostgresListener(func() (proxy.APIClient, error) { return env.PachClient.ProxyClient, nil })
 		t.Cleanup(func() {
 			require.NoError(t, listener.Close())
@@ -202,7 +202,7 @@ func PostgresCollectionWatchTests(suite *testing.T, newCollection func(context.C
 }
 
 func newTestDB(t testing.TB) (*sqlx.DB, string) {
-	options := testutil.NewTestDBOptions(t)
+	options := dockertestenv.NewTestDBOptions(t)
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)
@@ -213,7 +213,7 @@ func newTestDB(t testing.TB) (*sqlx.DB, string) {
 }
 
 func newTestDirectDB(t testing.TB) (*sqlx.DB, string) {
-	options := testutil.NewTestDirectDBOptions(t)
+	options := dockertestenv.NewTestDirectDBOptions(t)
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)

--- a/src/internal/dockertestenv/dockertestenv.go
+++ b/src/internal/dockertestenv/dockertestenv.go
@@ -24,6 +24,7 @@ const (
 
 func postgresHost() string {
 	return "127.0.0.1"
+	// TODO: this breaks in CI even though it works with minikube and docker desktop on mac.
 	endpoint, isSet := os.LookupEnv("DOCKER_HOST")
 	if !isSet {
 		return "127.0.0.1"
@@ -92,6 +93,9 @@ func NewTestDirectDB(t testing.TB) *sqlx.DB {
 func ensureDBEnv(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "bash", "-c", `
 set -ve
+unset DOCKER_HOST
+unset DOCKER_CERT_PATH	
+unset DOCKER_TLS_VERIFY
 
 if ! docker ps | grep -q postgres
 then

--- a/src/internal/dockertestenv/dockertestenv.go
+++ b/src/internal/dockertestenv/dockertestenv.go
@@ -4,9 +4,6 @@ package dockertestenv
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/url"
-	"os"
 	"os/exec"
 	"sync"
 	"testing"
@@ -29,19 +26,20 @@ const (
 
 func postgresHost() string {
 	return "127.0.0.1"
-	endpoint, isSet := os.LookupEnv("DOCKER_HOST")
-	if !isSet {
-		return "127.0.0.1"
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		panic(err)
-	}
-	host, _, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		panic(err)
-	}
-	return host
+	// TODO: this lets you use minikube or docker desktop on macOS, but doesn't work in CI.
+	// endpoint, isSet := os.LookupEnv("DOCKER_HOST")
+	// if !isSet {
+	// 	return "127.0.0.1"
+	// }
+	// u, err := url.Parse(endpoint)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// host, _, err := net.SplitHostPort(u.Host)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// return host
 }
 
 func pgBouncerHost() string {

--- a/src/internal/dockertestenv/dockertestenv.go
+++ b/src/internal/dockertestenv/dockertestenv.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -24,6 +23,7 @@ const (
 )
 
 func postgresHost() string {
+	return "127.0.0.1"
 	endpoint, isSet := os.LookupEnv("DOCKER_HOST")
 	if !isSet {
 		return "127.0.0.1"
@@ -121,11 +121,8 @@ fi
 	`)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
-	}
-	if ec := cmd.ProcessState.ExitCode(); ec != 0 {
 		fmt.Println(string(output))
-		return errors.Errorf("dockertestenv: non zero exit code during setup %v", ec)
+		return err
 	}
 	return nil
 }

--- a/src/internal/dockertestenv/dockertestenv.go
+++ b/src/internal/dockertestenv/dockertestenv.go
@@ -1,0 +1,79 @@
+// package dockertestenv provides test environment where service dependencies are docker containers
+package dockertestenv
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+)
+
+const (
+	postgresPort  = 30228
+	pgBouncerPort = 30229
+	postgresHost  = "127.0.0.1"
+	pgBouncerHost = postgresHost
+	pgUsername    = "pachyderm"
+)
+
+func NewTestDB(t testing.TB) *sqlx.DB {
+	ctx := context.Background()
+	require.NoError(t, ensureDBEnv(ctx))
+	opts := []dbutil.Option{
+		dbutil.WithDBName(pgUsername),
+		dbutil.WithHostPort(pgBouncerHost, pgBouncerPort),
+		dbutil.WithUserPassword(testutil.DefaultPostgresUser, testutil.DefaultPostgresPassword),
+	}
+	return testutil.NewTestDB(t, opts...)
+}
+
+func NewTestDirectDB(t testing.TB) *sqlx.DB {
+	ctx := context.Background()
+	require.NoError(t, ensureDBEnv(ctx))
+	opts := []dbutil.Option{
+		dbutil.WithDBName("pachyderm"),
+		dbutil.WithHostPort(postgresHost, postgresPort),
+		dbutil.WithUserPassword(testutil.DefaultPostgresUser, testutil.DefaultPostgresPassword),
+	}
+	return testutil.NewTestDirectDB(t, opts...)
+}
+
+// TODO: use the docker client.
+func ensureDBEnv(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "bash", "-c", `
+set -ve
+
+if ! docker ps | grep -q postgres
+then
+    echo "starting postgres..."
+    postgres_id=$(docker run -d \
+    -e POSTGRES_DB=pachyderm \
+    -e POSTGRES_USER=pachyderm \
+    -e POSTGRES_HOST_AUTH_METHOD=trust \
+    -p 30228:5432 \
+    postgres:13.0-alpine)
+
+    postgres_ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $postgres_id)
+
+    docker run -d \
+    -e AUTH_TYPE=any \
+    -e DB_USER="pachyderm" \
+    -e DB_PASS="password" \
+    -e DB_HOST=$postgres_ip \
+    -e DB_PORT=5432 \
+    -e POOL_MODE=transaction \
+    -p 30229:5432 \
+    edoburu/pgbouncer:1.15.0
+else
+    echo "postgres already started"
+fi
+	`)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/internal/dockertestenv/dockertestenv.go
+++ b/src/internal/dockertestenv/dockertestenv.go
@@ -26,20 +26,10 @@ const (
 
 func postgresHost() string {
 	return "127.0.0.1"
-	// TODO: this lets you use minikube or docker desktop on macOS, but doesn't work in CI.
-	// endpoint, isSet := os.LookupEnv("DOCKER_HOST")
-	// if !isSet {
-	// 	return "127.0.0.1"
-	// }
-	// u, err := url.Parse(endpoint)
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// host, _, err := net.SplitHostPort(u.Host)
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// return host
+	// TODO: it should be possible to set the docker API endpoint using the DOCKER_HOST environment variable.
+	// Switching between minikube and docker desktop on macOS was working with that method.
+	// However, it seems to break in CI, which uses minikube, but doesn't seem to expose the ports on DOCKER_HOST.
+	// So for now we are just hardcoding localhost.
 }
 
 func pgBouncerHost() string {
@@ -105,7 +95,9 @@ func NewTestDirectDBOptions(t testing.TB) []dbutil.Option {
 
 var spawnLock sync.Mutex
 
-// TODO: use the docker client.
+// TODO: use the docker client, instead of the bash script
+// TODO: use the bitnami pg_bouncer image
+// TODO: look into https://github.com/ory/dockertest
 func ensureDBEnv(t testing.TB, ctx context.Context) error {
 	spawnLock.Lock()
 	defer spawnLock.Unlock()

--- a/src/internal/dockertestenv/dockertestenv.go
+++ b/src/internal/dockertestenv/dockertestenv.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -104,8 +105,12 @@ func NewTestDirectDBOptions(t testing.TB) []dbutil.Option {
 	})
 }
 
+var spawnLock sync.Mutex
+
 // TODO: use the docker client.
 func ensureDBEnv(t testing.TB, ctx context.Context) error {
+	spawnLock.Lock()
+	defer spawnLock.Unlock()
 	cmd := exec.CommandContext(ctx, "bash", "-c", `
 set -ve
 

--- a/src/internal/migrations/migrations_test.go
+++ b/src/internal/migrations/migrations_test.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
 
 func TestMigration(t *testing.T) {
-	db := testutil.NewTestDB(t)
+	db := dockertestenv.NewTestDB(t)
 	state := InitialState().
 		Apply("test 1", func(ctx context.Context, env Env) error {
 			// NoOp

--- a/src/internal/storage/chunk/chunk_test.go
+++ b/src/internal/storage/chunk/chunk_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/chmduquesne/rollinghash/buzhash64"
 	units "github.com/docker/go-units"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"modernc.org/mathutil"
 )
@@ -206,7 +206,7 @@ func readAnnotations(t *testing.T, chunks *Storage, annotations []*testAnnotatio
 // newTestStorage is like NewTestStorage except it doesn't need an external tracker
 // it is for testing this package, not for reuse.
 func newTestStorage(t testing.TB) (obj.Client, *Storage) {
-	db := testutil.NewTestDB(t)
+	db := dockertestenv.NewTestDB(t)
 	tr := track.NewTestTracker(t, db)
 	return NewTestStorage(t, db, tr)
 }

--- a/src/internal/storage/chunk/gc_test.go
+++ b/src/internal/storage/chunk/gc_test.go
@@ -8,15 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 func TestGC(t *testing.T) {
 	ctx := context.Background()
-	db := testutil.NewTestDB(t)
+	db := dockertestenv.NewTestDB(t)
 	tracker := track.NewTestTracker(t, db)
 	oc, s := NewTestStorage(t, db, tracker)
 

--- a/src/internal/storage/fileset/fileset_test.go
+++ b/src/internal/storage/fileset/fileset_test.go
@@ -13,13 +13,13 @@ import (
 	units "github.com/docker/go-units"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 const (
@@ -68,7 +68,7 @@ func checkFile(t *testing.T, f File, tf *testFile) {
 // newTestStorage creates a storage object with a test db and test tracker
 // both of those components are kept hidden, so this is only appropriate for testing this package.
 func newTestStorage(t *testing.T) *Storage {
-	db := testutil.NewTestDB(t)
+	db := dockertestenv.NewTestDB(t)
 	tr := track.NewTestTracker(t, db)
 	return NewTestStorage(t, db, tr)
 }

--- a/src/internal/storage/fileset/gc_test.go
+++ b/src/internal/storage/fileset/gc_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 func TestGC(t *testing.T) {
 	ctx := context.Background()
-	db := testutil.NewTestDB(t)
+	db := dockertestenv.NewTestDB(t)
 	tr := track.NewTestTracker(t, db)
 	s := NewTestStorage(t, db, tr)
 	gc := s.newGC()

--- a/src/internal/storage/fileset/index/index_test.go
+++ b/src/internal/storage/fileset/index/index_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 func write(tb testing.TB, chunks *chunk.Storage, fileNames []string) *Index {
@@ -53,7 +53,7 @@ func pathRange(fileNames []string) *PathRange {
 }
 
 func Check(t *testing.T, permString string) {
-	db := testutil.NewTestDB(t)
+	db := dockertestenv.NewTestDB(t)
 	tr := track.NewTestTracker(t, db)
 	_, chunks := chunk.NewTestStorage(t, db, tr)
 	fileNames := Generate(permString)

--- a/src/internal/storage/fileset/postgres_store_test.go
+++ b/src/internal/storage/fileset/postgres_store_test.go
@@ -3,12 +3,12 @@ package fileset
 import (
 	"testing"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 )
 
 func TestPostgresStore(t *testing.T) {
 	StoreTestSuite(t, func(t testing.TB) MetadataStore {
-		db := testutil.NewTestDB(t)
+		db := dockertestenv.NewTestDB(t)
 		return NewTestStore(t, db)
 	})
 }

--- a/src/internal/storage/track/postgres_tracker_test.go
+++ b/src/internal/storage/track/postgres_tracker_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	_ "github.com/lib/pq"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 )
 
 func TestPostgresTracker(t *testing.T) {
 	t.Parallel()
 	TestTracker(t, func(testing.TB) Tracker {
-		db := testutil.NewTestDB(t)
+		db := dockertestenv.NewTestDB(t)
 		db.MustExec("CREATE SCHEMA storage")
 		db.MustExec(schema)
 		return NewPostgresTracker(db)

--- a/src/internal/testutil/db.go
+++ b/src/internal/testutil/db.go
@@ -123,7 +123,9 @@ func NewTestDirectDBOptions(t testing.TB, opts ...dbutil.Option) []dbutil.Option
 	}
 	db := OpenDB(t, opts...)
 	dbName := CreateEphemeralDB(t, db)
-	opts2 := []dbutil.Option{}
+	opts2 := []dbutil.Option{
+		dbutil.WithMaxOpenConns(maxOpenConnsPerPool),
+	}
 	opts2 = append(opts2, opts...)
 	opts2 = append(opts2, dbutil.WithDBName(dbName))
 	return opts2
@@ -136,7 +138,9 @@ func NewTestDBOptions(t testing.TB, opts ...dbutil.Option) []dbutil.Option {
 	}
 	db := OpenDB(t, opts...)
 	dbName := CreateEphemeralDB(t, db)
-	opts2 := []dbutil.Option{}
+	opts2 := []dbutil.Option{
+		dbutil.WithMaxOpenConns(maxOpenConnsPerPool),
+	}
 	opts2 = append(opts2, opts...)
 	opts2 = append(opts2, dbutil.WithDBName(dbName))
 	return opts2

--- a/src/internal/testutil/db.go
+++ b/src/internal/testutil/db.go
@@ -3,9 +3,7 @@ package testutil
 import (
 	"crypto/rand"
 	"fmt"
-	"os"
 	"runtime"
-	"strconv"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
@@ -41,56 +39,6 @@ type TestDatabaseDeployment interface {
 	NewDatabase(t testing.TB) (*sqlx.DB, col.PostgresListener)
 	NewDatabaseConfig(t testing.TB) serviceenv.ConfigOption
 }
-
-func postgresHost() string {
-	if host, ok := os.LookupEnv("POSTGRES_HOST"); ok {
-		return host
-	}
-	return DefaultPostgresHost
-}
-
-func postgresPort() int {
-	if port, ok := os.LookupEnv("POSTGRES_PORT"); ok {
-		if portInt, err := strconv.Atoi(port); err == nil {
-			return portInt
-		}
-	}
-	return DefaultPostgresPort
-}
-
-func pgBouncerHost() string {
-	if host, ok := os.LookupEnv("PG_BOUNCER_HOST"); ok {
-		return host
-	}
-	return DefaultPGBouncerHost
-}
-
-func pgBouncerPort() int {
-	if port, ok := os.LookupEnv("PG_BOUNCER_PORT"); ok {
-		if portInt, err := strconv.Atoi(port); err == nil {
-			return portInt
-		}
-	}
-	return DefaultPGBouncerPort
-}
-
-// func MinikubeDBOptions() []dbutil.Option {
-// 	return []dbutil.Option{
-// 		dbutil.WithHostPort(pgBouncerHost(), pgBouncerPort()),
-// 		dbutil.WithDBName(DefaultPostgresDatabase),
-// 		dbutil.WithMaxOpenConns(1),
-// 		dbutil.WithUserPassword(DefaultPostgresUser, DefaultPostgresPassword),
-// 	}
-// }
-
-// func MinikubeDirectDBOptions() []dbutil.Option {
-// 	return []dbutil.Option{
-// 		dbutil.WithHostPort(postgresHost(), postgresPort()),
-// 		dbutil.WithDBName(DefaultPostgresDatabase),
-// 		dbutil.WithMaxOpenConns(1),
-// 		dbutil.WithUserPassword(DefaultPostgresUser, DefaultPostgresPassword),
-// 	}
-// }
 
 // NewTestDBOptions connects to postgres using opts, creates a database
 // with a unique name then returns options to connect to the new database

--- a/src/server/identity/server/dex_web_test.go
+++ b/src/server/identity/server/dex_web_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	logrus "github.com/sirupsen/logrus"
 
 	dex_storage "github.com/dexidp/dex/storage"
@@ -23,7 +23,7 @@ import (
 
 func getTestEnv(t *testing.T) serviceenv.ServiceEnv {
 	env := &serviceenv.TestServiceEnv{
-		DBClient: testutil.NewTestDB(t),
+		DBClient: dockertestenv.NewTestDB(t),
 		DexDB:    dex_memory.New(logrus.New()),
 		Log:      logrus.New(),
 	}

--- a/src/server/pfs/fuse/fuse_test.go
+++ b/src/server/pfs/fuse/fuse_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil/random"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
@@ -27,7 +27,7 @@ const (
 )
 
 func TestBasic(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	commit := client.NewCommit("repo", "master", "")
 	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
@@ -58,7 +58,7 @@ func TestBasic(t *testing.T) {
 }
 
 func TestChunkSize(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	err := env.PachClient.PutFile(client.NewCommit("repo", "master", ""), "file", strings.NewReader(strings.Repeat("p", int(pfs.ChunkSize))))
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestChunkSize(t *testing.T) {
 }
 
 func TestLargeFile(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	random.SeedRand(123)
 	src := random.String(GB + 17)
@@ -84,7 +84,7 @@ func TestLargeFile(t *testing.T) {
 }
 
 func BenchmarkLargeFile(b *testing.B) {
-	env := testpachd.NewRealEnv(b, testutil.NewTestDBConfig(b))
+	env := testpachd.NewRealEnv(b, dockertestenv.NewTestDBConfig(b))
 	require.NoError(b, env.PachClient.CreateRepo("repo"))
 	random.SeedRand(123)
 	src := random.String(GB)
@@ -102,7 +102,7 @@ func BenchmarkLargeFile(b *testing.B) {
 }
 
 func TestSeek(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	data := strings.Repeat("foo", MB)
 	err := env.PachClient.PutFile(client.NewCommit("repo", "master", ""), "file", strings.NewReader(data))
@@ -130,7 +130,7 @@ func TestSeek(t *testing.T) {
 }
 
 func TestHeadlessBranch(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	require.NoError(t, env.PachClient.CreateBranch("repo", "master", "", "", nil))
 	withMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -142,7 +142,7 @@ func TestHeadlessBranch(t *testing.T) {
 }
 
 func TestReadOnly(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	withMount(t, env.PachClient, &Options{
 		Fuse: &fs.Options{
@@ -156,7 +156,7 @@ func TestReadOnly(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo"))
 	commit := client.NewCommit("repo", "master", "")
 	// First, create a file
@@ -266,7 +266,7 @@ func TestWrite(t *testing.T) {
 }
 
 func TestRepoOpts(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("repo1"))
 	require.NoError(t, env.PachClient.CreateRepo("repo2"))
 	require.NoError(t, env.PachClient.CreateRepo("repo3"))
@@ -337,7 +337,7 @@ func TestRepoOpts(t *testing.T) {
 }
 
 func TestOpenCommit(t *testing.T) {
-	env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	require.NoError(t, env.PachClient.CreateRepo("in"))
 	require.NoError(t, env.PachClient.CreateRepo("out"))
 	require.NoError(t, env.PachClient.CreateBranch("out", "master", "", "", []*pfs.Branch{client.NewBranch("in", "master")}))

--- a/src/server/pfs/s3/master_test.go
+++ b/src/server/pfs/s3/master_test.go
@@ -11,6 +11,7 @@ import (
 
 	minio "github.com/minio/minio-go/v6"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
@@ -530,7 +531,7 @@ func TestMasterDriver(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	testRunner(t, env.PachClient, "master", NewMasterDriver(), func(t *testing.T, pachClient *client.APIClient, minioClient *minio.Client) {
 		t.Run("ListBuckets", func(t *testing.T) {
 			masterListBuckets(t, pachClient, minioClient)

--- a/src/server/pfs/s3/worker_test.go
+++ b/src/server/pfs/s3/worker_test.go
@@ -10,6 +10,7 @@ import (
 	minio "github.com/minio/minio-go/v6"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -228,7 +229,7 @@ func TestWorkerDriver(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	pachClient := env.PachClient
 
 	inputRepo := tu.UniqueString("testworkerdriverinput")

--- a/src/server/pfs/server/testing/load_test.go
+++ b/src/server/pfs/server/testing/load_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
-	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 func TestLoad(t *testing.T) {
-	env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 	c := env.PachClient
 	resp, err := c.PfsAPIClient.RunLoadTestDefault(c.Ctx(), &types.Empty{})
 	require.NoError(t, err)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/ancestry"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/clientsdk"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
@@ -89,7 +90,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InvalidRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.YesError(t, env.PachClient.CreateRepo("/repo"))
 
@@ -106,7 +107,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateSameRepoInParallel", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		numGoros := 1000
 		errCh := make(chan error)
@@ -132,7 +133,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateDifferentRepoInParallel", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		numGoros := 1000
 		errCh := make(chan error)
@@ -158,7 +159,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateRepoDeleteRepoRace", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		for i := 0; i < 100; i++ {
 			require.NoError(t, env.PachClient.CreateRepo("foo"))
@@ -183,7 +184,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("Branch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -204,7 +205,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ToggleBranchProvenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("in"))
 		require.NoError(t, env.PachClient.CreateRepo("out"))
@@ -258,7 +259,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("RecreateBranchProvenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("in"))
 		require.NoError(t, env.PachClient.CreateRepo("out"))
@@ -281,7 +282,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("RewindBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("a"))
 		require.NoError(t, env.PachClient.CreateRepo("b"))
@@ -346,7 +347,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateAndInspectRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -369,7 +370,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		numRepos := 10
 		var repoNames []string
@@ -387,7 +388,7 @@ func TestPFS(suite *testing.T) {
 	// Make sure that artifacts of deleted repos do not resurface
 	suite.Run("CreateDeletedRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -437,7 +438,7 @@ func TestPFS(suite *testing.T) {
 	// Make sure that commits of deleted repos do not resurface
 	suite.Run("ListCommitLimit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		commit := client.NewCommit(repo, "master", "")
@@ -465,7 +466,7 @@ func TestPFS(suite *testing.T) {
 	// d1      d2
 	suite.Run("UpdateProvenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		prov1 := "prov1"
 		require.NoError(t, env.PachClient.CreateRepo(prov1))
@@ -508,7 +509,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileIntoOpenCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -530,7 +531,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileDirectoryTraversal", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("repo"))
 
@@ -564,7 +565,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateInvalidBranchName", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -576,7 +577,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateBranchHeadOnOtherRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		// create two repos, and create a branch on one that tries to point on another's existing branch
 		repo := "test"
@@ -615,7 +616,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		numRepos := 10
 		repoNames := make(map[string]bool)
@@ -647,7 +648,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteRepoProvenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		// Create two repos, one as another's provenance
 		require.NoError(t, env.PachClient.CreateRepo("A"))
@@ -691,7 +692,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -736,7 +737,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectCommitWait", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -758,7 +759,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SquashCommitSet", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -792,7 +793,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SquashCommitSetOnlyCommitInBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -830,7 +831,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SquashCommitSetFinished", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -871,7 +872,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("BasicFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -892,7 +893,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SimpleFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -922,7 +923,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("StartCommitWithUnfinishedParent", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -940,7 +941,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ProvenanceWithinSingleRepoDisallowed", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -952,7 +953,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("AncestrySyntax", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1077,7 +1078,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("Provenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -1134,7 +1135,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CommitBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("input"))
 		require.NoError(t, env.PachClient.CreateRepo("output"))
@@ -1162,7 +1163,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CommitOnTwoBranchesProvenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("input"))
 		require.NoError(t, env.PachClient.CreateRepo("output"))
@@ -1218,7 +1219,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("Branch1", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1274,7 +1275,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileBig", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1300,7 +1301,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1322,7 +1323,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFile2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1380,7 +1381,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileBranchCommitID", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1391,7 +1392,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutSameFileInParallel", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1414,7 +1415,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1465,7 +1466,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectFile2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1508,7 +1509,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectFile3", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1554,7 +1555,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectDir", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1585,7 +1586,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectDir2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1626,7 +1627,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListFileTwoCommits", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1670,7 +1671,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1699,7 +1700,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListFile2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1741,7 +1742,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListFile3", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1793,7 +1794,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListFile4", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1825,7 +1826,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("RootDirectory", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1845,7 +1846,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1909,7 +1910,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteFile2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -1947,7 +1948,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteFile3", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2000,7 +2001,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteDir", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2073,7 +2074,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2148,7 +2149,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Decide on how to expose offset read.
 		t.Skip("Offset read exists (inefficient), just need to decide on how to expose it in V2")
 		//t.Parallel()
-		//env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		//repo := "test"
 		//require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2171,7 +2172,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("Branch2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2231,7 +2232,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeleteNonexistentBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2240,7 +2241,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SubscribeCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2287,7 +2288,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectRepoSimple", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2312,7 +2313,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("InspectRepoComplex", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2351,7 +2352,7 @@ func TestPFS(suite *testing.T) {
 		// TODO: Implement put file split writer in V2?
 		t.Skip("Put file split writer not implemented in V2")
 		//t.Parallel()
-		//env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		//repo := "test"
 		//require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2367,7 +2368,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("GetFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := tu.UniqueString("test")
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2419,7 +2420,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ManyPutsSingleFileSingleCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		if testing.Short() {
 			t.Skip("Skipping long tests in short mode")
@@ -2465,7 +2466,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileValidCharacters", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2493,7 +2494,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileValidPaths", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
 		// Duplicate paths, different tags.
@@ -2520,7 +2521,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("BigListFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
 		commit, err := env.PachClient.StartCommit(repo, "master")
@@ -2546,7 +2547,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("StartCommitLatestOnBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2571,7 +2572,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CreateBranchTwice", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2599,7 +2600,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WaitCommitSet", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -2623,7 +2624,7 @@ func TestPFS(suite *testing.T) {
 	// A ─▶ B ─▶ C ─▶ D
 	suite.Run("WaitCommitSet2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -2674,7 +2675,7 @@ func TestPFS(suite *testing.T) {
 	// B
 	suite.Run("WaitCommitSet3", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -2717,7 +2718,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WaitCommitSetWithNoDownstreamRepos", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -2732,7 +2733,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WaitOpenCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -2765,7 +2766,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WaitUninvolvedBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -2780,7 +2781,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WaitNonExistentBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		commit, err := env.PachClient.StartCommit("A", "master")
@@ -2796,7 +2797,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("EmptyWait", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		_, err := env.PachClient.WaitCommitSetAll("")
 		require.YesError(t, err)
@@ -2804,7 +2805,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WaitNonExistentCommitSet", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		_, err := env.PachClient.WaitCommitSetAll("fake-commitset")
 		require.YesError(t, err)
@@ -2815,7 +2816,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Implement put file split.
 		t.Skip("Put file split not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	if testing.Short() {
 		//		t.Skip("Skipping integration tests in short mode")
@@ -2924,7 +2925,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Implement put file split.
 		t.Skip("Put file split not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	if testing.Short() {
 		//		t.Skip("Skipping integration tests in short mode")
@@ -2955,7 +2956,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Implement put file split.
 		t.Skip("Put file split not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	// create repos
 		//	repo := "test"
@@ -2980,7 +2981,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Implement put file split.
 		t.Skip("Put file split not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	// create repos
 		//	repo := "test"
@@ -3044,7 +3045,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DiffFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -3145,7 +3146,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("GlobFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		if testing.Short() {
 			t.Skip("Skipping integration tests in short mode")
@@ -3267,7 +3268,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("GlobFile2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		if testing.Short() {
 			t.Skip("Skipping integration tests in short mode")
@@ -3303,7 +3304,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("GlobFile3", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -3334,7 +3335,7 @@ func TestPFS(suite *testing.T) {
 	// file matching 'glob', file2 is the next lowest, etc.
 	suite.Run("GetFileTARGlobOrder", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -3360,7 +3361,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ApplyWriteOrder", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		if testing.Short() {
 			t.Skip("Skipping integration tests in short mode")
@@ -3387,7 +3388,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Implement put file split.
 		t.Skip("Put file split not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	if testing.Short() {
 		//		t.Skip("Skipping integration tests in short mode")
@@ -3433,7 +3434,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CopyFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -3467,7 +3468,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PropagateBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo1 := "test1"
 		require.NoError(t, env.PachClient.CreateRepo(repo1))
@@ -3493,7 +3494,7 @@ func TestPFS(suite *testing.T) {
 	// B ──▶ D
 	suite.Run("BackfillBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -3532,7 +3533,7 @@ func TestPFS(suite *testing.T) {
 	//
 	suite.Run("UpdateBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -3627,7 +3628,7 @@ func TestPFS(suite *testing.T) {
 		for i, test := range tests {
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 				t.Parallel()
-				env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+				env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 				for _, repo := range []string{"A", "B", "C", "D", "E"} {
 					require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -3722,7 +3723,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ChildCommits", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateBranch("A", "master", "", "", nil))
@@ -3808,7 +3809,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("StartCommitFork", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		commit, err := env.PachClient.StartCommit("A", "master")
@@ -3843,7 +3844,7 @@ func TestPFS(suite *testing.T) {
 	// C should create a new output commit to process its unprocessed inputs in B
 	suite.Run("UpdateBranchNewOutputCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -3890,7 +3891,7 @@ func TestPFS(suite *testing.T) {
 	//   a
 	suite.Run("SquashCommitSetMultipleChildrenSingleCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("repo"))
 		require.NoError(t, env.PachClient.CreateBranch("repo", "master", "", "", nil))
@@ -3982,7 +3983,7 @@ func TestPFS(suite *testing.T) {
 	// if appropriate
 	suite.Run("SquashCommitSetMultiLevelChildren", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("upstream1"))
 		require.NoError(t, env.PachClient.CreateRepo("upstream2"))
@@ -4127,7 +4128,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("CommitState", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		// two input repos, one with many commits (logs), and one with few (schema)
 		require.NoError(t, env.PachClient.CreateRepo("A"))
@@ -4173,7 +4174,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SubscribeStates", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -4224,7 +4225,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		numFiles := 25
 		repo := "repo"
@@ -4280,7 +4281,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileCommitNilBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -4292,7 +4293,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileCommitOverwrite", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		numFiles := 5
 		repo := "repo"
@@ -4310,7 +4311,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WalkFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -4337,7 +4338,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WalkFile2", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "WalkFile2"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -4363,7 +4364,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("WalkFileEmpty", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		latestCommit := client.NewCommit(repo, "master", "")
@@ -4404,7 +4405,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(2.0 optional): Decide on how to expose offset read.
 		t.Skip("Offset read exists (inefficient), just need to decide on how to expose it in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	require.NoError(t, env.PachClient.CreateRepo("test"))
 		//	require.NoError(t, env.PachClient.PutFile("test", "master", "", "file", strings.NewReader(strings.Repeat("a", 100*units.MB))))
@@ -4420,7 +4421,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileURL", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		if testing.Short() {
 			t.Skip("Skipping integration tests in short mode")
@@ -4443,7 +4444,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFilesURL", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		repoProto := client.NewRepo(repo)
@@ -4473,7 +4474,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFilesObjURL", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -4512,7 +4513,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("GetFilesObjURL", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -4542,7 +4543,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileOutputRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		inputRepo, outputRepo := "input", "output"
 		require.NoError(t, env.PachClient.CreateRepo(inputRepo))
@@ -4567,7 +4568,7 @@ func TestPFS(suite *testing.T) {
 		// we would need to spend some time thinking about the performance characteristics.
 		t.Skip("File history is not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	var err error
 		//
@@ -4608,7 +4609,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("UpdateRepo", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		var err error
 		repo := "test"
@@ -4644,7 +4645,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("DeferredProcessing", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("input"))
 		require.NoError(t, env.PachClient.CreateRepo("output1"))
@@ -4700,7 +4701,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ListAll", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("repo1"))
 		require.NoError(t, env.PachClient.CreateRepo("repo2"))
@@ -4723,7 +4724,7 @@ func TestPFS(suite *testing.T) {
 	suite.Run("MonkeyObjectStorage", func(t *testing.T) {
 		// This test cannot be done in parallel because the monkey object client
 		// modifies global state.
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		seedStr := func(seed int64) string {
 			return fmt.Sprint("seed: ", strconv.FormatInt(seed, 10))
 		}
@@ -4797,7 +4798,7 @@ func TestPFS(suite *testing.T) {
 		// TODO(optional 2.0): force-deleting the repo no longer creates dangling references
 		t.Skip("this test no longer creates invalid metadata")
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		input := "input"
 		output1 := "output1"
@@ -4828,7 +4829,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("PutFileAtomic", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		c := env.PachClient
 		test := "test"
@@ -4889,7 +4890,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("FuzzProvenance", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		seed := time.Now().UnixNano()
 		t.Log("Random seed is", seed)
@@ -5053,7 +5054,7 @@ func TestPFS(suite *testing.T) {
 		// we would need to spend some time thinking about the performance characteristics.
 		t.Skip("File history is not implemented in V2")
 		//	t.Parallel()
-		//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		//
 		//	repo := "test"
 		//	require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -5109,7 +5110,7 @@ func TestPFS(suite *testing.T) {
 	// TODO: This test can be refactored to remove a lot of the boilerplate.
 	suite.Run("Trigger", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		c := env.PachClient
 
 		t.Run("Simple", func(t *testing.T) {
@@ -5553,7 +5554,7 @@ func TestPFS(suite *testing.T) {
 	// TriggerValidation tests branch trigger validation
 	suite.Run("TriggerValidation", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		c := env.PachClient
 		require.NoError(t, c.CreateRepo("repo"))
@@ -5609,7 +5610,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("RegressionOrphanedFile", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		fsclient, err := env.PachClient.NewCreateFileSetClient()
 		require.NoError(t, err)
@@ -5632,7 +5633,7 @@ func TestPFS(suite *testing.T) {
 		t.Parallel()
 		env := testpachd.NewRealEnv(t, func(config *serviceenv.Configuration) {
 			config.StorageCompactionMaxFanIn = 10
-		}, tu.NewTestDBConfig(t))
+		}, dockertestenv.NewTestDBConfig(t))
 
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
@@ -5666,7 +5667,7 @@ func TestPFS(suite *testing.T) {
 
 		subsuite.Run("EmptyFile", func(t *testing.T) {
 			t.Parallel()
-			env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+			env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 			repo := "test"
 			require.NoError(t, env.PachClient.CreateRepo(repo))
 			c, err := env.PachClient.PfsAPIClient.ModifyFile(context.Background())
@@ -5699,7 +5700,7 @@ func TestPFS(suite *testing.T) {
 
 		subsuite.Run("SingleMessageFile", func(t *testing.T) {
 			t.Parallel()
-			env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+			env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 			repo := "test"
 			require.NoError(t, env.PachClient.CreateRepo(repo))
 			filePath := "file"
@@ -5729,7 +5730,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("TestPanicOnNilArgs", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		c := env.PachClient
 		requireNoPanic := func(err error) {
 			t.Helper()
@@ -5789,7 +5790,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("ErroredCommits", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		repo := "test"
 		require.NoError(t, env.PachClient.CreateRepo(repo))
 		checks := func(t *testing.T, branch string) {
@@ -5860,7 +5861,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SystemRepoDependence", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		sysRepo := client.NewSystemRepo("test", pfs.MetaRepoType)
 
@@ -5887,7 +5888,7 @@ func TestPFS(suite *testing.T) {
 		require.True(t, errutil.IsNotFoundError(err))
 	})
 	suite.Run("ErrorMessages", func(t *testing.T) {
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 		// don't show user .user suffix
 		_, err := env.PachClient.InspectRepo("test")
 		require.YesError(t, err)

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -28,7 +29,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestEmptyTransaction", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -54,7 +55,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestInvalidatedTransaction", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -84,7 +85,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestFailedAppend", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -117,7 +118,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestDependency", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -171,7 +172,7 @@ func TestTransactions(suite *testing.T) {
 	// inspect the new commit outside of the transaction STM and fail to find it.
 	suite.Run("TestCreateBranch", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -209,7 +210,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestDeleteAllTransactions", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		_, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -231,7 +232,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestMultiCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -259,7 +260,7 @@ func TestTransactions(suite *testing.T) {
 	//  E ────────╯
 	suite.Run("TestPropagateCommit", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		require.NoError(t, env.PachClient.CreateRepo("B"))
@@ -344,7 +345,7 @@ func TestTransactions(suite *testing.T) {
 	// performed within the transaction.
 	suite.Run("TestPropagateCommitRedux", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -393,7 +394,7 @@ func TestTransactions(suite *testing.T) {
 
 	suite.Run("TestBatchTransaction", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, testutil.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		var branchInfos []*pfs.BranchInfo
 		var info *transaction.TransactionInfo

--- a/src/server/worker/datum/iterator_test.go
+++ b/src/server/worker/datum/iterator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
@@ -14,7 +15,7 @@ import (
 
 func TestIterators(t *testing.T) {
 	t.Parallel()
-	env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 	c := env.PachClient
 	dataRepo := tu.UniqueString(t.Name() + "_data")
@@ -288,7 +289,7 @@ func TestIterators(t *testing.T) {
 // ends in a trailing slash.
 //func TestJoinTrailingSlash(t *testing.T) {
 //	t.Parallel()
-//  env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 //
 //	c := env.PachClient
 //	repo := []string{ // singular name b/c we only refer to individual elements

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
@@ -261,7 +262,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobSuccess", func(t *testing.T) {
 		t.Parallel()
 		pi := defaultPipelineInfo()
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 		testJobSuccess(t, env, pi, []tarutil.File{
 			tarutil.NewMemFile("/file", []byte("foobar")),
 		})
@@ -272,7 +273,7 @@ func TestTransformPipeline(suite *testing.T) {
 		objC, bucket := testutil.NewObjectClient(t)
 		pi := defaultPipelineInfo()
 		pi.Details.Egress = &pps.Egress{URL: fmt.Sprintf("local://%s/", bucket)}
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 
 		files := []tarutil.File{
 			tarutil.NewMemFile("/file1", []byte("foo")),
@@ -300,7 +301,7 @@ func TestTransformPipeline(suite *testing.T) {
 		pi := defaultPipelineInfo()
 		pi.Details.Input.Pfs.Glob = "/"
 		pi.Details.Egress = &pps.Egress{URL: fmt.Sprintf("local://%s/", bucket)}
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 
 		testJobSuccess(t, env, pi, nil)
 	})
@@ -308,7 +309,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobFailedDatum", func(t *testing.T) {
 		t.Parallel()
 		pi := defaultPipelineInfo()
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 
 		pi.Details.Transform.Cmd = []string{"bash", "-c", "(exit 1)"}
 		ctx, jobInfo := mockBasicJob(t, env, pi)
@@ -325,7 +326,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobMultiDatum", func(t *testing.T) {
 		t.Parallel()
 		pi := defaultPipelineInfo()
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 
 		ctx, jobInfo := mockBasicJob(t, env, pi)
 		tarFiles := []tarutil.File{
@@ -362,7 +363,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobSerial", func(t *testing.T) {
 		t.Parallel()
 		pi := defaultPipelineInfo()
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 
 		ctx, jobInfo := mockBasicJob(t, env, pi)
 		tarFiles := []tarutil.File{
@@ -405,7 +406,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobSerialDelete", func(t *testing.T) {
 		t.Parallel()
 		pi := defaultPipelineInfo()
-		env := newWorkerSpawnerPair(t, testutil.NewTestDBConfig(t), pi)
+		env := newWorkerSpawnerPair(t, dockertestenv.NewTestDBConfig(t), pi)
 
 		ctx, jobInfo := mockBasicJob(t, env, pi)
 		tarFiles := []tarutil.File{


### PR DESCRIPTION
The immediate issue addressed by this is that we don't have to use the bitnami postgres to provide the ephemeral dbs.

A couple notable features and improvement paths:
- `go test` will now run the tests for packages that use this for testing.  The only dependency is a docker api, and docker command.  It will work locally and in CI.
- We can add a minio instance for testing using the same pattern.
- We can attach to the containers and insert their logs in the test output.
