### PR TITLE
Set Nodeports to the same values as the service port

### DIFF
--- a/etc/helm/pachyderm/templates/enterprise-server/service.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/service.yaml
@@ -20,35 +20,30 @@ metadata:
 spec:
   ports:
   - name: api-grpc-port
+    # TODO: can we start serving enterprise server on 31650?
     {{- if eq .Values.enterpriseServer.service.type "NodePort" }}
-    nodePort: 31650
-    port: 1650
-    {{- else }}
-    port: 30650
+    nodePort: {{ .Values.enterpriseServer.service.apiGRPCPort }}
     {{- end }}
+    port: {{ .Values.enterpriseServer.service.apiGRPCPort }}
     protocol: TCP
     targetPort: api-grpc-port
   - name: oidc-port
     {{- if eq .Values.enterpriseServer.service.type "NodePort" }}
-    nodePort: 31657
-    port: 1657
-    {{ else }}
-    port: 31657
-    {{- end }}
+    nodePort: {{ .Values.enterpriseServer.service.oidcPort }}
+    {{ end }}
+    port: {{ .Values.enterpriseServer.service.oidcPort }}
     targetPort: oidc-port
   - name: identity-port
     {{- if eq .Values.enterpriseServer.service.type "NodePort" }}
-    nodePort: 31658
-    port: 1658
-    {{ else }}
-    port: 31658
-    {{- end }}
+    nodePort: {{ .Values.enterpriseServer.service.identityPort }}
+    {{ end }}
+    port: {{ .Values.enterpriseServer.service.identityPort }}
     targetPort: identity-port
   - name: prom-metrics
     {{- if eq .Values.enterpriseServer.service.type "NodePort" }}
-    nodePort: 31656
+    nodePort: {{ .Values.enterpriseServer.service.prometheusPort }}
     {{- end }}
-    port: 1656
+    port: {{ .Values.enterpriseServer.service.prometheusPort }}
     protocol: TCP
     targetPort: prom-metrics
   selector:

--- a/etc/helm/pachyderm/templates/pachd/config-job.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-job.yaml
@@ -37,13 +37,8 @@ spec:
               key: OAUTH_CLIENT_SECRET
         {{- end}}
         {{- if .Values.enterpriseServer.enabled }}
-        {{- if eq .Values.enterpriseServer.service.type "NodePort" }}
         - name: PACH_ADDR
-          value: "grpc://pach-enterprise:1650"
-        {{- else }}
-        - name: PACH_ADDR
-          value: "grpc://pach-enterprise:30650"        
-        {{- end }}
+          value: "grpc://pach-enterprise:"{{ .Values.enterpriseServer.service.apiGRPCPort }}    
         {{- end }}
         {{- if .Values.pachd.rootTokenSecretName }}    
         - name: ROOT_TOKEN

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -78,9 +78,9 @@ spec:
           value: {{ .Values.pachd.lokiLogging | quote}}
         {{- if .Values.pachd.lokiDeploy }}
         - name: LOKI_SERVICE_HOST_VAR
-          value: "PACHYDERM_LOKI_SERVICE_HOST"
+          value: "{{ snakecase .Release.Name | upper }}_LOKI_SERVICE_HOST"
         - name: LOKI_SERVICE_PORT_VAR
-          value: "PACHYDERM_LOKI_SERVICE_PORT"
+          value: "{{ snakecase .Release.Name | upper }}_LOKI_SERVICE_PORT"
         {{- end }}
         - name: PACH_ROOT
           value: "/pach"

--- a/etc/helm/pachyderm/templates/pachd/service.yaml
+++ b/etc/helm/pachyderm/templates/pachd/service.yaml
@@ -24,42 +24,34 @@ spec:
   ports:
   - name: api-grpc-port
     {{- if eq .Values.pachd.service.type "NodePort" }}
-    nodePort: 30650
-    port: 1650
-    {{- else }}
-    port: 30650
+    nodePort: {{ .Values.pachd.service.apiGRPCPort }}
     {{- end }}
+    port: {{ .Values.pachd.service.apiGRPCPort }}
     protocol: TCP
     targetPort: api-grpc-port
   - name: oidc-port
     {{- if eq .Values.pachd.service.type "NodePort" }}
-    nodePort: 30657
-    port: 1657
-    {{- else }}
-    port: 30657
+    nodePort: {{ .Values.pachd.service.oidcPort }}
     {{- end }}
+    port: {{ .Values.pachd.service.oidcPort }}
     targetPort: oidc-port
   - name: identity-port
     {{- if eq .Values.pachd.service.type "NodePort" }}
-    nodePort: 30658
-    port: 1658
-    {{- else }}
-    port: 30658
+    nodePort: {{ .Values.pachd.service.identityPort }}
     {{- end }}
+    port: {{ .Values.pachd.service.identityPort }}
     targetPort: identity-port
   - name: s3gateway-port
     {{- if eq .Values.pachd.service.type "NodePort" }}
-    nodePort: 30600
-    port: 1600
-    {{- else }}
-    port: 30600
+    nodePort: {{ .Values.pachd.service.s3GatewayPort }}
     {{- end }}
+    port: {{ .Values.pachd.service.s3GatewayPort }}
     targetPort: s3gateway-port
   - name: prom-metrics
     {{- if eq .Values.pachd.service.type "NodePort" }}
-    nodePort: 30656
+    nodePort: {{ .Values.pachd.service.prometheusPort }}
     {{- end }}
-    port: 1656
+    port: {{ .Values.pachd.service.prometheusPort }}
     protocol: TCP
     targetPort: prom-metrics
   selector:

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -180,6 +180,21 @@
                 "service": {
                     "type": "object",
                     "properties": {
+                        "apiGRPCPort": {
+                            "type": "integer"
+                        },
+                        "identityPort": {
+                            "type": "integer"
+                        },
+                        "oidcPort": {
+                            "type": "integer"
+                        },
+                        "prometheusPort": {
+                            "type": "integer"
+                        },
+                        "s3GatewayPort": {
+                            "type": "integer"
+                        },
                         "type": {
                             "type": "string"
                         }
@@ -627,8 +642,23 @@
                         "annotations": {
                             "type": "object"
                         },
+                        "apiGRPCPort": {
+                            "type": "integer"
+                        },
+                        "identityPort": {
+                            "type": "integer"
+                        },
                         "labels": {
                             "type": "object"
+                        },
+                        "oidcPort": {
+                            "type": "integer"
+                        },
+                        "prometheusPort": {
+                            "type": "integer"
+                        },
+                        "s3GatewayPort": {
+                            "type": "integer"
                         },
                         "type": {
                             "type": "string"

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -141,11 +141,11 @@ enterpriseServer:
   nodeSelector: {}
   service:
     type: ClusterIP
-    apiGRPCPort: 30650
-    prometheusPort: 30656
-    oidcPort: 30657
-    identityPort: 30658
-    s3GatewayPort: 30600
+    apiGRPCPort: 31650
+    prometheusPort: 31656
+    oidcPort: 31657
+    identityPort: 31658
+    s3GatewayPort: 31600
   # There are three options for TLS:
   # 1. Disabled
   # 2. Enabled, existingSecret, specify secret name

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -141,6 +141,11 @@ enterpriseServer:
   nodeSelector: {}
   service:
     type: ClusterIP
+    apiGRPCPort: 30650
+    prometheusPort: 30656
+    oidcPort: 30657
+    identityPort: 30658
+    s3GatewayPort: 30600
   # There are three options for TLS:
   # 1. Disabled
   # 2. Enabled, existingSecret, specify secret name
@@ -260,6 +265,11 @@ pachd:
     # type specifies the Kubernetes type of the pachd service.
     type: "ClusterIP"
     annotations: {}
+    apiGRPCPort: 30650
+    prometheusPort: 30656
+    oidcPort: 30657
+    identityPort: 30658
+    s3GatewayPort: 30600
     #apiGrpcPort:
     #  expose: true
     #  port: 30650

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -38,7 +38,7 @@ func TestRegisterPachd(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
 		  | match 'id: {{.id}}' \
@@ -57,8 +57,8 @@ func TestRegisterAuthenticated(t *testing.T) {
 	cluster := tu.UniqueString("cluster")
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
@@ -80,8 +80,8 @@ func TestEnterpriseRoleBindings(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth set enterprise clusterAdmin robot:test1
 		pachctl auth get enterprise | match robot:test1
@@ -101,8 +101,8 @@ func TestGetAndUseRobotToken(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth get-robot-token --enterprise -q {{.alice}} | tail -1 | pachctl auth use-auth-token --enterprise
 		pachctl auth get-robot-token -q {{.bob}} | pachctl auth use-auth-token
@@ -125,8 +125,8 @@ func TestConfig(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:1650 --pachd-address pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:31650 --pachd-address pachd.default:30650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 			`,
 		"id", tu.UniqueString("cluster"),
@@ -138,20 +138,20 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, tu.BashCmd(`
 		pachctl auth set-config --enterprise <<EOF
 {
-	"issuer": "http://pach-enterprise.enterprise:1658",
+	"issuer": "http://pach-enterprise.enterprise:31658",
         "localhost_issuer": true,
 	"client_id": localhost,
-	"redirect_uri": "http://pach-enterprise.enterprise:1650"
+	"redirect_uri": "http://pach-enterprise.enterprise:31650"
 }
 EOF
 	`).Run())
 
 	require.NoError(t, tu.BashCmd(`
 		pachctl auth get-config --enterprise \
-		  | match '"issuer": "http://pach-enterprise.enterprise:1658"' \
+		  | match '"issuer": "http://pach-enterprise.enterprise:31658"' \
 		  | match '"localhost_issuer": true' \
 		  | match '"client_id": "localhost"' \
-		  | match '"redirect_uri": "http://pach-enterprise.enterprise:1650"'
+		  | match '"redirect_uri": "http://pach-enterprise.enterprise:31650"'
 		`,
 	).Run())
 }
@@ -166,8 +166,8 @@ func TestLoginEnterprise(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
@@ -211,8 +211,8 @@ func TestLoginPachd(t *testing.T) {
 
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
@@ -254,8 +254,8 @@ func TestSyncContexts(t *testing.T) {
 	// register a new cluster
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650 --pachd-user-address grpc://pachd.default:1655 --cluster-deployment-id {{.clusterId}} 
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650 --pachd-user-address grpc://pachd.default:1655 --cluster-deployment-id {{.clusterId}} 
 		`,
 		"id", id,
 		"token", tu.RootToken,
@@ -341,8 +341,8 @@ func TestRegisterDefaultArgs(t *testing.T) {
 	// register a new cluster
 	require.NoError(t, tu.BashCmd(`
 		echo {{.license}} | pachctl license activate
-		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:1658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 
 		pachctl enterprise sync-contexts
 
@@ -375,7 +375,7 @@ func TestRegisterRollback(t *testing.T) {
 	// passing an unreachable enterprise-server-address to the `enterprise register` command
 	// causes it to fail, and rollback cluster record creation
 	require.YesError(t, tu.BashCmd(`
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc:/bad-address:1650 --pachd-address grpc://pachd.default:1650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc:/bad-address:31650 --pachd-address grpc://pachd.default:30650
 		`,
 		"id", id,
 	).Run())
@@ -389,7 +389,7 @@ func TestRegisterRollback(t *testing.T) {
 	).Run())
 
 	require.NoError(t, tu.BashCmd(`
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:1650 --pachd-address grpc://pachd.default:1650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
 		`,
 		"id", id,
 	).Run())

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -545,7 +545,7 @@ func TestS3SkippedDatums(t *testing.T) {
 					fmt.Sprintf(
 						// access background repo via regular s3g (not S3_ENDPOINT, which
 						// can only access inputs)
-						"aws --endpoint=http://pachd.%s:1600 s3 cp s3://master.%s/round /tmp/bg",
+						"aws --endpoint=http://pachd.%s:30600 s3 cp s3://master.%s/round /tmp/bg",
 						Namespace, background,
 					),
 					"aws --endpoint=${S3_ENDPOINT} s3 cp s3://s3g_in/file /tmp/s3in",
@@ -703,7 +703,7 @@ func TestS3SkippedDatums(t *testing.T) {
 					fmt.Sprintf(
 						// access background repo via regular s3g (not S3_ENDPOINT, which
 						// can only access inputs)
-						"aws --endpoint=http://pachd.%s:1600 s3 cp s3://master.%s/round /tmp/bg",
+						"aws --endpoint=http://pachd.%s:30600 s3 cp s3://master.%s/round /tmp/bg",
 						Namespace, background,
 					),
 					"cat /pfs/in/* >/tmp/pfsin",


### PR DESCRIPTION
I think this shouldn't be a breaking change unless customers use extra annotations in their setup that are outside our ingress. Since this is a significant change, I think we should prep for it being released in 2.2