### PR TITLE
Expose configuration for compaction sharding

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -149,6 +149,14 @@ spec:
           value: {{ .Values.pachd.storage.uploadConcurrencyLimit | quote }}
         - name: STORAGE_PUT_FILE_CONCURRENCY_LIMIT
           value: {{ .Values.pachd.storage.putFileConcurrencyLimit | quote }}
+        {{- if .Values.pachd.storage.compactionShardSizeThreshold }}
+        - name: STORAGE_COMPACTION_SHARD_SIZE_THRESHOLD
+          value: {{ .Values.pachd.storage.compactionShardSizeThreshold | quote }}
+        {{- end }}
+        {{- if .Values.pachd.storage.compactionShardCountThreshold }}
+        - name: STORAGE_COMPACTION_SHARD_COUNT_THRESHOLD
+          value: {{ .Values.pachd.storage.compactionShardCountThreshold | quote }}
+        {{- end }}
         {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR
           value:  /pachd-tls-cert

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -744,6 +744,12 @@
                         "backend": {
                             "type": "string"
                         },
+                        "compactionShardCountThreshold": {
+                            "type": "integer"
+                        },
+                        "compactionShardSizeThreshold": {
+                            "type": "integer"
+                        },
                         "google": {
                             "type": "object",
                             "properties": {

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -443,6 +443,8 @@ pachd:
     # object storage uploads per Pachd instance.  It is analogous to
     # the --upload-concurrency-limit argument to pachctl deploy.
     uploadConcurrencyLimit: 100
+    compactionShardSizeThreshold: 0
+    compactionShardCountThreshold: 0
   ppsWorkerGRPCPort: 1080
   # the number of seconds between pfs's garbage collection cycles. 
   # if this value is set to 0, it will default to pachyderm's internal configuration.

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -103,17 +103,18 @@ type PachdSpecificConfiguration struct {
 
 // StorageConfiguration contains the storage configuration.
 type StorageConfiguration struct {
-	StorageMemoryThreshold         int64 `env:"STORAGE_MEMORY_THRESHOLD"`
-	StorageShardThreshold          int64 `env:"STORAGE_SHARD_THRESHOLD"`
-	StorageLevelFactor             int64 `env:"STORAGE_LEVEL_FACTOR"`
-	StorageUploadConcurrencyLimit  int   `env:"STORAGE_UPLOAD_CONCURRENCY_LIMIT,default=100"`
-	StoragePutFileConcurrencyLimit int   `env:"STORAGE_PUT_FILE_CONCURRENCY_LIMIT,default=100"`
-	StorageGCPeriod                int64 `env:"STORAGE_GC_PERIOD,default=60"`
-	StorageChunkGCPeriod           int64 `env:"STORAGE_CHUNK_GC_PERIOD,default=60"`
-	StorageCompactionMaxFanIn      int   `env:"STORAGE_COMPACTION_MAX_FANIN,default=10"`
-	StorageFileSetsMaxOpen         int   `env:"STORAGE_FILESETS_MAX_OPEN,default=50"`
-	StorageDiskCacheSize           int   `env:"STORAGE_DISK_CACHE_SIZE,default=100"`
-	StorageMemoryCacheSize         int   `env:"STORAGE_MEMORY_CACHE_SIZE,default=100"`
+	StorageMemoryThreshold               int64 `env:"STORAGE_MEMORY_THRESHOLD"`
+	StorageCompactionShardSizeThreshold  int64 `env:"STORAGE_COMPACTION_SHARD_SIZE_THRESHOLD"`
+	StorageCompactionShardCountThreshold int64 `env:"STORAGE_COMPACTION_SHARD_COUNT_THRESHOLD"`
+	StorageLevelFactor                   int64 `env:"STORAGE_LEVEL_FACTOR"`
+	StorageUploadConcurrencyLimit        int   `env:"STORAGE_UPLOAD_CONCURRENCY_LIMIT,default=100"`
+	StoragePutFileConcurrencyLimit       int   `env:"STORAGE_PUT_FILE_CONCURRENCY_LIMIT,default=100"`
+	StorageGCPeriod                      int64 `env:"STORAGE_GC_PERIOD,default=60"`
+	StorageChunkGCPeriod                 int64 `env:"STORAGE_CHUNK_GC_PERIOD,default=60"`
+	StorageCompactionMaxFanIn            int   `env:"STORAGE_COMPACTION_MAX_FANIN,default=10"`
+	StorageFileSetsMaxOpen               int   `env:"STORAGE_FILESETS_MAX_OPEN,default=50"`
+	StorageDiskCacheSize                 int   `env:"STORAGE_DISK_CACHE_SIZE,default=100"`
+	StorageMemoryCacheSize               int   `env:"STORAGE_MEMORY_CACHE_SIZE,default=100"`
 }
 
 // WorkerFullConfiguration contains the full worker configuration.

--- a/src/internal/storage/fileset/option.go
+++ b/src/internal/storage/fileset/option.go
@@ -19,11 +19,19 @@ func WithMemoryThreshold(threshold int64) StorageOption {
 	}
 }
 
-// WithShardThreshold sets the size threshold that must
+// WithShardSizeThreshold sets the size threshold that must
 // be met before a shard is created by the shard function.
-func WithShardThreshold(threshold int64) StorageOption {
+func WithShardSizeThreshold(threshold int64) StorageOption {
 	return func(s *Storage) {
 		s.shardSizeThreshold = threshold
+	}
+}
+
+// WithShardCountThreshold sets the count threshold that must
+// be met before a shard is created by the shard function.
+func WithShardCountThreshold(threshold int64) StorageOption {
+	return func(s *Storage) {
+		s.shardCountThreshold = threshold
 	}
 }
 
@@ -93,8 +101,11 @@ func StorageOptions(conf *serviceenv.StorageConfiguration) []StorageOption {
 	if conf.StorageMemoryThreshold > 0 {
 		opts = append(opts, WithMemoryThreshold(conf.StorageMemoryThreshold))
 	}
-	if conf.StorageShardThreshold > 0 {
-		opts = append(opts, WithShardThreshold(conf.StorageShardThreshold))
+	if conf.StorageCompactionShardSizeThreshold > 0 {
+		opts = append(opts, WithShardSizeThreshold(conf.StorageCompactionShardSizeThreshold))
+	}
+	if conf.StorageCompactionShardCountThreshold > 0 {
+		opts = append(opts, WithShardCountThreshold(conf.StorageCompactionShardCountThreshold))
 	}
 	if conf.StorageLevelFactor > 0 {
 		opts = append(opts, WithLevelFactor(conf.StorageLevelFactor))

--- a/src/internal/testpachd/real_env.go
+++ b/src/internal/testpachd/real_env.go
@@ -129,7 +129,6 @@ func NewRealEnv(t testing.TB, customOpts ...serviceenv.ConfigOption) *RealEnv {
 // DefaultConfigOptions is a serviceenv config option with the defaults used for tests
 func DefaultConfigOptions(config *serviceenv.Configuration) {
 	config.StorageMemoryThreshold = units.GB
-	config.StorageShardThreshold = units.GB
 	config.StorageLevelFactor = 10
 	config.StorageCompactionMaxFanIn = 10
 	config.StorageMemoryCacheSize = 20


### PR DESCRIPTION
This PR exposes configuration for the compaction sharding. The two environment variables are `STORAGE_COMPACTION_SHARD_SIZE_THRESHOLD` and `STORAGE_COMPACTION_SHARD_COUNT_THRESHOLD`. The corresponding helm configurations are `compactionShardSizeThreshold` and `compactionShardCountThreshold`. The shard size corresponds to the total size of the files in a shard and the shard count corresponds to the total number of files in a shard. If either criteria is met, a shard will be created.