### PR TITLE
Few miscellaneous changes

### DIFF
--- a/src/internal/storage/track/gc.go
+++ b/src/internal/storage/track/gc.go
@@ -49,11 +49,7 @@ func (gc *GarbageCollector) RunForever(ctx context.Context) error {
 	ticker := time.NewTicker(gc.period)
 	defer ticker.Stop()
 	for {
-		if err := func() error {
-			ctx, cf := context.WithTimeout(ctx, gc.period/2)
-			defer cf()
-			return gc.RunUntilEmpty(ctx)
-		}(); err != nil {
+		if err := gc.RunUntilEmpty(ctx); err != nil {
 			logrus.Errorf("gc: %v", err)
 		}
 		select {

--- a/src/server/worker/datum/datum.go
+++ b/src/server/worker/datum/datum.go
@@ -405,36 +405,9 @@ func (d *Datum) handleSymlinks(mf client.ModifyFile, storageRoot string) error {
 		if fi.Mode()&os.ModeNamedPipe != 0 {
 			return nil
 		}
+		// Upload the local files if they are not from PFS.
 		if !strings.HasPrefix(file, d.PFSStorageRoot()) {
-			cb := func(dstPath, file string) (retErr error) {
-				f, err := os.Open(file)
-				if err != nil {
-					return err
-				}
-				defer func() {
-					if err := f.Close(); retErr == nil {
-						retErr = err
-					}
-				}()
-				return mf.PutFile(dstPath, f, client.WithDatumPutFile(d.ID))
-			}
-			if fi.IsDir() {
-				dir := file
-				return filepath.Walk(dir, func(file string, fi os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if fi.IsDir() {
-						return nil
-					}
-					dstSubpath, err := filepath.Rel(dir, file)
-					if err != nil {
-						return err
-					}
-					return cb(path.Join(dstPath, dstSubpath), file)
-				})
-			}
-			return cb(dstPath, file)
+			return d.uploadSymlink(mf, dstPath, file, fi)
 		}
 		relPath, err := filepath.Rel(d.PFSStorageRoot(), file)
 		if err != nil {
@@ -447,10 +420,46 @@ func (d *Datum) handleSymlinks(mf client.ModifyFile, storageRoot string) error {
 				input = i
 			}
 		}
+		// Upload the local files if they are not using the empty files feature.
+		if !input.EmptyFiles {
+			return d.uploadSymlink(mf, dstPath, file, fi)
+		}
 		srcFile := proto.Clone(input.FileInfo.File).(*pfs.File)
 		srcFile.Path = path.Join(pathSplit[1:]...)
 		return mf.CopyFile(dstPath, srcFile, client.WithDatumCopyFile(d.ID))
 	})
+}
+
+func (d *Datum) uploadSymlink(mf client.ModifyFile, dstPath, file string, fi os.FileInfo) error {
+	cb := func(dstPath, file string) (retErr error) {
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := f.Close(); retErr == nil {
+				retErr = err
+			}
+		}()
+		return mf.PutFile(dstPath, f, client.WithDatumPutFile(d.ID))
+	}
+	if fi.IsDir() {
+		dir := file
+		return filepath.Walk(dir, func(file string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if fi.IsDir() {
+				return nil
+			}
+			dstSubpath, err := filepath.Rel(dir, file)
+			if err != nil {
+				return err
+			}
+			return cb(path.Join(dstPath, dstSubpath), file)
+		})
+	}
+	return cb(dstPath, file)
 }
 
 // TODO: I think these types would be unecessary if the dependencies were shuffled around a bit.


### PR DESCRIPTION
This PR contains a few miscellaneous changes:
- Remove the deadline for a gc run. It doesn't make sense to have a deadline, particularly a short one (5s), for a gc run that needs to run to completion.
- Call delete all before running the PPS load test in CI.
- Change symlink upload to only copy files from PFS when the empty file feature is used (this should be enabled for large files and disabled for small files). This provides an easy way to transition to the more performant small file symlink upload. It is more performant to upload small files from the local filesystem in a batch than a large number of small PFS copy file requests.