### PR TITLE
[2.0.x Backport] Unset Worker SecurityContexts when pachd.securityContext.enabled=false (#7218)

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -160,6 +160,8 @@ spec:
         - name: NO_PROXY
           value:  {{.Values.global.noProxy}}
         {{ end }}
+        - name: ENABLE_WORKER_SECURITY_CONTEXTS
+          value: {{ .Values.pachd.securityContext.enabled | quote }}    
         envFrom:
           - secretRef:
               name: pachyderm-storage-secret

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -93,7 +93,8 @@ type PachdSpecificConfiguration struct {
 	WorkerUsesRoot             bool   `env:"WORKER_USES_ROOT,default=false"`
 	RequireCriticalServersOnly bool   `env:"REQUIRE_CRITICAL_SERVERS_ONLY,default=false"`
 	// TODO: Merge this with the worker specific pod name (PPS_POD_NAME) into a global configuration pod name.
-	PachdPodName string `env:"PACHD_POD_NAME,required"`
+	PachdPodName                 string `env:"PACHD_POD_NAME,required"`
+	EnableWorkerSecurityContexts bool   `env:"ENABLE_WORKER_SECURITY_CONTEXTS,default=true"`
 }
 
 // StorageConfiguration contains the storage configuration.

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -300,7 +300,10 @@ func (a *apiServer) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pipe
 	}
 	var userSecurityCtx *v1.SecurityContext
 	userStr := pipelineInfo.Details.Transform.User
-	if a.workerUsesRoot {
+
+	if !a.env.Config().EnableWorkerSecurityContexts {
+		pachSecurityCtx = nil
+	} else if a.workerUsesRoot {
 		pachSecurityCtx = &v1.SecurityContext{RunAsUser: int64Ptr(0)}
 		userSecurityCtx = &v1.SecurityContext{RunAsUser: int64Ptr(0)}
 	} else if userStr != "" {


### PR DESCRIPTION

Exposing pachd env-var `ENABLE_WORKER_SECURITY_CONTEXTS` that is set to false when helm's `pachd.securityContext.enabled=false`