### PR TITLE
Remove branches from propagater on deletion.

### DIFF
--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -89,6 +89,12 @@ func (t *TransactionContext) PropagateBranch(branch *pfs.Branch) error {
 	return t.PfsPropagater.PropagateBranch(branch)
 }
 
+// DeleteBranch removes a branch from the list of branches to propagate, if
+// it is present.
+func (t *TransactionContext) DeleteBranch(branch *pfs.Branch) {
+	t.PfsPropagater.DeleteBranch(branch)
+}
+
 // Finish applies the deferred logic in the pfsPropagator and ppsPropagator to
 // the transaction
 func (t *TransactionContext) Finish() error {
@@ -119,6 +125,7 @@ func (t *TransactionContext) Finish() error {
 // the end of a transaction.  It is defined here to avoid a circular dependency.
 type PfsPropagater interface {
 	PropagateBranch(branch *pfs.Branch) error
+	DeleteBranch(branch *pfs.Branch)
 	Run() error
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1872,6 +1872,7 @@ func (d *driver) deleteBranch(txnCtx *txncontext.TransactionContext, branch *pfs
 			return err
 		}
 	}
+	txnCtx.DeleteBranch(branch)
 	return nil
 }
 

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5043,6 +5043,10 @@ func TestPFS(suite *testing.T) {
 			}
 			require.NoError(t, env.PachClient.FsckFastExit())
 		}
+
+		// make sure we can delete at the end
+		_, err = env.PachClient.PfsAPIClient.DeleteAll(env.PachClient.Ctx(), &types.Empty{})
+		require.NoError(t, err)
 	})
 
 	// TestAtomicHistory repeatedly writes to a file while concurrently reading

--- a/src/server/pfs/server/transaction_defer.go
+++ b/src/server/pfs/server/transaction_defer.go
@@ -36,6 +36,12 @@ func (t *Propagater) PropagateBranch(branch *pfs.Branch) error {
 	return nil
 }
 
+// DeleteBranch removes a branch from the list of those needing propagation
+// if present.
+func (t *Propagater) DeleteBranch(branch *pfs.Branch) {
+	delete(t.branches, pfsdb.BranchKey(branch))
+}
+
 // Run performs any final tasks and cleanup tasks in the transaction, such as
 // propagating branches
 func (t *Propagater) Run() error {


### PR DESCRIPTION
Deleting a branch will modify the provenance of all downstream branches.
This in turn marks those branches for propagation. Depending on the
order that delete all uses, this can end up attempting to propagate an
already-deleted branch. While we could simply ignore not found errors,
it seems safer to ensure the branch set is accurate.