### PR TITLE
Make postgres watches respect contexts.

### DIFF
--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -566,14 +566,15 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 		})
 	}); err != nil && !errors.Is(err, errutil.ErrBreak) {
 		// Ignore any additional error here - we're already attempting to send an error to the user
-		watcher.sendInitial(c.ctx, &watch.Event{Type: watch.EventError, Err: err})
+		// and use a background context in case we failed with context cancelled
+		watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err})
 		watcher.listener.Unregister(watcher)
 		return
 	}
 
 	if bufEvent != nil {
 		if err := watcher.sendInitial(c.ctx, bufEvent.WatchEvent(c.ctx, watcher.db, watcher.template)); err != nil {
-			watcher.sendInitial(c.ctx, &watch.Event{Type: watch.EventError, Err: err})
+			watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err})
 			watcher.listener.Unregister(watcher)
 			return
 		}

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -557,7 +557,7 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 			return errutil.ErrBreak
 		}
 
-		return watcher.sendInitial(&watch.Event{
+		return watcher.sendInitial(c.ctx, &watch.Event{
 			Key:      []byte(m.Key),
 			Value:    m.Proto,
 			Type:     watch.EventPut,
@@ -566,14 +566,14 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 		})
 	}); err != nil && !errors.Is(err, errutil.ErrBreak) {
 		// Ignore any additional error here - we're already attempting to send an error to the user
-		watcher.sendInitial(&watch.Event{Type: watch.EventError, Err: err})
+		watcher.sendInitial(c.ctx, &watch.Event{Type: watch.EventError, Err: err})
 		watcher.listener.Unregister(watcher)
 		return
 	}
 
 	if bufEvent != nil {
-		if err := watcher.sendInitial(bufEvent.WatchEvent(c.ctx, watcher.db, watcher.template)); err != nil {
-			watcher.sendInitial(&watch.Event{Type: watch.EventError, Err: err})
+		if err := watcher.sendInitial(c.ctx, bufEvent.WatchEvent(c.ctx, watcher.db, watcher.template)); err != nil {
+			watcher.sendInitial(c.ctx, &watch.Event{Type: watch.EventError, Err: err})
 			watcher.listener.Unregister(watcher)
 			return
 		}

--- a/src/internal/collection/postgres_listener.go
+++ b/src/internal/collection/postgres_listener.go
@@ -149,7 +149,7 @@ func (pw *postgresWatcher) sendInitial(ctx context.Context, event *watch.Event) 
 	case pw.c <- event:
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.EnsureStack(ctx.Err())
 	case <-pw.done:
 		return errors.New("failed to send initial event, watcher has been closed")
 	}

--- a/src/internal/collection/postgres_listener.go
+++ b/src/internal/collection/postgres_listener.go
@@ -144,10 +144,12 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 	}
 }
 
-func (pw *postgresWatcher) sendInitial(event *watch.Event) error {
+func (pw *postgresWatcher) sendInitial(ctx context.Context, event *watch.Event) error {
 	select {
 	case pw.c <- event:
 		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-pw.done:
 		return errors.New("failed to send initial event, watcher has been closed")
 	}

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -233,6 +233,21 @@ func watchTests(
 			tester.ExpectNoEvents()
 		})
 
+		suite.Run("InterruptionDuringBackfill", func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			reader, writer := newCollection(context.Background(), t)
+			for i := 0; i < 10; i++ {
+				writer(context.Background(), putItem(makeProto(makeID(i))))
+			}
+
+			tester := NewWatchTester(t, writer, makeWatcher(ctx, t, reader))
+			cancel()
+			tester.ExpectError(context.Canceled)
+			tester.ExpectNoEvents()
+		})
+
 		suite.Run("Delete", func(t *testing.T) {
 			t.Parallel()
 			reader, writer := newCollection(context.Background(), t)

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -207,6 +207,7 @@ func watchTests(
 		defer watcher.Close()
 
 		ev := nextEvent(watcher.Watch(), 5*time.Second)
+		require.NotNil(t, ev)
 		require.Equal(t, TestEvent{watch.EventError, "", nil}, newTestEvent(t, ev))
 		require.YesError(t, ev.Err)
 		require.True(t, errors.Is(ev.Err, context.Canceled))


### PR DESCRIPTION
Postgres watches could block indefinitely during the initial list backfill, as nothing connected the context to the watcher's `done` channel.