### PR TITLE
Remove mathutil dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.26.0
-	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
 	github.com/robfig/cron v1.2.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/segmentio/analytics-go v0.0.0-20160426181448-2d840d861c32
@@ -96,7 +95,6 @@ require (
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
-	modernc.org/mathutil v1.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,6 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 h1:/NRJ5vAYoqz+7sG51ubIDHXeWO8DlTSrToPu6q11ziA=
-github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -1038,8 +1036,6 @@ k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6 h1:p0Ai3qVtkbCG/Af26dBmU0E1W58NID3hSSh7cMyylpM=
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-modernc.org/mathutil v1.0.0 h1:93vKjrJopTPrtTNpZ8XIovER7iCIH1QU7wNbOQXC60I=
-modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=

--- a/src/internal/miscutil/math.go
+++ b/src/internal/miscutil/math.go
@@ -1,0 +1,17 @@
+package miscutil
+
+// Min returns the smaller of a and b.
+func Min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// MinInt64 returns the smaller of a and b.
+func MinInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/src/internal/pfsload/client.go
+++ b/src/internal/pfsload/client.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
-	"modernc.org/mathutil"
 )
 
 // Client is the standard interface for a load testing client.
@@ -102,7 +102,7 @@ type throughputLimitReader struct {
 func (tlr *throughputLimitReader) Read(data []byte) (int, error) {
 	var bytesRead int
 	for len(data) > 0 {
-		size := mathutil.Min(len(data), tlr.bytesPerSecond-tlr.bytesSinceSleep)
+		size := miscutil.Min(len(data), tlr.bytesPerSecond-tlr.bytesSinceSleep)
 		n, err := tlr.r.Read(data[:size])
 		data = data[n:]
 		bytesRead += n

--- a/src/internal/randutil/rand.go
+++ b/src/internal/randutil/rand.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"math/rand"
 
-	"modernc.org/mathutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 )
 
 var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -32,7 +32,7 @@ func NewBytesReader(random *rand.Rand, n int64) *bytesReader {
 }
 
 func (br *bytesReader) Read(data []byte) (int, error) {
-	size := int(mathutil.MinInt64(br.n, int64(len(data))))
+	size := int(miscutil.MinInt64(br.n, int64(len(data))))
 	for i := 0; i < size; i++ {
 		data[i] = letters[br.random.Intn(len(letters))]
 	}

--- a/src/internal/storage/chunk/chunk_test.go
+++ b/src/internal/storage/chunk/chunk_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/chmduquesne/rollinghash/buzhash64"
 	units "github.com/docker/go-units"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
-	"modernc.org/mathutil"
 )
 
 type test struct {
@@ -146,7 +146,7 @@ func generateAnnotations(random *rand.Rand, t test) []*testAnnotation {
 	var as []*testAnnotation
 	for t.n > 0 {
 		a := &testAnnotation{}
-		a.data = randutil.Bytes(random, mathutil.Min(rand.Intn(t.maxAnnotationSize)+1, t.n))
+		a.data = randutil.Bytes(random, miscutil.Min(rand.Intn(t.maxAnnotationSize)+1, t.n))
 		t.n -= len(a.data)
 		as = append(as, a)
 	}

--- a/src/internal/storage/fileset/index/reader.go
+++ b/src/internal/storage/fileset/index/reader.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
-	"modernc.org/mathutil"
 )
 
 // Reader is used for reading a multilevel index.
@@ -117,7 +117,7 @@ func (r *Reader) atEnd(name string) bool {
 	// A simple greater than check would not suffice here for the prefix filter functionality
 	// (for example, if the index consisted of the paths "a", "ab", "abc", and "b", then a
 	// reader with the prefix filter set to "a" would end at the "ab" path rather than the "b" path).
-	cmpSize := mathutil.Min(len(name), len(r.filter.prefix))
+	cmpSize := miscutil.Min(len(name), len(r.filter.prefix))
 	return name[:cmpSize] > r.filter.prefix[:cmpSize]
 }
 


### PR DESCRIPTION
This package is not strictly necessary and it's dependency was causing trouble for M1 macs.

I'm not sure why CI isn't passing -- none of the changes I've made seem to be causing them to fail, but I could be misunderstanding the logs.