### PR TITLE
Strip build directory from pachd stack traces

### DIFF
--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -14,6 +14,8 @@ builds:
       - linux
     goarch:
       - amd64
+    gcflags:
+      - "all=-trimpath={{.Env.PWD}}"
   -
     id: worker
     dir: src/server/cmd/worker
@@ -27,6 +29,8 @@ builds:
       - linux
     goarch:
       - amd64
+    gcflags:
+      - "all=-trimpath={{.Env.PWD}}"
   -
     id: worker_init
     dir: etc/worker
@@ -40,6 +44,8 @@ builds:
       - linux
     goarch:
       - amd64
+    gcflags:
+      - "all=-trimpath={{.Env.PWD}}"
   -
     id: pachctl
     dir: src/server/cmd/pachctl
@@ -52,6 +58,8 @@ builds:
       - darwin
     goarch:
       - amd64
+    gcflags:
+      - "all=-trimpath={{.Env.PWD}}"
   -
     id: pachtf
     dir: src/server/cmd/pachtf
@@ -65,6 +73,8 @@ builds:
       - linux
     goarch:
       - amd64
+    gcflags:
+      - "all=-trimpath={{.Env.PWD}}"
 
 archives:
   - format: binary
@@ -85,6 +95,7 @@ dockers:
     image_templates:
       - pachyderm/pachd
       - pachyderm/pachd:local
+      - "pachyderm/pachd:{{.Version}}"
     ids:
       - pachd
     goos: linux

--- a/goreleaser/pachctl.yml
+++ b/goreleaser/pachctl.yml
@@ -16,7 +16,7 @@ builds:
     ldflags:
       - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }}
     gcflags:
-      - all=-trimpath={{ .Env.PWD }}
+      - "all=-trimpath={{.Env.GOBIN}}"
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This is the master version of #7412 

Currently, stack traces emitted by pachd include the directory that pachd was built in, e.g. `/Users/avigil`:
```
Info 2022-03-09T23:16:08.889986614Z error stack:
  github.com/pachyderm/pachyderm/v2/src/internal/task.(*etcdDoer).Do.func1.2.1 /Users/avigil/Pachyderm/Pachyderm_releases_2.1.x/pachyderm/src/internal/task/etcd_service.go:145
  github.com/pachyderm/pachyderm/v2/src/internal/collection.watchF /Users/avigil/Pachyderm/Pachyderm_releases_2.1.x/pachyderm/src/internal/collection/etcd_collection.go:587
  github.com/pachyderm/pachyderm/v2/src/internal/collection.(*etcdReadOnlyCollection).WatchOneF /Users/avigil/Pachyderm/Pachyderm_releases_2.1.x/pachyderm/src/internal/collection/etcd_collection.go:697
  github.com/pachyderm/pachyderm/v2/src/internal/task.(*etcdDoer).Do.func1.2 /Users/avigil/Pachyderm/Pachyderm_releases_2.1.x/pachyderm/src/internal/task/etcd_service.go:131 golang.org/x/sync/errgroup.(*Group).Go.func1 /Users/avigil/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 runtime.goexit /usr/local/go/src/runtime/asm_amd64.s:1581
```

This removes the `/Users/avigil` from pachd/pachctl stack traces (tested manually, locally)