### PR TITLE
Let Envoy terminate TLS

### DIFF
--- a/etc/generate-envoy-config/Makefile
+++ b/etc/generate-envoy-config/Makefile
@@ -15,11 +15,17 @@ format: *.jsonnet *.libsonnet
 check-envoy-config: ../helm/pachyderm/envoy.json
 	envoy -c ../helm/pachyderm/envoy.json --mode validate
 
-check-envoy-config-tls: ../helm/pachyderm/envoy.json
-	sudo mkdir -p /etc/envoy # Sadly, we have to make the local machine look like a k8s pod.
-	sudo mkdir -p /tls
-	sudo touch /tls/tls.key /tls/tls.crt
-	sudo cp ../helm/pachyderm/envoy-sds.yaml /etc/envoy/sds.yaml
+# This requires that the CI machine or your workstation look a little like the Kubernetes pod we run
+# in; ../helm/pachyderm/envoy-sds.yaml needs to be copied to /etc/envoy/sds.yaml and you need to
+# have TLS certificates (empty files ok) in /tls.  If you want to make requests to Envoy (that you
+# start up like the validation command below, but without `--mode validate`), they need to be real
+# certs.  I got mine out of here: https://go.dev/src/net/http/internal/testcert/testcert.go.
+check-envoy-config-tls: ../helm/pachyderm/envoy-tls.json
+	mkdir -p /etc/envoy
+	mkdir -p /tls
+	test -e /tls/tls.key || touch /tls/tls.key
+	test -e /tls/tls.crt || touch /tls/tls.crt
+	test -e /etc/envoy/sds.yaml || cp ../helm/pachyderm/envoy-sds.yaml /etc/envoy/sds.yaml
 	envoy -c ../helm/pachyderm/envoy-tls.json --mode validate --service-node localhost --service-zone localhost --service-cluster envoy
 
 # So that CI can fail when you forget to run jsonnetfmt.
@@ -38,6 +44,6 @@ check-generated-tls:
 	diff -u ../helm/pachyderm/envoy-tls.json /tmp/test-formatting.envoy.json  --label in-repo --label would-generate
 	echo "tls codegen ok"
 
-test: all check-formatting check-generated check-generated-tls check-envoy-config check-envoy-config-tls
+test: check-formatting check-generated check-generated-tls check-envoy-config check-envoy-config-tls
 
 .PHONY: all format check-envoy-config check-envoy-config-tls check-formatting check-generated check-generated-tls test

--- a/etc/generate-envoy-config/Makefile
+++ b/etc/generate-envoy-config/Makefile
@@ -16,6 +16,10 @@ check-envoy-config: ../helm/pachyderm/envoy.json
 	envoy -c ../helm/pachyderm/envoy.json --mode validate
 
 check-envoy-config-tls: ../helm/pachyderm/envoy.json
+	sudo mkdir -p /etc/envoy # Sadly, we have to make the local machine look like a k8s pod.
+	sudo mkdir -p /tls
+	sudo touch /tls/tls.key /tls/tls.crt
+	sudo cp ../helm/pachyderm/envoy-sds.yaml /etc/envoy/sds.yaml
 	envoy -c ../helm/pachyderm/envoy-tls.json --mode validate --service-node localhost --service-zone localhost --service-cluster envoy
 
 # So that CI can fail when you forget to run jsonnetfmt.

--- a/etc/generate-envoy-config/Makefile
+++ b/etc/generate-envoy-config/Makefile
@@ -16,7 +16,7 @@ check-envoy-config: ../helm/pachyderm/envoy.json
 	envoy -c ../helm/pachyderm/envoy.json --mode validate
 
 check-envoy-config-tls: ../helm/pachyderm/envoy.json
-	envoy -c ../helm/pachyderm/envoy-tls.json --mode validate
+	envoy -c ../helm/pachyderm/envoy-tls.json --mode validate --service-node localhost --service-zone localhost --service-cluster envoy
 
 # So that CI can fail when you forget to run jsonnetfmt.
 check-formatting:

--- a/etc/generate-envoy-config/Makefile
+++ b/etc/generate-envoy-config/Makefile
@@ -1,7 +1,12 @@
-../helm/pachyderm/envoy.json: envoy.jsonnet envoy.libsonnet
+all: ../helm/pachyderm/envoy.json ../helm/pachyderm/envoy-tls.json
+
+../helm/pachyderm/envoy.json: envoy.jsonnet envoy.libsonnet pachyderm-services.libsonnet
 	jsonnet envoy.jsonnet > ../helm/pachyderm/envoy.json
 
-format: envoy.jsonnet envoy.libsonnet
+../helm/pachyderm/envoy-tls.json: envoy-tls.jsonnet envoy.libsonnet pachyderm-services.libsonnet
+	jsonnet envoy-tls.jsonnet > ../helm/pachyderm/envoy-tls.json
+
+format: *.jsonnet *.libsonnet
 	jsonnetfmt -i *.jsonnet *.libsonnet
 
 # This requires that you install Envoy, which is a big pain.  I just "docker cp" it out of the
@@ -9,6 +14,9 @@ format: envoy.jsonnet envoy.libsonnet
 # https://www.envoyproxy.io/docs/envoy/latest/start/install
 check-envoy-config: ../helm/pachyderm/envoy.json
 	envoy -c ../helm/pachyderm/envoy.json --mode validate
+
+check-envoy-config-tls: ../helm/pachyderm/envoy.json
+	envoy -c ../helm/pachyderm/envoy-tls.json --mode validate
 
 # So that CI can fail when you forget to run jsonnetfmt.
 check-formatting:
@@ -21,6 +29,11 @@ check-generated:
 	diff -u ../helm/pachyderm/envoy.json /tmp/test-formatting.envoy.json  --label in-repo --label would-generate
 	echo "codegen ok"
 
-test: check-formatting check-generated check-envoy-config
+check-generated-tls:
+	jsonnet envoy-tls.jsonnet > /tmp/test-formatting.envoy.json
+	diff -u ../helm/pachyderm/envoy-tls.json /tmp/test-formatting.envoy.json  --label in-repo --label would-generate
+	echo "tls codegen ok"
 
-.PHONY: format check-envoy-config check-formatting check-generated test
+test: all check-formatting check-generated check-generated-tls check-envoy-config check-envoy-config-tls
+
+.PHONY: all format check-envoy-config check-envoy-config-tls check-formatting check-generated check-generated-tls test

--- a/etc/generate-envoy-config/envoy-tls.jsonnet
+++ b/etc/generate-envoy-config/envoy-tls.jsonnet
@@ -1,4 +1,31 @@
 local Envoy = import 'envoy.libsonnet';
 local Services = import 'pachyderm-services.libsonnet';
 
-Envoy.bootstrap(listeners=[], clusters=[])
+Envoy.bootstrap(
+  listeners=[
+    // The HTTP port just redirects to HTTPS.
+    Envoy.httpListener(
+      port=8080,
+      name='https-redirect',
+      routes=[Envoy.redirectToHttpsRoute],
+    ),
+
+    // The HTTPS port serves the multiplexed route table with TLS.  (Additionally, if a cleartext
+    // request reaches this port, we generate a redirect to the https protocol.)  Note: the order of
+    // the routes we select below is crucial to the multiplexing working.
+    Envoy.httpsListener(
+      port=8443,
+      name='proxy-https',
+      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'console'])
+    ),
+
+    // Unlike the cleartext configuration, we don't serve direct routes to individual pachd/console
+    // ports.  This is so that people don't go down the rabbit hole of trying to provision a TLS
+    // certificate for a port number.  We say we don't support it, and they won't waste their time
+    // trying.
+  ],
+  clusters=[
+    Envoy.serviceAsCluster(name, Services[name])
+    for name in std.objectFields(Services)
+  ],
+)

--- a/etc/generate-envoy-config/envoy-tls.jsonnet
+++ b/etc/generate-envoy-config/envoy-tls.jsonnet
@@ -1,0 +1,4 @@
+local Envoy = import 'envoy.libsonnet';
+local Services = import 'pachyderm-services.libsonnet';
+
+Envoy.bootstrap(listeners=[], clusters=[])

--- a/etc/generate-envoy-config/envoy.jsonnet
+++ b/etc/generate-envoy-config/envoy.jsonnet
@@ -1,173 +1,6 @@
-// Services that we want to proxy; where they are and how to route them.
-local services = {
-  'pachd-grpc': {
-    internal_port: 1650,
-    external_port: 30650,
-    grpc: true,
-    service: 'pachd-proxy-backend',
-    routes: [
-      {
-        match: {
-          grpc: {},
-          prefix: '/',
-        },
-        route: {
-          cluster: 'pachd-grpc',
-          timeout: '604800s',
-        },
-      },
-    ],
-    health_check: {
-      grpc_health_check: {},
-      healthy_threshold: 1,
-      interval: '10s',
-      timeout: '10s',
-      unhealthy_threshold: 2,
-      no_traffic_interval: '10s',
-      no_traffic_healthy_interval: '10s',
-    },
-  },
-  'pachd-s3': {
-    internal_port: 1600,
-    external_port: 30600,
-    service: 'pachd-proxy-backend',
-    routes: local base = {
-      route: {
-        cluster: 'pachd-s3',
-        idle_timeout: '600s',
-        timeout: '604800s',
-      },
-    }; [
-      base {  // S3v4
-        match: {
-          prefix: '/',
-          headers: [
-            {
-              name: 'authorization',
-              string_match: {
-                prefix: 'AWS4-HMAC-SHA256',
-              },
-            },
-          ],
-        },
-      },
-      base {  // S3v2
-        match: {
-          prefix: '/',
-          headers: [
-            {
-              name: 'authorization',
-              string_match: {
-                prefix: 'AWS ',
-              },
-            },
-          ],
-        },
-      },
-    ],
-  },
-  'pachd-identity': {
-    internal_port: 1658,
-    external_port: 30658,
-    service: 'pachd-proxy-backend',
-    routes: [
-      {
-        match: {
-          prefix: '/dex',
-        },
-        route: {
-          cluster: 'pachd-identity',
-          idle_timeout: '60s',
-          timeout: '60s',
-        },
-      },
-    ],
-    health_check: {
-      healthy_threshold: 1,
-      http_health_check: {
-        host: 'localhost',
-        path: '/dex/.well-known/openid-configuration',
-      },
-      interval: '30s',
-      timeout: '10s',
-      unhealthy_threshold: 2,
-      no_traffic_interval: '10s',
-      no_traffic_healthy_interval: '10s',
-    },
-  },
-  'pachd-oidc': {
-    internal_port: 1657,
-    external_port: 30657,
-    service: 'pachd-proxy-backend',
-    routes: [
-      {
-        match: {
-          prefix: '/authorization-code/callback',
-        },
-        route: {
-          cluster: 'pachd-oidc',
-          idle_timeout: '60s',
-          timeout: '60s',
-        },
-      },
-    ],
-  },
-  console: {
-    internal_port: 4000,
-    external_port: 4000,
-    service: 'console-proxy-backend',
-    routes: [
-      {
-        match: {
-          prefix: '/',
-        },
-        route: {
-          cluster: 'console',
-          idle_timeout: '600s',
-          timeout: '3600s',
-          upgrade_configs: [
-            {
-              enabled: true,
-              upgrade_type: 'websocket',
-            },
-          ],
-        },
-      },
-    ],
-    health_check: {
-      healthy_threshold: 1,
-      http_health_check: {
-        host: 'localhost',  // This is just the value of the Host: header, not something to connect to.
-        path: '/',
-      },
-      interval: '30s',
-      timeout: '10s',
-      unhealthy_threshold: 2,
-      no_traffic_interval: '10s',
-      no_traffic_healthy_interval: '10s',
-    },
-  },
-  'pachd-metrics': {
-    internal_port: 1656,
-    external_port: 30656,
-    service: 'pachd-proxy-backend',
-    routes: [
-      {
-        match: {
-          prefix: '/',
-        },
-        route: {
-          cluster: 'pachd-metrics',
-          idle_timeout: '60s',
-          timeout: '60s',
-        },
-      },
-    ],
-  },
-};
-
-// This is the generation code.
 local Envoy = import 'envoy.libsonnet';
+local Services = import 'pachyderm-services.libsonnet';
+
 Envoy.bootstrap(
   listeners=[
     Envoy.httpListener(
@@ -175,10 +8,10 @@ Envoy.bootstrap(
       name='proxy-http',
       // Everything except the metrics service is served on the multiplexed route.  The order of
       // services' routes is important!
-      routes=std.flatMap(function(name) services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'console'])
+      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'console'])
     ),
   ] + [
-    local svc = services[name];
+    local svc = Services[name];
     Envoy.httpListener(
       port=svc.internal_port,
       name='direct-' + name,
@@ -186,15 +19,15 @@ Envoy.bootstrap(
     )
     // Every service gets a direct route.  We sort the keys so that the output is
     // stable across regeneration.
-    for name in std.sort(std.objectFields(services), keyF=function(name) services[name].internal_port)
+    for name in std.sort(std.objectFields(Services), keyF=function(name) Services[name].internal_port)
   ],
   clusters=[
-    local svc = services[name];
+    local svc = Services[name];
     (if 'grpc' in svc && svc.grpc then Envoy.GRPCCluster else Envoy.defaultCluster) + {
       name: name,
       load_assignment: Envoy.loadAssignment(name=name, address=svc.service, port=svc.internal_port),
       health_checks: if 'health_check' in svc then [svc.health_check] else [],
     }
-    for name in std.objectFields(services)
+    for name in std.objectFields(Services)
   ],
 )

--- a/etc/generate-envoy-config/envoy.jsonnet
+++ b/etc/generate-envoy-config/envoy.jsonnet
@@ -3,12 +3,23 @@ local Services = import 'pachyderm-services.libsonnet';
 
 Envoy.bootstrap(
   listeners=[
+    // Serve the multiplexed route table on port 8080.
     Envoy.httpListener(
       port=8080,  // Not port 80, because we run as user 101 and not root.
       name='proxy-http',
       // Everything except the metrics service is served on the multiplexed route.  The order of
       // services' routes is important!
       routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'console'])
+    ),
+
+    // In case someone port-forwards port 8443 because they were expecting TLS to be working, this
+    // will tell them why it isn't.
+    Envoy.httpListener(
+      port=8443,
+      name='https-warning',
+      routes=[
+        Envoy.messageRoute(500, 'This is the cleartext installation of pachyderm-proxy; enable TLS in the helm chart and reinstall.'),
+      ],
     ),
   ] + [
     local svc = Services[name];
@@ -17,17 +28,13 @@ Envoy.bootstrap(
       name='direct-' + name,
       routes=svc.routes,
     )
-    // Every service gets a direct route.  We sort the keys so that the output is
-    // stable across regeneration.
+    // Every service gets a direct route.  Whether or not traffic from the Internet can reach these
+    // is controlled by helm values (the service won't bind the ports if the user doesn't want to
+    // use them).  We sort the keys here so that the output is stable across regeneration.
     for name in std.sort(std.objectFields(Services), keyF=function(name) Services[name].internal_port)
   ],
   clusters=[
-    local svc = Services[name];
-    (if 'grpc' in svc && svc.grpc then Envoy.GRPCCluster else Envoy.defaultCluster) + {
-      name: name,
-      load_assignment: Envoy.loadAssignment(name=name, address=svc.service, port=svc.internal_port),
-      health_checks: if 'health_check' in svc then [svc.health_check] else [],
-    }
+    Envoy.serviceAsCluster(name, Services[name])
     for name in std.objectFields(Services)
   ],
 )

--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -70,7 +70,7 @@
     },
   },
 
-  loadAssignment(name, address, port): {
+  loadAssignment(name, address, port):: {
     cluster_name: name,
     endpoints: [
       {
@@ -90,6 +90,93 @@
     ],
   },
 
+  httpConnectionManager(name, routes):: {
+    name: 'envoy.http_connection_manager',
+    typed_config: {
+      '@type': 'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
+      access_log: [
+        {
+          name: 'envoy.access_loggers.stdout',
+          typed_config: {
+            '@type': 'type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog',
+          },
+        },
+      ],
+      codec_type: 'auto',
+      common_http_protocol_options: {
+        headers_with_underscores_action: 'REJECT_REQUEST',
+        idle_timeout: '60s',
+      },
+      http2_protocol_options: {
+        initial_connection_window_size: 1048576,
+        initial_stream_window_size: 65536,
+        max_concurrent_streams: 100,
+      },
+      http_filters: std.prune([
+        // If there's a GRPC router, enable grpc_stats.
+        if std.foldl(function(last, route) last || 'grpc' in route.match, routes, false) then
+          {
+            name: 'envoy.filters.http.grpc_stats',
+            typed_config: {
+              '@type': 'type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig',
+              enable_upstream_stats: true,
+              // Stats for all methods = true would let anyone on the Internet fill up the
+              // statistics buffer with bogus RPC method names, so we have to leave it off.
+              stats_for_all_methods: false,
+            },
+          } else {},
+        {
+          name: 'envoy.filters.http.router',
+          typed_config: {
+            '@type': 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router',
+          },
+        },
+      ]),
+      http_protocol_options: {
+        accept_http_10: false,
+      },
+      request_timeout: '604800s',  // Necessary to allow long file uploads.
+      stream_idle_timeout: '600s',  // Only completely idle streams are dropped after this timeout.
+      route_config: {
+        virtual_hosts: [
+          {
+            domains: ['*'],
+            name: 'any',
+            routes: routes,
+            retry_policy: {
+              retry_on: 'connect-failure',
+              num_retries: 4,
+              host_selection_retry_max_attempts: 4,
+            },
+          },
+        ],
+      },
+      stat_prefix: name,
+      use_remote_address: true,
+    },
+  },
+
+  redirectToHttpsRoute: {
+    match: {
+      prefix: '/',
+    },
+    redirect: {
+      https_redirect: true,
+    },
+  },
+
+  messageRoute(status, message): {
+    match: {
+      prefix: '/',
+    },
+    direct_response: {
+      status: status,
+      body: {
+        inline_string: message,
+      },
+    },
+  },
+
   httpListener(port, name, routes): {
     name: name,
     per_connection_buffer_limit_bytes: 32768,
@@ -102,79 +189,80 @@
     },
     filter_chains: [
       {
-        filters: [
-          {
-            name: 'envoy.http_connection_manager',
-            typed_config: {
-              '@type': 'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
-              access_log: [
-                {
-                  name: 'envoy.access_loggers.stdout',
-                  typed_config: {
-                    '@type': 'type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog',
-                  },
-                },
-              ],
-              codec_type: 'auto',
-              common_http_protocol_options: {
-                headers_with_underscores_action: 'REJECT_REQUEST',
-                idle_timeout: '60s',
-              },
-              http2_protocol_options: {
-                initial_connection_window_size: 1048576,
-                initial_stream_window_size: 65536,
-                max_concurrent_streams: 100,
-              },
-              http_filters: std.prune([
-                // If there's a GRPC router, enable grpc_stats.
-                if std.foldl(function(last, route) last || 'grpc' in route.match, routes, false) then
-                  {
-                    name: 'envoy.filters.http.grpc_stats',
-                    typed_config: {
-                      '@type': 'type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig',
-                      enable_upstream_stats: true,
-                      // Stats for all methods = true would let anyone on the Internet fill up the
-                      // statistics buffer with bogus RPC method names, so we have to leave it off.
-                      stats_for_all_methods: false,
-                    },
-                  } else {},
-                {
-                  name: 'envoy.filters.http.router',
-                  typed_config: {
-                    '@type': 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router',
-                  },
-                },
-              ]),
-              http_protocol_options: {
-                accept_http_10: false,
-              },
-              request_timeout: '604800s',  // Necessary to allow long file uploads.
-              stream_idle_timeout: '600s',  // Only completely idle streams are dropped after this timeout.
-              route_config: {
-                virtual_hosts: [
-                  {
-                    domains: [
-                      '*',
-                    ],
-                    name: 'any',
-                    routes: routes,
-                    retry_policy: {
-                      retry_on: 'connect-failure',
-                      num_retries: 4,
-                      host_selection_retry_max_attempts: 4,
-                    },
-                  },
-                ],
-              },
-              stat_prefix: name,
-              use_remote_address: true,
-            },
-          },
-        ],
+        filters: [$.httpConnectionManager(name, routes)],
       },
     ],
   },
-  defaultCluster: {
+
+  httpsListener(port, name, routes): {
+    name: name,
+    per_connection_buffer_limit_bytes: 32768,
+    traffic_direction: 'INBOUND',
+    address: {
+      socket_address: {
+        address: '0.0.0.0',
+        port_value: port,
+      },
+    },
+    listener_filters: [
+      {
+        name: 'envoy.filters.listener.tls_inspector',
+        typed_config: {
+          '@type': 'type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector',
+        },
+      },
+    ],
+    filter_chains: [
+      {
+        filter_chain_match: {
+          transport_protocol: 'tls',
+        },
+        transport_socket: {
+          name: 'envoy.transport_sockets.tls',
+          typed_config: {
+            '@type': 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext',
+            common_tls_context: {
+              alpn_protocols: ['h2', 'http/1.1'],
+              tls_params: {
+                tls_minimum_protocol_version: 'TLSv1_2',
+                cipher_suites: [
+                  '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]',
+                  '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]',
+                  'ECDHE-ECDSA-AES256-GCM-SHA384',
+                  'ECDHE-RSA-AES256-GCM-SHA384',
+                ],
+              },
+              tls_certificate_sds_secret_configs: [
+                {
+                  name: 'tls',
+                  sds_config: {
+                    resource_api_version: 'V3',
+                    path_config_source: {
+                      path: '/etc/envoy/sds.yaml',
+                      watched_directory: {
+                        path: '/etc/envoy',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        filters: [$.httpConnectionManager(name, routes)],
+      },
+
+      // Redirect to https if this request wasn't sent over TLS.
+      {
+        filter_chain_match: {
+          transport_protocol: 'raw_buffer',
+        },
+        filters: [$.httpConnectionManager(name + '-cleartext', [$.redirectToHttpsRoute])],
+      },
+    ],
+  },
+
+  defaultCluster:: {
     connect_timeout: '10s',
     dns_lookup_family: 'V4_ONLY',
     dns_refresh_rate: '5s',
@@ -188,7 +276,8 @@
       tcp_keepalive: {},
     },
   },
-  GRPCCluster: self.defaultCluster {
+
+  defaultGRPCCluster:: self.defaultCluster {
     typed_extension_protocol_options: {
       'envoy.extensions.upstreams.http.v3.HttpProtocolOptions': {
         '@type': 'type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions',
@@ -198,4 +287,11 @@
       },
     },
   },
+
+  serviceAsCluster(name, service):
+    ((if 'grpc' in service && service.grpc then $.defaultGRPCCluster else $.defaultCluster) + {
+       name: name,
+       load_assignment: $.loadAssignment(name=name, address=service.service, port=service.internal_port),
+       health_checks: if 'health_check' in service then [service.health_check] else [],
+     }),
 }

--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -1,0 +1,166 @@
+{
+  'pachd-grpc': {
+    internal_port: 1650,
+    external_port: 30650,
+    grpc: true,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          grpc: {},
+          prefix: '/',
+        },
+        route: {
+          cluster: 'pachd-grpc',
+          timeout: '604800s',
+        },
+      },
+    ],
+    health_check: {
+      grpc_health_check: {},
+      healthy_threshold: 1,
+      interval: '10s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
+  },
+  'pachd-s3': {
+    internal_port: 1600,
+    external_port: 30600,
+    service: 'pachd-proxy-backend',
+    routes: local base = {
+      route: {
+        cluster: 'pachd-s3',
+        idle_timeout: '600s',
+        timeout: '604800s',
+      },
+    }; [
+      base {  // S3v4
+        match: {
+          prefix: '/',
+          headers: [
+            {
+              name: 'authorization',
+              string_match: {
+                prefix: 'AWS4-HMAC-SHA256',
+              },
+            },
+          ],
+        },
+      },
+      base {  // S3v2
+        match: {
+          prefix: '/',
+          headers: [
+            {
+              name: 'authorization',
+              string_match: {
+                prefix: 'AWS ',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  'pachd-identity': {
+    internal_port: 1658,
+    external_port: 30658,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/dex',
+        },
+        route: {
+          cluster: 'pachd-identity',
+          idle_timeout: '60s',
+          timeout: '60s',
+        },
+      },
+    ],
+    health_check: {
+      healthy_threshold: 1,
+      http_health_check: {
+        host: 'localhost',
+        path: '/dex/.well-known/openid-configuration',
+      },
+      interval: '30s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
+  },
+  'pachd-oidc': {
+    internal_port: 1657,
+    external_port: 30657,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/authorization-code/callback',
+        },
+        route: {
+          cluster: 'pachd-oidc',
+          idle_timeout: '60s',
+          timeout: '60s',
+        },
+      },
+    ],
+  },
+  console: {
+    internal_port: 4000,
+    external_port: 4000,
+    service: 'console-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/',
+        },
+        route: {
+          cluster: 'console',
+          idle_timeout: '600s',
+          timeout: '3600s',
+          upgrade_configs: [
+            {
+              enabled: true,
+              upgrade_type: 'websocket',
+            },
+          ],
+        },
+      },
+    ],
+    health_check: {
+      healthy_threshold: 1,
+      http_health_check: {
+        host: 'localhost',  // This is just the value of the Host: header, not something to connect to.
+        path: '/',
+      },
+      interval: '30s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
+  },
+  'pachd-metrics': {
+    internal_port: 1656,
+    external_port: 30656,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/',
+        },
+        route: {
+          cluster: 'pachd-metrics',
+          idle_timeout: '60s',
+          timeout: '60s',
+        },
+      },
+    ],
+  },
+}

--- a/etc/helm/pachyderm/envoy-sds.yaml
+++ b/etc/helm/pachyderm/envoy-sds.yaml
@@ -1,0 +1,10 @@
+resources:
+  - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: "tls"
+    tls_certificate:
+      watched_directory:
+        path: "/tls"
+      certificate_chain:
+        filename: "/tls/tls.crt"
+      private_key:
+        filename: "/tls/tls.key"

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -64,7 +64,624 @@
       ]
    },
    "static_resources": {
-      "clusters": [ ],
-      "listeners": [ ]
+      "clusters": [
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "console",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "console-proxy-backend",
+                                    "port_value": 4000
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "console",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "grpc_health_check": { },
+                  "healthy_threshold": 1,
+                  "interval": "10s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-grpc",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1650
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-grpc",
+            "type": "strict_dns",
+            "typed_extension_protocol_options": {
+               "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                  "explicit_http_config": {
+                     "http2_protocol_options": { }
+                  }
+               }
+            },
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/dex/.well-known/openid-configuration"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-identity",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1658
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-identity",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [ ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-metrics",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1656
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-metrics",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [ ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-oidc",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1657
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-oidc",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [ ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-s3",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1600
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-s3",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         }
+      ],
+      "listeners": [
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 8080
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "prefix": "/"
+                                          },
+                                          "redirect": {
+                                             "https_redirect": true
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "https-redirect",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "https-redirect",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 8443
+               }
+            },
+            "filter_chains": [
+               {
+                  "filter_chain_match": {
+                     "transport_protocol": "tls"
+                  },
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.grpc_stats",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                                    "enable_upstream_stats": true,
+                                    "stats_for_all_methods": false
+                                 }
+                              },
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "grpc": { },
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-grpc",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "headers": [
+                                                {
+                                                   "name": "authorization",
+                                                   "string_match": {
+                                                      "prefix": "AWS4-HMAC-SHA256"
+                                                   }
+                                                }
+                                             ],
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-s3",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "headers": [
+                                                {
+                                                   "name": "authorization",
+                                                   "string_match": {
+                                                      "prefix": "AWS "
+                                                   }
+                                                }
+                                             ],
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-s3",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/dex"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-identity",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/authorization-code/callback"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-oidc",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "console",
+                                             "idle_timeout": "600s",
+                                             "timeout": "3600s",
+                                             "upgrade_configs": [
+                                                {
+                                                   "enabled": true,
+                                                   "upgrade_type": "websocket"
+                                                }
+                                             ]
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "proxy-https",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ],
+                  "transport_socket": {
+                     "name": "envoy.transport_sockets.tls",
+                     "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                        "common_tls_context": {
+                           "alpn_protocols": [
+                              "h2",
+                              "http/1.1"
+                           ],
+                           "tls_certificate_sds_secret_configs": [
+                              {
+                                 "name": "tls",
+                                 "sds_config": {
+                                    "path_config_source": {
+                                       "path": "/etc/envoy/sds.yaml",
+                                       "watched_directory": {
+                                          "path": "/etc/envoy"
+                                       }
+                                    },
+                                    "resource_api_version": "V3"
+                                 }
+                              }
+                           ],
+                           "tls_params": {
+                              "cipher_suites": [
+                                 "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
+                                 "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
+                                 "ECDHE-ECDSA-AES256-GCM-SHA384",
+                                 "ECDHE-RSA-AES256-GCM-SHA384"
+                              ],
+                              "tls_minimum_protocol_version": "TLSv1_2"
+                           }
+                        }
+                     }
+                  }
+               },
+               {
+                  "filter_chain_match": {
+                     "transport_protocol": "raw_buffer"
+                  },
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "prefix": "/"
+                                          },
+                                          "redirect": {
+                                             "https_redirect": true
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "proxy-https-cleartext",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "listener_filters": [
+               {
+                  "name": "envoy.filters.listener.tls_inspector",
+                  "typed_config": {
+                     "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+                  }
+               }
+            ],
+            "name": "proxy-https",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         }
+      ]
    }
 }

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -1,0 +1,70 @@
+{
+   "admin": {
+      "access_log": [
+         {
+            "name": "envoy.access_loggers.stderr",
+            "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StderrAccessLog"
+            }
+         }
+      ],
+      "address": {
+         "socket_address": {
+            "address": "0.0.0.0",
+            "port_value": 9901
+         }
+      }
+   },
+   "layered_runtime": {
+      "layers": [
+         {
+            "name": "static_layer_0",
+            "static_layer": {
+               "overload": {
+                  "global_downstream_max_connections": 50000
+               }
+            }
+         }
+      ]
+   },
+   "overload_manager": {
+      "actions": [
+         {
+            "name": "envoy.overload_actions.shrink_heap",
+            "triggers": [
+               {
+                  "name": "envoy.resource_monitors.fixed_heap",
+                  "threshold": {
+                     "value": 0.94999999999999996
+                  }
+               }
+            ]
+         },
+         {
+            "name": "envoy.overload_actions.stop_accepting_requests",
+            "triggers": [
+               {
+                  "name": "envoy.resource_monitors.fixed_heap",
+                  "threshold": {
+                     "value": 0.97999999999999998
+                  }
+               }
+            ]
+         }
+      ],
+      "refresh_interval": "0.25s",
+      "resource_monitors": [
+         {
+            "name": "envoy.resource_monitors.fixed_heap",
+            "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig",
+               "max_heap_size_bytes": 500000000
+            }
+         }
+      ]
+   },
+   "static_resources": {
+      "clusters": [ ],
+      "listeners": [ ]
+   }
+}

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -458,6 +458,14 @@
                            },
                            "request_timeout": "604800s",
                            "route_config": {
+                              "response_headers_to_add": [
+                                 {
+                                    "header": {
+                                       "key": "strict-transport-security",
+                                       "value": "max-age=604800"
+                                    }
+                                 }
+                              ],
                               "virtual_hosts": [
                                  {
                                     "domains": [

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -488,6 +488,90 @@
             "address": {
                "socket_address": {
                   "address": "0.0.0.0",
+                  "port_value": 8443
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "direct_response": {
+                                             "body": {
+                                                "inline_string": "This is the cleartext installation of pachyderm-proxy; enable TLS in the helm chart and reinstall."
+                                             },
+                                             "status": 500
+                                          },
+                                          "match": {
+                                             "prefix": "/"
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "https-warning",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "https-warning",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
                   "port_value": 1600
                }
             },

--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -37,7 +37,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{- define "pachyderm.ingressproto" -}}
-{{- if or .Values.ingress.tls.enabled .Values.ingress.uriHttpsProtoOverride -}}
+{{- if or .Values.ingress.tls.enabled .Values.proxy.tls.enabled .Values.ingress.uriHttpsProtoOverride -}}
 https
 {{- else -}}
 http

--- a/etc/helm/pachyderm/templates/proxy/configmap.yaml
+++ b/etc/helm/pachyderm/templates/proxy/configmap.yaml
@@ -15,5 +15,22 @@ metadata:
   name: pachyderm-proxy-config
 data:
   envoy.json: |
+    {{- if .Values.proxy.tls.enabled }}
+    {{- .Files.Get "envoy-tls.json" | nindent 4 }}
+    {{- else -}}
     {{- .Files.Get "envoy.json" | nindent 4 }}
+    {{- end }}
+  {{- if .Values.proxy.tls.enabled }}
+  sds.yaml: |
+    resources:
+      - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+        name: "tls"
+        tls_certificate:
+          watched_directory:
+            path: "/tls"
+          certificate_chain:
+            filename: "/tls/tls.crt"
+          private_key:
+            filename: "/tls/tls.key"
+  {{- end }}
 {{- end }}

--- a/etc/helm/pachyderm/templates/proxy/configmap.yaml
+++ b/etc/helm/pachyderm/templates/proxy/configmap.yaml
@@ -22,15 +22,6 @@ data:
     {{- end }}
   {{- if .Values.proxy.tls.enabled }}
   sds.yaml: |
-    resources:
-      - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-        name: "tls"
-        tls_certificate:
-          watched_directory:
-            path: "/tls"
-          certificate_chain:
-            filename: "/tls/tls.crt"
-          private_key:
-            filename: "/tls/tls.key"
+    {{- .Files.Get "envoy-sds.yaml" | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
@@ -2,7 +2,8 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.proxy.enabled .Values.console.enabled -}}
+{{- /* Deploy even if console is disabled, so the lack of endpoints is more easily apparent. */ -}}
+{{- if and .Values.proxy.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -113,6 +113,6 @@ spec:
         {{- if .Values.proxy.tls.enabled }}
         - name: tls
           secret:
-            secretName: {{ .Values.proxy.tls.secretName }}
+            secretName: {{ required "proxy.tls.secretName must be set when TLS is enabled on the proxy" .Values.proxy.tls.secretName }}
         {{- end }}
 {{- end }}

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -71,8 +71,8 @@ spec:
               containerPort: 9901
             - name: http-port
               containerPort: 8080
-            # - name: https
-            #   containerPort: 8443
+            - name: https-port
+              containerPort: 8443
             - name: console-direct
               containerPort: 4000
             - name: s3-direct
@@ -102,8 +102,17 @@ spec:
           volumeMounts:
             - name: envoy-config
               mountPath: /etc/envoy
+            {{- if .Values.proxy.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+            {{- end }}
       volumes:
         - name: envoy-config
           configMap:
             name: pachyderm-proxy-config
+        {{- if .Values.proxy.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.proxy.tls.secretName }}
+        {{- end }}
 {{- end }}

--- a/etc/helm/pachyderm/templates/proxy/pachyderm-proxy-tls.secret.yaml
+++ b/etc/helm/pachyderm/templates/proxy/pachyderm-proxy-tls.secret.yaml
@@ -1,9 +1,15 @@
 {{- /* This is only for testing; you won't want to put your private key material in values.yaml */ -}}
+{{- if or
+    (and .Values.proxy.tls.secret.key (not .Values.proxy.tls.secret.cert))
+    (and (not .Values.proxy.tls.secret.key) .Values.proxy.tls.secret.cert)
+-}}
+{{- fail "if one of proxy.tls.secret.key or proxy.tls.secret.cert is set, they must both be set" -}}
+{{- end -}}
 {{- if and .Values.proxy.tls.secret.key .Values.proxy.tls.secret.cert -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pachyderm-proxy-tls
+  name: {{ required "proxy.tls.secretName must be set when creating a secret from literal key/cert" .Values.proxy.tls.secretName }}
 type: kubernetes.io/tls
 stringData:
   tls.crt: |

--- a/etc/helm/pachyderm/templates/proxy/pachyderm-proxy-tls.secret.yaml
+++ b/etc/helm/pachyderm/templates/proxy/pachyderm-proxy-tls.secret.yaml
@@ -1,0 +1,13 @@
+{{- /* This is only for testing; you won't want to put your private key material in values.yaml */ -}}
+{{- if and .Values.proxy.tls.secret.key .Values.proxy.tls.secret.cert -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pachyderm-proxy-tls
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |
+{{ .Values.proxy.tls.secret.cert | indent 4 }}
+  tls.key: |
+{{ .Values.proxy.tls.secret.key | indent 4 }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/proxy/pachyderm-proxy-tls.secret.yaml
+++ b/etc/helm/pachyderm/templates/proxy/pachyderm-proxy-tls.secret.yaml
@@ -1,8 +1,5 @@
 {{- /* This is only for testing; you won't want to put your private key material in values.yaml */ -}}
-{{- if or
-    (and .Values.proxy.tls.secret.key (not .Values.proxy.tls.secret.cert))
-    (and (not .Values.proxy.tls.secret.key) .Values.proxy.tls.secret.cert)
--}}
+{{- if or (and .Values.proxy.tls.secret.key (not .Values.proxy.tls.secret.cert)) (and (not .Values.proxy.tls.secret.key) .Values.proxy.tls.secret.cert) -}}
 {{- fail "if one of proxy.tls.secret.key or proxy.tls.secret.cert is set, they must both be set" -}}
 {{- end -}}
 {{- if and .Values.proxy.tls.secret.key .Values.proxy.tls.secret.cert -}}

--- a/etc/helm/pachyderm/templates/proxy/service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/service.yaml
@@ -17,12 +17,14 @@ metadata:
 spec:
   type: {{ .Values.proxy.service.type }}
   ports:
+    {{- if .Values.proxy.service.httpPort }}
     - name: http-port
       targetPort: http-port
       port: {{ .Values.proxy.service.httpPort }}
       {{- if eq .Values.proxy.service.type "NodePort" }}
       nodePort: {{ .Values.proxy.service.httpNodePort }}
       {{- end }}
+    {{- end }}
     {{- if .Values.proxy.tls.enabled }}
     - name: https-port
       targetPort: https-port

--- a/etc/helm/pachyderm/templates/proxy/service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/service.yaml
@@ -23,6 +23,14 @@ spec:
       {{- if eq .Values.proxy.service.type "NodePort" }}
       nodePort: {{ .Values.proxy.service.httpNodePort }}
       {{- end }}
+    {{- if .Values.proxy.tls.enabled }}
+    - name: https-port
+      targetPort: https-port
+      port: {{ .Values.proxy.service.httpsPort }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.httpsNodePort }}
+      {{- end }}
+    {{- end }}
     {{ if .Values.proxy.service.legacyPorts.console }}
     - name: console-direct
       targetPort: console-direct

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -745,10 +745,10 @@ proxy:
     # The port to serve plain HTTP traffic on.
     httpPort: 80
     # The port to serve HTTPS traffic on, if enabled below.
-    httpsPort: 443 # Not implemented yet.
+    httpsPort: 443
     # If the service is a NodePort, you can specify the port to receive HTTP traffic on.
     httpNodePort: 30080
-    httpsNodePort: 30443 # Not implemented yet.
+    httpsNodePort: 30443
     # Any additional annotations to add.
     annotations: {}
     # Any additional labels to add to the service itself (not the selector!).
@@ -763,4 +763,21 @@ proxy:
       oidc: 0 # legacy 30657
       identity: 0 # legacy 30658
       metrics: 0 # legacy 30656
-  tls: {} # Not implemented yet.
+  # Configuration for TLS (SSL, HTTPS).
+  tls:
+    # If true, enable TLS serving.  Enabling TLS is incompatible with support for legacy ports (you
+    # can't get a generally-trusted certificate for port numbers), and disables support for
+    # cleartext communication (cleartext requests will redirect to the secure server, and HSTS
+    # headers are set to prevent downgrade attacks).
+    #
+    # Note that if you are planning on putting the proxy behind an ingress controller, you probably
+    # want to configure TLS for the ingress controller, not the proxy.  This is intended for the
+    # case where the proxy is exposed directly to the Internet.  (It is possible to have your
+    # ingress controller talk to the proxy over TLS, in which case, it's fine to enable TLS here in
+    # addition to in the ingress section above.)
+    enabled: false
+    # The secret containing "tls.key" and "tls.crt" keys that contain PEM-encoded private key and
+    # certificate material.  Generate one with "kubectl create secret tls <name> --key=tls.key
+    # --cert=tls.cert".  This format is compatible with the secrets produced by cert-manager, and
+    # the proxy will pick up new data when cert-manager rotates the certificate.
+    secretName: ""

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -781,3 +781,5 @@ proxy:
     # --cert=tls.cert".  This format is compatible with the secrets produced by cert-manager, and
     # the proxy will pick up new data when cert-manager rotates the certificate.
     secretName: ""
+    # If set, generate the secret from values here.  This is intended only for unit tests.
+    secret: {}

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -238,6 +238,15 @@ func WithRootCAs(path string) Option {
 	}
 }
 
+// WithCertPool instructs the New* functions to create a client that uses the provided cert pool to
+// validate the server's identity when connecting with TLS.
+func WithCertPool(pool *x509.CertPool) Option {
+	return func(settings *clientSettings) error {
+		settings.caCerts = pool
+		return nil
+	}
+}
+
 // WithAdditionalRootCAs instructs the New* functions to additionally trust the
 // given base64-encoded, signed x509 certificates as root certificates.
 // Introduced to pass certs in the Pachyderm config

--- a/src/internal/minikubetestenv/client_factory.go
+++ b/src/internal/minikubetestenv/client_factory.go
@@ -28,7 +28,7 @@ type acquireSettings struct {
 
 type Option func(*acquireSettings)
 
-var WaitForLokiOption = func(ds *acquireSettings) {
+var WaitForLokiOption Option = func(ds *acquireSettings) {
 	ds.WaitForLoki = true
 }
 

--- a/src/internal/minikubetestenv/client_factory.go
+++ b/src/internal/minikubetestenv/client_factory.go
@@ -2,8 +2,10 @@ package minikubetestenv
 
 import (
 	"context"
+	"crypto/x509"
 	"flag"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,21 +23,6 @@ const (
 	namespacePrefix = "test-cluster-"
 )
 
-type acquireSettings struct {
-	WaitForLoki      bool
-	EnterpriseMember bool
-}
-
-type Option func(*acquireSettings)
-
-var WaitForLokiOption Option = func(ds *acquireSettings) {
-	ds.WaitForLoki = true
-}
-
-var EnterpriseMemberOption = func(ds *acquireSettings) {
-	ds.EnterpriseMember = true
-}
-
 var (
 	clusterFactory      *ClusterFactory
 	setup               sync.Once
@@ -44,18 +31,57 @@ var (
 	cleanupDataAfter    *bool = flag.Bool("clusters.data.cleanup", true, "cleanup the data following each test")
 )
 
+type acquireSettings struct {
+	WaitForLoki      bool
+	TLS              bool
+	EnterpriseMember bool
+	CertPool         *x509.CertPool
+	ValueOverrides   map[string]string
+}
+
+type Option func(*acquireSettings)
+
+var WaitForLokiOption Option = func(as *acquireSettings) {
+	as.WaitForLoki = true
+}
+
+var WithTLS Option = func(as *acquireSettings) {
+	as.TLS = true
+}
+
+func WithCertPool(pool *x509.CertPool) Option {
+	return func(as *acquireSettings) {
+		as.CertPool = pool
+	}
+}
+
+func WithValueOverrides(v map[string]string) Option {
+	return func(as *acquireSettings) {
+		as.ValueOverrides = v
+	}
+}
+
+var EnterpriseMemberOption Option = func(as *acquireSettings) {
+	as.EnterpriseMember = true
+}
+
+type managedCluster struct {
+	client   *client.APIClient
+	settings *acquireSettings
+}
+
 type ClusterFactory struct {
 	// ever growing registry of managed clusters. Removing registries would break the current PortOffset logic
-	managedClusters   map[string]*client.APIClient
+	managedClusters   map[string]*managedCluster
 	availableClusters map[string]struct{}
 	mu                sync.Mutex         // guards modifications to the ClusterFactory maps
 	sem               semaphore.Weighted // enforces max concurrency
 }
 
-func (cf *ClusterFactory) assignClient(assigned string, c *client.APIClient) {
+func (cf *ClusterFactory) assignClient(assigned string, mc *managedCluster) {
 	cf.mu.Lock()
 	defer cf.mu.Unlock()
-	cf.managedClusters[assigned] = c
+	cf.managedClusters[assigned] = mc
 }
 
 func clusterIdx(t testing.TB, name string) int {
@@ -65,22 +91,28 @@ func clusterIdx(t testing.TB, name string) int {
 	return r
 }
 
-func deployOpts(clusterIdx int, loki bool) *DeployOpts {
+func deployOpts(clusterIdx int, as *acquireSettings) *DeployOpts {
 	return &DeployOpts{
 		PortOffset:         uint16(clusterIdx * 10),
 		UseLeftoverCluster: *useLeftoverClusters,
-		Loki:               loki,
+		Loki:               as.WaitForLoki,
+		TLS:                as.TLS,
+		CertPool:           as.CertPool,
+		ValueOverrides:     as.ValueOverrides,
 	}
 }
 
 func deleteAll(t testing.TB, c *client.APIClient) {
+	if c == nil {
+		return
+	}
 	tok := c.AuthToken()
 	c.SetAuthToken(testutil.RootToken)
 	require.NoError(t, c.DeleteAll())
 	c.SetAuthToken(tok)
 }
 
-func (cf *ClusterFactory) acquireFreeCluster() (string, *client.APIClient) {
+func (cf *ClusterFactory) acquireFreeCluster() (string, *managedCluster) {
 	cf.mu.Lock()
 	defer cf.mu.Unlock()
 	if len(cf.availableClusters) > 0 {
@@ -95,7 +127,7 @@ func (cf *ClusterFactory) acquireFreeCluster() (string, *client.APIClient) {
 	return "", nil
 }
 
-func (cf *ClusterFactory) acquireNewCluster(t testing.TB, as *acquireSettings) (string, *client.APIClient) {
+func (cf *ClusterFactory) acquireNewCluster(t testing.TB, as *acquireSettings) (string, *managedCluster) {
 	assigned, clusterIdx := func() (string, int) {
 		cf.mu.Lock()
 		defer cf.mu.Unlock()
@@ -119,10 +151,14 @@ func (cf *ClusterFactory) acquireNewCluster(t testing.TB, as *acquireSettings) (
 		context.Background(),
 		assigned,
 		kube,
-		deployOpts(clusterIdx, as.WaitForLoki),
+		deployOpts(clusterIdx, as),
 	)
-	cf.assignClient(assigned, c)
-	return assigned, c
+	mc := &managedCluster{
+		client:   c,
+		settings: as,
+	}
+	cf.assignClient(assigned, mc)
+	return assigned, mc
 }
 
 // AcquireCluster returns a pachyderm APIClient from one of a pool of managed pachyderm
@@ -130,7 +166,7 @@ func (cf *ClusterFactory) acquireNewCluster(t testing.TB, as *acquireSettings) (
 func AcquireCluster(t testing.TB, opts ...Option) (*client.APIClient, string) {
 	setup.Do(func() {
 		clusterFactory = &ClusterFactory{
-			managedClusters:   map[string]*client.APIClient{},
+			managedClusters:   map[string]*managedCluster{},
 			availableClusters: map[string]struct{}{},
 			sem:               *semaphore.NewWeighted(int64(*poolSize)),
 		}
@@ -141,7 +177,9 @@ func AcquireCluster(t testing.TB, opts ...Option) (*client.APIClient, string) {
 	t.Cleanup(func() {
 		clusterFactory.mu.Lock()
 		if *cleanupDataAfter {
-			deleteAll(t, clusterFactory.managedClusters[assigned])
+			if mc := clusterFactory.managedClusters[assigned]; mc != nil {
+				deleteAll(t, mc.client)
+			}
 		}
 		clusterFactory.availableClusters[assigned] = struct{}{}
 		clusterFactory.mu.Unlock()
@@ -151,19 +189,22 @@ func AcquireCluster(t testing.TB, opts ...Option) (*client.APIClient, string) {
 	for _, o := range opts {
 		o(as)
 	}
-	assigned, c := clusterFactory.acquireFreeCluster()
+	assigned, mc := clusterFactory.acquireFreeCluster()
 	if assigned == "" {
-		assigned, c = clusterFactory.acquireNewCluster(t, as)
+		assigned, mc = clusterFactory.acquireNewCluster(t, as)
 	}
-	// in the case loki is requested, upgrade the cluster to include it
-	if as.WaitForLoki {
-		c = UpgradeRelease(t,
+
+	// If the cluster settings have changed, upgrade the cluster to make them take effect.
+	if !reflect.DeepEqual(mc.settings, as) {
+		t.Logf("%v: cluster settings have changed; upgrading cluster", assigned)
+		mc.client = UpgradeRelease(t,
 			context.Background(),
 			assigned,
 			testutil.GetKubeClient(t),
-			deployOpts(clusterIdx(t, assigned), as.WaitForLoki),
+			deployOpts(clusterIdx(t, assigned), as),
 		)
+		mc.settings = as
 	}
-	deleteAll(t, c)
-	return c, assigned
+	deleteAll(t, mc.client)
+	return mc.client, assigned
 }

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -2,6 +2,7 @@ package minikubetestenv
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
@@ -54,6 +55,8 @@ type DeployOpts struct {
 	EnterpriseMember bool
 	EnterpriseServer bool
 	ValueOverrides   map[string]string
+	TLS              bool
+	CertPool         *x509.CertPool
 }
 
 type helmPutE func(t terraTest.TestingT, options *helm.Options, chart string, releaseName string) error
@@ -81,7 +84,7 @@ func helmChartLocalPath(t testing.TB) string {
 	return filepath.Join(relPathParts...)
 }
 
-func getPachAddress(t testing.TB) *grpcutil.PachdAddress {
+func GetPachAddress(t testing.TB) *grpcutil.PachdAddress {
 	if computedPachAddress == nil {
 		cfg, err := config.Read(true, true)
 		require.NoError(t, err)
@@ -242,27 +245,47 @@ func withEnterpriseMember(host string, grpcPort int) *helm.Options {
 	}}
 }
 
-func withPort(namespace string, port uint16) *helm.Options {
-	return &helm.Options{
+func withPort(namespace string, port uint16, tls bool) *helm.Options {
+	opts := &helm.Options{
 		KubectlOptions: &k8s.KubectlOptions{Namespace: namespace},
-		SetValues: map[string]string{
-			// Run gRPC traffic through the full router.
-			"proxy.service.httpPort":     fmt.Sprintf("%v", port),
-			"proxy.service.httpNodePort": fmt.Sprintf("%v", port),
-			// Let everything else use the legacy way.  We use the same mapping for
-			// internal ports, so in-cluster traffic doesn't go through the proxy, but
-			// doesn't need to confusingly use a different port number.
-			"pachd.service.apiGRPCPort":           fmt.Sprintf("%v", port),
-			"proxy.service.legacyPorts.oidc":      fmt.Sprintf("%v", port+7),
-			"pachd.service.oidcPort":              fmt.Sprintf("%v", port+7),
-			"proxy.service.legacyPorts.identity":  fmt.Sprintf("%v", port+8),
-			"pachd.service.identityPort":          fmt.Sprintf("%v", port+8),
-			"proxy.service.legacyPorts.s3Gateway": fmt.Sprintf("%v", port+3),
-			"pachd.service.s3GatewayPort":         fmt.Sprintf("%v", port+3),
-			"proxy.service.legacyPorts.metrics":   fmt.Sprintf("%v", port+4),
-			"pachd.service.prometheusPort":        fmt.Sprintf("%v", port+4),
-		},
+		SetValues:      map[string]string{},
 	}
+
+	// Allow the internal use to have the same port numbers as the proxy.
+	opts.SetValues["pachd.service.apiGRPCPort"] = fmt.Sprintf("%v", port)
+	opts.SetValues["pachd.service.oidcPort"] = fmt.Sprintf("%v", port+7)
+	opts.SetValues["pachd.service.identityPort"] = fmt.Sprintf("%v", port+8)
+	opts.SetValues["pachd.service.s3GatewayPort"] = fmt.Sprintf("%v", port+3)
+	opts.SetValues["pachd.service.prometheusPort"] = fmt.Sprintf("%v", port+4)
+
+	if tls {
+		// Use the default port for HTTPS.
+		opts.SetValues["proxy.service.httpsPort"] = fmt.Sprintf("%v", port)
+		opts.SetValues["proxy.service.httpsNodePort"] = fmt.Sprintf("%v", port)
+
+		// Disable HTTP.
+		opts.SetValues["proxy.service.httpPort"] = "0"
+		opts.SetValues["proxy.service.httpNodePort"] = "0"
+
+		// Disable the legacy services, since anything depending on the TLS argument to this
+		// function expects to do everything through the proxy
+		opts.SetValues["proxy.service.legacyPorts.console"] = "0"
+		opts.SetValues["proxy.service.legacyPorts.oidc"] = "0"
+		opts.SetValues["proxy.service.legacyPorts.identity"] = "0"
+		opts.SetValues["proxy.service.legacyPorts.s3Gateway"] = "0"
+		opts.SetValues["proxy.service.legacyPorts.metrics"] = "0"
+	} else {
+		// Run gRPC traffic through the full router.
+		opts.SetValues["proxy.service.httpPort"] = fmt.Sprintf("%v", port)
+		opts.SetValues["proxy.service.httpNodePort"] = fmt.Sprintf("%v", port)
+
+		// Let the legacy ports go through the proxy.
+		opts.SetValues["proxy.service.legacyPorts.oidc"] = fmt.Sprintf("%v", port+7)
+		opts.SetValues["proxy.service.legacyPorts.identity"] = fmt.Sprintf("%v", port+8)
+		opts.SetValues["proxy.service.legacyPorts.s3Gateway"] = fmt.Sprintf("%v", port+3)
+		opts.SetValues["proxy.service.legacyPorts.metrics"] = fmt.Sprintf("%v", port+4)
+	}
+	return opts
 }
 
 // withoutProxy disables the Pachyderm proxy.  It's used to test upgrades from versions of Pachyderm
@@ -350,18 +373,24 @@ func waitForPgbouncer(t testing.TB, ctx context.Context, kubeClient *kube.Client
 	}, backoff.RetryEvery(5*time.Second).For(5*time.Minute)))
 }
 
-func pachClient(t testing.TB, pachAddress *grpcutil.PachdAddress, authUser, namespace string) *client.APIClient {
+func pachClient(t testing.TB, pachAddress *grpcutil.PachdAddress, authUser, namespace string, certpool *x509.CertPool) *client.APIClient {
 	var c *client.APIClient
 	// retry connecting if it doesn't immediately work
 	require.NoError(t, backoff.Retry(func() error {
 		t.Logf("Connecting to pachd on port: %v, in namespace: %s", pachAddress.Port, namespace)
 		var err error
-		c, err = client.NewFromPachdAddress(pachAddress, client.WithDialTimeout(10*time.Second))
+		opts := []client.Option{client.WithDialTimeout(10 * time.Second)}
+		if certpool != nil {
+			opts = append(opts, client.WithCertPool(certpool))
+		}
+		c, err = client.NewFromPachdAddress(pachAddress, opts...)
 		if err != nil {
+			t.Logf("retryable: failed to connect to pachd on port %v: %v", pachAddress.Port, err)
 			return errors.Wrapf(err, "failed to connect to pachd on port %v", pachAddress.Port)
 		}
 		// Ensure that pachd is really ready to receive requests.
 		if _, err := c.InspectCluster(); err != nil {
+			t.Logf("retryable: failed to inspect cluster on port %v: %v", pachAddress.Port, err)
 			return errors.Wrapf(err, "failed to inspect cluster on port %v", pachAddress.Port)
 		}
 		return nil
@@ -430,7 +459,7 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 	}
 	if opts.PortOffset != 0 {
 		pachAddress.Port += opts.PortOffset
-		helmOpts = union(helmOpts, withPort(namespace, pachAddress.Port))
+		helmOpts = union(helmOpts, withPort(namespace, pachAddress.Port, opts.TLS))
 	}
 	if opts.Enterprise || opts.EnterpriseServer {
 		createSecretEnterpriseKeySecret(t, ctx, kubeClient, namespace)
@@ -452,9 +481,12 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 	if opts.ValueOverrides != nil {
 		helmOpts = union(helmOpts, &helm.Options{SetValues: opts.ValueOverrides})
 	}
+	if opts.TLS {
+		pachAddress.Secured = true
+	}
 	if err := f(t, helmOpts, chartPath, namespace); err != nil {
 		if opts.UseLeftoverCluster {
-			return pachClient(t, pachAddress, opts.AuthUser, namespace)
+			return pachClient(t, pachAddress, opts.AuthUser, namespace, opts.CertPool)
 		}
 		deleteRelease(t, context.Background(), namespace, kubeClient)
 		// When CircleCI was experiencing network slowness, downloading
@@ -470,7 +502,7 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 	if opts.WaitSeconds > 0 {
 		time.Sleep(time.Duration(opts.WaitSeconds) * time.Second)
 	}
-	return pachClient(t, pachAddress, opts.AuthUser, namespace)
+	return pachClient(t, pachAddress, opts.AuthUser, namespace, opts.CertPool)
 }
 
 // Deploy pachyderm using a `helm upgrade ...`

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -448,7 +448,7 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 		helmOpts.Version = version
 		helmOpts.SetValues["pachd.image.tag"] = version
 	}
-	pachAddress := getPachAddress(t)
+	pachAddress := GetPachAddress(t)
 	if opts.EnterpriseServer {
 		helmOpts = union(helmOpts, withEnterpriseServer(version, pachAddress.Host))
 		pachAddress.Port = uint16(31650)

--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -427,6 +427,9 @@ func NoErrorWithinTRetry(tb testing.TB, t time.Duration, f func() error, msgAndA
 	var userError error
 	err := backoff.RetryUntilCancel(ctx, func() error {
 		userError = f()
+		if userError != nil {
+			tb.Logf("retryable: %v", userError)
+		}
 		return userError
 	}, backoff.NewExponentialBackOff(), nil)
 	if err != nil {

--- a/src/internal/testutil/enterprise.go
+++ b/src/internal/testutil/enterprise.go
@@ -14,10 +14,9 @@ import (
 func GetTestEnterpriseCode(t testing.TB) string {
 	acode, exists := os.LookupEnv("ENT_ACT_CODE")
 	if !exists {
-		t.Error("Enterprise Activation code not found in Env Vars")
+		t.Error("Enterprise activation code not found in environment variable (ENT_ACT_CODE)")
 	}
 	return acode
-
 }
 
 // ActivateEnterprise activates enterprise in Pachyderm (if it's not on already.)

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/minio/minio-go/v6"
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+func get(t *testing.T, url string) error {
+	t.Helper()
+	hc := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	ctx, c := context.WithTimeout(context.Background(), 5*time.Second)
+	defer c()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return errors.Errorf("create http request for %v: %w", url, err)
+	}
+
+	res, err := hc.Do(req)
+	if err != nil {
+		return errors.Errorf("execute http request for %v: %w", url, err)
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Logf("warning: get %v: problem reading body: %v", url, err)
+	}
+	if got, want := res.StatusCode, http.StatusOK; got != want {
+		t.Logf("get %v: body:\n%s", url, body)
+		return errors.Errorf("get %v: response code\n  got: %v\n want: %v", url, got, want)
+	}
+	return nil
+}
+
+func proxyTest(t *testing.T, c *client.APIClient, secure bool) {
+	t.Helper()
+	httpPrefix := "http://"
+	if secure {
+		httpPrefix = "https://"
+	}
+	addr := fmt.Sprintf("%v:%d", c.GetAddress().Host, c.GetAddress().Port)
+
+	// Test console.
+	t.Run("TestConsole", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			return get(t, httpPrefix+addr+"/")
+		}, "should be able to load console")
+	})
+
+	// Test OIDC.
+	t.Run("TestOIDC", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			return get(t, httpPrefix+addr+"/dex/.well-known/openid-configuration")
+		}, "should be able to load openid config")
+	})
+
+	testText := []byte("this is a test\n")
+	for i := 0; i < 8*1024*1024; i++ {
+		// Make sure the file doesn't fit in a single message.  Default message size is 4MB,
+		// so 8MiB is comfortably large enough to ensure that both pachd and Envoy agree on
+		// that it won't fit in a single message.
+		testText = append(testText, (byte(i)%26)+'A')
+	}
+
+	// Test GRPC API.
+	t.Run("TestGRPC", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			if err := c.CreateRepo("test"); err != nil {
+				return errors.Errorf("create repo: %w", err)
+			}
+			if err := c.PutFile(client.NewRepo("test").NewCommit("master", ""), "test.txt", bytes.NewReader(testText)); err != nil {
+				return errors.Errorf("put file: %w", err)
+			}
+			return nil
+		}, "should be able to upload a file over grpc")
+	})
+
+	// Test S3 API.
+	t.Run("TestS3", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			s3v4, err := minio.NewV4(addr, c.AuthToken(), c.AuthToken(), secure)
+			if err != nil {
+				return errors.Errorf("get s3v4 client: %w", err)
+			}
+			s3v2, err := minio.NewV2(addr, c.AuthToken(), c.AuthToken(), secure)
+			if err != nil {
+				return errors.Errorf("get s3v2 client: %w", err)
+			}
+
+			for name, client := range map[string]interface {
+				GetObject(string, string, minio.GetObjectOptions) (*minio.Object, error)
+			}{"v4": s3v4, "v2": s3v2} {
+				obj, err := client.GetObject("master.test", "test.txt", minio.GetObjectOptions{})
+				if err != nil {
+					return errors.Errorf("s3%v: get object: %w", name, err)
+				}
+				got, err := io.ReadAll(obj)
+				if err != nil {
+					return errors.Errorf("s3%v: read all: %w", name, err)
+				}
+				want := testText
+				if diff := cmp.Diff(got, want); diff != "" {
+					return errors.Errorf("s3%v: content:\n%v", name, diff)
+				}
+			}
+			return nil
+		}, "should be able to retrieve files over S3")
+	})
+}
+
+func deployFakeConsole(t *testing.T, ns string) {
+	t.Helper()
+	ctx := context.Background()
+	c := testutil.GetKubeClient(t)
+	lbl := map[string]string{
+		"app":   "console",
+		"suite": "pachyderm",
+	}
+	aopts := metav1.ApplyOptions{
+		FieldManager: "proxy_test",
+	}
+
+	cm := applyv1.ConfigMap("fake-console-html", ns)
+	cm.Data = map[string]string{
+		"index.html": "<html><head><title>Hi</title></head><body><p>Hello from console!</p></body></html>",
+	}
+	_, err := c.CoreV1().ConfigMaps(ns).Apply(ctx, cm, aopts)
+	require.NoError(t, err, "should create a configmap for the fake console HTML files")
+
+	cm = applyv1.ConfigMap("fake-console-config", ns)
+	cm.Data = map[string]string{
+		"default.conf": `server {
+			listen       4000;
+			server_name  localhost;
+
+			access_log  /dev/stdout  main;
+
+			location / {
+			    root   /usr/share/nginx/html;
+			    index  index.html;
+			}
+		    }`,
+	}
+	_, err = c.CoreV1().ConfigMaps(ns).Apply(ctx, cm, aopts)
+	require.NoError(t, err, "should create a configmap for the fake console config files")
+
+	dep := applyappsv1.Deployment("console", ns)
+	dep.ObjectMetaApplyConfiguration.Labels = lbl
+	dep.Spec = applyappsv1.DeploymentSpec().WithReplicas(1).WithSelector(applymetav1.LabelSelector().WithMatchLabels(lbl))
+	dep.Spec.Template = applyv1.PodTemplateSpec()
+	dep.Spec.Template.ObjectMetaApplyConfiguration = applymetav1.ObjectMeta().WithName("console").WithNamespace(ns).WithLabels(lbl)
+	dep.Spec.Template.Spec = applyv1.PodSpec().
+		WithContainers(applyv1.Container().
+			WithName("console").
+			WithImage("nginx:latest").
+			WithPorts(applyv1.ContainerPort().WithContainerPort(4000).WithName("console-http").WithProtocol(v1.ProtocolTCP)).
+			WithVolumeMounts(
+				applyv1.VolumeMount().WithName("html").WithMountPath("/usr/share/nginx/html"),
+				applyv1.VolumeMount().WithName("config").WithMountPath("/etc/nginx/conf.d"),
+			).
+			WithReadinessProbe(applyv1.Probe().WithHTTPGet(
+				applyv1.HTTPGetAction().WithPort(intstr.FromInt(4000)).WithPath("/")))).
+		WithVolumes(
+			applyv1.Volume().WithName("html").WithConfigMap(applyv1.ConfigMapVolumeSource().WithName("fake-console-html")),
+			applyv1.Volume().WithName("config").WithConfigMap(applyv1.ConfigMapVolumeSource().WithName("fake-console-config")),
+		)
+	_, err = c.AppsV1().Deployments(ns).Apply(ctx, dep, aopts)
+	require.NoError(t, err, "should create a 'console' deployment")
+
+	t.Log("waiting for the console backend service to have endpoints")
+	var ok bool
+	for i := 0; i < 30; i++ {
+		ep, err := c.CoreV1().Endpoints(ns).Get(ctx, "console-proxy-backend", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("get console service endpoints: %v", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		if ss := ep.Subsets; len(ss) > 0 {
+			t.Logf("console endpoints: %v", ss)
+			ok = true
+			break
+		}
+		t.Log("no endpoints yet")
+		time.Sleep(time.Second)
+	}
+	if !ok {
+		t.Fatal("never got console endpoints")
+	}
+}
+
+func TestTrafficThroughProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	c, ns := minikubetestenv.AcquireCluster(t)
+	deployFakeConsole(t, ns)
+	testutil.ActivateAuthClient(t, c)
+	testutil.ConfigureOIDCProvider(t, c)
+	proxyTest(t, c, false)
+}


### PR DESCRIPTION
This adds a configuration to values.yaml to let Envoy terminate TLS.  If you have a cert (or can get one with, say, cert-manager), then you can put this directly on the Internet and get HTTPS support.

The way this works is that we have different envoy config files for the TLS and non-TLS case, generated with `etc/generate-envoy-config` as normal.

I've adjusted the routes for the TLS and non-TLS case to be as friendly as possible.  If you install the non-TLS version and port-forward port 8443 on the pachyderm-proxy pod, you'll get a message saying to reconfigure helm to enable TLS.  (Note that the LoadBalancer/NodePort won't have this port forwarded, however.  You have to dig pretty deep to start debugging.)

For the TLS case, we still serve traffic on port 80, but it redirects to 443.  (Actually, it redirects by changing the scheme from http to https, so if you're using non-standard port numbers, it won't work.)  Port 443 will respond to cleartext requests (`GET http://example.com:443`) with the same redirect.

To test this locally, you'll need to start console with `NODE_TLS_REJECT_UNAUTHORIZED=0` (because it goes through the proxy to get the openid config) and hack up pachctl to trust whatever self-signed certs you're using for testing.  If you do that, it does work though, including websockets.

This PR adds test for the proxy, including console.  Console is deployed as an nginx container that serves static HTML that we make sure we can retrieve through the proxy.  We also test file uploads that are larger than the GRPC max message size, and S3 downloads.  Some refactoring of minikubetestenv was necessary to let us cleanly deploy with TLS; minikubetestenv records "extra options" that were used and when a cluster is reassigned, it is upgraded to match the desired options if it didn't already have those options.  (This does not work if you use `-cluster.reuse` but I don't think that ever worked correctly if the last test did an upgrade.)  Maybe it would be best to always upgrade after a cluster is assigned?  I think most of the time, that will make `reuse` work?

Need to test:
[x] ~~Against a real/trusted TLS certificate.~~ (Works.)
[x] ~~That cert rotation works (things have changed since I wrote https://jrock.us/posts/rotating-envoy-certs/)~~ (works.)
[x] ~~How settings here interact with `ingress.tls` (namely making the issuer uri https://).~~  (Done.  Will lead to problems if someone tries to do http -> ingress controller -> https -> proxy, but that is not really possible with the current state of the helm chart.)

Need to add:
[x] ~~HSTS headers~~
[x] ~~Tests that deploy this during CI, and try to make grpc, auth, and s3 requests over HTTPS.~~ (Added in proxy_test.go.)


