### PR TITLE
Add Envoy Proxy as Optional Component

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - containerPort: {{ .Values.console.config.graphqlPort }}
           name: console-http
         env:
-        {{- if not .Values.ingress.enabled }}
+        {{- if and (not .Values.ingress.enabled) (not .Values.pachd.externalService.serviceProxy) }}
         - name: REACT_APP_RUNTIME_SUBSCRIPTIONS_PREFIX
           value: ":{{ .Values.console.config.graphqlPort }}/graphql"
         {{- end }}

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -149,11 +149,11 @@ spec:
           value: {{ .Values.pachd.storage.uploadConcurrencyLimit | quote }}
         - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
           value: {{ .Values.pachd.storage.putFileConcurrencyLimit | quote }}
-        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        {{- if and (not .Values.pachd.externalService.serviceProxy ) .Values.pachd.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR
           value:  /pachd-tls-cert
         {{- end }}
-        {{ if .Values.global.proxy }}
+        {{- if .Values.global.proxy }}
         - name: http_proxy
           value: {{ .Values.global.proxy }}
         - name: https_proxy
@@ -219,7 +219,7 @@ spec:
           name: pach-disk
         - mountPath: /pachyderm-storage-secret
           name: pachyderm-storage-secret
-        {{- if .Values.pachd.tls.enabled }}
+        {{- if and (not .Values.pachd.externalService.serviceProxy) .Values.pachd.tls.enabled }}
         - mountPath: /pachd-tls-cert
           name: pachd-tls-cert
         {{- end }}
@@ -242,7 +242,7 @@ spec:
       - name: pachyderm-storage-secret
         secret:
           secretName: pachyderm-storage-secret
-      {{- if .Values.pachd.tls.enabled }}
+      {{- if and (not .Values.pachd.externalService.serviceProxy) .Values.pachd.tls.enabled  }}
       - name: pachd-tls-cert
         secret:
           secretName: {{ required "If pachd.tls.enabled, you must set pachd.tls.secretName" .Values.pachd.tls.secretName | quote }}

--- a/etc/helm/pachyderm/templates/proxy/configmap.yaml
+++ b/etc/helm/pachyderm/templates/proxy/configmap.yaml
@@ -1,0 +1,297 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: pachd
+    suite: pachyderm
+  name: proxy-config
+  namespace: {{ .Release.Namespace }}
+data:
+  envoy.yaml: |
+    overload_manager:
+        refresh_interval: 0.25s
+        resource_monitors:
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                  max_heap_size_bytes: 640000000 # 640MB
+        actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+                  - name: "envoy.resource_monitors.fixed_heap"
+                    threshold:
+                        value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+                  - name: "envoy.resource_monitors.fixed_heap"
+                    threshold:
+                        value: 0.98
+    admin:
+        access_log:
+            - name: envoy.access_loggers.stderr
+              typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StderrAccessLog
+        address:
+            socket_address: { address: 0.0.0.0, port_value: 9901 }
+    static_resources:
+        listeners:
+            - name: public-listener
+              address:
+                  socket_address: { address: 0.0.0.0, port_value: {{ if .Values.pachd.tls.enabled -}} 443 {{ else -}} 80 {{ end -}} }
+              per_connection_buffer_limit_bytes: 32768
+              traffic_direction: INBOUND
+              filter_chains:
+                  - filters:
+                        - name: envoy.http_connection_manager
+                          typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                              access_log:
+                                  - name: envoy.access_loggers.stdout
+                                    typed_config:
+                                        "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                              codec_type: auto
+                              common_http_protocol_options:
+                                  idle_timeout: 5s
+                                  headers_with_underscores_action: REJECT_REQUEST
+                              http_protocol_options:
+                                  accept_http_10: false
+                              http2_protocol_options:
+                                  max_concurrent_streams: 100
+                                  initial_stream_window_size: 65536 # 64 KiB
+                                  initial_connection_window_size: 1048576 # 1 MiB
+                              stream_idle_timeout: 60s
+                              request_timeout: 60s
+                              use_remote_address: true
+                              stat_prefix: pachyderm_envoy_http
+                              route_config:
+                                  virtual_hosts:
+                                      - name: any
+                                        domains: ["*"]
+                                        routes:
+                                            - match:
+                                                  prefix: /
+                                                  grpc: {}
+                                              route:
+                                                  cluster: pachd-grpc
+                                                  timeout: 604800s # 1 week, for long uploads.
+                                                  idle_timeout: 600s
+                                            - match:
+                                                  prefix: /
+                                                  headers:
+                                                      - name: authorization
+                                                        string_match:
+                                                            prefix: AWS4-HMAC-SHA256
+                                              route:
+                                                  cluster: pachd-s3gateway
+                                                  timeout: 604800s # 1 week, for long uploads
+                                                  idle_timeout: 600s
+                                            - match:
+                                                  prefix: /dex
+                                              route:
+                                                  cluster: pachd-identity
+                                                  timeout: 60s
+                                                  idle_timeout: 60s
+                                            - match:
+                                                  prefix: /authorization-code/callback
+                                              route:
+                                                  cluster: pachd-oidc
+                                                  timeout: 60s
+                                                  idle_timeout: 60s
+                                            - match:
+                                                  prefix: /envoy/
+                                              route:
+                                                  prefix_rewrite: /
+                                                  cluster: envoy-admin
+                                                  timeout: 60s
+                                                  idle_timeout: 60s
+                                            - match:
+                                                  prefix: /
+                                              route:
+                                                  cluster: console
+                                                  timeout: 3600s
+                                                  idle_timeout: 600s
+                                                  upgrade_configs:
+                                                      - upgrade_type: websocket
+                                                        enabled: true
+                              http_filters:
+                                  - name: envoy.filters.http.grpc_stats
+                                    # Note: not appropriate for actual public instances.
+                                    typed_config:
+                                        "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                                        stats_for_all_methods: true
+                                        enable_upstream_stats: true
+                                  - name: envoy.filters.http.router
+                {{- if .Values.pachd.tls.enabled }}
+                    transport_socket:
+                      name: envoy.transport_sockets.tls
+                      typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                          common_tls_context:
+                              tls_certificates:
+                              - certificate_chain: {filename: "/pachd-tls-cert/tls.crt"}
+                                private_key: {filename: "/pachd-tls-cert/tls.key"}
+                {{- end }}
+        clusters:
+            - name: pachd-grpc
+              type: logical_dns
+              lb_policy: round_robin
+              connect_timeout: 10s
+              dns_lookup_family: V4_ONLY
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              typed_extension_protocol_options:
+                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                      explicit_http_config:
+                          http2_protocol_options: {}
+              health_checks:
+                  - timeout: 10s
+                    interval: 10s
+                    healthy_threshold: 1
+                    unhealthy_threshold: 2
+                    grpc_health_check: {}
+              load_assignment:
+                  cluster_name: pachd-grpc
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: pachd
+                                          port_value: 30650
+            - name: pachd-peer
+              type: logical_dns
+              lb_policy: round_robin
+              connect_timeout: 10s
+              dns_lookup_family: V4_ONLY
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              typed_extension_protocol_options:
+                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                      explicit_http_config:
+                          http2_protocol_options: {}
+              health_checks:
+                  - timeout: 10s
+                    interval: 10s
+                    healthy_threshold: 1
+                    unhealthy_threshold: 2
+                    grpc_health_check: {}
+              load_assignment:
+                  cluster_name: pachd-peer
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: pachd-peer
+                                          port_value: 30653
+            - name: pachd-identity
+              type: logical_dns
+              lb_policy: round_robin
+              connect_timeout: 10s
+              dns_lookup_family: V4_ONLY
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              load_assignment:
+                  cluster_name: pachd-identity
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: pachd
+                                          port_value: 30658
+              health_checks:
+                  - timeout: 10s
+                    interval: 30s
+                    healthy_threshold: 1
+                    unhealthy_threshold: 2
+                    http_health_check:
+                        host: localhost
+                        path: /dex/.well-known/openid-configuration
+            - name: pachd-oidc
+              type: logical_dns
+              lb_policy: round_robin
+              connect_timeout: 10s
+              dns_lookup_family: V4_ONLY
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              load_assignment:
+                  cluster_name: pachd-oidc
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: pachd
+                                          port_value: 30657
+            - name: pachd-s3gateway
+              type: logical_dns
+              lb_policy: round_robin
+              connect_timeout: 10s
+              dns_lookup_family: V4_ONLY
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              load_assignment:
+                  cluster_name: pachd-s3gateway
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: pachd
+                                          port_value: 30600
+            - name: console
+              type: logical_dns
+              lb_policy: round_robin
+              connect_timeout: 10s
+              dns_lookup_family: V4_ONLY
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              health_checks:
+                  - timeout: 10s
+                    interval: 30s
+                    healthy_threshold: 1
+                    unhealthy_threshold: 2
+                    http_health_check:
+                        host: localhost
+                        path: /
+              load_assignment:
+                  cluster_name: pachd-s3gateway
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: console
+                                          port_value: 4000
+            - name: envoy-admin
+              type: static
+              lb_policy: random
+              connect_timeout: 1s
+              upstream_connection_options:
+                  tcp_keepalive: {}
+              typed_extension_protocol_options:
+                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                      explicit_http_config:
+                          http2_protocol_options: {}
+              load_assignment:
+                  cluster_name: envoy-admin
+                  endpoints:
+                      - lb_endpoints:
+                            - endpoint:
+                                  address:
+                                      socket_address:
+                                          address: 127.0.0.1
+                                          port_value: 9901
+
+    layered_runtime:
+        layers:
+            - name: static_layer_0
+              static_layer:
+                  overload:
+                      global_downstream_max_connections: 50000
+
+

--- a/etc/helm/pachyderm/templates/proxy/configmap.yaml
+++ b/etc/helm/pachyderm/templates/proxy/configmap.yaml
@@ -159,33 +159,6 @@ data:
                                       socket_address:
                                           address: pachd
                                           port_value: 30650
-            - name: pachd-peer
-              type: logical_dns
-              lb_policy: round_robin
-              connect_timeout: 10s
-              dns_lookup_family: V4_ONLY
-              upstream_connection_options:
-                  tcp_keepalive: {}
-              typed_extension_protocol_options:
-                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-                      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-                      explicit_http_config:
-                          http2_protocol_options: {}
-              health_checks:
-                  - timeout: 10s
-                    interval: 10s
-                    healthy_threshold: 1
-                    unhealthy_threshold: 2
-                    grpc_health_check: {}
-              load_assignment:
-                  cluster_name: pachd-peer
-                  endpoints:
-                      - lb_endpoints:
-                            - endpoint:
-                                  address:
-                                      socket_address:
-                                          address: pachd-peer
-                                          port_value: 30653
             - name: pachd-identity
               type: logical_dns
               lb_policy: round_robin

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -2,6 +2,10 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
+{{- if and .Values.pachd.externalService.serviceProxy .Values.ingress.enabled -}}
+{{- fail "Cannot have both .Values.pachd.externalService.serviceProxy and .Values.ingress.enabled" }}
+{{- end }}
+
 {{- if and .Values.pachd.externalService.enabled .Values.pachd.externalService.serviceProxy -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -1,0 +1,96 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if and .Values.pachd.externalService.enabled .Values.pachd.externalService.serviceProxy -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    app: pachd-proxy
+    suite: pachyderm
+  name: pachd-proxy
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pachd-proxy
+  template:
+    metadata:
+      labels:
+        app: pachd-proxy
+      name: pachd-proxy
+    spec:
+      containers:
+      - args:
+        - -c
+        - /etc/envoy/envoy.yaml
+        - --service-node
+        - $(MY_POD_NAME)
+        - --service-zone
+        - $(MY_NODE_NAME)
+        - --service-cluster
+        - pachyderm-envoy
+        command:
+        - envoy
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: envoyproxy/envoy:v1.20.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /server_info
+            port: 9901
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: envoy
+        ports:
+        - containerPort: 9901
+          name: envoy-admin
+          protocol: TCP
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9901
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: proxy-config
+        {{- if .Values.pachd.tls.enabled }}
+        - mountPath: /pachd-tls-cert
+          name: pachd-tls-cert
+        {{- end }}
+      volumes:
+      - configMap:
+          name: proxy-config
+        name: proxy-config
+        {{- if .Values.pachd.tls.enabled }}
+      - name: pachd-tls-cert
+        secret:
+          secretName: {{ required "If pachd.tls.enabled, you must set pachd.tls.secretName" .Values.pachd.tls.secretName | quote }}
+        {{- end }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/proxy/external-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/external-service.yaml
@@ -9,7 +9,17 @@ metadata:
   name: pachd-lb
   namespace: {{ .Release.Namespace }}
 spec:
-  ports:
+  ports: 
+  {{- if .Values.pachd.externalService.serviceProxy }}
+  - name: http
+    port: 80
+  {{- if .Values.pachd.tls.enabled }}
+  - name: https
+    port: 443
+  {{- end }}
+  selector:
+    app: pachd-proxy
+  {{ else -}}
   - name: api-grpc-port
     port: {{ .Values.pachd.externalService.apiGRPCPort }}
     targetPort: api-grpc-port
@@ -18,6 +28,7 @@ spec:
     targetPort: s3gateway-port
   selector:
     app: pachd
+  {{ end -}}
   type: LoadBalancer
   loadBalancerIP: {{ .Values.pachd.externalService.loadBalancerIP }}
 {{ end -}}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -538,6 +538,9 @@
                         },
                         "s3GatewayPort": {
                             "type": "integer"
+                        },
+                        "serviceProxy": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -258,6 +258,9 @@ pachd:
     loadBalancerIP: ""
     apiGRPCPort: 30650
     s3GatewayPort: 30600
+    # by default use the service proxy. set to false for upgrades of existing installs using ingress
+    # set your externally accessible hostname at oidc.userAccessibleOauthIssuerHost and include port if needed (localhost:8080)
+    serviceProxy: true
     annotations: {}
   service:
     # labels specifies labels to add to the pachd service.
@@ -578,6 +581,7 @@ oidc:
   IDTokenExpiry: 24h
   # (Optional) If set, enables OIDC rotation tokens, and specifies the duration where they are valid.
   RotationTokenExpiry: 48h
+  # Required if using Proxy- Set the externally available hostname clients will use to access 
   # (Optional) Only set in cases where the issuerURI is not user accessible (ie. localhost install)
   userAccessibleOauthIssuerHost: ""
   ## to set up upstream IDPs, set pachd.mockIDP to false,


### PR DESCRIPTION
Adds Envoy proxy under `pachd.externalService.serviceProxy` and is enabled by default. Any upgrades from a previous version will work as-is long as they set that value to false.

