### PR TITLE
Don't Filter PFS Logs

### DIFF
--- a/etc/testing/pfs_server.sh
+++ b/etc/testing/pfs_server.sh
@@ -3,5 +3,4 @@ set -euxo pipefail
 
 export TIMEOUT=$1
 
-# grep out PFS server logs, as otherwise the test output is too verbose
-go test -v -count=1 ./src/server/pfs/server ./src/server/pfs/server/testing -timeout "$TIMEOUT" | grep -v "$(date +^%FT)"
+go test -v -count=1 ./src/server/pfs/server ./src/server/pfs/server/testing -timeout "$TIMEOUT"


### PR DESCRIPTION
We were previously filtering any timestamped logs because travis couldn't handle all of the logs output during a test run.
Circle doesn't seem to have a problem.  It won't display them all in the browser, but you can download the full output.
This will let use see which test is hanging better than a mysterious timeout.