### PR TITLE
re-enable rootless ci tests (#7467)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,9 @@ workflows:
                 - LOAD5
                 - LOAD6
                 - LOAD7
+  rootless:
+    jobs:
+      - rootless
   deploy:
     jobs:
     - deploy

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ release-pachctl:
 
 docker-build:
 	docker build -f etc/test-images/Dockerfile.testuser -t pachyderm/testuser:local .
-	docker build -f etc/test-images/Dockerfile.netcat -t pachyderm/ubuntuplusnetcat:local .
+	docker build --network=host -f etc/test-images/Dockerfile.netcat -t pachyderm/ubuntuplusnetcat:local .
 	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --rm-dist -f goreleaser/docker.yml
 
 docker-build-proto:

--- a/etc/testing/circle/rootless_test.sh
+++ b/etc/testing/circle/rootless_test.sh
@@ -6,10 +6,24 @@ export PATH="${PWD}:${PWD}/cached-deps:${GOPATH}/bin:${PATH}"
 
 VERSION=v1.19.0
 
+# wait for docker or timeout
+timeout=120
+while ! docker version >/dev/null 2>&1; do
+  timeout=$((timeout - 1))
+  if [ $timeout -eq 0 ]; then
+    echo "Timed out waiting for docker daemon"
+    exit 1
+  fi
+  sleep 1
+done
+
 # start minikube with pod security admission plugin
 minikube start \
     --vm-driver=docker \
     --kubernetes-version=${VERSION} \
+    --cpus=4 \
+    --memory=12Gi \
+    --wait=all \
     --extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy \
     --addons=pod-security-policy
 

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -107,6 +107,7 @@ dockers:
       - LICENSE
       - licenses
     build_flag_templates:
+      - "--network=host"
       - "--label=version={{.Version}}"
       - "--label=release={{.Version}}"
   -
@@ -119,6 +120,7 @@ dockers:
     skip_push: false
     dockerfile: Dockerfile.pachctl
     build_flag_templates:
+      - "--network=host"
       - "--progress=plain"
       - "--label=version={{.Version}}"
       - "--label=release={{.Version}}"


### PR DESCRIPTION
* debugging rootless workflow

* trying pass host flag to docker build

* Update docker build flag for pachd

* Add --network=host to docker build pachctl

* debug pachd testing pod

* remove extra debug log pachd testing pod

* bump docker version for rootless tests

* bump docker version for rootless tests

* reverting back to 1.19.0 for docker test driver

* try bump minikube and dokcer version

* undo docker and minikube version bump

* add minikube addons default-storageclass for rootless tests

* wait for docker ready on rootless tests

* Update rootless_test.sh

* remove debug kubectl logs on rootless tests

* re-enable rootless ci tests