### PR TITLE
Don't propagate TotalFileSet if parent commit errored in alias commits

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -649,13 +649,14 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 			if parentCommitInfo.Finished != nil {
 				commitInfo.Finished = txnCtx.Timestamp
 				commitInfo.Details = parentCommitInfo.Details
-				// if the parent is already finished we can just use its total fileset.
-				total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.Commit)
-				if err != nil {
-					return nil, errors.EnsureStack(err)
-				}
-				if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commitInfo.Commit, *total); err != nil {
-					return nil, errors.EnsureStack(err)
+				if parentCommitInfo.Error == "" {
+					total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.Commit)
+					if err != nil {
+						return nil, errors.EnsureStack(err)
+					}
+					if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commitInfo.Commit, *total); err != nil {
+						return nil, errors.EnsureStack(err)
+					}
 				}
 			}
 			commitInfo.Error = parentCommitInfo.Error


### PR DESCRIPTION
Updating `2.1.x` branch first because there are changes in the `master` branch that no longer reproduces the `sql: no rows in result set` error. We can cherry-pick this change into master later.