### PR TITLE
[CORE-295] Check repo existence before put file

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1035,7 +1035,6 @@ $ {{alias}} repo@branch -i http://host/path`,
 			if err != nil {
 				return err
 			}
-
 			opts := []client.Option{client.WithMaxConcurrentStreams(parallelism)}
 			if compress {
 				opts = append(opts, client.WithGZIPCompression())
@@ -1046,12 +1045,13 @@ $ {{alias}} repo@branch -i http://host/path`,
 			}
 			defer c.Close()
 			defer progress.Wait()
+
 			// check whether or not the repo exists before attempting to upload
 			if _, err = c.InspectRepo(file.Commit.Branch.Repo.Name); err != nil {
 				if errutil.IsNotFoundError(err) {
-					return errors.Errorf("repo %s not found", file.Commit.Branch.Repo.Name)
+					return err
 				}
-				return errors.Errorf("could not inspect repo %s: %w", file.Commit.Branch.Repo.Name, err)
+				return errors.Wrapf(err, "could not inspect repo %s", err, file.Commit.Branch.Repo.Name)
 			}
 
 			// TODO: Rethink put file parallelism for 2.0.

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1049,9 +1049,9 @@ $ {{alias}} repo@branch -i http://host/path`,
 			// check whether or not the repo exists before attempting to upload
 			if _, err = c.InspectRepo(file.Commit.Branch.Repo.Name); err != nil {
 				if errutil.IsNotFoundError(err) {
-					return fmt.Errorf("repo %s not found", file.Commit.Branch.Repo.Name)
+					return errors.Errorf("repo %s not found", file.Commit.Branch.Repo.Name)
 				}
-				return fmt.Errorf("could not inspect repo %s: %w", file.Commit.Branch.Repo.Name, err)
+				return errors.Errorf("could not inspect repo %s: %w", file.Commit.Branch.Repo.Name, err)
 			}
 
 			// TODO: Rethink put file parallelism for 2.0.

--- a/src/server/pfs/cmds/cmds_test.go
+++ b/src/server/pfs/cmds/cmds_test.go
@@ -93,7 +93,7 @@ func TestPutFileNonexistentRepo(t *testing.T) {
 		"repo", repoName).Run())
 	// experimentally, the repo check should take less than three quarters
 	// of a second, while uploading 1GB of data takes well over two seconds
-	if time.Now().Sub(start) > 2*time.Second {
+	if time.Since(start) > 2*time.Second {
 		t.Error("pachctl put file appeared not to check if repo existed before uploading")
 	}
 }


### PR DESCRIPTION
Previously, `pachctl put file` would upload the file in question only to find that the indicated repo didn’t exist; this change checks for the existence of the repo first.