### PR TITLE
Update to Pachyderm 2.1.0, fix PostgreSQL password

### DIFF
--- a/etc/deploy/gcp/gcp-doco-script.sh
+++ b/etc/deploy/gcp/gcp-doco-script.sh
@@ -122,7 +122,7 @@ pachd:
     aPIGrpcport:    31400
     loadBalancerIP: ${STATIC_IP_ADDR}
   image:
-    tag: "2.1.0"
+    tag: "2.1.1"
   storage:
     google:
       bucket: "${BUCKET_NAME}"

--- a/etc/deploy/gcp/gcp-doco-script.sh
+++ b/etc/deploy/gcp/gcp-doco-script.sh
@@ -122,7 +122,7 @@ pachd:
     aPIGrpcport:    31400
     loadBalancerIP: ${STATIC_IP_ADDR}
   image:
-    tag: "2.0.0-rc.6"
+    tag: "2.1.0"
   storage:
     google:
       bucket: "${BUCKET_NAME}"
@@ -156,7 +156,7 @@ global:
     postgresqlPort: "5432"
     postgresqlSSL: "disable"
     postgresqlUsername: "postgres"
-    postgresqlPassword: "batteryhorsestaple"
+    postgresqlPassword: "${SQL_ADMIN_PASSWORD}"
 EOF
 
 helm repo add pach https://helm.pachyderm.com


### PR DESCRIPTION
The password was hard-coded, but should be changed for each usage. Also the Pachyderm version was old.

PR #7184 does a lot more, but it has not been accepted, and these two changes are pretty important on their own.