### PR TITLE
[2.0.x] Applies #7006

### DIFF
--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -36,6 +36,7 @@ type dbConfig struct {
 	maxIdleConns    int
 	connMaxLifetime time.Duration
 	connMaxIdleTime time.Duration
+	sslMode         string
 }
 
 func newConfig(opts ...Option) *dbConfig {
@@ -44,6 +45,7 @@ func newConfig(opts ...Option) *dbConfig {
 		maxIdleConns:    DefaultMaxIdleConns,
 		connMaxLifetime: DefaultConnMaxLifetime,
 		connMaxIdleTime: DefaultConnMaxIdleTime,
+		sslMode:         DefaultSSLMode,
 	}
 	for _, opt := range opts {
 		opt(dbc)
@@ -53,8 +55,8 @@ func newConfig(opts ...Option) *dbConfig {
 
 func getDSN(dbc *dbConfig) string {
 	fields := map[string]string{
-		"sslmode":         "disable",
 		"connect_timeout": "30",
+		"sslmode":         dbc.sslMode,
 
 		// https://github.com/lib/pq/issues/889
 		"binary_parameters": "yes",

--- a/src/internal/dbutil/option.go
+++ b/src/internal/dbutil/option.go
@@ -57,3 +57,17 @@ func WithConnMaxIdleTime(d time.Duration) Option {
 		dbc.connMaxIdleTime = d
 	}
 }
+
+const (
+	SSLModeDisable = "disable"
+	SSLModeEnable  = "verify-full"
+
+	DefaultSSLMode = SSLModeDisable
+)
+
+// WithSSLMode sets the SSL mode for connections to the database
+func WithSSLMode(mode string) Option {
+	return func(dbc *dbConfig) {
+		dbc.sslMode = mode
+	}
+}

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -299,6 +299,7 @@ func (env *NonblockingServiceEnv) initDirectDBClient() error {
 		dbutil.WithMaxIdleConns(env.config.PostgresMaxIdleConns),
 		dbutil.WithConnMaxLifetime(time.Duration(env.config.PostgresConnMaxLifetimeSeconds)*time.Second),
 		dbutil.WithConnMaxIdleTime(time.Duration(env.config.PostgresConnMaxIdleSeconds)*time.Second),
+		dbutil.WithSSLMode(env.config.PostgresSSL),
 	)
 	if err != nil {
 		return err
@@ -322,6 +323,7 @@ func (env *NonblockingServiceEnv) initDBClient() error {
 		dbutil.WithMaxIdleConns(env.config.PGBouncerMaxIdleConns),
 		dbutil.WithConnMaxLifetime(time.Duration(env.config.PostgresConnMaxLifetimeSeconds)*time.Second),
 		dbutil.WithConnMaxIdleTime(time.Duration(env.config.PostgresConnMaxIdleSeconds)*time.Second),
+		dbutil.WithSSLMode(dbutil.SSLModeDisable),
 	)
 	if err != nil {
 		return err

--- a/src/internal/serviceenv/service_env_nocgo.go
+++ b/src/internal/serviceenv/service_env_nocgo.go
@@ -1,9 +1,11 @@
+//go:build !cgo
 // +build !cgo
 
 package serviceenv
 
 import (
 	dex_sql "github.com/dexidp/dex/storage/sql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 )
 
 // InitDexDB initiates the connection to postgres to populate the Dex DB.
@@ -23,7 +25,7 @@ func (env *NonblockingServiceEnv) InitDexDB() {
 				Port:     uint16(env.Config().PGBouncerPort),
 			},
 			SSL: dex_sql.SSL{
-				Mode: env.Config().PostgresSSL,
+				Mode: dbutil.SSLModeDisable,
 			},
 		}).Open(env.Logger().WithField("source", "identity-db"))
 		return


### PR DESCRIPTION
This adds support for the PostgresSSL environment variable, which we have been setting with the helm chart, but not actually looking at in pachd. Additionally, pg-bouncer is set to always use sslmode=disable.