### PR TITLE
Remove node port exception for ports

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/service.yaml
+++ b/etc/helm/pachyderm/templates/pachd/service.yaml
@@ -20,45 +20,35 @@ metadata:
 spec:
   ports:
   - name: api-grpc-port
+    targetPort: api-grpc-port
+    port: 1650
     {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30650
-    port: 1650
-    {{- else }}
-    port: 30650
     {{- end }}
-    protocol: TCP
-    targetPort: api-grpc-port
   - name: oidc-port
+    targetPort: oidc-port
+    port: 1657
     {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30657
-    port: 1657
-    {{- else }}
-    port: 30657
     {{- end }}
-    targetPort: oidc-port
   - name: identity-port
+    targetPort: identity-port
+    port: 1658
     {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30658
-    port: 1658
-    {{- else }}
-    port: 30658
     {{- end }}
-    targetPort: identity-port
   - name: s3gateway-port
+    targetPort: s3gateway-port
+    port: 1600
     {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30600
-    port: 1600
-    {{- else }}
-    port: 30600
     {{- end }}
-    targetPort: s3gateway-port
   - name: prom-metrics
+    targetPort: prom-metrics
+    port: 1656
     {{- if eq .Values.pachd.service.type "NodePort" }}
     nodePort: 30656
     {{- end }}
-    port: 1656
-    protocol: TCP
-    targetPort: prom-metrics
   selector:
     app: pachd
   type: {{ .Values.pachd.service.type }}


### PR DESCRIPTION
This is a breaking change that requires further consideration. This may block helm upgrades for customers that have already installed 2.0RC