### PR TITLE
CORE-75 Switch log levels based on gRPC status codes in logging middleware

### DIFF
--- a/src/internal/errors/errors.go
+++ b/src/internal/errors/errors.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -52,6 +54,11 @@ func EnsureStack(err error) error {
 		return err
 	}
 
+	// wrap gRPC status error with stack, then wrap again with an implementation of GRPCStatus
+	if _, ok := status.FromError(err); ok {
+		return &gRPCStatusError{WithStack(err)}
+	}
+
 	return WithStack(err)
 }
 
@@ -94,4 +101,27 @@ func ForEachStackFrame(err error, f func(Frame)) {
 			f(Frame{frame})
 		}
 	}
+}
+
+type gRPCStatusError struct {
+	err error
+}
+
+func (e *gRPCStatusError) GRPCStatus() *status.Status {
+	if se, ok := e.err.(interface{ GRPCStatus() *status.Status }); ok {
+		return se.GRPCStatus()
+	}
+	if se, ok := errors.Unwrap(e.err).(interface{ GRPCStatus() *status.Status }); ok {
+		return se.GRPCStatus()
+	}
+	// should not get here unless wrapped a non GRPCStatus error
+	return status.New(codes.Unknown, e.Error())
+}
+
+func (e *gRPCStatusError) Error() string {
+	return e.err.Error()
+}
+
+func (e *gRPCStatusError) Unwrap() error {
+	return e.err
 }

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -33,9 +33,9 @@ func defaultLevel(err error) logrus.Level {
 	case codes.OK:
 		// status.Code(nil) returns OK
 		return logrus.InfoLevel
-	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.OutOfRange:
+	case codes.InvalidArgument, codes.OutOfRange:
 		return logrus.InfoLevel
-	case codes.Unauthenticated:
+	case codes.NotFound, codes.AlreadyExists, codes.Unauthenticated:
 		return logrus.WarnLevel
 	default:
 		return logrus.ErrorLevel

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -11,7 +11,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
@@ -27,10 +29,17 @@ type logConfig struct {
 }
 
 func defaultLevel(err error) logrus.Level {
-	if err == nil {
+	switch status.Code(err) {
+	case codes.OK:
+		// status.Code(nil) returns OK
 		return logrus.InfoLevel
+	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.OutOfRange:
+		return logrus.InfoLevel
+	case codes.Unauthenticated:
+		return logrus.WarnLevel
+	default:
+		return logrus.ErrorLevel
 	}
-	return logrus.ErrorLevel
 }
 
 var defaultConfig = logConfig{level: defaultLevel}

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -133,32 +133,64 @@ func (e ErrFileNotFound) Error() string {
 	return fmt.Sprintf("file %v not found in repo %v at commit %v", e.File.Path, e.File.Commit.Branch.Repo, e.File.Commit.ID)
 }
 
+func (e ErrFileNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
+}
+
 func (e ErrRepoNotFound) Error() string {
 	return fmt.Sprintf("repo %v not found", e.Repo)
+}
+
+func (e ErrRepoNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
 }
 
 func (e ErrRepoExists) Error() string {
 	return fmt.Sprintf("repo %v already exists", e.Repo)
 }
 
+func (e ErrRepoExists) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, e.Error())
+}
+
 func (e ErrBranchNotFound) Error() string {
 	return fmt.Sprintf("branch %q not found in repo %v", e.Branch.Name, e.Branch.Repo)
+}
+
+func (e ErrBranchNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
 }
 
 func (e ErrBranchExists) Error() string {
 	return fmt.Sprintf("branch %q already exists in repo %v", e.Branch.Name, e.Branch.Repo)
 }
 
+func (e ErrBranchExists) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, e.Error())
+}
+
 func (e ErrCommitNotFound) Error() string {
 	return fmt.Sprintf("commit %v not found", e.Commit)
+}
+
+func (e ErrCommitNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
 }
 
 func (e ErrCommitSetNotFound) Error() string {
 	return fmt.Sprintf("no commits found for commitset %v", e.CommitSet.ID)
 }
 
+func (e ErrCommitSetNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
+}
+
 func (e ErrCommitExists) Error() string {
 	return fmt.Sprintf("commit %v already exists", e.Commit)
+}
+
+func (e ErrCommitExists) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, e.Error())
 }
 
 func (e ErrCommitFinished) Error() string {
@@ -175,6 +207,10 @@ func (e ErrCommitDeleted) Error() string {
 
 func (e ErrParentCommitNotFound) Error() string {
 	return fmt.Sprintf("parent commit %v not found", e.Commit)
+}
+
+func (e ErrParentCommitNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
 }
 
 func (e ErrOutputCommitNotFinished) Error() string {

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -228,7 +228,7 @@ func (d *driver) inspectRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Re
 	}
 	repoInfo := &pfs.RepoInfo{}
 	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(repo, repoInfo); err != nil {
-		return nil, errors.EnsureStack(err)
+		return nil, errors.EnsureStack(pfsserver.ErrRepoNotFound{Repo: repo})
 	}
 	if includeAuth {
 		resp, err := d.env.AuthServer.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{
@@ -1824,7 +1824,7 @@ func (d *driver) inspectBranch(txnCtx *txncontext.TransactionContext, branch *pf
 
 	result := &pfs.BranchInfo{}
 	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, result); err != nil {
-		return nil, errors.EnsureStack(err)
+		return nil, errors.EnsureStack(pfsserver.ErrBranchNotFound{Branch: branch})
 	}
 	return result, nil
 }


### PR DESCRIPTION
Currently, all errors returned by our system are logged at ERROR level. However, we want to reduce the noise in our logs because some errors are caused by user error, and are not relevant for debugging real problems.

This PR:

- adds the ability to control the log level based on the gRPC status codes returned by the handlers 
- implements `GRPCStatus()` interface for a subset of the pfs server errors
- updates the widely used `EnsureStack(error)` function to return a wrapped error that still implements the GRPCStatus interface so that the middleware can get the status from these errors.
 
Note that it is still up the gRPC handlers to leverage these structured errors, so if a gRPC handler does not return these structured errors, then the logs would still be ERROR level. This PR updated `inspectRepo` and `inspectBranch` to return the appropriate errors, but it's not exhaustive. This PR mostly only provides a foundation for future logging level changes.