### PR TITLE
Update aws helm examples

### DIFF
--- a/etc/helm/Makefile
+++ b/etc/helm/Makefile
@@ -11,11 +11,14 @@ all: pachyderm/values.schema.json
 lint:
 	helm lint pachyderm --set deployTarget=LOCAL
 
-test: pachyderm/values.schema.json kubeval-aws kubeval-gcp kubeval-gcp-tls kubeval-hub kubeval-local kubeval-local-dev kubeval-minio kubeval-microsoft
+test: pachyderm/values.schema.json kubeval-aws-gp2 kubeval-aws-gp3 kubeval-gcp kubeval-gcp-tls kubeval-hub kubeval-local kubeval-local-dev kubeval-minio kubeval-microsoft
 	go test -race ./... -count 1
 
-kubeval-aws:
-	helm template pachyderm -f examples/aws-values.yaml | kubeval --strict
+kubeval-aws-gp2:
+	helm template pachyderm -f examples/aws-gp2-values.yaml | kubeval --strict
+
+kubeval-aws-gp3:
+	helm template pachyderm -f examples/aws-gp3-values.yaml | kubeval --strict
 
 kubeval-gcp:
 	helm template pachyderm -f examples/gcp-values.yaml | kubeval --strict

--- a/etc/helm/examples/aws-gp2-values.yaml
+++ b/etc/helm/examples/aws-gp2-values.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+# SPDX-License-Identifier: Apache-2.0
+
+deployTarget: AMAZON
+
+etcd:
+    size: 500Gi
+
+pachd:
+  storage:
+    amazon:
+      bucket: blah
+      # this is an example access key ID taken from https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      id: AKIAIOSFODNN7EXAMPLE
+      # this is an example secret access key taken from https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+      secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      cloudFrontDistribution: cfd-123
+  serviceAccount:
+    additionalAnnotations:
+      eks.amazonaws.com/role-arn: blah123
+  worker:
+    serviceAccount:
+      additionalAnnotations:
+        eks.amazonaws.com/role-arn: blah123
+
+postgresql:
+  persistence:
+    size: 500Gi

--- a/etc/helm/examples/aws-gp3-values.yaml
+++ b/etc/helm/examples/aws-gp3-values.yaml
@@ -1,7 +1,16 @@
 # SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 # SPDX-License-Identifier: Apache-2.0
 
+# Uses GP3 Storage
+
 deployTarget: AMAZON
+
+# This uses GP3 which requires the CSI Driver https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+# And a storageclass configured named gp3
+
+etcd:
+  storageClass: gp3
+
 
 pachd:
   storage:
@@ -19,3 +28,7 @@ pachd:
     serviceAccount:
       additionalAnnotations:
         eks.amazonaws.com/role-arn: blah123
+
+postgresql:
+  persistence:
+    storageClass: gp3


### PR DESCRIPTION
Delineates between GP2 and GP3 examples. Also increases the storage size on GP2 for performance.