### PR TITLE
[mount server] Error if trying to mount nonexistent repo

### DIFF
--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -441,8 +441,16 @@ func Server(c *client.APIClient, sopts *ServerOptions) error {
 			}
 			// TODO: use response (serialize it to the client, it's polite to hand
 			// back the object you just modified in the API response)
-			// TODO: Only mount if the repo passed actually exists. Otherwise, results
-			// in weird behavior when trying to mount to "name" again.
+			l, err := mm.List()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if _, ok := l[key.Repo]; !ok {
+				http.Error(w, "repo does not exist", http.StatusBadRequest)
+				return
+			}
+
 			_, err = mm.MountBranch(key, name, mode)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -319,6 +319,17 @@ func TestUnauthenticatedCode(t *testing.T) {
 	})
 }
 
+func TestMountNonexistentRepo(t *testing.T) {
+	tu.DeleteAll(t)
+	defer tu.DeleteAll(t)
+	env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+
+	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
+		resp, _ := put("repos/repo1/master/_mount?name=repo1&mode=ro", nil)
+		require.Equal(t, 400, resp.StatusCode)
+	})
+}
+
 // TODO: pass reference to the MountManager object to the test func, so that the
 // test can call MountBranch, UnmountBranch etc directly for convenience
 func withServerMount(tb testing.TB, c *client.APIClient, sopts *ServerOptions, f func(mountPoint string)) {


### PR DESCRIPTION
Prevents server from mounting a nonexistent repo which leads to some funky behavior.

Jira: https://pachyderm.atlassian.net/browse/INT-499