### PR TITLE
Remove etcd storage class from Azure helm example

### DIFF
--- a/etc/helm/examples/microsoft-values.yaml
+++ b/etc/helm/examples/microsoft-values.yaml
@@ -9,6 +9,4 @@ pachd:
       container: "foo"
       id: "bar"
       secret: "baz"
-etcd:
-  storageClass: "default"
 


### PR DESCRIPTION
Previously, I was testing these values with a VM size that does not support premium storage, which is what we use by default. However, it is better to just go with VMs that support premium storage for better iops.