### PR TITLE
Batch copy operations in unordered writer. (#7436)

### DIFF
--- a/src/internal/storage/fileset/buffer.go
+++ b/src/internal/storage/fileset/buffer.go
@@ -8,14 +8,22 @@ import (
 )
 
 type Buffer struct {
-	additive map[string]map[string]*file
-	deletive map[string]map[string]*file
+	additive  map[string]map[string]*file
+	deletive  map[string]map[string]*file
+	fileCount int // the number of files stored in the additive and deletive maps
 }
 
 type file struct {
-	path  string
-	datum string
-	buf   *bytes.Buffer
+	path     string
+	datum    string
+	contents []fileContent
+}
+
+// contents are either raw bytes to be appended or an existing file to be copied
+// Exactly one will be non-nil
+type fileContent struct {
+	buf  *bytes.Buffer
+	copy File
 }
 
 func NewBuffer() *Buffer {
@@ -25,7 +33,7 @@ func NewBuffer() *Buffer {
 	}
 }
 
-func (b *Buffer) Add(path, datum string) io.Writer {
+func (b *Buffer) add(path, datum string) *file {
 	path = Clean(path, false)
 	if _, ok := b.additive[path]; !ok {
 		b.additive[path] = make(map[string]*file)
@@ -35,11 +43,20 @@ func (b *Buffer) Add(path, datum string) io.Writer {
 		datumFiles[datum] = &file{
 			path:  path,
 			datum: datum,
-			buf:   &bytes.Buffer{},
 		}
+		b.fileCount++
 	}
-	f := datumFiles[datum]
-	return f.buf
+	return datumFiles[datum]
+}
+
+func (b *Buffer) Add(path, datum string) io.Writer {
+	f := b.add(path, datum)
+	if len(f.contents) > 0 && f.contents[len(f.contents)-1].copy == nil {
+		return f.contents[len(f.contents)-1].buf
+	}
+	buf := &bytes.Buffer{}
+	f.contents = append(f.contents, fileContent{buf: buf})
+	return buf
 }
 
 func (b *Buffer) Delete(path, datum string) {
@@ -47,15 +64,17 @@ func (b *Buffer) Delete(path, datum string) {
 	if IsDir(path) {
 		// TODO: Linear scan for directory delete is less than ideal.
 		// Fine for now since this should be rare and is an in-memory operation.
-		for file := range b.additive {
+		for file, datumFiles := range b.additive {
 			if strings.HasPrefix(file, path) {
 				delete(b.additive, file)
+				b.fileCount -= len(datumFiles)
 			}
 		}
 		return
 	}
-	if datumFiles, ok := b.additive[path]; ok {
-		delete(datumFiles, datum)
+	if _, ok := b.additive[path][datum]; ok {
+		delete(b.additive[path], datum)
+		b.fileCount--
 	}
 	if _, ok := b.deletive[path]; !ok {
 		b.deletive[path] = make(map[string]*file)
@@ -65,12 +84,24 @@ func (b *Buffer) Delete(path, datum string) {
 		path:  path,
 		datum: datum,
 	}
+	b.fileCount++
 }
 
-func (b *Buffer) WalkAdditive(cb func(path, datum string, r io.Reader) error) error {
+func (b *Buffer) Copy(file File, datum string) {
+	f := b.add(file.Index().Path, datum)
+	f.contents = append(f.contents, fileContent{copy: file})
+}
+
+func (b *Buffer) WalkAdditive(onAdd func(path, datum string, r io.Reader) error, onCopy func(file File, datum string) error) error {
 	for _, file := range sortFiles(b.additive) {
-		if err := cb(file.path, file.datum, bytes.NewReader(file.buf.Bytes())); err != nil {
-			return err
+		for _, content := range file.contents {
+			if content.copy != nil {
+				if err := onCopy(content.copy, file.datum); err != nil {
+					return err
+				}
+			} else if err := onAdd(file.path, file.datum, bytes.NewReader(content.buf.Bytes())); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -103,4 +134,9 @@ func (b *Buffer) WalkDeletive(cb func(path, datum string) error) error {
 
 func (b *Buffer) Empty() bool {
 	return len(b.additive) == 0 && len(b.deletive) == 0
+}
+
+// Count gives the number of paths tracked in the buffer, meant as a proxy for metadata memory usage
+func (b *Buffer) Count() int {
+	return b.fileCount
 }

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -94,7 +94,7 @@ func (s *Storage) ChunkStorage() *chunk.Storage {
 
 // NewUnorderedWriter creates a new unordered file set writer.
 func (s *Storage) NewUnorderedWriter(ctx context.Context, opts ...UnorderedWriterOption) (*UnorderedWriter, error) {
-	return newUnorderedWriter(ctx, s, s.memThreshold, opts...)
+	return newUnorderedWriter(ctx, s, s.memThreshold, s.shardCountThreshold/2, opts...)
 }
 
 // NewWriter creates a new file set writer.


### PR DESCRIPTION
Previously, copy operations during a modify file stream forced a new
underlying file set to be created, which made operations with many
separate copies (e.g. shuffle pipelines) unnecessarily slow. The
unordered writer only really needs to serialize its pending writes when
it hits the memory limit, and copies have the advantage that they can be
recorded without eating into that budget.

This change records per-file copy operations in the unordered writer, 
deferring the actual data reference writes to serialization time. It also 
sets a file count threshold for serialization, enforcing a lower bound on 
the size of file sets produced from copies.