### PR TITLE
make pachd cluster scoped resource naming dynamic to avoid conflicts

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -4,6 +4,19 @@ SPDX-License-Identifier: Apache-2.0
 */ -}}
 {{- /* vim: set filetype=mustache: */ -}}
 
+{{- define "pachd.fullname" -}}
+{{- if .Values.pachd.fullnameOverride }}
+{{- .Values.pachd.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.pachd.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "pachyderm.storageBackend" -}}
 {{- if eq .Values.deployTarget "" }}
 {{ fail "deployTarget must be set" }}

--- a/etc/helm/pachyderm/templates/pachd/rbac/clusterrole.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: ""
     suite: pachyderm
-  name: pachyderm
+  name: {{ include "pachd.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:

--- a/etc/helm/pachyderm/templates/pachd/rbac/clusterrolebinding.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: ""
     suite: pachyderm
-  name: pachyderm
+  name: {{ include "pachd.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: ""

--- a/etc/helm/pachyderm/templates/pachd/rbac/role.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/role.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: ""
     suite: pachyderm
-  name: pachyderm
+  name: {{ include "pachd.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:

--- a/etc/helm/pachyderm/templates/pachd/rbac/rolebinding.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/rolebinding.yaml
@@ -9,14 +9,14 @@ metadata:
   labels:
     app: ""
     suite: pachyderm
-  name: pachyderm
+  name: {{ include "pachd.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: ""
   kind: Role
-  name: pachyderm
+  name: {{ include "pachd.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: pachyderm
+  name: {{ .Values.pachd.serviceAccount.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{ end -}}

--- a/etc/helm/pachyderm/templates/pachd/rbac/worker-role.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/worker-role.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: ""
     suite: pachyderm
-  name: pachyderm-worker
+  name: {{ include "pachd.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:

--- a/etc/helm/pachyderm/templates/pachd/rbac/worker-rolebinding.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/worker-rolebinding.yaml
@@ -9,12 +9,12 @@ metadata:
   labels:
     app: ""
     suite: pachyderm
-  name: pachyderm-worker
+  name: {{ include "pachd.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: ""
   kind: Role
-  name: pachyderm-worker
+  name: {{ include "pachd.fullname" . }}-worker
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.pachd.worker.serviceAccount.name }}

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -158,6 +158,8 @@ ingress:
 
 pachd:
   enabled: true
+  nameOverride: "pachd"
+  fullnameOverride: ""
   affinity: {}
   # clusterDeploymentID sets the Pachyderm cluster ID.
   clusterDeploymentID: ""


### PR DESCRIPTION
This PR fixes cluster scoped resource naming (all RBAC resources) to be dynamic in case there are multiple pachyderm releases in a single cluster. It also updates the non-cluster scoped resources to be dynamic as well.