### PR TITLE
First pass at supporting reading from open commits in s3g

### DIFF
--- a/src/server/pfs/s3/bucket.go
+++ b/src/server/pfs/s3/bucket.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gogo/protobuf/types"
 	glob "github.com/pachyderm/ohmyglob"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ancestry"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
@@ -17,7 +16,7 @@ import (
 )
 
 func newContents(fileInfo *pfsClient.FileInfo) (s2.Contents, error) {
-	t, err := types.TimestampFromProto(fileInfo.Committed)
+	t, err := permissiveTimestampFromProto(fileInfo)
 	if err != nil {
 		return s2.Contents{}, err
 	}

--- a/src/server/pfs/s3/multipart.go
+++ b/src/server/pfs/s3/multipart.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
@@ -131,7 +130,7 @@ func (c *controller) ListMultipart(r *http.Request, bucketName, keyMarker, uploa
 			return errutil.ErrBreak
 		}
 
-		timestamp, err := types.TimestampFromProto(fileInfo.Committed)
+		timestamp, err := permissiveTimestampFromProto(fileInfo)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
S3G currently errors when trying to list or read objects in open commits:

```
2021-11-11 05:52:37,366 - MainThread - botocore.parsers - DEBUG - Response body:
b'<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>InternalError</Code><Message>timestamp: nil Timestamp</Message><Resource>/master.hello</Resource><RequestId>9afa06d0-853e-49d8-b7
```

I hypothesize this is due to files in open commits not yet having a `Committed` time recorded in Pach, so we hit the error case here: https://github.com/pachyderm/pachyderm/blob/master/src/server/pfs/s3/bucket.go#L20-L23

In protobuf module source we can see the same error message we're getting on the client in the function `validateTimestamp` that `TimestampFromProto` calls:
```
func validateTimestamp(ts *Timestamp) error {
	if ts == nil {
		return errors.New("timestamp: nil Timestamp")
	}
```

This PR makes S3G just return 1970-01-01 timestamps for those files, because listing objects with the wrong modified time is better than failing to list them at all.

A less wrong answer might be to list a more recent known time (lower bound) on the modification time, but doing that well requires more insight than I have at present. (e.g. can we return the correct commit time for files that were last modified in earlier commits, and return the timestamp of the start of the open commit for files that have been modified in the open commit?)