### PR TITLE
Explicitly disable securityContexts for pachd & etcd

### DIFF
--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -96,9 +96,11 @@ spec:
         secret:
           secretName: {{ required "If enterpriseServer.tls.enabled, you must set enterpriseServer.tls.secretName" .Values.enterpriseServer.tls.secretName | quote }}
       {{- end }}
+      {{- if .Values.pachd.securityContext.enabled }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      {{- end }}
       initContainers:
       - name: init-etcd
         image: busybox:1.28

--- a/etc/helm/pachyderm/templates/etcd/statefulset.yaml
+++ b/etc/helm/pachyderm/templates/etcd/statefulset.yaml
@@ -70,10 +70,12 @@ spec:
         volumeMounts:
         - mountPath: /var/data/etcd
           name: etcd-storage
+      {{- if  .Values.etcd.securityContext.enabled }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       labels:

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -36,6 +36,7 @@ spec:
       affinity: {{ toYaml .Values.pachd.affinity | nindent 8 }}
       {{- end }}
       {{- include "pachyderm.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.pachd.securityContext.enabled }}
       {{- if and (eq (include "pachyderm.storageBackend" . ) "LOCAL") .Values.pachd.storage.local.requireRoot }}
       securityContext:
         runAsUser: 0 # Need to run as root local for hostpath support
@@ -44,6 +45,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       {{- end }} 
+      {{- end }}
       containers:
       - command:
         - /pachd

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -211,6 +211,14 @@
                 "resources": {
                     "type": "object"
                 },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "service": {
                     "type": "object",
                     "properties": {
@@ -435,6 +443,14 @@
                 },
                 "rootToken": {
                     "type": "string"
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "service": {
                     "type": "object",

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -107,6 +107,8 @@ etcd:
     labels: {}
     # type specifies the Kubernetes type of the etcd service.
     type: ClusterIP
+  securityContext:
+    enabled: true
 
 enterpriseServer:
   enabled: false
@@ -187,7 +189,8 @@ pachd:
     #requests:
     #  cpu: "1"
     #  memory: "2G"
-
+  securityContext:
+      enabled: true
   # requireCriticalServersOnly only requires the critical pachd
   # servers to startup and run without errors.  It is analogous to the
   # --require-critical-servers-only argument to pachctl deploy.


### PR DESCRIPTION
It turns out that OpenShift actually automatically sets UID/GID to non-root in non-default namespace. It also turns out that explicitly setting the security context may otherwise conflict with OpenShifts SecurityContext Constraint model.

With this change, OpenShift users will add `pachd.securityContext.enabled=false` and `etcd.securityContext.enabled=false`