### PR TITLE
Error on writing to alias commit.

### DIFF
--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -53,6 +53,11 @@ func (d *driver) modifyFile(ctx context.Context, commit *pfs.Commit, cb func(*fi
 				return parentID, nil
 			}))
 		}
+		if commitInfo.Origin.Kind == pfs.OriginKind_ALIAS {
+			// open alias commit
+			// TODO: resolve this to the proper commit, which the user likely intended?
+			return errors.Errorf("cannot write to alias commit %s", commitInfo.Commit)
+		}
 		return d.withCommitUnorderedWriter(ctx, renewer, commitInfo.Commit, cb)
 	})
 }


### PR DESCRIPTION
Better alias UX would probably be this and finish commit resolving to
the intended commit instead, at least in the case of a branch reference.