### PR TITLE
[2.2.x Backport] Worker Master deletes meta files for unskippable datums (#7635)

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6066,19 +6066,113 @@ func TestSkippedDatums(t *testing.T) {
 	ji = jis[0]
 	require.Equal(t, ji.State, pps.JobState_JOB_SUCCESS)
 
-	/*
-		jobs, err := c.ListJob(pipelineName, nil, nil, -1, true)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(jobs))
+	jobs, err := c.ListJob(pipelineName, nil, -1, true)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(jobs))
 
-		datums, err := c.ListDatumAll(jobs[1].Job.ID)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(datums))
+	job1 := jobs[1]
+	datums, err := c.ListDatumAll(pipelineName, job1.Job.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(datums))
+	datum, err := c.InspectDatum(pipelineName, job1.Job.ID, datums[0].Datum.ID)
+	require.NoError(t, err)
+	require.Equal(t, pps.DatumState_SUCCESS, datum.State)
 
-		datum, err := c.InspectDatum(jobs[1].Job.ID, datums[0].ID)
-		require.NoError(t, err)
-		require.Equal(t, pps.DatumState_SUCCESS, datum.State)
-	*/
+	job2 := jobs[0]
+	// check the successful datum from job1 is now skipped
+	datum, err = c.InspectDatum(pipelineName, job2.Job.ID, datums[0].Datum.ID)
+	require.NoError(t, err)
+	require.Equal(t, pps.DatumState_SKIPPED, datum.State)
+	// load datums for job2
+	datums, err = c.ListDatumAll(pipelineName, job2.Job.ID)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(datums))
+	require.NoError(t, err)
+	require.Equal(t, int64(1), job2.DataSkipped)
+	require.Equal(t, pps.JobState_JOB_SUCCESS, job2.State)
+}
+
+func TestMetaRepoContents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t)
+	dataRepo := tu.UniqueString("TestPipeline_data")
+	require.NoError(t, c.CreateRepo(dataRepo))
+	pipelineName := tu.UniqueString("pipeline")
+	_, err := c.PpsAPIClient.CreatePipeline(context.Background(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(pipelineName),
+			Transform: &pps.Transform{
+				Cmd: []string{"bash"},
+				Stdin: []string{
+					fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo),
+				},
+			},
+			ParallelismSpec: &pps.ParallelismSpec{
+				Constant: 1,
+			},
+			Input: client.NewPFSInput(dataRepo, "/*"),
+		})
+	require.NoError(t, err)
+	assertMetaContents := func(commitID string, inputFile string) {
+		var datumID string
+		require.NoError(t, c.ListDatum(pipelineName, commitID, func(di *pps.DatumInfo) error {
+			datumID = di.Datum.ID
+			return nil
+		}))
+		expectedFiles := map[string]struct{}{
+			fmt.Sprintf("/meta/%v/meta", datumID):                      {},
+			fmt.Sprintf("/pfs/%v/%v/%v", datumID, dataRepo, inputFile): {},
+			fmt.Sprintf("/pfs/%v/out/%v", datumID, inputFile):          {},
+		}
+		metaCommit := &pfs.Commit{
+			Branch: client.NewSystemRepo(pipelineName, pfs.MetaRepoType).NewBranch("master"),
+			ID:     commitID,
+		}
+		var files []string
+		require.NoError(t, c.WalkFile(metaCommit, "", func(fi *pfs.FileInfo) error {
+			if fi.FileType == pfs.FileType_FILE {
+				files = append(files, fi.File.Path)
+			}
+			return nil
+		}))
+		require.Equal(t, len(expectedFiles), len(files))
+		for _, f := range files {
+			delete(expectedFiles, f)
+		}
+		require.Equal(t, 0, len(expectedFiles))
+	}
+	// Do first commit to repo
+	commit1, err := c.StartCommit(dataRepo, "master")
+	require.NoError(t, err)
+	require.NoError(t, c.PutFile(commit1, "foo", strings.NewReader("foo\n")))
+	require.NoError(t, c.FinishCommit(dataRepo, commit1.Branch.Name, commit1.ID))
+	jis, err := c.WaitJobSetAll(commit1.ID, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(jis))
+	ji := jis[0]
+	require.Equal(t, ji.State, pps.JobState_JOB_SUCCESS)
+	assertMetaContents(commit1.ID, "foo")
+	// Replace file in input repo
+	commit2, err := c.StartCommit(dataRepo, "master")
+	require.NoError(t, err)
+	require.NoError(t, c.PutFile(commit2, "bar", strings.NewReader("bar\n")))
+	require.NoError(t, c.DeleteFile(commit2, "/foo"))
+	require.NoError(t, c.FinishCommit(dataRepo, commit2.Branch.Name, commit2.ID))
+	_, err = c.WaitJobSetAll(commit2.ID, false)
+	require.NoError(t, err)
+	assertMetaContents(commit2.ID, "bar")
+	fileCount := 0
+	var fileName string
+	require.NoError(t, c.ListFile(client.NewCommit(pipelineName, "master", commit2.ID), "", func(fi *pfs.FileInfo) error {
+		fileCount++
+		fileName = fi.File.Path
+		return nil
+	}))
+	require.Equal(t, 1, fileCount)
+	require.Equal(t, "/bar", fileName)
 }
 
 func TestCronPipeline(t *testing.T) {


### PR DESCRIPTION
* Worker Master deletes meta files for unskippable datums

* Fix path for deleting unskippable base meta commit datum job input files