### PR TITLE
Add storageClass to example helm values for Microsoft

### DIFF
--- a/etc/helm/examples/microsoft-values.yaml
+++ b/etc/helm/examples/microsoft-values.yaml
@@ -9,3 +9,6 @@ pachd:
       container: "foo"
       id: "bar"
       secret: "baz"
+etcd:
+  storageClass: "default"
+


### PR DESCRIPTION
I ran into an issue, where the Azure VM is configured to be `Standard_D2_v2`, which does not support premium storage. Without setting storageClass to `default`, we end up getting Premium storage instead. I think it's better to explicitly set storageClass here in this example, because most likely the user will use a Standard VM that doesn't support premium storage class.