### PR TITLE
Check spec commit to determine RC freshness.

### DIFF
--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -658,7 +658,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		EOF
 		`).Run())
 
-	require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
 		| match my-pipeline \
@@ -671,7 +671,7 @@ func TestPipelineCrashingRecovers(t *testing.T) {
 		kubectl uncordon minikube
 	`).Run())
 
-	require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
+	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
 		return tu.BashCmd(`
 		pachctl list pipeline \
 		| match my-pipeline \

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -159,7 +159,7 @@ eventLoop:
 				m.pcMgr.Lock()
 				defer m.pcMgr.Unlock()
 				if pc, ok := m.pcMgr.pcs[e.pipeline]; ok {
-					pc.Bump() // raises flag in pipelineController to run again whenever it finishes
+					pc.Bump(e.timestamp) // raises flag in pipelineController to run again whenever it finishes
 				} else {
 					// pc's ctx is cancelled in pipelineController.tryFinish(), to avoid leaking resources
 					pcCtx, pcCancel := context.WithCancel(m.masterCtx)

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -29,10 +29,11 @@ import (
 )
 
 const (
-	pipelineNameLabel         = "pipelineName"
-	pachVersionAnnotation     = "pachVersion"
-	pipelineVersionAnnotation = "pipelineVersion"
-	hashedAuthTokenAnnotation = "authTokenHash"
+	pipelineNameLabel            = "pipelineName"
+	pachVersionAnnotation        = "pachVersion"
+	pipelineVersionAnnotation    = "pipelineVersion"
+	pipelineSpecCommitAnnotation = "specCommit"
+	hashedAuthTokenAnnotation    = "authTokenHash"
 )
 
 // Parameters used when creating the kubernetes replication controller in charge
@@ -591,10 +592,11 @@ func (pc *pipelineController) getWorkerOptions(pipelineInfo *pps.PipelineInfo) (
 	}
 
 	annotations := map[string]string{
-		pipelineNameLabel:         pipelineName,
-		pachVersionAnnotation:     version.PrettyVersion(),
-		pipelineVersionAnnotation: strconv.FormatUint(pipelineInfo.Version, 10),
-		hashedAuthTokenAnnotation: hashAuthToken(pipelineInfo.AuthToken),
+		pipelineNameLabel:            pipelineName,
+		pachVersionAnnotation:        version.PrettyVersion(),
+		pipelineVersionAnnotation:    strconv.FormatUint(pipelineInfo.Version, 10),
+		pipelineSpecCommitAnnotation: pipelineInfo.SpecCommit.ID,
+		hashedAuthTokenAnnotation:    hashAuthToken(pipelineInfo.AuthToken),
 	}
 
 	// add the user's custom metadata (annotations and labels).


### PR DESCRIPTION
If a pipeline was deleted and recreated quickly, it's possible for the
delete event not to get processed. This is fine as long as the pipeline
controller notices the RC is out of date and recreates the pipeline
resources. However, our freshness checks only use the version number,
which could be the same before and after, resulting in the RC being
incorrectly left up.

Also propagate update timestamps through to the trace and bump the wait
time for the flaky test back down now that the actual bug is fixed.