### PR TITLE
Pipeline Templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/protobuf v1.5.2
+	github.com/google/go-jsonnet v0.17.0 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/grafana/loki v1.5.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-jsonnet v0.17.0 h1:/9NIEfhK1NQRKl3sP2536b2+x5HnZMdql7x3yK/l8JY=
+github.com/google/go-jsonnet v0.17.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -1000,6 +1002,7 @@ github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c/go.mod h1:kJ9mm
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/sercand/kuberesolver v1.0.1-0.20200204133151-f60278fd3dac h1:wKskA8GJPKu+Quc4JkN0mw9+QMDvgNrd6VlqMXwCKoM=
 github.com/sercand/kuberesolver v1.0.1-0.20200204133151-f60278fd3dac/go.mod h1:7Ns4EAwey2akZQIvbJfM3dcAgjU1j4s5IgKRPwyOSfU=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/src/internal/ppsutil/decoder.go
+++ b/src/internal/ppsutil/decoder.go
@@ -17,6 +17,7 @@ type PipelineManifestReader struct {
 	// Do first round of parsing (yaml -> holder) here (not serde), in case of
 	// multi-pipeline document
 	decoder *yaml.Decoder
+	next    func() (*ppsclient.CreatePipelineRequest, error)
 }
 
 // NewPipelineManifestReader creates a new manifest reader from a path.
@@ -26,18 +27,52 @@ func NewPipelineManifestReader(pipelineBytes []byte) (result *PipelineManifestRe
 	}, nil
 }
 
+func convertRequest(request interface{}) (*ppsclient.CreatePipelineRequest, error) {
+	var result ppsclient.CreatePipelineRequest
+	if err := serde.RoundTrip(request, &result); err != nil {
+		return nil, errors.Wrapf(err, "malformed pipeline spec")
+	}
+	return &result, nil
+}
+
 // NextCreatePipelineRequest gets the next request from the manifest reader.
 func (r *PipelineManifestReader) NextCreatePipelineRequest() (*ppsclient.CreatePipelineRequest, error) {
-	holder := make(map[string]interface{})
+	// return 2nd or later pipeline spec in a list (from a template)
+	if r.next != nil {
+		result, err := r.next()
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil, err
+		case err != nil:
+			return nil, errors.Wrapf(err, "malformed pipeline spec")
+		default:
+			return result, nil
+		}
+	}
+
+	// No list is in progress--parse next doc (either a single spec or a
+	// list)
+	var holder interface{}
 	if err := r.decoder.Decode(&holder); err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, err
 		}
 		return nil, errors.Wrapf(err, "malformed pipeline spec")
 	}
-	var result ppsclient.CreatePipelineRequest
-	if err := serde.RoundTrip(holder, &result); err != nil {
-		return nil, err
+	switch document := holder.(type) {
+	case []interface{}:
+		// doc is a list of requests--return elements one by one
+		index := 0 // captured in r.next(), below
+		r.next = func() (*ppsclient.CreatePipelineRequest, error) {
+			index++
+			if index >= len(document) {
+				r.next = nil // last request in the list--reset r.next
+			}
+			return convertRequest(document[index-1])
+		}
+		return r.NextCreatePipelineRequest() // Just load first result from next()
+	default:
+		// doc is a single request
+		return convertRequest(document)
 	}
-	return &result, nil
 }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/google/go-jsonnet"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	pachdclient "github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/clientsdk"
@@ -677,14 +678,18 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	var registry string
 	var username string
 	var pipelinePath string
+	var jsonnetPath string
+	var jsonnetArgs []string
 	createPipeline := &cobra.Command{
 		Short: "Create a new pipeline.",
 		Long:  "Create a new pipeline from a pipeline specification. For details on the format, see http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(false, pushImages, registry, username, pipelinePath, false)
+			return pipelineHelper(false, pushImages, registry, username, pipelinePath, jsonnetPath, jsonnetArgs, false)
 		}),
 	}
-	createPipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The JSON file containing the pipeline, it can be a url or local file. - reads from stdin.")
+	createPipeline.Flags().StringVarP(&pipelinePath, "file", "f", "", "A JSON file (url or filepath) containing one or more pipelines. \"-\" reads from stdin (the default behavior). Exactly one of --file and --jsonnet must be set.")
+	createPipeline.Flags().StringVar(&jsonnetPath, "jsonnet", "", "A Jsonnet template file (url or filepath) for one or more pipelines. \"-\" reads from stdin. Exactly one of --file and --jsonnet must be set. Jsonnet templates must contain a top-level function; strings can be passed to this function with --arg (below)")
+	createPipeline.Flags().StringSliceVar(&jsonnetArgs, "arg", nil, "Top-level argument passed to the Jsonnet template in --jsonnet (which must be set if any --arg arugments are passed). Value must be of the form 'param=value'. For multiple args, --arg may be set more than once, or it may be passed a comma-separated list of 'param=value' pairs.")
 	createPipeline.Flags().BoolVarP(&pushImages, "push-images", "p", false, "If true, push local docker images into the docker registry.")
 	createPipeline.Flags().StringVarP(&registry, "registry", "r", "index.docker.io", "The registry to push images to.")
 	createPipeline.Flags().StringVarP(&username, "username", "u", "", "The username to push images as.")
@@ -695,10 +700,12 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 		Short: "Update an existing Pachyderm pipeline.",
 		Long:  "Update a Pachyderm pipeline with a new pipeline specification. For details on the format, see http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html.",
 		Run: cmdutil.RunFixedArgs(0, func(args []string) (retErr error) {
-			return pipelineHelper(reprocess, pushImages, registry, username, pipelinePath, true)
+			return pipelineHelper(reprocess, pushImages, registry, username, pipelinePath, jsonnetPath, jsonnetArgs, true)
 		}),
 	}
-	updatePipeline.Flags().StringVarP(&pipelinePath, "file", "f", "-", "The JSON file containing the pipeline, it can be a url or local file. - reads from stdin.")
+	updatePipeline.Flags().StringVarP(&pipelinePath, "file", "f", "", "A JSON file (url or filepath) containing one or more pipelines. \"-\" reads from stdin (the default behavior). Exactly one of --file and --jsonnet must be set.")
+	updatePipeline.Flags().StringVar(&jsonnetPath, "jsonnet", "", "A Jsonnet template file (url or filepath) for one or more pipelines. \"-\" reads from stdin. Exactly one of --file and --jsonnet must be set. Jsonnet templates must contain a top-level function; strings can be passed to this function with --arg (below)")
+	updatePipeline.Flags().StringSliceVar(&jsonnetArgs, "arg", nil, "Top-level argument passed to the Jsonnet template in --jsonnet (which must be set if any --arg arugments are passed). Value must be of the form 'param=value'. For multiple args, --arg may be set more than once, or it may be passed a comma-separated list of 'param=value' pairs.")
 	updatePipeline.Flags().BoolVarP(&pushImages, "push-images", "p", false, "If true, push local docker images into the docker registry.")
 	updatePipeline.Flags().StringVarP(&registry, "registry", "r", "index.docker.io", "The registry to push images to.")
 	updatePipeline.Flags().StringVarP(&username, "username", "u", "", "The username to push images as.")
@@ -1166,9 +1173,30 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	return commands
 }
 
-// readPipelineBytes reads the pipeline spec at 'pipelinePath' (which may be
-// '-' for stdin, a local path, or a remote URL) and returns the bytes stored
-// there.
+func evaluateJsonnetTemplate(jsonnetPath string, jsonnetArgs []string) ([]byte, error) {
+	templateBytes, err := readPipelineBytes(jsonnetPath)
+	if err != nil {
+		return nil, err
+	}
+	vm := jsonnet.MakeVM()
+	for _, argStr := range jsonnetArgs {
+		kv := strings.SplitN(argStr, "=", 2)
+		if len(kv) != 2 {
+			return nil, errors.Errorf("invalid template argument %q: must have form \"key=value\"", argStr)
+		}
+		vm.TLAVar(kv[0], kv[1])
+
+	}
+	output, err := vm.EvaluateAnonymousSnippet(jsonnetPath, string(templateBytes))
+	if err != nil {
+		return nil, errors.Wrapf(err, "template err")
+	}
+	return []byte(output), nil
+}
+
+// readPipelineBytes reads the pipeline spec or template at 'pipelinePath'
+// (which may be '-' for stdin, a local path, or a remote URL) and returns
+// the bytes stored there.
 //
 // TODO(msteffen) This is very similar to readConfigBytes in
 // s/s/identity/cmds/cmds.go (which differs only in not supporting URLs),
@@ -1205,11 +1233,27 @@ func readPipelineBytes(pipelinePath string) (pipelineBytes []byte, retErr error)
 	return pipelineBytes, nil
 }
 
-func pipelineHelper(reprocess bool, pushImages bool, registry, username, pipelinePath string, update bool) error {
-	pipelineBytes, err := readPipelineBytes(pipelinePath)
+func pipelineHelper(reprocess bool, pushImages bool, registry, username, pipelinePath, jsonnetPath string, jsonnetArgs []string, update bool) error {
+	// validate arguments
+	if pipelinePath != "" && jsonnetPath != "" {
+		return errors.New("cannot set both --file and --jsonnet; exactly one must be set")
+	}
+	if pipelinePath == "" && jsonnetPath == "" {
+		pipelinePath = "-" // default input
+	}
+
+	// read/compute pipeline spec(s) (file, stdin, url, or via template)
+	var pipelineBytes []byte
+	var err error
+	if pipelinePath != "" {
+		pipelineBytes, err = readPipelineBytes(pipelinePath)
+	} else if jsonnetPath != "" {
+		pipelineBytes, err = evaluateJsonnetTemplate(jsonnetPath, jsonnetArgs)
+	}
 	if err != nil {
 		return err
 	}
+
 	pipelineReader, err := ppsutil.NewPipelineManifestReader(pipelineBytes)
 	if err != nil {
 		return err

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -679,3 +679,130 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		`).Run()
 	})
 }
+
+func TestJsonnetPipelineTemplate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	require.NoError(t, tu.BashCmd(`
+		yes | pachctl delete all
+	`).Run())
+	require.NoError(t, tu.BashCmd(`
+		pachctl create repo data
+		pachctl put file data@master:/foo <<<"foo-data"
+		pachctl create pipeline --jsonnet - --arg name=foo --arg output=bar <<EOF
+		function(name, output) {
+		  pipeline: { name: name+"-pipeline" },
+		  input: {
+		    pfs: {
+		      name: "input",
+		      glob: "/*",
+		      repo: "data"
+		    }
+		  },
+		  transform: {
+		    cmd: [ "/bin/bash" ],
+		    stdin: [ "cp /pfs/input/* /pfs/out/"+output ]
+		  }
+		}
+		EOF
+		pachctl list pipeline | match foo-pipeline
+		pachctl wait commit foo-pipeline@master
+		pachctl get file foo-pipeline@master:/bar | match foo-data
+		`).Run())
+}
+
+func TestJsonnetPipelineTemplateMulti(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	require.NoError(t, tu.BashCmd(`
+		yes | pachctl delete all
+	`).Run())
+	require.NoError(t, tu.BashCmd(`
+		pachctl create repo data
+		pachctl put file data@master:/foo <<<"foo-data"
+		pachctl create pipeline --jsonnet - \
+		  --arg firstname=foo --arg lastname=bar --arg output=baz <<EOF
+		function(firstname, lastname, output) [ {
+		  pipeline: { name: firstname+"-pipeline" },
+		  input: {
+		    pfs: {
+		      name: "input",
+		      glob: "/*",
+		      repo: "data"
+		    }
+		  },
+		  transform: {
+		    cmd: [ "/bin/bash" ],
+		    stdin: [ "cp /pfs/input/* /pfs/out/"+output+"-middle" ]
+		  }
+		}, {
+		  pipeline: { name: lastname+"-pipeline" },
+		  input: {
+		    pfs: {
+		      name: "input",
+		      glob: "/*",
+		      repo: firstname+"-pipeline"
+		    }
+		  },
+		  transform: {
+		    cmd: [ "/bin/bash" ],
+		    stdin: [ "cp /pfs/input/"+output+"-middle /pfs/out/"+output+"-final" ]
+		  }
+		} ]
+		EOF
+		pachctl list pipeline | match foo-pipeline | match bar-pipeline
+		pachctl wait commit bar-pipeline@master
+		pachctl get file foo-pipeline@master:/baz-middle | match foo-data
+		pachctl get file bar-pipeline@master:/baz-final | match foo-data
+		`).Run())
+}
+
+func TestJsonnetPipelineTemplateError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	require.NoError(t, tu.BashCmd(`
+		yes | pachctl delete all
+	`).Run())
+	require.NoError(t, tu.BashCmd(`
+		pachctl create repo data
+		pachctl put file data@master:/foo <<<"foo-data"
+
+		# expect 'create pipeline' to fail, but still run 'match'
+		set +e +o pipefail
+		# create a pipeline, and confirm that error message appears on stderr
+		# Note: discard stdout, and send stderr on stdout instead
+		createpipeline_stderr="$(
+		  pachctl create pipeline \
+		    --jsonnet - --arg parallelism=NaN 2>&1 >/dev/null <<EOF
+		function(parallelism) {
+		  pipeline: { name: "pipeline" },
+		  input: {
+		    pfs: {
+		      name: "input",
+		      glob: "/*",
+		      repo: "data"
+		    }
+		  },
+		  parallelism_spec: {
+		    constant: std.parseInt(parallelism)
+		  },
+		  transform: {
+		    cmd: [ "/bin/bash" ],
+		    stdin: [ "cp /pfs/input/* /pfs/out/" ]
+		  }
+		}
+		EOF
+		  )"
+		createpipeline_status="$?"
+
+		# reset error options before testing output
+		set -e -o pipefail
+		echo "${createpipeline_status}" | match -v "0"
+		echo "${createpipeline_stderr}" | match 'NaN is not a base 10 integer'
+
+		pachctl list pipeline | match -v foo-pipeline
+		`).Run())
+}


### PR DESCRIPTION
This PR implements the MVP of Pipeline Templates, giving pachctl the ability to execute Jsonnet templates in {create,update} pipeline. For context, and the design, see https://docs.google.com/document/d/1VC8SY2hmf5BQShJSmUvQ_q0hXV6ErRl25BmgK1f_KtI/edit