### PR TITLE
Increase wait time for pipeline crashing recovery test.

### DIFF
--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -658,7 +658,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		EOF
 		`).Run())
 
-	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+	require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
 		| match my-pipeline \
@@ -671,7 +671,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		kubectl uncordon minikube
 	`).Run())
 
-	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+	require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
 		| match my-pipeline \


### PR DESCRIPTION
The crashing monitor interval is 15 seconds, so the previous limits
might only allow 15 seconds in some cases. I'm not sure what we should
really expect, but increasing it a bit more seems safe.