### PR TITLE
debug dump: collect logs for all suite=pachyderm pods

### DIFF
--- a/src/internal/testutil/debug.go
+++ b/src/internal/testutil/debug.go
@@ -51,7 +51,7 @@ func DebugFiles(t testing.TB, dataRepo string) (map[string]*globlib.Glob, []stri
 	}
 	for _, app := range []string{"etcd", "pg-bouncer"} {
 		for _, file := range []string{"describe.txt", "logs.txt", "logs-previous**", "logs-loki.txt"} {
-			pattern := path.Join(app, "*", file)
+			pattern := path.Join(app, "**", file)
 			g, err := globlib.Compile(pattern, '/')
 			require.NoError(t, err)
 			expectedFiles[pattern] = g

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -156,11 +156,13 @@ func (s *debugServer) appLogs(tw *tar.Writer) error {
 		if err := s.collectDescribe(tw, pod.Name, prefix); err != nil {
 			return err
 		}
-		if err := s.collectLogs(tw, pod.Name, "", prefix); err != nil {
-			return err
-		}
-		if err := s.collectLogsLoki(tw, pod.Name, "", join(pod.Labels["app"], pod.Name)); err != nil {
-			return err
+		for _, container := range pod.Spec.Containers {
+			if err := s.collectLogs(tw, pod.Name, container.Name, prefix); err != nil {
+				return err
+			}
+			if err := s.collectLogsLoki(tw, pod.Name, container.Name, join(pod.Labels["app"], pod.Name)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -152,15 +152,16 @@ func (s *debugServer) appLogs(tw *tar.Writer) error {
 		return errors.EnsureStack(err)
 	}
 	for _, pod := range pods.Items {
-		prefix := join(pod.Labels["app"], pod.Name)
-		if err := s.collectDescribe(tw, pod.Name, prefix); err != nil {
+		podPrefix := join(pod.Labels["app"], pod.Name)
+		if err := s.collectDescribe(tw, pod.Name, podPrefix); err != nil {
 			return err
 		}
 		for _, container := range pod.Spec.Containers {
+			prefix := join(podPrefix, container.Name)
 			if err := s.collectLogs(tw, pod.Name, container.Name, prefix); err != nil {
 				return err
 			}
-			if err := s.collectLogsLoki(tw, pod.Name, container.Name, join(pod.Labels["app"], pod.Name)); err != nil {
+			if err := s.collectLogsLoki(tw, pod.Name, container.Name, prefix); err != nil {
 				return err
 			}
 		}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9279,6 +9279,13 @@ func TestDebug(t *testing.T) {
 			}
 		}
 	}
+	if len(expectedFiles) > 0 {
+		var names []string
+		for name, glob := range expectedFiles {
+			names = append(names, fmt.Sprintf("%v (matched by %v)", name, glob))
+		}
+		t.Logf("missing files: %v", names)
+	}
 	require.Equal(t, 0, len(expectedFiles))
 }
 

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9263,6 +9263,7 @@ func TestDebug(t *testing.T) {
 		require.NoError(t, gr.Close())
 	}()
 	// Check that all of the expected files were returned.
+	var gotFiles []string
 	tr := tar.NewReader(gr)
 	for {
 		hdr, err := tr.Next()
@@ -9272,6 +9273,7 @@ func TestDebug(t *testing.T) {
 			}
 			require.NoError(t, err)
 		}
+		gotFiles = append(gotFiles, hdr.Name)
 		for pattern, g := range expectedFiles {
 			if g.Match(hdr.Name) {
 				delete(expectedFiles, pattern)
@@ -9280,11 +9282,12 @@ func TestDebug(t *testing.T) {
 		}
 	}
 	if len(expectedFiles) > 0 {
+		t.Logf("got files: %v", gotFiles)
 		var names []string
-		for name, glob := range expectedFiles {
-			names = append(names, fmt.Sprintf("%v (matched by %v)", name, glob))
+		for n := range expectedFiles {
+			names = append(names, n)
 		}
-		t.Logf("missing files: %v", names)
+		t.Logf("no files match: %v", names)
 	}
 	require.Equal(t, 0, len(expectedFiles))
 }


### PR DESCRIPTION
Issue CORE-548

Also remove the pachd special case, since this will collect pachd logs.

I've tested this locally and we get all the information that we expect to have:

```
$ tar xzvf out.tgz
source-repos/images_brainy-sivatherium/commits.json
source-repos/images_brainy-sivatherium/commits-chart.png
pachd/pachd-57cc784579-pn4lp/pachd/version.txt
pachd/pachd-57cc784579-pn4lp/pachd/goroutine
pachd/pachd-57cc784579-pn4lp/pachd/heap
pipelines/montage_brainy-sivatherium/spec.json
pipelines/montage_brainy-sivatherium/commits.json
pipelines/montage_brainy-sivatherium/commits-chart.png
pipelines/montage_brainy-sivatherium/jobs.json
pipelines/montage_brainy-sivatherium/jobs-chart.png
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/describe.txt
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/user/logs.txt
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/user/logs-previous/error.txt
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/storage/logs.txt
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/storage/logs-previous/error.txt
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/user/goroutine
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/user/heap
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/storage/goroutine
pipelines/montage_brainy-sivatherium/pods/pipeline-montage-brainy-sivatherium-v1-q8drk/storage/heap
pipelines/edges_brainy-sivatherium/spec.json
pipelines/edges_brainy-sivatherium/commits.json
pipelines/edges_brainy-sivatherium/commits-chart.png
pipelines/edges_brainy-sivatherium/jobs.json
pipelines/edges_brainy-sivatherium/jobs-chart.png
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/describe.txt
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/logs.txt
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/logs-previous/error.txt
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/logs.txt
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/logs-previous/error.txt
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/goroutine
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/heap
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/goroutine
pipelines/edges_brainy-sivatherium/pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/heap
console/console-7dd4c6b89-q8fsc/describe.txt
console/console-7dd4c6b89-q8fsc/console/logs.txt
console/console-7dd4c6b89-q8fsc/console/logs-previous/error.txt
etcd/etcd-0/describe.txt
etcd/etcd-0/etcd/logs.txt
etcd/etcd-0/etcd/logs-previous/error.txt
pachd/pachd-57cc784579-pn4lp/describe.txt
pachd/pachd-57cc784579-pn4lp/pachd/logs.txt
pachd/pachd-57cc784579-pn4lp/pachd/logs-previous/error.txt
pachyderm-proxy/pachyderm-proxy-6bd976bd49-7lxlv/describe.txt
pachyderm-proxy/pachyderm-proxy-6bd976bd49-7lxlv/envoy/logs.txt
pachyderm-proxy/pachyderm-proxy-6bd976bd49-7lxlv/envoy/logs-previous/error.txt
pg-bouncer/pg-bouncer-66d8b86c4-jxf65/describe.txt
pg-bouncer/pg-bouncer-66d8b86c4-jxf65/pg-bouncer/logs.txt
pg-bouncer/pg-bouncer-66d8b86c4-jxf65/pg-bouncer/logs-previous/error.txt
```

I checked that the logs contain data etc. ;)  I also tried a worker-only dump to make sure it's not broken:

```
$ pachctl debug dump /tmp/out.tgz --worker pipeline-edges-brainy-sivatherium-v1-sp98f
$ tar xzvf out.tgz
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/describe.txt
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/logs.txt
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/logs-previous/error.txt
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/logs.txt
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/logs-previous/error.txt
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/goroutine
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/user/heap
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/goroutine
pods/pipeline-edges-brainy-sivatherium-v1-sp98f/storage/heap
```

This structure, and the content, looks good to me too.