### PR TITLE
New Entrypoint `pachtf` and `transforms` package

### DIFF
--- a/Dockerfile.pachtf
+++ b/Dockerfile.pachtf
@@ -10,4 +10,3 @@ WORKDIR /app
 COPY pachtf .
 
 USER 1000
-

--- a/Dockerfile.pachtf
+++ b/Dockerfile.pachtf
@@ -1,0 +1,13 @@
+FROM scratch
+
+LABEL name="Pachyderm" \
+      vendor="Pachyderm"
+
+COPY LICENSE /LICENSE
+COPY licenses /licenses
+
+WORKDIR /app
+COPY pachtf .
+
+USER 1000
+

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -52,6 +52,19 @@ builds:
       - darwin
     goarch:
       - amd64
+  -
+    id: pachtf
+    dir: src/server/cmd/pachtf
+    main: main.go
+    binary: pachtf
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "{{ .Env.LD_FLAGS }}"
+    goos:
+      - linux
+    goarch:
+      - amd64
 
 archives:
   - format: binary
@@ -120,3 +133,20 @@ dockers:
     extra_files:
       - LICENSE
       - licenses
+  -
+    image_templates:
+      - pachyderm/pachtf
+    ids:
+      - pachtf
+    goos: linux
+    goarch: amd64
+    skip_push: false
+    dockerfile: Dockerfile.pachtf
+    build_flag_templates:
+      - "--progress=plain"
+      - "--label=version={{.Version}}"
+      - "--label=release={{.Version}}"
+    extra_files:
+      - LICENSE
+      - licenses
+ 

--- a/src/internal/dockertestenv/mysql.go
+++ b/src/internal/dockertestenv/mysql.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	mysqlPort     = 9100
-	mysqlPassword = "root"
+	MySQLPassword = "root"
 	mysqlUser     = "root"
 )
 
@@ -22,6 +22,12 @@ const (
 // backed by a docker container.
 // The database is cleaned up after the test is closed.
 func NewMySQL(t testing.TB) *pachsql.DB {
+	u := NewMySQLURL(t)
+	return testutil.OpenDBURL(t, u, MySQLPassword)
+}
+
+// NewMySQLURL returns a pachsql.URL to an ephemeral database.
+func NewMySQLURL(t testing.TB) pachsql.URL {
 	ctx := context.Background()
 	log := logrus.StandardLogger()
 
@@ -32,7 +38,7 @@ func NewMySQL(t testing.TB) *pachsql.DB {
 			mysqlPort: 3306,
 		},
 		Env: map[string]string{
-			"MYSQL_ROOT_PASSWORD": mysqlPassword,
+			"MYSQL_ROOT_PASSWORD": MySQLPassword,
 		},
 	})
 	require.NoError(t, err)
@@ -43,12 +49,12 @@ func NewMySQL(t testing.TB) *pachsql.DB {
 		Port:     mysqlPort,
 		Database: "",
 	}
-	db := testutil.OpenDBURL(t, u, mysqlPassword)
+	db := testutil.OpenDBURL(t, u, MySQLPassword)
 	ctx, cf := context.WithTimeout(ctx, 30*time.Second)
 	defer cf()
 	require.NoError(t, dbutil.WaitUntilReady(ctx, log, db))
 	dbName := testutil.CreateEphemeralDB(t, db)
 	u2 := u
 	u2.Database = dbName
-	return testutil.OpenDBURL(t, u2, mysqlPassword)
+	return u2
 }

--- a/src/internal/secrets/secrets.go
+++ b/src/internal/secrets/secrets.go
@@ -1,0 +1,11 @@
+package secrets
+
+import "fmt"
+
+// Secret is the type of secret data.
+// It prevents the actual contents of the secret from being logged
+type Secret string
+
+func (s Secret) String() string {
+	return fmt.Sprintf("Secret{len=%d}", len(s))
+}

--- a/src/internal/transforms/sqlingest.go
+++ b/src/internal/transforms/sqlingest.go
@@ -25,7 +25,8 @@ type SQLIngestParams struct {
 	Format   string
 }
 
-// SQLIngest connects to a SQL database at params.URL and runs params.Query.
+// SQLIngest connects to a SQL database at params.URL and runs queries
+// read from files in the input.
 // The resulting rows are written to files in params.OutputDir.
 // The format of the output file is controlled by params.Format.
 // Valid options are "json" and "csv"

--- a/src/internal/transforms/sqlingest.go
+++ b/src/internal/transforms/sqlingest.go
@@ -1,0 +1,108 @@
+package transforms
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/sdata"
+	"github.com/pachyderm/pachyderm/v2/src/internal/secrets"
+	"github.com/sirupsen/logrus"
+)
+
+type SQLIngestParams struct {
+	// Instrumentation
+	Logger *logrus.Logger
+
+	// PFS In/Out
+	InputDir, OutputDir string
+
+	URL      pachsql.URL
+	Password secrets.Secret
+	Query    string
+	Format   string
+	// Shard affects the number appended to the file path.
+	Shard int
+}
+
+// SQLIngest connects to a SQL database at params.URL and runs params.Query.
+// The resulting rows are written to files in params.OutputDir.
+// The format of the output file is controlled by params.Format.
+// Valid options are "json" and "csv"
+//
+// It makes outgoing connections using pachsql.OpenURL
+// It accesses the filesystem only within params.InputDir, and params.OutputDir
+func SQLIngest(ctx context.Context, params SQLIngestParams) error {
+	log := params.Logger
+	log.Infof("Connecting to DB at %v...", params.URL)
+	db, err := pachsql.OpenURL(params.URL, string(params.Password))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := func() error {
+		ctx, cf := context.WithTimeout(ctx, 10*time.Second)
+		defer cf()
+		return db.PingContext(ctx)
+	}(); err != nil {
+		return err
+	}
+	log.Infof("Connected to DB")
+	writerFactory, err := makeWriterFactory(params.Format)
+	if err != nil {
+		return err
+	}
+	outputPath := filepath.Join(params.OutputDir, fmt.Sprintf("%04d", params.Shard))
+	outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+	log.Infof("Writing output to %q", outputPath)
+	log.Infof("Begin query %q", params.Query)
+	rows, err := db.QueryContext(ctx, params.Query)
+	if err != nil {
+		return err
+	}
+	log.Infof("Query complete, begin reading rows...")
+	colNames, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	log.Infof("Column names: %v", colNames)
+	tw := writerFactory(outputFile, colNames)
+	res, err := sdata.MaterializeSQL(tw, rows)
+	if err != nil {
+		return err
+	}
+	log.Infof("Successfully materialized %d rows", res.RowCount)
+	if err := outputFile.Close(); err != nil {
+		return err
+	}
+	log.Infof("DONE")
+	return nil
+}
+
+type writerFactory = func(w io.Writer, fieldNames []string) sdata.TupleWriter
+
+func makeWriterFactory(formatName string) (writerFactory, error) {
+	var factory writerFactory
+	switch formatName {
+	case "json", "jsonlines":
+		factory = func(w io.Writer, fieldNames []string) sdata.TupleWriter {
+			return sdata.NewJSONWriter(w, fieldNames)
+		}
+	case "csv":
+		factory = func(w io.Writer, fieldNames []string) sdata.TupleWriter {
+			return sdata.NewCSVWriter(w, fieldNames)
+		}
+	default:
+		return nil, errors.Errorf("unrecognized format %v", formatName)
+	}
+	return factory, nil
+}

--- a/src/internal/transforms/sqlingest_test.go
+++ b/src/internal/transforms/sqlingest_test.go
@@ -1,0 +1,75 @@
+package transforms
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLIngest(t *testing.T) {
+	ctx := context.Background()
+	inputDir, outputDir := t.TempDir(), t.TempDir()
+	u := dockertestenv.NewMySQLURL(t)
+
+	db := testutil.OpenDBURL(t, u, dockertestenv.MySQLPassword)
+	_, err := db.Exec(`CREATE TABLE test_data (
+			id SERIAL PRIMARY KEY,
+			col_a VARCHAR(100)
+	)`)
+	require.NoError(t, err)
+	const N = 100
+	for i := 0; i < N; i++ {
+		_, err := db.Exec(`INSERT INTO test_data (col_a) VALUES (?)`, randutil.UniqueString(""))
+		require.NoError(t, err)
+	}
+
+	err = SQLIngest(ctx, SQLIngestParams{
+		Logger: logrus.StandardLogger(),
+
+		InputDir:  inputDir,
+		OutputDir: outputDir,
+
+		URL:      u,
+		Password: dockertestenv.MySQLPassword,
+		Query:    "select * from test_data",
+		Format:   "json",
+	})
+	require.NoError(t, err)
+
+	// check the file exists
+	dirEnts, err := os.ReadDir(outputDir)
+	require.NoError(t, err)
+	require.Len(t, dirEnts, 1)
+	const outputName = "0000"
+	require.Equal(t, outputName, dirEnts[0].Name())
+	lineCount := countLinesInFile(t, filepath.Join(outputDir, outputName))
+	require.Equal(t, N, lineCount)
+}
+
+func countLinesInFile(t testing.TB, p string) int {
+	f, err := os.Open(p)
+	require.NoError(t, err)
+	defer f.Close()
+	br := bufio.NewReader(f)
+	var count int
+	for {
+		ru, _, err := br.ReadRune()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if ru == '\n' {
+			count++
+		}
+	}
+	return count
+}

--- a/src/internal/transforms/transforms.go
+++ b/src/internal/transforms/transforms.go
@@ -1,0 +1,61 @@
+// package transforms contains PPS Pipeline Transform implementations
+package transforms
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// DataMapper maps one stream to another or errors
+type DataMapper = func(r io.Reader, w io.Writer) error
+
+// IdentityDM is the DataMapper which maps data to itself
+func IdentityDM(r io.Reader, w io.Writer) error {
+	_, err := io.Copy(w, r)
+	return err
+}
+
+// PathMapper is a function that maps one path to another
+type PathMapper = func(string) string
+
+// IdentityPM is the PathMapper which maps a path to itself
+func IdentityPM(x string) string {
+	return x
+}
+
+// bijectiveMap walks files in inputDir and applies a mapping to both the path
+// and the file content and writes the result to the corresponding path in outputDir
+//
+// To leave paths unchanged use IdentityPM for pm
+// To leave file content unchanged use IdentityDM for dm
+func bijectiveMap(inputDir, outputDir string, pm PathMapper, dm DataMapper) error {
+	return filepath.WalkDir(inputDir, func(inputPath string, dirEnt fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if dirEnt.IsDir() {
+			return nil
+		}
+		inputRelPath, err := filepath.Rel(inputDir, inputPath)
+		if err != nil {
+			return err
+		}
+		outputPath := filepath.Join(outputDir, pm(inputRelPath))
+		inputFile, err := os.OpenFile(inputPath, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+		defer inputFile.Close()
+		outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE, 0755)
+		if err != nil {
+			return err
+		}
+		defer outputFile.Close()
+		if err := dm(inputFile, outputFile); err != nil {
+			return err
+		}
+		return outputFile.Close()
+	})
+}

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -20,11 +20,12 @@ const (
 func main() {
 	ctx := context.Background()
 	log := logrus.StandardLogger()
-	if len(os.Args) < 1 {
+	args := os.Args[1:]
+	if len(args) < 1 {
 		log.Fatal("at least 1 argument required")
 	}
-	transformName := os.Args[0]
-	transformArgs := os.Args[1:]
+	transformName := args[0]
+	transformArgs := args[1:]
 	switch transformName {
 	case "sql-ingest":
 		if err := sqlIngest(ctx, log, transformArgs); err != nil {
@@ -38,7 +39,7 @@ func main() {
 func sqlIngest(ctx context.Context, log *logrus.Logger, args []string) error {
 	const passwordEnvar = "PACHYDERM_SQL_PASSWORD"
 	if len(args) < 3 {
-		return errors.Errorf("must provide db url, format, and query")
+		return errors.Errorf("must provide db url, format, and query repo name")
 	}
 	urlStr, formatName, repoName := args[0], args[1], args[2]
 	password, ok := os.LookupEnv(passwordEnvar)

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -30,7 +30,7 @@ func main() {
 			log.Fatal(err)
 		}
 	default:
-		log.Fatal("unrecognized transform name %q", transformName)
+		log.Fatalf("unrecognized transform name %q", transformName)
 	}
 }
 

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/secrets"
+	"github.com/pachyderm/pachyderm/v2/src/internal/transforms"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+const (
+	pfsIn  = "/pfs/in"
+	pfsOut = "/pfs/out"
+)
+
+func main() {
+	ctx := context.Background()
+	log := logrus.StandardLogger()
+	if len(os.Args) < 1 {
+		log.Fatal("1 argument required")
+	}
+	transformName := os.Args[0]
+	transformArgs := os.Args[1:]
+	switch transformName {
+	case "sql-ingest":
+		if err := sqlIngest(ctx, log, transformArgs); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		log.Fatal("unrecognized transform name %q", transformName)
+	}
+}
+
+func sqlIngest(ctx context.Context, log *logrus.Logger, args []string) error {
+	if len(args) < 3 {
+		return errors.Errorf("must provide db url, format, and query")
+	}
+	urlStr, formatName, query := args[0], args[1], args[2]
+	const passwordEnvar = "PACHYDERM_SQL_PASSWORD"
+	password, ok := os.LookupEnv(passwordEnvar)
+	if !ok {
+		return errors.Errorf("must set %v", passwordEnvar)
+	}
+	u, err := pachsql.ParseURL(urlStr)
+	if err != nil {
+		return err
+	}
+	return transforms.SQLIngest(ctx, transforms.SQLIngestParams{
+		Logger: log,
+
+		InputDir:  pfsIn,
+		OutputDir: pfsOut,
+
+		URL:      *u,
+		Password: secrets.Secret(password),
+		Query:    query,
+		Format:   formatName,
+	})
+}

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	pfsIn  = "/pfs/in"
+	pfs    = "/pfs"
 	pfsOut = "/pfs/out"
 )
 
@@ -38,10 +38,10 @@ func main() {
 
 func sqlIngest(ctx context.Context, log *logrus.Logger, args []string) error {
 	const passwordEnvar = "PACHYDERM_SQL_PASSWORD"
-	if len(args) < 3 {
-		return errors.Errorf("must provide db url, format, and query repo name")
+	if len(args) < 2 {
+		return errors.Errorf("must provide db url and format")
 	}
-	urlStr, formatName, repoName := args[0], args[1], args[2]
+	urlStr, formatName := args[0], args[1]
 	password, ok := os.LookupEnv(passwordEnvar)
 	if !ok {
 		return errors.Errorf("must set %v", passwordEnvar)
@@ -50,7 +50,7 @@ func sqlIngest(ctx context.Context, log *logrus.Logger, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputDir := filepath.Join(filepath.FromSlash(pfsIn), repoName)
+	inputDir := filepath.FromSlash(pfs + "/in")
 	outputDir := filepath.FromSlash(pfsOut)
 	return transforms.SQLIngest(ctx, transforms.SQLIngestParams{
 		Logger: log,


### PR DESCRIPTION
Adds a package transforms for pipeline transforms that we intend to provide batteries included.
Adds a new entrypoint pachtf which will be the program that calls into the transforms library package.

`transforms.SQLIngest` reads queries from its input directory and writes results to the output directory.