### PR TITLE
Fix a couple task service issues

### DIFF
--- a/src/internal/collection/collection_test.go
+++ b/src/internal/collection/collection_test.go
@@ -77,7 +77,7 @@ func populateCollection(rw col.ReadWriteCollection) error {
 
 func initCollection(
 	t *testing.T,
-	newCollection func(context.Context, *testing.T) (ReadCallback, WriteCallback),
+	newCollection func(context.Context, *testing.T, ...bool) (ReadCallback, WriteCallback),
 ) (col.ReadOnlyCollection, WriteCallback) {
 	reader, writer := newCollection(context.Background(), t)
 	require.NoError(t, writer(context.Background(), populateCollection))
@@ -170,7 +170,7 @@ type TestConstructor = func(context.Context, *testing.T) (ReadCallback, WriteCal
 
 func collectionTests(
 	parent *testing.T,
-	newCollection func(context.Context, *testing.T) (ReadCallback, WriteCallback),
+	newCollection func(context.Context, *testing.T, ...bool) (ReadCallback, WriteCallback),
 ) {
 	parent.Run("ReadOnly", func(suite *testing.T) {
 		suite.Parallel()
@@ -384,7 +384,7 @@ func collectionTests(
 
 				subsuite.Run("UpdatedAt", func(t *testing.T) {
 					// Create a new collection that we can modify to get a different ordering here
-					reader, writer := newCollection(context.Background(), t)
+					reader, writer := newCollection(context.Background(), t, true)
 					modRead := reader(context.Background())
 					require.NoError(suite, writer(context.Background(), populateCollection))
 

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -316,6 +316,12 @@ func (c *etcdReadWriteCollection) putLease(key string, val proto.Message, lease 
 	})
 }
 
+func (c *etcdReadWriteCollection) putIgnoreLease(key string, val proto.Message) error {
+	return c.put(key, val, func(key string, val string, ptr uintptr) error {
+		return errors.EnsureStack(c.stm.PutIgnoreLease(key, val, ptr))
+	})
+}
+
 // Update reads the current value associated with 'key', calls 'f' to update
 // the value, and writes the new value back to the collection. 'key' must be
 // present in the collection, or a 'Not Found' error is returned
@@ -336,7 +342,7 @@ func (c *etcdReadWriteCollection) Update(maybeKey interface{}, val proto.Message
 	if err := f(); err != nil {
 		return err
 	}
-	return c.Put(key, val)
+	return c.putIgnoreLease(key, val)
 }
 
 // Upsert is like Update but 'key' is not required to be present

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -36,9 +36,13 @@ var (
 
 func TestEtcdCollections(suite *testing.T) {
 	etcdEnv := testetcd.NewEnv(suite)
-	newCollection := func(ctx context.Context, t *testing.T) (ReadCallback, WriteCallback) {
+	newCollection := func(ctx context.Context, t *testing.T, noIndex ...bool) (ReadCallback, WriteCallback) {
 		prefix := testutil.UniqueString("test-etcd-collections-")
-		testCol := col.NewEtcdCollection(etcdEnv.EtcdClient, prefix, []*col.Index{TestSecondaryIndex}, &col.TestItem{}, nil, nil)
+		index := []*col.Index{TestSecondaryIndex}
+		if len(noIndex) > 0 && noIndex[0] {
+			index = nil
+		}
+		testCol := col.NewEtcdCollection(etcdEnv.EtcdClient, prefix, index, &col.TestItem{}, nil, nil)
 
 		readCallback := func(ctx context.Context) col.ReadOnlyCollection {
 			return testCol.ReadOnly(ctx)

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -60,8 +60,8 @@ func TestPostgresCollectionsProxy(suite *testing.T) {
 	}))
 }
 
-func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col.PostgresListener)) func(context.Context, *testing.T) (ReadCallback, WriteCallback) {
-	return func(ctx context.Context, t *testing.T) (ReadCallback, WriteCallback) {
+func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col.PostgresListener)) func(context.Context, *testing.T, ...bool) (ReadCallback, WriteCallback) {
+	return func(ctx context.Context, t *testing.T, noIndex ...bool) (ReadCallback, WriteCallback) {
 		db, listener := setup(ctx, t)
 		opts := []col.Option{col.WithListBufferCapacity(3)} // set the list buffer capacity to 3
 		testCol := col.NewPostgresCollection("test_items", db, listener, &col.TestItem{}, []*col.Index{TestSecondaryIndex}, opts...)
@@ -83,7 +83,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col
 	}
 }
 
-func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.Context, *testing.T) (ReadCallback, WriteCallback)) {
+func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.Context, *testing.T, ...bool) (ReadCallback, WriteCallback)) {
 	collectionTests(suite, newCollection)
 
 	// Postgres collections support getting multiple rows by a secondary index,
@@ -201,7 +201,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 	// TODO: test keycheck function
 }
 
-func PostgresCollectionWatchTests(suite *testing.T, newCollection func(context.Context, *testing.T) (ReadCallback, WriteCallback)) {
+func PostgresCollectionWatchTests(suite *testing.T, newCollection func(context.Context, *testing.T, ...bool) (ReadCallback, WriteCallback)) {
 	watchTests(suite, newCollection)
 }
 

--- a/src/internal/collection/transaction.go
+++ b/src/internal/collection/transaction.go
@@ -38,6 +38,7 @@ type STM interface {
 	// Put adds a value for a key to the write set.
 	Put(key, val string, ttl int64, ptr uintptr) error
 	PutLease(key, val string, lease v3.LeaseID, ptr uintptr) error
+	PutIgnoreLease(key, val string, ptr uintptr) error
 	// Del deletes a key.
 	Del(key string)
 	// TTL returns the remaining time to live for 'key', or 0 if 'key' has no TTL
@@ -225,6 +226,13 @@ func (s *stm) PutLease(key, val string, lease v3.LeaseID, ptr uintptr) error {
 	s.Lock()
 	defer s.Unlock()
 	s.wset[key] = stmPut{val, ttl, v3.OpPut(key, val, v3.WithLease(lease)), ptr}
+	return nil
+}
+
+func (s *stm) PutIgnoreLease(key, val string, ptr uintptr) error {
+	s.Lock()
+	defer s.Unlock()
+	s.wset[key] = stmPut{val, ttl, v3.OpPut(key, val, v3.WithIgnoreLease()), ptr}
 	return nil
 }
 

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -194,7 +194,7 @@ func NewWatchShim(ctx context.Context, t *testing.T, doWatch func(context.Contex
 
 func watchTests(
 	parent *testing.T,
-	newCollection func(context.Context, *testing.T) (ReadCallback, WriteCallback),
+	newCollection func(context.Context, *testing.T, ...bool) (ReadCallback, WriteCallback),
 ) {
 	testInterruptionPreemptive := func(t *testing.T, makeWatcher func() (watch.Watcher, error)) {
 		watcher, err := makeWatcher()

--- a/src/internal/storage/fileset/postgres_cache_test.go
+++ b/src/internal/storage/fileset/postgres_cache_test.go
@@ -61,7 +61,7 @@ func TestPostgresCache(t *testing.T) {
 	checkNotExists := func(i int) {
 		_, err := cache.Get(ctx, strconv.Itoa(i))
 		require.YesError(t, err)
-		exists, err := storage.exists(ctx, ids[0])
+		exists, err := storage.exists(ctx, ids[i])
 		require.NoError(t, err)
 		require.False(t, exists)
 	}


### PR DESCRIPTION
This PR fixes a couple of task service issues:
- When workers would update the task entries in etcd, they would remove the lease which ensures cleanup when the client crashes. A put operation in etcd does this by default, but there is an option to ignore the lease which prevents this from happening. The update operation on etcd collections now does this by default.
- Tracker entries were not cleared by the postgres cache clear operation. The unit testing was updated to test this properly.