### PR TITLE
Today's random CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   go: circleci/go@1.6.0
-  gcp-cli: circleci/gcp-cli@2.4.0
+  gcp-cli: circleci/gcp-cli@2.4.1
 
 parameters:
   machine_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           path: /tmp/test-results
   helm-build:
     docker:
-      - image: circleci/golang:1.18
+      - image: circleci/golang:1.15
     working_directory: ~/project/etc/helm
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Collect node stats
-          command: sar 10 -bdHwz -I SUM -m ALL -n TCP,UDP,IP,DEV -q ALL -r ALL -u ALL --human --pretty
+          command: sar 10 -bdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,6 @@ jobs:
     steps:
       - checkout
       - gcp-cli/initialize
-      - gcp-cli/install
       - run: |
           echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run: etc/testing/circle/install.sh
@@ -178,7 +177,6 @@ jobs:
     steps:
       - checkout
       - gcp-cli/initialize
-      - gcp-cli/install
       - run: |
           echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run: etc/testing/circle/install.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Collect node stats
-          command: sar 10 -bdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
+          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
         type: string
     resource_class: xlarge
     machine:
-      image: << parameters.machine_image >>
+      image: << pipeline.parameters.machine_image >>
     environment:
       PPS_BUCKETS: "6"
       GOPROXY: https://proxy.golang.org
@@ -144,7 +144,7 @@ jobs:
   load_test:
     resource_class: xlarge
     machine:
-      image: << parameters.machine_image >>
+      image: << pipeline.parameters.machine_image >>
     environment:
       GOOGLE_PROJECT_ID: build-release-001
       GOOGLE_COMPUTE_ZONE: us-east1-b
@@ -169,7 +169,7 @@ jobs:
         type: string
     resource_class: xlarge
     machine:
-      image: << parameters.machine_image >>
+      image: << pipeline.parameters.machine_image >>
     environment:
       BUCKET: << parameters.bucket >>
       GOOGLE_PROJECT_ID: build-release-001
@@ -194,7 +194,7 @@ jobs:
   rootless:
     resource_class: large
     machine:
-      image: << parameters.machine_image >>
+      image: << pipeline.parameters.machine_image >>
     steps:
       - checkout
       - run: etc/testing/circle/install.sh
@@ -202,7 +202,7 @@ jobs:
   deploy:
     resource_class: xlarge
     machine:
-      image: << parameters.machine_image >>
+      image: << pipeline.parameters.machine_image >>
     steps:
       - checkout
       - run: etc/testing/circle/install.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ orbs:
   gcp-cli: circleci/gcp-cli@2.4.0
 
 parameters:
+  machine_image:
+    type: string
+    default: "ubuntu-2004:202201-02"
   run_flaky_tests:
     type: string
     default: ""
@@ -29,7 +32,7 @@ jobs:
         type: string
     resource_class: xlarge
     machine:
-      image: ubuntu-2004:202101-01
+      image: << parameters.machine_image >>
     environment:
       PPS_BUCKETS: "6"
       GOPROXY: https://proxy.golang.org
@@ -49,10 +52,9 @@ jobs:
           key: pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
           paths:
             - cached-deps/
-      - run: etc/testing/circle/start-minikube.sh
       - run:
-          name: Collect kube events
-          command: ./cached-deps/kubectl get events -o wide --watch --all-namespaces | ts '%Y-%m-%dT%H:%M:%S'
+          name: Start minikube
+          command: etc/testing/circle/start-minikube.sh
           background: true
       # The build cache will grow indefinitely, so we rotate the cache once a week.
       # This ensures the time to restore the cache isn't longer than the speedup in compilation.
@@ -80,6 +82,11 @@ jobs:
                 key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
                 paths:
                   - /home/circleci/.gocache
+      - run: etc/testing/circle/wait-minikube.sh
+      - run:
+          name: Collect kube events
+          command: ./cached-deps/kubectl get events -o wide --watch --all-namespaces | ts '%Y-%m-%dT%H:%M:%S'
+          background: true
       - run: etc/testing/circle/launch.sh
       - run:
           no_output_timeout: 20m
@@ -95,7 +102,7 @@ jobs:
           path: /tmp/test-results
   helm-build:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.18
     working_directory: ~/project/etc/helm
     steps:
       - checkout:
@@ -137,7 +144,7 @@ jobs:
   load_test:
     resource_class: xlarge
     machine:
-      image: ubuntu-2004:202101-01
+      image: << parameters.machine_image >>
     environment:
       GOOGLE_PROJECT_ID: build-release-001
       GOOGLE_COMPUTE_ZONE: us-east1-b
@@ -162,7 +169,7 @@ jobs:
         type: string
     resource_class: xlarge
     machine:
-      image: ubuntu-2004:202101-01
+      image: << parameters.machine_image >>
     environment:
       BUCKET: << parameters.bucket >>
       GOOGLE_PROJECT_ID: build-release-001
@@ -187,7 +194,7 @@ jobs:
   rootless:
     resource_class: large
     machine:
-      image: ubuntu-2004:202101-01
+      image: << parameters.machine_image >>
     steps:
       - checkout
       - run: etc/testing/circle/install.sh
@@ -195,7 +202,7 @@ jobs:
   deploy:
     resource_class: xlarge
     machine:
-      image: ubuntu-2004:202101-01
+      image: << parameters.machine_image >>
     steps:
       - checkout
       - run: etc/testing/circle/install.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Collect node stats
-          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
+          command: sar 10 -bdHwz -I SUM -m ALL -n TCP,UDP,IP,DEV -q ALL -r ALL -u ALL --human --pretty
           background: true
       - restore_cache:
           keys:

--- a/etc/kube/start-minikube.sh
+++ b/etc/kube/start-minikube.sh
@@ -3,7 +3,7 @@
 set -Eex
 
 # Parse flags
-VERSION=v1.19.0
+VERSION=v1.25.2
 minikube_args=(
   "--vm-driver=none"
   "--kubernetes-version=${VERSION}"

--- a/etc/testing/circle/build.sh
+++ b/etc/testing/circle/build.sh
@@ -5,12 +5,30 @@ set -ex
 # shellcheck disable=SC1090
 source "$(dirname "$0")/env.sh"
 
-eval "$(minikube docker-env)"
-
+## pachctl build
 go version
-
 make install
 VERSION=$(pachctl version --client-only)
+
+## local docker build
+
+# first, wait for minikube's docker to be ready (minikube is starting up async in a background job)
+for _ in $(seq 36); do
+    if minikube docker-env &>/dev/null; then
+        echo 'minikube docker ready' | ts
+        eval "$(minikube docker-env)"
+        break
+    fi
+    echo 'sleeping' | ts
+    sleep 5
+done
+
+if [[-z "${MINIKUBE_ACTIVE_DOCKERD}" ]]; then
+    echo 'never setup docker, aborting' | ts
+    exit 1
+fi
+
+# then actually do the build
 git config user.email "donotreply@pachyderm.com"
 git config user.name "anonymous"
 git tag -f -am "Circle CI test v$VERSION" v"$VERSION"

--- a/etc/testing/circle/build.sh
+++ b/etc/testing/circle/build.sh
@@ -23,7 +23,7 @@ for _ in $(seq 36); do
     sleep 5
 done
 
-if [[-z "${MINIKUBE_ACTIVE_DOCKERD}" ]]; then
+if [[ -z "${MINIKUBE_ACTIVE_DOCKERD}" ]]; then
     echo 'never setup docker, aborting' | ts
     exit 1
 fi

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -33,7 +33,7 @@ pip3 install --upgrade --user awscli s3transfer==0.3.4
 # To get the latest kubectl version:
 # curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
 if [ ! -f cached-deps/kubectl ] ; then
-    KUBECTL_VERSION=v1.19.2
+    KUBECTL_VERSION=v1.23.5
     curl -L -o kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
         chmod +x ./kubectl
         mv ./kubectl cached-deps/kubectl
@@ -61,7 +61,7 @@ fi
 
 # Install kubeval
 if [ ! -f cached-deps/kubeval ]; then
-  KUBEVAL_VERSION=0.15.0
+  KUBEVAL_VERSION=0.16.1
   curl -L https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz \
       | tar xzf - kubeval
       mv ./kubeval cached-deps/kubeval

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -61,7 +61,7 @@ fi
 
 # Install kubeval
 if [ ! -f cached-deps/kubeval ]; then
-  KUBEVAL_VERSION=0.16.1
+  KUBEVAL_VERSION=0.15.0
   curl -L https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz \
       | tar xzf - kubeval
       mv ./kubeval cached-deps/kubeval

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -43,7 +43,7 @@ fi
 # To get the latest minikube version:
 # curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[].tag_name | sort -V | tail -n1
 if [ ! -f cached-deps/minikube ] ; then
-    MINIKUBE_VERSION=v1.19.0 # If changed, also do etc/kube/start-minikube.sh
+    MINIKUBE_VERSION=v1.25.2 # If changed, also do etc/kube/start-minikube.sh
     curl -L -o minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
         chmod +x ./minikube
         mv ./minikube cached-deps/minikube

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -37,16 +37,3 @@ while ! docker version >/dev/null 2>&1; do
 done
 
 minikube start "${minikube_args[@]}"
-
-# Try to connect for three minutes
-for _ in $(seq 36); do
-  if kubectl version &>/dev/null; then
-    exit 0
-  fi
-  sleep 5
-done
-
-# Give up--kubernetes isn't coming up
-minikube delete
-sleep 30 # Wait for minikube to go completely down
-exit 1

--- a/etc/testing/circle/wait-minikube.sh
+++ b/etc/testing/circle/wait-minikube.sh
@@ -7,11 +7,11 @@ export PATH="${PWD}:${PWD}/cached-deps:${GOPATH}/bin:${PATH}"
 # Try to connect for three minutes
 for _ in $(seq 36); do
     if kubectl version &>/dev/null; then
-        echo 'Minikube ready!' | ts
-    exit 0
+        echo 'minikube ready' | ts
+        exit 0
     fi
     echo 'sleeping' | ts
-  sleep 5
+    sleep 5
 done
 
 # Give up--kubernetes isn't coming up

--- a/etc/testing/circle/wait-minikube.sh
+++ b/etc/testing/circle/wait-minikube.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -Eex
+
+export PATH="${PWD}:${PWD}/cached-deps:${GOPATH}/bin:${PATH}"
+
+# Try to connect for three minutes
+for _ in $(seq 36); do
+    if kubectl version &>/dev/null; then
+        echo 'Minikube ready!' | ts
+    exit 0
+    fi
+    echo 'sleeping' | ts
+  sleep 5
+done
+
+# Give up--kubernetes isn't coming up
+exit 1

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -123,6 +123,7 @@ func (tester *ChannelWatchTester) ExpectEventSet(expected ...TestEvent) {
 }
 
 func (tester *ChannelWatchTester) ExpectError(err error) {
+	tester.t.Helper()
 	ev := tester.nextEvent(5 * time.Second)
 	require.NotNil(tester.t, ev)
 	require.Equal(tester.t, TestEvent{watch.EventError, "", nil}, newTestEvent(tester.t, ev))

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2854,9 +2854,11 @@ func TestGetPachdLogsRequiresPerm(t *testing.T) {
 	require.True(t, strings.Contains(pachdLogsIter.Err().Error(), "is not authorized to perform this operation"))
 
 	// alice can view the pipeline logs
-	pipelineLogsIter := aliceClient.GetLogs(alicePipeline, "", nil, "", false, false, 0)
-	pipelineLogsIter.Next()
-	require.NoError(t, pipelineLogsIter.Err())
+	require.NoErrorWithinTRetry(t, time.Minute, func() error {
+		pipelineLogsIter := aliceClient.GetLogs(alicePipeline, "", nil, "", false, false, 0)
+		pipelineLogsIter.Next()
+		return pipelineLogsIter.Err()
+	}, "alice can view the pipeline logs")
 
 	// PachdLogReaderRole grants authorized retrieval of pachd logs
 	_, err = adminClient.AuthAPIClient.ModifyRoleBinding(adminClient.Ctx(),

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7234,14 +7234,21 @@ func TestPipelineWithJobTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for the job to get scheduled / appear in listjob
-	// A sleep of 15s is insufficient
-	time.Sleep(25 * time.Second)
-	jobs, err := c.ListJob(pipeline, nil, -1, true)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(jobs))
+	var job *pps.JobInfo
+	require.NoErrorWithinTRetry(t, 90*time.Second, func() error {
+		jobs, err := c.ListJob(pipeline, nil, -1, true)
+		if err != nil {
+			return fmt.Errorf("list job: %w", err)
+		}
+		if got, want := len(jobs), 1; got != want {
+			return fmt.Errorf("job count: got %v want %v (jobs: %v)", got, want, jobs)
+		}
+		job = jobs[0]
+		return nil
+	}, "pipeline should appear in list jobs")
 
 	// Block on the job being complete before we call ListDatum
-	jobInfo, err := c.WaitJob(jobs[0].Job.Pipeline.Name, jobs[0].Job.ID, false)
+	jobInfo, err := c.WaitJob(job.Job.Pipeline.Name, job.Job.ID, false)
 	require.NoError(t, err)
 	require.Equal(t, pps.JobState_JOB_KILLED.String(), jobInfo.State.String())
 	started, err := types.TimestampFromProto(jobInfo.Started)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7238,10 +7238,11 @@ func TestPipelineWithJobTimeout(t *testing.T) {
 	require.NoErrorWithinTRetry(t, 90*time.Second, func() error {
 		jobs, err := c.ListJob(pipeline, nil, -1, true)
 		if err != nil {
-			return fmt.Errorf("list job: %w", err)
+			return fmt.Errorf("list job: %w", err) //nolint:wrapcheck
+
 		}
 		if got, want := len(jobs), 1; got != want {
-			return fmt.Errorf("job count: got %v want %v (jobs: %v)", got, want, jobs)
+			return fmt.Errorf("job count: got %v want %v (jobs: %v)", got, want, jobs) //nolint:wrapcheck
 		}
 		job = jobs[0]
 		return nil


### PR DESCRIPTION
* Update dependencies to newer version; latest k8s and machine image
* Updating the machine image broke the gcloud installer script, but fortunately the machine already has a newer version of gcloud installed anyway, so I deleted the orb-based install step.
* Fix a few persistently flaky tests
* I made the container build and starting of minikube happen in parallel; saves about 45-60 seconds.

