### PR TITLE
Move worker under pachd in helm

### DIFF
--- a/etc/helm/examples/aws-values.yaml
+++ b/etc/helm/examples/aws-values.yaml
@@ -15,8 +15,7 @@ pachd:
   serviceAccount:
     additionalAnnotations:
       eks.amazonaws.com/role-arn: blah123
-
-worker:
-  serviceAccount:
-    additionalAnnotations:
-      eks.amazonaws.com/role-arn: blah123
+  worker:
+    serviceAccount:
+      additionalAnnotations:
+        eks.amazonaws.com/role-arn: blah123

--- a/etc/helm/examples/gcp-values.yaml
+++ b/etc/helm/examples/gcp-values.yaml
@@ -12,8 +12,7 @@ pachd:
   serviceAccount:
     additionalAnnotations:
       iam.gke.io/gcp-service-account: blah123
-
-worker:
-  serviceAccount:
-    additionalAnnotations:
-      iam.gke.io/gcp-service-account: blah123
+  worker:
+    serviceAccount:
+      additionalAnnotations:
+        iam.gke.io/gcp-service-account: blah123

--- a/etc/helm/examples/hub-values.yaml
+++ b/etc/helm/examples/hub-values.yaml
@@ -71,12 +71,11 @@ pachd:
     additionalAnnotations:
       # serviceAccountName is configured per workspace.
       iam.gke.io/gcp-service-account: "test-service-account"
-
-worker:
-  serviceAccount:
-    additionalAnnotations:
-      # serviceAccountName is configured per workspace.
-      iam.gke.io/gcp-service-account: "test-service-account"
+  worker:
+    serviceAccount:
+      additionalAnnotations:
+        # serviceAccountName is configured per workspace.
+        iam.gke.io/gcp-service-account: "test-service-account"
 
 postgresql:
   # Set to false if you are bringing your own PostgreSQL instance. PostgreSQL is a requirement for Pachyderm.

--- a/etc/helm/examples/local-dev-values.yaml
+++ b/etc/helm/examples/local-dev-values.yaml
@@ -15,6 +15,9 @@ pachd:
     enabled: false
   clusterDeploymentID: dev
   enterpriseLicenseKey: ""
+  worker:
+    image:
+      tag: local
 
 console:
   enabled: false
@@ -30,10 +33,6 @@ console:
 
 enterpriseServer:
   enabled: false
-
-worker:
-  image:
-    tag: local
 
 etcd:
   service:

--- a/etc/helm/examples/local-dev-values.yaml
+++ b/etc/helm/examples/local-dev-values.yaml
@@ -15,9 +15,6 @@ pachd:
     enabled: false
   clusterDeploymentID: dev
   enterpriseLicenseKey: ""
-  worker:
-    image:
-      tag: local
 
 console:
   enabled: false

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           value: {{ .Values.pachd.storage.local.hostPath | default $randHostPath }}pachd
           {{- end }}
         - name: WORKER_IMAGE
-          value: "{{ .Values.worker.image.repository }}:{{ default .Chart.AppVersion .Values.pachd.image.tag }}"
+          value: "{{ .Values.pachd.worker.image.repository }}:{{ default .Chart.AppVersion .Values.pachd.image.tag }}"
         {{- if and (eq ( include "pachyderm.storageBackend" . ) "LOCAL") .Values.pachd.storage.local.requireRoot }}
         - name: WORKER_USES_ROOT
           value: "True"
@@ -87,9 +87,9 @@ spec:
         - name: WORKER_SIDECAR_IMAGE
           value: "{{ .Values.pachd.image.repository }}:{{ default .Chart.AppVersion .Values.pachd.image.tag }}"
         - name: WORKER_IMAGE_PULL_POLICY
-          value: {{ .Values.worker.image.pullPolicy | quote }}
+          value: {{ .Values.pachd.worker.image.pullPolicy | quote }}
         - name: WORKER_SERVICE_ACCOUNT
-          value: {{ .Values.worker.serviceAccount.name | quote }}
+          value: {{ .Values.pachd.worker.serviceAccount.name | quote }}
         - name: METRICS
           value: {{ .Values.pachd.metrics.enabled | quote }}
         {{- if .Values.pachd.metricsEndpoint}}

--- a/etc/helm/pachyderm/templates/pachd/rbac/worker-rolebinding.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/worker-rolebinding.yaml
@@ -17,6 +17,6 @@ roleRef:
   name: pachyderm-worker
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.worker.serviceAccount.name }}
+  name: {{ .Values.pachd.worker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/etc/helm/pachyderm/templates/pachd/rbac/worker-serviceaccount.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/worker-serviceaccount.yaml
@@ -2,16 +2,16 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{ if and .Values.worker.serviceAccount.create .Values.pachd.enabled }}
+{{ if and .Values.pachd.worker.serviceAccount.create .Values.pachd.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if .Values.worker.serviceAccount.additionalAnnotations }}
-  annotations: {{ toYaml .Values.worker.serviceAccount.additionalAnnotations | nindent 3 }}
+  {{- if .Values.pachd.worker.serviceAccount.additionalAnnotations }}
+  annotations: {{ toYaml .Values.pachd.worker.serviceAccount.additionalAnnotations | nindent 3 }}
   {{- end }}
   labels:
     app: ""
     suite: pachyderm
-  name: {{ .Values.worker.serviceAccount.name }}
+  name: {{ .Values.pachd.worker.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -355,6 +355,9 @@
                         },
                         "repository": {
                             "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
                         }
                     }
                 },
@@ -570,7 +573,34 @@
                     }
                 },
                 "worker": {
-                    "type": "null"
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "serviceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "additionalAnnotations": {
+                                    "type": "object"
+                                },
+                                "create": {
+                                    "type": "boolean"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -355,9 +355,6 @@
                         },
                         "repository": {
                             "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
                         }
                     }
                 },
@@ -571,6 +568,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "worker": {
+                    "type": "null"
                 }
             }
         },
@@ -644,36 +644,6 @@
                 },
                 "create": {
                     "type": "boolean"
-                }
-            }
-        },
-        "worker": {
-            "type": "object",
-            "properties": {
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "serviceAccount": {
-                    "type": "object",
-                    "properties": {
-                        "additionalAnnotations": {
-                            "type": "object"
-                        },
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    }
                 }
             }
         }

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -340,15 +340,15 @@ pachd:
       crt: ""
       key: ""
   worker:
-  image:
-    repository: "pachyderm/worker"
-    pullPolicy: "IfNotPresent"
-  serviceAccount:
-    create: true
-    additionalAnnotations: {}
-    # name sets the name of the worker service account.  Analogous to
-    # the --worker-service-account argument to pachctl deploy.
-    name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
+    image:
+      repository: "pachyderm/worker"
+      pullPolicy: "IfNotPresent"
+    serviceAccount:
+      create: true
+      additionalAnnotations: {}
+      # name sets the name of the worker service account.  Analogous to
+      # the --worker-service-account argument to pachctl deploy.
+      name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
 
 rbac:
   # create indicates whether RBAC resources should be created.

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -168,6 +168,7 @@ pachd:
     repository: "pachyderm/pachd"
     pullPolicy: "IfNotPresent"
     # tag defaults to the chart’s specified appVersion.
+    # This sets the worker image tag as well (they should be kept in lock step)
     tag: ""
   logLevel: "info"
   # lokiLogging enables Loki logging if set.
@@ -343,6 +344,7 @@ pachd:
     image:
       repository: "pachyderm/worker"
       pullPolicy: "IfNotPresent"
+      # Worker tag is set under pachd.image.tag (they should be kept in lock step)
     serviceAccount:
       create: true
       additionalAnnotations: {}

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -339,6 +339,16 @@ pachd:
       create: false
       crt: ""
       key: ""
+  worker:
+  image:
+    repository: "pachyderm/worker"
+    pullPolicy: "IfNotPresent"
+  serviceAccount:
+    create: true
+    additionalAnnotations: {}
+    # name sets the name of the worker service account.  Analogous to
+    # the --worker-service-account argument to pachctl deploy.
+    name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
 
 rbac:
   # create indicates whether RBAC resources should be created.
@@ -350,16 +360,7 @@ rbac:
   # of --local-roles passed to pachctl deploy.
   clusterRBAC: true
 
-worker:
-  image:
-    repository: "pachyderm/worker"
-    pullPolicy: "IfNotPresent"
-  serviceAccount:
-    create: true
-    additionalAnnotations: {}
-    # name sets the name of the worker service account.  Analogous to
-    # the --worker-service-account argument to pachctl deploy.
-    name: "pachyderm-worker" #TODO Set default in helpers / Wire up in templates
+
 
 pgbouncer:
   service:

--- a/etc/helm/test/aws_test.go
+++ b/etc/helm/test/aws_test.go
@@ -109,8 +109,8 @@ func TestAWS(t *testing.T) {
 
 	helmValues := map[string]string{
 		"deployTarget": "AMAZON",
-		`pachd.serviceAccount.additionalAnnotations.eks\.amazonaws\.com/role-arn`:  expectedServiceAccount,
-		`worker.serviceAccount.additionalAnnotations.eks\.amazonaws\.com/role-arn`: expectedServiceAccount,
+		`pachd.serviceAccount.additionalAnnotations.eks\.amazonaws\.com/role-arn`:        expectedServiceAccount,
+		`pachd.worker.serviceAccount.additionalAnnotations.eks\.amazonaws\.com/role-arn`: expectedServiceAccount,
 	}
 	for _, tc := range testCases {
 		helmValues[tc.helmKey] = tc.value

--- a/etc/helm/test/exampleWorkerAnnotations.yaml
+++ b/etc/helm/test/exampleWorkerAnnotations.yaml
@@ -1,4 +1,5 @@
-worker:
-  serviceAccount:
-    additionalAnnotations:
-      eks.amazonaws.com/role-arn: blah123
+pachd:
+  worker:
+    serviceAccount:
+      additionalAnnotations:
+        eks.amazonaws.com/role-arn: blah123

--- a/etc/helm/test/google_test.go
+++ b/etc/helm/test/google_test.go
@@ -40,8 +40,8 @@ func TestGoogle(t *testing.T) {
 	)
 	helmValues := map[string]string{
 		"deployTarget": expectedStorageBackend,
-		`pachd.serviceAccount.additionalAnnotations.iam\.gke\.io/gcp-service-account`:  expectedServiceAccount,
-		`worker.serviceAccount.additionalAnnotations.iam\.gke\.io/gcp-service-account`: expectedServiceAccount,
+		`pachd.serviceAccount.additionalAnnotations.iam\.gke\.io/gcp-service-account`:        expectedServiceAccount,
+		`pachd.worker.serviceAccount.additionalAnnotations.iam\.gke\.io/gcp-service-account`: expectedServiceAccount,
 	}
 	for _, tc := range testCases {
 		helmValues[tc.helmKey] = tc.value


### PR DESCRIPTION
This moves worker configuration under `pachd`  in the values file to make it more clear of the relationship between the two.