### PR TITLE
Move RPC logging into an interceptor

### DIFF
--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -1,219 +1,14 @@
 package log
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/fatih/camelcase"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
-
-// This needs to be a global var, not a field on the logger, because multiple servers
-// create new loggers, and the prometheus registration uses a global namespace
-var reportMetricGauge prometheus.Gauge
-var reportMetricsOnce sync.Once
-
-// Logger is a helper for emitting our grpc API logs
-type Logger interface {
-	Log(ctx context.Context, request interface{}, response interface{}, err error, duration time.Duration)
-	LogAtLevelFromDepth(ctx context.Context, request interface{}, response interface{}, err error, duration time.Duration, level logrus.Level, depth int)
-}
-
-type logger struct {
-	*logrus.Entry
-	histogram   map[string]*prometheus.HistogramVec
-	counter     map[string]prometheus.Counter
-	mutex       *sync.Mutex // synchronizes access to both histogram and counter maps
-	exportStats bool
-	service     string
-}
-
-// NewLogger creates a new logger
-func NewLogger(service string, l *logrus.Logger) Logger {
-	return newLogger(service, true, l)
-}
-
-// NewLocalLogger creates a new logger for local testing (which does not report prometheus metrics)
-func NewLocalLogger(service string, l *logrus.Logger) Logger {
-	return newLogger(service, false, l)
-}
-
-func newLogger(service string, exportStats bool, l *logrus.Logger) Logger {
-	l.Formatter = FormatterFunc(Pretty)
-	newLogger := &logger{
-		l.WithFields(logrus.Fields{"service": service}),
-		make(map[string]*prometheus.HistogramVec),
-		make(map[string]prometheus.Counter),
-		&sync.Mutex{},
-		exportStats,
-		service,
-	}
-	if exportStats {
-		reportMetricsOnce.Do(func() {
-			newReportMetricGauge := prometheus.NewGauge(
-				prometheus.GaugeOpts{
-					Namespace: "pachyderm",
-					Subsystem: "pachd",
-					Name:      "report_metric",
-					Help:      "gauge of number of calls to ReportMetric()",
-				},
-			)
-			if err := prometheus.Register(newReportMetricGauge); err != nil {
-				// metrics may be redundantly registered; ignore these errors
-				if !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
-					entry := newLogger.WithFields(logrus.Fields{"method": "NewLogger"})
-					newLogger.LogAtLevel(entry, logrus.WarnLevel, fmt.Sprintf("error registering prometheus metric: %v", newReportMetricGauge), err)
-				}
-			} else {
-				reportMetricGauge = newReportMetricGauge
-			}
-		})
-	}
-	return newLogger
-}
-
-// Helper function used to log requests and responses from our GRPC method
-// implementations
-func (l *logger) Log(ctx context.Context, request interface{}, response interface{}, err error, duration time.Duration) {
-	if err != nil {
-		l.LogAtLevelFromDepth(ctx, request, response, err, duration, logrus.ErrorLevel, 4)
-	} else {
-		l.LogAtLevelFromDepth(ctx, request, response, err, duration, logrus.InfoLevel, 4)
-	}
-	// We have to grab the method's name here before we
-	// enter the goro's stack
-	go l.ReportMetric(getMethodName(), duration, err)
-}
-
-func getMethodName() string {
-	depth := 4
-	pc := make([]uintptr, depth)
-	runtime.Callers(depth, pc)
-	split := strings.Split(runtime.FuncForPC(pc[0]).Name(), ".")
-	return split[len(split)-1]
-}
-
-func (l *logger) ReportMetric(method string, duration time.Duration, err error) {
-	if !l.exportStats {
-		return
-	}
-	// Count the number of ReportMetric() goros in case we start to leak them
-	if reportMetricGauge != nil {
-		reportMetricGauge.Inc()
-	}
-	defer func() {
-		if reportMetricGauge != nil {
-			reportMetricGauge.Dec()
-		}
-	}()
-	l.mutex.Lock() // for conccurent map access (histogram,counter)
-	defer l.mutex.Unlock()
-	state := "started"
-	if err != nil {
-		state = "errored"
-	} else {
-		if duration.Seconds() > 0 {
-			state = "finished"
-		}
-	}
-	entry := l.WithFields(logrus.Fields{"method": method})
-
-	var tokens []string
-	for _, token := range camelcase.Split(method) {
-		tokens = append(tokens, strings.ToLower(token))
-	}
-	rootStatName := strings.Join(tokens, "_")
-
-	// Recording the distribution of started times is meaningless
-	if state != "started" {
-		runTimeName := fmt.Sprintf("%v_seconds", rootStatName)
-		runTime, ok := l.histogram[runTimeName]
-		if !ok {
-			runTime = prometheus.NewHistogramVec(
-				prometheus.HistogramOpts{
-					Namespace: "pachyderm",
-					Subsystem: fmt.Sprintf("pachd_%v", topLevelService(l.service)),
-					Name:      runTimeName,
-					Help:      fmt.Sprintf("Run time of %v", method),
-					Buckets:   []float64{0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 86400},
-				},
-				[]string{
-					"state", // Since both finished and errored API calls can have run times
-				},
-			)
-			if err := prometheus.Register(runTime); err != nil {
-				// metrics may be redundantly registered; ignore these errors
-				if !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
-					l.LogAtLevel(entry, logrus.WarnLevel, fmt.Sprintf("error registering prometheus metric %v: %v", runTimeName, err))
-				}
-			} else {
-				l.histogram[runTimeName] = runTime
-			}
-		}
-		if hist, err := runTime.GetMetricWithLabelValues(state); err != nil {
-			l.LogAtLevel(entry, logrus.WarnLevel, fmt.Sprintf("failed to get histogram w labels: state (%v) with error %v", state, err))
-		} else {
-			hist.Observe(duration.Seconds())
-		}
-	}
-}
-
-func (l *logger) LogAtLevel(entry *logrus.Entry, level logrus.Level, args ...interface{}) {
-	entry.Log(level, args...)
-}
-
-func (l *logger) LogAtLevelFromDepth(ctx context.Context, request interface{}, response interface{}, err error, duration time.Duration, level logrus.Level, depth int) {
-	// We're only interested in 1 stack frame, however due to weirdness with
-	// inlining sometimes you need to get more than 1 caller so that
-	// CallersFrames can resolve the first function. 2 seems to be enough be
-	// we've set it to 5 to insulate us more, because this at one point broke
-	// due to some compile optimization changes.
-	pc := make([]uintptr, 5)
-	runtime.Callers(depth, pc)
-	frames := runtime.CallersFrames(pc)
-	frame, ok := frames.Next()
-	fields := logrus.Fields{}
-	if ok {
-		split := strings.Split(frame.Function, ".")
-		method := split[len(split)-1]
-		fields["method"] = method
-	} else {
-		fields["warn"] = "failed to resolve method"
-	}
-	fields["request"] = request
-	if response != nil {
-		fields["response"] = response
-	}
-	if err != nil {
-		// "err" itself might be a code or even an empty struct
-		fields["error"] = err.Error()
-		var frames []string
-		errors.ForEachStackFrame(err, func(frame errors.Frame) {
-			frames = append(frames, fmt.Sprintf("%+v", frame))
-		})
-		fields["stack"] = frames
-	}
-	if duration > 0 {
-		fields["duration"] = duration
-	}
-	if user := auth.GetWhoAmI(ctx); user != "" {
-		fields["user"] = user
-	}
-	l.LogAtLevel(l.WithFields(fields), level)
-}
-
-func topLevelService(fullyQualifiedService string) string {
-	tokens := strings.Split(fullyQualifiedService, ".")
-	return tokens[0]
-}
 
 // FormatterFunc is a type alias for a function that satisfies logrus'
 // `Formatter` interface
@@ -239,6 +34,7 @@ func Pretty(entry *logrus.Entry) ([]byte, error) {
 	)
 	if entry.Data["service"] != nil && entry.Data["method"] != nil {
 		serialized = append(serialized, []byte(fmt.Sprintf("%v.%v ", entry.Data["service"], entry.Data["method"]))...)
+		// TODO: seems like a bad idea to modify the log statement data
 		delete(entry.Data, "service")
 		delete(entry.Data, "method")
 	}

--- a/src/internal/middleware/auth/interceptor.go
+++ b/src/internal/middleware/auth/interceptor.go
@@ -38,7 +38,6 @@ var authHandlers = map[string]authHandler{
 	"/auth_v2.API/GetOIDCLogin": unauthenticated,
 
 	// TODO: restrict GetClusterRoleBinding to cluster admins?
-	"/auth_v2.API/CreateRoleBinding":     authenticated,
 	"/auth_v2.API/GetRoleBinding":        authenticated,
 	"/auth_v2.API/ModifyRoleBinding":     authenticated,
 	"/auth_v2.API/RevokeAuthToken":       authenticated,

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -1,0 +1,462 @@
+//nolint:wrapcheck
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/identity"
+	"github.com/pachyderm/pachyderm/v2/src/license"
+)
+
+type logConfig struct {
+	// interfaces here are the request and response protobufs, respectively
+	level             func(interface{}, interface{}, error) logrus.Level
+	transformRequest  func(interface{}) interface{}
+	transformResponse func(interface{}) interface{}
+}
+
+func defaultLevel(req interface{}, res interface{}, err error) logrus.Level {
+	if err == nil {
+		return logrus.InfoLevel
+	}
+	return logrus.ErrorLevel
+}
+
+var defaultConfig = logConfig{level: defaultLevel}
+
+// The config used for auth endpoints suppresses 'not activated' errors to the
+// debug level
+var authConfig = logConfig{
+	level: func(req interface{}, resp interface{}, err error) logrus.Level {
+		if err == nil {
+			return logrus.InfoLevel
+		} else if auth.IsErrNotActivated(err) {
+			return logrus.DebugLevel
+		}
+		return logrus.ErrorLevel
+	},
+}
+
+// Special handling for some endpoints, usually regarding redaction or
+// suppressing to a different log level.
+// TODO: would be nice if we could annotate the protobuf fields for redaction,
+// then auto-generate this code (or even just handle it dynamically).
+var endpoints = map[string]logConfig{
+	"/license_v2.API/Activate": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*license.ActivateRequest)).(*license.ActivateRequest)
+			copyReq.ActivationCode = ""
+			return copyReq
+		},
+	},
+
+	"/license_v2.API/GetActivationCode": {
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*license.GetActivationCodeResponse)).(*license.GetActivationCodeResponse)
+			copyResp.ActivationCode = ""
+			return copyResp
+		},
+	},
+
+	"/license_v2.API/AddCluster": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*license.AddClusterRequest)).(*license.AddClusterRequest)
+			copyReq.Secret = ""
+			return copyReq
+		},
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*license.AddClusterResponse)).(*license.AddClusterResponse)
+			copyResp.Secret = ""
+			return copyResp
+		},
+	},
+
+	"/license_v2.API/Heartbeat": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*license.HeartbeatRequest)).(*license.HeartbeatRequest)
+			copyReq.Secret = ""
+			return copyReq
+		},
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*license.HeartbeatResponse)).(*license.HeartbeatResponse)
+			copyResp.License.ActivationCode = ""
+			return copyResp
+		},
+	},
+
+	"/enterprise_v2.API/GetActivationCode": {
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*enterprise.GetActivationCodeResponse)).(*enterprise.GetActivationCodeResponse)
+			copyResp.ActivationCode = ""
+			return copyResp
+		},
+	},
+
+	"/enterprise_v2.API/Activate": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*enterprise.ActivateRequest)).(*enterprise.ActivateRequest)
+			copyReq.Secret = ""
+			return copyReq
+		},
+	},
+
+	"/identity_v2.API/CreateIDPConnector": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*identity.CreateIDPConnectorRequest)).(*identity.CreateIDPConnectorRequest)
+			copyReq.Connector.JsonConfig = ""
+			return copyReq
+		},
+	},
+
+	"/identity_v2.API/GetIDPConnector": {
+		transformResponse: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*identity.GetIDPConnectorResponse)).(*identity.GetIDPConnectorResponse)
+			copyReq.Connector.JsonConfig = ""
+			return copyReq
+		},
+	},
+
+	"/identity_v2.API/UpdateIDPConnector": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*identity.UpdateIDPConnectorRequest)).(*identity.UpdateIDPConnectorRequest)
+			copyReq.Connector.JsonConfig = ""
+			return copyReq
+		},
+	},
+
+	"/identity_v2.API/ListIDPConnectors": {
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*identity.ListIDPConnectorsResponse)).(*identity.ListIDPConnectorsResponse)
+			for _, c := range copyResp.Connectors {
+				c.JsonConfig = ""
+			}
+			return copyResp
+		},
+	},
+
+	"/identity_v2.API/CreateOIDCClient": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*identity.CreateOIDCClientRequest)).(*identity.CreateOIDCClientRequest)
+			copyReq.Client.Secret = ""
+			return copyReq
+		},
+	},
+
+	"/identity_v2.API/UpdateOIDCClient": {
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*identity.UpdateOIDCClientRequest)).(*identity.UpdateOIDCClientRequest)
+			copyReq.Client.Secret = ""
+			return copyReq
+		},
+	},
+
+	"/identity_v2.API/GetOIDCClient": {
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*identity.GetOIDCClientResponse)).(*identity.GetOIDCClientResponse)
+			copyResp.Client.Secret = ""
+			return copyResp
+		},
+	},
+
+	"/identity_v2.API/ListOIDCClients": {
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*identity.ListOIDCClientsResponse)).(*identity.ListOIDCClientsResponse)
+			for _, c := range copyResp.Clients {
+				c.Secret = ""
+			}
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/Deactivate":                 authConfig,
+	"/auth_v2.API/Authorize":                  authConfig,
+	"/auth_v2.API/GetPermissionsForPrincipal": authConfig,
+	"/auth_v2.API/GetPermissions":             authConfig,
+	"/auth_v2.API/ModifyRoleBinding":          authConfig,
+	"/auth_v2.API/GetRoleBinding":             authConfig,
+	"/auth_v2.API/SetGroupsForUser":           authConfig,
+	"/auth_v2.API/ModifyMembers":              authConfig,
+	"/auth_v2.API/GetGroups":                  authConfig,
+	"/auth_v2.API/GetGroupsForPrincipal":      authConfig,
+	"/auth_v2.API/GetUsers":                   authConfig,
+	"/auth_v2.API/GetRolesForPermission":      authConfig,
+	"/auth_v2.API/DeleteExpiredAuthTokens":    authConfig,
+	"/auth_v2.API/RevokeAuthTokensForUser":    authConfig,
+
+	"/auth_v2.API/WhoAmI": {
+		level: func(req interface{}, resp interface{}, err error) logrus.Level {
+			if err == nil {
+				return logrus.DebugLevel
+			}
+			return authConfig.level(req, resp, err)
+		},
+	},
+
+	"/auth_v2.API/Activate": {
+		level: authConfig.level,
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*auth.ActivateRequest)).(*auth.ActivateRequest)
+			copyReq.RootToken = ""
+			return copyReq
+		},
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*auth.ActivateResponse)).(*auth.ActivateResponse)
+			copyResp.PachToken = ""
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/Authenticate": {
+		level: authConfig.level,
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*auth.AuthenticateRequest)).(*auth.AuthenticateRequest)
+			copyReq.OIDCState = ""
+			copyReq.IdToken = ""
+			return copyReq
+		},
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*auth.AuthenticateResponse)).(*auth.AuthenticateResponse)
+			copyResp.PachToken = ""
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/RotateRootToken": {
+		level: authConfig.level,
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*auth.RotateRootTokenRequest)).(*auth.RotateRootTokenRequest)
+			copyReq.RootToken = ""
+			return copyReq
+		},
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*auth.RotateRootTokenResponse)).(*auth.RotateRootTokenResponse)
+			copyResp.RootToken = ""
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/GetOIDCLogin": {
+		level: authConfig.level,
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*auth.GetOIDCLoginResponse)).(*auth.GetOIDCLoginResponse)
+			copyResp.LoginURL = ""
+			copyResp.State = ""
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/SetConfiguration": {
+		level: authConfig.level,
+		transformRequest: func(r interface{}) interface{} {
+			req := r.(*auth.SetConfigurationRequest)
+			if req.Configuration == nil {
+				return r
+			}
+			copyReq := proto.Clone(req).(*auth.SetConfigurationRequest)
+			copyReq.Configuration.ClientSecret = ""
+			return copyReq
+		},
+	},
+
+	"/auth_v2.API/GetRobotToken": {
+		level: authConfig.level,
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*auth.GetRobotTokenResponse)).(*auth.GetRobotTokenResponse)
+			copyResp.Token = ""
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/RevokeAuthToken": {
+		level: authConfig.level,
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*auth.RevokeAuthTokenRequest)).(*auth.RevokeAuthTokenRequest)
+			copyReq.Token = ""
+			return copyReq
+		},
+	},
+
+	"/auth_v2.API/ExtractAuthTokens": {
+		level: authConfig.level,
+		transformResponse: func(r interface{}) interface{} {
+			copyResp := proto.Clone(r.(*auth.ExtractAuthTokensResponse)).(*auth.ExtractAuthTokensResponse)
+			copyResp.Tokens = nil
+			return copyResp
+		},
+	},
+
+	"/auth_v2.API/RestoreAuthToken": {
+		level: authConfig.level,
+		transformRequest: func(r interface{}) interface{} {
+			copyReq := proto.Clone(r.(*auth.RestoreAuthTokenRequest)).(*auth.RestoreAuthTokenRequest)
+			copyReq.Token = nil
+			return copyReq
+		},
+	},
+
+	"/auth_v2.API/GetConfiguration": {
+		level: authConfig.level,
+		transformResponse: func(r interface{}) interface{} {
+			resp := r.(*auth.GetConfigurationResponse)
+			if resp.Configuration == nil {
+				return resp
+			}
+			copyResp := proto.Clone(resp).(*auth.GetConfigurationResponse)
+			copyResp.Configuration.ClientSecret = ""
+			return copyResp
+		},
+	},
+
+	"/pfs_v2.API/CreateFileSet": {
+		transformRequest: func(r interface{}) interface{} {
+			return nil
+		},
+	},
+}
+
+func getConfig(fullMethod string) logConfig {
+	if config, ok := endpoints[fullMethod]; ok {
+		return config
+	}
+	return defaultConfig
+}
+
+func isNilInterface(x interface{}) bool {
+	val := reflect.ValueOf(x)
+	return x == nil || (val.Kind() == reflect.Ptr && val.IsNil())
+}
+
+func (li *LoggingInterceptor) UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, retErr error) {
+	start := time.Now()
+	config := getConfig(info.FullMethod)
+	level := defaultLevel(req, nil, nil)
+	if config.level != nil {
+		level = config.level(req, nil, nil)
+	}
+
+	logReq := req
+	if config.transformRequest != nil && !isNilInterface(req) {
+		logReq = config.transformRequest(req)
+	}
+
+	li.logUnaryBefore(ctx, level, logReq, info.FullMethod, start)
+	defer func() {
+		level := defaultLevel(req, resp, retErr)
+		if config.level != nil {
+			level = config.level(req, resp, retErr)
+		}
+
+		logResp := resp
+		if config.transformResponse != nil && !isNilInterface(resp) {
+			logResp = config.transformResponse(resp)
+		}
+		li.logUnaryAfter(ctx, level, logReq, info.FullMethod, start, logResp, retErr)
+	}()
+
+	return handler(ctx, req)
+}
+
+func (li *LoggingInterceptor) StreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (retErr error) {
+	start := time.Now()
+	config := getConfig(info.FullMethod)
+	wrapper := &streamWrapper{stream: stream}
+
+	// Log the first received message as the request
+	var req interface{}
+	var logReq interface{}
+	wrapper.onFirstRecv = func(m interface{}) {
+		req = m
+		level := defaultLevel(req, nil, nil)
+		if config.level != nil {
+			level = config.level(req, nil, nil)
+		}
+
+		logReq = req
+		if config.transformRequest != nil && !isNilInterface(req) {
+			logReq = config.transformRequest(req)
+		}
+		li.logUnaryBefore(stream.Context(), level, logReq, info.FullMethod, start)
+	}
+
+	var resp interface{}
+	if !info.IsServerStream {
+		// Not a streaming response, save the first sent message for the defer
+		wrapper.onFirstSend = func(m interface{}) {
+			resp = m
+		}
+	}
+
+	defer func() {
+		level := defaultLevel(req, resp, retErr)
+		if config.level != nil {
+			level = config.level(req, resp, retErr)
+		}
+
+		logResp := resp
+		if config.transformResponse != nil && !isNilInterface(resp) {
+			logResp = config.transformResponse(resp)
+		} else if info.IsServerStream {
+			logResp = fmt.Sprintf("stream containing %d objects", wrapper.sent)
+		}
+		li.logUnaryAfter(stream.Context(), level, logReq, info.FullMethod, start, logResp, retErr)
+	}()
+
+	return handler(srv, wrapper)
+}
+
+type streamWrapper struct {
+	stream      grpc.ServerStream
+	received    int
+	sent        int
+	onFirstSend func(interface{})
+	onFirstRecv func(interface{})
+}
+
+func (sw *streamWrapper) SetHeader(m metadata.MD) error {
+	return sw.stream.SetHeader(m)
+}
+
+func (sw *streamWrapper) SendHeader(m metadata.MD) error {
+	return sw.stream.SendHeader(m)
+}
+
+func (sw *streamWrapper) SetTrailer(m metadata.MD) {
+	sw.stream.SetTrailer(m)
+}
+
+func (sw *streamWrapper) Context() context.Context {
+	return sw.stream.Context()
+}
+
+func (sw *streamWrapper) SendMsg(m interface{}) error {
+	err := sw.stream.SendMsg(m)
+	if err == nil {
+		if sw.sent == 0 && sw.onFirstSend != nil {
+			sw.onFirstSend(m)
+		}
+		sw.sent++
+	}
+	return err
+}
+
+func (sw *streamWrapper) RecvMsg(m interface{}) error {
+	err := sw.stream.RecvMsg(m)
+	if err != io.EOF {
+		if sw.received == 0 && sw.onFirstRecv != nil {
+			sw.onFirstRecv(m)
+		}
+		sw.received++
+	}
+	return err
+}

--- a/src/internal/middleware/logging/util.go
+++ b/src/internal/middleware/logging/util.go
@@ -1,0 +1,173 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fatih/camelcase"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// This needs to be a global var, not a field on the logger, because multiple servers
+// create new loggers, and the prometheus registration uses a global namespace
+var reportDurationGauge prometheus.Gauge
+var reportDurationsOnce sync.Once
+
+type LoggingInterceptor struct {
+	logger    *logrus.Logger
+	histogram map[string]*prometheus.HistogramVec
+	counter   map[string]prometheus.Counter
+	mutex     *sync.Mutex // synchronizes access to both histogram and counter maps
+}
+
+// NewLoggingInterceptor creates a new interceptor that logs method start and end
+func NewLoggingInterceptor(logger *logrus.Logger) *LoggingInterceptor {
+	logger.Formatter = log.FormatterFunc(log.Pretty)
+	interceptor := &LoggingInterceptor{
+		logger,
+		make(map[string]*prometheus.HistogramVec),
+		make(map[string]prometheus.Counter),
+		&sync.Mutex{},
+	}
+
+	reportDurationsOnce.Do(func() {
+		newReportMetricGauge := prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "pachyderm",
+				Subsystem: "pachd",
+				Name:      "report_metric",
+				Help:      "gauge of number of calls to reportDuration()",
+			},
+		)
+		if err := prometheus.Register(newReportMetricGauge); err != nil {
+			// metrics may be redundantly registered; ignore these errors
+			if !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+				entry := logger.WithFields(logrus.Fields{"method": "NewLogger"})
+				entry.Logf(logrus.WarnLevel, "error registering prometheus metric: %v", err)
+			}
+		} else {
+			reportDurationGauge = newReportMetricGauge
+		}
+	})
+	return interceptor
+}
+
+func parseMethod(fullMethod string) (string, string) {
+	fullMethod = strings.Trim(fullMethod, "/")
+	parts := strings.SplitN(fullMethod, "/", 2)
+	service := strings.Replace(parts[0], "_v2.", ".", 1)
+	if len(parts) < 2 {
+		return service, ""
+	}
+	return service, parts[1]
+}
+
+func makeLogFields(ctx context.Context, request interface{}, fullMethod string, response interface{}, err error, duration time.Duration) logrus.Fields {
+	fields := logrus.Fields{}
+	fields["service"], fields["method"] = parseMethod(fullMethod)
+	fields["request"] = request
+	if response != nil {
+		fields["response"] = response
+	}
+	if err != nil {
+		// "err" itself might be a code or even an empty struct
+		fields["error"] = err.Error()
+		var frames []string
+		errors.ForEachStackFrame(err, func(frame errors.Frame) {
+			frames = append(frames, fmt.Sprintf("%+v", frame))
+		})
+		fields["stack"] = frames
+	}
+	if duration > 0 {
+		fields["duration"] = duration
+	}
+	if user := auth.GetWhoAmI(ctx); user != "" {
+		fields["user"] = user
+	}
+	return fields
+}
+
+func (li *LoggingInterceptor) logUnaryBefore(ctx context.Context, level logrus.Level, req interface{}, fullMethod string, start time.Time) {
+	fields := makeLogFields(ctx, req, fullMethod, nil, nil, 0)
+	li.logger.WithFields(fields).Log(level)
+}
+
+func (li *LoggingInterceptor) logUnaryAfter(ctx context.Context, level logrus.Level, req interface{}, fullMethod string, start time.Time, resp interface{}, err error) {
+	duration := time.Since(start)
+	fields := makeLogFields(ctx, req, fullMethod, resp, err, duration)
+	go li.reportDuration(fields["service"].(string), fields["method"].(string), duration, err)
+	li.logger.WithFields(fields).Log(level)
+}
+
+func topLevelService(fullyQualifiedService string) string {
+	tokens := strings.Split(fullyQualifiedService, ".")
+	return tokens[0]
+}
+
+func (li *LoggingInterceptor) getHistogram(service string, method string) *prometheus.HistogramVec {
+	fullyQualifiedName := fmt.Sprintf("%v/%v", service, method)
+	histVec, ok := li.histogram[fullyQualifiedName]
+	if !ok {
+		var tokens []string
+		for _, token := range camelcase.Split(method) {
+			tokens = append(tokens, strings.ToLower(token))
+		}
+		rootStatName := strings.Join(tokens, "_")
+
+		histogramName := fmt.Sprintf("%v_seconds", rootStatName)
+		histVec = prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "pachyderm",
+				Subsystem: fmt.Sprintf("pachd_%v", topLevelService(service)),
+				Name:      histogramName,
+				Help:      fmt.Sprintf("Run time of %v", method),
+				Buckets:   []float64{0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 86400},
+			},
+			[]string{
+				"state", // Since both finished and errored API calls can have run times
+			},
+		)
+		if err := prometheus.Register(histVec); err != nil {
+			// metrics may be redundantly registered; ignore these errors
+			if !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+				entry := li.logger.WithFields(logrus.Fields{"method": method})
+				entry.Logf(logrus.WarnLevel, "error registering prometheus metric %v: %v", histogramName, err)
+			}
+		} else {
+			li.histogram[fullyQualifiedName] = histVec
+		}
+	}
+	return histVec
+}
+
+func (li *LoggingInterceptor) reportDuration(service string, method string, duration time.Duration, err error) {
+	// Count the number of reportDuration() goros in case we start to leak them
+	if reportDurationGauge != nil {
+		reportDurationGauge.Inc()
+	}
+	defer func() {
+		if reportDurationGauge != nil {
+			reportDurationGauge.Dec()
+		}
+	}()
+	li.mutex.Lock() // for concurrent map access (histogram,counter)
+	defer li.mutex.Unlock()
+
+	state := "finished"
+	if err != nil {
+		state = "errored"
+	}
+	if hist, err := li.getHistogram(service, method).GetMetricWithLabelValues(state); err != nil {
+		entry := li.logger.WithFields(logrus.Fields{"method": method})
+		entry.Logf(logrus.WarnLevel, "failed to get histogram for state %v: %v", state, err)
+	} else {
+		hist.Observe(duration.Seconds())
+	}
+}

--- a/src/server/admin/server/api_server.go
+++ b/src/server/admin/server/api_server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/admin"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/sirupsen/logrus"
 
@@ -33,7 +32,6 @@ type APIServer interface {
 // NewAPIServer returns a new admin.APIServer
 func NewAPIServer(env Env) APIServer {
 	return &apiServer{
-		Logger: log.NewLogger("admin.API", env.Logger),
 		clusterInfo: &admin.ClusterInfo{
 			ID:           env.ClusterID,
 			DeploymentID: env.Config.DeploymentID,
@@ -42,7 +40,6 @@ func NewAPIServer(env Env) APIServer {
 }
 
 type apiServer struct {
-	log.Logger
 	clusterInfo *admin.ClusterInfo
 }
 

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/keycache"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	internalauth "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
@@ -54,7 +53,6 @@ var DefaultOIDCConfig = auth.OIDCConfig{}
 // including all RPCs defined in the protobuf spec.
 type apiServer struct {
 	env Env
-	log log.Logger
 
 	configCache             *keycache.Cache
 	clusterRoleBindingCache *keycache.Cache
@@ -84,29 +82,6 @@ type apiServer struct {
 	watchesEnabled bool
 }
 
-// LogReq is like log.Logger.Log(), but it assumes that it's being called from
-// the top level of a GRPC method implementation, and correspondingly extracts
-// the method name from the parent stack frame
-func (a *apiServer) LogReq(ctx context.Context, request interface{}) {
-	a.log.Log(ctx, request, nil, nil, 0)
-}
-
-// LogResp is like log.Logger.Log(). However,
-// 1) It assumes that it's being called from a defer() statement in a GRPC
-//    method , and correspondingly extracts the method name from the grandparent
-//    stack frame
-// 2) It logs NotActivatedError at DebugLevel instead of ErrorLevel, as, in most
-//    cases, this error is expected, and logging it frequently may confuse users
-func (a *apiServer) LogResp(ctx context.Context, request interface{}, response interface{}, err error, duration time.Duration) {
-	if err == nil {
-		a.log.LogAtLevelFromDepth(ctx, request, response, err, duration, logrus.InfoLevel, 4)
-	} else if auth.IsErrNotActivated(err) {
-		a.log.LogAtLevelFromDepth(ctx, request, response, err, duration, logrus.DebugLevel, 4)
-	} else {
-		a.log.LogAtLevelFromDepth(ctx, request, response, err, duration, logrus.ErrorLevel, 4)
-	}
-}
-
 // NewAuthServer returns an implementation of auth.APIServer.
 func NewAuthServer(env Env, public, requireNoncriticalServers, watchesEnabled bool) (authiface.APIServer, error) {
 	oidcStates := col.NewEtcdCollection(
@@ -119,7 +94,6 @@ func NewAuthServer(env Env, public, requireNoncriticalServers, watchesEnabled bo
 	)
 	s := &apiServer{
 		env:            env,
-		log:            log.NewLogger("auth.API", env.Logger), // TODO this should be configured in the env
 		authConfig:     authConfigCollection(env.DB, env.Listener),
 		roleBindings:   roleBindingsCollection(env.DB, env.Listener),
 		members:        membersCollection(env.DB, env.Listener),
@@ -283,9 +257,6 @@ func (a *apiServer) hasClusterRole(ctx context.Context, username string, role st
 
 // Activate implements the protobuf auth.Activate RPC
 func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (resp *auth.ActivateResponse, retErr error) {
-	// We don't want to actually log the request/response since they contain
-	// credentials.
-	defer func(start time.Time) { a.LogResp(ctx, nil, nil, retErr, time.Since(start)) }(time.Now())
 	// If the cluster's Pachyderm Enterprise token isn't active, the auth system
 	// cannot be activated
 	state, err := a.getEnterpriseTokenState(ctx)
@@ -343,9 +314,6 @@ func (a *apiServer) Activate(ctx context.Context, req *auth.ActivateRequest) (re
 
 // RotateRootToken implements the protobuf auth.RotateRootToken RPC
 func (a *apiServer) RotateRootToken(ctx context.Context, req *auth.RotateRootTokenRequest) (resp *auth.RotateRootTokenResponse, retErr error) {
-	// We don't want to actually log the request/response since they contain credentials.
-	defer func(start time.Time) { a.LogResp(ctx, nil, nil, retErr, time.Since(start)) }(time.Now())
-
 	// TODO(acohen4): Merge with postgres-integration library changes
 	var rootToken string
 	if err := a.env.TxnEnv.WithWriteContext(ctx, func(txCtx *txncontext.TransactionContext) error {
@@ -372,9 +340,6 @@ func (a *apiServer) RotateRootToken(ctx context.Context, req *auth.RotateRootTok
 
 // Deactivate implements the protobuf auth.Deactivate RPC
 func (a *apiServer) Deactivate(ctx context.Context, req *auth.DeactivateRequest) (resp *auth.DeactivateResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *pachsql.Tx) error {
 		a.roleBindings.ReadWrite(sqlTx).DeleteAll()
 		a.deleteAllAuthTokens(ctx, sqlTx)
@@ -405,10 +370,6 @@ func (a *apiServer) Authenticate(ctx context.Context, req *auth.AuthenticateRequ
 	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
-
-	// We don't want to actually log the request/response since they contain
-	// credentials.
-	defer func(start time.Time) { a.LogResp(ctx, nil, nil, retErr, time.Since(start)) }(time.Now())
 
 	// verify whatever credential the user has presented, and write a new
 	// Pachyderm token for the user that their credential belongs to
@@ -579,9 +540,6 @@ func (a *apiServer) Authorize(
 	ctx context.Context,
 	req *auth.AuthorizeRequest,
 ) (resp *auth.AuthorizeResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	var response *auth.AuthorizeResponse
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
@@ -594,9 +552,6 @@ func (a *apiServer) Authorize(
 }
 
 func (a *apiServer) GetPermissionsForPrincipal(ctx context.Context, req *auth.GetPermissionsForPrincipalRequest) (resp *auth.GetPermissionsResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	permissions := make(map[auth.Permission]bool)
 	for p := range auth.Permission_name {
 		permissions[auth.Permission(p)] = true
@@ -620,9 +575,6 @@ func (a *apiServer) GetPermissionsForPrincipal(ctx context.Context, req *auth.Ge
 
 // GetPermissions implements the protobuf auth.GetPermissions RPC
 func (a *apiServer) GetPermissions(ctx context.Context, req *auth.GetPermissionsRequest) (resp *auth.GetPermissionsResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	callerInfo, err := a.getAuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -661,9 +613,6 @@ func (a *apiServer) getPermissionsForPrincipalInTransaction(txnCtx *txncontext.T
 
 // WhoAmI implements the protobuf auth.WhoAmI RPC
 func (a *apiServer) WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (resp *auth.WhoAmIResponse, retErr error) {
-	a.log.LogAtLevelFromDepth(ctx, req, nil, nil, 0, logrus.DebugLevel, 2)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
@@ -864,9 +813,6 @@ func (a *apiServer) setUserRoleBindingInTransaction(txnCtx *txncontext.Transacti
 
 // ModifyRoleBinding implements the protobuf auth.ModifyRoleBinding RPC
 func (a *apiServer) ModifyRoleBinding(ctx context.Context, req *auth.ModifyRoleBindingRequest) (resp *auth.ModifyRoleBindingResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	var response *auth.ModifyRoleBindingResponse
 	if err := a.env.TxnEnv.WithTransaction(ctx, func(txn txnenv.Transaction) error {
 		var err error
@@ -924,9 +870,6 @@ func (a *apiServer) GetRoleBindingInTransaction(
 
 // GetRoleBinding implements the protobuf auth.GetRoleBinding RPC
 func (a *apiServer) GetRoleBinding(ctx context.Context, req *auth.GetRoleBindingRequest) (resp *auth.GetRoleBindingResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	var response *auth.GetRoleBindingResponse
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
@@ -940,9 +883,6 @@ func (a *apiServer) GetRoleBinding(ctx context.Context, req *auth.GetRoleBinding
 
 // GetRobotToken implements the protobuf auth.GetRobotToken RPC
 func (a *apiServer) GetRobotToken(ctx context.Context, req *auth.GetRobotTokenRequest) (resp *auth.GetRobotTokenResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	// If the user specified a redundant robot: prefix, strip it. Colons are not permitted in robot names.
 	subject := strings.TrimPrefix(req.Robot, auth.RobotPrefix)
 	if strings.Contains(subject, ":") {
@@ -984,11 +924,6 @@ func (a *apiServer) GetPipelineAuthTokenInTransaction(txnCtx *txncontext.Transac
 
 // GetOIDCLogin implements the protobuf auth.GetOIDCLogin RPC
 func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequest) (resp *auth.GetOIDCLoginResponse, retErr error) {
-	a.LogReq(ctx, req)
-	// Don't log response to avoid logging OIDC state token
-	defer func(start time.Time) { a.LogResp(ctx, req, nil, retErr, time.Since(start)) }(time.Now())
-	var err error
-
 	authURL, state, err := a.GetOIDCLoginURL(ctx)
 	if err != nil {
 		return nil, err
@@ -1001,8 +936,6 @@ func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequ
 
 // RevokeAuthToken implements the protobuf auth.RevokeAuthToken RPC
 func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
 	a.env.TxnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		resp, retErr = a.RevokeAuthTokenInTransaction(txnCtx, req)
 		return retErr
@@ -1076,9 +1009,6 @@ func (a *apiServer) setGroupsForUserInternal(ctx context.Context, subject string
 
 // SetGroupsForUser implements the protobuf auth.SetGroupsForUser RPC
 func (a *apiServer) SetGroupsForUser(ctx context.Context, req *auth.SetGroupsForUserRequest) (resp *auth.SetGroupsForUserResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if err := a.checkCanonicalSubject(req.Username); err != nil {
 		return nil, err
 	}
@@ -1091,9 +1021,6 @@ func (a *apiServer) SetGroupsForUser(ctx context.Context, req *auth.SetGroupsFor
 
 // ModifyMembers implements the protobuf auth.ModifyMembers RPC
 func (a *apiServer) ModifyMembers(ctx context.Context, req *auth.ModifyMembersRequest) (resp *auth.ModifyMembersResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if err := a.checkCanonicalSubjects(req.Add); err != nil {
 		return nil, err
 	}
@@ -1191,9 +1118,6 @@ func (a *apiServer) getGroupsInTransaction(txnCtx *txncontext.TransactionContext
 
 // GetGroups implements the protobuf auth.GetGroups RPC
 func (a *apiServer) GetGroups(ctx context.Context, req *auth.GetGroupsRequest) (resp *auth.GetGroupsResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	callerInfo, err := a.getAuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -1208,9 +1132,6 @@ func (a *apiServer) GetGroups(ctx context.Context, req *auth.GetGroupsRequest) (
 
 // GetGroupsForPrincipal implements the protobuf auth.GetGroupsForPrincipal RPC
 func (a *apiServer) GetGroupsForPrincipal(ctx context.Context, req *auth.GetGroupsForPrincipalRequest) (resp *auth.GetGroupsResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	groups, err := a.getGroups(ctx, req.Principal)
 	if err != nil {
 		return nil, err
@@ -1220,9 +1141,6 @@ func (a *apiServer) GetGroupsForPrincipal(ctx context.Context, req *auth.GetGrou
 
 // GetUsers implements the protobuf auth.GetUsers RPC
 func (a *apiServer) GetUsers(ctx context.Context, req *auth.GetUsersRequest) (resp *auth.GetUsersResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	// Filter by group
 	if req.Group != "" {
 		var membersProto auth.Users
@@ -1253,9 +1171,6 @@ func (a *apiServer) GetUsers(ctx context.Context, req *auth.GetUsersRequest) (re
 
 // GetRolesForPermission implements the protobuf auth.GetRolesForPermission RPC
 func (a *apiServer) GetRolesForPermission(ctx context.Context, req *auth.GetRolesForPermissionRequest) (resp *auth.GetRolesForPermissionResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	return &auth.GetRolesForPermissionResponse{Roles: rolesForPermission(req.Permission)}, nil
 }
 
@@ -1344,17 +1259,6 @@ func (a *apiServer) checkCanonicalSubject(subject string) error {
 
 // GetConfiguration implements the protobuf auth.GetConfiguration RPC.
 func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigurationRequest) (resp *auth.GetConfigurationResponse, retErr error) {
-	removeSecret := func(r *auth.GetConfigurationResponse) *auth.GetConfigurationResponse {
-		if r == nil || r.Configuration == nil {
-			return r
-		}
-		copyResp := proto.Clone(r).(*auth.GetConfigurationResponse)
-		copyResp.Configuration.ClientSecret = ""
-		return copyResp
-	}
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
-
 	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
@@ -1375,17 +1279,6 @@ func (a *apiServer) GetConfiguration(ctx context.Context, req *auth.GetConfigura
 
 // SetConfiguration implements the protobuf auth.SetConfiguration RPC
 func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigurationRequest) (resp *auth.SetConfigurationResponse, retErr error) {
-	removeSecret := func(r *auth.SetConfigurationRequest) *auth.SetConfigurationRequest {
-		if r.Configuration == nil {
-			return r
-		}
-		copyReq := proto.Clone(r).(*auth.SetConfigurationRequest)
-		copyReq.Configuration.ClientSecret = ""
-		return copyReq
-	}
-	a.LogReq(ctx, removeSecret(req))
-	defer func(start time.Time) { a.LogResp(ctx, removeSecret(req), resp, retErr, time.Since(start)) }(time.Now())
-
 	if !a.watchesEnabled {
 		return nil, errors.New("watches are not enabled, unable to set config")
 	}
@@ -1426,10 +1319,6 @@ func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigura
 }
 
 func (a *apiServer) ExtractAuthTokens(ctx context.Context, req *auth.ExtractAuthTokensRequest) (resp *auth.ExtractAuthTokensResponse, retErr error) {
-	// We don't want to actually log the request/response since they contain
-	// credentials.
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.LogResp(ctx, nil, nil, retErr, time.Since(start)) }(time.Now())
 	if err := a.isActive(ctx); err != nil {
 		return nil, err
 	}
@@ -1442,10 +1331,6 @@ func (a *apiServer) ExtractAuthTokens(ctx context.Context, req *auth.ExtractAuth
 }
 
 func (a *apiServer) RestoreAuthToken(ctx context.Context, req *auth.RestoreAuthTokenRequest) (resp *auth.RestoreAuthTokenResponse, retErr error) {
-	// We don't want to actually log the request/response since they contain
-	// credentials.
-	defer func(start time.Time) { a.LogResp(ctx, nil, nil, retErr, time.Since(start)) }(time.Now())
-
 	var ttl int64
 	if req.Token.Expiration != nil {
 		ttl = int64(time.Until(*req.Token.Expiration).Seconds())
@@ -1469,7 +1354,6 @@ func (a *apiServer) RestoreAuthToken(ctx context.Context, req *auth.RestoreAuthT
 
 // implements the protobuf auth.DeleteExpiredAuthTokens RPC
 func (a *apiServer) DeleteExpiredAuthTokens(ctx context.Context, req *auth.DeleteExpiredAuthTokensRequest) (*auth.DeleteExpiredAuthTokensResponse, error) {
-	logrus.Info("Deleting expired auth tokens")
 	if _, err := a.env.DB.Exec(`DELETE FROM auth.auth_tokens WHERE NOW() > expiration`); err != nil {
 		return nil, errors.Wrapf(err, "error deleting expired tokens")
 	}
@@ -1477,8 +1361,6 @@ func (a *apiServer) DeleteExpiredAuthTokens(ctx context.Context, req *auth.Delet
 }
 
 func (a *apiServer) RevokeAuthTokensForUser(ctx context.Context, req *auth.RevokeAuthTokensForUserRequest) (resp *auth.RevokeAuthTokensForUserResponse, retErr error) {
-	defer func(start time.Time) { a.LogResp(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	// Allow revoking auth tokens for pipelines, robots and IDP users,
 	// but not the root token or PPS user
 	if strings.HasPrefix(req.Username, auth.PachPrefix) {

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/keycache"
 	"github.com/pachyderm/pachyderm/v2/src/internal/license"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	lc "github.com/pachyderm/pachyderm/v2/src/license"
 )
@@ -35,8 +34,7 @@ const (
 )
 
 type apiServer struct {
-	pachLogger log.Logger
-	env        Env
+	env Env
 
 	enterpriseTokenCache *keycache.Cache
 
@@ -45,10 +43,6 @@ type apiServer struct {
 
 	// configCol is a collection containing the license server configuration
 	configCol col.PostgresCollection
-}
-
-func (a *apiServer) LogReq(ctx context.Context, request interface{}) {
-	a.pachLogger.Log(ctx, request, nil, nil, 0)
 }
 
 // NewEnterpriseServer returns an implementation of ec.APIServer.
@@ -64,7 +58,6 @@ func NewEnterpriseServer(env Env, heartbeat bool) (ec.APIServer, error) {
 	)
 
 	s := &apiServer{
-		pachLogger:           log.NewLogger("enterprise.API", env.Logger),
 		env:                  env,
 		enterpriseTokenCache: keycache.NewCache(env.BackgroundContext, enterpriseTokenCol.ReadOnly(env.BackgroundContext), enterpriseTokenKey, defaultEnterpriseRecord),
 		enterpriseTokenCol:   enterpriseTokenCol,
@@ -174,9 +167,6 @@ func (a *apiServer) heartbeatToServer(ctx context.Context, licenseServer, id, se
 
 // Heartbeat implements the Heartbeat RPC. It exists mostly to test the heartbeat logic
 func (a *apiServer) Heartbeat(ctx context.Context, req *ec.HeartbeatRequest) (resp *ec.HeartbeatResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if err := a.heartbeatIfConfigured(ctx); err != nil {
 		return nil, err
 	}
@@ -185,16 +175,6 @@ func (a *apiServer) Heartbeat(ctx context.Context, req *ec.HeartbeatRequest) (re
 
 // Activate implements the Activate RPC
 func (a *apiServer) Activate(ctx context.Context, req *ec.ActivateRequest) (resp *ec.ActivateResponse, retErr error) {
-	// Redact the secret from the request when logging
-	removeSecret := func(r *ec.ActivateRequest) *ec.ActivateRequest {
-		copyReq := proto.Clone(r).(*ec.ActivateRequest)
-		copyReq.Secret = ""
-		return copyReq
-	}
-
-	a.LogReq(ctx, removeSecret(req))
-	defer func(start time.Time) { a.pachLogger.Log(ctx, removeSecret(req), resp, retErr, time.Since(start)) }(time.Now())
-
 	// Try to heartbeat before persisting the configuration
 	heartbeatResp, err := a.heartbeatToServer(ctx, req.LicenseServer, req.Id, req.Secret)
 	if err != nil {
@@ -273,15 +253,6 @@ func (a *apiServer) GetState(ctx context.Context, req *ec.GetStateRequest) (resp
 
 // GetActivationCode returns the current state of the cluster's Pachyderm Enterprise key (ACTIVE, EXPIRED, or NONE), including the enterprise activation code
 func (a *apiServer) GetActivationCode(ctx context.Context, req *ec.GetActivationCodeRequest) (resp *ec.GetActivationCodeResponse, retErr error) {
-	// Redact the activation code from the response
-	removeSecret := func(r *ec.GetActivationCodeResponse) *ec.GetActivationCodeResponse {
-		copyResp := proto.Clone(r).(*ec.GetActivationCodeResponse)
-		copyResp.ActivationCode = ""
-		return copyResp
-	}
-
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
 	return a.getEnterpriseRecord()
 }
 
@@ -323,9 +294,6 @@ func (a *apiServer) getEnterpriseRecord() (*ec.GetActivationCodeResponse, error)
 // Deactivate deletes the current cluster's enterprise token, and puts the
 // cluster in the "NONE" enterprise state.
 func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (resp *ec.DeactivateResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if _, err := col.NewSTM(ctx, a.env.EtcdClient, func(stm col.STM) error {
 		err := a.enterpriseTokenCol.ReadWrite(stm).Delete(enterpriseTokenKey)
 		if err != nil && !col.IsErrNotFound(err) {

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/server/auth"
-	logrus "github.com/sirupsen/logrus"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -26,7 +25,6 @@ type Env struct {
 	AuthServer    auth.APIServer
 	GetPachClient func(context.Context) *client.APIClient
 
-	Logger            *logrus.Logger
 	BackgroundContext context.Context
 }
 
@@ -42,7 +40,6 @@ func EnvFromServiceEnv(senv serviceenv.ServiceEnv, etcdPrefix string, txEnv *txn
 		AuthServer:    senv.AuthServer(),
 		GetPachClient: senv.GetPachClient,
 
-		Logger:            senv.Logger(),
 		BackgroundContext: senv.Context(),
 	}
 }

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/license"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/random"
 	lc "github.com/pachyderm/pachyderm/v2/src/license"
@@ -25,32 +23,23 @@ const (
 )
 
 type apiServer struct {
-	pachLogger log.Logger
-	env        Env
+	env Env
 
 	// license is the database record where we store the active enterprise license
 	license col.PostgresCollection
 }
 
-func (a *apiServer) LogReq(ctx context.Context, request interface{}) {
-	a.pachLogger.Log(ctx, request, nil, nil, 0)
-}
-
 // New returns an implementation of license.APIServer.
 func New(env Env) (lc.APIServer, error) {
 	s := &apiServer{
-		pachLogger: log.NewLogger("license.API", env.Logger),
-		env:        env,
-		license:    licenseCollection(env.DB, env.Listener),
+		env:     env,
+		license: licenseCollection(env.DB, env.Listener),
 	}
 	return s, nil
 }
 
 // Activate implements the Activate RPC
 func (a *apiServer) Activate(ctx context.Context, req *lc.ActivateRequest) (resp *lc.ActivateResponse, retErr error) {
-	a.LogReq(ctx, nil)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, nil, resp, retErr, time.Since(start)) }(time.Now())
-
 	// Validate the activation code
 	expiration, err := license.Validate(req.ActivationCode)
 	if err != nil {
@@ -88,16 +77,6 @@ func (a *apiServer) Activate(ctx context.Context, req *lc.ActivateRequest) (resp
 
 // GetActivationCode returns the current state of the cluster's Pachyderm Enterprise key (ACTIVE, EXPIRED, or NONE), including the enterprise activation code
 func (a *apiServer) GetActivationCode(ctx context.Context, req *lc.GetActivationCodeRequest) (resp *lc.GetActivationCodeResponse, retErr error) {
-	// Redact the activation code from the response
-	removeSecret := func(r *lc.GetActivationCodeResponse) *lc.GetActivationCodeResponse {
-		copyResp := proto.Clone(r).(*lc.GetActivationCodeResponse)
-		copyResp.ActivationCode = ""
-		return copyResp
-	}
-
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, removeSecret(resp), retErr, time.Since(start)) }(time.Now())
-
 	return a.getLicenseRecord(ctx)
 }
 
@@ -161,15 +140,6 @@ func (a *apiServer) validateClusterConfig(ctx context.Context, address string) e
 // AddCluster registers a new pachd with this license server. Each pachd is configured with a shared secret
 // which is used to authenticate to the license server when heartbeating.
 func (a *apiServer) AddCluster(ctx context.Context, req *lc.AddClusterRequest) (resp *lc.AddClusterResponse, retErr error) {
-	// Redact the secret from the request
-	removeSecret := func(r *lc.AddClusterRequest) *lc.AddClusterRequest {
-		copyReq := proto.Clone(r).(*lc.AddClusterRequest)
-		copyReq.Secret = ""
-		return copyReq
-	}
-	a.LogReq(ctx, removeSecret(req))
-	defer func(start time.Time) { a.pachLogger.Log(ctx, removeSecret(req), nil, retErr, time.Since(start)) }(time.Now())
-
 	// Make sure we have an active license
 	if err := a.checkLicenseState(ctx); err != nil {
 		return nil, err
@@ -206,17 +176,7 @@ func (a *apiServer) AddCluster(ctx context.Context, req *lc.AddClusterRequest) (
 	}, nil
 }
 
-func stripSecretFromRequest(req *lc.HeartbeatRequest) *lc.HeartbeatRequest {
-	r := *req
-	r.Secret = ""
-	return &r
-}
-
 func (a *apiServer) Heartbeat(ctx context.Context, req *lc.HeartbeatRequest) (resp *lc.HeartbeatResponse, retErr error) {
-	redactedRequest := stripSecretFromRequest(req)
-	a.LogReq(ctx, redactedRequest)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, redactedRequest, nil, retErr, time.Since(start)) }(time.Now())
-
 	var count int
 	if err := a.env.DB.GetContext(ctx, &count, `SELECT COUNT(*) FROM license.clusters WHERE id=$1 and secret=$2`, req.Id, req.Secret); err != nil {
 		return nil, errors.Wrapf(err, "unable to look up cluster in database")
@@ -241,9 +201,6 @@ func (a *apiServer) Heartbeat(ctx context.Context, req *lc.HeartbeatRequest) (re
 }
 
 func (a *apiServer) DeleteAll(ctx context.Context, req *lc.DeleteAllRequest) (resp *lc.DeleteAllResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	// TODO: attempt to synchronously deactivate enterprise licensing on every registered cluster
 
 	if _, err := a.env.DB.ExecContext(ctx, `DELETE FROM license.clusters`); err != nil {
@@ -264,9 +221,6 @@ func (a *apiServer) DeleteAll(ctx context.Context, req *lc.DeleteAllRequest) (re
 }
 
 func (a *apiServer) ListClusters(ctx context.Context, req *lc.ListClustersRequest) (resp *lc.ListClustersResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	clusters := make([]*lc.ClusterStatus, 0)
 	err := a.env.DB.SelectContext(ctx, &clusters, "SELECT id, address, version, auth_enabled, last_heartbeat FROM license.clusters;")
 	if err != nil {
@@ -279,9 +233,6 @@ func (a *apiServer) ListClusters(ctx context.Context, req *lc.ListClustersReques
 }
 
 func (a *apiServer) DeleteCluster(ctx context.Context, req *lc.DeleteClusterRequest) (resp *lc.DeleteClusterResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	// TODO: attempt to synchronously deactivate enterprise licensing on the specified cluster
 
 	_, err := a.env.DB.ExecContext(ctx, "DELETE FROM license.clusters WHERE id=$1", req.Id)
@@ -292,9 +243,6 @@ func (a *apiServer) DeleteCluster(ctx context.Context, req *lc.DeleteClusterRequ
 }
 
 func (a *apiServer) UpdateCluster(ctx context.Context, req *lc.UpdateClusterRequest) (resp *lc.UpdateClusterResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
-
 	if req.Address != "" {
 		if err := a.validateClusterConfig(ctx, req.Address); err != nil {
 			return nil, err
@@ -328,8 +276,6 @@ func (a *apiServer) UpdateCluster(ctx context.Context, req *lc.UpdateClusterRequ
 }
 
 func (a *apiServer) ListUserClusters(ctx context.Context, req *lc.ListUserClustersRequest) (resp *lc.ListUserClustersResponse, retErr error) {
-	a.LogReq(ctx, req)
-	defer func(start time.Time) { a.pachLogger.Log(ctx, req, resp, retErr, time.Since(start)) }(time.Now())
 	clusters := make([]*lc.UserClusterInfo, 0)
 	if err := a.env.DB.SelectContext(ctx, &clusters, `SELECT id, cluster_deployment_id, user_address, is_enterprise_server FROM license.clusters WHERE is_enterprise_server = false`); err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/server/license/server/env.go
+++ b/src/server/license/server/env.go
@@ -4,21 +4,17 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
-	"github.com/sirupsen/logrus"
 )
 
 // Env is the dependencies required for a license API Server
 type Env struct {
 	DB       *pachsql.DB
 	Listener collection.PostgresListener
-
-	Logger *logrus.Logger
 }
 
 func EnvFromServiceEnv(senv serviceenv.ServiceEnv) Env {
 	return Env{
 		DB:       senv.GetDBClient(),
 		Listener: senv.GetPostgresListener(),
-		Logger:   senv.Logger(),
 	}
 }

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -12,7 +12,6 @@ import (
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth"
 	ppsserver "github.com/pachyderm/pachyderm/v2/src/server/pps"
-	"github.com/sirupsen/logrus"
 	etcd "go.etcd.io/etcd/client/v3"
 	"golang.org/x/net/context"
 )
@@ -35,7 +34,6 @@ type Env struct {
 	GetPachClient func(ctx context.Context) *client.APIClient
 
 	BackgroundContext context.Context
-	Logger            *logrus.Logger
 	StorageConfig     serviceenv.StorageConfiguration
 }
 
@@ -64,6 +62,5 @@ func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv)
 
 		BackgroundContext: env.Context(),
 		StorageConfig:     env.Config().StorageConfiguration,
-		Logger:            env.Logger(),
 	}, nil
 }

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -74,7 +73,6 @@ func EnvFromServiceEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv
 func NewAPIServer(env Env) (ppsiface.APIServer, error) {
 	config := env.Config
 	apiServer := &apiServer{
-		Logger:                log.NewLogger("pps.API", env.Logger),
 		env:                   env,
 		txnEnv:                env.TxnEnv,
 		etcdPrefix:            env.EtcdPrefix,
@@ -110,7 +108,6 @@ func NewSidecarAPIServer(
 	peerPort uint16,
 ) (*apiServer, error) {
 	apiServer := &apiServer{
-		Logger:         log.NewLogger("pps.API", env.Logger),
 		env:            env,
 		txnEnv:         env.TxnEnv,
 		etcdPrefix:     env.EtcdPrefix,

--- a/src/server/transaction/server/api_server.go
+++ b/src/server/transaction/server/api_server.go
@@ -1,13 +1,10 @@
 package server
 
 import (
-	"time"
-
 	"github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
@@ -15,7 +12,6 @@ import (
 )
 
 type apiServer struct {
-	log.Logger
 	driver *driver
 }
 
@@ -28,37 +24,24 @@ func newAPIServer(
 		return nil, err
 	}
 	s := &apiServer{
-		Logger: log.NewLogger("transaction.API", env.Logger()),
 		driver: d,
 	}
 	return s, nil
 }
 
 func (a *apiServer) BatchTransaction(ctx context.Context, request *transaction.BatchTransactionRequest) (response *transaction.TransactionInfo, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	return a.driver.batchTransaction(ctx, request.Requests)
 }
 
 func (a *apiServer) StartTransaction(ctx context.Context, request *transaction.StartTransactionRequest) (response *transaction.Transaction, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	return a.driver.startTransaction(ctx)
 }
 
 func (a *apiServer) InspectTransaction(ctx context.Context, request *transaction.InspectTransactionRequest) (response *transaction.TransactionInfo, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	return a.driver.inspectTransaction(ctx, request.Transaction)
 }
 
 func (a *apiServer) DeleteTransaction(ctx context.Context, request *transaction.DeleteTransactionRequest) (response *types.Empty, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	err := a.driver.deleteTransaction(ctx, request.Transaction)
 	if err != nil {
 		return nil, err
@@ -68,9 +51,6 @@ func (a *apiServer) DeleteTransaction(ctx context.Context, request *transaction.
 }
 
 func (a *apiServer) ListTransaction(ctx context.Context, request *transaction.ListTransactionRequest) (response *transaction.TransactionInfos, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	transactions, err := a.driver.listTransaction(ctx)
 	if err != nil {
 		return nil, err
@@ -79,16 +59,10 @@ func (a *apiServer) ListTransaction(ctx context.Context, request *transaction.Li
 }
 
 func (a *apiServer) FinishTransaction(ctx context.Context, request *transaction.FinishTransactionRequest) (response *transaction.TransactionInfo, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	return a.driver.finishTransaction(ctx, request.Transaction)
 }
 
 func (a *apiServer) DeleteAll(ctx context.Context, request *transaction.DeleteAllRequest) (response *types.Empty, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	if err := dbutil.WithTx(ctx, a.driver.db, func(sqlTx *pachsql.Tx) error {
 		return a.driver.deleteAll(ctx, sqlTx, nil)
 	}); err != nil {
@@ -101,9 +75,6 @@ func (a *apiServer) DeleteAll(ctx context.Context, request *transaction.DeleteAl
 // AppendRequest is not an RPC, but is called from other systems in pachd to
 // add an operation to an existing transaction.
 func (a *apiServer) AppendRequest(ctx context.Context, txn *transaction.Transaction, request *transaction.TransactionRequest) (response *transaction.TransactionResponse, retErr error) {
-	func() { a.Log(ctx, request, nil, nil, 0) }()
-	defer func(start time.Time) { a.Log(ctx, request, response, retErr, time.Since(start)) }(time.Now())
-
 	items := []*transaction.TransactionRequest{request}
 	info, err := a.driver.appendTransaction(ctx, txn, items)
 	if err != nil {


### PR DESCRIPTION
This moves the RPC logging functionality all into one place, from `src/internal/log` to `src/internal/middleware/logging`, and RPCs no longer need to explicitly log their request and response.  In addition:

* Got rid of the janky stack inspection that RPC logging did to figure out the RPC name, since we have that provided by grpc to the interceptor
* Performed a bit of a reorg and cleanup up the logging code that was moved into the middleware
* Removed the dependency on the logger for several API servers
* Provided a way to customize the logging behavior for certain endpoints, similar to how the auth middleware does it
  * Some auth endpoints customize the log level (for example, `WhoAmI` is always debug level unless an error occurs, and 'not activated' errors are moved to the debug level)
  * Several APIs have sensitive information that we don't want to log, so some endpoints copy the request/response and redact that information
* Streaming RPCs will now always log the first received message as the request and count the number of responses to log 'stream containing %d objects' in the response field
 
I think in the future, it would be better to annotate the protobufs for sensitive fields and not have all this necessary boilerplate, but that's a separate project.