### PR TITLE
SQL Query Generation from Cron Tick

### DIFF
--- a/Dockerfile.pachtf
+++ b/Dockerfile.pachtf
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine:3.15
 
 LABEL name="Pachyderm" \
       vendor="Pachyderm"

--- a/etc/testing/mysql.yaml
+++ b/etc/testing/mysql.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+  - port: 3306
+    name: mysql
+  clusterIP: None
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  serviceName: mysql
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: mysql
+        image: mysql:latest
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+        ports:
+        - containerPort: 9000
+          name: s3
+        - containerPort: 9001
+          name: console
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /data
+        env:
+        - name: "MYSQL_ROOT_PASSWORD"
+          value: "root"
+
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-data
+      labels:
+        app: mysql
+    spec:
+      accessModes: [ "ReadWriteOnce"]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi

--- a/src/internal/transforms/sqlingest_test.go
+++ b/src/internal/transforms/sqlingest_test.go
@@ -22,6 +22,7 @@ func TestSQLIngest(t *testing.T) {
 	inputDir, outputDir := t.TempDir(), t.TempDir()
 	u := dockertestenv.NewMySQLURL(t)
 
+	// load  DB
 	db := testutil.OpenDBURL(t, u, dockertestenv.MySQLPassword)
 	_, err := db.Exec(`CREATE TABLE test_data (
 			id SERIAL PRIMARY KEY,

--- a/src/internal/transforms/sqlingest_test.go
+++ b/src/internal/transforms/sqlingest_test.go
@@ -12,29 +12,21 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
+const outputName = "0000"
+
 func TestSQLIngest(t *testing.T) {
 	ctx := context.Background()
 	inputDir, outputDir := t.TempDir(), t.TempDir()
 	u := dockertestenv.NewMySQLURL(t)
-
-	// load  DB
-	db := testutil.OpenDBURL(t, u, dockertestenv.MySQLPassword)
-	_, err := db.Exec(`CREATE TABLE test_data (
-			id SERIAL PRIMARY KEY,
-			col_a VARCHAR(100)
-	)`)
-	require.NoError(t, err)
 	const N = 100
-	for i := 0; i < N; i++ {
-		_, err := db.Exec(`INSERT INTO test_data (col_a) VALUES (?)`, randutil.UniqueString(""))
-		require.NoError(t, err)
-	}
+	loadDB(t, u, N)
 
 	// write queries
 	const Shards = 2
@@ -46,7 +38,7 @@ func TestSQLIngest(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = SQLIngest(ctx, SQLIngestParams{
+	err := SQLIngest(ctx, SQLIngestParams{
 		Logger: logrus.StandardLogger(),
 
 		InputDir:  inputDir,
@@ -62,7 +54,6 @@ func TestSQLIngest(t *testing.T) {
 	dirEnts, err := os.ReadDir(outputDir)
 	require.NoError(t, err)
 	require.Len(t, dirEnts, Shards)
-	const outputName = "0000"
 	require.Equal(t, outputName, dirEnts[0].Name())
 	lineCount := countLinesInFile(t, filepath.Join(outputDir, outputName))
 	require.Equal(t, N, lineCount)
@@ -89,14 +80,12 @@ func countLinesInFile(t testing.TB, p string) int {
 
 func TestSQLQueryGeneration(t *testing.T) {
 	ctx := context.Background()
+	log := logrus.StandardLogger()
 	inputDir, outputDir := t.TempDir(), t.TempDir()
-	// write timestamp file
-	now := time.Now().UTC()
-	timestampStr := now.Format(time.RFC3339)
-	err := ioutil.WriteFile(filepath.Join(inputDir, timestampStr), nil, 0755)
-	require.NoError(t, err)
+	writeCronFile(t, inputDir)
 
-	err = SQLQueryGeneration(ctx, SQLQueryGenerationParams{
+	err := SQLQueryGeneration(ctx, SQLQueryGenerationParams{
+		Logger:    log,
 		InputDir:  inputDir,
 		OutputDir: outputDir,
 		Query:     "select * from test_data",
@@ -106,5 +95,77 @@ func TestSQLQueryGeneration(t *testing.T) {
 	dirEnts, err := os.ReadDir(outputDir)
 	require.NoError(t, err)
 	require.Len(t, dirEnts, 1)
-	require.Equal(t, "0000", dirEnts[0].Name())
+	require.Equal(t, outputName, dirEnts[0].Name())
+	data, err := ioutil.ReadFile(filepath.Join(outputDir, outputName))
+	require.NoError(t, err)
+	t.Log(string(data))
+}
+
+func writeCronFile(t testing.TB, inputDir string) {
+	now := time.Now().UTC()
+	timestampStr := now.Format(time.RFC3339)
+	err := ioutil.WriteFile(filepath.Join(inputDir, timestampStr), nil, 0755)
+	require.NoError(t, err)
+}
+
+func loadDB(t testing.TB, u pachsql.URL, numRows int) {
+	// load  DB
+	db := testutil.OpenDBURL(t, u, dockertestenv.MySQLPassword)
+	_, err := db.Exec(`CREATE TABLE test_data (
+			id SERIAL PRIMARY KEY,
+			col_a VARCHAR(100)
+	)`)
+	require.NoError(t, err)
+	for i := 0; i < numRows; i++ {
+		_, err := db.Exec(`INSERT INTO test_data (col_a) VALUES (?)`, randutil.UniqueString(""))
+		require.NoError(t, err)
+	}
+}
+
+func TestSQLChain(t *testing.T) {
+	ctx := context.Background()
+	log := logrus.StandardLogger()
+	u := dockertestenv.NewMySQLURL(t)
+	const N = 100
+	loadDB(t, u, N)
+	inputDir, outputDir := t.TempDir(), t.TempDir()
+	t.Logf("input: %v, output: %v", inputDir, outputDir)
+	writeCronFile(t, inputDir)
+
+	runChain(t, inputDir, outputDir, []func(string, string) error{
+		func(inDir, outDir string) error {
+			return SQLQueryGeneration(ctx, SQLQueryGenerationParams{
+				Logger:    log,
+				InputDir:  inDir,
+				OutputDir: outDir,
+				Query:     "select * FROM test_data",
+			})
+		},
+		func(inDir, outDir string) error {
+			return SQLIngest(ctx, SQLIngestParams{
+				Logger:    log,
+				InputDir:  inDir,
+				OutputDir: outDir,
+				URL:       u,
+				Password:  dockertestenv.MySQLPassword,
+				Format:    "csv",
+			})
+		},
+	})
+	lineCount := countLinesInFile(t, filepath.Join(outputDir, outputName))
+	require.Equal(t, N, lineCount)
+}
+
+func runChain(t testing.TB, inDir, outDir string, stages []func(inDir, outDir string) error) {
+	for i, stage := range stages {
+		var outDir2 string
+		if i == len(stages)-1 {
+			outDir2 = outDir
+		} else {
+			outDir2 = t.TempDir()
+		}
+		err := stage(inDir, outDir2)
+		require.NoError(t, err, "error in stage %d/%d", i+1, len(stages))
+		inDir = outDir2
+	}
 }

--- a/src/internal/transforms/sqlingest_test.go
+++ b/src/internal/transforms/sqlingest_test.go
@@ -22,7 +22,6 @@ func TestSQLIngest(t *testing.T) {
 	inputDir, outputDir := t.TempDir(), t.TempDir()
 	u := dockertestenv.NewMySQLURL(t)
 
-	// load  DB
 	db := testutil.OpenDBURL(t, u, dockertestenv.MySQLPassword)
 	_, err := db.Exec(`CREATE TABLE test_data (
 			id SERIAL PRIMARY KEY,


### PR DESCRIPTION
Adds a transform `sql-gen-queries` to `pachtf` which reads cron timestamp files from the input repo, and generates SQL queries with the timestamp as a comment in the output repo.

This is a component of a SQL ingest DAG, it can be replaced with something more complicated to allow for custom sharding, or snapshotting the database table before ingest.