### PR TITLE
Skip alias commits during traversal

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1000,6 +1000,9 @@ func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.Com
 				}
 				return nil, err
 			}
+			if commitInfo.Origin.Kind == pfs.OriginKind_ALIAS {
+				i--
+			}
 			commit = commitInfo.ParentCommit
 		}
 	} else {


### PR DESCRIPTION
I'm not sure this is actually the best thing to do in all cases.
If the base commit is an alias commit, should that be skipped as well?
Is it worth adding a flag to InspectCommit to skip aliases?
