### PR TITLE
Add buffering to debug dump stream

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -317,9 +317,6 @@ func writeProfile(w io.Writer, profile *debug.Profile) error {
 	if p == nil {
 		return errors.Errorf("unable to find profile %q", profile.Name)
 	}
-	if profile.Name == "goroutine" {
-		return errors.EnsureStack(p.WriteTo(w, 2))
-	}
 	return errors.EnsureStack(p.WriteTo(w, 0))
 }
 


### PR DESCRIPTION
This PR adds buffering to the debug dump streaming. This should improve the reliability of the debug dump functionality in the case where workers crash or get deleted (e.g. standby / autoscaling) midstream. Also, the goroutine dump was switched to the proto format to enable the use of `go tool pprof` for exploring / visualizing the goroutine dump.