### PR TITLE
Update pachub links to point at landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,6 @@ Introducing Pachyderm 2.0 with several foundational improvements. Read more deta
 
 Updated docs are at [docs.pachyderm.com](https://docs.pachyderm.com/latest/)
 
-Try Pachyderm 2.0 on [hub.pachyderm.com](https://hub.pachyderm.com/landing?redirect=%2F)
+Try Pachyderm 2.0 on [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/)
 
 Pachyderm 2.x is not backwards compatible with Pachyderm 1.x data formats. If you require assistance or have any questions, please contact [support@pachyderm.com](mailto:support@pachyderm.com)

--- a/doc/docs/1.12.x/hub/hub_getting_started.md
+++ b/doc/docs/1.12.x/hub/hub_getting_started.md
@@ -21,7 +21,7 @@ and can get started right away.
 ## Get started in 4 simple steps
 ![Hub Steps](../images/hub_steps.png)
 ## Before you start
-Log in with your GitHub or Google account to start using [hub.pachyderm.com](https://hub.pachyderm.com). 
+Log in with your GitHub or Google account to start using [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
 ![Hub Login](../images/hub_login.png)
 ## 1- Create a Workspace 
 Click the **Create a 4-hr Workspace** button and fill out the form.

--- a/doc/docs/1.13.x/hub/hub_getting_started.md
+++ b/doc/docs/1.13.x/hub/hub_getting_started.md
@@ -22,7 +22,7 @@ and can get started right away.
 ## Get started in 4 simple steps
 ![Hub Steps](../images/hub_steps.png)
 ## Before you start
-Log in with your GitHub or Google account to start using [hub.pachyderm.com](https://hub.pachyderm.com). 
+Log in with your GitHub or Google account to start using [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
 ![Hub Login](../images/hub_login.png)
 ## 1- Create a Workspace 
 Click the **Create a 4-hr Workspace** button and fill out the form.

--- a/doc/docs/2.0.x/enterprise/overview.md
+++ b/doc/docs/2.0.x/enterprise/overview.md
@@ -33,7 +33,7 @@ Pachyderm Enterprise also comes with two complementary tools that will quickly b
 - [**Notebooks(beta)**](#notebooks-beta) - Run experiments and explore your data from your favorite Jupyter notebooks using `pachctl` or our Python client [`python-pachyderm`](../../reference/clients). 
 
 !!! Note
-    Both are readily accessible on [Hub](https://hub.pachyderm.com/). The coming GA release of Notebooks will be an Enterprise Feature.
+    Both are readily accessible on [Hub](https://www.pachyderm.com/try-pachyderm-hub/). The coming GA release of Notebooks will be an Enterprise Feature.
 
 ## Console
 Pachyderm Enterprise Edition includes a full UI for visualizing pipelines and exploring data.  It automatically infers the structure of data scientists' DAGs and displays them visually. Data scientists and cluster admins can click on individual segments of pipelines and repos to see how many jobs have run, explore commits and data, or access Pachyderm logs. Console is an indispensable tool when designing and troubleshooting your data workflow.

--- a/doc/docs/2.0.x/getting_started/whats_new.md
+++ b/doc/docs/2.0.x/getting_started/whats_new.md
@@ -111,7 +111,7 @@ User Access Management is an Enterprise feature.
 
 ### New Console and Notebooks
 
-We have entirely re-worked our Web UI (`Console`) and are launching a beta version of our new integrated development environment (`Notebooks`) - namely, JupyterLab on Pachyderm. Both are readily accessible on [Hub](https://hub.pachyderm.com/). 
+We have entirely re-worked our Web UI (`Console`) and are launching a beta version of our new integrated development environment (`Notebooks`) - namely, JupyterLab on Pachyderm. Both are readily accessible on [Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
 
 - Introducing Pachyderm `Console`: Console replaces our Dashboard in Pachyderm 1. 
 
@@ -122,7 +122,7 @@ We have entirely re-worked our Web UI (`Console`) and are launching a beta versi
 !!! Note
     [Deploy Console Locally](../../deploy-manage/deploy/console/#deploy-locally) on your Minikube or Docker Desktop and browse through your DAGs' pipelines, check the content of your commits in a repo, look at the files they contain, check your DAG's jobs, or zoom in on their logs.
 
-- Additionally, we are releasing the first iteration of our `Notebooks` product (In its beta version), accessible on [Hub](https://hub.pachyderm.com/). The coming GA release of Notebooks will be an Enterprise Feature. 
+- Additionally, we are releasing the first iteration of our `Notebooks` product (In its beta version), accessible on [Hub](https://www.pachyderm.com/try-pachyderm-hub/). The coming GA release of Notebooks will be an Enterprise Feature. 
 
      You can now run and test your pipelines and data experiments from your favorite Jupiter notebooks.
 

--- a/doc/docs/2.0.x/how-tos/use-pachyderm-ide/index.md
+++ b/doc/docs/2.0.x/how-tos/use-pachyderm-ide/index.md
@@ -1,7 +1,7 @@
 # Notebooks (beta)
 
 !!! Warning 
-     - Notebooks [**beta**](../../contributing/supported-releases/#beta) is available on our Saas solution [Hub](https://hub.pachyderm.com). 
+     - Notebooks [**beta**](../../contributing/supported-releases/#beta) is available on our Saas solution [Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
      - [Contact us](mailto:sales@pachyderm.com) to create a workspace and start experimenting with Notebooks right away with our **21-day free trial**\*.
 
      *\*Offer limited to one single user workspace with 4 vCPUs, 15GB RAM, and unlimited object storage.*
@@ -27,7 +27,7 @@ Run `pip install` from a cell to install any additional library.
 ## Getting Started
 
 !!! Note 
-     On [Hub](https://hub.pachyderm.com), click the `Notebooks` button on your workspace.
+     On [Hub](https://www.pachyderm.com/try-pachyderm-hub/), click the `Notebooks` button on your workspace.
 
 
 From the landing page of Notebooks, in the `/examples` directory, click on the **Intro to Pachyderm Tutorial**. 

--- a/doc/docs/2.0.x/hub/hub_getting_started.md
+++ b/doc/docs/2.0.x/hub/hub_getting_started.md
@@ -22,7 +22,7 @@ and can get started right away.
 ## Get started in 4 simple steps
 ![Hub Steps](../images/hub_steps.png)
 ## Before you start
-Log in with your GitHub or Google account to start using [hub.pachyderm.com](https://hub.pachyderm.com). 
+Log in with your GitHub or Google account to start using [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
 ![Hub Login](../images/hub_login.png)
 ## 1- Create a Workspace 
 Click the **Create a 4-hr Workspace** button and fill out the form.

--- a/doc/docs/archived/1.10.x/getting_started/index.md
+++ b/doc/docs/archived/1.10.x/getting_started/index.md
@@ -8,7 +8,7 @@ provider, or in our fully managed service, Pachyderm Hub.
   <div class="column-2">
     <div class="card-square mdl-card mdl-shadow--2dp">
       <div class="mdl-card__title mdl-card--expand">
-        <h4 class="mdl-card__title-text">Deploy on PacHub &nbsp;&nbsp;&nbsp;<i class="fa fa-rocket"></i></h4>
+        <h4 class="mdl-card__title-text">Deploy on Pachyderm Hub &nbsp;&nbsp;&nbsp;<i class="fa fa-rocket"></i></h4>
       </div>
       <div class="mdl-card__supporting-text">
         Deploy a new cluster in seconds and try out
@@ -17,14 +17,14 @@ provider, or in our fully managed service, Pachyderm Hub.
       <div class="mdl-card__actions mdl-card--border">
         <ul>
           <li><a href="../pachub/pachub_getting_started/" class="md-typeset md-link">
-          Getting Started with PacHub
+          Getting Started with Pachyderm Hub
           </a>
           </li>
           <li><a href="beginner_tutorial/" class="md-typeset md-link">
           Beginner Tutorial
           </a>
-          <li><a href="https://hub.pachyderm.com" class="md-typeset md-link">
-          Go to PacHub
+          <li><a href="https://www.pachyderm.com/try-pachyderm-hub/" class="md-typeset md-link">
+          Go to Pachyderm Hub
           </a>
         </li>
        </ul>

--- a/doc/docs/archived/1.10.x/pachub/pachub_getting_started.md
+++ b/doc/docs/archived/1.10.x/pachub/pachub_getting_started.md
@@ -40,7 +40,7 @@ in [Join GitHub](https://github.com/join).
 
 To log in to Pachyderm Hub, complete the following steps:
 
-1. Go to [hub.pachyderm.com](https://hub.pachyderm.com).
+1. Go to [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/).
 1. Click **Try for free**.
 1. Authorize Pachyderm Hub with your GitHub account by typing your
    GitHub user name and password.

--- a/doc/docs/archived/1.11.x/getting_started/index.md
+++ b/doc/docs/archived/1.11.x/getting_started/index.md
@@ -8,7 +8,7 @@ provider, or in our fully managed service, Pachyderm Hub.
   <div class="column-2">
     <div class="card-square mdl-card mdl-shadow--2dp">
       <div class="mdl-card__title mdl-card--expand">
-        <h4 class="mdl-card__title-text">Deploy on PachHub &nbsp;&nbsp;&nbsp;<i class="fa fa-rocket"></i></h4>
+        <h4 class="mdl-card__title-text">Deploy on Pachyderm Hub &nbsp;&nbsp;&nbsp;<i class="fa fa-rocket"></i></h4>
       </div>
       <div class="mdl-card__supporting-text">
         Deploy a new cluster in seconds and try out
@@ -17,14 +17,14 @@ provider, or in our fully managed service, Pachyderm Hub.
       <div class="mdl-card__actions mdl-card--border">
         <ul>
           <li><a href="../pachhub/pachhub_getting_started/" class="md-typeset md-link">
-          Getting Started with PachHub
+          Getting Started with Pachyderm Hub
           </a>
           </li>
           <li><a href="beginner_tutorial/" class="md-typeset md-link">
           Beginner Tutorial
           </a>
-          <li><a href="https://hub.pachyderm.com" class="md-typeset md-link">
-          Go to PachHub
+          <li><a href="https://www.pachyderm.com/try-pachyderm-hub/" class="md-typeset md-link">
+          Go to Pachyderm Hub
           </a>
         </li>
        </ul>

--- a/doc/docs/archived/1.11.x/pachhub/pachhub_getting_started.md
+++ b/doc/docs/archived/1.11.x/pachhub/pachhub_getting_started.md
@@ -40,7 +40,7 @@ in [Join GitHub](https://github.com/join).
 
 To log in to Pachyderm Hub, complete the following steps:
 
-1. Go to [hub.pachyderm.com](https://hub.pachyderm.com).
+1. Go to [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/).
 1. Click **Try for free**.
 1. Authorize Pachyderm Hub with your GitHub account by typing your
    GitHub user name and password.

--- a/doc/docs/archived/1.9.x/getting_started/index.md
+++ b/doc/docs/archived/1.9.x/getting_started/index.md
@@ -8,7 +8,7 @@ provider, or in our fully managed service, Pachyderm Hub.
   <div class="column-2">
     <div class="card-square mdl-card mdl-shadow--2dp">
       <div class="mdl-card__title mdl-card--expand">
-        <h4 class="mdl-card__title-text">Deploy on PacHub &nbsp;&nbsp;&nbsp;<i class="fa fa-rocket"></i></h4>
+        <h4 class="mdl-card__title-text">Deploy on Pachyderm Hub &nbsp;&nbsp;&nbsp;<i class="fa fa-rocket"></i></h4>
       </div>
       <div class="mdl-card__supporting-text">
         Deploy a new cluster in seconds and try out
@@ -17,14 +17,14 @@ provider, or in our fully managed service, Pachyderm Hub.
       <div class="mdl-card__actions mdl-card--border">
         <ul>
           <li><a href="../pachub/pachub_getting_started/" class="md-typeset md-link">
-          Getting Started with PacHub
+          Getting Started with Pachyderm Hub
           </a>
           </li>
           <li><a href="beginner_tutorial/" class="md-typeset md-link">
           Beginner Tutorial
           </a>
-          <li><a href="https://hub.pachyderm.com" class="md-typeset md-link">
-          Go to PacHub
+          <li><a href="https://www.pachyderm.com/try-pachyderm-hub/" class="md-typeset md-link">
+          Go to Pachyderm Hub
           </a>
         </li>
        </ul>

--- a/doc/docs/archived/1.9.x/pachub/pachub_getting_started.md
+++ b/doc/docs/archived/1.9.x/pachub/pachub_getting_started.md
@@ -40,7 +40,7 @@ in [Join GitHub](https://github.com/join).
 
 To log in to Pachyderm Hub, complete the following steps:
 
-1. Go to [hub.pachyderm.com](https://hub.pachyderm.com).
+1. Go to [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/).
 1. Click **Try for free**.
 1. Authorize Pachyderm Hub with your GitHub account by typing your
    GitHub user name and password.

--- a/doc/docs/master/enterprise/overview.md
+++ b/doc/docs/master/enterprise/overview.md
@@ -33,7 +33,7 @@ Pachyderm Enterprise also comes with two complementary tools that will quickly b
 - [**Notebooks(beta)**](#notebooks-beta) - Run experiments and explore your data from your favorite Jupyter notebooks using `pachctl` or our Python client [`python-pachyderm`](../../reference/clients). 
 
 !!! Note
-    Both are readily accessible on [Hub](https://hub.pachyderm.com/). The coming GA release of Notebooks will be an Enterprise Feature.
+    Both are readily accessible on [Hub](https://www.pachyderm.com/try-pachyderm-hub/). The coming GA release of Notebooks will be an Enterprise Feature.
 
 ## Console
 Pachyderm Enterprise Edition includes a full UI for visualizing pipelines and exploring data.  It automatically infers the structure of data scientists' DAGs and displays them visually. Data scientists and cluster admins can click on individual segments of pipelines and repos to see how many jobs have run, explore commits and data, or access Pachyderm logs. Console is an indispensable tool when designing and troubleshooting your data workflow.

--- a/doc/docs/master/getting_started/whats_new.md
+++ b/doc/docs/master/getting_started/whats_new.md
@@ -111,7 +111,7 @@ User Access Management is an Enterprise feature.
 
 ### New Console and Notebooks
 
-We have entirely re-worked our Web UI (`Console`) and are launching a beta version of our new integrated development environment (`Notebooks`) - namely, JupyterLab on Pachyderm. Both are readily accessible on [Hub](https://hub.pachyderm.com/). 
+We have entirely re-worked our Web UI (`Console`) and are launching a beta version of our new integrated development environment (`Notebooks`) - namely, JupyterLab on Pachyderm. Both are readily accessible on [Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
 
 - Introducing Pachyderm `Console`: Console replaces our Dashboard in Pachyderm 1. 
 
@@ -122,7 +122,7 @@ We have entirely re-worked our Web UI (`Console`) and are launching a beta versi
 !!! Note
     [Deploy Console Locally](../../deploy-manage/deploy/console/#deploy-locally) on your Minikube or Docker Desktop and browse through your DAGs' pipelines, check the content of your commits in a repo, look at the files they contain, check your DAG's jobs, or zoom in on their logs.
 
-- Additionally, we are releasing the first iteration of our `Notebooks` product (In its beta version), accessible on [Hub](https://hub.pachyderm.com/). The coming GA release of Notebooks will be an Enterprise Feature. 
+- Additionally, we are releasing the first iteration of our `Notebooks` product (In its beta version), accessible on [Hub](https://www.pachyderm.com/try-pachyderm-hub/). The coming GA release of Notebooks will be an Enterprise Feature. 
 
      You can now run and test your pipelines and data experiments from your favorite Jupiter notebooks.
 

--- a/doc/docs/master/how-tos/use-pachyderm-ide/index.md
+++ b/doc/docs/master/how-tos/use-pachyderm-ide/index.md
@@ -1,7 +1,7 @@
 # Notebooks (beta)
 
 !!! Warning 
-     - Notebooks [**beta**](../../contributing/supported-releases/#beta) is available on our Saas solution [Hub](https://hub.pachyderm.com). 
+     - Notebooks [**beta**](../../contributing/supported-releases/#beta) is available on our Saas solution [Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
      - [Contact us](mailto:sales@pachyderm.com) to create a workspace and start experimenting with Notebooks right away with our **21-day free trial**\*.
 
      *\*Offer limited to one single user workspace with 4 vCPUs, 15GB RAM, and unlimited object storage.*
@@ -27,7 +27,7 @@ Run `pip install` from a cell to install any additional library.
 ## Getting Started
 
 !!! Note 
-     On [Hub](https://hub.pachyderm.com), click the `Notebooks` button on your workspace.
+     On [Hub](https://www.pachyderm.com/try-pachyderm-hub/), click the `Notebooks` button on your workspace.
 
 
 From the landing page of Notebooks, in the `/examples` directory, click on the **Intro to Pachyderm Tutorial**. 

--- a/doc/docs/master/hub/hub_getting_started.md
+++ b/doc/docs/master/hub/hub_getting_started.md
@@ -22,7 +22,7 @@ and can get started right away.
 ## Get started in 4 simple steps
 ![Hub Steps](../images/hub_steps.png)
 ## Before you start
-Log in with your GitHub or Google account to start using [hub.pachyderm.com](https://hub.pachyderm.com). 
+Log in with your GitHub or Google account to start using [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/). 
 ![Hub Login](../images/hub_login.png)
 ## 1- Create a Workspace 
 Click the **Create a 4-hr Workspace** button and fill out the form.

--- a/doc/overrides/home.html
+++ b/doc/overrides/home.html
@@ -23,7 +23,7 @@ solid;font-size:.685rem;font-weight:700;font-family:'Montserrat', sans-serif;cur
   
             Deploy locally, on the cloud, or Pachyderm Hub in minutes.
           </p>
-          <a href="https://hub.pachyderm.com" title="{{ lang.t('source.link.title') }}" class="md-link">
+          <a href="https://www.pachyderm.com/try-pachyderm-hub/" title="{{ lang.t('source.link.title') }}" class="md-link">
               Try Pachyderm on Hub
           </a>
           <p style=line-height:24px;>

--- a/doc/overrides/main.html
+++ b/doc/overrides/main.html
@@ -162,7 +162,7 @@ body {
   </a>
    <div class="tx-hero" style="float:right">
   
-  <!--a class="hub-button" href="https://hub.pachyderm.com">Try on Hub!
+  <!--a class="hub-button" href="https://www.pachyderm.com/try-pachyderm-hub/">Try on Hub!
     <span class="beta">Free</span></a>
   </div-->
 {% endblock %}

--- a/examples/ml/housing-prices/README.md
+++ b/examples/ml/housing-prices/README.md
@@ -56,7 +56,7 @@ Sample:
 Before you can deploy this example you need to have the following components:
 
 1. A clone of this Pachyderm repository on your local computer. (could potentially include those instructions)
-2. A Pachyderm cluster - You can deploy a cluster on [PacHub](hub.pachyderm.com) or deploy locally as described [here](https://docs.pachyderm.com/latest/getting_started/).
+2. A Pachyderm cluster - You can deploy a cluster on [Pachyderm Hub](https://www.pachyderm.com/try-pachyderm-hub/) or deploy locally as described [here](https://docs.pachyderm.com/latest/getting_started/).
 
 Verify that your environment is accessible by running `pachctl version` which will show both the `pachctl` and `pachd` versions.
 ```shell


### PR DESCRIPTION
To be put live once the new hub landing page is live in WordPress