### PR TITLE
Propagate validation errors to the meta commit.

### DIFF
--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -303,10 +303,10 @@ func (d *driver) propagateError(txnCtx *txncontext.TransactionContext, commit *p
 	if needsUpdate {
 		return d.forEachAliasDescendent(txnCtx, &commitInfo, func(aliasInfo *pfs.CommitInfo) error {
 			var toUpdate pfs.CommitInfo
-			return d.commits.ReadWrite(txnCtx.SqlTx).Update(aliasInfo.Commit, &toUpdate, func() error {
+			return errors.EnsureStack(d.commits.ReadWrite(txnCtx.SqlTx).Update(aliasInfo.Commit, &toUpdate, func() error {
 				toUpdate.Error = valError
 				return nil
-			})
+			}))
 		})
 	}
 	return nil


### PR DESCRIPTION
The job registry relies on the meta commits for information about job
status and history, including whether another job is suitable as a
"base". Jobs which encountered validation errors should not be used as a
base, but previously the associated meta commit would not reflect this,
resulting in an error loop as it tried to wait for an already-errored
output commit.