### PR TITLE
[2.2.x backport] Include gRPC status codes for more errors. (#7663)

### DIFF
--- a/src/internal/collection/errors.go
+++ b/src/internal/collection/errors.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ErrNotFound indicates that a key was not found when it was expected to
@@ -25,6 +28,10 @@ func (err ErrNotFound) Error() string {
 		return err.customMessage
 	}
 	return fmt.Sprintf("%s %s not found", strings.TrimPrefix(err.Type, DefaultPrefix), err.Key)
+}
+
+func (e ErrNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
 }
 
 // IsErrNotFound determines if an error is an ErrNotFound error
@@ -50,6 +57,10 @@ func (err ErrExists) Error() string {
 		return err.customMessage
 	}
 	return fmt.Sprintf("%s %s already exists", strings.TrimPrefix(err.Type, DefaultPrefix), err.Key)
+}
+
+func (e ErrExists) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, e.Error())
 }
 
 // IsErrExists determines if an error is an ErrExists error

--- a/src/internal/middleware/errors/interceptor.go
+++ b/src/internal/middleware/errors/interceptor.go
@@ -2,31 +2,72 @@ package errors
 
 import (
 	"context"
-	"errors"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 // UnaryServerInterceptor translates errors for unary RPCs
 func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	res, err := handler(ctx, req)
-	return res, unwrapGRPC(err)
+	return res, errorForGRPC(err)
 }
 
 // StreamServerInterceptor translates errors for streaming RPCs
 func StreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	err := handler(srv, stream)
-	return unwrapGRPC(err)
+	return errorForGRPC(err)
 }
 
-func unwrapGRPC(err error) error {
+func errorForGRPC(err error) error {
+	// strip off the initial stack trace layer, in case this is just a once-wrapped auth error
 	cursor := err
 	for cursor != nil {
-		cursor = errors.Unwrap(cursor)
-		if res, ok := status.FromError(cursor); ok && res != nil {
-			return cursor //nolint:wrapcheck
+		if _, ok := cursor.(errors.StackTracer); ok {
+			cursor = errors.Unwrap(cursor)
+		} else {
+			break
 		}
 	}
-	return err
+	if cursor == nil && err != nil {
+		// this should never happen, we unwrapped an error consisting only of stack traces
+		// reset to the original error, we have no idea what this is
+		cursor = err
+	}
+	if _, ok := status.FromError(cursor); ok {
+		// handles nil as well
+		return cursor //nolint:wrapcheck
+	}
+	code := codes.Unknown
+	for cursor != nil {
+		if res, ok := status.FromError(cursor); ok {
+			code = res.Code()
+			break
+		}
+		cursor = errors.Unwrap(cursor)
+	}
+	return &gRPCStatusError{
+		code: code,
+		err:  err,
+	} //nolint:wrapcheck
+}
+
+type gRPCStatusError struct {
+	err  error
+	code codes.Code
+}
+
+func (e *gRPCStatusError) GRPCStatus() *status.Status {
+	return status.New(e.code, e.Error())
+}
+
+func (e *gRPCStatusError) Error() string {
+	return e.err.Error()
+}
+
+func (e *gRPCStatusError) Unwrap() error {
+	return e.err
 }

--- a/src/server/pps/pps.go
+++ b/src/server/pps/pps.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ErrJobFinished represents a finished job error.
@@ -23,6 +26,22 @@ type ErrPipelineNotFound struct {
 
 func (e ErrPipelineNotFound) Error() string {
 	return fmt.Sprintf("pipeline %q not found", e.Pipeline.Name)
+}
+
+func (e ErrPipelineNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
+}
+
+type ErrPipelineAlreadyExists struct {
+	Pipeline *pps.Pipeline
+}
+
+func (e ErrPipelineAlreadyExists) Error() string {
+	return fmt.Sprintf("pipeline %q already exists", e.Pipeline.Name)
+}
+
+func (e ErrPipelineAlreadyExists) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, e.Error())
 }
 
 var (

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1838,7 +1838,9 @@ func (a *apiServer) CreatePipelineInTransaction(
 	}
 
 	if oldPipelineInfo != nil && !request.Update {
-		return errors.Errorf("pipeline %q already exists", pipelineName)
+		return ppsServer.ErrPipelineAlreadyExists{
+			Pipeline: request.Pipeline,
+		}
 	}
 
 	newPipelineInfo, err := a.initializePipelineInfo(request, oldPipelineInfo)


### PR DESCRIPTION
Our error interceptor discarded the outermost layers of an error until
it found a status code, which in turn required that we maintain a status
code at the top level of all errors we returned. Our logging library
also relied on this top-level status to make decisions about log level.

Instead of worrying about this at all error return points, we can fix
the interceptor behavior to always preserve the full error. We can also
extract status codes from arbitrary errors via unwrapping as needed.

One wrinkle is that auth errors have some particular expectations 
around their handling and double-wrapping a grpc status error
violates them. While the test enforcing these might be too strict,
we can match the old behavior (which *always* stripped the outer
error) by unwrapping all outer stack traces.