### PR TITLE
Support using an external database in helm chart

### DIFF
--- a/etc/helm/pachyderm/Chart.yaml
+++ b/etc/helm/pachyderm/Chart.yaml
@@ -21,14 +21,14 @@ type: application
 # each time you make changes to the chart and its templates, including
 # the app version.  Versions are expected to follow Semantic
 # Versioning (https://semver.org/)
-version: 2.0.0-beta.8
+version: 2.0.1
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to
 # the application. Versions are not expected to follow Semantic
 # Versioning. They should reflect the version the application is
 # using.
-appVersion: 2.0.0-beta.8
+appVersion: 2.0.0-beta-8
 
 kubeVersion: ">= 1.16.0-0"
 

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -41,13 +41,13 @@ spec:
         - /pachd
         env:
         - name: POSTGRES_HOST
-          value: {{ required "postgresql host required" .Values.global.postgresql.postgresqlHost | quote }}
+          value: {{ required "postgresql host required" .Values.externalDatabase.host | default .Values.global.postgresql.postgresqlHost | quote }}
         - name: POSTGRES_PORT
-          value:  {{ required "postgresql port required" .Values.global.postgresql.postgresqlPort | quote }}
+          value:  {{ required "postgresql port required" .Values.externalDatabase.port | default .Values.global.postgresql.postgresqlPort | quote }}
         - name: POSTGRES_USER
-          value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
+          value: {{ required "postgresql username required" .Values.externalDatabase.user | default .Values.global.postgresql.postgresqlUsername | quote }}
         - name: POSTGRES_DATABASE
-          value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
+          value: {{ required "postgresql database name required" .Values.externalDatabase.database | default .Values.global.postgresql.postgresqlDatabase | quote }}
         {{- if .Values.global.postgresql.ssl }}
         - name: POSTGRES_SSL
           value: {{ .Values.global.postgresql.ssl | quote }}
@@ -55,12 +55,15 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres # Must match secret setup by postgres subchart or postgres-secret.yaml
-              key: postgresql-password
+              # Must match secret setup by postgres subchart or postgres-secret.yaml
+              name: {{ .Values.externalDatabase.existingSecretName | default "postgres" }} 
+              key: {{ .Values.externalDatabase.existingSecretKey | default "postgres-password" }}
+        {{- if .Values.pgbouncer.enabled }}
         - name: PG_BOUNCER_HOST
           value: pg-bouncer # Must match pgbouncer service name
         - name: PG_BOUNCER_PORT
           value: "5432" # Must match pbouncer service port
+        {{- end }}
         - name: LOKI_LOGGING
           value: {{ .Values.pachd.lokiLogging | quote}}
         - name: PACH_ROOT

--- a/etc/helm/pachyderm/templates/pachd/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/postgres-secret.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.pachd.enabled  (not .Values.postgresql.enabled) -}}
+{{- if and .Values.pachd.enabled  (not .Values.postgresql.enabled) (not .Values.externalDatabase.enabled) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pgbouncer.enabled }}
 {{- /*
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
@@ -55,3 +56,4 @@ spec:
           requests:
             cpu: 250m
             memory: 256M
+{{- end }}

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -30,6 +30,18 @@ global:
   #   - regcred
   imagePullSecrets: []
 
+# Use an external database instead of the containerized one.
+# NOTE: You should disable pg_bouncer when this is enabled!
+externalDatabase:
+  enabled: false
+  host: ""
+  port: ""
+  database: ""
+  # Secret name used to supply the password to the pachd deployment
+  existingSecretName: ""
+  # Key of the above secret used to supply the password to the pachd deployment
+  existingSecretKey: ""
+
 console:
   # enabled controls whether the console manifests are created or not.
   enabled: false
@@ -364,6 +376,7 @@ pachd:
 
 
 pgbouncer:
+  enabled: true
   service:
     type: ClusterIP
   resources: {}


### PR DESCRIPTION
This PR adds support for using an external database. 

- Adds value structure for `externalDatabase` to configure the connection parameters
- Adds a flag to disable `pgbouncer` because it should probably be disabled in the case of using an external database

Templated it locally using (did not spin it up in a local cluster):
```
helm template . --set deployTarget=AMAZON --set externalDatabase.enabled=true --set externalDatabase.host="some.host" --set externalDatabase.port=5432 --set externalDatabase.database="database" --set externalDatabase.user="user" --set externalDatabase.existingSecretName="existing" --set externalDatabase.existingSecretKey="existing-key" --set pgbouncer.enabled=false --set postgresql.enabled=false
```