### PR TITLE
Use NewOnUserMachine() instead of NewFromURI in go client example

### DIFF
--- a/examples/opencv/goclient-example/opencv-example.go
+++ b/examples/opencv/goclient-example/opencv-example.go
@@ -19,7 +19,7 @@ func main() {
 	// Replace the IP address with your `pachd` address.
 	// If running in minikube, this will be your minikube
 	// IP.
-	c, err := client.NewFromURI("grpc://localhost:30650")
+	c, err := client.NewOnUserMachine("")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The reason for this change is that NewOnUserMachine pulls auth information from the user's context