### PR TITLE
Add IDLE_TRANSACTION_TIMEOUT to pg_bouncer

### DIFF
--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           value: "1000"
         - name: POOL_MODE
           value: "transaction"
+        - name: IDLE_TRANSACTION_TIMEOUT
+          value: "300"
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
When looking into one of the hanging clusters, killing the pachd pod did not remove the many active transactions waiting on `ClientRead` (the client sending data to postgres).
The long lived (~1 day) hanging queries were `BEGIN ISOLATION SERIALIZABLE READ WRITE`.  Which is how a transaction is setup almost anywhere in our code.  With the exception of a few places that use weaker isolation (auth and migrations).

They did clear once I killed pg_bouncer.  So pg_bouncer is holding transactions open.  It could be our code, it could be the driver, or it could be a problem with how we have pg_bouncer configured.
Before the reset I was unable to do small queries from the filesets table.  It was definitely impacting normal use of the database.
