### PR TITLE
Don't propagate TotalFileSet if parent commit errored in alias commits (#7383)

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9968,3 +9968,47 @@ func TestLoad(t *testing.T) {
 	require.NoError(t, cmdutil.Encoder("", buf).EncodeProto(resp))
 	require.Equal(t, "", resp.Error, buf.String())
 }
+
+func TestPutFileNoErrorOnErroredParentCommit(t *testing.T) {
+	// Test whether PutFile still works on a repo where a parent commit errored
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
+
+	require.NoError(t, c.CreateRepo("inA"))
+	require.NoError(t, c.CreateRepo("inB"))
+	require.NoError(t, c.CreatePipeline(
+		"A",
+		"",
+		[]string{"bash"},
+		[]string{"exit -1"},
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewPFSInput("inA", "/*"),
+		"",
+		false,
+	))
+	require.NoError(t, c.CreatePipeline(
+		"B",
+		"",
+		[]string{"bash"},
+		[]string{"sleep 3"},
+		&pps.ParallelismSpec{
+			Constant: 1,
+		},
+		client.NewUnionInput(
+			client.NewPFSInput("inB", "/*"),
+			client.NewPFSInput("A", "/*"),
+		),
+		"",
+		false,
+	))
+	require.NoError(t, c.PutFile(client.NewCommit("inA", "master", ""), "file", strings.NewReader("foo")))
+	commitInfo, err := c.WaitCommit("A", "master", "")
+	require.NoError(t, err)
+	require.True(t, strings.Contains(commitInfo.Error, "failed"))
+	require.NoError(t, c.PutFile(client.NewCommit("inB", "master", ""), "file", strings.NewReader("foo")))
+}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -649,13 +649,14 @@ func (d *driver) aliasCommit(txnCtx *txncontext.TransactionContext, parent *pfs.
 			if parentCommitInfo.Finished != nil {
 				commitInfo.Finished = txnCtx.Timestamp
 				commitInfo.Details = parentCommitInfo.Details
-				// if the parent is already finished we can just use its total fileset.
-				total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.Commit)
-				if err != nil {
-					return nil, errors.EnsureStack(err)
-				}
-				if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commitInfo.Commit, *total); err != nil {
-					return nil, errors.EnsureStack(err)
+				if parentCommitInfo.Error == "" {
+					total, err := d.commitStore.GetTotalFileSetTx(txnCtx.SqlTx, parentCommitInfo.Commit)
+					if err != nil {
+						return nil, errors.EnsureStack(err)
+					}
+					if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commitInfo.Commit, *total); err != nil {
+						return nil, errors.EnsureStack(err)
+					}
 				}
 			}
 			commitInfo.Error = parentCommitInfo.Error


### PR DESCRIPTION
This PR brings the fix that was originally merged into 2.1.x into master branch.