### PR TITLE
Block on establishing pg proxy Listen()

### DIFF
--- a/src/client/proxy.go
+++ b/src/client/proxy.go
@@ -48,6 +48,10 @@ func (ppl *proxyPostgresListener) setup() error {
 	return err
 }
 
+// TODO: for now, calls to Register() will block on the Listener being established
+// on the main pachd instance. This could become a bottleneck if many Watchers are
+// instantiated at once. Consider finer grained locking at the channel level using
+// a mechanism such as the "WorkDeduper" (src/internal/miscutil/work_deduper.go).
 func (ppl *proxyPostgresListener) Register(notifier col.Notifier) error {
 	ppl.mu.Lock()
 	defer ppl.mu.Unlock()
@@ -83,6 +87,7 @@ func (ppl *proxyPostgresListener) listen(notifier col.Notifier) {
 		notifier.Error(err)
 		cancel()
 		delete(ppl.channelInfos, channel)
+		return
 	}
 
 	go func() {

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -553,7 +553,7 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 			}
 		}
 
-		if bufEvent != nil && bufEvent.time.Unix() <= lastTimestamp(m, options.SortTarget).Unix() {
+		if bufEvent != nil && bufEvent.time.Before(lastTimestamp(m, options.SortTarget)) {
 			return errutil.ErrBreak
 		}
 

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -545,7 +545,7 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 		if err := proto.Unmarshal(m.Proto, val); err != nil {
 			return errors.EnsureStack(err)
 		}
-		lastTs := lastTimestamp(m, options.SortTarget)
+		lastTs = lastTimestamp(m, options.SortTarget)
 
 		if bufEvent == nil {
 			select {
@@ -559,6 +559,7 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 			if err := watcher.sendInitial(bufEvent.WatchEvent(c.ctx, watcher.db, watcher.template)); err != nil {
 				return err
 			}
+			lastTs = bufEvent.time
 			bufEvent = nil
 			return errutil.ErrBreak
 		}

--- a/src/proxy/proxy.pb.go
+++ b/src/proxy/proxy.pb.go
@@ -155,6 +155,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type APIClient interface {
+	// Listen streams database events.
+	// It signals that it is internally set up by sending an initial empty ListenResponse.
 	Listen(ctx context.Context, in *ListenRequest, opts ...grpc.CallOption) (API_ListenClient, error)
 }
 
@@ -200,6 +202,8 @@ func (x *aPIListenClient) Recv() (*ListenResponse, error) {
 
 // APIServer is the server API for API service.
 type APIServer interface {
+	// Listen streams database events.
+	// It signals that it is internally set up by sending an initial empty ListenResponse.
 	Listen(*ListenRequest, API_ListenServer) error
 }
 

--- a/src/proxy/proxy.proto
+++ b/src/proxy/proxy.proto
@@ -12,5 +12,7 @@ message ListenResponse {
 }
 
 service API {
+  // Listen streams database events. 
+  // It signals that it is internally set up by sending an initial empty ListenResponse.
   rpc Listen(ListenRequest) returns (stream ListenResponse) {}
 }

--- a/src/server/proxy/server/api_server.go
+++ b/src/server/proxy/server/api_server.go
@@ -31,9 +31,7 @@ func (a *APIServer) Listen(request *proxy.ListenRequest, server proxy.API_Listen
 	}
 
 	// send initial empty event to indicate to client that the listener has been registered
-	if err := server.Send(&proxy.ListenResponse{
-		Extra: "",
-	}); err != nil {
+	if err := server.Send(&proxy.ListenResponse{}); err != nil {
 		return errors.EnsureStack(err)
 	}
 

--- a/src/server/proxy/server/api_server.go
+++ b/src/server/proxy/server/api_server.go
@@ -23,6 +23,8 @@ func NewAPIServer(env Env) *APIServer {
 	}
 }
 
+// Listen streams database events.
+// It signals that it is internally set up by sending an initial empty ListenResponse.
 func (a *APIServer) Listen(request *proxy.ListenRequest, server proxy.API_ListenServer) (retErr error) {
 	listener := a.env.Listener
 	notifier := newNotifier(server, request.Channel)

--- a/src/server/proxy/server/api_server.go
+++ b/src/server/proxy/server/api_server.go
@@ -34,8 +34,7 @@ func (a *APIServer) Listen(request *proxy.ListenRequest, server proxy.API_Listen
 	if err := server.Send(&proxy.ListenResponse{
 		Extra: "",
 	}); err != nil {
-		notifier.sendError(err)
-		return
+		return errors.EnsureStack(err)
 	}
 
 	go notifier.send()


### PR DESCRIPTION
There are two fixes here involving the Watcher implementation.
1.) For workers that listen for events via a proxy that streams events from a pachd instance, we change that proxy's grpc so that it signals when it is completely set up and ready to stream events. We make sure to wait for the initially empty event on the client side.

2.) Fix a bug in the Watcher logic where we incorrectly manage the last timestamp variable that is used once the watcher hands off streaming from the list() call to database events