### PR TITLE
Wait for initial commit to finish in TestPipelineAutoscaling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-pfs-server:
 test-pps: launch-stats docker-build-spout-test
 	@# Use the count flag to disable test caching for this test suite.
 	PROM_PORT=$$(kubectl --namespace=monitoring get svc/prometheus -o json | jq -r .spec.ports[0].nodePort) \
-	  go test -v -count=1 ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) $(RUN) $(TESTFLAGS)
+	  go test -v -count=20 -failfast ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) -run TestPipelineAutoscaling $(TESTFLAGS)
 
 test-cmds:
 	go install -v ./src/testing/match

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-pfs-server:
 test-pps: launch-stats docker-build-spout-test
 	@# Use the count flag to disable test caching for this test suite.
 	PROM_PORT=$$(kubectl --namespace=monitoring get svc/prometheus -o json | jq -r .spec.ports[0].nodePort) \
-	  go test -v -count=20 -failfast ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) -run TestPipelineAutoscaling $(TESTFLAGS)
+	  go test -v -count=1 ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) $(RUN) $(TESTFLAGS)
 
 test-cmds:
 	go install -v ./src/testing/match

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9731,7 +9731,7 @@ func TestPipelineAutoscaling(t *testing.T) {
 				Cmd: []string{"bash"},
 				Stdin: []string{
 					fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo),
-					"sleep 30",
+					"sleep 5",
 				},
 			},
 			Input:           client.NewPFSInput(dataRepo, "/*"),
@@ -10195,6 +10195,7 @@ func monitorReplicas(t testing.TB, c *client.APIClient, namespace, pipeline stri
 				enoughReplicas = true
 			}
 			if int(scale.Spec.Replicas) > n {
+				t.Logf("too many replicas %d > %d", int(scale.Spec.Replicas), n)
 				tooManyReplicas = true
 			}
 			ci, err := c.InspectCommit(pipeline, "master", "")

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9731,7 +9731,7 @@ func TestPipelineAutoscaling(t *testing.T) {
 				Cmd: []string{"bash"},
 				Stdin: []string{
 					fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo),
-					"sleep 5",
+					"sleep 30",
 				},
 			},
 			Input:           client.NewPFSInput(dataRepo, "/*"),

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9740,6 +9740,8 @@ func TestPipelineAutoscaling(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	_, err = c.WaitCommit(pipeline, "master", "")
+	require.NoError(t, err)
 
 	fileIndex := 0
 	commitNFiles := func(n int) {

--- a/src/server/pps/server/kube_driver.go
+++ b/src/server/pps/server/kube_driver.go
@@ -134,6 +134,7 @@ func (kd *kubeDriver) ReadReplicationController(ctx context.Context, pi *pps.Pip
 func (kd *kubeDriver) UpdateReplicationController(ctx context.Context, old *v1.ReplicationController, update func(rc *v1.ReplicationController) bool) error {
 	// Apply op's update to rc
 	rc := old.DeepCopy()
+	rc.ResourceVersion = ""
 	if update(rc) {
 		// write updated RC to k8s
 		kd.limiter.Acquire()

--- a/src/server/pps/server/kube_driver.go
+++ b/src/server/pps/server/kube_driver.go
@@ -134,6 +134,11 @@ func (kd *kubeDriver) ReadReplicationController(ctx context.Context, pi *pps.Pip
 func (kd *kubeDriver) UpdateReplicationController(ctx context.Context, old *v1.ReplicationController, update func(rc *v1.ReplicationController) bool) error {
 	// Apply op's update to rc
 	rc := old.DeepCopy()
+	// clearing resourceVersion effectively tells k8s to ignore concurrent modifications.
+	// While this has a chance of overwriting a direct change to the RC outside of pachyderm,
+	// the most likely source of conflict is replica state changes, which can be safely ignored.
+	// Ensuring an uninterrupted update would require changing our retry logic,
+	// as currently a failure here leads to failing the pipeline
 	rc.ResourceVersion = ""
 	if update(rc) {
 		// write updated RC to k8s

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -572,7 +572,10 @@ func (pc *pipelineController) scaleUpPipeline(ctx context.Context, pi *pps.Pipel
 			var nTasks int32
 			// TODO: should this run through internal PPS service?
 			err := pc.env.GetPachClient(ctx).ListTask("pps", driver.TaskNamespace(pi), "", func(info *task.TaskInfo) error {
-				nTasks++
+				switch info.State {
+				case task.State_CLAIMED, task.State_RUNNING:
+					nTasks++
+				}
 				return nil
 			})
 			// Set parallelism

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -572,15 +571,10 @@ func (pc *pipelineController) scaleUpPipeline(ctx context.Context, pi *pps.Pipel
 			// Master is scheduled; see if tasks have been calculated
 			var nTasks int32
 			// TODO: should this run through internal PPS service?
-			var taskDescs []string
 			err := pc.env.GetPachClient(ctx).ListTask("pps", driver.TaskNamespace(pi), "", func(info *task.TaskInfo) error {
-				taskDescs = append(taskDescs, fmt.Sprint(info.State, info.Group, info.InputType))
 				nTasks++
 				return nil
 			})
-			if len(taskDescs) > 1 {
-				log.Infof("QQQ tasks for %s@%d: %s\n", pi.Pipeline.Name, pi.Version, strings.Join(taskDescs, "\n"))
-			}
 			// Set parallelism
 			log.Debugf("Beginning scale-up check for %q, which has %d tasks",
 				pi.Pipeline.Name, nTasks)


### PR DESCRIPTION
There was a race condition where, due to parallel jobs, the first
intended job could start while the initial (empty) job was still being
processed, leading to an unexpected scale of two. While totally correct
behavior, the test expects serial jobs.