### PR TITLE
Worker Master deletes meta files for unskippable datums

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6179,6 +6179,7 @@ func TestSkippedDatums(t *testing.T) {
 	job2 := jobs[0]
 	// check the successful datum from job1 is now skipped
 	datum, err = c.InspectDatum(pipelineName, job2.Job.ID, datums[0].Datum.ID)
+	require.NoError(t, err)
 	require.Equal(t, pps.DatumState_SKIPPED, datum.State)
 	// load datums for job2
 	datums, err = c.ListDatumAll(pipelineName, job2.Job.ID)
@@ -6260,6 +6261,7 @@ func TestMetaRepoContents(t *testing.T) {
 	require.NoError(t, c.DeleteFile(commit2, "/foo"))
 	require.NoError(t, c.FinishCommit(dataRepo, commit2.Branch.Name, commit2.ID))
 	_, err = c.WaitJobSetAll(commit2.ID, false)
+	require.NoError(t, err)
 	assertMetaContents(commit2.ID, "bar")
 	fileCount := 0
 	var fileName string

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6164,19 +6164,112 @@ func TestSkippedDatums(t *testing.T) {
 	ji = jis[0]
 	require.Equal(t, ji.State, pps.JobState_JOB_SUCCESS)
 
-	/*
-		jobs, err := c.ListJob(pipelineName, nil, nil, -1, true)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(jobs))
+	jobs, err := c.ListJob(pipelineName, nil, -1, true)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(jobs))
 
-		datums, err := c.ListDatumAll(jobs[1].Job.ID)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(datums))
+	job1 := jobs[1]
+	datums, err := c.ListDatumAll(pipelineName, job1.Job.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(datums))
+	datum, err := c.InspectDatum(pipelineName, job1.Job.ID, datums[0].Datum.ID)
+	require.NoError(t, err)
+	require.Equal(t, pps.DatumState_SUCCESS, datum.State)
 
-		datum, err := c.InspectDatum(jobs[1].Job.ID, datums[0].ID)
-		require.NoError(t, err)
-		require.Equal(t, pps.DatumState_SUCCESS, datum.State)
-	*/
+	job2 := jobs[0]
+	// check the successful datum from job1 is now skipped
+	datum, err = c.InspectDatum(pipelineName, job2.Job.ID, datums[0].Datum.ID)
+	require.Equal(t, pps.DatumState_SKIPPED, datum.State)
+	// load datums for job2
+	datums, err = c.ListDatumAll(pipelineName, job2.Job.ID)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(datums))
+	require.NoError(t, err)
+	require.Equal(t, int64(1), job2.DataSkipped)
+	require.Equal(t, pps.JobState_JOB_SUCCESS, job2.State)
+}
+
+func TestMetaRepoContents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t)
+	// create repos
+	dataRepo := tu.UniqueString("TestPipeline_data")
+	require.NoError(t, c.CreateRepo(dataRepo))
+	pipelineName := tu.UniqueString("pipeline")
+	_, err := c.PpsAPIClient.CreatePipeline(context.Background(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(pipelineName),
+			Transform: &pps.Transform{
+				Cmd: []string{"bash"},
+				Stdin: []string{
+					fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo),
+				},
+			},
+			ParallelismSpec: &pps.ParallelismSpec{
+				Constant: 1,
+			},
+			Input: client.NewPFSInput(dataRepo, "/*"),
+		})
+	require.NoError(t, err)
+	assertMetaContents := func(commitID string, inputFile string) {
+		var datumID string
+		require.NoError(t, c.ListDatum(pipelineName, commitID, func(di *pps.DatumInfo) error {
+			datumID = di.Datum.ID
+			return nil
+		}))
+		expectedFiles := map[string]struct{}{
+			fmt.Sprintf("/meta/%v/meta", datumID):                      {},
+			fmt.Sprintf("/pfs/%v/%v/%v", datumID, dataRepo, inputFile): {},
+			fmt.Sprintf("/pfs/%v/out/%v", datumID, inputFile):          {},
+		}
+		metaCommit := &pfs.Commit{
+			Branch: client.NewSystemRepo(pipelineName, pfs.MetaRepoType).NewBranch("master"),
+			ID:     commitID,
+		}
+		var files []string
+		require.NoError(t, c.WalkFile(metaCommit, "", func(fi *pfs.FileInfo) error {
+			if fi.FileType == pfs.FileType_FILE {
+				files = append(files, fi.File.Path)
+			}
+			return nil
+		}))
+		require.Equal(t, len(expectedFiles), len(files))
+		for _, f := range files {
+			delete(expectedFiles, f)
+		}
+		require.Equal(t, 0, len(expectedFiles))
+	}
+	// Do first commit to repo
+	commit1, err := c.StartCommit(dataRepo, "master")
+	require.NoError(t, err)
+	require.NoError(t, c.PutFile(commit1, "foo", strings.NewReader("foo\n")))
+	require.NoError(t, c.FinishCommit(dataRepo, commit1.Branch.Name, commit1.ID))
+	jis, err := c.WaitJobSetAll(commit1.ID, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(jis))
+	ji := jis[0]
+	require.Equal(t, ji.State, pps.JobState_JOB_SUCCESS)
+	assertMetaContents(commit1.ID, "foo")
+	// Replace file in input repo
+	commit2, err := c.StartCommit(dataRepo, "master")
+	require.NoError(t, err)
+	require.NoError(t, c.PutFile(commit2, "bar", strings.NewReader("bar\n")))
+	require.NoError(t, c.DeleteFile(commit2, "/foo"))
+	require.NoError(t, c.FinishCommit(dataRepo, commit2.Branch.Name, commit2.ID))
+	_, err = c.WaitJobSetAll(commit2.ID, false)
+	assertMetaContents(commit2.ID, "bar")
+	fileCount := 0
+	var fileName string
+	require.NoError(t, c.ListFile(client.NewCommit(pipelineName, "master", commit2.ID), "", func(fi *pfs.FileInfo) error {
+		fileCount++
+		fileName = fi.File.Path
+		return nil
+	}))
+	require.Equal(t, 1, fileCount)
+	require.Equal(t, "/bar", fileName)
 }
 
 func TestCronPipeline(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6196,7 +6196,6 @@ func TestMetaRepoContents(t *testing.T) {
 	}
 	t.Parallel()
 	c, _ := minikubetestenv.AcquireCluster(t)
-	// create repos
 	dataRepo := tu.UniqueString("TestPipeline_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
 	pipelineName := tu.UniqueString("pipeline")

--- a/src/server/worker/datum/datum.go
+++ b/src/server/worker/datum/datum.go
@@ -494,7 +494,7 @@ func NewDeleter(metaFileWalker fileWalkerFunc, metaOutputClient, pfsOutputClient
 	return func(meta *Meta) error {
 		ID := common.DatumID(meta.Inputs)
 		tagOption := client.WithDatumDeleteFile(ID)
-		// Delete the datum directory in the meta output.
+		// Delete the datum's meta file from the meta commit.
 		if err := metaOutputClient.DeleteFile(path.Join(MetaPrefix, ID, MetaFileName), tagOption); err != nil {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/worker/datum/datum.go
+++ b/src/server/worker/datum/datum.go
@@ -495,15 +495,12 @@ func NewDeleter(metaFileWalker fileWalkerFunc, metaOutputClient, pfsOutputClient
 		ID := common.DatumID(meta.Inputs)
 		tagOption := client.WithDatumDeleteFile(ID)
 		// Delete the datum directory in the meta output.
-		if err := metaOutputClient.DeleteFile(path.Join(MetaPrefix, ID)+"/", tagOption); err != nil {
+		if err := metaOutputClient.DeleteFile(path.Join(MetaPrefix, ID, MetaFileName), tagOption); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := metaOutputClient.DeleteFile(path.Join(PFSPrefix, ID)+"/", tagOption); err != nil {
-			return errors.EnsureStack(err)
-		}
-		// Delete the content output by the datum.
-		outputDir := "/" + path.Join(PFSPrefix, ID, OutputPrefix)
-		files, err := metaFileWalker(outputDir)
+		pfsDir := "/" + path.Join(PFSPrefix, ID)
+		outDir := path.Join(pfsDir, OutputPrefix)
+		files, err := metaFileWalker(pfsDir)
 		if err != nil {
 			if pfsserver.IsFileNotFoundErr(err) {
 				return nil
@@ -511,13 +508,19 @@ func NewDeleter(metaFileWalker fileWalkerFunc, metaOutputClient, pfsOutputClient
 			return err
 		}
 		for i := range files {
-			// Remove the output directory prefix.
-			file, err := filepath.Rel(outputDir, files[i])
-			if err != nil {
+			if err := metaOutputClient.DeleteFile(files[i], tagOption); err != nil {
 				return errors.EnsureStack(err)
 			}
-			if err := pfsOutputClient.DeleteFile(file, tagOption); err != nil {
-				return errors.EnsureStack(err)
+			// Delete the content output by the datum.
+			if strings.HasPrefix(files[i], outDir) {
+				// Remove the output directory prefix.
+				file, err := filepath.Rel(outDir, files[i])
+				if err != nil {
+					return errors.EnsureStack(err)
+				}
+				if err := pfsOutputClient.DeleteFile(file, tagOption); err != nil {
+					return errors.EnsureStack(err)
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Execute point deletes from the client on the PPS Worker Master because directory deletes are slow when operating on a commit with many intermediate filesets