### PR TITLE
Merge origin/master into the branch under test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       TEST_RESULTS_BUCKET: pach-test-data
     steps:
       - checkout
+      - run: git merge origin/master
       - restore_cache:
          keys:
          - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5010,6 +5010,7 @@ func TestPFS(suite *testing.T) {
 				branch := inputBranches[r.Intn(len(inputBranches))]
 				commit, err := env.PachClient.StartCommit(branch.Repo.Name, branch.Name)
 				require.NoError(t, err)
+				require.NoError(t, env.PachClient.FinishCommit(branch.Repo.Name, branch.Name, ""))
 				// find and finish all commits in output branches, too
 				infos, err := env.PachClient.InspectCommitSet(commit.ID)
 				require.NoError(t, err)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4709,7 +4709,7 @@ func TestPFS(suite *testing.T) {
 
 	suite.Run("SquashCommitEmptyChild", func(t *testing.T) {
 		t.Parallel()
-		env := testpachd.NewRealEnv(t, tu.NewTestDBConfig(t))
+		env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo"
 		file := "foo"


### PR DESCRIPTION
Per [slack thread](https://pachyderm.slack.com/archives/CDWDPKPMY/p1628968352019900), a build breakage was introduced into `master` because a dependency was moved while a feature branch was in development, and then the feature branch was merged into master (CI did not catch the change, because our CI currently only tests the HEAD of feature branches).

This PR aims to prevent this going forward: branches will fail CI if any of their dependencies have changed in a breaking way in master. Note that this cannot fully prevent the issue (as a dependency could always be removed after running tests and before clicking merge), and it will make our CI runs non-repeatable, but it may help significantly, as it reduces the window for PR races from "age of PR" (days/weeks) to "age of last test run" (minutes).

(Aside: to fully prevent this issue, we would need CI and Merge to be coordinated. We would have to create a merge/squash commit, test that commit in CI, and then "Merge" would have to atomically 1) confirm that `master` is in the ancestry of the merge/squash commit (to prevent racing merges) and then 2) move `master` to the merge commit.)