### PR TITLE
upgrade ingress from v1beta to v1

### DIFF
--- a/etc/helm/Makefile
+++ b/etc/helm/Makefile
@@ -15,31 +15,31 @@ test: pachyderm/values.schema.json kubeval-aws-gp2 kubeval-aws-gp3 kubeval-gcp k
 	go test -race ./... -count 1
 
 kubeval-aws-gp2:
-	helm template pachyderm -f examples/aws-gp2-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/aws-gp2-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-aws-gp3:
-	helm template pachyderm -f examples/aws-gp3-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/aws-gp3-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-gcp:
-	helm template pachyderm -f examples/gcp-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/gcp-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-gcp-tls:
-	helm template pachyderm -f examples/gcp-values-tls.yaml | kubeval --strict
+	helm template pachyderm -f examples/gcp-values-tls.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-hub:
-	helm template pachyderm -f examples/hub-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/hub-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-local-dev:
-	helm template pachyderm -f examples/local-dev-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/local-dev-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-minio:
-	helm template pachyderm -f examples/minio-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/minio-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-microsoft:
-	helm template pachyderm -f examples/microsoft-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/microsoft-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 kubeval-enterprise:
-	helm template pachyderm -f examples/enterprise-values.yaml | kubeval --strict
+	helm template pachyderm -f examples/enterprise-values.yaml | kubeval --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --strict
 
 schema:
 	helm schema-gen pachyderm/values.yaml > pachyderm/values.schema.json

--- a/etc/helm/pachyderm/templates/ingress/ingress.yaml
+++ b/etc/helm/pachyderm/templates/ingress/ingress.yaml
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
 {{- if and .Values.console.enabled .Values.ingress.enabled -}}
-apiVersion: "networking.k8s.io/v1beta1"
+apiVersion: "networking.k8s.io/v1"
 kind: "Ingress"
 metadata:
   name: "console"
@@ -24,15 +24,24 @@ spec:
       http:
         paths:
           - path: "/dex"
+            pathType: Prefix
             backend:
-              serviceName: "pachd"
-              servicePort: "identity-port"
+              service:
+                name: "pachd"
+                port:
+                  name: "identity-port"
           - path: "/authorization-code/callback"
+            pathType: Prefix
             backend:
-              serviceName: "pachd"
-              servicePort: "oidc-port"
-          - path: "/*"
+              service:
+                name: "pachd"
+                port:
+                  name: "oidc-port"
+          - path: "/"
+            pathType: Prefix
             backend:
-              serviceName: "console"
-              servicePort: "console-http"
+              service:
+                name: "console"
+                port:
+                  name: "console-http"
 {{ end -}}

--- a/etc/helm/pachyderm/templates/ingress/ingress.yaml
+++ b/etc/helm/pachyderm/templates/ingress/ingress.yaml
@@ -23,10 +23,6 @@ spec:
     - host: {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
       http:
         paths:
-          - path: "/"
-            backend:
-              serviceName: "console"
-              servicePort: "console-http"
           - path: "/dex"
             backend:
               serviceName: "pachd"
@@ -35,4 +31,8 @@ spec:
             backend:
               serviceName: "pachd"
               servicePort: "oidc-port"
+          - path: "/*"
+            backend:
+              serviceName: "console"
+              servicePort: "console-http"
 {{ end -}}

--- a/etc/helm/test/hub_test.go
+++ b/etc/helm/test/hub_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	appsV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
 )
 
 func TestHub(t *testing.T) {
@@ -43,7 +42,7 @@ func TestHub(t *testing.T) {
 	}
 	for _, object := range objects {
 		switch object := object.(type) {
-		case *v1beta1.Ingress:
+		case *appsV1.Ingress:
 			for _, rule := range object.Spec.Rules {
 				if rule.Host == "console.test" {
 					checks["ingress"] = true

--- a/etc/helm/test/hub_test.go
+++ b/etc/helm/test/hub_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	appsV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	netV1 "k8s.io/api/networking/v1"
 )
 
 func TestHub(t *testing.T) {
@@ -42,7 +43,7 @@ func TestHub(t *testing.T) {
 	}
 	for _, object := range objects {
 		switch object := object.(type) {
-		case *appsV1.Ingress:
+		case *netV1.Ingress:
 			for _, rule := range object.Spec.Rules {
 				if rule.Host == "console.test" {
 					checks["ingress"] = true


### PR DESCRIPTION
Some ingress controllers don't treat paths without `*` as prefix types in v1beta. Also moved the `/*` to the end as the catchall