### PR TITLE
fix broken helm chart icon path

### DIFF
--- a/etc/helm/pachyderm/Chart.yaml
+++ b/etc/helm/pachyderm/Chart.yaml
@@ -32,7 +32,7 @@ appVersion: 2.1.0
 
 kubeVersion: ">= 1.16.0-0"
 
-icon: https://www.pachyderm.com/favicons/favicon-32x32.png
+icon: https://www.pachyderm.com/wp-content/themes/pachyderm/dist/img/favicons/favicon-32x32.png
 
 annotations:
   artifacthub.io/prerelease: "false" # NOTE: update prior to releasing


### PR DESCRIPTION
artifacthub throwing log errors from broken icon path i.e

`error getting logo image https://www.pachyderm.com/favicons/favicon-32x32.png: image: unknown format (package: pachyderm version: 2.1.4-76b39d64c7730e`