### PR TITLE
Restart repo watch on base commit error.

### DIFF
--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -168,6 +168,11 @@ func (d *driver) finishRepoCommits(ctx context.Context, compactor *compactor, re
 				// Finish the commit.
 				return d.finalizeCommit(ctx, commit, validationError, details, totalId)
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
+				var baseErr pfsserver.ErrBaseCommitNotFinished
+				if ok := errors.As(err, &baseErr); ok {
+					// likely got commits out of order, restart watch to find out
+					return err
+				}
 				log.Errorf("error finishing commit %v: %v, retrying in %v", commit, err, d)
 				return nil
 			})


### PR DESCRIPTION
When we encounter this error during finishing, it's essentially
impossible for us to succeed as we will never attempt to finish the base
commit. By restarting the watch, we have an opportunity to pick up the
commits in the right order.