### PR TITLE
Use request context in s3 gateway.

### DIFF
--- a/src/server/pfs/s3/s3.go
+++ b/src/server/pfs/s3/s3.go
@@ -67,7 +67,7 @@ func (c *controller) requestClient(r *http.Request) (*client.APIClient, error) {
 		}
 	}
 
-	return pc, nil
+	return pc.WithCtx(r.Context()), nil
 }
 
 // Router creates an http server like object that serves an S3-like API for PFS. This allows you to


### PR DESCRIPTION
The s3 gateway was keeping requests open even after the corresponding
http request had been closed, making it very easy to OOM on larger
requests.