### PR TITLE
2.1.x backport: debug dump: collect logs for all suite=pachyderm pods (#7553)

### DIFF
--- a/src/internal/testutil/debug.go
+++ b/src/internal/testutil/debug.go
@@ -51,7 +51,7 @@ func DebugFiles(t testing.TB, dataRepo string) (map[string]*globlib.Glob, []stri
 	}
 	for _, app := range []string{"etcd", "pg-bouncer"} {
 		for _, file := range []string{"describe.txt", "logs.txt", "logs-previous**", "logs-loki.txt"} {
-			pattern := path.Join(app, "*", file)
+			pattern := path.Join(app, "**", file)
 			g, err := globlib.Compile(pattern, '/')
 			require.NoError(t, err)
 			expectedFiles[pattern] = g

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -70,7 +70,6 @@ func (s *debugServer) handleRedirect(
 	collectWorker collectWorkerFunc,
 	redirect redirectFunc,
 	collect collectFunc,
-	extraApps ...string,
 ) error {
 	return grpcutil.WithStreamingBytesWriter(server, func(w io.Writer) error {
 		return withDebugWriter(w, func(tw *tar.Writer) error {
@@ -124,15 +123,13 @@ func (s *debugServer) handleRedirect(
 					return err
 				}
 			}
-			if len(extraApps) > 0 {
-				return s.appLogs(tw, extraApps)
-			}
-			return nil
+			// All other pachyderm apps (console, pg-bouncer, etcd, etc.).
+			return s.appLogs(tw)
 		})
 	})
 }
 
-func (s *debugServer) appLogs(tw *tar.Writer, apps []string) error {
+func (s *debugServer) appLogs(tw *tar.Writer) error {
 	pods, err := s.env.GetKubeClient().CoreV1().Pods(s.env.Config().Namespace).List(s.env.Context(), metav1.ListOptions{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ListOptions",
@@ -142,26 +139,33 @@ func (s *debugServer) appLogs(tw *tar.Writer, apps []string) error {
 			MatchLabels: map[string]string{
 				"suite": "pachyderm",
 			},
-			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "app",
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   apps,
-			}},
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "component",
+					Operator: metav1.LabelSelectorOpNotIn,
+					// Worker and pachd logs are collected by separate
+					// functions.
+					Values: []string{"worker", "pachd"},
+				},
+			},
 		}),
 	})
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
 	for _, pod := range pods.Items {
-		prefix := join(pod.Labels["app"], pod.Name)
-		if err := s.collectDescribe(tw, pod.Name, prefix); err != nil {
+		podPrefix := join(pod.Labels["app"], pod.Name)
+		if err := s.collectDescribe(tw, pod.Name, podPrefix); err != nil {
 			return err
 		}
-		if err := s.collectLogs(tw, pod.Name, "", prefix); err != nil {
-			return err
-		}
-		if err := s.collectLogsLoki(tw, pod.Name, "", join(pod.Labels["app"], pod.Name)); err != nil {
-			return err
+		for _, container := range pod.Spec.Containers {
+			prefix := join(podPrefix, container.Name)
+			if err := s.collectLogs(tw, pod.Name, container.Name, prefix); err != nil {
+				return err
+			}
+			if err := s.collectLogsLoki(tw, pod.Name, container.Name, prefix); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -387,7 +391,6 @@ func (s *debugServer) Dump(request *debug.DumpRequest, server debug.Debug_DumpSe
 		s.collectWorkerDump,
 		redirectDumpFunc(pachClient.Ctx()),
 		collectDump,
-		"pg-bouncer", "etcd",
 	)
 }
 

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9276,6 +9276,7 @@ func TestDebug(t *testing.T) {
 		require.NoError(t, gr.Close())
 	}()
 	// Check that all of the expected files were returned.
+	var gotFiles []string
 	tr := tar.NewReader(gr)
 	for {
 		hdr, err := tr.Next()
@@ -9285,12 +9286,21 @@ func TestDebug(t *testing.T) {
 			}
 			require.NoError(t, err)
 		}
+		gotFiles = append(gotFiles, hdr.Name)
 		for pattern, g := range expectedFiles {
 			if g.Match(hdr.Name) {
 				delete(expectedFiles, pattern)
 				break
 			}
 		}
+	}
+	if len(expectedFiles) > 0 {
+		t.Logf("got files: %v", gotFiles)
+		var names []string
+		for n := range expectedFiles {
+			names = append(names, n)
+		}
+		t.Logf("no files match: %v", names)
 	}
 	require.Equal(t, 0, len(expectedFiles))
 }


### PR DESCRIPTION
* debug dump: collect logs for all suite=pachyderm pods; remove pachd special case

* debug dump: collect logs from all containers

* debug dump: give each container its own log file

* collect pachd logs as a special case; for filter=pachd

* pachyderm_test: print all the files in the dump

* debug dump: one directory per container, for etcd, pg-bouncer, etc.