### PR TITLE
Add clear cache entry in auth interceptor

### DIFF
--- a/src/internal/middleware/auth/interceptor.go
+++ b/src/internal/middleware/auth/interceptor.go
@@ -160,6 +160,7 @@ var authHandlers = map[string]authHandler{
 	"/pfs_v2.API/CheckStorage":       authDisabledOr(authenticated),
 	"/pfs_v2.API/PutCache":           authDisabledOr(authenticated),
 	"/pfs_v2.API/GetCache":           authDisabledOr(authenticated),
+	"/pfs_v2.API/ClearCache":         authDisabledOr(authenticated),
 	"/pfs_v2.API/RunLoadTest":        authDisabledOr(authenticated),
 	"/pfs_v2.API/RunLoadTestDefault": authDisabledOr(authenticated),
 	"/pfs_v2.API/ListTask":           authDisabledOr(authenticated),


### PR DESCRIPTION
This PR adds the entry for clear cache in the auth interceptor. Clear cache is best effort under the hood, so this issue went unnoticed since it doesn't cause failures.