### PR TITLE
Change when job started time is set

### DIFF
--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -342,7 +342,7 @@ func UpdateJobState(pipelines col.ReadWriteCollection, jobs col.ReadWriteCollect
 
 	// Update job info
 	var err error
-	if state == pps.JobState_JOB_STARTING {
+	if state == pps.JobState_JOB_RUNNING {
 		jobInfo.Started, err = types.TimestampProto(time.Now())
 		if err != nil {
 			return err

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -125,13 +125,13 @@ func (reg *registry) startJob(jobInfo *pps.JobInfo) (retErr error) {
 			return err
 		}
 	}
-	if err := pj.load(); err != nil {
-		return err
-	}
 	// Inputs must be ready before we can construct a datum iterator.
 	if err := pj.logger.LogStep("waiting for job inputs", func() error {
 		return reg.processJobStarting(pj)
 	}); err != nil {
+		return err
+	}
+	if err := pj.load(); err != nil {
 		return err
 	}
 	// TODO: This could probably be scoped to a callback.


### PR DESCRIPTION
This PR changes the job started time to be set when it transitions to the running state. Currently, we set it when it transitions to the starting state, which will cause the duration to include the time spent waiting on upstream jobs.