### PR TITLE
Fix encoding of config files

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -231,7 +231,7 @@ func (c *Config) write() error {
 		panic("config V1 included (this is a bug)")
 	}
 
-	rawConfig, err := serde.EncodeJSON(c)
+	rawConfig, err := serde.EncodeJSON(c, serde.WithIndent(2))
 	if err != nil {
 		return err
 	}

--- a/src/internal/testutil/cmds.go
+++ b/src/internal/testutil/cmds.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -50,6 +51,9 @@ func dedent(cmd string) string {
 			dedentedCmd.WriteString(s.Text()[len(prefix):]) // remove prefix
 			dedentedCmd.WriteRune('\n')
 		} else {
+			fmt.Fprintf(os.Stderr,
+				"\nWARNING: the line\n  %q\ncannot be dedented as missing the prefix %q\n",
+				s.Text(), prefix)
 			return cmd // no common prefix--break early
 		}
 	}


### PR DESCRIPTION
I previously made a change to fix the way config files are encoded (so that they go through the serde library, which encodes them with jsonpb), and I forgot to add an option to indent the output, which this PR adds.

This also adds a small fix to the cmdutil testing library: `BashCmd` now warns if the given command text can't be dedented properly (which can affect the semantics of bash), in particular catching the case where a bash command in indented with a mix of spaces and tabs (which the go compiler doesn't catch because the bash commands in our tests are strings)