### PR TITLE
Fix job start time being reset during update

### DIFF
--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -310,7 +310,7 @@ func UpdateJobState(pipelines col.PostgresReadWriteCollection, jobs col.ReadWrit
 
 	// Update job info
 	var err error
-	if state == pps.JobState_JOB_RUNNING {
+	if jobInfo.State == pps.JobState_JOB_STARTING && state == pps.JobState_JOB_RUNNING {
 		jobInfo.Started, err = types.TimestampProto(time.Now())
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes an issue where the job start time was reset by an update while the job is running. This happens because each update "transitions" the job state to running, which is when we set the started time. The fix is to check that we are transitioning from the starting state to the running state before setting the start time.