### PR TITLE
Initial script for pushing redhat marketplace images (#7420)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,19 @@ jobs:
       - checkout
       - run: sudo npm install -g prettier
       - run: prettier -c etc/helm/pachyderm/values.yaml .circleci/config.yml
+  push_redhat:
+    docker:
+      - image: cimg/go:1.17.3
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.12"
+      - run:
+          name: Install Goreleaser
+          command: |
+            curl -Lo - https://github.com/goreleaser/goreleaser/releases/download/v1.4.1/goreleaser_Linux_x86_64.tar.gz | sudo tar -C /usr/local/bin -xvzf - goreleaser
+      - run: etc/redhat/push_images.sh
 workflows:
   circleci:
     when:
@@ -332,6 +345,11 @@ workflows:
     when: << pipeline.parameters.RELEASE_PACH_CORE >>
     jobs:
       - release_job:
+          filters:
+            branches:
+              only:
+                - 2.1.x
+      - push_redhat:
           filters:
             branches:
               only:

--- a/etc/redhat/README.md
+++ b/etc/redhat/README.md
@@ -1,0 +1,19 @@
+Pachyderm has partnered with Red Hat and put an [offering in the Red Hat
+Marketplace](https://marketplace.redhat.com/en-us/products/pachyderm). That
+offering is similar to Pachyderm's usual release images (including Console's
+release image) but has a few differences, required by Red Hat for our inclusion
+in their marketplace:
+
+- The image is based on Red Hat's Universal Base Image, rather than scratch or
+  Node or any standard, non-Red Hat images
+- Extra labels have been added to the image indicating that they're maintained
+  by Pachyderm
+- A licenses/ directory is built into the image, containing the licenses of any
+  open-source dependencies
+- For the Red Hat-specific Console image, extra security checks are run
+
+This project was done in partnership with Red Hat, who has done most of the
+work of integrating Pachyderm into their data science offerings. If this image
+causes the Console build/release process to fail, contact the Integrations team
+(who built Pachyderm's part of this) or disable/remove the release workflow for
+this image in CircleCI (this image is released on a Best Effort basis)

--- a/etc/redhat/push_images.sh
+++ b/etc/redhat/push_images.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# This builds a version of the pachd and worker images based on Red Hat's UBI,
+# rather than on 'scratch'.
+
+set -ex
+
+# Validate env vars
+if [[ -z "${CIRCLE_TAG}" ]]; then
+  echo "Must set CIRCLE_TAG to release tag (e.g. '2.1.20')" >/dev/stderr
+  exit 1
+fi
+for img in pachd worker; do
+  echo "checking REDHAT_MARKETPLACE_${img^^}_OSPID REDHAT_MARKETPLACE_${img^^}_PASSWORD"
+  ospid=$(eval "echo \${REDHAT_MARKETPLACE_${img^^}_OSPID}")
+  password=$(eval "echo \${REDHAT_MARKETPLACE_${img^^}_PASSWORD}")
+  if [[ -z "${ospid}" ]]; then
+    echo "Must set REDHAT_MARKETPLACE_${img^^}_OSPID" >/dev/stderr
+    exit 1
+  elif [[ "${ospid}" != ospid-* ]]; then
+    echo "Must set REDHAT_MARKETPLACE_${img^^}_OSPID to ospid-* (with prefix)" >/dev/stderr
+    exit 1
+  elif [[ -z "${password}" ]]; then
+    echo "Must set REDHAT_MARKETPLACE_${img^^}_PASSWORD" >/dev/stderr
+    exit 1
+  fi
+done
+
+# Generate Dockerfiles based on RedHat's UBI instead of scratch.
+#
+# This is effectively required for our RedHat Marketplace offering (as
+# implemented by our OpenShift operator in
+# github.com/pachyderm/openshift-operator. Users are given an interface that
+# allows them to run a shell in their pachd/worker containers, and RedHat's
+# Universal Base Image provides a shell they can run while conforming to the
+# the RedHat Marketplace image approval rules)
+for img in pachd worker; do
+  sed \
+    's#FROM scratch#FROM registry.access.redhat.com/ubi8/ubi-minimal#g' \
+    "Dockerfile.${img}" \
+    >"Dockerfile.redhat.${img}"
+done
+
+# Build images from the modified Dockerfiles
+make docker-build
+
+# Push the image to our Red Hat Technology Portal project
+for img in pachd worker; do
+  ospid=$(eval "echo \${REDHAT_MARKETPLACE_${img^^}_OSPID}")
+  password=$(eval "echo \${REDHAT_MARKETPLACE_${img^^}_PASSWORD}")
+  docker login -u unused scan.connect.redhat.com --password-stdin <<<"${password}"
+  docker tag "pachyderm/${img}:local" "scan.connect.redhat.com/${ospid}/${img}:${CIRCLE_TAG}"
+  docker push "scan.connect.redhat.com/${ospid}/${img}:${CIRCLE_TAG}"
+done


### PR DESCRIPTION
Release job def for the image based on Red Hat's Universal Base Image, rather than scratch or Node or any standard, non-Red Hat images