### PR TITLE
Fix Secure (HTTPS) setting for Minio

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -420,11 +420,17 @@ pachd:
       id: ""
       secret: ""
     minio:
+      # minio bucket name
       bucket: ""
+      # the minio endpoint. Should only be the hostname:port, no http/https.
       endpoint: ""
+      # the username/id with readwrite access to the bucket.
       id: ""
+      # the secret/password of the user with readwrite access to the bucket.
       secret: ""
+      # enable https for minio with "true" defaults to "false"
       secure: ""
+      # Enable S3v2 support by setting signature to "1". This feature is being deprecated
       signature: ""
     # putFileConcurrencyLimit sets the maximum number of files to
     # upload or fetch from remote sources (HTTP, blob storage) using

--- a/src/internal/obj/factory.go
+++ b/src/internal/obj/factory.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-
+	"strconv"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -309,11 +309,15 @@ func NewMinioClientFromSecret(bucket string) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	secureBool, err := strconv.ParseBool(secure)
+	if err != nil {
+		return nil, err
+	}
 	isS3V2, err := readSecretFile(fmt.Sprintf("/%s", MinioSignatureEnvVar))
 	if err != nil {
 		return nil, err
 	}
-	return NewMinioClient(endpoint, bucket, id, secret, secure == "1", isS3V2 == "1")
+	return NewMinioClient(endpoint, bucket, id, secret, secureBool, isS3V2 == "1")
 }
 
 // NewMinioClientFromEnv creates a Minio client based on environment variables.

--- a/src/internal/obj/factory.go
+++ b/src/internal/obj/factory.go
@@ -311,7 +311,7 @@ func NewMinioClientFromSecret(bucket string) (Client, error) {
 	}
 	secureBool, err := strconv.ParseBool(secure)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("Failed to convert minio secure boolean setting")
 	}
 	isS3V2, err := readSecretFile(fmt.Sprintf("/%s", MinioSignatureEnvVar))
 	if err != nil {
@@ -342,11 +342,15 @@ func NewMinioClientFromEnv() (Client, error) {
 	if !ok {
 		return nil, errors.Errorf("%s not found", MinioSecureEnvVar)
 	}
+	secureBool, err := strconv.ParseBool(secure)
+	if err != nil {
+		return nil, errors.Errorf("Failed to convert minio secure boolean setting")
+	}
 	isS3V2, ok := os.LookupEnv(MinioSignatureEnvVar)
 	if !ok {
 		return nil, errors.Errorf("%s not found", MinioSignatureEnvVar)
 	}
-	return NewMinioClient(endpoint, bucket, id, secret, secure == "1", isS3V2 == "1")
+	return NewMinioClient(endpoint, bucket, id, secret, secureBool, isS3V2 == "1")
 }
 
 // NewAmazonClientFromSecret constructs an amazon client by reading credentials


### PR DESCRIPTION
currently only `"1"` enables this. Using `ParseBool` to accept `"true"` and update values file documentation.