### PR TITLE
[2.1.x Backport] Propagating Custom certs referenced in pachd's SSL_CERT_DIR to side-cars (#7414)

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -150,6 +150,10 @@ spec:
         - name: SSL_CERT_DIR
           value:  /pachd-tls-cert
         {{- end }}
+        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        - name: TLS_CERT_SECRET_NAME
+          value: {{ required "If pachd.tls.enabled, you must set pachd.tls.secretName" .Values.pachd.tls.secretName | quote }}  
+        {{- end }}
         {{ if .Values.global.proxy }}
         - name: http_proxy
           value: {{ .Values.global.proxy }}

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -98,6 +98,7 @@ type PachdSpecificConfiguration struct {
 	// TODO: Merge this with the worker specific pod name (PPS_POD_NAME) into a global configuration pod name.
 	PachdPodName                 string `env:"PACHD_POD_NAME,required"`
 	EnableWorkerSecurityContexts bool   `env:"ENABLE_WORKER_SECURITY_CONTEXTS,default=true"`
+	TLSCertSecretName            string `env:"TLS_CERT_SECRET_NAME,default="`
 }
 
 // StorageConfiguration contains the storage configuration.

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -88,6 +88,22 @@ func getPachctlSecretVolumeAndMount(secret string) (v1.Volume, v1.VolumeMount) {
 		}
 }
 
+// getTLSCertSecretVolumeAndMount returns a Volume and VolumeMount object
+// configured for the pach-tls secret to be stored in pipeline side-cars.
+func getTLSCertSecretVolumeAndMount(secret, mountPath string) (v1.Volume, v1.VolumeMount) {
+	return v1.Volume{
+			Name: secret,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: secret,
+				},
+			},
+		}, v1.VolumeMount{
+			Name:      secret,
+			MountPath: mountPath,
+		}
+}
+
 func (pc *pipelineController) workerPodSpec(options *workerOptions, pipelineInfo *pps.PipelineInfo) (v1.PodSpec, error) {
 	pullPolicy := pc.env.Config.WorkerImagePullPolicy
 	if pullPolicy == "" {
@@ -267,6 +283,14 @@ func (pc *pipelineController) workerPodSpec(options *workerOptions, pipelineInfo
 	options.volumes = append(options.volumes, secretVolume)
 	sidecarVolumeMounts = append(sidecarVolumeMounts, secretMount)
 	userVolumeMounts = append(userVolumeMounts, secretMount)
+
+	// in the case the pachd is deployed with custom root certs, propagate them to the side-cars
+	if path, ok := os.LookupEnv("SSL_CERT_DIR"); ok {
+		sidecarEnv = append(sidecarEnv, v1.EnvVar{Name: "SSL_CERT_DIR", Value: path})
+		certSecretVolume, certSecretMount := getTLSCertSecretVolumeAndMount(pc.env.Config.TLSCertSecretName, path)
+		options.volumes = append(options.volumes, certSecretVolume)
+		sidecarVolumeMounts = append(sidecarVolumeMounts, certSecretMount)
+	}
 
 	// mount secret for spouts using pachctl
 	if pipelineInfo.Details.Spout != nil {


### PR DESCRIPTION
* Propagating Custom certs referenced in pachd's SSL_CERT_DIR to side-cars