### PR TITLE
Allow incorrect use of update pipeline. (#7332)

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1859,15 +1859,15 @@ func (a *apiServer) CreatePipelineInTransaction(
 		return visitErr
 	}
 
+	update := request.Update && oldPipelineInfo != nil
 	// Authorize pipeline creation
 	operation := pipelineOpCreate
-	if request.Update {
+	if update {
 		operation = pipelineOpUpdate
 	}
 	if err := a.authorizePipelineOpInTransaction(txnCtx, operation, newPipelineInfo.Details.Input, newPipelineInfo.Pipeline.Name); err != nil {
 		return err
 	}
-	update := request.Update && oldPipelineInfo != nil
 
 	var (
 		// provenance for the pipeline's output branch (includes the spec branch)


### PR DESCRIPTION
With auth enabled, an update pipeline call results in a missing role
binding error as it tries to authorize a write on a repo that doesn't
exist. We detect spurious updates in the rest of the logic, and will
error in the case the repo already exists, so this auth check seems
unintended and doesn't add security.