### PR TITLE
Fix a flaky etcd collection test, improve etcd logging

### DIFF
--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -252,7 +252,8 @@ func watchTests(
 			watcher := makeWatcher(ctx, t, reader)
 			tester := NewWatchTester(t, writer, watcher)
 			cancel()
-			for i := 0; i < 10; i++ {
+			var canceled bool
+			for i := 0; i < 11; i++ {
 				// Consume events until we receive the cancellation event.  (Some
 				// events may have arrived before cancellation.)
 				ev := nextEvent(watcher.Watch(), time.Second)
@@ -261,8 +262,10 @@ func watchTests(
 					continue
 				}
 				require.ErrorIs(t, ev.Err, context.Canceled)
+				canceled = true
 				break
 			}
+			require.True(t, canceled, "we should have gotten the cancellation event in the loop")
 			tester.ExpectNoEvents()
 		})
 

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -74,6 +74,7 @@ func (tester *ChannelWatchTester) nextEvent(timeout time.Duration) *watch.Event 
 }
 
 func (tester *ChannelWatchTester) Write(item *col.TestItem) {
+	tester.t.Helper()
 	err := tester.writer(context.Background(), func(rw col.ReadWriteCollection) error {
 		return putItem(item)(rw)
 	})
@@ -81,6 +82,7 @@ func (tester *ChannelWatchTester) Write(item *col.TestItem) {
 }
 
 func (tester *ChannelWatchTester) Delete(id string) {
+	tester.t.Helper()
 	err := tester.writer(context.Background(), func(rw col.ReadWriteCollection) error {
 		return errors.EnsureStack(rw.Delete(id))
 	})
@@ -88,6 +90,7 @@ func (tester *ChannelWatchTester) Delete(id string) {
 }
 
 func (tester *ChannelWatchTester) DeleteAll() {
+	tester.t.Helper()
 	err := tester.writer(context.Background(), func(rw col.ReadWriteCollection) error {
 		return errors.EnsureStack(rw.DeleteAll())
 	})
@@ -99,6 +102,7 @@ func (tester *ChannelWatchTester) ExpectEvent(expected TestEvent) {
 }
 
 func (tester *ChannelWatchTester) ExpectEventSet(expected ...TestEvent) {
+	tester.t.Helper()
 	actual := []TestEvent{}
 	for range expected {
 		ev := tester.nextEvent(5 * time.Second)
@@ -131,6 +135,7 @@ func (tester *ChannelWatchTester) ExpectError(err error) {
 }
 
 func (tester *ChannelWatchTester) ExpectNoEvents() {
+	tester.t.Helper()
 	require.Nil(tester.t, tester.nextEvent(100*time.Millisecond))
 }
 
@@ -244,9 +249,20 @@ func watchTests(
 				writer(context.Background(), putItem(makeProto(makeID(i))))
 			}
 
-			tester := NewWatchTester(t, writer, makeWatcher(ctx, t, reader))
+			watcher := makeWatcher(ctx, t, reader)
+			tester := NewWatchTester(t, writer, watcher)
 			cancel()
-			tester.ExpectError(context.Canceled)
+			for i := 0; i < 10; i++ {
+				// Consume events until we receive the cancellation event.  (Some
+				// events may have arrived before cancellation.)
+				ev := nextEvent(watcher.Watch(), time.Second)
+				require.NotNil(t, ev, "event %v should not be nil, since we haven't been canceled yet", i)
+				if ev.Err == nil {
+					continue
+				}
+				require.ErrorIs(t, ev.Err, context.Canceled)
+				break
+			}
 			tester.ExpectNoEvents()
 		})
 


### PR DESCRIPTION
This PR attempts to fix the VERY flaky `InterruptionDuringBackfill` test.  I'm not 100% sure this is the correct fix.  What I think is happening here is that we're writing to a channel and canceling the context, and expecting to get the cancellation and not any of the writes.  But the writes happen before the cancellation (depending on how fast the computer is today), so I have no idea how that could work.  As a result, I've adjusted the test to drain the channel looking for the cancellation, and confirming that the cancellation is the last event.

We also had some code to try to integrate etcd's logger with the tests, and filter out noisy startup messages.  At some point etcd dropped support for capnslog, which is the logger we're expecting to adjust to make that happen.  They use Zap now, so I've changed the tests to use Zap.  This has two benefits; the startup messages are now filtered, and the tests log to the per-test logger.  This lets you see exactly which test the etcd messages are from.  (The client also logs stuff, and I've made those logs go to the same place.  They are tagged with "etcd-client" so you can distinguish between them.) 