### PR TITLE
[2.0.x PR] Stop pachctl mount panicking on unmount and 200x performance 😉  (#7092)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grafana/loki v1.5.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340
-	github.com/hanwen/go-fuse/v2 v2.0.3
+	github.com/hanwen/go-fuse/v2 v2.1.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/itchyny/gojq v0.11.2
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451

--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,8 @@ github.com/hanwen/go-fuse v1.0.0 h1:GxS9Zrn6c35/BnfiVsZVWmsG803xwE7eVRDvcf/BEVc=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.0.3 h1:kpV28BKeSyVgZREItBLnaVBvOEwv2PuhNdKetwnvNHo=
 github.com/hanwen/go-fuse/v2 v2.0.3/go.mod h1:0EQM6aH2ctVpvZ6a+onrQ/vaykxh2GH7hy3e13vzTUY=
+github.com/hanwen/go-fuse/v2 v2.1.0 h1:+32ffteETaLYClUj0a3aHjZ1hOPxxaNEHiZiujuDaek=
+github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -1248,6 +1250,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
* Stop pachctl mount panicking on unmount.

Looks like the go-fuse lib changed its behavior from the consumer having to call Serve() to Mount() calling Serve() automatically, this change switches the extra Serve() for a Wait() so that we just wait on the lib's call. This fixes the following panic (and various flavors like it):

panic: sync: negative WaitGroup counter

goroutine 835 [running]:
sync.(*WaitGroup).Add(0xc000db80b8, 0xc0016c01b0)
        /snap/go/8627/src/sync/waitgroup.go:74 +0x105
sync.(*WaitGroup).Done(0x0)
        /snap/go/8627/src/sync/waitgroup.go:99 +0x25
github.com/hanwen/go-fuse/v2/fuse.(*Server).loop(0xc000db8000, 0x0)
        /home/luke/gocode/pkg/mod/github.com/hanwen/go-fuse/v2@v2.0.3/fuse/server.go:448 +0x194
github.com/hanwen/go-fuse/v2/fuse.(*Server).Serve(0xc000db8000)
        /home/luke/gocode/pkg/mod/github.com/hanwen/go-fuse/v2@v2.0.3/fuse/server.go:367 +0x35
created by github.com/hanwen/go-fuse/v2/fs.Mount
        /home/luke/gocode/pkg/mod/github.com/hanwen/go-fuse/v2@v2.0.3/fs/mount.go:32 +0x150
FAIL    github.com/pachyderm/pachyderm/v2/src/server/pfs/fuse   12.416s

* Also disable progress bars to speed things up significantly.