### PR TITLE
Remove special case logic for pachctl commands in workers.

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -645,31 +645,6 @@ func NewInCluster(options ...Option) (*APIClient, error) {
 	return NewFromURI(fmt.Sprintf("%s:%s", host, port), options...)
 }
 
-// NewInWorker constructs a new APIClient intended to be used from a worker
-// to talk to the sidecar pachd container
-func NewInWorker(options ...Option) (*APIClient, error) {
-	cfg, err := config.Read(false, true)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not read config")
-	}
-	_, context, err := cfg.ActiveContext(true)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get active context")
-	}
-
-	if localPort, ok := os.LookupEnv("PEER_PORT"); ok {
-		client, err := NewFromURI(fmt.Sprintf("127.0.0.1:%s", localPort), options...)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not create client")
-		}
-		if context.SessionToken != "" {
-			client.authenticationToken = context.SessionToken
-		}
-		return client, nil
-	}
-	return nil, errors.New("PEER_PORT not set")
-}
-
 // Close the connection to gRPC
 func (c *APIClient) Close() error {
 	if err := c.clientConn.Close(); err != nil {

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	prompt "github.com/c-bata/go-prompt"
@@ -281,7 +280,7 @@ $ {{alias}} test@fork -p XXX`,
 			if err != nil {
 				return err
 			}
-			c, err := newClient("user")
+			c, err := client.NewOnUserMachine("user")
 			if err != nil {
 				return err
 			}
@@ -332,7 +331,7 @@ $ {{alias}} test@fork -p XXX`,
 			if err != nil {
 				return err
 			}
-			c, err := newClient("user")
+			c, err := client.NewOnUserMachine("user")
 			if err != nil {
 				return err
 			}
@@ -1012,7 +1011,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 			if compress {
 				opts = append(opts, client.WithGZIPCompression())
 			}
-			c, err := newClient("user", opts...)
+			c, err := client.NewOnUserMachine("user", opts...)
 			if err != nil {
 				return err
 			}
@@ -1185,7 +1184,7 @@ $ {{alias}} 'foo@master:/test\[\].txt'`,
 			if err != nil {
 				return err
 			}
-			c, err := newClient("user")
+			c, err := client.NewOnUserMachine("user")
 			if err != nil {
 				return err
 			}
@@ -1728,19 +1727,6 @@ func forEachDiffFile(newFiles, oldFiles []*pfs.FileInfo, f func(newFile, oldFile
 			return err
 		}
 	}
-}
-
-func newClient(name string, options ...client.Option) (*client.APIClient, error) {
-	if inWorkerStr, ok := os.LookupEnv("PACH_IN_WORKER"); ok {
-		inWorker, err := strconv.ParseBool(inWorkerStr)
-		if err != nil {
-			return nil, errors.Wrap(err, "couldn't parse PACH_IN_WORKER")
-		}
-		if inWorker {
-			return client.NewInWorker(options...)
-		}
-	}
-	return client.NewOnUserMachine(name, options...)
 }
 
 func parseOriginKind(input string) (pfs.OriginKind, error) {


### PR DESCRIPTION
When we switched spouts to use pachctl, we needed to add handling to
ensure that the client knew to connect via localhost. This was
accomplished through an environment variable checked for some commands.
Our solution for allowing auth, however, also created an entire
pachyderm config via a secret.

This inadvertently made it difficult to override how a pipeline
connected to pachd, since the alternate path did not make use of the
usual environment variables. By making the special in-worker config
available to all workers and removing the special logic, the default
logic will connect to the sidecar as desired, without any surprising
behavior.

Fix #6802 in 2.1.x