### PR TITLE
storage/fileset/index: Fix issue where `levelWriter` callback points to wrong level.

### DIFF
--- a/src/internal/storage/fileset/index/writer.go
+++ b/src/internal/storage/fileset/index/writer.go
@@ -85,7 +85,7 @@ func (w *Writer) setupLevel(idx *Index, level int) {
 	}
 	// then get the write lock, check again and maybe create another level.
 	w.levelsMu.Lock()
-	defer w.levelsMu.RLock()
+	defer w.levelsMu.Unlock()
 	if level < len(w.levels) {
 		cw := w.chunks.NewWriter(w.ctx, w.tmpID, w.callback(level), chunk.WithRollingHashConfig(averageBits, int64(level)))
 		lw := &levelWriter{

--- a/src/internal/storage/fileset/index/writer.go
+++ b/src/internal/storage/fileset/index/writer.go
@@ -86,7 +86,7 @@ func (w *Writer) setupLevel(idx *Index, level int) {
 	// then get the write lock, check again and maybe create another level.
 	w.levelsMu.Lock()
 	defer w.levelsMu.Unlock()
-	if level < len(w.levels) {
+	if level >= len(w.levels) {
 		cw := w.chunks.NewWriter(w.ctx, w.tmpID, w.callback(level), chunk.WithRollingHashConfig(averageBits, int64(level)))
 		lw := &levelWriter{
 			cw:       cw,


### PR DESCRIPTION
Previously we checked if a level needed to be created using the read lock with `numLevels`, then if necessary, we created a level using `createLevel(lw *levelWriter)`.

The callback for a levelWriter is configured using the index which that levelWriter will be assigned to.  It can't go anywhere on the level stack.  It has to go at it's index or the callback will be messed up.

In `createLevel` we append without checking the length, potentially inserting a levelWriter with a callback for the wrong level at the end of the stack of levels.

These changes check whether a level needs to be added while holding the lock, and then add it, so that no other levelWriters will be created in between.  It also does a check with the read lock first, so that in the common case we only need the read lock to get a level writer.