### PR TITLE
Improve tracker GC query performance.

### DIFF
--- a/src/internal/storage/track/postgres_tracker.go
+++ b/src/internal/storage/track/postgres_tracker.go
@@ -218,28 +218,23 @@ func (t *postgresTracker) DeleteTx(tx *sqlx.Tx, id string) error {
 }
 
 func (t *postgresTracker) IterateDeletable(ctx context.Context, cb func(id string) error) (retErr error) {
-	rows, err := t.db.QueryxContext(ctx,
-		`SELECT str_id FROM storage.tracker_objects
-		WHERE int_id NOT IN (SELECT to_id FROM storage.tracker_refs)
-		AND expires_at <= CURRENT_TIMESTAMP`)
+	var toDelete []string
+	// select 1 in inner query as we don't actually care about the results, just existence
+	// set arbitrary limit to guarantee we can iterate, doesn't matter for GC as we run this repeatedly
+	err := t.db.SelectContext(ctx, &toDelete,
+		`SELECT str_id FROM storage.tracker_objects as objs
+		WHERE NOT EXISTS (SELECT 1 FROM storage.tracker_refs as refs where objs.int_id = refs.to_id)
+		AND expires_at <= CURRENT_TIMESTAMP LIMIT 10000`)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := rows.Close(); retErr == nil {
-			retErr = err
-		}
-	}()
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return err
-		}
+
+	for _, id := range toDelete {
 		if err := cb(id); err != nil {
 			return err
 		}
 	}
-	return rows.Err()
+	return nil
 }
 
 func (t *postgresTracker) getDownstream(tx *sqlx.Tx, intID int) ([]string, error) {

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -54,7 +54,8 @@ type Tracker interface {
 	// If the id doesn't exist, no error is returned
 	DeleteTx(tx *sqlx.Tx, id string) error
 
-	// IterateDeletable calls cb with all the objects objects which are no longer referenced and have expired
+	// IterateDeletable calls cb with some top-level objects which are no longer referenced and have expired
+	// Even if it deletes all top-level objects, there may be more to delete after it runs
 	IterateDeletable(ctx context.Context, cb func(id string) error) error
 }
 


### PR DESCRIPTION
In some database engines, NOT IN prevents certain optimizations (in
particular, treating the query as an anti-join) even when all columns
involved are marked NOT NULL. Switching this to an equivalent NOT EXISTS
query resulted in a dramatic speedup when tested on a customer cluster.

Additionally, to avoid needlessly holding a query open, add a limit to
the deletable object query and simply iterate over the results in a
slice. We already run the query multiple times until completion, so no
other code needs to change.