### PR TITLE
[Mount Server] Add 401 return code for unauthenticated user

### DIFF
--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -295,6 +295,30 @@ func TestAuthLoginLogout(t *testing.T) {
 	})
 }
 
+func TestUnauthenticatedCode(t *testing.T) {
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+
+	c := tu.GetUnauthenticatedPachClient(t)
+	withServerMount(t, c, nil, func(mountPoint string) {
+		resp, _ := get("repos")
+		require.Equal(t, 200, resp.StatusCode)
+	})
+
+	tu.ActivateAuth(t)
+	c = tu.GetUnauthenticatedPachClient(t)
+	withServerMount(t, c, nil, func(mountPoint string) {
+		resp, _ := get("repos")
+		require.Equal(t, 401, resp.StatusCode)
+	})
+
+	c = tu.GetAuthenticatedPachClient(t, "test")
+	withServerMount(t, c, nil, func(mountPoint string) {
+		resp, _ := get("repos")
+		require.Equal(t, 200, resp.StatusCode)
+	})
+}
+
 // TODO: pass reference to the MountManager object to the test func, so that the
 // test can call MountBranch, UnmountBranch etc directly for convenience
 func withServerMount(tb testing.TB, c *client.APIClient, sopts *ServerOptions, f func(mountPoint string)) {


### PR DESCRIPTION
For the FE to bring up a UI to log in to auth when auth is active and the user is unauthenticated, it needs to be able to differentiate an unauthenticated user error from other sever errors. This PR makes it clear when an error on the backend is because of an unauthenticated user.

Jira: https://pachyderm.atlassian.net/browse/INT-533