### PR TITLE
Remove deleted load tests from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,9 +262,6 @@ workflows:
                 - LOAD5
                 - LOAD6
                 - LOAD7
-                - LOAD8
-                - LOAD9
-                - LOAD10
   deploy:
     jobs:
     - deploy

--- a/etc/testing/circle/run_hub_load_tests.sh
+++ b/etc/testing/circle/run_hub_load_tests.sh
@@ -24,13 +24,4 @@ case "${BUCKET}" in
  LOAD7)
     etc/testing/circle/run_hub_tests.sh etc/testing/loads/load-7.yaml -s 1630089896104084026
     ;;
- LOAD8)
-    etc/testing/circle/run_hub_tests.sh etc/testing/loads/load-8.yaml -s 1630089896104084026
-    ;;
- LOAD9)
-    etc/testing/circle/run_hub_tests.sh etc/testing/loads/load-9.yaml -s 1630089896104084026
-    ;;
- LOAD10)
-    etc/testing/circle/run_hub_tests.sh etc/testing/loads/load-10.yaml -s 1630089896104084026
-    ;;
 esac


### PR DESCRIPTION
This PR removes the load tests that were deleted from the circle config.