### PR TITLE
Collect more information during tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Collect node stats
-          command: sar 10 -bdHwz -I SUM -m ALL -n TCP,UDP,IP,DEV -q ALL -r ALL -u ALL --human --pretty
+          command: sar 10 -bdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
       BUCKET: << parameters.bucket >>
     steps:
       - checkout
+      - run:
+          name: Collect node stats
+          command: sar 10 -bdHwz -I SUM -m ALL -n TCP,UDP,IP,DEV -q ALL -r ALL -u ALL --human --pretty
+          background: true
       - restore_cache:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Collect node stats
-          command: sar 10 -bdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
+          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
       - restore_cache:
           keys:
@@ -50,7 +50,10 @@ jobs:
           paths:
             - cached-deps/
       - run: etc/testing/circle/start-minikube.sh
-
+      - run:
+          name: Collect kube events
+          command: ./cached-deps/kubectl get events -o wide --watch --all-namespaces | ts '%Y-%m-%dT%H:%M:%S'
+          background: true
       # The build cache will grow indefinitely, so we rotate the cache once a week.
       # This ensures the time to restore the cache isn't longer than the speedup in compilation.
       - run: "echo $(($(date +%s)/604800)) > current_week"
@@ -80,7 +83,7 @@ jobs:
       - run: etc/testing/circle/launch.sh
       - run:
           no_output_timeout: 20m
-          command: etc/testing/circle/run_tests.sh
+          command: etc/testing/circle/run_tests.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run: etc/testing/circle/upload_stats.sh
       - run:
           name: Dump debugging info in case of failure

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -16,6 +16,7 @@ sudo apt-get install -y -qq \
   conntrack \
   pv \
   shellcheck \
+  moreutils \
   docker-ce-cli
 
 # Install fuse
@@ -74,7 +75,7 @@ if [ ! -f cached-deps/helm ]; then
       mv ./linux-amd64/helm cached-deps/helm
 fi
 
-# Install goreleaser 
+# Install goreleaser
 if [ ! -f cached-deps/goreleaser ]; then
   GORELEASER_VERSION=0.169.0
   curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \


### PR DESCRIPTION
3 new things:

* Run `sar` in the background to print interesting node-level stats every 10 seconds.

* Run `kubectl get events -o wide --all-namespaces --watch` during the tests.

* Add timestamping to the output of tests.

This is already useful for debugging the flakes with the CI run listed here.  For example, auth_test failed with: `auth_test.go:2859: No error is expected but got no pods belonging to the rc "pipeline-pipeline-for-logs12e065d61764-v1" were found` at `2022-05-02T23:24:12`.  Looking at the event logs for that RC, we see: `2022-05-02T23:24:13 test-cluster-3   0s          Normal    SuccessfulCreate               replicationcontroller/pipeline-pipeline-for-logs12e065d61764-v1                                          replication-controller                                                   Created pod: pipeline-pipeline-for-logs12e065d61764-v1-z4h92                                                                                                                                                                                                                                                                                0s           1       pipeline-pipeline-for-logs12e065d61764-v1.16eb6d4a39618321`.  

One second away from success!!

What was the machine doing around this time?  No idea really, but we can look at the `sar` output:

```
11:24:02 PM     CPU      %usr     %nice      %sys   %iowait    %steal      %irq     %soft    %guest    %gnice     %idle
11:24:12 PM     all     40.8%      0.0%     10.6%      2.7%      0.0%      0.0%      1.5%      0.0%      0.0%     44.5%

11:24:02 PM    proc/s   cswch/s
11:24:12 PM    110.30 126811.40

11:24:02 PM      INTR    intr/s
11:24:12 PM       sum  69568.60

11:24:02 PM  pgpgin/s pgpgout/s   fault/s  majflt/s  pgfree/s pgscank/s pgscand/s pgsteal/s    %vmeff
11:24:12 PM    258.00  55460.00 139619.40      0.00 181657.30      0.00      0.00      0.00      0.0%

11:24:02 PM       tps      rtps      wtps      dtps   bread/s   bwrtn/s   bdscd/s
11:24:12 PM    890.60     64.50    826.10      0.00    516.00 110920.80      0.00

11:24:02 PM kbmemfree   kbavail kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty  kbanonpg    kbslab  kbkstack   kbpgtbl  kbvmused
11:24:12 PM     11.5G     27.1G      2.9G      9.5%    359.2M     14.7G     21.9G     70.8%      6.6G     11.2G      3.8M      2.7G      1.4G     45.2M     38.1M     56.7M

11:24:02 PM kbswpfree kbswpused  %swpused  kbswpcad   %swpcad
11:24:12 PM      0.0k      0.0k      0.0%      0.0k      0.0%

11:24:02 PM kbhugfree kbhugused  %hugused kbhugrsvd kbhugsurp
11:24:12 PM      0.0k      0.0k      0.0%      0.0k      0.0k

11:24:02 PM   runq-sz  plist-sz   ldavg-1   ldavg-5  ldavg-15   blocked
11:24:12 PM         4      2873      3.57      2.89      1.52         0

11:24:02 PM       tps     rkB/s     wkB/s     dkB/s   areq-sz    aqu-sz     await     %util DEV
11:24:12 PM    890.60    258.0k     54.2M      0.0k     62.6k      0.04      1.09     68.8% nvme0n1

11:24:02 PM   rxpck/s   txpck/s    rxkB/s    txkB/s   rxcmp/s   txcmp/s  rxmcst/s   %ifutil IFACE
11:24:12 PM     12.40     16.50      1.7k      5.5k      0.00      0.00      0.00      0.0% ens5
11:24:12 PM     61.80     43.00     13.2k      4.1k      0.00      0.00      0.00      0.0% vethf78ef4d
11:24:12 PM      7.60      7.60    680.4B    680.4B      0.00      0.00      0.00      0.0% lo
11:24:12 PM     61.80     42.90     12.3k      4.1k      0.00      0.00      0.00      0.0% br-e828ebfbd565
```

Using 40% of the CPU, 4 tasks waiting for the CPU, using 70.8% of RAM, paging out pages at 55.4MB/s and writing to the SSD at 54.2MB/s.  Weird, I don't know what this means but maybe someday it will be a smoking gun.  (Why are we paging out when swap is disabled?  Not really sure.  Replacing disk cache with actual application pages?  I don't know.)