### PR TITLE
Make OpenTrace setup easier

### DIFF
--- a/etc/helm/examples/local-dev-values.yaml
+++ b/etc/helm/examples/local-dev-values.yaml
@@ -38,3 +38,9 @@ etcd:
 postgresql:
   service:
     type: NodePort
+
+jaeger:
+  enabled: true
+  query:
+    service:
+      type: ClusterIP

--- a/etc/helm/pachyderm/templates/jaeger/deployment.yaml
+++ b/etc/helm/pachyderm/templates/jaeger/deployment.yaml
@@ -1,0 +1,57 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if .Values.jaeger.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  labels:
+    app: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one
+    suite: pachyderm
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: all-in-one
+  template:
+    metadata:
+      labels:
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: all-in-one
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "16686"
+    spec:
+        containers:
+        -   env:
+            - name: COLLECTOR_ZIPKIN_HTTP_PORT
+              value: "9411"
+            image: jaegertracing/all-in-one:1.15.1
+            name: jaeger
+            ports:
+              - containerPort: 16686
+                protocol: TCP
+              - containerPort: 9411
+                protocol: TCP
+              # These ports are referenced by the jaeger-collector service but
+              # aren't in the original manifest
+              - containerPort: 14267
+                protocol: TCP
+              - containerPort: 14268
+                protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: "/"
+                port: 14269
+              initialDelaySeconds: 5
+{{- end }}

--- a/etc/helm/pachyderm/templates/jaeger/service.yaml
+++ b/etc/helm/pachyderm/templates/jaeger/service.yaml
@@ -1,0 +1,57 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if .Values.jaeger.enabled }}
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: jaeger-query
+    labels:
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: query
+      suite: pachyderm
+    namespace: {{ .Release.Namespace }}
+  spec:
+    ports:
+      - name: query-http
+        port: 80
+        protocol: TCP
+        targetPort: 16686
+    selector:
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: all-in-one
+    type: {{ .Values.jaeger.query.service.type }}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: jaeger-collector
+    labels:
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: collector
+      suite: pachyderm
+    namespace: {{ .Release.Namespace }}
+  spec:
+    ports:
+    - name: jaeger-collector-tchannel
+      port: 14267
+      protocol: TCP
+      targetPort: 14267
+    - name: jaeger-collector-http
+      port: 14268
+      protocol: TCP
+      targetPort: 14268
+    - name: jaeger-collector-zipkin
+      port: 9411
+      protocol: TCP
+      targetPort: 9411
+    selector:
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: all-in-one
+    type: ClusterIP
+{{- end }}

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           value: "/pach"
         - name: ETCD_PREFIX
           #value:
+        {{- if .Values.jaeger.enabled }}
+        - name: JAEGER_ENDPOINT
+          value: jaeger-collector:14268
+        {{- end }}
         - name: STORAGE_BACKEND
           value: {{ include "pachyderm.storageBackend" . | quote }}
           {{- if eq (include "pachyderm.storageBackend" . ) "LOCAL" }}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -309,6 +309,27 @@
                 }
             }
         },
+        "jaeger": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "query": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "pachd": {
             "type": "object",
             "properties": {

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -157,6 +157,12 @@ ingress:
       crt: ""
       key: ""
 
+jaeger:
+  enabled: false
+  query:
+    service: 
+      type: ClusterIP
+
 pachd:
   enabled: true
   affinity: {}

--- a/src/internal/cmdutil/util.go
+++ b/src/internal/cmdutil/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/serde"
@@ -51,6 +52,19 @@ func PagerFlags(noPager *bool) *pflag.FlagSet {
 	pagerFlags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	pagerFlags.BoolVar(noPager, "no-pager", false, "Don't pipe output into a pager (i.e. less).")
 	return pagerFlags
+}
+
+func TraceFlags(opentrace *bool) *pflag.FlagSet {
+	traceFlags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	traceFlags.BoolVarP(opentrace, "trace", "t", false, "To tag the request as traced to the backend")
+	return traceFlags
+}
+
+func SetupTrace(opentrace bool) {
+	os.Setenv("PACH_TRACE", strconv.FormatBool(opentrace))
+	if _, ok := os.LookupEnv("PACH_TRACE_DURATION"); !ok {
+		os.Setenv("PACH_TRACE_DURATION", "5m")
+	}
 }
 
 func readLine(r io.Reader) (string, error) {

--- a/src/internal/testutil/pach_client.go
+++ b/src/internal/testutil/pach_client.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
+	"github.com/pachyderm/pachyderm/v2/src/internal/tracing/extended"
 )
 
 var (
@@ -18,6 +20,18 @@ var (
 // running both inside and outside the cluster. Note that multiple calls to
 // GetPachClient will return the same instance.
 func GetPachClient(t testing.TB) *client.APIClient {
+	// to use opentracing within a test, PACH_TRACE and JAEGER_ENDPOINT must be set
+	_, useOpenTrace := os.LookupEnv(tracing.ShortTraceEnvVar)
+	if useOpenTrace {
+		tracing.InstallJaegerTracerFromEnv()
+		if _, ok := os.LookupEnv(extended.TraceDurationEnvVar); !ok {
+			err := os.Setenv(extended.TraceDurationEnvVar, "5m")
+			if err != nil {
+				t.Fatalf("error getting Pachyderm client: %s", err.Error())
+			}
+		}
+	}
+
 	clientOnce.Do(func() {
 		if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
 			pachClient, pachErr = client.NewInCluster()
@@ -27,6 +41,14 @@ func GetPachClient(t testing.TB) *client.APIClient {
 	})
 	if pachErr != nil {
 		t.Fatalf("error getting Pachyderm client: %s", pachErr.Error())
+	}
+
+	if useOpenTrace {
+		ctx, err := extended.EmbedAnyDuration(pachClient.Ctx())
+		if err != nil {
+			t.Fatalf("Could not embed duration in Pachyderm client: %s", err.Error())
+		}
+		pachClient = pachClient.WithCtx(ctx)
 	}
 	return pachClient
 }

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -37,6 +37,8 @@ func main() {
 func do(config interface{}) error {
 	// must run InstallJaegerTracer before InitWithKube/pach client initialization
 	tracing.InstallJaegerTracerFromEnv()
+	defer tracing.CloseAndReportTraces()
+
 	env := serviceenv.InitServiceEnv(serviceenv.NewConfiguration(config))
 
 	// Enable cloud profilers if the configuration allows.

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -126,6 +126,9 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 	}, {
 		Name:  client.PPSPipelineNameEnv,
 		Value: pipelineInfo.Pipeline.Name,
+	}, {
+		Name:  "JAEGER_ENDPOINT",
+		Value: os.Getenv("JAEGER_ENDPOINT"),
 	},
 		// These are set explicitly below to prevent kubernetes from setting them to the service host and port.
 		{

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
@@ -116,6 +117,10 @@ func (td *testDriver) UpdateJobState(job *pps.Job, state pps.JobState, reason st
 }
 func (td *testDriver) NewSQLTx(cb func(*sqlx.Tx) error) error {
 	return td.inner.NewSQLTx(cb)
+}
+
+func (td *testDriver) AddSpanToAnyPipelineTrace(operation string, kvs ...interface{}) (opentracing.Span, context.Context) {
+	return td.inner.AddSpanToAnyPipelineTrace(operation, kvs...)
 }
 
 // newTestEnv provides a test env with etcd and pachd instances and connected

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"github.com/pachyderm/pachyderm/v2/src/internal/work"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/driver"
@@ -73,6 +74,9 @@ func NewWorker(
 	}
 
 	worker.APIServer = server.NewAPIServer(driver, worker.status, env.Config().PodName)
+
+	span, _ := driver.AddSpanToAnyPipelineTrace("/worker.Master/Startup")
+	tracing.FinishAnySpan(span)
 
 	go worker.master(env)
 	go worker.worker()


### PR DESCRIPTION
Each of the first 4 commits handle a different set of suggested changes. They are:

1. Setup Tracing in Test Client
  - setting PACH_TRACE and JAEGER_ENDPOINT should enable Extended Traces across all requests to pachd within a test
2. Adding Jaeger to helm
  - I pulled the k8s resources from the previously recommended URL into helm.
3. Instrument Workers with OpenTrace
  - I found it useful to have the workers create spans against their Pipeline's Trace. I added a utility to their driver
4. Adding a `--trace` argument to pachctl create/update pipeline
  - This way the user only needs to have JAEGER_ENDPOINT var set, and can ergonomically set requests to have traces (includes extended traces)