### PR TITLE
Use published helm manifest in pre-upgrade deployment of the Upgrade Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,17 +168,7 @@ jobs:
       - run: etc/testing/circle/install.sh
       - run: etc/testing/circle/start-minikube.sh
       - run: etc/testing/circle/launch-loki.sh
-
-      - run: |
-          if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-            url=https://api.github.com/repos/pachyderm/pachyderm/pulls/${CIRCLE_PULL_REQUEST##*/}
-            base=$(curl $url | jq '.base.ref' | tr -d '"')
-            head=$(git rev-parse --abbrev-ref HEAD)
-            ./etc/testing/circle/upgrade_test.sh $base $head
-          elif [[ "$CIRCLE_BRANCH" != "master" ]]; then
-            echo "$CIRCLE_PULL_REQUEST must be set to run upgrade test. For now, this fails on the first CI run of a PR - please re-run this failed job."
-            exit 1;
-          fi;
+      - run: etc/testing/circle/upgrade_test.sh
 
 workflows:
   circleci:

--- a/etc/testing/circle/launch-published.sh
+++ b/etc/testing/circle/launch-published.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/env.sh"
+
+# deploy object storage
+kubectl apply -f etc/testing/minio.yaml
+
+helm repo add pach https://helm.pachyderm.com
+helm repo update
+
+VERSION="2.0.4"
+helm install pachyderm -f etc/testing/circle/helm-values.yaml pach/pachyderm --version "$VERSION" --set pachd.image.tag="$VERSION";
+
+kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
+
+# Wait for loki to be deployed
+kubectl wait --for=condition=ready pod -l release=loki --timeout=5m
+
+pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/etc/testing/circle/upgrade_test.sh
+++ b/etc/testing/circle/upgrade_test.sh
@@ -2,16 +2,12 @@
 
 set -ve
 
-
-git checkout "$1" &&
-
 ./etc/testing/circle/build.sh &&
-./etc/testing/circle/launch.sh &&
 
-git checkout "$2" &&
+./etc/testing/circle/launch-published.sh &&
+
 go test -v ./src/testing/upgrade -run TestPreUpgrade &&
 
-# build and upgrade to HEAD
-./etc/testing/circle/build.sh &&
 ./etc/testing/circle/helm-upgrade.sh &&
+
 go test -v ./src/testing/upgrade -run TestPostUpgrade


### PR DESCRIPTION
Remove the git-magic happening in the Upgrade test by first deploying a published pachyderm version