### PR TITLE
Fix console ingress annotation

### DIFF
--- a/etc/helm/pachyderm/templates/ingress/ingress.yaml
+++ b/etc/helm/pachyderm/templates/ingress/ingress.yaml
@@ -7,7 +7,7 @@ apiVersion: "networking.k8s.io/v1beta1"
 kind: "Ingress"
 metadata:
   name: "console"
-  annotations: {{ toYaml .Values.console.annotations | nindent 4 }}
+  annotations: {{ toYaml .Values.ingress.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: "console"


### PR DESCRIPTION
Based on [`values.yaml`](https://github.com/pachyderm/pachyderm/blob/master/etc/helm/pachyderm/values.yaml#L144-L146), I think the Ingress annotations need be read from `.Values.ingress.annotations`.