### PR TITLE
Pachctl ARM64

### DIFF
--- a/goreleaser/pachctl.yml
+++ b/goreleaser/pachctl.yml
@@ -24,6 +24,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
 
 archives:
   -


### PR DESCRIPTION
This updates the goreleaser for pachctl to also generate arm64 packages as well. A companion PR to the homebrew-tap will be created as well