### PR TITLE
PPS master event nits

### DIFF
--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -36,15 +36,7 @@ var (
 	falseVal bool  // used to delete RCs in deletePipelineResources and restartPipeline()
 )
 
-type eventType int
-
-const (
-	writeEv eventType = iota
-	deleteEv
-)
-
 type pipelineEvent struct {
-	eventType
 	pipeline  string
 	timestamp time.Time
 }
@@ -90,11 +82,6 @@ type ppsMaster struct {
 // The master process is responsible for creating/deleting workers as
 // pipelines are created/removed.
 func (a *apiServer) master() {
-	m := &ppsMaster{
-		a:     a,
-		pcMgr: newPcManager(a.env.Config.PPSMaxConcurrentK8sRequests),
-	}
-
 	masterLock := dlock.NewDLock(a.env.EtcdClient, path.Join(a.etcdPrefix, masterLockPath))
 	backoff.RetryNotify(func() error {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -108,7 +95,11 @@ func (a *apiServer) master() {
 		defer masterLock.Unlock(ctx)
 
 		log.Infof("PPS master: launching master process")
-		m.masterCtx = ctx
+		m := &ppsMaster{
+			a:         a,
+			pcMgr:     newPcManager(a.env.Config.PPSMaxConcurrentK8sRequests),
+			masterCtx: ctx,
+		}
 		m.run()
 		return errors.Wrapf(ctx.Err(), "ppsMaster.Run() exited unexpectedly")
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {

--- a/src/server/pps/server/poller.go
+++ b/src/server/pps/server/poller.go
@@ -124,7 +124,7 @@ func (m *ppsMaster) pollPipelines(ctx context.Context) {
 						return errors.New("'pipelineName' label missing from rc " + rc.Name)
 					}
 					if !dbPipelines[pipeline] {
-						m.eventCh <- &pipelineEvent{eventType: deleteEv, pipeline: pipeline}
+						m.eventCh <- &pipelineEvent{pipeline: pipeline}
 					}
 				}
 			}
@@ -153,7 +153,7 @@ func (m *ppsMaster) pollPipelines(ctx context.Context) {
 		// generate a pipeline event for 'pipeline'
 		log.Debugf("PPS master: polling pipeline %q", pipeline)
 		select {
-		case m.eventCh <- &pipelineEvent{eventType: writeEv, pipeline: pipeline}:
+		case m.eventCh <- &pipelineEvent{pipeline: pipeline}:
 			break
 		case <-ctx.Done():
 			break
@@ -288,13 +288,11 @@ func (m *ppsMaster) watchPipelines(ctx context.Context) {
 			switch event.Type {
 			case watch.EventPut:
 				e = &pipelineEvent{
-					eventType: writeEv,
 					pipeline:  pipelineName,
 					timestamp: time.Unix(event.Rev, 0),
 				}
 			case watch.EventDelete:
 				e = &pipelineEvent{
-					eventType: deleteEv,
 					pipeline:  pipelineName,
 					timestamp: time.Unix(event.Rev, 0),
 				}


### PR DESCRIPTION
This is some logic cleanup that was missed at the end of the "parallelize pps master" work. We now decide on whether an event was a delete by querying the database at the beginning of a pipeline controller's step.