### PR TITLE
Reduce the chunk batch size

### DIFF
--- a/src/internal/storage/chunk/writer.go
+++ b/src/internal/storage/chunk/writer.go
@@ -122,7 +122,7 @@ func (w *Writer) ChunkCount() int64 {
 // Annotate associates an annotation with the current data.
 func (w *Writer) Annotate(a *Annotation) error {
 	// Create chunks at annotation boundaries if past the min chunk size.
-	if w.buf.Len() >= w.chunk.min {
+	if w.buf.Len() >= w.chunkSize.min {
 		if err := w.createChunk(); err != nil {
 			return err
 		}

--- a/src/internal/storage/chunk/writer.go
+++ b/src/internal/storage/chunk/writer.go
@@ -121,8 +121,8 @@ func (w *Writer) ChunkCount() int64 {
 
 // Annotate associates an annotation with the current data.
 func (w *Writer) Annotate(a *Annotation) error {
-	// Create chunks at annotation boundaries if past the average chunk size.
-	if w.buf.Len() >= w.chunkSize.avg {
+	// Create chunks at annotation boundaries if past the min chunk size.
+	if w.buf.Len() >= w.chunk.min {
 		if err := w.createChunk(); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR reduces the chunk batch size. The benefit of this change is that more medium size (MB) files will be cheaper to copy (shuffling references rather than reading then writing new chunks), which should result with improved performance during compaction and copy file operations (the functionality used for a symlink upload). The cost is that this will result with more chunks and tracker activity, but load testing and real usage suggests that the rewrite cost outweighed the read benefit for medium size files.