### PR TITLE
Collect all minikubetestenv logs, avoid minikubetestenv port conflicts

### DIFF
--- a/etc/kubernetes-prometheus/manifests-all.yaml
+++ b/etc/kubernetes-prometheus/manifests-all.yaml
@@ -392,6 +392,7 @@ spec:
   ports:
   - name: alertmanager
     protocol: TCP
+    nodePort: 30200
     port: 9093
     targetPort: 9093
 ---
@@ -2420,6 +2421,7 @@ spec:
   type: NodePort
   ports:
     - port: 3000
+      nodePort: 32001
   selector:
     app: grafana
     component: core
@@ -2612,7 +2614,7 @@ kind: Deployment
 metadata:
   name: kube-state-metrics
   namespace: monitoring
-  labels: 
+  labels:
     app: kube-state-metrics
 spec:
   replicas: 1
@@ -2905,6 +2907,7 @@ spec:
   ports:
     - port: 9090
       protocol: TCP
+      nodePort: 32002
       name: webui
   selector:
     app: prometheus

--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -28,8 +28,15 @@ cmds=(
   'kubectl describe pod -l suite=pachyderm,app=etcd'
   'curl -s http://$(minikube ip):30656/metrics'
   # Set --tail b/c by default 'kubectl logs' only outputs 10 lines if -l is set
-  'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd'
-  'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd --previous # if pachd restarted'
+  'kubectl logs --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  'kubectl logs --namespace=test-cluster-1 --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  'kubectl logs --namespace=test-cluster-2 --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  'kubectl logs --namespace=test-cluster-3 --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  'kubectl logs --namespace=test-cluster-4 --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  'kubectl logs --namespace=test-cluster-5 --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  'kubectl logs --namespace=test-cluster-6 --tail=1500 -l suite=pachyderm --all-containers=true --prefix=true'
+  # if pachd restarted
+  'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd --previous --prefix=true'
   'sudo dmesg | tail -n 40'
   'minikube logs | tail -n 100'
   'top -b -n 1 | head -n 40'


### PR DESCRIPTION
This is two unrelated changes ;)

kube_debug.sh: Dump all pachyderm logs, not just pachd.  Also do this for the default namespace and all 6 possible minikubetestenv namespaces.  Very helpful for debugging stuff :)

kubernetes-prometheus/all-manifests.yaml: This allocates a bunch of NodePorts with no `nodePort` specified.  Sometimes it picks a NodePort in the range 30660-31020, which are used by Pachyderm when started with minikubetestenv.  This results in the tests failing (at max timeout!) when this happens.  The change just hard-codes port numbers that don't conflict with anything.