### PR TITLE
[2.1.x Backport] Run config-job when license is provided via secret & Automated testing of enterprise deployments (#7299)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
       - checkout
       - run: etc/testing/circle/install.sh
       - run: etc/testing/circle/rootless_test.sh
-  upgrade:
+  deploy:
     resource_class: large
     machine:
       image: ubuntu-2004:202101-01
@@ -167,7 +167,7 @@ jobs:
       - run: etc/testing/circle/install.sh
       - run: etc/testing/circle/start-minikube.sh
       - run: etc/testing/circle/build.sh
-      - run: etc/testing/circle/upgrade_test.sh
+      - run: etc/testing/circle/deploy_test.sh
 
 workflows:
   circleci:
@@ -232,6 +232,6 @@ workflows:
                 - LOAD8
                 - LOAD9
                 - LOAD10
-  upgrade:
+  deploy:
     jobs:
-    - upgrade
+    - deploy

--- a/etc/helm/pachyderm/templates/pachd/config-job.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-job.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{ if or (.Values.pachd.activateEnterprise) (and .Release.IsInstall (or .Values.pachd.enterpriseLicenseKey .Values.pachd.activateEnterpriseMember)) }}
+{{ if or (.Values.pachd.activateEnterprise) (and .Release.IsInstall (or .Values.pachd.enterpriseLicenseKeySecretName .Values.pachd.enterpriseLicenseKey .Values.pachd.activateEnterpriseMember)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/etc/helm/pachyderm/templates/pachd/config-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-secret.yaml
@@ -8,7 +8,7 @@ if pachd.activateEnterprise is set, always run the bootstrap config.
 On Installs, setting the pachd.enterpriseLicenseKey or pachd.activateEnterpriseMember 
 will also start bootstrapping.
 */ -}}
-{{ if or .Values.pachd.activateEnterprise (and .Release.IsInstall (or .Values.pachd.enterpriseLicenseKey .Values.pachd.activateEnterpriseMember) ) }}
+{{ if or .Values.pachd.activateEnterprise (and .Release.IsInstall (or .Values.pachd.enterpriseLicenseKeySecretName .Values.pachd.enterpriseLicenseKey .Values.pachd.activateEnterpriseMember) ) }}
 
 {{- $oidcSecret := "" -}}
 {{- if .Values.pachd.oauthClientSecretSecretName -}}

--- a/etc/testing/circle/deploy_test.sh
+++ b/etc/testing/circle/deploy_test.sh
@@ -14,4 +14,4 @@ helm repo add pach https://helm.pachyderm.com
 
 helm repo update
 
-go test -v ./src/testing/upgrade
+go test -v ./src/testing/deploy

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -2,6 +2,7 @@ package minikubetestenv
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -10,7 +11,9 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	v1 "k8s.io/api/core/v1"
@@ -24,7 +27,21 @@ const (
 	helmRelease            = "test-release"
 	ns                     = "default"
 	localImage             = "local"
+	licenseKeySecretName   = "enterprise-license-key-secret"
 )
+
+func getPachAddress(t testing.TB) *grpcutil.PachdAddress {
+	cfg, err := config.Read(false, false)
+	require.NoError(t, err)
+
+	_, context, err := cfg.ActiveContext(true)
+	require.NoError(t, err)
+
+	pa, err := grpcutil.ParsePachdAddress(context.PachdAddress)
+	require.NoError(t, err)
+
+	return pa
+}
 
 func localDeploymentWithMinioOptions(namespace, image string) *helm.Options {
 	return &helm.Options{
@@ -32,8 +49,10 @@ func localDeploymentWithMinioOptions(namespace, image string) *helm.Options {
 		SetValues: map[string]string{
 			"deployTarget": "custom",
 
-			"pachd.service.type":           "NodePort",
-			"pachd.image.tag":              image,
+			"pachd.service.type":        "NodePort",
+			"pachd.image.tag":           image,
+			"pachd.clusterDeploymentID": "dev",
+
 			"pachd.storage.backend":        "MINIO",
 			"pachd.storage.minio.bucket":   "pachyderm-test",
 			"pachd.storage.minio.endpoint": "minio.default.svc.cluster.local:9000",
@@ -50,7 +69,41 @@ func localDeploymentWithMinioOptions(namespace, image string) *helm.Options {
 	}
 }
 
-func waitForPachd(t *testing.T, ctx context.Context, kubeClient *kube.Clientset, namespace, version string) {
+func withEnterprise(t testing.TB, namespace string) *helm.Options {
+	addr := getPachAddress(t)
+	return &helm.Options{
+		KubectlOptions: &k8s.KubectlOptions{Namespace: namespace},
+		SetValues: map[string]string{
+			"pachd.enterpriseLicenseKeySecretName": licenseKeySecretName,
+			"pachd.rootToken":                      testutil.RootToken,
+			"pachd.oauthClientSecret":              "oidc-client-secret",
+			"pachd.enterpriseSecret":               "enterprise-secret",
+			"oidc.userAccessibleOauthIssuerHost":   fmt.Sprintf("%s:30658", addr.Host),
+			"ingress.host":                         fmt.Sprintf("%s:30657", addr.Host),
+		},
+	}
+}
+
+func union(a, b *helm.Options) *helm.Options {
+	c := &helm.Options{
+		KubectlOptions: &k8s.KubectlOptions{Namespace: b.KubectlOptions.Namespace},
+		SetValues:      make(map[string]string),
+		SetStrValues:   make(map[string]string),
+	}
+	copy := func(src, dst *helm.Options) {
+		for k, v := range src.SetValues {
+			dst.SetValues[k] = v
+		}
+		for k, v := range src.SetStrValues {
+			dst.SetStrValues[k] = v
+		}
+	}
+	copy(a, c)
+	copy(b, c)
+	return c
+}
+
+func waitForPachd(t testing.TB, ctx context.Context, kubeClient *kube.Clientset, namespace, version string) {
 	require.NoError(t, backoff.Retry(func() error {
 		pachds, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=pachd"})
 		if err != nil {
@@ -66,19 +119,37 @@ func waitForPachd(t *testing.T, ctx context.Context, kubeClient *kube.Clientset,
 }
 
 // Deploy pachyderm using a `helm install ...`, then run a test with an API Client corresponding to the deployment
-func InstallPublishedRelease(t *testing.T, ctx context.Context, kubeClient *kube.Clientset, version, user string) *client.APIClient {
+func InstallPublishedRelease(t testing.TB, ctx context.Context, kubeClient *kube.Clientset, version, user string, cleanup bool) *client.APIClient {
+	maybeCleanup(t, cleanup, kubeClient)
 	require.NoError(t, helm.InstallE(t, localDeploymentWithMinioOptions(ns, version), helmChartPublishedPath, helmRelease))
 	waitForPachd(t, ctx, kubeClient, ns, version)
 	return testutil.AuthenticatedPachClient(t, testutil.NewPachClient(t), user)
 }
 
-func UpgradeRelease(t *testing.T, ctx context.Context, kubeClient *kube.Clientset, user string) *client.APIClient {
+func UpgradeRelease(t testing.TB, ctx context.Context, kubeClient *kube.Clientset, user string, cleanup bool) *client.APIClient {
+	maybeCleanup(t, cleanup, kubeClient)
 	require.NoError(t, helm.UpgradeE(t, localDeploymentWithMinioOptions(ns, localImage), helmChartLocalPath, helmRelease))
 	waitForPachd(t, ctx, kubeClient, ns, localImage)
 	return testutil.AuthenticatedPachClient(t, testutil.NewPachClient(t), user)
 }
 
-func DeleteRelease(t *testing.T, ctx context.Context, kubeClient *kube.Clientset) {
+func InstallReleaseEnterprise(t testing.TB, ctx context.Context, kubeClient *kube.Clientset, user string, cleanup bool) *client.APIClient {
+	maybeCleanup(t, cleanup, kubeClient)
+	createSecretEnterpriseKeySecret(t, ctx, kubeClient, ns)
+	opts := union(localDeploymentWithMinioOptions(ns, localImage), withEnterprise(t, ns))
+	require.NoError(t, helm.InstallE(t, opts, helmChartLocalPath, helmRelease))
+	waitForPachd(t, ctx, kubeClient, ns, localImage)
+	return testutil.AuthenticatedPachClientPostActivate(t, testutil.NewPachClient(t), user)
+}
+func maybeCleanup(t testing.TB, cleanup bool, kubeClient *kube.Clientset) {
+	if cleanup {
+		t.Cleanup(func() {
+			deleteRelease(t, context.Background(), kubeClient)
+		})
+	}
+}
+
+func deleteRelease(t testing.TB, ctx context.Context, kubeClient *kube.Clientset) {
 	options := &helm.Options{
 		KubectlOptions: &k8s.KubectlOptions{Namespace: ns},
 	}
@@ -95,4 +166,14 @@ func DeleteRelease(t *testing.T, ctx context.Context, kubeClient *kube.Clientset
 		}
 		return errors.Errorf("pvcs have yet to be deleted")
 	}, backoff.RetryEvery(5*time.Second).For(2*time.Minute)))
+}
+
+func createSecretEnterpriseKeySecret(t testing.TB, ctx context.Context, kubeClient *kube.Clientset, ns string) {
+	_, err := kubeClient.CoreV1().Secrets(ns).Create(ctx, &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: licenseKeySecretName},
+		StringData: map[string]string{
+			"enterprise-license-key": testutil.GetTestEnterpriseCode(t),
+		},
+	}, metav1.CreateOptions{})
+	require.True(t, err == nil || strings.Contains(err.Error(), "already exists"))
 }

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -47,11 +47,10 @@ func ActivateAuth(tb testing.TB) {
 	activateAuthHelper(tb, client)
 }
 
-func AuthenticatedPachClient(tb testing.TB, c *client.APIClient, subject string) *client.APIClient {
+// creates a new authenticated pach client, without re-activating
+func AuthenticatedPachClientPostActivate(tb testing.TB, c *client.APIClient, subject string) *client.APIClient {
 	tb.Helper()
 	rootClient := UnauthenticatedPachClient(tb, c)
-	activateAuthHelper(tb, c)
-
 	rootClient.SetAuthToken(RootToken)
 	if subject == auth.RootUser {
 		return rootClient
@@ -61,6 +60,12 @@ func AuthenticatedPachClient(tb testing.TB, c *client.APIClient, subject string)
 	client := UnauthenticatedPachClient(tb, c)
 	client.SetAuthToken(token.Token)
 	return client
+}
+
+func AuthenticatedPachClient(tb testing.TB, c *client.APIClient, subject string) *client.APIClient {
+	tb.Helper()
+	activateAuthHelper(tb, c)
+	return AuthenticatedPachClientPostActivate(tb, c, subject)
 }
 
 // GetAuthenticatedPachClient activates auth, if it is not activated, and returns

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+)
+
+func TestDeployEnterprise(t *testing.T) {
+	k := testutil.GetKubeClient(t)
+	c := minikubetestenv.InstallReleaseEnterprise(t, context.Background(), k, auth.RootUser, true)
+	whoami, err := c.AuthAPIClient.WhoAmI(c.Ctx(), &auth.WhoAmIRequest{})
+	require.NoError(t, err)
+	require.Equal(t, auth.RootUser, whoami.Username)
+	c.SetAuthToken("")
+	mockIDPLogin(t, c)
+}
+
+func mockIDPLogin(t testing.TB, c *client.APIClient) {
+	// login using mock IDP admin
+	hc := &http.Client{}
+	c.SetAuthToken("")
+	loginInfo, err := c.GetOIDCLogin(c.Ctx(), &auth.GetOIDCLoginRequest{})
+	require.NoError(t, err)
+	state := loginInfo.State
+
+	// Get the initial URL from the grpc, which should point to the dex login page
+	resp, err := hc.Get(loginInfo.LoginURL)
+	require.NoError(t, err)
+
+	vals := make(url.Values)
+	vals.Add("login", "admin")
+	vals.Add("password", "password")
+
+	_, err = hc.PostForm(resp.Request.URL.String(), vals)
+	require.NoError(t, err)
+
+	authResp, err := c.AuthAPIClient.Authenticate(c.Ctx(), &auth.AuthenticateRequest{OIDCState: state})
+	require.NoError(t, err)
+	c.SetAuthToken(authResp.PachToken)
+	whoami, err := c.AuthAPIClient.WhoAmI(c.Ctx(), &auth.WhoAmIRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "user:"+testutil.DexMockConnectorEmail, whoami.Username)
+}

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -26,18 +27,18 @@ var (
 	fromVersions = []string{
 		"2.0.4",
 		"2.0.5",
+		"2.1.0",
 	}
 )
 
 // runs the upgrade test from all versions specified in "fromVersions" against the local image
-func upgradeTest(t *testing.T, ctx context.Context, preUpgrade func(*testing.T, *client.APIClient), postUpgrade func(*testing.T, *client.APIClient)) {
-	k := testutil.GetKubeClient(t)
+func upgradeTest(suite *testing.T, ctx context.Context, preUpgrade func(*testing.T, *client.APIClient), postUpgrade func(*testing.T, *client.APIClient)) {
+	k := testutil.GetKubeClient(suite)
 	for _, from := range fromVersions {
-		minikubetestenv.DeleteRelease(t, ctx, k) // cleanup cluster
-
-		preUpgrade(t, minikubetestenv.InstallPublishedRelease(t, ctx, k, from, upgradeSubject))
-
-		postUpgrade(t, minikubetestenv.UpgradeRelease(t, ctx, k, upgradeSubject))
+		suite.Run(fmt.Sprintf("UpgradeFrom_%s", from), func(t *testing.T) {
+			preUpgrade(t, minikubetestenv.InstallPublishedRelease(t, ctx, k, from, upgradeSubject, false))
+			postUpgrade(t, minikubetestenv.UpgradeRelease(t, ctx, k, upgradeSubject, true))
+		})
 	}
 }
 


### PR DESCRIPTION
* Testing enterprise deployments

* Login with mock IDP in deploy enterprise tests