### PR TITLE
Use a real context in the chunk renewer

### DIFF
--- a/src/internal/storage/chunk/client.go
+++ b/src/internal/storage/chunk/client.go
@@ -33,26 +33,21 @@ type trackedClient struct {
 
 // NewClient returns a client which will write to objc, mdstore, and tracker.  Name is used
 // for the set of temporary objects
-func NewClient(store kv.Store, db *sqlx.DB, tr track.Tracker, name string) Client {
-	var renewer *Renewer
-	if name != "" {
-		renewer = NewRenewer(tr, name, defaultChunkTTL)
-	}
-	c := &trackedClient{
+func NewClient(store kv.Store, db *sqlx.DB, tr track.Tracker, renewer *Renewer) Client {
+	return &trackedClient{
 		store:   store,
 		db:      db,
 		tracker: tr,
 		renewer: renewer,
 		ttl:     defaultChunkTTL,
 	}
-	return c
 }
 
 // Create creates a new chunk from metadata and chunkData.
 // It returns the ID for the chunk
 func (c *trackedClient) Create(ctx context.Context, md Metadata, chunkData []byte) (_ ID, retErr error) {
 	if c.renewer == nil {
-		panic("client must be named to create chunks")
+		panic("client must have a renewer to create chunks")
 	}
 	chunkID := Hash(chunkData)
 	var pointsTo []string

--- a/src/internal/storage/chunk/renewer.go
+++ b/src/internal/storage/chunk/renewer.go
@@ -12,14 +12,14 @@ type Renewer struct {
 	ss *renew.StringSet
 }
 
-func NewRenewer(tr track.Tracker, name string, ttl time.Duration) *Renewer {
+func NewRenewer(ctx context.Context, tr track.Tracker, name string, ttl time.Duration) *Renewer {
 	renewFunc := func(ctx context.Context, x string, ttl time.Duration) error {
 		_, err := tr.SetTTL(ctx, x, ttl)
 		return err
 	}
 	composeFunc := renew.NewTmpComposer(tr, name)
 	return &Renewer{
-		ss: renew.NewStringSet(context.TODO(), ttl, renewFunc, composeFunc),
+		ss: renew.NewStringSet(ctx, ttl, renewFunc, composeFunc),
 	}
 }
 

--- a/src/internal/storage/chunk/storage.go
+++ b/src/internal/storage/chunk/storage.go
@@ -55,8 +55,7 @@ func NewStorage(objC obj.Client, memCache kv.GetPut, db *sqlx.DB, tracker track.
 
 // NewReader creates a new Reader.
 func (s *Storage) NewReader(ctx context.Context, dataRefs []*DataRef, opts ...ReaderOption) *Reader {
-	// using the empty string for the tmp id to disable the renewer
-	client := NewClient(s.store, s.db, s.tracker, "")
+	client := NewClient(s.store, s.db, s.tracker, nil)
 	return newReader(ctx, client, s.memCache, s.deduper, s.prefetchLimit, dataRefs, opts...)
 }
 
@@ -67,7 +66,7 @@ func (s *Storage) NewWriter(ctx context.Context, name string, cb WriterCallback,
 	if name == "" {
 		panic("name must not be empty")
 	}
-	client := NewClient(s.store, s.db, s.tracker, name)
+	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL))
 	return newWriter(ctx, client, s.memCache, s.deduper, s.createOpts, cb, opts...)
 }
 


### PR DESCRIPTION
This PR refactors the chunk renewer setup slightly to allow us to use a real context. A real context is needed to cancel the renewal in the error case because a file set writer is only closed when it is successful.