### PR TITLE
Fix flaky transactions

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -235,7 +235,10 @@ func (d *driver) inspectRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Re
 	}
 	repoInfo := &pfs.RepoInfo{}
 	if err := d.repos.ReadWrite(txnCtx.SqlTx).Get(repo, repoInfo); err != nil {
-		return nil, errors.EnsureStack(pfsserver.ErrRepoNotFound{Repo: repo})
+		if col.IsErrNotFound(err) {
+			return nil, pfsserver.ErrRepoNotFound{Repo: repo}
+		}
+		return nil, errors.EnsureStack(err)
 	}
 	if includeAuth {
 		resp, err := d.env.AuthServer.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{
@@ -1831,7 +1834,10 @@ func (d *driver) inspectBranch(txnCtx *txncontext.TransactionContext, branch *pf
 
 	result := &pfs.BranchInfo{}
 	if err := d.branches.ReadWrite(txnCtx.SqlTx).Get(branch, result); err != nil {
-		return nil, errors.EnsureStack(pfsserver.ErrBranchNotFound{Branch: branch})
+		if col.IsErrNotFound(err) {
+			return nil, pfsserver.ErrBranchNotFound{Branch: branch}
+		}
+		return nil, errors.EnsureStack(err)
 	}
 	return result, nil
 }


### PR DESCRIPTION
This PR is intended to fix the recent issue with flaky transactions.

The issue was that a recent change to inspect repo & inspect branch made it such that all errors during the get operation would be converted to not found errors. This was likely hiding a serialization error that we were not respecting in a larger transaction which was leading to transaction abortion errors in later queries. This was predominately affecting the deletion of cron pipelines because they are probably the most subject to serialization errors since they have a component performing operations in parallel with the deletion that is occurring.