### PR TITLE
[CORE-370] Fix reference to non-existent AccessLevel (#7571)

### DIFF
--- a/src/internal/pretty/pretty.go
+++ b/src/internal/pretty/pretty.go
@@ -2,6 +2,7 @@ package pretty
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -81,4 +82,25 @@ func ProgressBar(width, green, yellow, red int) string {
 		}
 	}
 	return sb.String()
+}
+
+func Commafy(items interface{}) string {
+	v := reflect.ValueOf(items)
+	switch v.Kind() {
+	case reflect.Array, reflect.Slice:
+		switch v.Len() {
+		case 0:
+			return ""
+		case 1:
+			return fmt.Sprintf("%v", v.Index(0).Interface())
+		default:
+			s := fmt.Sprintf("%v", v.Index(0).Interface())
+			for i := 1; i < v.Len()-1; i++ {
+				s = fmt.Sprintf("%s, %v", s, v.Index(i).Interface())
+			}
+			return fmt.Sprintf("%s and %v", s, v.Index(v.Len()-1))
+		}
+	default:
+		return fmt.Sprintf("%v", items)
+	}
 }

--- a/src/internal/pretty/pretty_test.go
+++ b/src/internal/pretty/pretty_test.go
@@ -1,0 +1,25 @@
+package pretty_test
+
+import (
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pretty"
+)
+
+func TestCommafy(t *testing.T) {
+	if expected, actual := "foo", pretty.Commafy("foo"); expected != actual {
+		t.Errorf("expected %q; got %q", expected, actual)
+	}
+	if expected, actual := "", pretty.Commafy([]string{}); expected != actual {
+		t.Errorf("expected %q; got %q", expected, actual)
+	}
+	if expected, actual := "foo", pretty.Commafy([]string{"foo"}); expected != actual {
+		t.Errorf("expected %q; got %q", expected, actual)
+	}
+	if expected, actual := "foo and bar", pretty.Commafy([]string{"foo", "bar"}); expected != actual {
+		t.Errorf("expected %q; got %q", expected, actual)
+	}
+	if expected, actual := "foo, bar and baz", pretty.Commafy([]string{"foo", "bar", "baz"}); expected != actual {
+		t.Errorf("expected %q; got %q", expected, actual)
+	}
+}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -2310,6 +2310,65 @@ func TestPrettyPrinting(t *testing.T) {
 	require.NoError(t, ppspretty.PrintDetailedJobInfo(os.Stdout, ppspretty.NewPrintableJobInfo(jobInfos[0])))
 }
 
+func TestAuthPrettyPrinting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t)
+	tu.ActivateAuthClient(t, c)
+	rc := tu.AuthenticateClient(t, c, auth.RootUser)
+
+	// create repos
+	dataRepo := tu.UniqueString("TestPrettyPrinting_data")
+	require.NoError(t, rc.CreateRepo(dataRepo))
+
+	// create pipeline
+	pipelineName := tu.UniqueString("pipeline")
+	_, err := rc.PpsAPIClient.CreatePipeline(
+		rc.Ctx(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(pipelineName),
+			Transform: &pps.Transform{
+				Cmd: []string{"cp", path.Join("/pfs", dataRepo, "file"), "/pfs/out/file"},
+			},
+			ParallelismSpec: &pps.ParallelismSpec{
+				Constant: 1,
+			},
+			Input: client.NewPFSInput(dataRepo, "/*"),
+		})
+	require.NoError(t, err)
+
+	// Do a commit to repo
+	commit, err := c.StartCommit(dataRepo, "master")
+	require.NoError(t, err)
+	require.NoError(t, c.PutFile(commit, "file", strings.NewReader("foo\n"), client.WithAppendPutFile()))
+	require.NoError(t, c.FinishCommit(dataRepo, commit.Branch.Name, commit.ID))
+
+	commitInfos, err := c.WaitCommitSetAll(commit.ID)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(commitInfos))
+
+	repoInfo, err := c.InspectRepo(dataRepo)
+	require.NoError(t, err)
+	require.NoError(t, pfspretty.PrintDetailedRepoInfo(pfspretty.NewPrintableRepoInfo(repoInfo)))
+	for _, c := range commitInfos {
+		require.NoError(t, pfspretty.PrintDetailedCommitInfo(os.Stdout, pfspretty.NewPrintableCommitInfo(c)))
+	}
+
+	fileInfo, err := c.InspectFile(commit, "file")
+	require.NoError(t, err)
+	require.NoError(t, pfspretty.PrintDetailedFileInfo(fileInfo))
+	pipelineInfo, err := c.InspectPipeline(pipelineName, true)
+	require.NoError(t, err)
+	require.NoError(t, ppspretty.PrintDetailedPipelineInfo(os.Stdout, ppspretty.NewPrintablePipelineInfo(pipelineInfo)))
+	jobInfos, err := c.ListJob("", nil, -1, true)
+	require.NoError(t, err)
+	require.True(t, len(jobInfos) > 0)
+	require.NoError(t, ppspretty.PrintDetailedJobInfo(os.Stdout, ppspretty.NewPrintableJobInfo(jobInfos[0])))
+}
+
 func TestDeleteAll(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -76,7 +76,8 @@ Description: {{.Description}}{{end}}{{if .FullTimestamps}}
 Created: {{.Created}}{{else}}
 Created: {{prettyAgo .Created}}{{end}}{{if .Details}}
 Size of HEAD on master: {{prettySize .Details.SizeBytes}}{{end}}{{if .AuthInfo}}
-Access level: {{ .AuthInfo.AccessLevel.String }}{{end}}
+Roles: {{ .AuthInfo.Roles | commafy }}
+Permissions: {{ .AuthInfo.Permissions | commafy }}{{end}}
 `)
 	if err != nil {
 		return errors.EnsureStack(err)
@@ -306,6 +307,7 @@ var funcMap = template.FuncMap{
 	"prettySize":   pretty.Size,
 	"fileType":     fileType,
 	"printTrigger": printTrigger,
+	"commafy":      pretty.Commafy,
 }
 
 // CompactPrintCommit renders 'c' as a compact string, e.g.


### PR DESCRIPTION
Replace reference to AccessLevel with ones to Roles & Permissions, and display them
attractively. Also add a regression test.