### PR TITLE
Open commits performance changes

### DIFF
--- a/src/server/pfs/fuse/fuse_test.go
+++ b/src/server/pfs/fuse/fuse_test.go
@@ -341,6 +341,7 @@ func TestOpenCommit(t *testing.T) {
 	require.NoError(t, env.PachClient.CreateRepo("in"))
 	require.NoError(t, env.PachClient.CreateRepo("out"))
 	require.NoError(t, env.PachClient.CreateBranch("out", "master", "", "", []*pfs.Branch{client.NewBranch("in", "master")}))
+	require.NoError(t, env.PachClient.FinishCommit("out", "master", ""))
 	_, err := env.PachClient.StartCommit("in", "master")
 	require.NoError(t, err)
 

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -228,7 +228,7 @@ func (e ErrCommitNotFinished) Error() string {
 }
 
 func (e ErrBaseCommitNotFinished) Error() string {
-	return fmt.Sprintf("base commit %v for commit %v not finished", e.BaseCommit, e.Commit)
+	return fmt.Sprintf("base commit %v for commit %v unfinished", e.BaseCommit, e.Commit)
 }
 
 func (e ErrAmbiguousCommit) Error() string {
@@ -263,7 +263,7 @@ var (
 	fileNotFoundRe            = regexp.MustCompile(`file .+ not found`)
 	outputCommitNotFinishedRe = regexp.MustCompile("output commit .+ not finished")
 	commitNotFinishedRe       = regexp.MustCompile("commit .+ not finished")
-	baseCommitNotFinishedRe   = regexp.MustCompile("base commit .+ not finished")
+	baseCommitNotFinishedRe   = regexp.MustCompile("base commit .+ unfinished")
 	ambiguousCommitRe         = regexp.MustCompile("commit .+ is ambiguous")
 	inconsistentCommitRe      = regexp.MustCompile("branch already has a commit in this transaction")
 	commitOnOutputBranchRe    = regexp.MustCompile("cannot start a commit on an output branch")

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -84,6 +84,12 @@ type ErrCommitNotFinished struct {
 	Commit *pfs.Commit
 }
 
+// ErrBaseCommitNotFinished represents an error where a base commit has not been finished.
+type ErrBaseCommitNotFinished struct {
+	BaseCommit *pfs.Commit
+	Commit     *pfs.Commit
+}
+
 // ErrAmbiguousCommit represents an error where a user-specified commit did not
 // specify a branch and resolved to multiple commits on different branches.
 type ErrAmbiguousCommit struct {
@@ -221,6 +227,10 @@ func (e ErrCommitNotFinished) Error() string {
 	return fmt.Sprintf("commit %v not finished", e.Commit)
 }
 
+func (e ErrBaseCommitNotFinished) Error() string {
+	return fmt.Sprintf("base commit %v for commit %v not finished", e.BaseCommit, e.Commit)
+}
+
 func (e ErrAmbiguousCommit) Error() string {
 	return fmt.Sprintf("commit %v is ambiguous (specify the branch to resolve)", e.Commit)
 }
@@ -253,6 +263,7 @@ var (
 	fileNotFoundRe            = regexp.MustCompile(`file .+ not found`)
 	outputCommitNotFinishedRe = regexp.MustCompile("output commit .+ not finished")
 	commitNotFinishedRe       = regexp.MustCompile("commit .+ not finished")
+	baseCommitNotFinishedRe   = regexp.MustCompile("base commit .+ not finished")
 	ambiguousCommitRe         = regexp.MustCompile("commit .+ is ambiguous")
 	inconsistentCommitRe      = regexp.MustCompile("branch already has a commit in this transaction")
 	commitOnOutputBranchRe    = regexp.MustCompile("cannot start a commit on an output branch")
@@ -363,6 +374,13 @@ func IsCommitNotFinishedErr(err error) bool {
 		return false
 	}
 	return commitNotFinishedRe.MatchString(err.Error())
+}
+
+func IsBaseCommitNotFinishedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return baseCommitNotFinishedRe.MatchString(err.Error())
 }
 
 // IsAmbiguousCommitErr returns true if the err is due to attempting to resolve

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1176,7 +1176,6 @@ func (d *driver) listCommit(
 					ci = cis[len(cis)-1-i]
 				}
 				var err error
-				// TODO: Set SizeBytesUpperBound to a sentinel value when the base is not finished.
 				ci.SizeBytesUpperBound, err = d.commitSizeUpperBound(ctx, ci.Commit)
 				if err != nil && !pfsserver.IsBaseCommitNotFinishedErr(err) {
 					return err

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dlock"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
@@ -21,7 +23,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 
-	"github.com/gogo/protobuf/types"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -132,6 +133,11 @@ func (d *driver) finishRepoCommits(ctx context.Context, compactor *compactor, re
 					}
 					return err
 				}
+				// Skip compaction / validation for errored commits.
+				if commitInfo.Error != "" {
+					return d.finalizeCommit(ctx, commit, "", nil, id)
+				}
+				details := &pfs.CommitInfo_Details{}
 				// Compact the commit.
 				// TODO: Implement task service cache for compaction.
 				taskDoer := d.env.TaskService.NewDoer(storageTaskNamespace, commit.ID, nil)
@@ -147,58 +153,26 @@ func (d *driver) finishRepoCommits(ctx context.Context, compactor *compactor, re
 				}); err != nil {
 					return err
 				}
-				compactingDuration := time.Since(start)
+				details.CompactingTime = types.DurationProto(time.Since(start))
 				// Validate the commit.
 				start = time.Now()
-				var size int64
 				var validationError string
 				if err := miscutil.LogStep(fmt.Sprintf("validating commit %v", commit), func() error {
 					var err error
-					size, validationError, err = d.validate(ctx, totalId)
+					details.SizeBytes, validationError, err = d.validate(ctx, totalId)
 					return err
 				}); err != nil {
 					return err
 				}
-				validatingDuration := time.Since(start)
+				details.ValidatingTime = types.DurationProto(time.Since(start))
 				// Finish the commit.
-				return miscutil.LogStep(fmt.Sprintf("finish commit %v", commit), func() error {
-					return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-						commitInfo := &pfs.CommitInfo{}
-						if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(commit), commitInfo, func() error {
-							commitInfo.Finished = txnCtx.Timestamp
-							commitInfo.SizeBytesUpperBound = size
-							if commitInfo.Details == nil {
-								commitInfo.Details = &pfs.CommitInfo_Details{}
-							}
-							commitInfo.Details.SizeBytes = size
-							if commitInfo.Error == "" {
-								commitInfo.Error = validationError
-							}
-							commitInfo.Details.CompactingTime = types.DurationProto(compactingDuration)
-							commitInfo.Details.ValidatingTime = types.DurationProto(validatingDuration)
-							return nil
-						}); err != nil {
-							return errors.EnsureStack(err)
-						}
-						if commitInfo.Commit.Branch.Repo.Type == pfs.UserRepoType {
-							txnCtx.FinishJob(commitInfo)
-						}
-						if err := d.finishAliasDescendents(txnCtx, commitInfo, *totalId); err != nil {
-							return err
-						}
-						// TODO(2.0 optional): This is a hack to ensure that commits created by triggers have the same ID as the finished commit.
-						// Creating an alias in the branch of the finished commit, then having the trigger alias that commit seems
-						// like a better model.
-						txnCtx.CommitSetID = commitInfo.Commit.ID
-						return d.triggerCommit(txnCtx, commitInfo.Commit)
-					})
-				})
+				return d.finalizeCommit(ctx, commit, validationError, details, totalId)
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 				log.Errorf("error finishing commit %v: %v, retrying in %v", commit, err, d)
 				return nil
 			})
 		})
-	}, watch.IgnoreDelete)
+	}, watch.WithSort(col.SortByCreateRevision, col.SortAscend), watch.IgnoreDelete)
 	return errors.EnsureStack(err)
 }
 
@@ -228,6 +202,38 @@ func (d *driver) validate(ctx context.Context, id *fileset.ID) (int64, string, e
 		return 0, "", errors.EnsureStack(err)
 	}
 	return size, validationError, nil
+}
+
+func (d *driver) finalizeCommit(ctx context.Context, commit *pfs.Commit, validationError string, details *pfs.CommitInfo_Details, totalId *fileset.ID) error {
+	return miscutil.LogStep(fmt.Sprintf("finalizing commit %v", commit), func() error {
+		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
+			commitInfo := &pfs.CommitInfo{}
+			if err := d.commits.ReadWrite(txnCtx.SqlTx).Update(pfsdb.CommitKey(commit), commitInfo, func() error {
+				commitInfo.Finished = txnCtx.Timestamp
+				if details != nil {
+					commitInfo.SizeBytesUpperBound = details.SizeBytes
+				}
+				if commitInfo.Error == "" {
+					commitInfo.Error = validationError
+				}
+				commitInfo.Details = details
+				return nil
+			}); err != nil {
+				return errors.EnsureStack(err)
+			}
+			if commitInfo.Commit.Branch.Repo.Type == pfs.UserRepoType {
+				txnCtx.FinishJob(commitInfo)
+			}
+			if err := d.finishAliasDescendents(txnCtx, commitInfo, *totalId); err != nil {
+				return err
+			}
+			// TODO(2.0 optional): This is a hack to ensure that commits created by triggers have the same ID as the finished commit.
+			// Creating an alias in the branch of the finished commit, then having the trigger alias that commit seems
+			// like a better model.
+			txnCtx.CommitSetID = commitInfo.Commit.ID
+			return d.triggerCommit(txnCtx, commitInfo.Commit)
+		})
+	})
 }
 
 // finishAliasDescendents will traverse the given commit's descendents, finding all

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -123,7 +123,7 @@ func (d *driver) finishRepoCommits(ctx context.Context, compactor *compactor, re
 			return nil
 		}
 		commit := commitInfo.Commit
-		return miscutil.LogStep(fmt.Sprintf("finishing commit %v", commit.ID), func() error {
+		return miscutil.LogStep(fmt.Sprintf("finishing commit %v", commit), func() error {
 			// TODO: This retry might not be getting us much if the outer watch still errors due to a transient error.
 			return backoff.RetryUntilCancel(ctx, func() error {
 				id, err := d.getFileSet(ctx, commit)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5360,6 +5360,7 @@ func TestPFS(suite *testing.T) {
 			// Create a downstream branch
 			require.NoError(t, c.CreateRepo("out"))
 			require.NoError(t, c.CreateBranch("out", "master", "", "", []*pfs.Branch{client.NewBranch("in", "trigger")}))
+			require.NoError(t, c.FinishCommit("out", "master", ""))
 			require.NoError(t, c.CreateBranchTrigger("out", "trigger", "", "", &pfs.Trigger{
 				Branch: "master",
 				Size_:  "1K",


### PR DESCRIPTION
This PR includes a set of changes to improve performance when dealing with open commit chains. 

**The user facing changes are:**
- Open commits with an unfinished base commit (most recent ancestor commit that isn't errored) are no longer readable. This only impacts output repos with parallel jobs since we already prevent the creation of a commit without a finished parent in source repos.
- Errored commits (commits associated with a killed / failed job) are no longer compacted. They are still readable, but the performance will be worse since they are not compacted. This seems like the right tradeoff in most cases and it simplifies the above change since a job can be killed before its base commit is finished.
- Repo sizes are based on the most recent commit in master that is finished (rather than open).
- ~~Commits that are not readable due to this change will have a sentinel value set for the `SizeBytesUpperBound` field (TODO)~~ (We are going to leave the size as 0 until it is in a readable state).


The problem we are hitting in a few different ways is that we are creating n file sets for each commit operation where n is the number of open ancestor commits. With list operations this can end up being n^2, which creates a lot of garbage in the system that further degrades performance. Another issue that is somewhat related is that commit finishing order is based on an updated at timestamp, which can be the same for multiple commits when a pipeline is stopped. This scenario causes the commits to be finished in a pathological order which results with the first issue and more seriously a lot of duplicate compaction work. The primary change to address these issues is a new invariant that prevents us from getting a file set for a commit with an unfinished base commit. Having this invariant ensures that there is no way to hit these problems anywhere in the system. The changes in this PR are the new invariant and the corresponding changes required to satisfy the invariant.

