### PR TITLE
Light config/cmd refactor

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serde"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -110,7 +110,7 @@ func Read(ignoreCache, readOnly bool) (*Config, error) {
 		// Read json file
 		p := configPath()
 		if raw, err := ioutil.ReadFile(p); err == nil {
-			err = json.Unmarshal(raw, &cachedConfig)
+			err = serde.DecodeYAML(raw, &cachedConfig)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not parse config json at %q", p)
 			}
@@ -206,7 +206,7 @@ func (c *Config) Write() error {
 		panic("config V1 included (this is a bug)")
 	}
 
-	rawConfig, err := json.MarshalIndent(c, "", "  ")
+	rawConfig, err := serde.EncodeJSON(c)
 	if err != nil {
 		return err
 	}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -180,8 +180,8 @@ func Read(ignoreCache, readOnly bool) (*Config, error) {
 	}
 
 	cloned := proto.Clone(cachedConfig).(*Config)
-	// in the case of an empty map, `proto.Clone` incorrectly clones
-	// `Contexts` as nil. This fixes the issue.
+	// In the case of an empty map, `proto.Clone` clones `Contexts` as nil. This
+	// fixes the issue.
 	if cloned.V2.Contexts == nil {
 		cloned.V2.Contexts = map[string]*Context{}
 	}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -206,13 +206,18 @@ func (c *Config) Write() error {
 		panic("config V1 included (this is a bug)")
 	}
 
+	// Write() overwrites both the on-disk config and the cachedConfig; configMu
+	// ensures that Write() calls are serialized so that these two representations
+	// stay in sync.
+	configMu.Lock()
+	defer configMu.Unlock()
+
 	rawConfig, err := serde.EncodeJSON(c)
 	if err != nil {
 		return err
 	}
 
 	p := configPath()
-
 	// Because we're writing the config back to disk, we'll also need to make sure
 	// that the directory we're writing the config into exists. The approach we
 	// use for doing this depends on whether PACH_CONFIG is being used (if it is,


### PR DESCRIPTION
This PR:
- moves the src/internal/config package over to serde (instead of encoding/json) for consistency with other YAML serialization/deserialization=
- makes a few readability-motivated changes to src/internal/config/config.go