### PR TITLE
Fix `pachctl unmount --all` bug for mac

### DIFF
--- a/src/server/pfs/cmds/mount_darwin.go
+++ b/src/server/pfs/cmds/mount_darwin.go
@@ -1,9 +1,9 @@
-// +build darwin
+//go:build darwin
 
 package cmds
 
 import "fmt"
 
 func printWarning() {
-	fmt.Println(`WARNING: Mount is supported on macOS versions 1.10.5 and earlier. Mount is implemented using FUSE which isn't supported in macOS 1.11. FUSE on macOS differs from Linux FUSE which causes some issues known issues. For the best experience we recommend using mount on Linux.`)
+	fmt.Println(`WARNING: Download the latest macOS and macFUSE versions or use mount on Linux for the best experience.`)
 }

--- a/src/server/pfs/cmds/mount_unix.go
+++ b/src/server/pfs/cmds/mount_unix.go
@@ -151,8 +151,9 @@ func mountCmds() []*cobra.Command {
 			}
 			if all {
 				stdin := strings.NewReader(fmt.Sprintf(`
-		mount | grep fuse.%s | cut -f 3 -d " "
-		`, name))
+					mount | grep -w %s | grep fuse | cut -f 3 -d " "`,
+					name,
+				))
 				var stdout bytes.Buffer
 				if err := cmdutil.RunIO(cmdutil.IO{
 					Stdin:  stdin,


### PR DESCRIPTION
The previous grep check worked for linux but didn't find our pfs mounts on mac. Updated so it catches our pfs mounts on both platforms.