### PR TITLE
Replaces `sqlx.DB` with `pachsql.DB`

### DIFF
--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -17,13 +17,14 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/watch"
 	"github.com/pachyderm/pachyderm/v2/src/version"
 )
 
 type postgresCollection struct {
 	table    string
-	db       *sqlx.DB
+	db       *pachsql.DB
 	listener PostgresListener
 	template proto.Message
 	indexes  []*Index
@@ -72,7 +73,7 @@ func WithNotFoundMessage(format func(interface{}) string) Option {
 }
 
 // NewPostgresCollection creates a new collection backed by postgres.
-func NewPostgresCollection(name string, db *sqlx.DB, listener PostgresListener, template proto.Message, indexes []*Index, opts ...Option) PostgresCollection {
+func NewPostgresCollection(name string, db *pachsql.DB, listener PostgresListener, template proto.Message, indexes []*Index, opts ...Option) PostgresCollection {
 	col := &postgresCollection{
 		table:    name,
 		db:       db,
@@ -122,7 +123,7 @@ func (c *postgresCollection) ReadWrite(tx *sqlx.Tx) PostgresReadWriteCollection 
 
 // NewDryrunSQLTx is identical to NewSQLTx except it will always roll back the
 // transaction instead of committing it.
-func NewDryrunSQLTx(ctx context.Context, db *sqlx.DB, apply func(*sqlx.Tx) error) error {
+func NewDryrunSQLTx(ctx context.Context, db *pachsql.DB, apply func(*sqlx.Tx) error) error {
 	err := dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
 		if err := apply(tx); err != nil {
 			return err

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -117,14 +117,14 @@ func (c *postgresCollection) ReadOnly(ctx context.Context) PostgresReadOnlyColle
 	return &postgresReadOnlyCollection{c, ctx}
 }
 
-func (c *postgresCollection) ReadWrite(tx *sqlx.Tx) PostgresReadWriteCollection {
+func (c *postgresCollection) ReadWrite(tx *pachsql.Tx) PostgresReadWriteCollection {
 	return &postgresReadWriteCollection{c, tx}
 }
 
 // NewDryrunSQLTx is identical to NewSQLTx except it will always roll back the
 // transaction instead of committing it.
-func NewDryrunSQLTx(ctx context.Context, db *pachsql.DB, apply func(*sqlx.Tx) error) error {
-	err := dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
+func NewDryrunSQLTx(ctx context.Context, db *pachsql.DB, apply func(*pachsql.Tx) error) error {
+	err := dbutil.WithTx(ctx, db, func(tx *pachsql.Tx) error {
 		if err := apply(tx); err != nil {
 			return err
 		}
@@ -607,7 +607,7 @@ func (c *postgresReadOnlyCollection) WatchByIndexF(index *Index, indexVal string
 
 type postgresReadWriteCollection struct {
 	*postgresCollection
-	tx *sqlx.Tx
+	tx *pachsql.Tx
 }
 
 func (c *postgresReadWriteCollection) Get(key interface{}, val proto.Message) error {

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
-
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
@@ -20,7 +18,7 @@ import (
 func TestPostgresCollections(suite *testing.T) {
 	PostgresCollectionBasicTests(suite, newCollectionFunc(func(ctx context.Context, t *testing.T) (*pachsql.DB, col.PostgresListener) {
 		db, dsn := newTestDB(t)
-		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *sqlx.Tx) error {
+		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *pachsql.Tx) error {
 			if err := col.CreatePostgresSchema(ctx, sqlTx); err != nil {
 				return err
 			}
@@ -35,7 +33,7 @@ func TestPostgresCollections(suite *testing.T) {
 	}))
 	PostgresCollectionWatchTests(suite, newCollectionFunc(func(ctx context.Context, t *testing.T) (*pachsql.DB, col.PostgresListener) {
 		db, dsn := newTestDirectDB(t)
-		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *sqlx.Tx) error {
+		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *pachsql.Tx) error {
 			if err := col.CreatePostgresSchema(ctx, sqlTx); err != nil {
 				return err
 			}
@@ -67,7 +65,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col
 		db, listener := setup(ctx, t)
 
 		testCol := col.NewPostgresCollection("test_items", db, listener, &col.TestItem{}, []*col.Index{TestSecondaryIndex})
-		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *sqlx.Tx) error {
+		require.NoError(t, dbutil.WithTx(ctx, db, func(sqlTx *pachsql.Tx) error {
 			return col.SetupPostgresCollections(ctx, sqlTx, testCol)
 		}))
 
@@ -76,7 +74,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col
 		}
 
 		writeCallback := func(ctx context.Context, f func(col.ReadWriteCollection) error) error {
-			return dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
+			return dbutil.WithTx(ctx, db, func(tx *pachsql.Tx) error {
 				return f(testCol.ReadWrite(tx))
 			})
 		}

--- a/src/internal/collection/postgres_listener.go
+++ b/src/internal/collection/postgres_listener.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/internal/watch"
 )
@@ -51,7 +51,7 @@ const (
 )
 
 type postgresWatcher struct {
-	db       *sqlx.DB
+	db       *pachsql.DB
 	listener PostgresListener
 	c        chan *watch.Event
 	buf      chan *postgresEvent // buffer for messages before the initial table list is complete
@@ -68,7 +68,7 @@ type postgresWatcher struct {
 }
 
 func newPostgresWatcher(
-	db *sqlx.DB,
+	db *pachsql.DB,
 	listener PostgresListener,
 	channel string,
 	template proto.Message,
@@ -290,7 +290,7 @@ func parsePostgresEvent(payload string) *postgresEvent {
 	return result
 }
 
-func (pe *postgresEvent) WatchEvent(ctx context.Context, db *sqlx.DB, template proto.Message) *watch.Event {
+func (pe *postgresEvent) WatchEvent(ctx context.Context, db *pachsql.DB, template proto.Message) *watch.Event {
 	if pe.err != nil {
 		return &watch.Event{Err: pe.err, Type: watch.EventError}
 	}

--- a/src/internal/collection/postgres_schema.go
+++ b/src/internal/collection/postgres_schema.go
@@ -5,19 +5,18 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jmoiron/sqlx"
-
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
-func CreatePostgresSchema(ctx context.Context, sqlTx *sqlx.Tx) error {
+func CreatePostgresSchema(ctx context.Context, sqlTx *pachsql.Tx) error {
 	_, err := sqlTx.ExecContext(ctx, `CREATE SCHEMA collections`)
 	return err
 }
 
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func SetupPostgresV0(ctx context.Context, sqlTx *sqlx.Tx) error {
+func SetupPostgresV0(ctx context.Context, sqlTx *pachsql.Tx) error {
 	updatedAtFunction := `
 create or replace function collections.updatedat_trigger_fn() returns trigger as $$
 begin
@@ -171,7 +170,7 @@ create trigger updatedat_trigger
 	return nil
 }
 
-func SetupPostgresCollections(ctx context.Context, sqlTx *sqlx.Tx, collections ...PostgresCollection) error {
+func SetupPostgresCollections(ctx context.Context, sqlTx *pachsql.Tx, collections ...PostgresCollection) error {
 	for _, pgc := range collections {
 		col := pgc.(*postgresCollection)
 		columns := []string{

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -3,10 +3,10 @@ package collection
 import (
 	"context"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/watch"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/jmoiron/sqlx"
 )
 
 // Collection implements helper functions that makes common operations
@@ -21,7 +21,7 @@ type PostgresCollection interface {
 	// invalidated at the end of the transaction.  Basically, it's
 	// software transactional memory.  See this blog post for details:
 	// https://coreos.com/blog/transactional-memory-with-etcd3.html
-	ReadWrite(tx *sqlx.Tx) PostgresReadWriteCollection
+	ReadWrite(tx *pachsql.Tx) PostgresReadWriteCollection
 
 	// For read-only operations, use the ReadOnly for better performance
 	ReadOnly(ctx context.Context) PostgresReadOnlyCollection

--- a/src/internal/dbutil/tx.go
+++ b/src/internal/dbutil/tx.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
@@ -109,7 +110,7 @@ func WithBackOff(bo backoff.BackOff) WithTxOption {
 // WithTx calls cb with a transaction,
 // The transaction is committed IFF cb returns nil.
 // If cb returns an error the transaction is rolled back.
-func WithTx(ctx context.Context, db *sqlx.DB, cb func(tx *sqlx.Tx) error, opts ...WithTxOption) error {
+func WithTx(ctx context.Context, db *pachsql.DB, cb func(tx *sqlx.Tx) error, opts ...WithTxOption) error {
 	backoffStrategy := backoff.NewExponentialBackOff()
 	backoffStrategy.InitialInterval = 1 * time.Millisecond
 	backoffStrategy.MaxElapsedTime = 0

--- a/src/internal/dbutil/tx.go
+++ b/src/internal/dbutil/tx.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/prometheus/client_golang/prometheus"
@@ -110,7 +109,7 @@ func WithBackOff(bo backoff.BackOff) WithTxOption {
 // WithTx calls cb with a transaction,
 // The transaction is committed IFF cb returns nil.
 // If cb returns an error the transaction is rolled back.
-func WithTx(ctx context.Context, db *pachsql.DB, cb func(tx *sqlx.Tx) error, opts ...WithTxOption) error {
+func WithTx(ctx context.Context, db *pachsql.DB, cb func(tx *pachsql.Tx) error, opts ...WithTxOption) error {
 	backoffStrategy := backoff.NewExponentialBackOff()
 	backoffStrategy.InitialInterval = 1 * time.Millisecond
 	backoffStrategy.MaxElapsedTime = 0
@@ -165,7 +164,7 @@ func WithTx(ctx context.Context, db *pachsql.DB, cb func(tx *sqlx.Tx) error, opt
 	return nil
 }
 
-func tryTxFunc(tx *sqlx.Tx, cb func(tx *sqlx.Tx) error) error {
+func tryTxFunc(tx *pachsql.Tx, cb func(tx *pachsql.Tx) error) error {
 	if err := cb(tx); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
 			underlyingTxFinishMetric.WithLabelValues("rollback_failed").Inc()

--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -57,12 +57,12 @@ func NewTestDBConfig(t testing.TB) serviceenv.ConfigOption {
 	}
 }
 
-func NewTestDB(t testing.TB) *sqlx.DB {
+func NewTestDB(t testing.TB) *pachsql.DB {
 	opts := NewTestDBOptions(t)
 	return testutil.NewTestDB(t, opts)
 }
 
-func NewTestDirectDB(t testing.TB) *sqlx.DB {
+func NewTestDirectDB(t testing.TB) *pachsql.DB {
 	opts := NewTestDirectDBOptions(t)
 	return testutil.NewTestDB(t, opts)
 }

--- a/src/internal/migrations/migrations.go
+++ b/src/internal/migrations/migrations.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -18,7 +17,7 @@ import (
 type Env struct {
 	// TODO: etcd
 	ObjectClient obj.Client
-	Tx           *sqlx.Tx
+	Tx           *pachsql.Tx
 }
 
 // MakeEnv returns a new Env
@@ -186,7 +185,7 @@ func BlockUntil(ctx context.Context, db *pachsql.DB, state State) error {
 	}
 }
 
-func isFinished(ctx context.Context, tx *sqlx.Tx, state State) (bool, error) {
+func isFinished(ctx context.Context, tx *pachsql.Tx, state State) (bool, error) {
 	var name string
 	if err := tx.GetContext(ctx, &name, `
 	SELECT name

--- a/src/internal/pachsql/db.go
+++ b/src/internal/pachsql/db.go
@@ -10,12 +10,12 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 )
 
-// DB is an alias for sqlx.DB which is the standard database type used throughout the project
+// DB is an alias for pachsql.DB which is the standard database type used throughout the project
 type DB = sqlx.DB
 
 // OpenURL returns a database connection pool to the database specified by u
 // If password != "" then it will be used for authentication.
-// This function does not confirm that the database is reachable; callers may be interested in sqlx.DB.Ping()
+// This function does not confirm that the database is reachable; callers may be interested in pachsql.DB.Ping()
 func OpenURL(u URL, password string) (*DB, error) {
 	var driver string
 	var dsn string

--- a/src/internal/pachsql/db.go
+++ b/src/internal/pachsql/db.go
@@ -10,8 +10,11 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 )
 
-// DB is an alias for pachsql.DB which is the standard database type used throughout the project
+// DB is an alias for sqlx.DB which is the standard database type used throughout the project
 type DB = sqlx.DB
+
+// Tx is an alias for sqlx.Tx which is the standard transaction type used throughout the project
+type Tx = sqlx.Tx
 
 // OpenURL returns a database connection pool to the database specified by u
 // If password != "" then it will be used for authentication.

--- a/src/internal/pfsdb/pfsdb.go
+++ b/src/internal/pfsdb/pfsdb.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/jmoiron/sqlx"
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
@@ -49,7 +49,7 @@ func repoKeyCheck(key string) error {
 }
 
 // Repos returns a collection of repos
-func Repos(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func Repos(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		reposCollectionName,
 		db,
@@ -105,7 +105,7 @@ func CommitBranchlessKey(commit *pfs.Commit) string {
 }
 
 // Commits returns a collection of commits
-func Commits(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func Commits(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		commitsCollectionName,
 		db,
@@ -142,7 +142,7 @@ func BranchKey(branch *pfs.Branch) string {
 }
 
 // Branches returns a collection of branches
-func Branches(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func Branches(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		branchesCollectionName,
 		db,

--- a/src/internal/ppsdb/ppsdb.go
+++ b/src/internal/ppsdb/ppsdb.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/jmoiron/sqlx"
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
@@ -57,7 +57,7 @@ func ParsePipelineKey(key string) (string, string, error) {
 }
 
 // Pipelines returns a PostgresCollection of pipelines
-func Pipelines(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func Pipelines(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		pipelinesCollectionName,
 		db,
@@ -115,7 +115,7 @@ func JobKey(job *pps.Job) string {
 }
 
 // Jobs returns a PostgresCollection of Jobs
-func Jobs(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func Jobs(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		jobsCollectionName,
 		db,

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
@@ -185,7 +184,7 @@ func SetPipelineState(ctx context.Context, db *pachsql.DB, pipelinesCollection c
 	logSetPipelineState(pipeline, from, to, reason)
 	var resultMessage string
 	var warn bool
-	err := dbutil.WithTx(ctx, db, func(sqlTx *sqlx.Tx) error {
+	err := dbutil.WithTx(ctx, db, func(sqlTx *pachsql.Tx) error {
 		resultMessage = ""
 		warn = false
 		pipelines := pipelinesCollection.ReadWrite(sqlTx)

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	auth_server "github.com/pachyderm/pachyderm/v2/src/server/auth"
 	enterprise_server "github.com/pachyderm/pachyderm/v2/src/server/enterprise"
 	pfs_server "github.com/pachyderm/pachyderm/v2/src/server/pfs"
@@ -13,7 +14,6 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	dex_storage "github.com/dexidp/dex/storage"
 	loki "github.com/grafana/loki/pkg/logcli/client"
-	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	kube "k8s.io/client-go/kubernetes"
@@ -27,7 +27,7 @@ type TestServiceEnv struct {
 	EtcdClient               *etcd.Client
 	KubeClient               *kube.Clientset
 	LokiClient               *loki.Client
-	DBClient, DirectDBClient *sqlx.DB
+	DBClient, DirectDBClient *pachsql.DB
 	PostgresListener         col.PostgresListener
 	DexDB                    dex_storage.Storage
 	Log                      *log.Logger
@@ -68,10 +68,10 @@ func (s *TestServiceEnv) GetKubeClient() *kube.Clientset {
 func (s *TestServiceEnv) GetLokiClient() (*loki.Client, error) {
 	return s.LokiClient, nil
 }
-func (s *TestServiceEnv) GetDBClient() *sqlx.DB {
+func (s *TestServiceEnv) GetDBClient() *pachsql.DB {
 	return s.DBClient
 }
-func (s *TestServiceEnv) GetDirectDBClient() *sqlx.DB {
+func (s *TestServiceEnv) GetDirectDBClient() *pachsql.DB {
 	return s.DirectDBClient
 }
 func (s *TestServiceEnv) GetPostgresListener() col.PostgresListener {

--- a/src/internal/storage/chunk/client.go
+++ b/src/internal/storage/chunk/client.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -58,7 +57,7 @@ func (c *trackedClient) Create(ctx context.Context, md Metadata, chunkData []byt
 	chunkTID := chunkID.TrackerID()
 	var needUpload bool
 	var gen uint64
-	if err := dbutil.WithTx(ctx, c.db, func(tx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, c.db, func(tx *pachsql.Tx) error {
 		if err := c.tracker.CreateTx(tx, chunkTID, pointsTo, c.ttl); err != nil {
 			return err
 		}
@@ -148,7 +147,7 @@ var _ track.Deleter = &deleter{}
 
 type deleter struct{}
 
-func (d *deleter) DeleteTx(tx *sqlx.Tx, id string) error {
+func (d *deleter) DeleteTx(tx *pachsql.Tx, id string) error {
 	chunkID, err := ParseTrackerID(id)
 	if err != nil {
 		return errors.Wrapf(err, "cannot delete")

--- a/src/internal/storage/chunk/client.go
+++ b/src/internal/storage/chunk/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
@@ -25,7 +26,7 @@ type Client interface {
 // a tracker and an kv.Store
 type trackedClient struct {
 	store   kv.Store
-	db      *sqlx.DB
+	db      *pachsql.DB
 	tracker track.Tracker
 	renewer *Renewer
 	ttl     time.Duration
@@ -33,7 +34,7 @@ type trackedClient struct {
 
 // NewClient returns a client which will write to objc, mdstore, and tracker.  Name is used
 // for the set of temporary objects
-func NewClient(store kv.Store, db *sqlx.DB, tr track.Tracker, renewer *Renewer) Client {
+func NewClient(store kv.Store, db *pachsql.DB, tr track.Tracker, renewer *Renewer) Client {
 	return &trackedClient{
 		store:   store,
 		db:      db,

--- a/src/internal/storage/chunk/metadata.go
+++ b/src/internal/storage/chunk/metadata.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachhash"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 // ID uniquely identifies a chunk. It is the hash of its content
@@ -98,10 +99,10 @@ type KeyStore interface {
 }
 
 type postgresKeyStore struct {
-	db *sqlx.DB
+	db *pachsql.DB
 }
 
-func NewPostgresKeyStore(db *sqlx.DB) *postgresKeyStore {
+func NewPostgresKeyStore(db *pachsql.DB) *postgresKeyStore {
 	return &postgresKeyStore{
 		db: db,
 	}

--- a/src/internal/storage/chunk/metadata.go
+++ b/src/internal/storage/chunk/metadata.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"strings"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachhash"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -69,7 +68,7 @@ type Entry struct {
 // SetupPostgresStoreV0 sets up tables in db
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func SetupPostgresStoreV0(tx *sqlx.Tx) error {
+func SetupPostgresStoreV0(tx *pachsql.Tx) error {
 	_, err := tx.Exec(`
 	CREATE TABLE storage.chunk_objects (
 		chunk_id BYTEA NOT NULL,

--- a/src/internal/storage/chunk/storage.go
+++ b/src/internal/storage/chunk/storage.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
@@ -22,7 +22,7 @@ const (
 // Storage is the abstraction that manages chunk storage.
 type Storage struct {
 	objClient     obj.Client
-	db            *sqlx.DB
+	db            *pachsql.DB
 	tracker       track.Tracker
 	store         kv.Store
 	memCache      kv.GetPut
@@ -33,7 +33,7 @@ type Storage struct {
 }
 
 // NewStorage creates a new Storage.
-func NewStorage(objC obj.Client, memCache kv.GetPut, db *sqlx.DB, tracker track.Tracker, opts ...StorageOption) *Storage {
+func NewStorage(objC obj.Client, memCache kv.GetPut, db *pachsql.DB, tracker track.Tracker, opts ...StorageOption) *Storage {
 	s := &Storage{
 		objClient:     objC,
 		db:            db,

--- a/src/internal/storage/chunk/util.go
+++ b/src/internal/storage/chunk/util.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
@@ -15,7 +15,7 @@ import (
 
 // NewTestStorage creates a local storage instance for testing during the lifetime of
 // the callback.
-func NewTestStorage(t testing.TB, db *sqlx.DB, tr track.Tracker, opts ...StorageOption) (obj.Client, *Storage) {
+func NewTestStorage(t testing.TB, db *pachsql.DB, tr track.Tracker, opts ...StorageOption) (obj.Client, *Storage) {
 	objC := dockertestenv.NewTestObjClient(t)
 	db.MustExec(`CREATE SCHEMA IF NOT EXISTS storage`)
 	require.NoError(t, dbutil.WithTx(context.Background(), db, SetupPostgresStoreV0))

--- a/src/internal/storage/fileset/metadata_store.go
+++ b/src/internal/storage/fileset/metadata_store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
@@ -24,10 +23,10 @@ var (
 // All filesets exist in the same keyspace and can be merged by prefix
 type MetadataStore interface {
 	DB() *pachsql.DB
-	SetTx(tx *sqlx.Tx, id ID, md *Metadata) error
+	SetTx(tx *pachsql.Tx, id ID, md *Metadata) error
 	Get(ctx context.Context, id ID) (*Metadata, error)
-	GetTx(tx *sqlx.Tx, id ID) (*Metadata, error)
-	DeleteTx(tx *sqlx.Tx, id ID) error
+	GetTx(tx *pachsql.Tx, id ID) (*Metadata, error)
+	DeleteTx(tx *pachsql.Tx, id ID) error
 }
 
 // StoreTestSuite is a suite of tests for a Store.
@@ -55,13 +54,13 @@ func StoreTestSuite(t *testing.T, newStore func(t testing.TB) MetadataStore) {
 }
 
 func setMetadata(ctx context.Context, mds MetadataStore, id ID, md *Metadata) error {
-	return dbutil.WithTx(ctx, mds.DB(), func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, mds.DB(), func(tx *pachsql.Tx) error {
 		return mds.SetTx(tx, id, md)
 	})
 }
 
 func deleteMetadata(ctx context.Context, mds MetadataStore, id ID) error {
-	return dbutil.WithTx(ctx, mds.DB(), func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, mds.DB(), func(tx *pachsql.Tx) error {
 		return mds.DeleteTx(tx, id)
 	})
 }

--- a/src/internal/storage/fileset/metadata_store.go
+++ b/src/internal/storage/fileset/metadata_store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
@@ -22,7 +23,7 @@ var (
 // MetadataStore stores filesets. A fileset is a path -> index relationship
 // All filesets exist in the same keyspace and can be merged by prefix
 type MetadataStore interface {
-	DB() *sqlx.DB
+	DB() *pachsql.DB
 	SetTx(tx *sqlx.Tx, id ID, md *Metadata) error
 	Get(ctx context.Context, id ID) (*Metadata, error)
 	GetTx(tx *sqlx.Tx, id ID) (*Metadata, error)

--- a/src/internal/storage/fileset/postgres_store.go
+++ b/src/internal/storage/fileset/postgres_store.go
@@ -40,7 +40,7 @@ func (s *postgresStore) DB() *pachsql.DB {
 	return s.db
 }
 
-func (s *postgresStore) SetTx(tx *sqlx.Tx, id ID, md *Metadata) error {
+func (s *postgresStore) SetTx(tx *pachsql.Tx, id ID, md *Metadata) error {
 	if md == nil {
 		md = &Metadata{}
 	}
@@ -127,11 +127,11 @@ func (s *postgresStore) putInCache(ctx context.Context, id ID, md *Metadata) err
 	return s.cache.Put(ctx, id[:], mdData)
 }
 
-func (s *postgresStore) GetTx(tx *sqlx.Tx, id ID) (*Metadata, error) {
+func (s *postgresStore) GetTx(tx *pachsql.Tx, id ID) (*Metadata, error) {
 	return s.get(context.Background(), tx, id)
 }
 
-func (s *postgresStore) DeleteTx(tx *sqlx.Tx, id ID) error {
+func (s *postgresStore) DeleteTx(tx *pachsql.Tx, id ID) error {
 	_, err := tx.Exec(`DELETE FROM storage.filesets WHERE id = $1`, id)
 	return err
 }
@@ -139,7 +139,7 @@ func (s *postgresStore) DeleteTx(tx *sqlx.Tx, id ID) error {
 // SetupPostgresStoreV0 sets up the tables for a Store
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func SetupPostgresStoreV0(ctx context.Context, tx *sqlx.Tx) error {
+func SetupPostgresStoreV0(ctx context.Context, tx *pachsql.Tx) error {
 	const schema = `
 	CREATE TABLE storage.filesets (
 		id UUID NOT NULL PRIMARY KEY,

--- a/src/internal/storage/fileset/postgres_store.go
+++ b/src/internal/storage/fileset/postgres_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 )
@@ -20,14 +21,14 @@ import (
 var _ MetadataStore = &postgresStore{}
 
 type postgresStore struct {
-	db      *sqlx.DB
+	db      *pachsql.DB
 	cache   kv.GetPut
 	deduper *miscutil.WorkDeduper
 }
 
 // NewPostgresStore returns a Store backed by db
 // TODO: Expose configuration for cache size?
-func NewPostgresStore(db *sqlx.DB) MetadataStore {
+func NewPostgresStore(db *pachsql.DB) MetadataStore {
 	return &postgresStore{
 		db:      db,
 		cache:   kv.NewMemCache(100),
@@ -35,7 +36,7 @@ func NewPostgresStore(db *sqlx.DB) MetadataStore {
 	}
 }
 
-func (s *postgresStore) DB() *sqlx.DB {
+func (s *postgresStore) DB() *pachsql.DB {
 	return s.db
 }
 
@@ -151,7 +152,7 @@ func SetupPostgresStoreV0(ctx context.Context, tx *sqlx.Tx) error {
 }
 
 // NewTestStore returns a Store scoped to the lifetime of the test.
-func NewTestStore(t testing.TB, db *sqlx.DB) MetadataStore {
+func NewTestStore(t testing.TB, db *pachsql.DB) MetadataStore {
 	ctx := context.Background()
 	tx := db.MustBegin()
 	tx.MustExec(`CREATE SCHEMA IF NOT EXISTS storage`)

--- a/src/internal/storage/fileset/util.go
+++ b/src/internal/storage/fileset/util.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachhash"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
@@ -18,7 +18,7 @@ import (
 )
 
 // NewTestStorage constructs a local storage instance scoped to the lifetime of the test
-func NewTestStorage(t testing.TB, db *sqlx.DB, tr track.Tracker) *Storage {
+func NewTestStorage(t testing.TB, db *pachsql.DB, tr track.Tracker) *Storage {
 	_, chunks := chunk.NewTestStorage(t, db, tr)
 	store := NewTestStore(t, db)
 	return NewStorage(store, tr, chunks)

--- a/src/internal/storage/renew/tmp.go
+++ b/src/internal/storage/renew/tmp.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 )
@@ -21,7 +21,7 @@ func NewTmpDeleter() track.Deleter {
 	return &tmpDeleter{}
 }
 
-func (*tmpDeleter) DeleteTx(tx *sqlx.Tx, _ string) error {
+func (*tmpDeleter) DeleteTx(tx *pachsql.Tx, _ string) error {
 	return nil
 }
 

--- a/src/internal/storage/track/gc.go
+++ b/src/internal/storage/track/gc.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/sirupsen/logrus"
 )
 
 // Deleter is used to delete external data associated with a tracked object
 type Deleter interface {
-	DeleteTx(tx *sqlx.Tx, id string) error
+	DeleteTx(tx *pachsql.Tx, id string) error
 }
 
 // DeleterMux returns a Deleter based on the id being deleted
 type DeleterMux func(string) Deleter
 
 // DeleteTx implements Deleter
-func (dm DeleterMux) DeleteTx(tx *sqlx.Tx, id string) error {
+func (dm DeleterMux) DeleteTx(tx *pachsql.Tx, id string) error {
 	deleter := dm(id)
 	if deleter == nil {
 		return errors.Errorf("deleter mux does not have deleter for (%s)", id)
@@ -90,7 +90,7 @@ func (gc *GarbageCollector) RunOnce(ctx context.Context) (int, error) {
 
 func (gc *GarbageCollector) deleteObject(ctx context.Context, id string) error {
 	db := gc.tracker.DB()
-	return dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, db, func(tx *pachsql.Tx) error {
 		if err := gc.tracker.DeleteTx(tx, id); err != nil {
 			return err
 		}

--- a/src/internal/storage/track/postgres_tracker.go
+++ b/src/internal/storage/track/postgres_tracker.go
@@ -10,20 +10,21 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 var _ Tracker = &postgresTracker{}
 
 type postgresTracker struct {
-	db *sqlx.DB
+	db *pachsql.DB
 }
 
 // NewPostgresTracker returns a
-func NewPostgresTracker(db *sqlx.DB) Tracker {
+func NewPostgresTracker(db *pachsql.DB) Tracker {
 	return &postgresTracker{db: db}
 }
 
-func (t *postgresTracker) DB() *sqlx.DB {
+func (t *postgresTracker) DB() *pachsql.DB {
 	return t.db
 }
 

--- a/src/internal/storage/track/postgres_tracker_test.go
+++ b/src/internal/storage/track/postgres_tracker_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
@@ -19,7 +19,7 @@ func TestPostgresTracker(t *testing.T) {
 	track.TestTracker(t, func(testing.TB) track.Tracker {
 		db := dockertestenv.NewTestDB(t)
 		ctx := context.Background()
-		err := dbutil.WithTx(ctx, db, func(tx *sqlx.Tx) error {
+		err := dbutil.WithTx(ctx, db, func(tx *pachsql.Tx) error {
 			db.MustExec("CREATE SCHEMA storage")
 			return track.SetupPostgresTrackerV0(ctx, tx)
 		})

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -37,7 +36,7 @@ type Tracker interface {
 	// CreateTx creates an object with id=id, and pointers to everything in pointsTo
 	// It errors with ErrDifferentObjectExists if the object already exists.  Callers may be able to ignore this.
 	// It errors with ErrDanglingRef if any of the elements in pointsTo do not exist
-	CreateTx(tx *sqlx.Tx, id string, pointsTo []string, ttl time.Duration) error
+	CreateTx(tx *pachsql.Tx, id string, pointsTo []string, ttl time.Duration) error
 
 	// SetTTL sets the expiration time to current_time + ttl for the specified object
 	SetTTL(ctx context.Context, id string, ttl time.Duration) (time.Time, error)
@@ -53,7 +52,7 @@ type Tracker interface {
 
 	// DeleteTx deletes the object, or returns ErrDanglingRef if deleting it would create dangling refs.
 	// If the id doesn't exist, no error is returned
-	DeleteTx(tx *sqlx.Tx, id string) error
+	DeleteTx(tx *pachsql.Tx, id string) error
 
 	// IterateDeletable calls cb with all the objects objects which are no longer referenced and have expired
 	IterateDeletable(ctx context.Context, cb func(id string) error) error

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
@@ -31,7 +32,7 @@ const ExpireNow = time.Duration(math.MinInt32)
 // Tracker tracks objects and their references to one another.
 type Tracker interface {
 	// DB returns the database the tracker is using
-	DB() *sqlx.DB
+	DB() *pachsql.DB
 
 	// CreateTx creates an object with id=id, and pointers to everything in pointsTo
 	// It errors with ErrDifferentObjectExists if the object already exists.  Callers may be able to ignore this.
@@ -219,7 +220,7 @@ func runGC(t *testing.T, tracker Tracker) int {
 }
 
 // NewTestTracker returns a tracker scoped to the lifetime of the test
-func NewTestTracker(t testing.TB, db *sqlx.DB) Tracker {
+func NewTestTracker(t testing.TB, db *pachsql.DB) Tracker {
 	db.MustExec("CREATE SCHEMA IF NOT EXISTS storage")
 	db.MustExec(schema)
 	return NewPostgresTracker(db)

--- a/src/internal/storage/track/util.go
+++ b/src/internal/storage/track/util.go
@@ -4,20 +4,20 @@ import (
 	"context"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 // Create creates uses tracker to create the object id.
 func Create(ctx context.Context, tr Tracker, id string, pointsTo []string, ttl time.Duration) error {
-	return dbutil.WithTx(ctx, tr.DB(), func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, tr.DB(), func(tx *pachsql.Tx) error {
 		return tr.CreateTx(tx, id, pointsTo, ttl)
 	})
 }
 
 // Delete deletes id from the tracker
 func Delete(ctx context.Context, tr Tracker, id string) error {
-	return dbutil.WithTx(ctx, tr.DB(), func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, tr.DB(), func(tx *pachsql.Tx) error {
 		return tr.DeleteTx(tx, id)
 	})
 }

--- a/src/internal/testutil/db.go
+++ b/src/internal/testutil/db.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
@@ -45,15 +45,15 @@ func NewTestDBOptions(t testing.TB, opts []dbutil.Option) []dbutil.Option {
 }
 
 // NewTestDB connects to postgres using opts, creates a database
-// with a unique name then returns a sqlx.DB configured to use the newly created database.
+// with a unique name then returns a pachsql.DB configured to use the newly created database.
 // After t finishes, the database is dropped.
-func NewTestDB(t testing.TB, opts []dbutil.Option) *sqlx.DB {
+func NewTestDB(t testing.TB, opts []dbutil.Option) *pachsql.DB {
 	return OpenDB(t, NewTestDBOptions(t, opts)...)
 }
 
 // OpenDB connects to a database using opts and returns it.
 // The database will be closed at the end of the test.
-func OpenDB(t testing.TB, opts ...dbutil.Option) *sqlx.DB {
+func OpenDB(t testing.TB, opts ...dbutil.Option) *pachsql.DB {
 	db, err := dbutil.NewDB(opts...)
 	require.NoError(t, err)
 	require.NoError(t, db.Ping())
@@ -63,7 +63,7 @@ func OpenDB(t testing.TB, opts ...dbutil.Option) *sqlx.DB {
 
 // CreateEphemeralDB creates a new database using db with a lifetime scoped to the test t
 // and returns its name
-func CreateEphemeralDB(t testing.TB, db *sqlx.DB) string {
+func CreateEphemeralDB(t testing.TB, db *pachsql.DB) string {
 	dbName := ephemeralDBName(t)
 	_, err := db.Exec(`CREATE DATABASE ` + dbName)
 	require.NoError(t, err)

--- a/src/internal/transactiondb/transactiondb.go
+++ b/src/internal/transactiondb/transactiondb.go
@@ -3,9 +3,8 @@
 package transactiondb
 
 import (
-	"github.com/jmoiron/sqlx"
-
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/transaction"
 )
 
@@ -16,7 +15,7 @@ const (
 var transactionsIndexes = []*col.Index{}
 
 // Transactions returns a collection of open transactions
-func Transactions(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func Transactions(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		transactionsCollectionName,
 		db,

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/jmoiron/sqlx"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -293,7 +293,7 @@ func (env *TransactionEnv) WithTransaction(ctx context.Context, cb func(Transact
 	}
 }
 
-func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *sqlx.Tx, cb func(*txncontext.TransactionContext) error) error {
+func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *pachsql.Tx, cb func(*txncontext.TransactionContext) error) error {
 	txnCtx, err := txncontext.New(ctx, sqlTx, env.serviceEnv.AuthServer())
 	if err != nil {
 		return err
@@ -317,7 +317,7 @@ func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *sqlx.Tx, cb fun
 // WithWriteContext will call the given callback with a txncontext.TransactionContext
 // which can be used to perform reads and writes on the current cluster state.
 func (env *TransactionEnv) WithWriteContext(ctx context.Context, cb func(*txncontext.TransactionContext) error) error {
-	return dbutil.WithTx(ctx, env.serviceEnv.GetDBClient(), func(sqlTx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, env.serviceEnv.GetDBClient(), func(sqlTx *pachsql.Tx) error {
 		return env.attemptTx(ctx, sqlTx, cb)
 	})
 }
@@ -326,7 +326,7 @@ func (env *TransactionEnv) WithWriteContext(ctx context.Context, cb func(*txncon
 // which can be used to perform reads of the current cluster state. If the
 // transaction is used to perform any writes, they will be silently discarded.
 func (env *TransactionEnv) WithReadContext(ctx context.Context, cb func(*txncontext.TransactionContext) error) error {
-	return col.NewDryrunSQLTx(ctx, env.serviceEnv.GetDBClient(), func(sqlTx *sqlx.Tx) error {
+	return col.NewDryrunSQLTx(ctx, env.serviceEnv.GetDBClient(), func(sqlTx *pachsql.Tx) error {
 		return env.attemptTx(ctx, sqlTx, cb)
 	})
 }

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
@@ -20,7 +20,7 @@ import (
 type TransactionContext struct {
 	username string
 	// SqlTx is the ongoing database transaction.
-	SqlTx *sqlx.Tx
+	SqlTx *pachsql.Tx
 	// CommitSetID is the ID of the CommitSet corresponding to PFS changes in this transaction.
 	CommitSetID string
 	// Timestamp is the canonical timestamp to be used for writes in this transaction.
@@ -38,7 +38,7 @@ type identifier interface {
 	WhoAmI(context.Context, *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 }
 
-func New(ctx context.Context, sqlTx *sqlx.Tx, authServer identifier) (*TransactionContext, error) {
+func New(ctx context.Context, sqlTx *pachsql.Tx, authServer identifier) (*TransactionContext, error) {
 	var username string
 	// check auth once now so that we can refer to it later
 	if authServer != nil {

--- a/src/server/auth/db.go
+++ b/src/server/auth/db.go
@@ -1,12 +1,12 @@
 package auth
 
 import (
-	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"golang.org/x/net/context"
 )
 
 // CreateTokensTable sets up the postgres table which tracks active clusters
-func CreateAuthTokensTable(ctx context.Context, tx *sqlx.Tx) error {
+func CreateAuthTokensTable(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS auth.auth_tokens (
 	token_hash VARCHAR(4096) PRIMARY KEY,

--- a/src/server/auth/server/authdb.go
+++ b/src/server/auth/server/authdb.go
@@ -1,10 +1,9 @@
 package server
 
 import (
-	"github.com/jmoiron/sqlx"
-
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 const (
@@ -16,7 +15,7 @@ const (
 
 var authConfigIndexes = []*col.Index{}
 
-func authConfigCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func authConfigCollection(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		authConfigCollectionName,
 		db,
@@ -28,7 +27,7 @@ func authConfigCollection(db *sqlx.DB, listener col.PostgresListener) col.Postgr
 
 var roleBindingsIndexes = []*col.Index{}
 
-func roleBindingsCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func roleBindingsCollection(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		roleBindingsCollectionName,
 		db,
@@ -40,7 +39,7 @@ func roleBindingsCollection(db *sqlx.DB, listener col.PostgresListener) col.Post
 
 var membersIndexes = []*col.Index{}
 
-func membersCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func membersCollection(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		membersCollectionName,
 		db,
@@ -52,7 +51,7 @@ func membersCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresC
 
 var groupsIndexes = []*col.Index{}
 
-func groupsCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func groupsCollection(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		groupsCollectionName,
 		db,

--- a/src/server/auth/server/env.go
+++ b/src/server/auth/server/env.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	etcd "github.com/coreos/etcd/clientv3"
-	"github.com/jmoiron/sqlx"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/server/enterprise"
@@ -13,7 +13,7 @@ import (
 
 // Env is the environment required for an apiServer
 type Env struct {
-	DB         *sqlx.DB
+	DB         *pachsql.DB
 	EtcdClient *etcd.Client
 	Listener   col.PostgresListener
 	TxnEnv     *txnenv.TransactionEnv

--- a/src/server/identity/db.go
+++ b/src/server/identity/db.go
@@ -1,16 +1,16 @@
 package identity
 
 import (
-	"github.com/jmoiron/sqlx"
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 // CreateUsersTable sets up the postgres table which tracks active IDP users
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func CreateUsersTable(ctx context.Context, tx *sqlx.Tx) error {
+func CreateUsersTable(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 CREATE TABLE identity.users (
 	email VARCHAR(4096) PRIMARY KEY,
@@ -27,7 +27,7 @@ CREATE TABLE identity.users (
 // `issuer` must be a well-known URL where all pachds can reach this server.
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func CreateConfigTable(ctx context.Context, tx *sqlx.Tx) error {
+func CreateConfigTable(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 CREATE TABLE identity.config (
 	id INT PRIMARY KEY,
@@ -40,7 +40,7 @@ CREATE TABLE identity.config (
 // AddTokenExpiryConfig adds expiry fields for token lifespan to the server config
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func AddTokenExpiryConfig(ctx context.Context, tx *sqlx.Tx) error {
+func AddTokenExpiryConfig(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 ALTER TABLE identity.config ADD COLUMN
 	id_token_expiry VARCHAR(4096)`)
@@ -50,7 +50,7 @@ ALTER TABLE identity.config ADD COLUMN
 // AddRotationTokenExpiryConfig adds expiry fields for the rotation token lifespan to the server config
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func AddRotationTokenExpiryConfig(ctx context.Context, tx *sqlx.Tx) error {
+func AddRotationTokenExpiryConfig(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 ALTER TABLE identity.config ADD COLUMN
 	rotation_token_expiry VARCHAR(4096)`)

--- a/src/server/identity/server/db.go
+++ b/src/server/identity/server/db.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-
-	"github.com/jmoiron/sqlx"
 )
 
 func listUsers(ctx context.Context, db *pachsql.DB) ([]*identity.User, error) {
@@ -18,7 +16,7 @@ func listUsers(ctx context.Context, db *pachsql.DB) ([]*identity.User, error) {
 	return users, nil
 }
 
-func addUserInTx(ctx context.Context, tx *sqlx.Tx, email string) error {
+func addUserInTx(ctx context.Context, tx *pachsql.Tx, email string) error {
 	_, err := tx.ExecContext(ctx, `INSERT INTO identity.users (email, last_authenticated, enabled) VALUES ($1, now(), true) ON CONFLICT(email) DO UPDATE SET last_authenticated=NOW()`, email)
 	return err
 }

--- a/src/server/identity/server/db.go
+++ b/src/server/identity/server/db.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pachyderm/pachyderm/v2/src/identity"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 
 	"github.com/jmoiron/sqlx"
 )
 
-func listUsers(ctx context.Context, db *sqlx.DB) ([]*identity.User, error) {
+func listUsers(ctx context.Context, db *pachsql.DB) ([]*identity.User, error) {
 	users := make([]*identity.User, 0)
 	err := db.SelectContext(ctx, &users, "SELECT email, last_authenticated FROM identity.users WHERE enabled=true;")
 	if err != nil {

--- a/src/server/identity/server/dex_web.go
+++ b/src/server/identity/server/dex_web.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -227,7 +227,7 @@ func (w *dexWeb) interceptApproval(server *dex_server.Server) func(http.Response
 			rw.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		if err := dbutil.WithTx(r.Context(), w.env.DB, func(tx *sqlx.Tx) error {
+		if err := dbutil.WithTx(r.Context(), w.env.DB, func(tx *pachsql.Tx) error {
 			err := addUserInTx(r.Context(), tx, authReq.Claims.Email)
 			return errors.Wrapf(err, "unable to record user identity for login")
 		}); err != nil {

--- a/src/server/identity/server/env.go
+++ b/src/server/identity/server/env.go
@@ -2,14 +2,14 @@ package server
 
 import (
 	"github.com/dexidp/dex/storage"
-	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	logrus "github.com/sirupsen/logrus"
 )
 
 // Env is the set of dependencies required by the API server
 type Env struct {
-	DB         *sqlx.DB
+	DB         *pachsql.DB
 	DexStorage storage.Storage
 	Logger     *logrus.Logger
 }

--- a/src/server/license/db.go
+++ b/src/server/license/db.go
@@ -1,16 +1,16 @@
 package license
 
 import (
-	"github.com/jmoiron/sqlx"
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 // CreateClustersTable sets up the postgres table which tracks active clusters
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func CreateClustersTableV0(ctx context.Context, tx *sqlx.Tx) error {
+func CreateClustersTableV0(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 CREATE TABLE license.clusters (
 	id VARCHAR(4096) PRIMARY KEY,
@@ -27,7 +27,7 @@ CREATE TABLE license.clusters (
 
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func AddUserContextsToClustersTable(ctx context.Context, tx *sqlx.Tx) error {
+func AddUserContextsToClustersTable(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 	ALTER TABLE license.clusters
 	ADD COLUMN cluster_deployment_id VARCHAR(4096),
@@ -39,7 +39,7 @@ func AddUserContextsToClustersTable(ctx context.Context, tx *sqlx.Tx) error {
 
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func AddClusterClientIdColumn(ctx context.Context, tx *sqlx.Tx) error {
+func AddClusterClientIdColumn(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 	ALTER TABLE license.clusters
 	ADD COLUMN client_id VARCHAR(4096)

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -16,6 +15,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/license"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/random"
 	lc "github.com/pachyderm/pachyderm/v2/src/license"
 )
@@ -73,7 +73,7 @@ func (a *apiServer) Activate(ctx context.Context, req *lc.ActivateRequest) (resp
 		Expires:        expirationProto,
 	}
 
-	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *pachsql.Tx) error {
 		return a.license.ReadWrite(sqlTx).Put(licenseRecordKey, newRecord)
 	}); err != nil {
 		return nil, err
@@ -250,7 +250,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, req *lc.DeleteAllRequest) (re
 		return nil, errors.Wrapf(err, "unable to delete clusters in database")
 	}
 
-	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *pachsql.Tx) error {
 		err := a.license.ReadWrite(sqlTx).Delete(licenseRecordKey)
 		if err != nil && !col.IsErrNotFound(err) {
 			return err

--- a/src/server/license/server/col.go
+++ b/src/server/license/server/col.go
@@ -1,10 +1,9 @@
 package server
 
 import (
-	"github.com/jmoiron/sqlx"
-
 	ec "github.com/pachyderm/pachyderm/v2/src/enterprise"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 const (
@@ -13,7 +12,7 @@ const (
 
 var licenseIndexes = []*col.Index{}
 
-func licenseCollection(db *sqlx.DB, listener col.PostgresListener) col.PostgresCollection {
+func licenseCollection(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
 	return col.NewPostgresCollection(
 		licenseCollectionName,
 		db,

--- a/src/server/license/server/env.go
+++ b/src/server/license/server/env.go
@@ -1,15 +1,15 @@
 package server
 
 import (
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/sirupsen/logrus"
 )
 
 // Env is the dependencies required for a license API Server
 type Env struct {
-	DB       *sqlx.DB
+	DB       *pachsql.DB
 	Listener collection.PostgresListener
 
 	Logger *logrus.Logger

--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
@@ -44,12 +45,12 @@ var _ commitStore = &postgresCommitStore{}
 // TODO: add deleter for the commitStore and stop making permanent filesets, keep the filesets
 // around, by referencing them with commit-fileset objects.
 type postgresCommitStore struct {
-	db *sqlx.DB
+	db *pachsql.DB
 	s  *fileset.Storage
 	tr track.Tracker
 }
 
-func newPostgresCommitStore(db *sqlx.DB, tr track.Tracker, s *fileset.Storage) *postgresCommitStore {
+func newPostgresCommitStore(db *pachsql.DB, tr track.Tracker, s *fileset.Storage) *postgresCommitStore {
 	return &postgresCommitStore{
 		db: db,
 		s:  s,

--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/jmoiron/sqlx"
-
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -23,21 +21,21 @@ type commitStore interface {
 	// AddFileSet appends a fileset to the diff.
 	AddFileSet(ctx context.Context, commit *pfs.Commit, filesetID fileset.ID) error
 	// AddFileSetTx is identical to AddFileSet except it runs in the provided transaction.
-	AddFileSetTx(tx *sqlx.Tx, commit *pfs.Commit, filesetID fileset.ID) error
+	AddFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, filesetID fileset.ID) error
 	// SetTotalFileSet sets the total fileset for the commit, overwriting whatever is there.
 	SetTotalFileSet(ctx context.Context, commit *pfs.Commit, id fileset.ID) error
 	// SetTotalFileSetTx is like SetTotalFileSet, but in a transaction
-	SetTotalFileSetTx(tx *sqlx.Tx, commit *pfs.Commit, id fileset.ID) error
+	SetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, id fileset.ID) error
 	// GetTotalFileSet returns the total fileset for a commit.
 	GetTotalFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error)
 	// GetTotalFileSetTx is like GetTotalFileSet, but in a transaction
-	GetTotalFileSetTx(tx *sqlx.Tx, commit *pfs.Commit) (*fileset.ID, error)
+	GetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit) (*fileset.ID, error)
 	// GetDiffFileSet returns the diff fileset for a commit
 	GetDiffFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error)
 	// DropFileSets clears the diff and total filesets for the commit.
 	DropFileSets(ctx context.Context, commit *pfs.Commit) error
 	// DropFileSetsTx is identical to DropFileSets except it runs in the provided transaction.
-	DropFileSetsTx(tx *sqlx.Tx, commit *pfs.Commit) error
+	DropFileSetsTx(tx *pachsql.Tx, commit *pfs.Commit) error
 }
 
 var _ commitStore = &postgresCommitStore{}
@@ -59,12 +57,12 @@ func newPostgresCommitStore(db *pachsql.DB, tr track.Tracker, s *fileset.Storage
 }
 
 func (cs *postgresCommitStore) AddFileSet(ctx context.Context, commit *pfs.Commit, id fileset.ID) error {
-	return dbutil.WithTx(ctx, cs.db, func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, cs.db, func(tx *pachsql.Tx) error {
 		return cs.AddFileSetTx(tx, commit, id)
 	})
 }
 
-func (cs *postgresCommitStore) AddFileSetTx(tx *sqlx.Tx, commit *pfs.Commit, id fileset.ID) error {
+func (cs *postgresCommitStore) AddFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, id fileset.ID) error {
 	id2, err := cs.s.CloneTx(tx, id, defaultTTL)
 	if err != nil {
 		return err
@@ -89,7 +87,7 @@ func (cs *postgresCommitStore) AddFileSetTx(tx *sqlx.Tx, commit *pfs.Commit, id 
 
 func (cs *postgresCommitStore) GetTotalFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
 	var id *fileset.ID
-	if err := dbutil.WithTx(ctx, cs.db, func(tx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, cs.db, func(tx *pachsql.Tx) error {
 		var err error
 		id, err = cs.GetTotalFileSetTx(tx, commit)
 		return err
@@ -99,7 +97,7 @@ func (cs *postgresCommitStore) GetTotalFileSet(ctx context.Context, commit *pfs.
 	return id, nil
 }
 
-func (cs *postgresCommitStore) GetTotalFileSetTx(tx *sqlx.Tx, commit *pfs.Commit) (*fileset.ID, error) {
+func (cs *postgresCommitStore) GetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit) (*fileset.ID, error) {
 	id, err := getTotal(tx, commit)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
@@ -112,7 +110,7 @@ func (cs *postgresCommitStore) GetTotalFileSetTx(tx *sqlx.Tx, commit *pfs.Commit
 
 func (cs *postgresCommitStore) GetDiffFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
 	var ids []fileset.ID
-	if err := dbutil.WithTx(ctx, cs.db, func(tx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, cs.db, func(tx *pachsql.Tx) error {
 		var err error
 		ids, err = getDiff(tx, commit)
 		if err != nil && err != sql.ErrNoRows {
@@ -126,12 +124,12 @@ func (cs *postgresCommitStore) GetDiffFileSet(ctx context.Context, commit *pfs.C
 }
 
 func (cs *postgresCommitStore) SetTotalFileSet(ctx context.Context, commit *pfs.Commit, id fileset.ID) error {
-	return dbutil.WithTx(ctx, cs.db, func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, cs.db, func(tx *pachsql.Tx) error {
 		return cs.SetTotalFileSetTx(tx, commit, id)
 	})
 }
 
-func (cs *postgresCommitStore) SetTotalFileSetTx(tx *sqlx.Tx, commit *pfs.Commit, id fileset.ID) error {
+func (cs *postgresCommitStore) SetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, id fileset.ID) error {
 	if err := dropTotal(tx, cs.tr, commit); err != nil {
 		return err
 	}
@@ -139,19 +137,19 @@ func (cs *postgresCommitStore) SetTotalFileSetTx(tx *sqlx.Tx, commit *pfs.Commit
 }
 
 func (cs *postgresCommitStore) DropFileSets(ctx context.Context, commit *pfs.Commit) error {
-	return dbutil.WithTx(ctx, cs.db, func(tx *sqlx.Tx) error {
+	return dbutil.WithTx(ctx, cs.db, func(tx *pachsql.Tx) error {
 		return cs.DropFileSetsTx(tx, commit)
 	})
 }
 
-func (cs *postgresCommitStore) DropFileSetsTx(tx *sqlx.Tx, commit *pfs.Commit) error {
+func (cs *postgresCommitStore) DropFileSetsTx(tx *pachsql.Tx, commit *pfs.Commit) error {
 	if err := dropTotal(tx, cs.tr, commit); err != nil {
 		return err
 	}
 	return cs.dropDiff(tx, commit)
 }
 
-func (cs *postgresCommitStore) dropDiff(tx *sqlx.Tx, commit *pfs.Commit) error {
+func (cs *postgresCommitStore) dropDiff(tx *pachsql.Tx, commit *pfs.Commit) error {
 	diffIDs, err := getDiff(tx, commit)
 	if err != nil {
 		return err
@@ -168,7 +166,7 @@ func (cs *postgresCommitStore) dropDiff(tx *sqlx.Tx, commit *pfs.Commit) error {
 	return nil
 }
 
-func getDiff(tx *sqlx.Tx, commit *pfs.Commit) ([]fileset.ID, error) {
+func getDiff(tx *pachsql.Tx, commit *pfs.Commit) ([]fileset.ID, error) {
 	var ids []fileset.ID
 	if err := tx.Select(&ids,
 		`SELECT fileset_id FROM pfs.commit_diffs
@@ -180,7 +178,7 @@ func getDiff(tx *sqlx.Tx, commit *pfs.Commit) ([]fileset.ID, error) {
 	return ids, nil
 }
 
-func getTotal(tx *sqlx.Tx, commit *pfs.Commit) (*fileset.ID, error) {
+func getTotal(tx *pachsql.Tx, commit *pfs.Commit) (*fileset.ID, error) {
 	var id fileset.ID
 	if err := tx.Get(&id,
 		`SELECT fileset_id FROM pfs.commit_totals
@@ -191,7 +189,7 @@ func getTotal(tx *sqlx.Tx, commit *pfs.Commit) (*fileset.ID, error) {
 	return &id, nil
 }
 
-func dropTotal(tx *sqlx.Tx, tr track.Tracker, commit *pfs.Commit) error {
+func dropTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit) error {
 	id, err := getTotal(tx, commit)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -207,7 +205,7 @@ func dropTotal(tx *sqlx.Tx, tr track.Tracker, commit *pfs.Commit) error {
 	return err
 }
 
-func setTotal(tx *sqlx.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.ID) error {
+func setTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.ID) error {
 	oid := commitTotalTrackerID(commit, id)
 	pointsTo := []string{id.TrackerID()}
 	if err := tr.CreateTx(tx, oid, pointsTo, track.NoTTL); err != nil {
@@ -233,7 +231,7 @@ func commitTotalTrackerID(commit *pfs.Commit, fs fileset.ID) string {
 // SetupPostgresCommitStoreV0 runs SQL to setup the commit store.
 // DO NOT MODIFY THIS FUNCTION
 // IT HAS BEEN USED IN A RELEASED MIGRATION
-func SetupPostgresCommitStoreV0(ctx context.Context, tx *sqlx.Tx) error {
+func SetupPostgresCommitStoreV0(ctx context.Context, tx *pachsql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 		CREATE TABLE pfs.commit_diffs (
 			commit_id TEXT NOT NULL,

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
@@ -33,7 +34,6 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -955,7 +955,7 @@ func (d *driver) inspectCommit(ctx context.Context, commit *pfs.Commit, wait pfs
 // be a commit ID or branch reference, plus '~' and/or '^') to a repo + commit
 // ID. It accepts a postgres transaction so that it can be used in a transaction
 // and avoids an inconsistent call to d.inspectCommit()
-func (d *driver) resolveCommit(sqlTx *sqlx.Tx, userCommit *pfs.Commit) (*pfs.CommitInfo, error) {
+func (d *driver) resolveCommit(sqlTx *pachsql.Tx, userCommit *pfs.Commit) (*pfs.CommitInfo, error) {
 	if userCommit == nil {
 		return nil, errors.Errorf("cannot resolve nil commit")
 	}

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/jmoiron/sqlx"
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
@@ -286,7 +286,7 @@ func (d *driver) fsck(ctx context.Context, fix bool, cb func(*pfs.FsckResponse) 
 	// TODO(global ids): is there any verification we can do for commitsets?
 
 	if fix {
-		return dbutil.WithTx(ctx, d.env.DB, func(sqlTx *sqlx.Tx) error {
+		return dbutil.WithTx(ctx, d.env.DB, func(sqlTx *pachsql.Tx) error {
 			for _, ci := range newCommitInfos {
 				// We've observed users getting ErrExists from this create,
 				// which doesn't make a lot of sense, but we insulate against

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -4,10 +4,10 @@ import (
 	"path"
 
 	etcd "github.com/coreos/etcd/clientv3"
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth"
@@ -19,7 +19,7 @@ import (
 // Env is the dependencies needed to run the PFS API server
 type Env struct {
 	ObjectClient obj.Client
-	DB           *sqlx.DB
+	DB           *pachsql.DB
 	EtcdPrefix   string
 	EtcdClient   *etcd.Client
 	TxnEnv       *txnenv.TransactionEnv

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
@@ -14,6 +13,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dlock"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -176,7 +176,7 @@ eventLoop:
 
 // setPipelineState is a PPS-master-specific helper that wraps
 // ppsutil.SetPipelineState in a trace
-func setPipelineState(ctx context.Context, db *sqlx.DB, pipelines collection.PostgresCollection, specCommit *pfs.Commit, state pps.PipelineState, reason string) (retErr error) {
+func setPipelineState(ctx context.Context, db *pachsql.DB, pipelines collection.PostgresCollection, specCommit *pfs.Commit, state pps.PipelineState, reason string) (retErr error) {
 	span, ctx := tracing.AddSpanToAnyExisting(ctx,
 		"/pps.Master/SetPipelineState", "pipeline", specCommit.Branch.Repo.Name, "new-state", state)
 	defer func() {

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -6,11 +6,11 @@ import (
 
 	etcd "github.com/coreos/etcd/clientv3"
 	loki "github.com/grafana/loki/pkg/logcli/client"
-	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
@@ -23,7 +23,7 @@ import (
 
 // Env contains the dependencies needed to create an API Server
 type Env struct {
-	DB         *sqlx.DB
+	DB         *pachsql.DB
 	TxnEnv     *txnenv.TransactionEnv
 	Listener   collection.PostgresListener
 	KubeClient *kubernetes.Clientset

--- a/src/server/transaction/server/api_server.go
+++ b/src/server/transaction/server/api_server.go
@@ -4,11 +4,11 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/transaction"
@@ -89,7 +89,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *transaction.DeleteAl
 	func() { a.Log(request, nil, nil, 0) }()
 	defer func(start time.Time) { a.Log(request, response, retErr, time.Since(start)) }(time.Now())
 
-	if err := dbutil.WithTx(ctx, a.driver.db, func(sqlTx *sqlx.Tx) error {
+	if err := dbutil.WithTx(ctx, a.driver.db, func(sqlTx *pachsql.Tx) error {
 		return a.driver.deleteAll(ctx, sqlTx, nil)
 	}); err != nil {
 		return nil, err

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactiondb"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
@@ -24,7 +25,7 @@ type driver struct {
 	// txnEnv stores references to other pachyderm APIServer instances so we can
 	// make calls within the same transaction without serializing through RPCs
 	txnEnv       *txnenv.TransactionEnv
-	db           *sqlx.DB
+	db           *pachsql.DB
 	transactions col.PostgresCollection
 }
 

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jmoiron/sqlx"
-
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
@@ -108,13 +107,13 @@ func (td *testDriver) RunUserCode(ctx context.Context, logger logs.TaggedLogger,
 func (td *testDriver) RunUserErrorHandlingCode(ctx context.Context, logger logs.TaggedLogger, env []string) error {
 	return td.inner.RunUserErrorHandlingCode(ctx, logger, env)
 }
-func (td *testDriver) DeleteJob(sqlTx *sqlx.Tx, ji *pps.JobInfo) error {
+func (td *testDriver) DeleteJob(sqlTx *pachsql.Tx, ji *pps.JobInfo) error {
 	return td.inner.DeleteJob(sqlTx, ji)
 }
 func (td *testDriver) UpdateJobState(job *pps.Job, state pps.JobState, reason string) error {
 	return td.inner.UpdateJobState(job, state, reason)
 }
-func (td *testDriver) NewSQLTx(cb func(*sqlx.Tx) error) error {
+func (td *testDriver) NewSQLTx(cb func(*pachsql.Tx) error) error {
 	return td.inner.NewSQLTx(cb)
 }
 

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -18,6 +17,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
@@ -221,7 +221,7 @@ func (reg *registry) superviseJob(pj *pendingJob) error {
 			}
 			// Output commit was deleted. Delete job as well
 			// TODO: This should be handled through a transaction defer when the commit is squashed.
-			if err := pj.driver.NewSQLTx(func(sqlTx *sqlx.Tx) error {
+			if err := pj.driver.NewSQLTx(func(sqlTx *pachsql.Tx) error {
 				// Delete the job if no other worker has deleted it yet
 				jobInfo := &pps.JobInfo{}
 				if err := pj.driver.Jobs().ReadWrite(sqlTx).Get(ppsdb.JobKey(pj.ji.Job), jobInfo); err != nil {

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/jmoiron/sqlx"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -19,6 +18,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -90,7 +90,7 @@ func newWorkerSpawnerPair(t *testing.T, dbConfig serviceenv.ConfigOption, pipeli
 	require.NoError(t, err)
 
 	// Put the pipeline info into the collection (which is read by the master)
-	err = env.driver.NewSQLTx(func(sqlTx *sqlx.Tx) error {
+	err = env.driver.NewSQLTx(func(sqlTx *pachsql.Tx) error {
 		pipelineInfo := &pps.PipelineInfo{
 			State:       pps.PipelineState_PIPELINE_STARTING,
 			Version:     1,


### PR DESCRIPTION
Blocked on #7032 

This should be a non-functional change.  Just a refactor, split out from the db URL PR.