### PR TITLE
Remove singleton cluster from testutil

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"golang.org/x/net/context"
@@ -460,7 +461,7 @@ func portForwarder(context *config.Context) (*PortForwarder, uint16, error) {
 
 // NewForTest constructs a new APIClient for tests.
 // TODO(actgardner): this should probably live in testutils and accept a testing.TB
-func NewForTest() (*APIClient, error) {
+func NewForTest(t testing.TB) (*APIClient, error) {
 	cfg, err := config.Read(false, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read config")
@@ -489,7 +490,7 @@ func NewForTest() (*APIClient, error) {
 
 // NewEnterpriseClientForTest constructs a new APIClient for tests.
 // TODO(actgardner): this should probably live in testutils and accept a testing.TB
-func NewEnterpriseClientForTest() (*APIClient, error) {
+func NewEnterpriseClientForTest(t testing.TB) (*APIClient, error) {
 	cfg, err := config.Read(false, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read config")

--- a/src/internal/minikubetestenv/pachclient.go
+++ b/src/internal/minikubetestenv/pachclient.go
@@ -12,10 +12,14 @@ import (
 var clusterLock sync.Mutex
 
 // NewPachClient gets a pachyderm client for use in tests.
-// The client will be connected to a full Pachyderm cluster deployed in minikube
+// The client will be connected to a full Pachyderm cluster deployed in minikube.
+// The cluster will be totally fresh, and will be cleared after the test is done.
+//
+// The current implementation blocks waiting to use a single shared cluster.
 // NewPachClient only allows one test to be run at a time.  After calling it with test t,
 // subsequent calls will block until t finishes.
 //
+// TODO: this should not
 // TODO: eventually we can manage multiple deployments across different namespaces.
 func NewPachClient(t testing.TB) *client.APIClient {
 	clusterLock.Lock()
@@ -23,9 +27,11 @@ func NewPachClient(t testing.TB) *client.APIClient {
 	var pachClient *client.APIClient
 	var err error
 	if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
+		t.Log("creating pach client using cluster config")
 		pachClient, err = client.NewInCluster()
 	} else {
-		pachClient, err = client.NewForTest()
+		t.Log("creating pach client using NewForTest")
+		pachClient, err = client.NewForTest(t)
 	}
 	if err != nil {
 		t.Fatalf("error getting Pachyderm client: %s", err.Error())

--- a/src/internal/minikubetestenv/pachclient.go
+++ b/src/internal/minikubetestenv/pachclient.go
@@ -1,0 +1,36 @@
+package minikubetestenv
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+)
+
+var clusterLock sync.Mutex
+
+// NewPachClient gets a pachyderm client for use in tests.
+// The client will be connected to a full Pachyderm cluster deployed in minikube
+// NewPachClient only allows one test to be run at a time.  After calling it with test t,
+// subsequent calls will block until t finishes.
+//
+// TODO: eventually we can manage multiple deployments across different namespaces.
+func NewPachClient(t testing.TB) *client.APIClient {
+	clusterLock.Lock()
+	t.Cleanup(clusterLock.Unlock)
+	var pachClient *client.APIClient
+	var err error
+	if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
+		pachClient, err = client.NewInCluster()
+	} else {
+		pachClient, err = client.NewForTest()
+	}
+	if err != nil {
+		t.Fatalf("error getting Pachyderm client: %s", err.Error())
+	}
+	require.NoError(t, pachClient.DeleteAll())
+	t.Cleanup(func() { require.NoError(t, pachClient.DeleteAll()) })
+	return pachClient
+}

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -34,9 +34,8 @@ func OIDCOIDCConfig() *auth.OIDCConfig {
 
 // ConfigureOIDCProvider configures the identity service and the auth service to
 // use a mock connector.
-func ConfigureOIDCProvider(t *testing.T) error {
-	adminClient := GetAuthenticatedPachClient(t, auth.RootUser)
-
+func ConfigureOIDCProvider(t *testing.T, client *client.APIClient) error {
+	adminClient := GetAuthenticatedPachClient(t, client, auth.RootUser)
 	_, err := adminClient.IdentityAPIClient.DeleteAll(adminClient.Ctx(), &identity.DeleteAllRequest{})
 	require.NoError(t, err)
 
@@ -132,7 +131,7 @@ func DoOAuthExchange(t testing.TB, pachClient, enterpriseClient *client.APIClien
 	require.NoError(t, err)
 }
 
-func GetOIDCTokenForTrustedApp(t testing.TB) string {
+func GetOIDCTokenForTrustedApp(t testing.TB, client *client.APIClient) string {
 	// Create an HTTP client that doesn't follow redirects.
 	// We rewrite the host names for each redirect to avoid issues because
 	// pachd is configured to reach dex with kube dns, but the tests might be
@@ -141,7 +140,7 @@ func GetOIDCTokenForTrustedApp(t testing.TB) string {
 	c.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	testClient := GetUnauthenticatedPachClient(t)
+	testClient := GetUnauthenticatedPachClient(t, client)
 
 	oauthConfig := oauth2.Config{
 		ClientID:     "testapp",

--- a/src/internal/testutil/pach_client.go
+++ b/src/internal/testutil/pach_client.go
@@ -1,34 +1,3 @@
 package testutil
 
-import (
-	"os"
-	"sync"
-	"testing"
-
-	"github.com/pachyderm/pachyderm/v2/src/client"
-)
-
 const DefaultTransformImage = "pachyderm/testuser:local"
-
-var (
-	pachClient *client.APIClient
-	pachErr    error
-	clientOnce sync.Once
-)
-
-// GetPachClient gets a pachyderm client for use in tests. It works for tests
-// running both inside and outside the cluster. Note that multiple calls to
-// GetPachClient will return the same instance.
-func GetPachClient(t testing.TB) *client.APIClient {
-	clientOnce.Do(func() {
-		if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
-			pachClient, pachErr = client.NewInCluster()
-		} else {
-			pachClient, pachErr = client.NewForTest()
-		}
-	})
-	if pachErr != nil {
-		t.Fatalf("error getting Pachyderm client: %s", pachErr.Error())
-	}
-	return pachClient
-}

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -170,9 +170,10 @@ func TestWhoAmI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
+	c := newTestClient(t)
 	alice := tu.UniqueString("robot:alice")
-	loginAsUser(t, alice)
-	defer tu.DeleteAll(t)
+	loginAsUser(t, c, alice)
+	defer tu.DeleteAll(t, c)
 	require.NoError(t, tu.BashCmd(`
 		pachctl auth whoami | match {{.alice}}`,
 		"alice", alice,

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -77,12 +77,13 @@ func TestActivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	// Get anonymous client (this will activate auth, which is about to be
 	// deactivated, but it also activates Pacyderm enterprise, which is needed for
 	// this test to pass)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	_, err := rootClient.Deactivate(rootClient.Ctx(), &auth.DeactivateRequest{})
 	require.NoError(t, err)
@@ -108,12 +109,13 @@ func TestActivateKnownToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	// Get anonymous client (this will activate auth, which is about to be
 	// deactivated, but it also activates Pacyderm enterprise, which is needed for
 	// this test to pass)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	_, err := rootClient.Deactivate(rootClient.Ctx(), &auth.DeactivateRequest{})
 	require.NoError(t, err)
@@ -139,11 +141,12 @@ func TestSuperAdminRWO(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// The initial set of admins is just the user "admin"
 	bindings, err := aliceClient.GetClusterRoleBinding()
@@ -241,11 +244,12 @@ func TestFSAdminRWO(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// The initial set of admins is just the user "admin"
 	bindings, err := aliceClient.GetClusterRoleBinding()
@@ -343,11 +347,12 @@ func TestFSAdminFixBrokenRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice creates a repo (that only she owns) and puts a file
 	repo := tu.UniqueString("TestAdmin")
@@ -393,10 +398,11 @@ func TestCannotRemoveRootAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Check that the initial set of admins is just "admin"
 	bindings, err := rootClient.GetClusterRoleBinding()
@@ -433,10 +439,11 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Deactivate auth
 	_, err := rootClient.Deactivate(rootClient.Ctx(), &auth.DeactivateRequest{})
@@ -493,7 +500,7 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 	require.NoError(t, err)
 
 	// re-authenticate, as old tokens were deleted
-	aliceClient = tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient = tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// Make sure alice cannot read the input repo (i.e. if the pipeline runs as
 	// alice, it will fail)
@@ -520,10 +527,11 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString("TestPipelinesRunAfterExpiration")
@@ -604,12 +612,13 @@ func TestListRepoAdminIsOwnerOfAllRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	// t.Parallel()
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repoWriter := tu.UniqueString("TestListRepoAdminIsOwnerOfAllRepos")
@@ -636,16 +645,17 @@ func TestGetIndefiniteRobotToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Generate auth credentials
 	robotUser := tu.UniqueString("rock-em-sock-em")
 	resp, err := rootClient.GetRobotToken(rootClient.Ctx(), &auth.GetRobotTokenRequest{Robot: robotUser})
 	require.NoError(t, err)
 	token1 := resp.Token
-	robotClient1 := tu.GetUnauthenticatedPachClient(t)
+	robotClient1 := tu.GetUnauthenticatedPachClient(t, c)
 	robotClient1.SetAuthToken(token1)
 
 	// Confirm identity tied to 'token1'
@@ -660,16 +670,17 @@ func TestGetTemporaryRobotToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Generate auth credentials
 	robotUser := tu.UniqueString("rock-em-sock-em")
 	resp, err := rootClient.GetRobotToken(rootClient.Ctx(), &auth.GetRobotTokenRequest{Robot: robotUser, TTL: 600})
 	require.NoError(t, err)
 	token1 := resp.Token
-	robotClient1 := tu.GetUnauthenticatedPachClient(t)
+	robotClient1 := tu.GetUnauthenticatedPachClient(t, c)
 	robotClient1.SetAuthToken(token1)
 
 	// Confirm identity tied to 'token1'
@@ -687,11 +698,12 @@ func TestGetRobotTokenErrorNonAdminUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 	resp, err := aliceClient.GetRobotToken(aliceClient.Ctx(), &auth.GetRobotTokenRequest{
 		Robot: tu.UniqueString("t-1000"),
 	})
@@ -706,9 +718,10 @@ func TestRobotUserWhoAmI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Generate a robot user auth credential, and create a client for that user
 	robotUser := tu.UniqueString("r2d2")
@@ -731,8 +744,9 @@ func TestRobotUserACL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
+	c := newClient(t)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Generate a robot user auth credential, and create a client for that user
 	robotUser := tu.UniqueString("voltron")
@@ -775,9 +789,10 @@ func TestGroupRoleBinding(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
+	c := newClient(t)
 	alice := robot(tu.UniqueString("alice"))
 	group := group(tu.UniqueString("testGroup"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// root creates a repo and adds a group writer access
 	repo := tu.UniqueString("TestGroupRoleBinding")
@@ -807,11 +822,12 @@ func TestRobotUserAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// Generate a robot user auth credential, and create a client for that user
 	robotUser := tu.UniqueString("bender")
@@ -863,9 +879,10 @@ func TestTokenRevoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Create repo (so alice has something to list)
 	repo := tu.UniqueString("TestTokenRevoke")
@@ -900,8 +917,9 @@ func TestRevokeTokensForUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	contains := func(tokens []*auth.TokenInfo, hashedToken string) bool {
 		for _, v := range tokens {
@@ -912,7 +930,7 @@ func TestRevokeTokensForUser(t *testing.T) {
 		return false
 	}
 
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Create repo (so alice has something to list)
 	repo := tu.UniqueString("TestTokenRevoke")
@@ -948,10 +966,10 @@ func TestRevokeTokensForUser(t *testing.T) {
 	require.True(t, contains(preRevokeTokens, auth.HashToken(aliceTokenB.Token)), "Alice's Token B should be extracted")
 	require.True(t, contains(preRevokeTokens, auth.HashToken(bobToken.Token)), "Bob's Token should be extracted")
 
-	aliceClient := tu.GetUnauthenticatedPachClient(t)
+	aliceClient := tu.GetUnauthenticatedPachClient(t, c)
 	aliceClient.SetAuthToken(aliceTokenA.Token)
 
-	bobClient := tu.GetUnauthenticatedPachClient(t)
+	bobClient := tu.GetUnauthenticatedPachClient(t, c)
 	bobClient.SetAuthToken(bobToken.Token)
 
 	// delete all tokens for user Alice
@@ -984,10 +1002,11 @@ func TestRevokePachUserToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	_, err := rootClient.RevokeAuthTokensForUser(rootClient.Ctx(), &auth.RevokeAuthTokensForUserRequest{Username: auth.RootUser})
 	require.YesError(t, err)
@@ -1003,11 +1022,12 @@ func TestDeleteAllAfterDeactivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice creates a pipeline
 	repo := tu.UniqueString("TestDeleteAllAfterDeactivate")
@@ -1066,10 +1086,11 @@ func TestDeleteRCInStandby(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	c := tu.GetAuthenticatedPachClient(t, alice)
+	c = tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -1136,10 +1157,11 @@ func TestPipelineFailingWithOpenCommit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -1184,10 +1206,11 @@ func TestRotateRootToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	rootClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	rootClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// create a repo for the purpose of testing access
 	repo := tu.UniqueString("TestRotateRootToken")

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -66,10 +66,11 @@ func TestGetSetBasic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -184,10 +185,11 @@ func TestGetSetReverse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -309,10 +311,11 @@ func TestCreateAndUpdateRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -364,10 +367,11 @@ func TestCreateRepoWithUpdateFlag(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -392,8 +396,9 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	type createArgs struct {
 		client     *client.APIClient
 		name, repo string
@@ -412,7 +417,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 		)
 	}
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// create repo, and check that alice is the owner of the new repo
 	dataRepo := tu.UniqueString(t.Name())
@@ -585,8 +590,9 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	type createArgs struct {
 		client *client.APIClient
 		name   string
@@ -606,7 +612,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 		)
 	}
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// create two repos, and check that alice is the owner of the new repos
 	dataRepo1 := tu.UniqueString(t.Name())
@@ -779,10 +785,11 @@ func TestPipelineRevoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo, and adds bob as a reader
 	repo := tu.UniqueString(t.Name())
@@ -886,10 +893,11 @@ func TestStopAndDeletePipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1017,9 +1025,10 @@ func TestStopJob(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1082,10 +1091,11 @@ func TestListAndInspectRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo and makes Bob a writer
 	repoWriter := tu.UniqueString(t.Name())
@@ -1190,10 +1200,11 @@ func TestGetPermissions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice creates a repo and makes Bob a writer
 	repo := tu.UniqueString(t.Name())
@@ -1232,10 +1243,11 @@ func TestUnprivilegedUserCannotMakeSelfOwner(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1256,10 +1268,11 @@ func TestListRepoNotLoggedInError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetUnauthenticatedPachClient(t)
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetUnauthenticatedPachClient(t, c)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1268,10 +1281,10 @@ func TestListRepoNotLoggedInError(t *testing.T) {
 		buildBindings(alice, auth.RepoOwnerRole), getRepoRoleBinding(t, aliceClient, repo))
 
 	// Anon (non-logged-in user) calls ListRepo, and must receive an error
-	c, err := anonClient.PfsAPIClient.ListRepo(anonClient.Ctx(),
+	rc, err := anonClient.PfsAPIClient.ListRepo(anonClient.Ctx(),
 		&pfs.ListRepoRequest{})
 	require.NoError(t, err)
-	_, err = clientsdk.ListRepoInfo(c)
+	_, err = clientsdk.ListRepoInfo(rc)
 	require.YesError(t, err)
 	require.Matches(t, "no authentication token", err.Error())
 }
@@ -1282,13 +1295,14 @@ func TestListRepoNoAuthInfoIfDeactivated(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	// Dont't run this test in parallel, since it deactivates the auth system
 	// globally, so any tests running concurrently will fail
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1329,10 +1343,11 @@ func TestCreateRepoAlreadyExistsError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1351,10 +1366,11 @@ func TestCreateRepoNotLoggedInError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-	tu.ActivateAuth(t)
-	anonClient := tu.GetUnauthenticatedPachClient(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
+	tu.ActivateAuth(t, c)
+	anonClient := tu.GetUnauthenticatedPachClient(t, c)
 
 	// anonClient tries and fails to create a repo
 	repo := tu.UniqueString(t.Name())
@@ -1368,10 +1384,11 @@ func TestCreatePipelineRepoAlreadyExists(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	inputRepo := tu.UniqueString(t.Name())
@@ -1416,11 +1433,12 @@ func TestAuthorizedEveryone(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1480,11 +1498,12 @@ func TestDeleteAll(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// admin creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1518,11 +1537,12 @@ func TestDeleteAllRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// admin creates a repo
 	adminRepo := tu.UniqueString(t.Name())
@@ -1549,10 +1569,11 @@ func TestListDatum(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repoA := tu.UniqueString(t.Name())
@@ -1641,10 +1662,11 @@ func TestListJob(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice, bob := robot(tu.UniqueString("alice")), robot(tu.UniqueString("bob"))
-	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, bob)
+	aliceClient, bobClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, bob)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1715,10 +1737,11 @@ func TestInspectDatum(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -1919,10 +1942,11 @@ func TestPipelineNewInput(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// alice creates three repos and commits to them
 	var repo []string
@@ -2005,8 +2029,9 @@ func TestModifyMembers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
 	bob := robot(tu.UniqueString("bob"))
@@ -2014,7 +2039,7 @@ func TestModifyMembers(t *testing.T) {
 	engineering := tu.UniqueString("engineering")
 	security := tu.UniqueString("security")
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// This is a sequence dependent list of tests
 	tests := []struct {
@@ -2131,15 +2156,16 @@ func TestSetGroupsForUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
 	organization := tu.UniqueString("organization")
 	engineering := tu.UniqueString("engineering")
 	security := tu.UniqueString("security")
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	groups := []string{organization, engineering}
 	_, err := adminClient.SetGroupsForUser(adminClient.Ctx(), &auth.SetGroupsForUserRequest{
@@ -2222,15 +2248,16 @@ func TestGetOwnGroups(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
 	organization := tu.UniqueString("organization")
 	engineering := tu.UniqueString("engineering")
 	security := tu.UniqueString("security")
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	_, err := adminClient.SetGroupsForUser(adminClient.Ctx(), &auth.SetGroupsForUserRequest{
 		Username: alice,
@@ -2238,7 +2265,7 @@ func TestGetOwnGroups(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 	groups, err := aliceClient.GetGroups(aliceClient.Ctx(), &auth.GetGroupsRequest{})
 	require.NoError(t, err)
 	require.ElementsEqual(t, []string{organization, engineering, security}, groups.Groups)
@@ -2254,10 +2281,11 @@ func TestGetJobsBugFix(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetUnauthenticatedPachClient(t)
+	aliceClient, anonClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetUnauthenticatedPachClient(t, c)
 
 	// alice creates a repo
 	repo := tu.UniqueString(t.Name())
@@ -2306,8 +2334,9 @@ func TestS3GatewayAuthRequests(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
+	c := newClient(t)
 	// generate auth credentials
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 	alice := tu.UniqueString("alice")
 	authResp, err := adminClient.GetRobotToken(adminClient.Ctx(), &auth.GetRobotTokenRequest{
 		Robot: alice,
@@ -2352,10 +2381,11 @@ func TestDeleteFailedPipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -2396,10 +2426,11 @@ func TestDeletePipelineMissingRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// Create input repo w/ initial commit
 	repo := tu.UniqueString(t.Name())
@@ -2440,8 +2471,9 @@ func TestDeactivateFSAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
+	c := newClient(t)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// admin makes alice an fs admin
 	require.NoError(t, adminClient.ModifyClusterRoleBinding(alice, []string{auth.RepoOwnerRole}))
@@ -2462,11 +2494,12 @@ func TestExtractAuthToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice can't extract auth tokens because she's not an admin
 	_, err := aliceClient.ExtractAuthTokens(aliceClient.Ctx(), &auth.ExtractAuthTokensRequest{})
@@ -2511,8 +2544,9 @@ func TestRestoreAuthToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	// Create a request to restore a token with known plaintext
 	req := &auth.RestoreAuthTokenRequest{
@@ -2523,7 +2557,7 @@ func TestRestoreAuthToken(t *testing.T) {
 	}
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	aliceClient, adminClient := tu.GetAuthenticatedPachClient(t, c, alice), tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// alice can't restore auth tokens because she's not an admin
 	_, err := aliceClient.RestoreAuthToken(aliceClient.Ctx(), req)
@@ -2580,16 +2614,17 @@ func TestDebug(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	// Get all the authenticated clients at the beginning of the test.
 	// GetAuthenticatedPachClient will always re-activate auth, which
 	// causes PPS to rotate all the pipeline tokens. This makes the RCs
 	// change and recreates all the pods, which used to race with collecting logs.
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	dataRepo := tu.UniqueString("TestDebug_data")
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
@@ -2656,11 +2691,12 @@ func TestDeleteExpiredAuthTokens(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	// generate auth credentials
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// create a token that will instantly expire, a token that will expire later, and a token that will never expire
 	noExpirationResp, noExpErr := adminClient.GetRobotToken(adminClient.Ctx(), &auth.GetRobotTokenRequest{Robot: "robot:alice"})
@@ -2721,13 +2757,14 @@ func TestExpiredClusterLocksOutUsers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	alice := tu.UniqueString("robot:alice")
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	repo := tu.UniqueString("TestRotateAuthToken")
 	require.NoError(t, aliceClient.CreateRepo(repo))
@@ -2786,13 +2823,14 @@ func TestGetPachdLogsRequiresPerm(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	alice := tu.UniqueString("robot:alice")
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	aliceRepo := tu.UniqueString("alice_repo")
 	err := aliceClient.CreateRepo(aliceRepo)
@@ -2845,9 +2883,9 @@ func TestRolesForPermission(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-
+	c := newClient(t)
 	alice := tu.UniqueString("robot:alice")
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 	resp, err := aliceClient.GetRolesForPermission(aliceClient.Ctx(), &auth.GetRolesForPermissionRequest{Permission: auth.Permission_REPO_READ})
 	require.NoError(t, err)
 
@@ -2866,10 +2904,11 @@ func TestLoad(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	alice := tu.UniqueString("robot:alice")
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 	resp, err := aliceClient.PfsAPIClient.RunLoadTestDefault(aliceClient.Ctx(), &types.Empty{})
 	require.NoError(t, err)
 	buf := &bytes.Buffer{}

--- a/src/server/auth/server/testing/config_test.go
+++ b/src/server/auth/server/testing/config_test.go
@@ -20,12 +20,13 @@ func TestSetGetConfigBasic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	tu.ConfigureOIDCProvider(t)
+	tu.ConfigureOIDCProvider(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
@@ -51,12 +52,13 @@ func TestIssuerNotLocalhost(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	tu.ConfigureOIDCProvider(t)
+	tu.ConfigureOIDCProvider(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// set the issuer to locahost:1658 so we don't need to set LocalhostIssuer = true
 	_, err := adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
@@ -91,10 +93,11 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 	// Confirm that the auth config starts out default
 	configResp, err := adminClient.GetConfiguration(adminClient.Ctx(),
 		&auth.GetConfigurationRequest{})
@@ -103,7 +106,7 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 	require.Equal(t, true, proto.Equal(&authserver.DefaultOIDCConfig, configResp.GetConfiguration()))
 
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient := tu.GetAuthenticatedPachClient(t, c, alice)
 
 	// Alice tries to set the current configuration and fails
 	conf := &auth.OIDCConfig{
@@ -128,7 +131,7 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, proto.Equal(&authserver.DefaultOIDCConfig, configResp.Configuration))
 
-	tu.ConfigureOIDCProvider(t)
+	tu.ConfigureOIDCProvider(t, c)
 
 	// Modify the configuration and make sure alice can't read it, but admin can
 	_, err = adminClient.SetConfiguration(adminClient.Ctx(),
@@ -157,12 +160,13 @@ func TestConfigRestartAuth(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	tu.ConfigureOIDCProvider(t)
+	tu.ConfigureOIDCProvider(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
@@ -234,7 +238,7 @@ func TestConfigRestartAuth(t *testing.T) {
 		&auth.GetConfigurationRequest{})
 	require.NoError(t, err)
 	require.Equal(t, true, proto.Equal(conf, configResp.Configuration))
-	tu.DeleteAll(t)
+	tu.DeleteAll(t, c)
 }
 
 // TestSetGetNilConfig tests that setting an empty config and setting a nil
@@ -243,12 +247,13 @@ func TestSetGetNilConfig(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
-	tu.ConfigureOIDCProvider(t)
+	tu.ConfigureOIDCProvider(t, c)
 
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+	adminClient := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
@@ -278,5 +283,5 @@ func TestSetGetNilConfig(t *testing.T) {
 	require.NoError(t, err)
 	conf = proto.Clone(&authserver.DefaultOIDCConfig).(*auth.OIDCConfig)
 	require.Equal(t, true, proto.Equal(conf, configResp.Configuration))
-	tu.DeleteAll(t)
+	tu.DeleteAll(t, c)
 }

--- a/src/server/config/cmds_test.go
+++ b/src/server/config/cmds_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
@@ -159,8 +160,9 @@ func TestConfigListContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := minikubetestenv.NewPachClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 
 	// Verify the * marker exists for the active-context when enterprise is disabled and the enterprise context isn't set
 	require.NoError(t, run(t, `

--- a/src/server/enterprise/cmds/cmds_test.go
+++ b/src/server/enterprise/cmds/cmds_test.go
@@ -3,17 +3,23 @@ package cmds
 import (
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
+
+func newTestClient(t testing.TB) *client.APIClient {
+	return minikubetestenv.NewPachClient(t)
+}
 
 func TestActivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	code := tu.GetTestEnterpriseCode(t)
 
 	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate`,
@@ -26,8 +32,9 @@ func TestManuallyJoinLicenseServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate --no-register
 		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://localhost:1653 --pachd-address grpc://localhost:1653

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -17,10 +17,10 @@ import (
 const enterpriseRootToken = "iamenterprise"
 
 func resetClusterState(t *testing.T) {
-	ec, err := client.NewEnterpriseClientForTest()
+	ec, err := client.NewEnterpriseClientForTest(t)
 	require.NoError(t, err)
 
-	c, err := client.NewForTest()
+	c, err := client.NewForTest(t)
 	require.NoError(t, err)
 
 	// Set the root token, in case a previous test failed
@@ -161,7 +161,7 @@ func TestLoginEnterprise(t *testing.T) {
 	resetClusterState(t)
 	defer resetClusterState(t)
 
-	ec, err := client.NewEnterpriseClientForTest()
+	ec, err := client.NewEnterpriseClientForTest(t)
 	require.NoError(t, err)
 
 	require.NoError(t, tu.BashCmd(`
@@ -203,10 +203,10 @@ func TestLoginPachd(t *testing.T) {
 	resetClusterState(t)
 	defer resetClusterState(t)
 
-	c, err := client.NewForTest()
+	c, err := client.NewForTest(t)
 	require.NoError(t, err)
 
-	ec, err := client.NewEnterpriseClientForTest()
+	ec, err := client.NewEnterpriseClientForTest(t)
 	require.NoError(t, err)
 
 	require.NoError(t, tu.BashCmd(`
@@ -323,7 +323,7 @@ func TestRegisterDefaultArgs(t *testing.T) {
 	resetClusterState(t)
 	defer resetClusterState(t)
 
-	c, err := client.NewForTest()
+	c, err := client.NewForTest(t)
 	require.NoError(t, err)
 
 	id := tu.UniqueString("cluster")

--- a/src/server/identity/cmds/cmds_test.go
+++ b/src/server/identity/cmds/cmds_test.go
@@ -3,16 +3,23 @@ package cmds
 import (
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
+
+func newTestClient(t *testing.T) *client.APIClient {
+	return minikubetestenv.NewPachClient(t)
+}
 
 func TestConnectorCRUD(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.ActivateAuth(t)
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.ActivateAuth(t, c)
+	defer tu.DeleteAll(t, c)
 	require.NoError(t, tu.BashCmd(`
 		echo '{"id": "{{.id}}", "name": "testconn", "type": "github", "config": {"id": 1234}}' | pachctl idp create-connector 
 		pachctl idp list-connector | match '{{.id}}'
@@ -43,8 +50,9 @@ func TestClientCRUD(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.ActivateAuth(t)
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.ActivateAuth(t, c)
+	defer tu.DeleteAll(t, c)
 	require.NoError(t, tu.BashCmd(`
 		echo '{"id": "{{.id}}", "name": "testclient", "secret": "a secret", "redirect_uris": ["https://localhost:1234"]}' | pachctl idp create-client  \
 		  | match 'secret: "a secret"'
@@ -72,8 +80,9 @@ func TestGetSetConfig(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.ActivateAuth(t)
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.ActivateAuth(t, c)
+	defer tu.DeleteAll(t, c)
 	require.NoError(t, tu.BashCmd(`
 		echo '{"issuer": "http://example.com:1234"}' | pachctl idp set-config 
 		pachctl idp get-config | match 'issuer: http://example.com:1234' 

--- a/src/server/license/cmds/cmds_test.go
+++ b/src/server/license/cmds/cmds_test.go
@@ -3,17 +3,23 @@ package cmds
 import (
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
+
+func newTestClient(t testing.TB) *client.APIClient {
+	return minikubetestenv.NewPachClient(t)
+}
 
 func TestActivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.DeleteAll(t, c)
+	defer tu.DeleteAll(t, c)
 	code := tu.GetTestEnterpriseCode(t)
 
 	require.NoError(t, tu.BashCmd(`echo {{.license}} | pachctl license activate --no-register`,
@@ -26,9 +32,10 @@ func TestClusterCRUD(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	tu.ActivateEnterprise(t, tu.GetPachClient(t))
-	defer tu.DeleteAll(t)
+	c := newTestClient(t)
+	tu.DeleteAll(t, c)
+	tu.ActivateEnterprise(t, c)
+	defer tu.DeleteAll(t, c)
 	require.NoError(t, tu.BashCmd(`
 		pachctl license add-cluster --id {{.id}} --address grpc://localhost:1653
 		pachctl license list-clusters \

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pretty"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
@@ -47,6 +48,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func newClient(t testing.TB) *client.APIClient {
+	return minikubetestenv.NewPachClient(t)
+}
 
 func newCountBreakFunc(maxCount int) func(func() error) error {
 	var count int
@@ -83,9 +88,8 @@ func TestSimplePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	c = c.WithDefaultTransformUser("1000")
-	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestSimplePipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -142,8 +146,7 @@ func TestRepoSize(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
-	require.NoError(t, c.DeleteAll())
+	c := newClient(t)
 
 	// create a data repo
 	dataRepo := tu.UniqueString("TestRepoSize_data")
@@ -208,7 +211,7 @@ func TestPFSPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPFSPipeline_data")
@@ -250,7 +253,7 @@ func TestPipelineWithParallelism(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithParallelism_data")
@@ -297,7 +300,7 @@ func TestPipelineWithLargeFiles(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithLargeFiles_data")
@@ -358,7 +361,7 @@ func TestDatumDedup(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestDatumDedup_data")
@@ -405,7 +408,7 @@ func TestPipelineInputDataModification(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineInputDataModification_data")
@@ -482,7 +485,7 @@ func TestMultipleInputsFromTheSameBranch(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestMultipleInputsFromTheSameBranch_data")
@@ -560,7 +563,7 @@ func TestMultipleInputsFromTheSameRepoDifferentBranches(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestMultipleInputsFromTheSameRepoDifferentBranches_data")
@@ -618,7 +621,7 @@ func TestRunPipeline(t *testing.T) {
 	//	t.Skip("Skipping integration tests in short mode")
 	//}
 
-	//c := tu.GetPachClient(t)
+	//c := newClient(t)
 	//require.NoError(t, c.DeleteAll())
 
 	//// Test on cross pipeline
@@ -1157,7 +1160,7 @@ func TestPipelineFailure(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineFailure_data")
@@ -1201,7 +1204,7 @@ func TestPipelineErrorHandling(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	t.Run("ErrCmd", func(t *testing.T) {
@@ -1333,7 +1336,7 @@ func TestLazyPipelinePropagation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestLazyPipelinePropagation_data")
@@ -1392,7 +1395,7 @@ func TestLazyPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestLazyPipeline_data")
@@ -1447,7 +1450,7 @@ func TestEmptyFiles(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestShufflePipeline_data")
@@ -1520,7 +1523,7 @@ func TestProvenance(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	aRepo := tu.UniqueString("A")
 	require.NoError(t, c.CreateRepo(aRepo))
@@ -1605,7 +1608,7 @@ func TestProvenance2(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	aRepo := tu.UniqueString("A")
 	require.NoError(t, c.CreateRepo(aRepo))
@@ -1712,7 +1715,7 @@ func TestStopPipelineExtraCommit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	aRepo := tu.UniqueString("A")
 	require.NoError(t, c.CreateRepo(aRepo))
@@ -1781,7 +1784,7 @@ func TestWaitJobSet(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	prefix := tu.UniqueString("repo")
 	makeRepoName := func(i int) string {
@@ -1830,7 +1833,7 @@ func TestWaitJobSetFailures(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	dataRepo := tu.UniqueString("TestWaitJobSetFailures")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -1904,7 +1907,7 @@ func TestWaitCommitSetAfterCreatePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -1944,7 +1947,7 @@ func TestRecreatePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -1983,7 +1986,7 @@ func TestDeletePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	repo := tu.UniqueString("data")
@@ -2086,7 +2089,7 @@ func TestPipelineState(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateRepo(repo))
@@ -2152,7 +2155,7 @@ func TestUpdatePipelineThatHasNoOutput(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestUpdatePipelineThatHasNoOutput")
@@ -2212,7 +2215,7 @@ func TestAcceptReturnCode(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestAcceptReturnCode")
@@ -2257,7 +2260,7 @@ func TestPrettyPrinting(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// create repos
@@ -2314,7 +2317,7 @@ func TestDeleteAll(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	// this test cannot be run in parallel because it deletes everything
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestDeleteAll_data")
@@ -2357,7 +2360,7 @@ func TestRecursiveCp(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestRecursiveCp_data")
@@ -2398,7 +2401,7 @@ func TestPipelineUniqueness(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	repo := tu.UniqueString("data")
@@ -2437,7 +2440,7 @@ func TestUpdatePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos and create the pipeline
 	dataRepo := tu.UniqueString("TestUpdatePipeline_data")
@@ -2603,7 +2606,7 @@ func TestUpdatePipelineWithInProgressCommitsAndStats(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	dataRepo := tu.UniqueString("TestUpdatePipelineWithInProgressCommitsAndStats_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -2657,7 +2660,7 @@ func TestUpdateFailedPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestUpdateFailedPipeline_data")
@@ -2730,7 +2733,7 @@ func TestUpdateStoppedPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repo & pipeline
 	dataRepo := tu.UniqueString("TestUpdateStoppedPipeline_data")
@@ -2847,7 +2850,7 @@ func TestUpdatePipelineRunningJob(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestUpdatePipeline_data")
@@ -2936,7 +2939,7 @@ func TestManyFilesSingleCommit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestManyFilesSingleCommit_data")
@@ -2962,7 +2965,7 @@ func TestManyFilesSingleOutputCommit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	dataRepo := tu.UniqueString("TestManyFilesSingleOutputCommit_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -3007,7 +3010,7 @@ func TestStopPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipeline_data")
@@ -3067,7 +3070,7 @@ func TestAutoscalingStandby(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	t.Run("ChainOf10", func(t *testing.T) {
 		require.NoError(t, c.DeleteAll())
 
@@ -3208,7 +3211,7 @@ func TestStopStandbyPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString(t.Name() + "_data")
@@ -3324,7 +3327,7 @@ func TestPipelineEnv(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// create repos
@@ -3412,7 +3415,7 @@ func TestPipelineWithFullObjects(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipeline_data")
@@ -3466,7 +3469,7 @@ func TestPipelineWithExistingInputCommits(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipeline_data")
@@ -3517,7 +3520,7 @@ func TestPipelineWithExistingInputCommits(t *testing.T) {
 }
 
 func TestPipelineThatSymlinks(t *testing.T) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// create repos
@@ -3645,7 +3648,7 @@ func TestChainedPipelines(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	aRepo := tu.UniqueString("A")
 	require.NoError(t, c.CreateRepo(aRepo))
@@ -3725,7 +3728,7 @@ func TestChainedPipelinesNoDelay(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	aRepo := tu.UniqueString("A")
 	require.NoError(t, c.CreateRepo(aRepo))
@@ -3816,7 +3819,7 @@ func TestJobDeletion(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipeline_data")
@@ -3853,7 +3856,7 @@ func TestStopJob(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestStopJob")
@@ -3919,7 +3922,7 @@ func TestGetLogs(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	iter := c.GetLogs("", "", nil, "", false, false, 0)
 	for iter.Next() {
@@ -4127,7 +4130,7 @@ func TestManyLogs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("data")
@@ -4184,7 +4187,7 @@ func TestLokiLogs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	tu.ActivateEnterprise(t, c)
 	// create repos
@@ -4251,7 +4254,7 @@ func TestAllDatumsAreProcessed(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo1 := tu.UniqueString("TestAllDatumsAreProcessed_data1")
@@ -4308,7 +4311,7 @@ func TestDatumStatusRestart(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestDatumDedup_data")
@@ -4442,7 +4445,7 @@ func TestPipelineResourceRequest(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipelineResourceRequest")
@@ -4514,7 +4517,7 @@ func TestPipelineResourceLimit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipelineResourceLimit")
@@ -4582,7 +4585,7 @@ func TestPipelineResourceLimitDefaults(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipelineResourceLimit")
@@ -4640,7 +4643,7 @@ func TestPipelinePartialResourceRequest(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipelinePartialResourceRequest")
@@ -4720,7 +4723,7 @@ func TestPipelineCrashing(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipelineCrashing_data")
@@ -4787,7 +4790,7 @@ func TestPodOpts(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPodSpecOpts_data")
@@ -4956,7 +4959,7 @@ func TestPipelineLargeOutput(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineInputDataModification_data")
@@ -4996,7 +4999,7 @@ func TestJoinInput(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	var repos []string
@@ -5090,7 +5093,7 @@ func TestGroupInput(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	t.Run("Basic", func(t *testing.T) {
@@ -5405,7 +5408,7 @@ func TestUnionInput(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	var repos []string
@@ -5561,7 +5564,7 @@ func TestPipelineWithStats(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithStats_data")
@@ -5627,7 +5630,7 @@ func TestPipelineWithStatsFailedDatums(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithStatsFailedDatums_data")
@@ -5701,7 +5704,7 @@ func TestPipelineWithStatsPaginated(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithStatsPaginated_data")
@@ -5784,7 +5787,7 @@ func TestPipelineWithStatsAcrossJobs(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithStatsAcrossJobs_data")
@@ -5880,7 +5883,7 @@ func TestPipelineOnStatsBranch(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineOnStatsBranch_data")
@@ -5934,7 +5937,7 @@ func TestSkippedDatums(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipeline_data")
@@ -6004,7 +6007,7 @@ func TestCronPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	t.Run("SimpleCron", func(t *testing.T) {
 		defer func() {
@@ -6294,7 +6297,7 @@ func TestSelfReferentialPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	pipeline := tu.UniqueString("pipeline")
 	require.YesError(t, c.CreatePipeline(
@@ -6314,7 +6317,7 @@ func TestPipelineBadImage(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	pipeline1 := tu.UniqueString("bad_pipeline_1_")
 	require.NoError(t, c.CreatePipeline(
@@ -6358,7 +6361,7 @@ func TestFixPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestFixPipeline_data")
@@ -6425,7 +6428,7 @@ func TestListJobTruncated(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 
 	dataRepo := tu.UniqueString("TestListJobTruncated_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -6477,7 +6480,7 @@ func TestPipelineEnvVarAlias(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineEnvVarAlias_data")
@@ -6523,7 +6526,7 @@ func TestService(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestService_data")
@@ -6631,7 +6634,7 @@ func TestServiceEnvVars(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString(t.Name() + "-input")
@@ -6732,7 +6735,7 @@ func TestDatumSetSpec(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestDatumSetSpec_data")
@@ -6801,7 +6804,7 @@ func TestLongDatums(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestLongDatums_data")
@@ -6850,7 +6853,7 @@ func TestPipelineWithDatumTimeout(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithDatumTimeout_data")
@@ -6910,7 +6913,7 @@ func TestListDatumDuringJob(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestListDatumDuringJob_data")
@@ -7001,7 +7004,7 @@ func TestPipelineWithDatumTimeoutControl(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithDatumTimeoutControl_data")
@@ -7054,7 +7057,7 @@ func TestPipelineWithJobTimeout(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithDatumTimeout_data")
@@ -7111,7 +7114,7 @@ func TestCommitDescription(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -7164,7 +7167,7 @@ func TestPipelineDescription(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineDescription_data")
@@ -7193,7 +7196,7 @@ func TestListJobInputCommits(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	aRepo := tu.UniqueString("TestListJobInputCommits_data_a")
@@ -7293,7 +7296,7 @@ func TestCancelJob(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// Create an input repo
@@ -7388,7 +7391,7 @@ func TestCancelManyJobs(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// Create an input repo
@@ -7471,7 +7474,7 @@ func TestSquashCommitSetPropagation(t *testing.T) {
 	// 		t.Skip("Skipping integration tests in short mode")
 	// 	}
 
-	// 	c := tu.GetPachClient(t)
+	// 	c := newClient(t)
 	// 	require.NoError(t, c.DeleteAll())
 
 	// 	// Create an input repo
@@ -7534,7 +7537,7 @@ func TestDeleteSpecRepo(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	dataRepo := tu.UniqueString("TestDeleteSpecRepo_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 
@@ -7564,7 +7567,7 @@ func TestDontReadStdin(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	dataRepo := tu.UniqueString("TestDontReadStdin_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 
@@ -7598,7 +7601,7 @@ func TestStatsDeleteAll(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineWithStats_data")
@@ -7655,7 +7658,7 @@ func TestRapidUpdatePipelines(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	pipeline := tu.UniqueString(t.Name() + "-pipeline-")
 	cronInput := client.NewCronInput("time", "@every 20s")
@@ -7719,7 +7722,7 @@ func TestDatumTries(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestDatumTries_data")
@@ -7763,7 +7766,7 @@ func TestInspectJob(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	_, err := c.PpsAPIClient.InspectJob(context.Background(), &pps.InspectJobRequest{})
@@ -7786,7 +7789,7 @@ func TestPipelineVersions(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineVersions_data")
@@ -7827,7 +7830,7 @@ func TestSplitFileHeader(t *testing.T) {
 	//		t.Skip("Skipping integration tests in short mode")
 	//	}
 	//
-	//	c := tu.GetPachClient(t)
+	//	c := newClient(t)
 	//	require.NoError(t, c.DeleteAll())
 	//
 	//	// put a SQL file w/ header
@@ -7888,7 +7891,7 @@ func TestNewHeaderCausesReprocess(t *testing.T) {
 	//		t.Skip("Skipping integration tests in short mode")
 	//	}
 	//
-	//	c := tu.GetPachClient(t)
+	//	c := newClient(t)
 	//	require.NoError(t, c.DeleteAll())
 	//
 	//	// put a SQL file w/ header
@@ -7948,7 +7951,7 @@ func TestDeferredCross(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// make repo for our dataset
@@ -8035,7 +8038,7 @@ func TestDeferredProcessing(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestDeferredProcessing_data")
@@ -8100,7 +8103,7 @@ func TestPipelineHistory(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	// create repos
 	dataRepo := tu.UniqueString("TestPipelineHistory_data")
@@ -8255,7 +8258,7 @@ func TestFileHistory(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo1 := tu.UniqueString("TestFileHistory_data1")
@@ -8315,7 +8318,7 @@ func TestCreatePipelineErrorNoPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// Create input repo
@@ -8344,7 +8347,7 @@ func TestCreatePipelineError(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// Create input repo
@@ -8372,7 +8375,7 @@ func TestCreatePipelineErrorNoCmd(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// Create input data
@@ -8410,7 +8413,7 @@ func TestCreatePipelineErrorNoCmd(t *testing.T) {
 func TestExtractPipeline(t *testing.T) {
 	// TODO: Implement extract pipeline.
 	t.Skip("Extract pipeline not implemented in V2")
-	//	c := tu.GetPachClient(t)
+	//	c := newClient(t)
 	//	require.NoError(t, c.DeleteAll())
 	//
 	//	dataRepo := tu.UniqueString("TestExtractPipeline_data")
@@ -8490,7 +8493,7 @@ func TestPodPatchUnmarshalling(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	// Create input data
@@ -8570,7 +8573,7 @@ func TestSecrets(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	b := []byte(
@@ -8619,12 +8622,12 @@ func TestSecretsUnauthenticated(t *testing.T) {
 	}
 
 	// Enable auth on the cluster
-	tu.DeleteAll(t)
-	tu.GetAuthenticatedPachClient(t, auth.RootUser)
-	defer tu.DeleteAll(t)
+	c := newClient(t)
+	ac := tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
+	tu.DeleteAll(t, ac)
+	defer tu.DeleteAll(t, ac)
 
 	// Get an unauthenticated client
-	c := tu.GetPachClient(t)
 	c.SetAuthToken("")
 
 	b := []byte(
@@ -8662,7 +8665,7 @@ func TestCopyOutToIn(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestCopyOutToIn_data")
@@ -8735,7 +8738,7 @@ func TestKeepRepo(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestKeepRepo_data")
@@ -8808,7 +8811,7 @@ func TestKeepRepo(t *testing.T) {
 
 // Regression test to make sure that pipeline creation doesn't crash pachd due to missing fields
 func TestMalformedPipeline(t *testing.T) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	pipelineName := tu.UniqueString("MalformedPipeline")
@@ -8964,7 +8967,7 @@ func TestMalformedPipeline(t *testing.T) {
 }
 
 func TestTrigger(t *testing.T) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestTrigger_data")
@@ -9096,7 +9099,7 @@ func TestTrigger(t *testing.T) {
 }
 
 func TestListDatum(t *testing.T) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	repo1 := tu.UniqueString("TestListDatum1")
@@ -9133,7 +9136,7 @@ func TestDebug(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestDebug_data")
@@ -9197,7 +9200,7 @@ func TestUpdateMultiplePipelinesInTransaction(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	input := tu.UniqueString("in")
 	commit := client.NewCommit(input, "master", "")
@@ -9256,7 +9259,7 @@ func TestInterruptedUpdatePipelineInTransaction(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	inputA := tu.UniqueString("A")
 	inputB := tu.UniqueString("B")
@@ -9304,7 +9307,7 @@ func TestPipelineAutoscaling(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestPipelineAutoscaling_data")
@@ -9355,7 +9358,7 @@ func TestListDeletedDatums(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	twoRepo := tu.UniqueString("TestListDeletedDatums_Two")
@@ -9455,7 +9458,7 @@ func TestNonrootPipeline(t *testing.T) {
 		t.Skip("Skipping non-root test because hostpath permissions can't be verified")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestNonrootPipeline_data")
@@ -9523,7 +9526,7 @@ func TestRewindCrossPipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestRewindCrossPipeline_data")
@@ -9604,7 +9607,7 @@ func TestMoveBranchTrigger(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString("TestRewindTrigger_data")
@@ -9653,7 +9656,7 @@ func TestPipelineAncestry(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	dataRepo := tu.UniqueString(t.Name())
@@ -9715,7 +9718,7 @@ func TestStandbyTransitions(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 
 	kc := tu.GetKubeClient(t)
@@ -9788,7 +9791,7 @@ func TestStandbyTransitions(t *testing.T) {
 }
 
 func monitorReplicas(t testing.TB, pipeline string, n int) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	kc := tu.GetKubeClient(t)
 	rcName := ppsutil.PipelineRcName(pipeline, 1)
 	enoughReplicas := false
@@ -9821,7 +9824,7 @@ func TestLoad(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	require.NoError(t, c.DeleteAll())
 	resp, err := c.PpsAPIClient.RunLoadTestDefault(c.Ctx(), &types.Empty{})
 	require.NoError(t, err)

--- a/src/server/pachyderm_validation_test.go
+++ b/src/server/pachyderm_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
@@ -18,7 +19,7 @@ func TestInvalidCreatePipeline(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c := tu.GetPachClient(t)
+	c := minikubetestenv.NewPachClient(t)
 
 	// Set up repo
 	dataRepo := tu.UniqueString("TestDuplicatedJob_data")
@@ -66,7 +67,7 @@ func TestPipelineThatUseNonexistentInputs(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	pipelineName := tu.UniqueString("pipeline")
 	require.YesError(t, c.CreatePipeline(
 		pipelineName,
@@ -88,7 +89,7 @@ func TestPipelineNamesThatContainUnderscoresAndHyphens(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 
 	dataRepo := tu.UniqueString("TestPipelineNamesThatContainUnderscoresAndHyphens")
 	require.NoError(t, c.CreateRepo(dataRepo))

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -33,9 +33,10 @@ func TestSpoutPachctl(t *testing.T) {
 	}
 
 	t.Run("SpoutAuth", func(t *testing.T) {
-		tu.DeleteAll(t)
-		defer tu.DeleteAll(t)
-		c := tu.GetAuthenticatedPachClient(t, auth.RootUser)
+		c := newClient(t)
+		c = tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
+		tu.DeleteAll(t, c)
+		defer tu.DeleteAll(t, c)
 
 		// create a spout pipeline
 		pipeline := tu.UniqueString("pipelinespoutauth")
@@ -95,8 +96,7 @@ func TestSpoutPachctl(t *testing.T) {
 		}))
 	})
 	t.Run("SpoutAuthEnabledAfter", func(t *testing.T) {
-		tu.DeleteAll(t)
-		c := tu.GetPachClient(t)
+		c := newClient(t)
 
 		// create a spout pipeline
 		pipeline := tu.UniqueString("pipelinespoutauthenabledafter")
@@ -136,8 +136,8 @@ func TestSpoutPachctl(t *testing.T) {
 
 		// activate auth, which will generate a new PPS token for the pipeline and trigger
 		// the RC to be recreated
-		c = tu.GetAuthenticatedPachClient(t, auth.RootUser)
-		defer tu.DeleteAll(t)
+		c = tu.GetAuthenticatedPachClient(t, c, auth.RootUser)
+		defer tu.DeleteAll(t, c)
 
 		// make sure we can delete commits
 		commitInfo, err := c.InspectCommit(pipeline, "master", "")
@@ -179,8 +179,8 @@ func TestSpoutPachctl(t *testing.T) {
 }
 
 func testSpout(t *testing.T, usePachctl bool) {
-	tu.DeleteAll(t)
-	c := tu.GetPachClient(t)
+	c := newClient(t)
+	tu.DeleteAll(t, c)
 
 	putFileCommand := func(branch, flags, file string) string {
 		if usePachctl {

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -472,7 +473,7 @@ func TestTransactions(suite *testing.T) {
 }
 
 func TestCreatePipelineTransaction(t *testing.T) {
-	c := testutil.GetPachClient(t)
+	c := minikubetestenv.NewPachClient(t)
 	require.NoError(t, c.DeleteAll())
 	repo := testutil.UniqueString("in")
 	pipeline := testutil.UniqueString("pipeline")

--- a/src/server/worker/datum/iterator_bench_test.go
+++ b/src/server/worker/datum/iterator_bench_test.go
@@ -6,12 +6,17 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
+func newClient(t testing.TB) *client.APIClient {
+	return minikubetestenv.NewPachClient(t)
+}
+
 func benchmarkIterators(j int, b *testing.B) {
-	c := tu.GetPachClient(b)
+	c := newClient(b)
 	defer require.NoError(b, c.DeleteAll())
 
 	b.ResetTimer()

--- a/src/server/worker/stats/stats_test.go
+++ b/src/server/worker/stats/stats_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -20,8 +21,12 @@ import (
 	prom_model "github.com/prometheus/common/model"
 )
 
+func newClient(t testing.TB) *client.APIClient {
+	return minikubetestenv.NewPachClient(t)
+}
+
 func TestPrometheusStats(t *testing.T) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	defer require.NoError(t, c.DeleteAll())
 	tu.ActivateEnterprise(t, c)
 
@@ -231,7 +236,7 @@ func TestPrometheusStats(t *testing.T) {
 // Regression: stats commits would not close when there were no input datums.
 //For more info, see github.com/pachyderm/pachyderm/v2/issues/3337
 func TestCloseStatsCommitWithNoInputDatums(t *testing.T) {
-	c := tu.GetPachClient(t)
+	c := newClient(t)
 	defer require.NoError(t, c.DeleteAll())
 	tu.ActivateEnterprise(t, c)
 


### PR DESCRIPTION
Removes the singleton cluster from testutil.  The helper functions in `testutil` no longer assume a single global pachyderm cluster.  Pach clients must now be passed as arguments to the helper functions, so they know which cluster to operate on.

This will eventually allow us to run tests concurrently, on multiple pachyderm clusters.

Adds package `minikubetestenv` which uses a minikube instance to spawn clusters.  This package can be thought of as an interface to the test infrastructure which produces pach clients.