### PR TITLE
WIP: Add oidc.additionalClients field

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/config-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-secret.yaml
@@ -3,9 +3,9 @@ SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
 
-{{- /* 
-if pachd.activateEnterprise is set, always run the bootstrap config. 
-On Installs, setting the pachd.enterpriseLicenseKey or pachd.activateEnterpriseMember 
+{{- /*
+if pachd.activateEnterprise is set, always run the bootstrap config.
+On Installs, setting the pachd.enterpriseLicenseKey or pachd.activateEnterpriseMember
 will also start bootstrapping.
 */ -}}
 {{ if or .Values.pachd.activateEnterprise (and .Release.IsInstall (or .Values.pachd.enterpriseLicenseKeySecretName .Values.pachd.enterpriseLicenseKey .Values.pachd.activateEnterpriseMember) ) }}
@@ -57,7 +57,7 @@ stringData:
   {{- end }}
 
   # TODO: Add config option for non embedded / multiple pachs?
-  # enterpriseClusters is the set of pachds covered by license service 
+  # enterpriseClusters is the set of pachds covered by license service
   enterpriseClusters: |
     - address: {{ .Values.pachd.enterpriseCallbackAddress }}
       id: {{ required "To register a pachd instance with an enterprise server, a unique ID must be set for this instance" .Values.pachd.oauthClientID }}
@@ -74,16 +74,16 @@ stringData:
 {{ else }}
   {{- if .Values.pachd.activateAuth }}
   # idps is the set of Identity Providers to support for logging in (dex "connectors")
-  
+
   {{- if .Values.oidc.upstreamIDPsSecretName }}
   idps: "$UPSTREAM_IDPS"
   {{- else }}
   idps: |
     {{ include "pachyderm.idps" . }}
   {{- end }}
-  
+
   {{- end }}
-  
+
   {{- if .Values.pachd.enterpriseLicenseKeySecretName }}
   license: "$ENTERPRISE_LICENSE_KEY"
   {{- else }}
@@ -111,17 +111,17 @@ stringData:
     - email
     - profile
     - groups
-    - openid 
+    - openid
 
   # identityServiceConfig configures the OIDC provider
   # id_token_expiry, and rotation_token_expiry value is parsed into golang's time.Duration: https://pkg.go.dev/time#example-ParseDuration
-  identityServiceConfig: |  
+  identityServiceConfig: |
     issuer: {{ include "pachyderm.issuerURI" . }}
     id_token_expiry: {{ .Values.oidc.IDTokenExpiry }}
     rotation_token_expiry: {{ .Values.oidc.RotationTokenExpiry }}
 
   # oidcClients is the set of OIDC clients registered with the OIDC provider
-  # the config-pod (job that sets up pachyderm using this data) resolves oidcClient 
+  # the config-pod (job that sets up pachyderm using this data) resolves oidcClient
   # values that are environment variables.
   oidcClients: |
     - id: {{ .Values.pachd.oauthClientID }}
@@ -132,6 +132,9 @@ stringData:
       {{- if .Values.console.enabled}}
       trusted_peers:
       - {{ .Values.console.config.oauthClientID | quote }}
+      {{- range .Values.oidc.additionalClients }}
+      - {{ .id | quote }}
+      {{- end }}
       {{- end }}
     {{- if .Values.console.enabled }}
     - id: {{ .Values.console.config.oauthClientID }}
@@ -139,6 +142,15 @@ stringData:
       secret: $CONSOLE_OAUTH_CLIENT_SECRET
       redirect_uris:
       - {{ include "pachyderm.consoleRedirectURI" . | quote }}
+    {{- end }}
+    {{- range .Values.oidc.additionalClients }}
+    - id: {{ .id }}
+      name: {{ .name }}
+      secret: {{ .secret }}
+      redirect_uris:
+      {{- range .redirect_uris }}
+      - {{ . }}
+      {{- end }}
     {{- end }}
 
   # rootToken is the auth token used to communicate with the cluster as the root user

--- a/etc/helm/test/config_secret_test.go
+++ b/etc/helm/test/config_secret_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package helmtest
+
+import (
+	"fmt"
+	"testing"
+
+	helm "github.com/gruntwork-io/terratest/modules/helm"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	ChartDir           = "../pachyderm"
+	ReleaseName        = "config-secret"
+	TemplatePath       = "templates/pachd/config-secret.yaml"
+	ExpectedSecretName = "pachyderm-bootstrap-config"
+	ExpectedLicense    = "$ENTERPRISE_LICENSE_KEY"
+)
+
+type Expectation func(*testing.T, *v1.Secret)
+
+func RenderSecret(
+	t *testing.T,
+	setValuesOverride map[string]string,
+	extraHelmArgs []string,
+) *v1.Secret {
+	options := helm.Options{
+		SetValues: map[string]string{
+			"deployTarget":                         "LOCAL",
+			"pachd.activateEnterprise":             "true",
+			"pachd.enterpriseLicenseKeySecretName": "shh",
+		},
+	}
+
+	for k, v := range setValuesOverride {
+		options.SetValues[k] = v
+	}
+
+	output, err := helm.RenderTemplateE(
+		t,
+		&options,
+		ChartDir,
+		ReleaseName,
+		[]string{TemplatePath},
+		extraHelmArgs...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var secret *v1.Secret
+	helm.UnmarshalK8SYaml(t, output, &secret)
+	return secret
+}
+
+func CheckCommon(t *testing.T, secret *v1.Secret) {
+	if ExpectedSecretName != secret.Name {
+		t.Errorf("Unexpected secret name '%s'", secret.Name)
+	}
+	if ExpectedLicense != secret.StringData["license"] {
+		t.Errorf("Unexpected secret name '%s'", secret.Name)
+	}
+}
+
+func TestConfigSecretNamespace(t *testing.T) {
+	setValuesOverride := map[string]string{}
+	expectedNamespace := "foo-namespace"
+	extraHelmArgs := []string{
+		fmt.Sprintf("--namespace=%s", expectedNamespace),
+	}
+
+	secret := RenderSecret(t, setValuesOverride, extraHelmArgs)
+	CheckCommon(t, secret)
+
+	if expectedNamespace != secret.Namespace {
+		t.Errorf("Unexpected namespace '%s'", secret.Namespace)
+	}
+}
+
+type TestCase struct {
+	setValuesOverride map[string]string
+	extraHelmArgs     []string
+	expectations      []Expectation
+}
+
+func TestConfigSecretEnterpriseSecret(t *testing.T) {
+	testCases := []TestCase{
+		{
+			map[string]string{
+				"pachd.enterpriseSecretSecretName": "shhhhh!",
+			},
+			[]string{},
+			[]Expectation{
+				func(t *testing.T, secret *v1.Secret) {
+					expectedEnterpriseSecret := "$ENTERPRISE_SECRET"
+					enterpriseSecret := secret.StringData["enterpriseSecret"]
+					if expectedEnterpriseSecret != enterpriseSecret {
+						t.Errorf("Unexpected enterpriseSecret '%s'", enterpriseSecret)
+					}
+				},
+			},
+		},
+		{
+			map[string]string{
+				"pachd.enterpriseSecretSecretName": "shhhhh!",
+			},
+			[]string{},
+			[]Expectation{
+				func(t *testing.T, secret *v1.Secret) {
+					expectedEnterpriseSecret := "$ENTERPRISE_SECRET"
+					enterpriseSecret := secret.StringData["enterpriseSecret"]
+					if expectedEnterpriseSecret != enterpriseSecret {
+						t.Errorf("Unexpected enterpriseSecret '%s'", enterpriseSecret)
+					}
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		secret := RenderSecret(t, testCase.setValuesOverride, testCase.extraHelmArgs)
+		CheckCommon(t, secret)
+		for _, expectation := range testCase.expectations {
+			expectation(t, secret)
+		}
+	}
+}
+
+// rootTokenLength := len(secret.StringData["rootToken"])
+// if rootTokenLength != 32 {
+// 	t.Errorf("Unexpected root token length '%d'", rootTokenLength)
+// }


### PR DESCRIPTION
### Purpose
This PR enables users to specify additional clients for the dex OIDC provider.

### Motivation
This feature satisfies a specific requirement for JupyterHub users, which is to allow users to reuse the ID token returned by JupyterHub's authenticator to retrieve a session token for `pachctl auth login -t`. However, this feature may be useful for other services that would like to authenticate against the dex provider and reuse the ID token.

### Details
JupyterHub allows one to specify an `auth_state_hook` that grabs authentication information (including an ID token) returned by an OIDC provider (dex, in this case):
```python
 async def auth_state_hook(self, auth_state):
     if auth_state is not None:
         self.env["OIDC_ID_TOKEN"] = auth_state["access_token"] # dex stores the ID token as an "access_token"
 c.KubeSpawner.auth_state_hook = auth_state_hook
```
When a Jupyter notebook server starts, the OIDC_ID_TOKEN will be available in the user's environment, allowing one to run the following command automatically as part of a startup script:
```bash
echo ${OIDC_ID_TOKEN} | pachctl auth login --id-token
```
Now, when a user logs into JupyterHub and starts a notebook server, the user will already have a `pachctl` session token created for them. 

Note: it is not possible for JupyterHub to use the same upstream provider as dex. The reason is because `pachctl` expects the ID token to be issued by dex. Using the upstream provider directly will result in an ID token with a different issuer.

### Example
Here's what a user might add to their values.yaml for Pachyderm's helm chart:
```yaml
oidc:
  additionalClients:
    - id: jupyter-hub
      name: jupyter-hub
      secret: {user's-secret} # this secret is then used in the JupyterHub authenticator
      redirect_uris:
        - https://{jupyter-hub-domain}/hub/oauth_callback
```

### TODO

- [ ] Determine if user should be allowed to specify whether an additional client is also a trusted peer of the pachd client
- [ ] Update schema
- [ ] Finish unit tests
