### PR TITLE
Check for validation errors when choosing a job's base commit. (#7519)

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10086,3 +10086,43 @@ func TestTemporaryDuplicatedPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", commitInfo.Error)
 }
+
+func TestValidationFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t)
+
+	repo := tu.UniqueString(t.Name())
+	pipeline := tu.UniqueString("pipeline-" + t.Name())
+
+	require.NoError(t, c.CreateRepo(repo))
+
+	require.NoError(t, c.PutFile(client.NewCommit(repo, "master", ""), "foo", strings.NewReader("baz")))
+	require.NoError(t, c.PutFile(client.NewCommit(repo, "master", ""), "bar", strings.NewReader("baz")))
+
+	req := basicPipelineReq(pipeline, repo)
+	req.Transform.Stdin = []string{
+		fmt.Sprintf("cat /pfs/%s/* > /pfs/out/overlap", repo), // write datums to the same path
+	}
+	_, err := c.PpsAPIClient.CreatePipeline(c.Ctx(), req)
+	require.NoError(t, err)
+
+	commitInfo, err := c.WaitCommit(pipeline, "master", "")
+	require.NoError(t, err)
+	require.NotEqual(t, "", commitInfo.Error)
+
+	// update the pipeline to fix things
+	req.Update = true
+	req.Transform.Stdin = []string{
+		fmt.Sprintf("cp /pfs/%s/* /pfs/out", repo),
+	}
+
+	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), req)
+	require.NoError(t, err)
+
+	commitInfo, err = c.WaitCommit(pipeline, "master", "")
+	require.NoError(t, err)
+	require.Equal(t, "", commitInfo.Error)
+}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10091,8 +10091,8 @@ func TestValidationFailure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c := tu.GetPachClient(t)
+	require.NoError(t, c.DeleteAll())
 
 	repo := tu.UniqueString(t.Name())
 	pipeline := tu.UniqueString("pipeline-" + t.Name())


### PR DESCRIPTION
Previously the base meta commit for a job was the most recent non-errored ancestor. As validation errors only show up in the output commit, we could end up picking a base commit that the job code would later reject, leading to an infinite loop. We might later want to enforce that output and meta commits have the same error status once finished, but this change will avoid the loop regardless.