### PR TITLE
[2.0.x Backport] Expose global.customCaCerts helm value for use of custom System Certs…

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -60,7 +60,25 @@ spec:
             secretKeyRef:
               name: pachyderm-console-secret
               key: OAUTH_CLIENT_SECRET
+        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        - name: NODE_EXTRA_CA_CERTS
+          value:  /pach-tls/certs/root.crt
+        {{- end }}
         {{- if .Values.console.resources }}
         resources: {{ toYaml .Values.console.resources | nindent 10 }}
         {{- end }}
+        volumeMounts:
+        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        - mountPath: /pach-tls/certs
+          name: pachd-tls-cert
+        {{- end }}
+      volumes:
+      {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+      - name: pachd-tls-cert
+        secret:
+          secretName: {{ required "If pachd.tls.enabled, you must set pachd.tls.secretName" .Values.pachd.tls.secretName | quote }}
+          items:
+          - key: tls.crt
+            path: root.crt
+      {{- end }}
 {{ end -}}

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -55,6 +55,10 @@ spec:
             secretKeyRef:
               name: postgres # Must match secret setup by postgres subchart or postgres-secret.yaml if using external postgres
               key: postgresql-password
+        {{- if and .Values.enterpriseServer.tls.enabled .Values.global.customCaCerts }}
+        - name: SSL_CERT_DIR
+          value:  /pachd-tls-cert
+        {{- end }}
         envFrom:
           - secretRef:
               name: pachyderm-deployment-id-secret

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -137,6 +137,10 @@ spec:
           value: {{ .Values.pachd.storage.uploadConcurrencyLimit | quote }}
         - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
           value: {{ .Values.pachd.storage.putFileConcurrencyLimit | quote }}
+        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        - name: SSL_CERT_DIR
+          value:  /pachd-tls-cert
+        {{- end }}
         envFrom:
           - secretRef:
               name: pachyderm-storage-secret

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -244,6 +244,9 @@
         "global": {
             "type": "object",
             "properties": {
+                "customCaCerts": {
+                    "type": "boolean"
+                },
                 "imagePullSecrets": {
                     "type": "array"
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -29,6 +29,8 @@ global:
   # imagePullSecrets:
   #   - regcred
   imagePullSecrets: []
+  # when set, the certificate file in pachd-tls-cert will be loaded as the root certificate for pachd, console, and enterprise-server pods
+  customCaCerts: false
 
 console:
   # enabled controls whether the console manifests are created or not.


### PR DESCRIPTION
… (#7155)

* Expose global.customCaCerts helm value to instruct usage of pachd-tls-cert#tls.crt k8s secret as the root cert for pachd, console, and enterprise-server

* Adding helm comment

* Use NODE_EXTRA_CA_CERTS envvar for console