### PR TITLE
pachctl port-forward: cleanup on SIGHUP (window closed)

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -655,8 +655,9 @@ This resets the cluster to its initial state.`,
 
 			fmt.Println("CTRL-C to exit")
 			ch := make(chan os.Signal, 1)
-			signal.Notify(ch, os.Interrupt)
-			signal.Notify(ch, syscall.SIGHUP)
+			// Handle Control-C, closing the terminal window, and pkill (and friends)
+			// cleanly.
+			signal.Notify(ch, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
 			<-ch
 
 			return nil

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 	"unicode"
@@ -655,6 +656,7 @@ This resets the cluster to its initial state.`,
 			fmt.Println("CTRL-C to exit")
 			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, os.Interrupt)
+			signal.Notify(ch, syscall.SIGHUP)
 			<-ch
 
 			return nil


### PR DESCRIPTION
This will clean up port forwards as though C-c was pressed when closing the terminal window that's running pachctl port-forward.  Tested on Linux by closing the terminal that was running this; we clean up successfully and the next invocation works perfectly (no warning about not having cleaned it up).

This uses syscall which is generally [non-portable](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=670s) and should be gated by build tags, but SIGHUP is in syscall for OS X, Linux, and Windows, so I think we're OK not doing anything special here.  (In fact, I tried all GOOSes and didn't find any without SIGHUP.)