### PR TITLE
pachctl: only print "reading from stdin" if stdin is a terminal

### DIFF
--- a/src/internal/cmdutil/util.go
+++ b/src/internal/cmdutil/util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mattn/go-isatty"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serde"
 	"github.com/spf13/pflag"
@@ -80,4 +81,12 @@ func InteractiveConfirm() (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// PrintStdinReminder will print a reminder if pachctl expects input on stdin, and stdin is a
+// terminal (and not a pipe from another command or file).
+func PrintStdinReminder() {
+	if fd := os.Stdin.Fd(); isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd) {
+		fmt.Fprintln(os.Stderr, "Reading from stdin.")
+	}
 }

--- a/src/server/config/cmds.go
+++ b/src/server/config/cmds.go
@@ -223,7 +223,7 @@ func Cmds() []*cobra.Command {
 			}
 
 			var context config.Context
-			fmt.Println("Reading from stdin.")
+			cmdutil.PrintStdinReminder()
 
 			var buf bytes.Buffer
 			var decoder *json.Decoder

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -564,10 +564,10 @@ each datum.`,
 		Example: `
 	# Return logs emitted by recent jobs in the "filter" pipeline
 	$ {{alias}} --pipeline=filter
-	
+
 	# Return logs emitted by the job aedfa12aedf
 	$ {{alias}} --job=aedfa12aedf
-	
+
 	# Return logs emitted by the pipeline \"filter\" while processing /apple.txt and a file with the hash 123aef
 	$ {{alias}} --pipeline=filter --inputs=/apple.txt,123aef`,
 		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
@@ -1185,7 +1185,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 // so the two could perhaps be refactored.
 func readPipelineBytes(pipelinePath string) (pipelineBytes []byte, retErr error) {
 	if pipelinePath == "-" {
-		fmt.Print("Reading from stdin.\n")
+		cmdutil.PrintStdinReminder()
 		var err error
 		pipelineBytes, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {


### PR DESCRIPTION
Users have reported being annoyed by "Reading from stdin." messages.  This suppresses them when stdin is not a terminal.  We also print the message to stderr now.


