### PR TITLE
add annotations to helm chart

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- end }}
       name: console
       namespace: {{ .Release.Namespace }}
+      {{- if .Values.console.annotations }}
+      annotations: {{ toYaml .Values.console.annotations | nindent 4 }}
+      {{- end }}
     spec:
 {{- include "pachyderm.imagePullSecrets" . | indent 6 }}
       containers:

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         {{- end }}
       name: pach-enterprise
       namespace: {{ .Release.Namespace }}
+      {{- if .Values.enterpriseServer.annotations }}
+      annotations: {{ toYaml .Values.enterpriseServer.annotations | nindent 4 }}
+      {{- end }}
     spec:
       {{-  if .Values.enterpriseServer.affinity }}
       affinity: {{ toYaml .Values.enterpriseServer.affinity | nindent 8 }}

--- a/etc/helm/pachyderm/templates/etcd/statefulset.yaml
+++ b/etc/helm/pachyderm/templates/etcd/statefulset.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
       name: etcd
       namespace: {{ .Release.Namespace }}
+      {{- if .Values.etcd.annotations }}
+      annotations: {{ toYaml .Values.etcd.annotations | nindent 4 }}
+      {{- end }}
     spec:
       {{-  if .Values.etcd.affinity }}
       affinity: {{ toYaml .Values.etcd.affinity | nindent 8 }}

--- a/etc/helm/pachyderm/templates/pachd/config-job.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-job.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded
+  {{- if .Values.pachd.configJob.annotations -}}
+    {{ toYaml .Values.pachd.configJob.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app: pachd
     suite: pachyderm

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -23,9 +23,9 @@ spec:
     metadata:
       annotations:
         checksum/storage-secret: {{ include (print $.Template.BasePath "/pachd/storage-secret.yaml") . | sha256sum }}
-          {{- if .Values.pachd.annotations -}}
-            {{ toYaml .Values.pachd.annotations | nindent 4 }}
-          {{- end }}
+        {{- if .Values.pachd.annotations -}}
+        {{ toYaml .Values.pachd.annotations | nindent 4 }}
+        {{- end }}
       labels:
         app: pachd
         suite: pachyderm

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -23,6 +23,9 @@ spec:
     metadata:
       annotations:
         checksum/storage-secret: {{ include (print $.Template.BasePath "/pachd/storage-secret.yaml") . | sha256sum }}
+          {{- if .Values.pachd.annotations -}}
+            {{ toYaml .Values.pachd.annotations | nindent 4 }}
+          {{- end }}
       labels:
         app: pachd
         suite: pachyderm

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         suite: pachyderm
       name: pg-bouncer
       namespace: {{ .Release.Namespace }}
+      {{- if .Values.pgbouncer.annotations }}
+      annotations: {{ toYaml .Values.pgbouncer.annotations | nindent 4 }}
+      {{- end }}
     spec:
 {{- include "pachyderm.imagePullSecrets" . | indent 6 }}
       containers:

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -53,6 +53,9 @@
         "console": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object"
+                },
                 "config": {
                     "type": "object",
                     "properties": {
@@ -121,6 +124,9 @@
                 "affinity": {
                     "type": "object"
                 },
+                "annotations": {
+                    "type": "object"
+                },
                 "clusterDeploymentID": {
                     "type": "string"
                 },
@@ -186,6 +192,9 @@
             "type": "object",
             "properties": {
                 "affinity": {
+                    "type": "object"
+                },
+                "annotations": {
                     "type": "object"
                 },
                 "dynamicNodes": {
@@ -355,8 +364,19 @@
                 "affinity": {
                     "type": "object"
                 },
+                "annotations": {
+                    "type": "object"
+                },
                 "clusterDeploymentID": {
                     "type": "string"
+                },
+                "configJob": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        }
+                    }
                 },
                 "enabled": {
                     "type": "boolean"
@@ -684,6 +704,9 @@
         "pgbouncer": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object"
+                },
                 "maxConnections": {
                     "type": "integer"
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -33,6 +33,7 @@ global:
 console:
   # enabled controls whether the console manifests are created or not.
   enabled: false
+  annotations: {}
   image:
     # repository is the image repo to pull from; together with tag it
     # replicates the --console-image & --registry arguments to pachctl
@@ -69,6 +70,7 @@ console:
 
 etcd:
   affinity: {}
+  annotations: {}
   # dynamicNodes sets the number of nodes in the etcd StatefulSet.  It
   # is analogous to the --dynamic-etcd-nodes argument to pachctl
   # deploy.
@@ -113,6 +115,7 @@ etcd:
 enterpriseServer:
   enabled: false
   affinity: {}
+  annotations: {}
   service:
     type: ClusterIP
   # There are three options for TLS:
@@ -163,8 +166,11 @@ ingress:
 pachd:
   enabled: true
   affinity: {}
+  annotations: {}
   # clusterDeploymentID sets the Pachyderm cluster ID.
   clusterDeploymentID: ""
+  configJob:
+    annotations: {}
   # goMaxProcs is passed as GOMAXPROCS to the pachd container.
   goMaxProcs: 0
   image:
@@ -385,6 +391,7 @@ pachd:
 pgbouncer:
   service:
     type: ClusterIP
+  annotations: {}
   resources: {}
     #limits:
     #  cpu: "1"


### PR DESCRIPTION
Adds annotation capability for pachd, etcd, enterpriseserver, console, pgbouncer, and configjob