### PR TITLE
Clean up jobs in delete/squash commit.

### DIFF
--- a/src/internal/testpachd/mock_transaction.go
+++ b/src/internal/testpachd/mock_transaction.go
@@ -77,6 +77,16 @@ func (mock *mockInspectPipelineInTransaction) Use(cb inspectPipelineInTransactio
 	mock.handler = cb
 }
 
+type deleteJobInTransactionFunc func(*txncontext.TransactionContext, *pps.DeleteJobRequest) error
+
+type mockDeleteJobInTransaction struct {
+	handler deleteJobInTransactionFunc
+}
+
+func (mock *mockDeleteJobInTransaction) Use(cb deleteJobInTransactionFunc) {
+	mock.handler = cb
+}
+
 type ppsTransactionAPI struct {
 	ppsServerAPI
 	mock *MockPPSTransactionServer
@@ -93,6 +103,7 @@ type MockPPSTransactionServer struct {
 	UpdateJobStateInTransaction  mockUpdateJobStateInTransaction
 	CreatePipelineInTransaction  mockCreatePipelineInTransaction
 	InspectPipelineInTransaction mockInspectPipelineInTransaction
+	DeleteJobInTransaction       mockDeleteJobInTransaction
 }
 
 type MockPPSPropagater struct{}

--- a/src/internal/testpachd/mock_transaction.go
+++ b/src/internal/testpachd/mock_transaction.go
@@ -170,6 +170,13 @@ func (api *ppsTransactionAPI) InspectPipelineInTransaction(txnCtx *txncontext.Tr
 	return nil, errors.Errorf("unhandled pachd mock: pps.InspectPipelineInTransaction")
 }
 
+func (api *ppsTransactionAPI) DeleteJobInTransaction(txnCtx *txncontext.TransactionContext, req *pps.DeleteJobRequest) error {
+	if api.mock.InspectPipelineInTransaction.handler != nil {
+		return api.mock.DeleteJobInTransaction.handler(txnCtx, req)
+	}
+	return errors.Errorf("unhandled pachd mock: pps.DeleteJobInTransaction")
+}
+
 // NewMockPPSTransactionServer instantiates a MockPPSTransactionServer
 func NewMockPPSTransactionServer() *MockPPSTransactionServer {
 	result := &MockPPSTransactionServer{}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -1520,6 +1520,14 @@ func (d *driver) squashCommitSetInternal(txnCtx *txncontext.TransactionContext, 
 		}
 	}
 
+	// 5) delete corresponding jobs, if any
+	for _, ci := range commitInfos {
+		if err := d.env.GetPPSServer().DeleteJobInTransaction(txnCtx, &pps.DeleteJobRequest{
+			Job: client.NewJob(ci.Commit.Branch.Repo.Name, ci.Commit.ID)}); err != nil && !errutil.IsNotFoundError(err) {
+			return errors.EnsureStack(err)
+		}
+	}
+
 	return nil
 }
 

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -19,4 +19,5 @@ type APIServer interface {
 	UpdateJobStateInTransaction(*txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
 	CreatePipelineInTransaction(*txncontext.TransactionContext, *pps_client.CreatePipelineRequest) error
 	InspectPipelineInTransaction(*txncontext.TransactionContext, string) (*pps_client.PipelineInfo, error)
+	DeleteJobInTransaction(ctx *txncontext.TransactionContext, request *pps_client.DeleteJobRequest) error
 }

--- a/src/server/pps/pps.go
+++ b/src/server/pps/pps.go
@@ -25,6 +25,15 @@ func (e ErrPipelineNotFound) Error() string {
 	return fmt.Sprintf("pipeline %q not found", e.Pipeline.Name)
 }
 
+type ErrOutputCommitExists struct {
+	Job *pps.Job
+}
+
+func (e ErrOutputCommitExists) Error() string {
+	return fmt.Sprintf("the output commit for job %v still exists, so deleting it would lead to "+
+		"inconsistent pachyderm state. Consider using squash commit or delete commit instead.", e.Job)
+}
+
 var (
 	jobFinishedRe      = regexp.MustCompile("job [^ ]+ has already finished")
 	pipelineNotFoundRe = regexp.MustCompile("pipeline [^ ]+ not found")


### PR DESCRIPTION
Also nudge users towards those in a new delete job error that prevents
breaking provenance.