### PR TITLE
Alias commits need total filesets

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -2026,6 +2026,13 @@ func (d *driver) makeEmptyCommit(txnCtx *txncontext.TransactionContext, branchIn
 	if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(commit, commitInfo); err != nil {
 		return nil, err
 	}
+	total, err := d.storage.ComposeTx(txnCtx.SqlTx, nil, defaultTTL)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commit, *total); err != nil {
+		return nil, err
+	}
 	return commit, nil
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -650,7 +650,7 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 				commitInfo.Finished = txnCtx.Timestamp
 				commitInfo.Details = parentCommitInfo.Details
 				// if the parent is already finished we can just use its total fileset.
-				total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.ParentCommit)
+				total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.Commit)
 				if err != nil {
 					return nil, err
 				}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -2022,15 +2022,15 @@ func (d *driver) makeEmptyCommit(txnCtx *txncontext.TransactionContext, branchIn
 		commitInfo.Finishing = txnCtx.Timestamp
 		commitInfo.Finished = txnCtx.Timestamp
 		commitInfo.Details = &pfs.CommitInfo_Details{}
+		total, err := d.storage.ComposeTx(txnCtx.SqlTx, nil, defaultTTL)
+		if err != nil {
+			return nil, err
+		}
+		if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commit, *total); err != nil {
+			return nil, err
+		}
 	}
 	if err := d.commits.ReadWrite(txnCtx.SqlTx).Create(commit, commitInfo); err != nil {
-		return nil, err
-	}
-	total, err := d.storage.ComposeTx(txnCtx.SqlTx, nil, defaultTTL)
-	if err != nil {
-		return nil, err
-	}
-	if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commit, *total); err != nil {
 		return nil, err
 	}
 	return commit, nil

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -649,6 +649,14 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 			if parentCommitInfo.Finished != nil {
 				commitInfo.Finished = txnCtx.Timestamp
 				commitInfo.Details = parentCommitInfo.Details
+				// if the parent is already finished we can just use its total fileset.
+				total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.ParentCommit)
+				if err != nil {
+					return nil, err
+				}
+				if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commitInfo.Commit, *total); err != nil {
+					return nil, err
+				}
 			}
 			commitInfo.Error = parentCommitInfo.Error
 		}

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -434,9 +434,6 @@ func (d *driver) getFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.I
 	if err != nil {
 		return nil, err
 	}
-	if commitInfo.Origin.Kind == pfs.OriginKind_ALIAS {
-		return d.getFileSet(ctx, commitInfo.ParentCommit)
-	}
 	// Get the total file set if the commit has been finished.
 	if commitInfo.Finished != nil {
 		id, err := d.commitStore.GetTotalFileSet(ctx, commitInfo.Commit)


### PR DESCRIPTION
Prior to these changes, alias commits did not have any filesets associated with them.  When getting the fileset for an alias commit, the commit was skipped and the content was instead retrieved from the parent.  Now only open commits require reading the parent.  The read path for alias commits is the same as regular commits.