### PR TITLE
Add special error message for inspect job/commit.

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -367,7 +367,7 @@ $ {{alias}} test@fork -p XXX`,
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			commit, err := cmdutil.ParseCommit(args[0])
 			if err != nil && uuid.IsUUIDWithoutDashes(args[0]) {
-				return errors.New(`Use "list commit <id>" to see commits with a given ID across different repos `)
+				return errors.New(`Use "list commit <id>" to see commits with a given ID across different repos`)
 			} else {
 				return err
 			}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -366,7 +366,9 @@ $ {{alias}} test@fork -p XXX`,
 		Long:  "Return info about a commit.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			commit, err := cmdutil.ParseCommit(args[0])
-			if err != nil {
+			if err != nil && uuid.IsUUIDWithoutDashes(args[0]) {
+				return errors.New(`Use "list commit <id>" to see commits with a given ID across different repos `)
+			} else {
 				return err
 			}
 			c, err := client.NewOnUserMachine("user")

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -77,7 +77,7 @@ If the job fails, the output commit will not be populated with data.`,
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			job, err := cmdutil.ParseJob(args[0])
 			if err != nil && uuid.IsUUIDWithoutDashes(args[0]) {
-				return errors.New(`Use "list job <id>" to see jobs with a given ID across different pipelines `)
+				return errors.New(`Use "list job <id>" to see jobs with a given ID across different pipelines`)
 			} else {
 				return err
 			}

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -76,7 +76,9 @@ If the job fails, the output commit will not be populated with data.`,
 		Long:  "Return info about a job.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			job, err := cmdutil.ParseJob(args[0])
-			if err != nil {
+			if err != nil && uuid.IsUUIDWithoutDashes(args[0]) {
+				return errors.New(`Use "list job <id>" to see jobs with a given ID across different pipelines `)
+			} else {
 				return err
 			}
 			client, err := pachdclient.NewOnUserMachine("user")


### PR DESCRIPTION
It seems reasonable to expect "inspect job <ID>" to do what "list job
<ID>" does, so if we detect that usage we should nudge users towards
the intended command.

Fix #7065 