### PR TITLE
Annotate which errors are caused by users and don't log stack traces for them

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -183,6 +183,7 @@ const errNoRoleBindingMsg = "no role binding exists for"
 
 // ErrNoRoleBinding is returned if no role binding exists for a resource.
 type ErrNoRoleBinding struct {
+	errors.UserError
 	Resource Resource
 }
 
@@ -201,8 +202,8 @@ func IsErrNoRoleBinding(err error) bool {
 // ErrNotAuthorized is returned if the user is not authorized to perform
 // a certain operation.
 type ErrNotAuthorized struct {
-	Subject string // subject trying to perform blocked operation -- always set
-
+	errors.UserError
+	Subject  string       // subject trying to perform blocked operation -- always set
 	Resource Resource     // Resource that the user is attempting to access
 	Required []Permission // Caller needs 'Required'-level access to 'Resource'
 }
@@ -228,6 +229,7 @@ func IsErrNotAuthorized(err error) bool {
 // ErrInvalidPrincipal indicates that a an argument to e.g. GetScope,
 // SetScope, or SetACL is invalid
 type ErrInvalidPrincipal struct {
+	errors.UserError
 	Principal string
 }
 
@@ -247,6 +249,7 @@ func IsErrInvalidPrincipal(err error) bool {
 // ErrTooShortTTL is returned by the ExtendAuthToken if request.Token already
 // has a TTL longer than request.TTL.
 type ErrTooShortTTL struct {
+	errors.UserError
 	RequestTTL, ExistingTTL int64
 }
 

--- a/src/auth/auth_err_test.go
+++ b/src/auth/auth_err_test.go
@@ -69,10 +69,10 @@ func TestIsErrNotAuthorized(t *testing.T) {
 
 func TestErrNoRoleBinding(t *testing.T) {
 	require.True(t, IsErrNoRoleBinding(&ErrNoRoleBinding{
-		Resource{Type: ResourceType_REPO, Name: "test"},
+		Resource: Resource{Type: ResourceType_REPO, Name: "test"},
 	}))
 	require.True(t, IsErrNoRoleBinding(grpcify(&ErrNoRoleBinding{
-		Resource{Type: ResourceType_REPO, Name: "test"},
+		Resource: Resource{Type: ResourceType_REPO, Name: "test"},
 	})))
 }
 

--- a/src/internal/errors/errors.go
+++ b/src/internal/errors/errors.go
@@ -33,6 +33,20 @@ var (
 	WithStack = errors.WithStack
 )
 
+// UserError is a type used to indicate that an error is not an internal error
+// so that we can log it differently (i.e. do not log at the ERROR level with a
+// stack trace)
+type UserError struct{}
+
+func (err UserError) IsUserError() bool {
+	return true
+}
+
+// Interface for type-checking user errors
+type UserErrorer interface {
+	IsUserError() bool
+}
+
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace = errors.StackTrace
 

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"google.golang.org/grpc/codes"
@@ -13,80 +14,95 @@ import (
 
 // ErrFileNotFound represents a file-not-found error.
 type ErrFileNotFound struct {
+	errors.UserError
 	File *pfs.File
 }
 
 // ErrRepoNotFound represents a repo-not-found error.
 type ErrRepoNotFound struct {
+	errors.UserError
 	Repo *pfs.Repo
 }
 
 // ErrRepoExists represents a repo-exists error.
 type ErrRepoExists struct {
+	errors.UserError
 	Repo *pfs.Repo
 }
 
 // ErrBranchNotFound represents a branch-not-found error.
 type ErrBranchNotFound struct {
+	errors.UserError
 	Branch *pfs.Branch
 }
 
 // ErrBranchExists represents a branch-exists error.
 type ErrBranchExists struct {
+	errors.UserError
 	Branch *pfs.Branch
 }
 
 // ErrCommitNotFound represents a commit-not-found error.
 type ErrCommitNotFound struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrCommitSetNotFound represents a commitset-not-found error.
 type ErrCommitSetNotFound struct {
+	errors.UserError
 	CommitSet *pfs.CommitSet
 }
 
 // ErrCommitExists represents an error where the commit already exists.
 type ErrCommitExists struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrCommitFinished represents an error where the commit has been finished
 // (e.g from PutFile or DeleteFile)
 type ErrCommitFinished struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrCommitError represents an error where the commit has been finished with an error.
 type ErrCommitError struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrCommitDeleted represents an error where the commit has been deleted (e.g.
 // from InspectCommit)
 type ErrCommitDeleted struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrParentCommitNotFound represents a parent-commit-not-found error.
 type ErrParentCommitNotFound struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrOutputCommitNotFinished represents an error where the commit has not
 // been finished
 type ErrOutputCommitNotFinished struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrCommitNotFinished represents an error where the commit has not been finished.
 type ErrCommitNotFinished struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
 // ErrAmbiguousCommit represents an error where a user-specified commit did not
 // specify a branch and resolved to multiple commits on different branches.
 type ErrAmbiguousCommit struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
@@ -94,6 +110,7 @@ type ErrAmbiguousCommit struct {
 // create a CommitSet with multiple commits in the same branch, which would
 // result in inconsistent data dependencies.
 type ErrInconsistentCommit struct {
+	errors.UserError
 	Branch *pfs.Branch
 	Commit *pfs.Commit
 }
@@ -108,6 +125,7 @@ func (e ErrInconsistentCommit) Is(other error) bool {
 // Users should not manually try to start a commit in an output branch, this
 // should only be done internally in PFS.
 type ErrCommitOnOutputBranch struct {
+	errors.UserError
 	Branch *pfs.Branch
 }
 
@@ -117,6 +135,7 @@ type ErrCommitOnOutputBranch struct {
 // this situation, so it is not allowed.  To proceed anyway, use the
 // DropCommitSet operation, which implies data loss.
 type ErrSquashWithoutChildren struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 
@@ -126,6 +145,7 @@ type ErrSquashWithoutChildren struct {
 // However, a drop is still allowed for a commit with no children as there is no
 // cleanup needed for child commits.
 type ErrDropWithChildren struct {
+	errors.UserError
 	Commit *pfs.Commit
 }
 

--- a/src/server/pfs/pfs_test.go
+++ b/src/server/pfs/pfs_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestErrorMatching(t *testing.T) {
 	c := client.NewCommit("foo", "bar", "")
-	require.True(t, IsCommitNotFoundErr(ErrCommitNotFound{c}))
-	require.False(t, IsCommitNotFoundErr(ErrCommitDeleted{c}))
-	require.False(t, IsCommitNotFoundErr(ErrCommitFinished{c}))
+	require.True(t, IsCommitNotFoundErr(ErrCommitNotFound{Commit: c}))
+	require.False(t, IsCommitNotFoundErr(ErrCommitDeleted{Commit: c}))
+	require.False(t, IsCommitNotFoundErr(ErrCommitFinished{Commit: c}))
 
-	require.False(t, IsCommitDeletedErr(ErrCommitNotFound{c}))
-	require.True(t, IsCommitDeletedErr(ErrCommitDeleted{c}))
-	require.False(t, IsCommitDeletedErr(ErrCommitFinished{c}))
+	require.False(t, IsCommitDeletedErr(ErrCommitNotFound{Commit: c}))
+	require.True(t, IsCommitDeletedErr(ErrCommitDeleted{Commit: c}))
+	require.False(t, IsCommitDeletedErr(ErrCommitFinished{Commit: c}))
 
-	require.False(t, IsCommitFinishedErr(ErrCommitNotFound{c}))
-	require.False(t, IsCommitFinishedErr(ErrCommitDeleted{c}))
-	require.True(t, IsCommitFinishedErr(ErrCommitFinished{c}))
+	require.False(t, IsCommitFinishedErr(ErrCommitNotFound{Commit: c}))
+	require.False(t, IsCommitFinishedErr(ErrCommitDeleted{Commit: c}))
+	require.True(t, IsCommitFinishedErr(ErrCommitFinished{Commit: c}))
 }

--- a/src/server/pps/pps.go
+++ b/src/server/pps/pps.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
 // ErrJobFinished represents a finished job error.
 type ErrJobFinished struct {
+	errors.UserError
 	Job *pps.Job
 }
 
@@ -18,6 +20,7 @@ func (e ErrJobFinished) Error() string {
 }
 
 type ErrPipelineNotFound struct {
+	errors.UserError
 	Pipeline *pps.Pipeline
 }
 


### PR DESCRIPTION
This PR adds a new type `errors.UserError` that error types can embed, which will be recognized by the RPC `Log` function to suppress logging stack traces.