### PR TITLE
Implement compaction cache

### DIFF
--- a/src/internal/storage/fileset/postgres_cache.go
+++ b/src/internal/storage/fileset/postgres_cache.go
@@ -65,6 +65,9 @@ func (c *Cache) Put(ctx context.Context, key string, value *types.Any, ids []ID,
 }
 
 func (c *Cache) put(tx *pachsql.Tx, key string, value []byte, ids []ID, tag string) error {
+	if ids == nil {
+		ids = []ID{}
+	}
 	_, err := tx.Exec(`
 		INSERT INTO storage.cache (key, value_pb, ids, tag)
 		VALUES ($1, $2, $3, $4)

--- a/src/server/pfs/server/compaction_cache.go
+++ b/src/server/pfs/server/compaction_cache.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"github.com/gogo/protobuf/types"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"golang.org/x/net/context"
+)
+
+type cache struct {
+	driver *driver
+	tag    string
+}
+
+func (d *driver) newCache(tag string) *cache {
+	return &cache{
+		driver: d,
+		tag:    tag,
+	}
+}
+
+func (c *cache) Get(ctx context.Context, key string) (*types.Any, error) {
+	output, err := c.driver.getCache(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (c *cache) Put(ctx context.Context, key string, output *types.Any) error {
+	var fileSetIds []string
+	switch {
+	case types.Is(output, &ShardTaskResult{}):
+	case types.Is(output, &CompactTaskResult{}):
+		ct, err := deserializeCompactTaskResult(output)
+		if err != nil {
+			return err
+		}
+		fileSetIds = append(fileSetIds, ct.Id)
+	case types.Is(output, &ConcatTaskResult{}):
+		ct, err := deserializeConcatTaskResult(output)
+		if err != nil {
+			return err
+		}
+		fileSetIds = append(fileSetIds, ct.Id)
+	case types.Is(output, &ValidateTaskResult{}):
+	default:
+		return errors.Errorf("unrecognized any type (%v) in compaction cache", output.TypeUrl)
+	}
+	var fsids []fileset.ID
+	for _, id := range fileSetIds {
+		fsid, err := fileset.ParseID(id)
+		if err != nil {
+			return err
+		}
+		fsids = append(fsids, *fsid)
+	}
+	return c.driver.putCache(ctx, key, output, fsids, c.tag)
+}
+
+func (c *cache) clear(ctx context.Context) error {
+	return c.driver.clearCache(ctx, c.tag)
+}

--- a/src/server/pfs/server/pfsserver.pb.go
+++ b/src/server/pfs/server/pfsserver.pb.go
@@ -383,6 +383,108 @@ func (m *ConcatTaskResult) GetId() string {
 	return ""
 }
 
+type ValidateTask struct {
+	Id                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ValidateTask) Reset()         { *m = ValidateTask{} }
+func (m *ValidateTask) String() string { return proto.CompactTextString(m) }
+func (*ValidateTask) ProtoMessage()    {}
+func (*ValidateTask) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5a92e512e703e9c, []int{7}
+}
+func (m *ValidateTask) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ValidateTask) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ValidateTask.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ValidateTask) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateTask.Merge(m, src)
+}
+func (m *ValidateTask) XXX_Size() int {
+	return m.Size()
+}
+func (m *ValidateTask) XXX_DiscardUnknown() {
+	xxx_messageInfo_ValidateTask.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ValidateTask proto.InternalMessageInfo
+
+func (m *ValidateTask) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+type ValidateTaskResult struct {
+	SizeBytes            int64    `protobuf:"varint,1,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Error                string   `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ValidateTaskResult) Reset()         { *m = ValidateTaskResult{} }
+func (m *ValidateTaskResult) String() string { return proto.CompactTextString(m) }
+func (*ValidateTaskResult) ProtoMessage()    {}
+func (*ValidateTaskResult) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5a92e512e703e9c, []int{8}
+}
+func (m *ValidateTaskResult) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ValidateTaskResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ValidateTaskResult.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ValidateTaskResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidateTaskResult.Merge(m, src)
+}
+func (m *ValidateTaskResult) XXX_Size() int {
+	return m.Size()
+}
+func (m *ValidateTaskResult) XXX_DiscardUnknown() {
+	xxx_messageInfo_ValidateTaskResult.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ValidateTaskResult proto.InternalMessageInfo
+
+func (m *ValidateTaskResult) GetSizeBytes() int64 {
+	if m != nil {
+		return m.SizeBytes
+	}
+	return 0
+}
+
+func (m *ValidateTaskResult) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*ShardTask)(nil), "pfsserver.ShardTask")
 	proto.RegisterType((*ShardTaskResult)(nil), "pfsserver.ShardTaskResult")
@@ -391,33 +493,38 @@ func init() {
 	proto.RegisterType((*CompactTaskResult)(nil), "pfsserver.CompactTaskResult")
 	proto.RegisterType((*ConcatTask)(nil), "pfsserver.ConcatTask")
 	proto.RegisterType((*ConcatTaskResult)(nil), "pfsserver.ConcatTaskResult")
+	proto.RegisterType((*ValidateTask)(nil), "pfsserver.ValidateTask")
+	proto.RegisterType((*ValidateTaskResult)(nil), "pfsserver.ValidateTaskResult")
 }
 
 func init() { proto.RegisterFile("server/pfs/server/pfsserver.proto", fileDescriptor_a5a92e512e703e9c) }
 
 var fileDescriptor_a5a92e512e703e9c = []byte{
-	// 322 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x52, 0xbd, 0x6e, 0xf2, 0x30,
-	0x14, 0x95, 0xe1, 0xfb, 0x90, 0x7c, 0xd3, 0x5f, 0x0b, 0xa1, 0x4c, 0x94, 0x9a, 0x0e, 0x4c, 0x44,
-	0x82, 0xa1, 0x43, 0xb7, 0xd2, 0xae, 0x55, 0x95, 0x76, 0x62, 0x41, 0xc6, 0x71, 0x49, 0xc4, 0x8f,
-	0x2d, 0xdb, 0xa1, 0xe2, 0x0d, 0x3b, 0xf6, 0x11, 0x2a, 0x9e, 0xa4, 0x8a, 0x4d, 0x93, 0x48, 0xfd,
-	0xd9, 0xce, 0x39, 0xf7, 0x38, 0xf7, 0x9c, 0xe8, 0xc2, 0xa5, 0x11, 0x7a, 0x2b, 0x74, 0xa4, 0x5e,
-	0x4c, 0x54, 0x41, 0x8f, 0x86, 0x4a, 0x4b, 0x2b, 0x09, 0x2e, 0x05, 0xda, 0x07, 0xfc, 0x94, 0x32,
-	0x9d, 0x3c, 0x33, 0xb3, 0x24, 0x1d, 0x68, 0x65, 0x1b, 0x95, 0x5b, 0x13, 0xa2, 0x5e, 0x73, 0x80,
-	0xe3, 0x03, 0xa3, 0x0f, 0x70, 0x5a, 0x9a, 0x62, 0x61, 0xf2, 0x95, 0x25, 0x37, 0x70, 0xcc, 0xe5,
-	0x5a, 0x31, 0x6e, 0x67, 0x96, 0x99, 0xa5, 0x7f, 0x11, 0x8c, 0x3a, 0xc3, 0x6a, 0xd7, 0xc4, 0xcf,
-	0xdd, 0xa3, 0x23, 0x5e, 0x11, 0x43, 0x77, 0x80, 0x1f, 0x99, 0x4d, 0x63, 0xb6, 0x59, 0x08, 0xd2,
-	0x86, 0xff, 0x2b, 0xf9, 0x2a, 0x74, 0x88, 0x7a, 0x68, 0x80, 0x63, 0x4f, 0x0a, 0x35, 0x57, 0x4a,
-	0xe8, 0xb0, 0xe1, 0x55, 0x47, 0xc8, 0x05, 0x04, 0x6e, 0x3c, 0x4b, 0x98, 0xcd, 0xd7, 0x61, 0xd3,
-	0xcd, 0xc0, 0x49, 0x77, 0x85, 0x52, 0x18, 0x9c, 0xf3, 0x60, 0xf8, 0xe7, 0x0d, 0x4e, 0x72, 0x06,
-	0x3a, 0x85, 0xa0, 0x96, 0xeb, 0xb7, 0xc6, 0x64, 0x0c, 0xa0, 0x98, 0x4d, 0x67, 0xba, 0x88, 0xe8,
-	0x32, 0x04, 0xa3, 0x76, 0xad, 0x5b, 0x19, 0x3f, 0xc6, 0xea, 0x0b, 0xd2, 0x3e, 0x9c, 0xd7, 0x3b,
-	0xfb, 0x1f, 0x75, 0x02, 0x8d, 0x2c, 0x39, 0x74, 0x6b, 0x64, 0x09, 0xbd, 0x02, 0x98, 0xc8, 0x0d,
-	0x67, 0x7f, 0xee, 0xa7, 0x14, 0xce, 0x2a, 0xd7, 0xcf, 0x5f, 0xba, 0xbd, 0x7f, 0xdb, 0x77, 0xd1,
-	0xfb, 0xbe, 0x8b, 0x3e, 0xf6, 0x5d, 0x34, 0xbd, 0x5e, 0x64, 0x36, 0xcd, 0xe7, 0x43, 0x2e, 0xd7,
-	0x91, 0x62, 0x3c, 0xdd, 0x25, 0x42, 0xd7, 0xd1, 0x76, 0x14, 0x19, 0xcd, 0xa3, 0x6f, 0xc7, 0x31,
-	0x6f, 0xb9, 0x9b, 0x18, 0x7f, 0x06, 0x00, 0x00, 0xff, 0xff, 0x39, 0x7e, 0x91, 0xa8, 0x38, 0x02,
-	0x00, 0x00,
+	// 369 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x52, 0xbd, 0x4e, 0xeb, 0x30,
+	0x14, 0x56, 0xda, 0x7b, 0x2b, 0xe5, 0xa4, 0xf7, 0x02, 0x51, 0x55, 0x65, 0x21, 0x14, 0x97, 0xa1,
+	0x53, 0x23, 0xb5, 0x03, 0x03, 0x5b, 0x0b, 0x03, 0x0b, 0x42, 0x01, 0x31, 0x74, 0x89, 0xdc, 0xc4,
+	0x34, 0x51, 0x7f, 0x6c, 0xd9, 0x4e, 0x51, 0x79, 0x42, 0x46, 0x1e, 0x01, 0xf5, 0x49, 0x90, 0xed,
+	0x90, 0x44, 0xa0, 0xb2, 0x9d, 0xef, 0xc7, 0xc7, 0xe7, 0x3b, 0x3a, 0x70, 0x2e, 0x08, 0xdf, 0x12,
+	0x1e, 0xb0, 0x67, 0x11, 0x54, 0xa5, 0xa9, 0x86, 0x8c, 0x53, 0x49, 0x5d, 0xbb, 0x24, 0x50, 0x1f,
+	0xec, 0x87, 0x14, 0xf3, 0xe4, 0x11, 0x8b, 0xa5, 0xdb, 0x85, 0x56, 0xb6, 0x61, 0xb9, 0x14, 0x9e,
+	0xd5, 0x6b, 0x0e, 0xec, 0xb0, 0x40, 0xe8, 0x0e, 0x8e, 0x4a, 0x53, 0x48, 0x44, 0xbe, 0x92, 0xee,
+	0x15, 0xfc, 0x8b, 0xe9, 0x9a, 0xe1, 0x58, 0x46, 0x12, 0x8b, 0xa5, 0x79, 0xe1, 0x8c, 0xba, 0xc3,
+	0xea, 0xaf, 0xa9, 0xd1, 0xf5, 0xa3, 0x76, 0x5c, 0x01, 0x81, 0x76, 0x60, 0xdf, 0x63, 0x99, 0x86,
+	0x78, 0xb3, 0x20, 0x6e, 0x07, 0xfe, 0xae, 0xe8, 0x0b, 0xe1, 0x9e, 0xd5, 0xb3, 0x06, 0x76, 0x68,
+	0x80, 0x62, 0x73, 0xc6, 0x08, 0xf7, 0x1a, 0x86, 0xd5, 0xc0, 0x3d, 0x03, 0x47, 0xcb, 0x51, 0x82,
+	0x65, 0xbe, 0xf6, 0x9a, 0x5a, 0x03, 0x4d, 0x5d, 0x2b, 0x46, 0x19, 0xb4, 0xb3, 0x30, 0xfc, 0x31,
+	0x06, 0x4d, 0x69, 0x03, 0x9a, 0x81, 0x53, 0x9b, 0xeb, 0x50, 0x62, 0x77, 0x0c, 0xc0, 0xb0, 0x4c,
+	0x23, 0xae, 0x46, 0xd4, 0x33, 0x38, 0xa3, 0x4e, 0x2d, 0x5b, 0x39, 0x7e, 0x68, 0xb3, 0xaf, 0x12,
+	0xf5, 0xe1, 0xa4, 0x9e, 0xd9, 0x2c, 0xea, 0x3f, 0x34, 0xb2, 0xa4, 0xc8, 0xd6, 0xc8, 0x12, 0x74,
+	0x01, 0x30, 0xa5, 0x9b, 0x18, 0xff, 0xfa, 0x3f, 0x42, 0x70, 0x5c, 0xb9, 0x0e, 0x74, 0xf2, 0xa1,
+	0xfd, 0x84, 0x57, 0x59, 0x82, 0x25, 0xd1, 0xbd, 0xbe, 0xeb, 0xb7, 0xe0, 0xd6, 0xf5, 0xa2, 0xcb,
+	0x29, 0x80, 0xc8, 0x5e, 0x49, 0x34, 0xdf, 0x49, 0x22, 0xb4, 0xbb, 0x19, 0xda, 0x8a, 0x99, 0x28,
+	0x42, 0xed, 0x9d, 0x70, 0x4e, 0xcb, 0xbd, 0x6b, 0x30, 0xb9, 0x79, 0xdb, 0xfb, 0xd6, 0xfb, 0xde,
+	0xb7, 0x3e, 0xf6, 0xbe, 0x35, 0xbb, 0x5c, 0x64, 0x32, 0xcd, 0xe7, 0xc3, 0x98, 0xae, 0x03, 0x86,
+	0xe3, 0x74, 0x97, 0x10, 0x5e, 0xaf, 0xb6, 0xa3, 0x40, 0xf0, 0x38, 0xf8, 0x71, 0x87, 0xf3, 0x96,
+	0x3e, 0xbf, 0xf1, 0x67, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7c, 0x74, 0x04, 0x8f, 0xa3, 0x02, 0x00,
+	0x00,
 }
 
 func (m *ShardTask) Marshal() (dAtA []byte, err error) {
@@ -704,6 +811,79 @@ func (m *ConcatTaskResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ValidateTask) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ValidateTask) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ValidateTask) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ValidateTaskResult) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ValidateTaskResult) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ValidateTaskResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Error) > 0 {
+		i -= len(m.Error)
+		copy(dAtA[i:], m.Error)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.Error)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.SizeBytes != 0 {
+		i = encodeVarintPfsserver(dAtA, i, uint64(m.SizeBytes))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintPfsserver(dAtA []byte, offset int, v uint64) int {
 	offset -= sovPfsserver(v)
 	base := offset
@@ -842,6 +1022,41 @@ func (m *ConcatTaskResult) Size() (n int) {
 	var l int
 	_ = l
 	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ValidateTask) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ValidateTaskResult) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SizeBytes != 0 {
+		n += 1 + sovPfsserver(uint64(m.SizeBytes))
+	}
+	l = len(m.Error)
 	if l > 0 {
 		n += 1 + l + sovPfsserver(uint64(l))
 	}
@@ -1549,6 +1764,191 @@ func (m *ConcatTaskResult) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPfsserver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ValidateTask) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPfsserver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ValidateTask: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ValidateTask: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPfsserver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ValidateTaskResult) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPfsserver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ValidateTaskResult: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ValidateTaskResult: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SizeBytes", wireType)
+			}
+			m.SizeBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SizeBytes |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Error", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Error = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/src/server/pfs/server/pfsserver.proto
+++ b/src/server/pfs/server/pfsserver.proto
@@ -34,3 +34,12 @@ message ConcatTask {
 message ConcatTaskResult {
   string id = 1;
 }
+
+message ValidateTask {
+  string id = 1;
+}
+
+message ValidateTaskResult {
+  int64 size_bytes = 1;
+  string error = 2;
+}


### PR DESCRIPTION
This PR implements caching for compaction tasks (similar to the caching model we use for job processing tasks). Also, the validation step when finishing a commit has been converted to a task that runs through the task service. This will take more load off of the PFS master and make the validation step eligible for caching.