### PR TITLE
add missing --global to git config for build bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,8 +234,8 @@ jobs:
       - run:
           name: setup pachydermbuildbot git
           command: |
-            git config user.email "buildbot@pachyderm.io"
-            git config user.name "pachydermbuildbot"      
+            git config --global user.email "buildbot@pachyderm.io"
+            git config --global user.name "pachydermbuildbot"      
       - when:
           condition:
             and:


### PR DESCRIPTION
fixes broken temp release workflow in circle `Author identity unknown` error