### PR TITLE
storage/chunk: Fix TaskChain executing callbacks after Wait has returned.

### DIFF
--- a/src/internal/storage/chunk/chain.go
+++ b/src/internal/storage/chunk/chain.go
@@ -3,7 +3,6 @@ package chunk
 import (
 	"context"
 	"math"
-	"sync"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"golang.org/x/sync/errgroup"
@@ -38,42 +37,44 @@ func NewTaskChain(ctx context.Context, parallelism int64) *TaskChain {
 	}
 }
 
+// TaskChainFunc is a function which is computed in parallel, and then returns
+// a closure to be computed serially, or an error.
+type TaskChainFunc = func(context.Context) (serCB func(context.Context) error, err error)
+
 // CreateTask creates a new task in the task chain.
-func (c *TaskChain) CreateTask(cb func(context.Context, func(func() error) error) error) error {
+func (c *TaskChain) CreateTask(cb TaskChainFunc) error {
 	if err := c.sem.Acquire(c.ctx, 1); err != nil {
 		return errors.EnsureStack(err)
 	}
-	scb := c.serialCallback()
+	// get our place in line for the serial portion
+	prevChan := c.prevChan
+	nextChan := make(chan struct{})
+	c.prevChan = nextChan
+	// spawn a new goroutine for the parallel portion
 	c.eg.Go(func() error {
 		defer c.sem.Release(1)
-		defer scb(func() error { return nil })
-		return cb(c.ctx, scb)
+		serCB, err := cb(c.ctx)
+		if err != nil {
+			return err
+		}
+		// Either:
+		// - There has been an error returned to the errgroup, and the signal will come from the context
+		// - There hasn't been an error from anything yet, and we need to wait our turn to do the serial callback
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		case <-prevChan:
+			if err := serCB(c.ctx); err != nil {
+				return err
+			}
+			close(nextChan)
+			return nil
+		}
 	})
 	return nil
 }
 
 // Wait waits on the currently executing tasks to finish.
 func (c *TaskChain) Wait() error {
-	select {
-	case <-c.ctx.Done():
-		return errors.EnsureStack(c.eg.Wait())
-	case <-c.prevChan:
-		return nil
-	}
-}
-
-func (c *TaskChain) serialCallback() func(func() error) error {
-	prevChan := c.prevChan
-	nextChan := make(chan struct{})
-	c.prevChan = nextChan
-	var once sync.Once
-	return func(cb func() error) error {
-		defer once.Do(func() { close(nextChan) })
-		select {
-		case <-prevChan:
-			return cb()
-		case <-c.ctx.Done():
-			return errors.EnsureStack(c.ctx.Err())
-		}
-	}
+	return errors.EnsureStack(c.eg.Wait())
 }

--- a/src/internal/storage/chunk/reader.go
+++ b/src/internal/storage/chunk/reader.go
@@ -86,11 +86,11 @@ func (r *Reader) Get(w io.Writer) (retErr error) {
 		}
 	}()
 	return r.Iterate(func(dr *DataReader) error {
-		return taskChain.CreateTask(func(ctx context.Context) (func(context.Context) error, error) {
+		return taskChain.CreateTask(func(ctx context.Context) (func() error, error) {
 			if err := dr.Prefetch(); err != nil {
 				return nil, err
 			}
-			return func(context.Context) error {
+			return func() error {
 				return dr.Get(w)
 			}, nil
 		})

--- a/src/internal/storage/chunk/reader.go
+++ b/src/internal/storage/chunk/reader.go
@@ -86,13 +86,13 @@ func (r *Reader) Get(w io.Writer) (retErr error) {
 		}
 	}()
 	return r.Iterate(func(dr *DataReader) error {
-		return taskChain.CreateTask(func(ctx context.Context, serial func(func() error) error) error {
+		return taskChain.CreateTask(func(ctx context.Context) (func(context.Context) error, error) {
 			if err := dr.Prefetch(); err != nil {
-				return err
+				return nil, err
 			}
-			return serial(func() error {
+			return func(context.Context) error {
 				return dr.Get(w)
-			})
+			}, nil
 		})
 	})
 }


### PR DESCRIPTION
In the previous implementation it was possible for serial callbacks to still be executing even after Wait has returned.

Now we simply call errgroup.Wait and return any error.  errgroup.Wait is presumably correct and provides the guarantee we want, so these changes are motivated around getting all the error states into the errgroup. The small change in API helps us do that because we are no longer dependent on the caller to pass errors up the chain.  For each task, first we call the parallel part, then if that succeeds we call the serial part, exactly once, in the right order.  There is no opportunity for the caller to execute serial code more than once, and any errors produced by either the parallel or serial part make their way to the errgroup.