### PR TITLE
Disambiguate some commit and job logs.

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -387,7 +387,7 @@ $ {{alias}} test@fork -p XXX`,
 				return grpcutil.ScrubGRPC(err)
 			}
 			if commitInfo == nil {
-				return errors.Errorf("commit %s not found", commit.ID)
+				return errors.Errorf("commit %s not found", commit)
 			}
 			if raw {
 				return cmdutil.Encoder(output, os.Stdout).EncodeProto(commitInfo)

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -150,7 +150,7 @@ func (e ErrBranchExists) Error() string {
 }
 
 func (e ErrCommitNotFound) Error() string {
-	return fmt.Sprintf("commit %v not found in repo %v", e.Commit.ID, e.Commit.Branch.Repo)
+	return fmt.Sprintf("commit %v not found", e.Commit)
 }
 
 func (e ErrCommitSetNotFound) Error() string {
@@ -158,35 +158,35 @@ func (e ErrCommitSetNotFound) Error() string {
 }
 
 func (e ErrCommitExists) Error() string {
-	return fmt.Sprintf("commit %v already exists in repo %v", e.Commit.ID, e.Commit.Branch.Repo)
+	return fmt.Sprintf("commit %v already exists", e.Commit)
 }
 
 func (e ErrCommitFinished) Error() string {
-	return fmt.Sprintf("commit %v in repo %v has already finished", e.Commit.ID, e.Commit.Branch.Repo)
+	return fmt.Sprintf("commit %v has already finished", e.Commit)
 }
 
 func (e ErrCommitError) Error() string {
-	return fmt.Sprintf("commit %v in repo %v finished with an error", e.Commit.ID, e.Commit.Branch.Repo)
+	return fmt.Sprintf("commit %v finished with an error", e.Commit)
 }
 
 func (e ErrCommitDeleted) Error() string {
-	return fmt.Sprintf("commit %v@%v was deleted", e.Commit.Branch.Repo, e.Commit.ID)
+	return fmt.Sprintf("commit %v was deleted", e.Commit)
 }
 
 func (e ErrParentCommitNotFound) Error() string {
-	return fmt.Sprintf("parent commit %v not found in repo %v", e.Commit.ID, e.Commit.Branch.Repo)
+	return fmt.Sprintf("parent commit %v not found", e.Commit)
 }
 
 func (e ErrOutputCommitNotFinished) Error() string {
-	return fmt.Sprintf("output commit %v not finished", e.Commit.ID)
+	return fmt.Sprintf("output commit %v not finished", e.Commit)
 }
 
 func (e ErrCommitNotFinished) Error() string {
-	return fmt.Sprintf("commit %v not finished", e.Commit.ID)
+	return fmt.Sprintf("commit %v not finished", e.Commit)
 }
 
 func (e ErrAmbiguousCommit) Error() string {
-	return fmt.Sprintf("commit %v is ambiguous (specify the branch to resolve)", e.Commit.ID)
+	return fmt.Sprintf("commit %v is ambiguous (specify the branch to resolve)", e.Commit)
 }
 
 func (e ErrInconsistentCommit) Error() string {
@@ -206,11 +206,11 @@ func (e ErrDropWithChildren) Error() string {
 }
 
 var (
-	commitNotFoundRe          = regexp.MustCompile("commit [^ ]+ not found in repo [^ ]+")
+	commitNotFoundRe          = regexp.MustCompile("commit [^ ]+ not found")
 	commitsetNotFoundRe       = regexp.MustCompile("no commits found for commitset")
 	commitDeletedRe           = regexp.MustCompile("commit [^ ]+ was deleted")
-	commitFinishedRe          = regexp.MustCompile("commit [^ ]+ in repo [^ ]+ has already finished")
-	commitErrorRe             = regexp.MustCompile("commit [^ ]+ in repo [^ ]+ finished with an error")
+	commitFinishedRe          = regexp.MustCompile("commit [^ ]+ has already finished")
+	commitErrorRe             = regexp.MustCompile("commit [^ ]+ finished with an error")
 	repoNotFoundRe            = regexp.MustCompile(`repos [a-zA-Z0-9.\-_]{1,255} not found`)
 	repoExistsRe              = regexp.MustCompile(`repo ?[a-zA-Z0-9.\-_]{1,255} already exists`)
 	branchNotFoundRe          = regexp.MustCompile(`branch [^ ]+ not found in repo [^ ]+`)

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -87,7 +87,7 @@ func (d *driver) finishCommits(ctx context.Context) error {
 				// Compact the commit.
 				var totalId *fileset.ID
 				start := time.Now()
-				if err := miscutil.LogStep(fmt.Sprintf("compacting commit %v", commit.ID), func() error {
+				if err := miscutil.LogStep(fmt.Sprintf("compacting commit %v", commit), func() error {
 					var err error
 					totalId, err = compactor.Compact(ctx, []fileset.ID{*id}, defaultTTL)
 					if err != nil {
@@ -102,7 +102,7 @@ func (d *driver) finishCommits(ctx context.Context) error {
 				start = time.Now()
 				var size int64
 				var validationError string
-				if err := miscutil.LogStep(fmt.Sprintf("validating commit %v", commit.ID), func() error {
+				if err := miscutil.LogStep(fmt.Sprintf("validating commit %v", commit), func() error {
 					var err error
 					size, validationError, err = d.validate(ctx, totalId)
 					return err
@@ -111,7 +111,7 @@ func (d *driver) finishCommits(ctx context.Context) error {
 				}
 				validatingDuration := time.Since(start)
 				// Finish the commit.
-				return miscutil.LogStep(fmt.Sprintf("finish commit %v", commit.ID), func() error {
+				return miscutil.LogStep(fmt.Sprintf("finish commit %v", commit), func() error {
 					return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 						commitInfo := &pfs.CommitInfo{}
 						if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(commit), commitInfo, func() error {

--- a/src/server/pps/pps.go
+++ b/src/server/pps/pps.go
@@ -14,7 +14,7 @@ type ErrJobFinished struct {
 }
 
 func (e ErrJobFinished) Error() string {
-	return fmt.Sprintf("job %v has already finished", e.Job.ID)
+	return fmt.Sprintf("job %v has already finished", e.Job)
 }
 
 type ErrPipelineNotFound struct {

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -562,7 +562,7 @@ func (step *pcStep) scaleUpPipeline() (retErr error) {
 // scaleDownPipeline edits the RC associated with pc's pipeline & spins down the
 // configured number of workers.
 func (step *pcStep) scaleDownPipeline() (retErr error) {
-	log.Infof("PPS master: scaling down workers for %q", step.pipelineInfo.Pipeline.Name)
+	log.Debugf("PPS master: scaling down workers for %q", step.pipelineInfo.Pipeline.Name)
 	span, _ := tracing.AddSpanToAnyExisting(step.ctx,
 		"/pps.Master/ScaleDownPipeline", "pipeline", step.pipelineInfo.Pipeline.Name)
 	defer func() {


### PR DESCRIPTION
A few logs and error messages did not show the branch that commits were
made on, which could be ambiguous and isn't consistent with how commits
are displayed elsewhere.