### PR TITLE
[Doc] [ci-skip] Removed the last  term open source from the docs. 

### DIFF
--- a/doc/docs/1.11.x/concepts/index.md
+++ b/doc/docs/1.11.x/concepts/index.md
@@ -1,11 +1,8 @@
 # Concepts
 
-Pachyderm is an enterprise-grade, open source data science platform that
-makes explainable, repeatable, and scalable Machine Learning (ML) and
-Artificial Intelligence (AI) a reality. The Pachyderm platform brings
-together version control for data with the tools to build scalable
-end-to-end ML/AI pipelines while empowering users to develop their
-code in any language, framework, or tool of their choice. Pachyderm
+The Pachyderm platform brings
+together **version control for data** with the tools to **build scalable end-to-end ML/AI pipelines** while empowering users to develop their
+**code in any language**, framework, or tool of their choice. Pachyderm
 has been proven to be the ideal foundation for teams looking to
 use ML and AI to solve real-world problems in a reliable way.
 

--- a/doc/docs/1.12.x/concepts/index.md
+++ b/doc/docs/1.12.x/concepts/index.md
@@ -1,11 +1,8 @@
 # Concepts
 
-Pachyderm is an enterprise-grade, open source data science platform that
-makes explainable, repeatable, and scalable Machine Learning (ML) and
-Artificial Intelligence (AI) a reality. The Pachyderm platform brings
-together version control for data with the tools to build scalable
-end-to-end ML/AI pipelines while empowering users to develop their
-code in any language, framework, or tool of their choice. Pachyderm
+The Pachyderm platform brings
+together **version control for data** with the tools to **build scalable end-to-end ML/AI pipelines** while empowering users to develop their
+**code in any language**, framework, or tool of their choice. Pachyderm
 has been proven to be the ideal foundation for teams looking to
 use ML and AI to solve real-world problems in a reliable way.
 

--- a/doc/docs/archived/1.10.x/concepts/index.md
+++ b/doc/docs/archived/1.10.x/concepts/index.md
@@ -1,11 +1,8 @@
 # Concepts
 
-Pachyderm is an enterprise-grade, open source data science platform that
-makes explainable, repeatable, and scalable Machine Learning (ML) and
-Artificial Intelligence (AI) a reality. The Pachyderm platform brings
-together version control for data with the tools to build scalable
-end-to-end ML/AI pipelines while empowering users to develop their
-code in any language, framework, or tool of their choice. Pachyderm
+The Pachyderm platform brings
+together **version control for data** with the tools to **build scalable end-to-end ML/AI pipelines** while empowering users to develop their
+**code in any language**, framework, or tool of their choice. Pachyderm
 has been proven to be the ideal foundation for teams looking to
 use ML and AI to solve real-world problems in a reliable way.
 

--- a/doc/docs/master/concepts/index.md
+++ b/doc/docs/master/concepts/index.md
@@ -1,11 +1,8 @@
 # Concepts
 
-Pachyderm is an enterprise-grade, open source data science platform that
-makes explainable, repeatable, and scalable Machine Learning (ML) and
-Artificial Intelligence (AI) a reality. The Pachyderm platform brings
-together version control for data with the tools to build scalable
-end-to-end ML/AI pipelines while empowering users to develop their
-code in any language, framework, or tool of their choice. Pachyderm
+The Pachyderm platform brings
+together **version control for data** with the tools to **build scalable end-to-end ML/AI pipelines** while empowering users to develop their
+**code in any language**, framework, or tool of their choice. Pachyderm
 has been proven to be the ideal foundation for teams looking to
 use ML and AI to solve real-world problems in a reliable way.
 


### PR DESCRIPTION
It added no value to the docs and was misunderstood. Our license details are clearly stated in the Readme of our main repo on GH and our main Website.