### PR TITLE
add the --wait all for minikube start

### DIFF
--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -11,6 +11,7 @@ minikube_args=(
   "--kubernetes-version=${VERSION}"
   "--cpus=7"
   "--memory=12Gi"
+  "--wait=all"
 )
 while getopts ":v" opt; do
   case "${opt}" in

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -25,6 +25,17 @@ while getopts ":v" opt; do
   esac
 done
 
+# wait for docker or timeout
+timeout=120
+while ! docker version >/dev/null 2>&1; do
+  timeout=$((timeout - 1))
+  if [ $timeout -eq 0 ]; then
+    echo "Timed out waiting for docker daemon"
+    exit 1
+  fi
+  sleep 1
+done
+
 minikube start "${minikube_args[@]}"
 
 # Try to connect for three minutes


### PR DESCRIPTION
There are constant failures on circle ci workflow due to `Exiting due to PROVIDER_DOCKER_NOT_RUNNING: deadline exceeded running "docker version --format -": signal: killed`

this is because we aren't waiting for the kubernetes daemon to fully be up and operational before running minikube start, so adding this check prior to minikube start. and added the wait all flag to minikube to make sure it is also ready to avoid this sporadic failures.