### PR TITLE
Add confirm prompt to port-forward.

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -560,7 +560,12 @@ This resets the cluster to its initial state.`,
 				return err
 			}
 			if context.PortForwarders != nil && len(context.PortForwarders) > 0 {
-				return errors.New("port forwarding appears to already be running for this context")
+				fmt.Println("Port forwarding appears to already be running for this context. Running multiple forwarders may not work correctly.")
+				if ok, err := cmdutil.InteractiveConfirm(); err != nil {
+					return err
+				} else if !ok {
+					return nil
+				}
 			}
 
 			fw, err := client.NewPortForwarder(context, namespace)


### PR DESCRIPTION
If the port forwarder doesn't clean up the context when it exits,
subsequent calls will error out, requiring a user to go in and delete
lines from the config file. For a quick fix, just add a confirm that
will start forwarding anyway if asked.