### PR TITLE
- Add NodePort rules to pachd issuer URI

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -42,7 +42,11 @@ imagePullSecrets:
 {{- else if .Values.ingress.host -}}
 https://{{ .Values.ingress.host }}/dex
 {{- else if eq .Values.deployTarget "LOCAL" -}}
+{{- if eq .Values.pachd.service.type "NodePort" -}}
 http://pachd:1658
+{{- else -}}
+http://pachd:30658
+{{- end -}}
 {{- else -}}
 {{ fail "For Authentication, an OIDC Issuer for this pachd must be set." }}
 {{- end -}}
@@ -50,9 +54,8 @@ http://pachd:1658
 
 {{- /*
 reactAppRuntimeIssuerURI: The URI without the path of the user accessible issuerURI. 
-ie. In local deployments, this is http://localhost:30658/, while the issuer URI is http://pachd:1658
+ie. In local deployments, this is http://localhost:30658, while the issuer URI is http://pachd:30658
 In deployments where the issuerURI is user accessible (ie. Via ingress) this would be the issuerURI without the path
-Trailing slash? 
 */ -}}
 {{- define "pachyderm.reactAppRuntimeIssuerURI" -}}
 {{- if .Values.console.config.reactAppRuntimeIssuerURI -}}
@@ -60,7 +63,7 @@ Trailing slash?
 {{- else if .Values.ingress.host -}}
 https://{{ .Values.ingress.host }}
 {{- else if eq .Values.deployTarget "LOCAL" -}}
-http://localhost:30658/
+http://localhost:30658
 {{- end }}
 {{- end }}
 

--- a/etc/helm/pachyderm/templates/ingress/ingress.yaml
+++ b/etc/helm/pachyderm/templates/ingress/ingress.yaml
@@ -16,6 +16,8 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - secretName: {{ required "if ingress.tls.enabled you must specify ingress.tls.secretName" .Values.ingress.tls.secretName }}
+      hosts:
+       - {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
   {{- end }}
   rules:
     - host: {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}

--- a/etc/helm/pachyderm/templates/pachd/config-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-secret.yaml
@@ -48,7 +48,7 @@ stringData:
   # TODO: Add config option for non embedded / multiple pachs?
   # enterpriseClusters is the set of pachds covered by license service 
   enterpriseClusters: |
-    - address: grpc://localhost:1650
+    - address: grpc://localhost:1653
       id: localhost
       secret: {{ $enterpriseSecret }}
       user_address: grpc://localhost:30650
@@ -58,7 +58,7 @@ stringData:
   # enterpiseConfig points the pachd to a license service (in this case itself)
   enterpriseConfig: |
     id: localhost
-    license_server: grpc://localhost:1650
+    license_server: grpc://localhost:1653
     secret: {{ $enterpriseSecret }}
 
   # identityServiceConfig configures the OIDC provider

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -663,7 +663,7 @@ This resets the cluster to its initial state.`,
 	portForward.Flags().Uint16Var(&remoteS3gatewayPort, "remote-s3gateway-port", 1600, "The remote port that the s3 gateway is bound to.")
 	portForward.Flags().Uint16Var(&dexPort, "dex-port", 30658, "The local port to bind the identity service to.")
 	portForward.Flags().Uint16Var(&remoteDexPort, "remote-dex-port", 1658, "The local port to bind the identity service to.")
-	portForward.Flags().Uint16Var(&consolePort, "console-port", 34000, "The local port to bind the console service to.")
+	portForward.Flags().Uint16Var(&consolePort, "console-port", 4000, "The local port to bind the console service to.")
 	portForward.Flags().Uint16Var(&remoteConsolePort, "remote-console-port", 4000, "The remote port to bind the console  service to.")
 	portForward.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace Pachyderm is deployed in.")
 	subcommands = append(subcommands, cmdutil.CreateAlias(portForward, "port-forward"))


### PR DESCRIPTION
- Remove trailing slash from reactAppRuntimeIssuerURI in local case
- Add hosts section to TLS section of ingress
- Change config pod enterpriseClusters and enterpriseConfig to use peer port instead of main pachd port for compatibility with TLS deployments where main port is encrypted
- Change console port in port forward to match console (4000)