### PR TITLE
obj: Don't hold locks while doing Gets in the cacheClient

### DIFF
--- a/src/internal/obj/cache_client.go
+++ b/src/internal/obj/cache_client.go
@@ -101,7 +101,8 @@ func (c *cacheClient) getFast(ctx context.Context, p string, w io.Writer) (bool,
 func (c *cacheClient) getSlow(ctx context.Context, p string, w io.Writer) error {
 	return miscutil.WithPipe(func(w2 io.Writer) error {
 		mw := io.MultiWriter(w, w2)
-		return c.slow.Get(ctx, p, mw)
+		err := c.slow.Get(ctx, p, mw)
+		return errors.EnsureStack(err)
 	}, func(r io.Reader) error {
 		if err := c.fast.Put(ctx, p, r); err != nil {
 			return errors.EnsureStack(err)

--- a/src/internal/obj/cache_client.go
+++ b/src/internal/obj/cache_client.go
@@ -107,7 +107,8 @@ func (c *cacheClient) getSlow(ctx context.Context, p string, w io.Writer) error 
 		return errors.EnsureStack(err)
 	}, func(r io.Reader) error {
 		if err := c.fast.Put(ctx, p, r); pacherr.IsNotExist(err) {
-			return err
+			// if the object could not be found, the first read will return a NotExist error
+			return errors.EnsureStack(err)
 		} else if err != nil {
 			c.log.Errorf("obj.cacheClient: writing to cache: %v", err)
 			return nil

--- a/src/internal/obj/cache_client.go
+++ b/src/internal/obj/cache_client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -65,19 +66,51 @@ func NewCacheClient(slow, fast Client, size int) Client {
 }
 
 func (c *cacheClient) Get(ctx context.Context, p string, w io.Writer) error {
-	c.doPopulateOnce(ctx)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if _, exists := c.cache.Get(p); exists {
+	c.doPopulateOnce(ctx) // always call before acquiring locks
+	if hit, err := c.getFast(ctx, p, w); err != nil {
+		return err
+	} else if hit {
 		cacheHitMetric.Inc()
-		return errors.EnsureStack(c.fast.Get(ctx, p, w))
+		return nil
 	}
 	cacheMissMetric.Inc()
-	if err := Copy(ctx, c.slow, c.fast, p, p); err != nil {
-		return err
+	return c.getSlow(ctx, p, w)
+}
+
+// getFast retrieves an object from c.fast if it exists, writes it to w and returns true.
+// if it does not exist nothing is written to w and false is returned.
+func (c *cacheClient) getFast(ctx context.Context, p string, w io.Writer) (bool, error) {
+	c.mu.Lock()
+	_, exists := c.cache.Get(p)
+	c.mu.Unlock()
+	if !exists {
+		return false, nil
 	}
-	c.cache.Add(p, struct{}{})
-	return errors.EnsureStack(c.fast.Get(ctx, p, w))
+	if err := c.fast.Get(ctx, p, w); err != nil && pacherr.IsNotExist(err) {
+		// could have been deleted since we released the lock, but that's fine.
+		return false, nil
+	} else if err != nil {
+		return false, errors.EnsureStack(err)
+	}
+	return true, nil
+}
+
+// getSlow retrieves an object from c.slow and concurrently writes it to w and to c.fast.
+// c.mu is not acquired until after a succesful put to prevent holding the lock while doing IO,
+// and to prevent a slow w from holding up cache access for other callers.
+func (c *cacheClient) getSlow(ctx context.Context, p string, w io.Writer) error {
+	return miscutil.WithPipe(func(w2 io.Writer) error {
+		mw := io.MultiWriter(w, w2)
+		return c.slow.Get(ctx, p, mw)
+	}, func(r io.Reader) error {
+		if err := c.fast.Put(ctx, p, r); err != nil {
+			return errors.EnsureStack(err)
+		}
+		c.mu.Lock()
+		c.cache.Add(p, struct{}{})
+		c.mu.Unlock()
+		return nil
+	})
 }
 
 func (c *cacheClient) Put(ctx context.Context, p string, r io.Reader) error {
@@ -115,7 +148,7 @@ func (c *cacheClient) deleteFromCache(ctx context.Context, p string) error {
 // the gorountine executing onEvicted will have c.mu
 func (c *cacheClient) onEvicted(key, value interface{}) {
 	p := key.(string)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := c.fast.Delete(ctx, p); err != nil && !pacherr.IsNotExist(err) {
 		log.Errorf("could not delete from cache's fast store: %v", err)

--- a/src/internal/obj/cache_client_test.go
+++ b/src/internal/obj/cache_client_test.go
@@ -1,0 +1,12 @@
+package obj
+
+import "testing"
+
+func TestCacheClient(t *testing.T) {
+	t.Parallel()
+	TestSuite(t, func(t testing.TB) Client {
+		fast := newTestLocalClient(t)
+		slow := newTestLocalClient(t)
+		return NewCacheClient(slow, fast, 3)
+	})
+}


### PR DESCRIPTION
Recently @jrockway observed something like 10k goroutines waiting on this lock.  It prevents any concurrent object storage access. 

The extremely coarse locking was chosen to deal with the semantics of the FS backed object client at the time.  That obj.Client implementation has since been improved to have typical object storage semantics, and so we no longer need to hold locks during Puts to the FS client because Puts are atomic.