### PR TITLE
Change to Bitnami rootless pg-bouncer image

### DIFF
--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -46,8 +46,6 @@ spec:
           value: "300"
         - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
           value: "extra_float_digits"
-        - name: PGBOUNCER_UNIX_SOCKET_DIR
-          value: " "
         - name: PGBOUNCER_EXTRA_ARGS
           value: "--with-udns"
         PGBOUNCER_EXTRA_ARGS

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -30,10 +30,14 @@ spec:
       - env:
         - name: POSTGRESQL_USERNAME
           value: {{ .Values.global.postgresql.postgresqlUsername }}
+        - name: PGBOUNCER_SET_USER
+          value: "True"
         - name: POSTGRESQL_HOST
           value: {{ .Values.global.postgresql.postgresqlHost }}      
         - name: PGBOUNCER_PORT
           value: "5432"
+        - name: PGBOUNCER_DATABASE
+          value: "*"
         - name: PGBOUNCER_MAX_CLIENT_CONN
           value: "1000"
         - name: PGBOUNCER_POOL_MODE
@@ -47,7 +51,7 @@ spec:
             secretKeyRef:
               name: postgres # Must match secret setup by postgres subchart, or postgres-secret.yaml 
               key: postgresql-password
-        image: bitnami/pgbouncer:1.16.0
+        image: vmtyler/pgbouncer:v1.1
         imagePullPolicy: IfNotPresent
         name: pg-bouncer
         ports:

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -28,24 +28,26 @@ spec:
 {{- include "pachyderm.imagePullSecrets" . | indent 6 }}
       containers:
       - env:
-        - name: DB_USER
+        - name: POSTGRESQL_USERNAME
           value: {{ .Values.global.postgresql.postgresqlUsername }}
-        - name: DB_HOST
-          value: {{ .Values.global.postgresql.postgresqlHost }}
-        - name: AUTH_TYPE
-          value: md5
-        - name: MAX_CLIENT_CONN
+        - name: POSTGRESQL_HOST
+          value: {{ .Values.global.postgresql.postgresqlHost }}      
+        - name: PGBOUNCER_PORT
+          value: "5432"
+        - name: PGBOUNCER_MAX_CLIENT_CONN
           value: "1000"
-        - name: POOL_MODE
+        - name: PGBOUNCER_POOL_MODE
           value: "transaction"
-        - name: IDLE_TRANSACTION_TIMEOUT
+        - name: PGBOUNCER_IDLE_TRANSACTION_TIMEOUT
           value: "300"
-        - name: DB_PASSWORD
+        - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
+          value: "extra_float_digits"
+        - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: postgres # Must match secret setup by postgres subchart, or postgres-secret.yaml 
               key: postgresql-password
-        image: edoburu/pgbouncer:1.15.0
+        image: bitnami/pgbouncer:1.16.0
         imagePullPolicy: IfNotPresent
         name: pg-bouncer
         ports:

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -46,6 +46,11 @@ spec:
           value: "300"
         - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
           value: "extra_float_digits"
+        - name: PGBOUNCER_UNIX_SOCKET_DIR
+          value: " "
+        - name: PGBOUNCER_EXTRA_ARGS
+          value: "--with-udns"
+        PGBOUNCER_EXTRA_ARGS
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -46,15 +46,14 @@ spec:
           value: "300"
         - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
           value: "extra_float_digits"
-        - name: PGBOUNCER_EXTRA_ARGS
-          value: "--with-udns"
-        PGBOUNCER_EXTRA_ARGS
+        - name: PGBOUNCER_UNIX_SOCKET_DIR
+          value: " "
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: postgres # Must match secret setup by postgres subchart, or postgres-secret.yaml 
               key: postgresql-password
-        image: vmtyler/pgbouncer:v1.1
+        image: bitnami/pgbouncer:1.16.0
         imagePullPolicy: IfNotPresent
         name: pg-bouncer
         ports:

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -33,7 +33,11 @@ spec:
         - name: PGBOUNCER_SET_USER
           value: "True"
         - name: POSTGRESQL_HOST
-          value: {{ .Values.global.postgresql.postgresqlHost }}      
+         {{- if .Values.postgresql.enabled }}
+          value: {{ .Values.global.postgresql.postgresqlHost }}.{{ .Release.Namespace }}.svc.cluster.local  
+         {{ else }}
+          value: {{ .Values.global.postgresql.postgresqlHost }}
+         {{- end }}
         - name: PGBOUNCER_PORT
           value: "5432"
         - name: PGBOUNCER_DATABASE


### PR DESCRIPTION
Switches the pg-bouncer image over to Bitnami. Is dependant on [this PR](https://github.com/bitnami/bitnami-docker-pgbouncer/pull/15) to work.