### PR TITLE
enable annotations for pachd externalService in helm chart

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/external-service.yaml
+++ b/etc/helm/pachyderm/templates/pachd/external-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
+  annotations: {{ toYaml .Values.pachd.externalService.annotations | nindent 4 }}
   labels:
     app: pachd
     suite: pachyderm

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -330,6 +330,9 @@
                 "externalService": {
                     "type": "object",
                     "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
                         "apiGRPCPort": {
                             "type": "integer"
                         },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -201,6 +201,7 @@ pachd:
     loadBalancerIP: ""
     apiGRPCPort: 30650
     s3GatewayPort: 30600
+    annotations: {}
   service:
     # labels specifies labels to add to the pachd service.
     labels: {}


### PR DESCRIPTION
Hi :wave: 

I need to add annotations pachd's external `Service` to facilitate [customising the NLB my aws load balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations/) will create for it.

For example:
```yaml
pachd:
  ...
  # in order to expose pachd via a load balancer in AWS
  externalService:
    enabled: true
    apiGRPCPort: 30650
    s3GatewayPort: 30600
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
      service.beta.kubernetes.io/aws-load-balancer-scheme: internal
      service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-xxxx, subnet-yyyy
````

This felt like the right way to implement based on other optional blocks in the chart. I just added to `values.yaml` and the `pachd/external-service.yaml ` yaml template, then ran `make schema` to populate the schema json.