### PR TITLE
Make Cron Auth work

### DIFF
--- a/src/server/auth/iface.go
+++ b/src/server/auth/iface.go
@@ -27,6 +27,7 @@ type APIServer interface {
 	// for specific permissions required to use a repo as a pipeline input/output.
 	AddPipelineReaderToRepoInTransaction(*txncontext.TransactionContext, string, string) error
 	AddPipelineWriterToRepoInTransaction(*txncontext.TransactionContext, string) error
+	AddPipelineWriterToSourceRepoInTransaction(*txncontext.TransactionContext, string, string) error
 	RemovePipelineReaderFromRepoInTransaction(*txncontext.TransactionContext, string, string) error
 
 	// Create and Delete are internal-only APIs used by other services when creating/destroying resources.

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -713,6 +713,19 @@ func (a *apiServer) AddPipelineReaderToRepoInTransaction(txnCtx *txncontext.Tran
 	return a.setUserRoleBindingInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_REPO, Name: sourceRepo}, auth.PipelinePrefix+pipeline, []string{auth.RepoReaderRole})
 }
 
+// AddPipelineReaderToRepoInTransaction gives a pipeline access to write data to the specified source repo.
+// The only time a pipeline needs write permission for a source repo is in the case of Cron inputs.
+// This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
+// that is included in the repoWriter role, versus being able to modify all role bindings which is
+// part of repoOwner. This method is for internal use and is not exposed as an RPC.
+func (a *apiServer) AddPipelineWriterToSourceRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo, pipeline string) error {
+	// Check that the user is allowed to add a pipeline to write to the output repo.
+	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, &pfs.Repo{Type: pfs.UserRepoType, Name: sourceRepo}, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
+		return err
+	}
+	return a.setUserRoleBindingInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_REPO, Name: sourceRepo}, auth.PipelinePrefix+pipeline, []string{auth.RepoWriterRole})
+}
+
 // AddPipelineWriterToRepoInTransaction gives a pipeline access to write to it's own output repo.
 // This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -713,7 +713,7 @@ func (a *apiServer) AddPipelineReaderToRepoInTransaction(txnCtx *txncontext.Tran
 	return a.setUserRoleBindingInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_REPO, Name: sourceRepo}, auth.PipelinePrefix+pipeline, []string{auth.RepoReaderRole})
 }
 
-// AddPipelineReaderToRepoInTransaction gives a pipeline access to write data to the specified source repo.
+// AddPipelineWriterToSourceRepoInTransaction gives a pipeline access to write data to the specified source repo.
 // The only time a pipeline needs write permission for a source repo is in the case of Cron inputs.
 // This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/license"
@@ -514,6 +515,95 @@ func TestPreActivationPipelinesKeepRunningAfterActivation(t *testing.T) {
 		_, err := rootClient.WaitCommit(pipeline, "master", commit.ID)
 		return err
 	})
+}
+
+func TestPreActivationCronPipelinesKeepRunningAfterActivation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	alice := robot(tu.UniqueString("alice"))
+	aliceClient, rootClient := tu.GetAuthenticatedPachClient(t, alice), tu.GetAuthenticatedPachClient(t, auth.RootUser)
+
+	// Deactivate auth
+	_, err := rootClient.Deactivate(rootClient.Ctx(), &auth.DeactivateRequest{})
+	require.NoError(t, err)
+
+	// Wait for auth to be deactivated
+	require.NoError(t, backoff.Retry(func() error {
+		_, err := aliceClient.WhoAmI(aliceClient.Ctx(), &auth.WhoAmIRequest{})
+		if err != nil && auth.IsErrNotActivated(err) {
+			return nil // WhoAmI should fail when auth is deactivated
+		}
+		return errors.New("auth is not yet deactivated")
+	}, backoff.NewTestingBackOff()))
+
+	// alice creates a pipeline
+	pipeline1 := tu.UniqueString("cron1-")
+	require.NoError(t, aliceClient.CreatePipeline(
+		pipeline1,
+		"",
+		[]string{"/bin/bash"},
+		[]string{"cp /pfs/time/* /pfs/out/"},
+		nil,
+		client.NewCronInput("time", "@every 10s"),
+		"",
+		false,
+	))
+	pipeline2 := tu.UniqueString("cron2-")
+	require.NoError(t, aliceClient.CreatePipeline(
+		pipeline2,
+		"",
+		[]string{"/bin/bash"},
+		[]string{"cp " + fmt.Sprintf("/pfs/%s/*", pipeline1) + " /pfs/out/"},
+		nil,
+		client.NewPFSInput(pipeline1, "/*"),
+		"",
+		false,
+	))
+
+	// subscribe to the pipeline2 cron repo and wait for inputs
+	repo := client.NewRepo(pipeline2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel() //cleanup resources
+
+	checkCronCommits := func(n int) error {
+		count := 0
+		return aliceClient.WithCtx(ctx).SubscribeCommit(repo, "master", "", pfs.CommitState_FINISHED, func(ci *pfs.CommitInfo) error {
+			files, err := aliceClient.ListFileAll(ci.Commit, "")
+			require.NoError(t, err)
+
+			require.Equal(t, count, len(files))
+			count++
+			if count > n {
+				return errutil.ErrBreak
+			}
+			return nil
+		})
+	}
+	// make sure the cron is working
+	require.NoError(t, checkCronCommits(1))
+
+	// activate auth
+	resp, err := rootClient.Activate(rootClient.Ctx(), &auth.ActivateRequest{RootToken: tu.RootToken})
+	require.NoError(t, err)
+	rootClient.SetAuthToken(resp.PachToken)
+
+	// activate auth in PFS
+	_, err = rootClient.PfsAPIClient.ActivateAuth(rootClient.Ctx(), &pfs.ActivateAuthRequest{})
+	require.NoError(t, err)
+
+	// activate auth in PPS
+	_, err = rootClient.PpsAPIClient.ActivateAuth(rootClient.Ctx(), &pps.ActivateAuthRequest{})
+	require.NoError(t, err)
+
+	// re-authenticate, as old tokens were deleted
+	aliceClient = tu.GetAuthenticatedPachClient(t, alice)
+	require.NoError(t, rootClient.ModifyClusterRoleBinding(alice, []string{auth.RepoWriterRole}))
+
+	// make sure the cron is working
+	require.NoError(t, checkCronCommits(5))
 }
 
 func TestPipelinesRunAfterExpiration(t *testing.T) {

--- a/src/server/auth/server/testing/admin_test.go
+++ b/src/server/auth/server/testing/admin_test.go
@@ -547,7 +547,7 @@ func TestPreActivationCronPipelinesKeepRunningAfterActivation(t *testing.T) {
 		[]string{"/bin/bash"},
 		[]string{"cp /pfs/time/* /pfs/out/"},
 		nil,
-		client.NewCronInput("time", "@every 10s"),
+		client.NewCronInput("time", "@every 3s"),
 		"",
 		false,
 	))

--- a/src/server/auth/testing/auth.go
+++ b/src/server/auth/testing/auth.go
@@ -54,6 +54,11 @@ func (a *InactiveAPIServer) AddPipelineWriterToRepoInTransaction(txnCtx *txncont
 	return auth.ErrNotActivated
 }
 
+// AddPipelineWriterToSourceRepoInTransaction implements the AddPipelineWriterToSourceRepoInTransaction internal API
+func (a *InactiveAPIServer) AddPipelineWriterToSourceRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo, pipeline string) error {
+	return auth.ErrNotActivated
+}
+
 // RemovePipelineReaderToRepoInTransaction implements the RemovePipelineReaderToRepoInTransaction internal API
 func (a *InactiveAPIServer) RemovePipelineReaderFromRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo, pipeline string) error {
 	return auth.ErrNotActivated

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1570,7 +1570,8 @@ func (a *apiServer) fixPipelineInputRepoACLs(ctx context.Context, pipelineInfo *
 }
 
 func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.TransactionContext, pipelineInfo *pps.PipelineInfo, prevPipelineInfo *pps.PipelineInfo) (retErr error) {
-	add := make(map[string]struct{})
+	addRead := make(map[string]struct{})
+	addWrite := make(map[string]struct{})
 	remove := make(map[string]struct{})
 	var pipelineName string
 	// Figure out which repos 'pipeline' might no longer be using
@@ -1617,7 +1618,10 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 			if _, ok := remove[repo]; ok {
 				delete(remove, repo)
 			} else {
-				add[repo] = struct{}{}
+				addRead[repo] = struct{}{}
+				if input.Cron != nil {
+					addWrite[repo] = struct{}{}
+				}
 			}
 			return nil
 		})
@@ -1629,7 +1633,8 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 
 	// make sure we don't touch the pipeline's permissions on its output repo
 	delete(remove, pipelineName)
-	delete(add, pipelineName)
+	delete(addRead, pipelineName)
+	delete(addWrite, pipelineName)
 
 	defer func() {
 		retErr = errors.Wrapf(retErr, "error fixing ACLs on \"%s\"'s input repos", pipelineName)
@@ -1643,12 +1648,20 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 		}
 	}
 	// Add pipeline to every new input's ACL as a READER
-	for repo := range add {
+	for repo := range addRead {
 		// This raises an error if the input repo doesn't exist, or if the user doesn't have permissions to add a pipeline as a reader on the input repo
 		if err := a.env.AuthServer.AddPipelineReaderToRepoInTransaction(txnCtx, repo, pipelineName); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
+
+	for repo := range addWrite {
+		// This raises an error if the input repo doesn't exist, or if the user doesn't have permissions to add a pipeline as a writer on the input repo
+		if err := a.env.AuthServer.AddPipelineWriterToSourceRepoInTransaction(txnCtx, repo, pipelineName); err != nil {
+			return errors.EnsureStack(err)
+		}
+	}
+
 	// Add pipeline to its output repo's ACL as a WRITER if it's new
 	if prevPipelineInfo == nil {
 		if err := a.env.AuthServer.AddPipelineWriterToRepoInTransaction(txnCtx, pipelineName); err != nil {


### PR DESCRIPTION
This PR makes it so that Cron pipelines work with Auth. 

The fundamental issue is that the pipeline auth subject, needs Write permissions to an input repo. I've added an internal transaction API to do so. 

I also added a test case that creates a Cron pipeline, and turns on auth