### PR TITLE
Fix debug dump segfault on failed jobs

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -472,7 +472,7 @@ func (s *debugServer) collectCommits(tw *tar.Writer, pachClient *client.APIClien
 			return errors.EnsureStack(err)
 		}
 		return clientsdk.ForEachCommit(client, func(ci *pfs.CommitInfo) error {
-			if ci.Finished != nil && ci.Details.CompactingTime != nil && ci.Details.ValidatingTime != nil {
+			if ci.Finished != nil && ci.Details != nil && ci.Details.CompactingTime != nil && ci.Details.ValidatingTime != nil {
 				compactingDuration, err := types.DurationFromProto(ci.Details.CompactingTime)
 				if err != nil {
 					return errors.EnsureStack(err)


### PR DESCRIPTION
Currently, when a user try to get a debug dump for a pipeline/job that failed, they get a cryptic `EOF` error. This is actually caused by a segmentation fault in our code, which crashes `pachd`.