### PR TITLE
Fix shellcheck in 'make lint'

### DIFF
--- a/etc/build/doc.sh
+++ b/etc/build/doc.sh
@@ -3,6 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck disable=SC1090
 source "${SCRIPT_DIR}/../govars.sh"
 
 version="$("${PACHCTL}" version --client-only)"

--- a/etc/build/make_release.sh
+++ b/etc/build/make_release.sh
@@ -2,18 +2,19 @@
 
 set -e
 
-INSTALLED_GOVER="`go version | cut -d ' ' -f 3`"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/../govars.sh"
+
+INSTALLED_GOVER="$(go version | cut -d ' ' -f 3)"
 EXPECTED_GOVER=go1.16.4
-if [ ${INSTALLED_GOVER} != "${EXPECTED_GOVER}" ]
+if [ "${INSTALLED_GOVER}" != "${EXPECTED_GOVER}" ]
 then
-    echo "Current go version "${INSTALLED_GOVER}
-    echo "Expected go version "${EXPECTED_GOVER}
+    echo "Current go version ${INSTALLED_GOVER}"
+    echo "Expected go version ${EXPECTED_GOVER}"
     echo "Install the expected version of go before doing a release!"
     exit 1
 fi
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${SCRIPT_DIR}/../govars.sh"
 
 make VERSION_ADDITIONAL="$VERSION_ADDITIONAL" install-clean
 version="$("${PACHCTL}" version --client-only)"

--- a/etc/build/reference_refresh.sh
+++ b/etc/build/reference_refresh.sh
@@ -3,6 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck disable=SC1090
 source "${SCRIPT_DIR}/../govars.sh"
 
 version="$("${PACHCTL}" version --client-only)"

--- a/etc/contributing/docker_clear.sh
+++ b/etc/contributing/docker_clear.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker kill $(docker container ls -q)
+docker kill "$(docker container ls -q)"

--- a/etc/contributing/start_postgres.sh
+++ b/etc/contributing/start_postgres.sh
@@ -12,13 +12,13 @@ then
     -p 30228:5432 \
     postgres:13.0-alpine)
 
-    postgres_ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $postgres_id)
+    postgres_ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "${postgres_id}")
 
     docker run -d \
     -e AUTH_TYPE=any \
     -e DB_USER="pachyderm" \
     -e DB_PASS="password" \
-    -e DB_HOST=$postgres_ip \
+    -e DB_HOST="${postgres_ip}" \
     -e DB_PORT=5432 \
     -e POOL_MODE=transaction \
     -p 30229:5432 \

--- a/etc/helm/reset.sh
+++ b/etc/helm/reset.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 helm delete pachyderm
 echo "Wait for pod teardown"

--- a/etc/testing/circle/build.sh
+++ b/etc/testing/circle/build.sh
@@ -2,9 +2,10 @@
 
 set -ex
 
+# shellcheck disable=SC1090
 source "$(dirname "$0")/env.sh"
 
-eval $(minikube docker-env)
+eval "$(minikube docker-env)"
 
 go version
 

--- a/etc/testing/circle/check_buckets.sh
+++ b/etc/testing/circle/check_buckets.sh
@@ -13,12 +13,12 @@ function child {
     target="^(- )?$1:"
     prefix=0
 
-    while read line; do
+    while read -r line; do
         if [[ $prefix -gt 0 ]]; then
             if [[ $line =~ ^[[:graph:]] ]]; then
                 exit 0
             fi
-            echo ${line:$prefix}
+            echo "${line:$prefix}"
         fi
 
         if [[ $line =~ $target ]]; then
@@ -31,10 +31,10 @@ function child {
     done
 }
 
-count=$(cat .circleci/config.yml | child jobs | child circleci | child environment | grep PPS_BUCKETS | cut -d \" -f 2)
+count=$(child jobs <.circleci/config.yml | child circleci | child environment | grep PPS_BUCKETS | cut -d \" -f 2)
 
 echo "should be $count buckets, checking for PPS$count"
 
-cat .circleci/config.yml | child workflows | child circleci | child jobs \
+child workflows <.circleci/config.yml | child circleci | child jobs \
     | child circleci | child matrix | child parameters | grep "PPS$count" || fail "PPS bucket number mismatch"
 

--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -2,6 +2,7 @@
 
 echo "=== TEST FAILED OR TIMED OUT, DUMPING DEBUG INFO ==="
 
+# shellcheck disable=SC1090
 source "$(dirname "$0")/env.sh"
 
 # TODO: Extend this to show kubectl describe output for failed pods, this will

--- a/etc/testing/circle/launch-loki.sh
+++ b/etc/testing/circle/launch-loki.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+# shellcheck disable=SC1090
 source "$(dirname "$0")/env.sh"
 
 # Deploy Loki but don't block until it's deployed - we'll check later

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -2,12 +2,13 @@
 
 set -ex
 
+# shellcheck disable=SC1090
 source "$(dirname "$0")/env.sh"
 
 # Normally `pachctl deploy local` adds a PodSecurityContext to run as root,
 # because we can't guarantee the hostpath will be writable by our normal UID (1000).
 # We want to run as UID 1000 in CI because that's more reflective of real life,
-# so we explicitly create the host path on the host machine and chmod it so we can write to it. 
+# so we explicitly create the host path on the host machine and chmod it so we can write to it.
 minikube ssh 'mkdir -p /tmp/pachyderm/pachd && chmod -R 777 /tmp/pachyderm'
 
 helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml

--- a/etc/testing/circle/run_hub_tests.sh
+++ b/etc/testing/circle/run_hub_tests.sh
@@ -2,9 +2,9 @@
 
 set -euxo pipefail
 
-mkdir -p $HOME/go/bin
+mkdir -p "${HOME}/go/bin"
 export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
-export GOPATH=$HOME/go
+export GOPATH="${HOME}/go"
 
 # Install go.
 sudo rm -rf /usr/local/go
@@ -12,7 +12,7 @@ curl -L https://golang.org/dl/go1.16.6.linux-amd64.tar.gz | sudo tar xzf - -C /u
 go version
 
 # install hubcli
-pushd $HOME/go/bin
+pushd "${HOME}/go/bin"
 rm -f hubcli
 wget https://github.com/pachyderm/hubcli/releases/download/0.0.2/hubcli
 chmod a+x hubcli
@@ -20,23 +20,35 @@ popd
 
 # Install goreleaser.
 GORELEASER_VERSION=0.169.0
-curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
-    | tar xzf - -C $HOME/go/bin goreleaser
+curl -L "https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz" \
+    | tar xzf - -C "${HOME}/go/bin" goreleaser
 
 # Build pachctl.
 make install
 pachctl version --client-only
 
 # Set version for docker builds.
-export VERSION=$(pachctl version --client-only)
+VERSION="$(pachctl version --client-only)"
+export VERSION
 
 # Build and push docker images.
 make docker-build
 make docker-push
 
 # Create a workspace running the image we just built.
-for i in {1..3}; do
-	hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op create-workspace-and-wait --orgid 2193 --loglevel trace --infofile workspace.json --version $VERSION --expiration 2h --description $CIRCLE_BUILD_URL --prefix "ci-" && break
+for _ in {1..3}; do
+  hubcli \
+    --endpoint https://hub.pachyderm.com/api/graphql \
+    --apikey "${HUB_API_KEY}" \
+    --op create-workspace-and-wait \
+    --orgid 2193 \
+    --loglevel trace \
+    --infofile workspace.json \
+    --version "${VERSION}" \
+    --expiration 2h \
+    --description "${CIRCLE_BUILD_URL}" \
+    --prefix "ci-" \
+    && break
 done
 
 # Print client and server versions, for debugging.
@@ -44,13 +56,13 @@ pachctl version
 
 # Run load tests.
 set +e
-pachctl run pfs-load-test "$@"
-if [ $? -ne 0 ]; then
+pachctl run pfs-load-test "${@}"
+if [ "${?}" -ne 0 ]; then
 	pachctl debug dump /tmp/debug-dump
 	exit 1
 fi
-pachctl run pps-load-test "$@"
-if [ $? -ne 0 ]; then
+pachctl run pps-load-test "${@}"
+if [ "${?}" -ne 0 ]; then
 	pachctl debug dump /tmp/debug-dump
 	exit 1
 fi
@@ -60,4 +72,9 @@ pachctl debug dump /tmp/debug-dump
 # Delete the workspace.  We don't do this in a "trap ... exit" statement so that you can log into
 # the workspace and debug it if the load tests fail.  Hub will automatically clean up the workspace
 # at its expiration time set above.
-hubcli --endpoint https://hub.pachyderm.com/api/graphql --apikey $HUB_API_KEY --op delete-workspace --loglevel trace --infofile workspace.json
+hubcli \
+  --endpoint https://hub.pachyderm.com/api/graphql \
+  --apikey "${HUB_API_KEY}" \
+  --op delete-workspace \
+  --loglevel trace \
+  --infofile workspace.json

--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+# shellcheck disable=SC1090
 source "$(dirname "$0")/env.sh"
 
 VM_IP="$(minikube ip)"
@@ -21,7 +22,7 @@ minikube status
 kubectl version
 
 # any tests that build images will do it directly in minikube's docker registry
-eval $(minikube docker-env)
+eval "$(minikube docker-env)"
 
 echo "Running test suite based on BUCKET=$BUCKET"
 

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -2,7 +2,7 @@
 
 set -Eex
 
-export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+export PATH="${PWD}:${PWD}/cached-deps:${GOPATH}/bin:${PATH}"
 
 # Parse flags
 VERSION=v1.19.0

--- a/etc/testing/circle/upload_stats.sh
+++ b/etc/testing/circle/upload_stats.sh
@@ -3,7 +3,7 @@
 set -xeuo pipefail
 
 export GOPATH=/home/circleci/.go_workspace
-export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+export PATH="${PWD}:${PWD}/cached-deps:${GOPATH}/bin:${PATH}"
 
 if [ -f /tmp/results ]; then
   mkdir -p /tmp/test-results

--- a/etc/testing/forward-postgres.sh
+++ b/etc/testing/forward-postgres.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [ -f /tmp/port-forwards/postgres.pid ]; then
-  kill $(cat /tmp/port-forwards/postgres.pid) || true
+  kill "$(cat /tmp/port-forwards/postgres.pid)" || true
 fi
 
 kubectl port-forward service/postgres 32228:5432 --address 127.0.0.1 >/dev/null 2>&1 &

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -24,4 +24,4 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 # shellcheck disable=SC2046
 find . \
   \( -path ./etc/plugin "${skip_paths[@]}" \) -prune -o -name "*.sh" -print0 \
-| xargs -P 16 shellcheck -e SC1091 -e SC2010 -e SC2181 -e SC2004 -e SC2219
+| xargs -0 -P 16 shellcheck -e SC1091 -e SC2010 -e SC2181 -e SC2004 -e SC2219

--- a/etc/testing/local.sh
+++ b/etc/testing/local.sh
@@ -18,19 +18,19 @@ set -xeuo pipefail
 forward() {
   NAME=$1
   PORT=$2
-  if [ -f /tmp/pach/port-forwards/$NAME.pid ]; then
-    kill $(cat /tmp/pach/port-forwards/$NAME.pid) || true
+  if [ -f "/tmp/pach/port-forwards/${NAME}.pid" ]; then
+    kill "$(cat "/tmp/pach/port-forwards/${NAME}.pid")" || true
   fi
 
-  kubectl port-forward service/$NAME $PORT --address 127.0.0.1 >/dev/null 2>&1 &
+  kubectl port-forward "service/${NAME}" "${PORT}" --address 127.0.0.1 >/dev/null 2>&1 &
   PID=$!
 
   mkdir -p /tmp/pach/port-forwards
-  echo $PID > /tmp/pach/port-forwards/$NAME.pid
+  echo "${PID}" > "/tmp/pach/port-forwards/${NAME}.pid"
 }
 
 # make sure we're testing against minikube
-kubectl config use-context ${LOCAL_PACH_CONTEXT:-'minikube'}
+kubectl config use-context "${LOCAL_PACH_CONTEXT:-'minikube'}"
 
 # TODO(jonathan): We should be able to make the helm chart generate this for us.
 # add rbac rules
@@ -138,6 +138,10 @@ export KUBERNETES_PORT=${LOCAL_PACH_APISERVER_PORT:-'8443'}
 
 # mount the bearer token for the default k8s service account
 export KUBERNETES_BEARER_TOKEN_FILE=/tmp/pach/kubernetes-default-token
-kubectl get -n default -o json secret $(kubectl -n default get secrets  | grep 'pachyderm-token' | awk '{print $1}') | jq -r '.data.token | @base64d' > $KUBERNETES_BEARER_TOKEN_FILE
+kubectl get -n default -o json secret "$(
+    kubectl -n default get secrets \
+    | grep 'pachyderm-token' \
+    | awk '{print $1}' \
+  )" | jq -r '.data.token | @base64d' > "${KUBERNETES_BEARER_TOKEN_FILE}"
 
-$@
+"${@}"

--- a/etc/testing/migration/v1_11/deploy.sh
+++ b/etc/testing/migration/v1_11/deploy.sh
@@ -2,6 +2,7 @@
 # deploy.sh deploys a pachyderm 1.11.9 cluster (the first release with auth extract/restore)
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck disable=SC1090
 source "${SCRIPT_DIR}/../../../govars.sh"
 
 set -x
@@ -29,6 +30,5 @@ if ! grep . <( kubectl get po -l suite=pachyderm 2>/dev/null ) \
   pachctl_1_11 deploy local
 
   # Wait for pachyderm to come up
-  HERE="$(dirname "${0}")"
   kubectl wait --for=condition=ready pod -l app=pachd --timeout=1m
 fi

--- a/etc/testing/migration/v1_7/deploy.sh
+++ b/etc/testing/migration/v1_7/deploy.sh
@@ -2,6 +2,7 @@
 # deploy.sh deploys a pachyderm 1.7 cluster
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck disable=SC1090
 source "${SCRIPT_DIR}/../../../govars.sh"
 
 set -x


### PR DESCRIPTION
Previously, `etc/testing/lint.sh` was failing to run `shellcheck` in CI because it was passing the output of a `find` command run with `-print0` (which instructs `find` to separate its output with null characters) to an `xargs` command that was not run with `-0` or `--null`. Thus, `xargs` was interpreting `find`'s output as one super-huge filename containing all of our shell files, and then exiting when that super-file didn't exist. It was logging a warning in CI, but not exiting with a non-zero exit code.

This PR passes the `-0` argument to xargs in lint.sh, so that it splits its input at null characters, effectively re-enabling shellcheck in CI. As this change revealed many previously-suppressed shellcheck errors, this PR fixes those errors as well.