### PR TITLE
Swap pipeline name and job id columns in job info pretty printing

### DIFF
--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -25,7 +25,7 @@ const (
 	// PipelineHeader is the header for pipelines.
 	PipelineHeader = "NAME\tVERSION\tINPUT\tCREATED\tSTATE / LAST JOB\tDESCRIPTION\t\n"
 	// JobHeader is the header for jobs
-	JobHeader = "ID\tPIPELINE\tSTARTED\tDURATION\tRESTART\tPROGRESS\tDL\tUL\tSTATE\t\n"
+	JobHeader = "PIPELINE\tID\tSTARTED\tDURATION\tRESTART\tPROGRESS\tDL\tUL\tSTATE\t\n"
 	// JobSetHeader is the header for jobsets
 	JobSetHeader = "ID\tSUBJOBS\tPROGRESS\tCREATED\tMODIFIED\n"
 	// DatumHeader is the header for datums
@@ -45,8 +45,8 @@ func safeTrim(s string, l int) string {
 
 // PrintJobInfo pretty-prints job info.
 func PrintJobInfo(w io.Writer, jobInfo *ppsclient.JobInfo, fullTimestamps bool) {
-	fmt.Fprintf(w, "%s\t", jobInfo.Job.ID)
 	fmt.Fprintf(w, "%s\t", jobInfo.Job.Pipeline.Name)
+	fmt.Fprintf(w, "%s\t", jobInfo.Job.ID)
 	if jobInfo.Started != nil {
 		if fullTimestamps {
 			fmt.Fprintf(w, "%s\t", jobInfo.Started.String())


### PR DESCRIPTION
This PR swaps the pipeline name and job id columns when pretty printing job info. This change was made because it is more consistent with the way we display commits and how you need to set up the parameters for requests that operate on a pipeline & job id.