### PR TITLE
Slight datum ID change

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"io"
 	"time"
 
@@ -83,17 +81,6 @@ func NewJob(pipelineName string, jobID string) *pps.Job {
 // NewJobSet creates a pps.JobSet.
 func NewJobSet(id string) *pps.JobSet {
 	return &pps.JobSet{ID: id}
-}
-
-// DatumTagPrefix hashes a pipeline salt to a string of a fixed size for use as
-// the prefix for datum output trees. This prefix allows us to do garbage
-// collection correctly.
-func DatumTagPrefix(salt string) string {
-	// We need to hash the salt because UUIDs are not necessarily
-	// random in every bit.
-	h := sha256.New()
-	h.Write([]byte(salt))
-	return hex.EncodeToString(h.Sum(nil))[:4]
 }
 
 // NewPFSInput returns a new PFS input. It only includes required options.

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -5496,6 +5496,38 @@ func TestUnionInput(t *testing.T) {
 			require.Equal(t, 8, len(fileInfos))
 		}
 	})
+
+	t.Run("union alias", func(t *testing.T) {
+		pipeline := tu.UniqueString("pipeline")
+		require.NoError(t, c.CreatePipeline(
+			pipeline,
+			"",
+			[]string{"bash"},
+			[]string{
+				"cp /pfs/in/* '/pfs/out/$RANDOM'",
+			},
+			&pps.ParallelismSpec{
+				Constant: 1,
+			},
+			client.NewUnionInput(
+				client.NewPFSInputOpts("in", repos[0], "", "/*", "", "", false, false, nil),
+				client.NewPFSInputOpts("in", repos[1], "", "/*", "", "", false, false, nil),
+				client.NewPFSInputOpts("in", repos[2], "", "/*", "", "", false, false, nil),
+				client.NewPFSInputOpts("in", repos[3], "", "/*", "", "", false, false, nil),
+			),
+			"",
+			false,
+		))
+
+		commitInfo, err := c.WaitCommit(pipeline, "master", "")
+		require.NoError(t, err)
+		fileInfos, err := c.ListFileAll(commitInfo.Commit, "")
+		require.NoError(t, err)
+		require.Equal(t, 8, len(fileInfos))
+		dis, err := c.ListDatumAll(pipeline, commitInfo.Commit.ID)
+		require.NoError(t, err)
+		require.Equal(t, 8, len(dis))
+	})
 }
 
 func TestPipelineWithStats(t *testing.T) {

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -37,12 +37,11 @@ const (
 )
 
 type hasher struct {
-	name string
 	salt string
 }
 
 func (h *hasher) Hash(inputs []*common.Input) string {
-	return common.HashDatum(h.name, h.salt, inputs)
+	return common.HashDatum(h.salt, inputs)
 }
 
 type registry struct {
@@ -116,7 +115,6 @@ func (reg *registry) startJob(jobInfo *pps.JobInfo) (retErr error) {
 		logger: reg.logger.WithJob(jobInfo.Job.ID),
 		ji:     jobInfo,
 		hasher: &hasher{
-			name: pi.Pipeline.Name,
 			salt: pi.Details.Salt,
 		},
 		noSkip: pi.Details.ReprocessSpec == client.ReprocessSpecEveryJob || pi.Details.S3Out,


### PR DESCRIPTION
This PR changes the datum ID computation slightly to account for uses cases that involve performing a union of inputs with the same input name and file paths. The datum ID computation is now based on input name + repo name + branch name + file path. In a followup PR, we will need to prevent the creation of pipelines with multiple inputs that have the same input, repo, and branch name. Also, this PR changes the datum hash computation to include the datum ID and just the file hashes and pipeline salt. The reason why the datum ID is included is to leave the door open to global skipping (across arbitrary jobs for a pipeline) in the future, so we could just perform the lookup using the datum hash.