### PR TITLE
Record task panics as errors.

### DIFF
--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 
@@ -341,43 +342,49 @@ func (es *etcdSource) createTaskFunc(ctx context.Context, taskKey string, cb Pro
 			if task.State != State_RUNNING {
 				return nil
 			}
-			err := es.claimCol.Claim(ctx, taskKey, &Claim{}, func(ctx context.Context) (retErr error) {
-				taskOutput, taskErr := cb(ctx, task.Input)
+			err := es.claimCol.Claim(ctx, taskKey, &Claim{}, func(ctx context.Context) error {
+				var taskOutput *types.Any
+				var taskErr error
+				// run task in separate function to capture potential panic
+				func() {
+					taskOutput, taskErr = cb(ctx, task.Input)
+					defer func() {
+						if err := recover(); err != nil {
+							stackTrace := debug.Stack()
+							taskOutput = nil
+							switch v := err.(type) {
+							case runtime.Error:
+								taskErr = fmt.Errorf("%v\n%s", v, stackTrace)
+							case string:
+								taskErr = fmt.Errorf("%s\n%s", v, stackTrace)
+							default:
+								taskErr = fmt.Errorf("unknown panic: %+v\n%s", v, stackTrace)
+							}
+						}
+						debug.Stack()
+					}()
+				}()
 				// If the task context was canceled or the claim was lost, just return with no error.
 				if errors.Is(ctx.Err(), context.Canceled) {
 					return nil
 				}
-				// write task result in a defer to catch panics during tasks
-				defer func() {
-					if err := recover(); err != nil {
-						taskOutput = nil
-						switch v := err.(type) {
-						case runtime.Error:
-							taskErr = v
-						case string:
-							taskErr = fmt.Errorf(v)
-						default:
-							taskErr = fmt.Errorf("unknown panic: %+v", v)
-						}
-					}
-					task := &Task{}
-					_, retErr = col.NewSTM(ctx, es.etcdClient, func(stm col.STM) error {
-						err := es.taskCol.ReadWrite(stm).Update(taskKey, task, func() error {
-							if task.State != State_RUNNING {
-								return nil
-							}
-							task.State = State_SUCCESS
-							task.Output = taskOutput
-							if taskErr != nil {
-								task.State = State_FAILURE
-								task.Reason = taskErr.Error()
-							}
+				task := &Task{}
+				_, err := col.NewSTM(ctx, es.etcdClient, func(stm col.STM) error {
+					err := es.taskCol.ReadWrite(stm).Update(taskKey, task, func() error {
+						if task.State != State_RUNNING {
 							return nil
-						})
-						return errors.EnsureStack(err)
+						}
+						task.State = State_SUCCESS
+						task.Output = taskOutput
+						if taskErr != nil {
+							task.State = State_FAILURE
+							task.Reason = taskErr.Error()
+						}
+						return nil
 					})
-				}()
-				return
+					return errors.EnsureStack(err)
+				})
+				return err
 			})
 			return errors.EnsureStack(err)
 		}(); err != nil {


### PR DESCRIPTION
Also limit compaction retries to avoid issues with persistent failures.