### PR TITLE
2.2.x patch - Convert SQL numeric types to string

### DIFF
--- a/src/internal/dockertestenv/mysql.go
+++ b/src/internal/dockertestenv/mysql.go
@@ -26,8 +26,17 @@ func NewMySQL(t testing.TB) *pachsql.DB {
 	return testutil.OpenDBURL(t, u, MySQLPassword)
 }
 
+func NewEphemeralMySQLDB(t testing.TB, name string) *pachsql.DB {
+	return testutil.OpenDBURL(t, newMySQLEphemeralURL(t, name), MySQLPassword)
+}
+
 // NewMySQLURL returns a pachsql.URL to an ephemeral database.
 func NewMySQLURL(t testing.TB) pachsql.URL {
+	dbName := testutil.GenerateEphermeralDBName(t)
+	return newMySQLEphemeralURL(t, dbName)
+}
+
+func newMySQLEphemeralURL(t testing.TB, name string) pachsql.URL {
 	ctx := context.Background()
 	log := logrus.StandardLogger()
 
@@ -53,7 +62,7 @@ func NewMySQLURL(t testing.TB) pachsql.URL {
 	ctx, cf := context.WithTimeout(ctx, 30*time.Second)
 	defer cf()
 	require.NoError(t, dbutil.WaitUntilReady(ctx, log, db))
-	dbName := testutil.CreateEphemeralDB(t, db, "public")
+	dbName := testutil.CreateEphemeralDB(t, db, name)
 	u2 := u
 	u2.Database = dbName
 	return u2

--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -62,9 +62,9 @@ func NewTestDB(t testing.TB) *pachsql.DB {
 	return testutil.OpenDB(t, NewTestDBOptions(t)...)
 }
 
-// NewTestDBFromName creates a new database with a user defined name,
+// NewEphemeralPostgresDB creates a new database with a user defined name,
 // and returns a database connection connected to the new database.
-func NewTestDBFromName(t testing.TB, dbName string) *pachsql.DB {
+func NewEphemeralPostgresDB(t testing.TB, dbName string) *pachsql.DB {
 	ctx := context.Background()
 	require.NoError(t, ensureDBEnv(t, ctx))
 	db := testutil.OpenDB(t,

--- a/src/internal/pachsql/table_info_test.go
+++ b/src/internal/pachsql/table_info_test.go
@@ -2,6 +2,7 @@ package pachsql_test
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -9,37 +10,38 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testsnowflake"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
-func TestGetTableInfo(t *testing.T) {
+func TestGetTableInfo(suite *testing.T) {
 	type testCase struct {
 		Name     string
-		NewDB    func(t testing.TB) *pachsql.DB
-		NewTable func(*pachsql.DB) error
+		NewDB    func(testing.TB, string) *pachsql.DB
 		Expected *pachsql.TableInfo
 	}
 	tcs := []testCase{
 		{
 			Name:  "Postgres",
-			NewDB: dockertestenv.NewPostgres,
-			NewTable: func(db *pachsql.DB) error {
-				return pachsql.CreateTestTable(db, "test_table", pachsql.TestRow{})
-			},
+			NewDB: dockertestenv.NewEphemeralPostgresDB,
 			Expected: &pachsql.TableInfo{
 				"test_table",
 				"public",
 				[]pachsql.ColumnInfo{
-					{"c_id", "INTEGER", false},
+					{"c_id", "SMALLINT", false},
 					{"c_smallint", "SMALLINT", false},
 					{"c_int", "INTEGER", false},
 					{"c_bigint", "BIGINT", false},
 					{"c_float", "DOUBLE PRECISION", false},
+					{"c_numeric_int", "NUMERIC", false},
+					{"c_numeric_float", "NUMERIC", false},
 					{"c_varchar", "CHARACTER VARYING", false},
 					{"c_time", "TIMESTAMP WITHOUT TIME ZONE", false},
 					{"c_smallint_null", "SMALLINT", true},
 					{"c_int_null", "INTEGER", true},
 					{"c_bigint_null", "BIGINT", true},
 					{"c_float_null", "DOUBLE PRECISION", true},
+					{"c_numeric_int_null", "NUMERIC", true},
+					{"c_numeric_float_null", "NUMERIC", true},
 					{"c_varchar_null", "CHARACTER VARYING", true},
 					{"c_time_null", "TIMESTAMP WITHOUT TIME ZONE", true},
 				},
@@ -47,25 +49,26 @@ func TestGetTableInfo(t *testing.T) {
 		},
 		{
 			Name:  "MySQL",
-			NewDB: dockertestenv.NewMySQL,
-			NewTable: func(db *pachsql.DB) error {
-				return pachsql.CreateTestTable(db, "public.test_table", pachsql.TestRow{})
-			},
+			NewDB: dockertestenv.NewEphemeralMySQLDB,
 			Expected: &pachsql.TableInfo{
 				"test_table",
-				"public",
+				"MySQL doesn't have schema, use database name instead",
 				[]pachsql.ColumnInfo{
-					{"c_id", "INT", false},
+					{"c_id", "SMALLINT", false},
 					{"c_smallint", "SMALLINT", false},
 					{"c_int", "INT", false},
 					{"c_bigint", "BIGINT", false},
 					{"c_float", "FLOAT", false},
+					{"c_numeric_int", "DECIMAL", false},
+					{"c_numeric_float", "DECIMAL", false},
 					{"c_varchar", "VARCHAR", false},
 					{"c_time", "TIMESTAMP", false},
 					{"c_smallint_null", "SMALLINT", true},
 					{"c_int_null", "INT", true},
 					{"c_bigint_null", "BIGINT", true},
 					{"c_float_null", "FLOAT", true},
+					{"c_numeric_int_null", "DECIMAL", true},
+					{"c_numeric_float_null", "DECIMAL", true},
 					{"c_varchar_null", "VARCHAR", true},
 					{"c_time_null", "TIMESTAMP", true},
 				},
@@ -73,10 +76,7 @@ func TestGetTableInfo(t *testing.T) {
 		},
 		{
 			Name:  "Snowflake",
-			NewDB: testsnowflake.NewSnowSQL,
-			NewTable: func(db *pachsql.DB) error {
-				return pachsql.CreateTestTable(db, "test_table", pachsql.TestRow{})
-			},
+			NewDB: testsnowflake.NewEphemeralSnowflakeDB,
 			Expected: &pachsql.TableInfo{
 				"test_table",
 				"public",
@@ -86,12 +86,16 @@ func TestGetTableInfo(t *testing.T) {
 					{"C_INT", "NUMBER", false},
 					{"C_BIGINT", "NUMBER", false},
 					{"C_FLOAT", "FLOAT", false},
+					{"C_NUMERIC_INT", "NUMBER", false},
+					{"C_NUMERIC_FLOAT", "NUMBER", false},
 					{"C_VARCHAR", "TEXT", false},
 					{"C_TIME", "TIMESTAMP_NTZ", false},
 					{"C_SMALLINT_NULL", "NUMBER", true},
 					{"C_INT_NULL", "NUMBER", true},
 					{"C_BIGINT_NULL", "NUMBER", true},
 					{"C_FLOAT_NULL", "FLOAT", true},
+					{"C_NUMERIC_INT_NULL", "NUMBER", true},
+					{"C_NUMERIC_FLOAT_NULL", "NUMBER", true},
 					{"C_VARCHAR_NULL", "TEXT", true},
 					{"C_TIME_NULL", "TIMESTAMP_NTZ", true},
 				},
@@ -100,11 +104,14 @@ func TestGetTableInfo(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tc := range tcs {
-		t.Run(tc.Name, func(t *testing.T) {
-			db := tc.NewDB(t)
-			// For mysql, we created a database named public via NewMySQL
-			require.NoError(t, tc.NewTable(db))
-			info, err := pachsql.GetTableInfo(ctx, db, "test_table")
+		suite.Run(tc.Name, func(t *testing.T) {
+			dbName := testutil.GenerateEphermeralDBName(t)
+			if tc.Name == "MySQL" {
+				tc.Expected.Schema = dbName
+			}
+			db := tc.NewDB(t, dbName)
+			require.NoError(t, pachsql.CreateTestTable(db, "test_table", pachsql.TestRow{}))
+			info, err := pachsql.GetTableInfo(ctx, db, fmt.Sprintf("%s.test_table", tc.Expected.Schema))
 			require.NoError(t, err)
 			require.Len(t, info.Columns, reflect.TypeOf(pachsql.TestRow{}).NumField())
 			require.Equal(t, tc.Expected, info)

--- a/src/internal/sdata/csv.go
+++ b/src/internal/sdata/csv.go
@@ -80,7 +80,7 @@ func (m *CSVWriter) format(x interface{}) (string, error) {
 		// Maybe have a list of base64 encoded columns.
 		y = string(*x)
 	case *time.Time:
-		y = x.Format(time.RFC3339Nano)
+		y = formatTimestampNTZ(x.Format(time.RFC3339Nano))
 	case *sql.NullBool:
 		if x.Valid {
 			y = strconv.FormatBool(x.Bool)
@@ -125,7 +125,7 @@ func (m *CSVWriter) format(x interface{}) (string, error) {
 		}
 	case *sql.NullTime:
 		if x.Valid {
-			y = x.Time.Format(time.RFC3339Nano)
+			y = formatTimestampNTZ(x.Time.Format(time.RFC3339Nano))
 		} else {
 			y = null
 		}

--- a/src/internal/sdata/json.go
+++ b/src/internal/sdata/json.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
+	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 )
@@ -81,10 +82,14 @@ func (m *JSONWriter) WriteTuple(row Tuple) error {
 			}
 		case *sql.NullTime:
 			if x.Valid {
-				y = x.Time
+				y = formatTimestampNTZ(x.Time.Format(time.RFC3339Nano))
 			} else {
 				y = nil
 			}
+		case *time.Time:
+			y = formatTimestampNTZ(x.Format(time.RFC3339Nano))
+		case *sql.RawBytes:
+			y = string(*x)
 		default:
 			y = row[i]
 		}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10198,8 +10198,8 @@ func TestPPSEgressToSnowflake(t *testing.T) {
 	dbName := tu.GenerateEphermeralDBName(t)
 	db := testsnowflake.NewEphemeralSnowflakeDB(t, dbName)
 	require.NoError(t, pachsql.CreateTestTable(db, "test_table", struct {
-		Id int    `sql:"ID,INT,PRIMARY KEY"`
-		A  string `sql:"A,VARCHAR(100)"`
+		Id int    `column:"ID" dtype:"INT" constraint:"PRIMARY KEY"`
+		A  string `column:"A" dtype:"VARCHAR(100)"`
 	}{}))
 
 	// create K8s secrets

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -6146,8 +6146,8 @@ func TestPFS(suite *testing.T) {
 		os.Setenv("PACHYDERM_SQL_PASSWORD", tu.DefaultPostgresPassword)
 
 		type Schema struct {
-			Id int    `sql:"ID,INT"`
-			A  string `sql:"A,VARCHAR(100)"`
+			Id int    `column:"ID" dtype:"INT"`
+			A  string `column:"A" dtype:"VARCHAR(100)"`
 		}
 
 		type File struct {


### PR DESCRIPTION
… (#7592)

* delete all rows from target table first before egressing

* Handle numeric types with precision and scale

* cleanup

* Fix EgressToPostgres test

* Read SQL numeric data as string instead

* improvements and cleanups

* cleanup databases

* Fix TestPPSEgressToSnowflake

* Trim the trailing Z in timestamps with no time zone

* Improve comments

* Fix TestEgressToPostgres