### PR TITLE
[2.2.x backport] Add a proxy to expose all external services on one port

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           path: /tmp/test-results
   helm-build:
     docker:
-      - image: circleci/golang:1.15
+      - image: cimg/go:1.17.6
     working_directory: ~/project/etc/helm
     steps:
       - checkout:
@@ -302,6 +302,18 @@ jobs:
       - checkout
       - run: sudo npm install -g prettier
       - run: prettier -c etc/helm/pachyderm/values.yaml .circleci/config.yml
+  test-envoy:
+    docker:
+      - image: envoyproxy/envoy:v1.22.0
+        entrypoint: /bin/sh
+    steps:
+      - run: apt update
+      - run: apt install -y make wget git ssh
+      - checkout
+      - run: wget https://github.com/google/jsonnet/releases/download/v0.17.0/jsonnet-bin-v0.17.0-linux.tar.gz
+      - run: tar xzvf jsonnet-bin-v0.17.0-linux.tar.gz
+      - run: mv jsonnet jsonnetfmt /usr/local/bin
+      - run: make -C etc/generate-envoy-config test
   push_redhat:
     docker:
       - image: cimg/go:1.17.3
@@ -323,6 +335,7 @@ workflows:
     jobs:
       - build
       - check-prettier
+      - test-envoy
       - circleci:
           matrix:
             parameters:

--- a/etc/generate-envoy-config/Makefile
+++ b/etc/generate-envoy-config/Makefile
@@ -1,0 +1,26 @@
+../helm/pachyderm/envoy.json: envoy.jsonnet envoy.libsonnet
+	jsonnet envoy.jsonnet > ../helm/pachyderm/envoy.json
+
+format: envoy.jsonnet envoy.libsonnet
+	jsonnetfmt -i *.jsonnet *.libsonnet
+
+# This requires that you install Envoy, which is a big pain.  I just "docker cp" it out of the
+# docker release, but there is a Homebrew package and a Debian package:
+# https://www.envoyproxy.io/docs/envoy/latest/start/install
+check-envoy-config: ../helm/pachyderm/envoy.json
+	envoy -c ../helm/pachyderm/envoy.json --mode validate
+
+# So that CI can fail when you forget to run jsonnetfmt.
+check-formatting:
+	jsonnetfmt --test *.jsonnet *.libsonnet
+	echo "jsonnetfmt ok"
+
+# So that CI can fail if you modify envoy.jsonnet but don't regenerate envoy.json.
+check-generated:
+	jsonnet envoy.jsonnet > /tmp/test-formatting.envoy.json
+	diff -u ../helm/pachyderm/envoy.json /tmp/test-formatting.envoy.json  --label in-repo --label would-generate
+	echo "codegen ok"
+
+test: check-formatting check-generated check-envoy-config
+
+.PHONY: format check-envoy-config check-formatting check-generated test

--- a/etc/generate-envoy-config/envoy.jsonnet
+++ b/etc/generate-envoy-config/envoy.jsonnet
@@ -1,0 +1,200 @@
+// Services that we want to proxy; where they are and how to route them.
+local services = {
+  'pachd-grpc': {
+    internal_port: 1650,
+    external_port: 30650,
+    grpc: true,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          grpc: {},
+          prefix: '/',
+        },
+        route: {
+          cluster: 'pachd-grpc',
+          timeout: '604800s',
+        },
+      },
+    ],
+    health_check: {
+      grpc_health_check: {},
+      healthy_threshold: 1,
+      interval: '10s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
+  },
+  'pachd-s3': {
+    internal_port: 1600,
+    external_port: 30600,
+    service: 'pachd-proxy-backend',
+    routes: local base = {
+      route: {
+        cluster: 'pachd-s3',
+        idle_timeout: '600s',
+        timeout: '604800s',
+      },
+    }; [
+      base {  // S3v4
+        match: {
+          prefix: '/',
+          headers: [
+            {
+              name: 'authorization',
+              string_match: {
+                prefix: 'AWS4-HMAC-SHA256',
+              },
+            },
+          ],
+        },
+      },
+      base {  // S3v2
+        match: {
+          prefix: '/',
+          headers: [
+            {
+              name: 'authorization',
+              string_match: {
+                prefix: 'AWS ',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  'pachd-identity': {
+    internal_port: 1658,
+    external_port: 30658,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/dex',
+        },
+        route: {
+          cluster: 'pachd-identity',
+          idle_timeout: '60s',
+          timeout: '60s',
+        },
+      },
+    ],
+    health_check: {
+      healthy_threshold: 1,
+      http_health_check: {
+        host: 'localhost',
+        path: '/dex/.well-known/openid-configuration',
+      },
+      interval: '30s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
+  },
+  'pachd-oidc': {
+    internal_port: 1657,
+    external_port: 30657,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/authorization-code/callback',
+        },
+        route: {
+          cluster: 'pachd-oidc',
+          idle_timeout: '60s',
+          timeout: '60s',
+        },
+      },
+    ],
+  },
+  console: {
+    internal_port: 4000,
+    external_port: 4000,
+    service: 'console-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/',
+        },
+        route: {
+          cluster: 'console',
+          idle_timeout: '600s',
+          timeout: '3600s',
+          upgrade_configs: [
+            {
+              enabled: true,
+              upgrade_type: 'websocket',
+            },
+          ],
+        },
+      },
+    ],
+    health_check: {
+      healthy_threshold: 1,
+      http_health_check: {
+        host: 'localhost',  // This is just the value of the Host: header, not something to connect to.
+        path: '/',
+      },
+      interval: '30s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
+  },
+  'pachd-metrics': {
+    internal_port: 1656,
+    external_port: 30656,
+    service: 'pachd-proxy-backend',
+    routes: [
+      {
+        match: {
+          prefix: '/',
+        },
+        route: {
+          cluster: 'pachd-metrics',
+          idle_timeout: '60s',
+          timeout: '60s',
+        },
+      },
+    ],
+  },
+};
+
+// This is the generation code.
+local Envoy = import 'envoy.libsonnet';
+Envoy.bootstrap(
+  listeners=[
+    Envoy.httpListener(
+      port=8080,  // Not port 80, because we run as user 101 and not root.
+      name='proxy-http',
+      // Everything except the metrics service is served on the multiplexed route.  The order of
+      // services' routes is important!
+      routes=std.flatMap(function(name) services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'console'])
+    ),
+  ] + [
+    local svc = services[name];
+    Envoy.httpListener(
+      port=svc.internal_port,
+      name='direct-' + name,
+      routes=svc.routes,
+    )
+    // Every service gets a direct route.  We sort the keys so that the output is
+    // stable across regeneration.
+    for name in std.sort(std.objectFields(services), keyF=function(name) services[name].internal_port)
+  ],
+  clusters=[
+    local svc = services[name];
+    (if 'grpc' in svc && svc.grpc then Envoy.GRPCCluster else Envoy.defaultCluster) + {
+      name: name,
+      load_assignment: Envoy.loadAssignment(name=name, address=svc.service, port=svc.internal_port),
+      health_checks: if 'health_check' in svc then [svc.health_check] else [],
+    }
+    for name in std.objectFields(services)
+  ],
+)

--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -1,0 +1,201 @@
+{
+  bootstrap(listeners, clusters): {
+    admin: {
+      access_log: [
+        {
+          name: 'envoy.access_loggers.stderr',
+          typed_config: {
+            '@type': 'type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StderrAccessLog',
+          },
+        },
+      ],
+      address: {
+        socket_address: {
+          address: '0.0.0.0',
+          port_value: 9901,
+        },
+      },
+    },
+    static_resources: {
+      clusters: clusters,
+      listeners: listeners,
+    },
+    overload_manager: {
+      actions: [
+        {
+          name: 'envoy.overload_actions.shrink_heap',
+          triggers: [
+            {
+              name: 'envoy.resource_monitors.fixed_heap',
+              threshold: {
+                value: 0.95,
+              },
+            },
+          ],
+        },
+        {
+          name: 'envoy.overload_actions.stop_accepting_requests',
+          triggers: [
+            {
+              name: 'envoy.resource_monitors.fixed_heap',
+              threshold: {
+                value: 0.98,
+              },
+            },
+          ],
+        },
+      ],
+      refresh_interval: '0.25s',
+      resource_monitors: [
+        {
+          name: 'envoy.resource_monitors.fixed_heap',
+          typed_config: {
+            '@type': 'type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig',
+            max_heap_size_bytes: 500000000,
+          },
+        },
+      ],
+    },
+    layered_runtime: {
+      layers: [
+        {
+          name: 'static_layer_0',
+          static_layer: {
+            overload: {
+              global_downstream_max_connections: 50000,
+            },
+          },
+        },
+      ],
+    },
+  },
+
+  loadAssignment(name, address, port): {
+    cluster_name: name,
+    endpoints: [
+      {
+        lb_endpoints: [
+          {
+            endpoint: {
+              address: {
+                socket_address: {
+                  address: address,
+                  port_value: port,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+
+  httpListener(port, name, routes): {
+    name: name,
+    per_connection_buffer_limit_bytes: 32768,
+    traffic_direction: 'INBOUND',
+    address: {
+      socket_address: {
+        address: '0.0.0.0',
+        port_value: port,
+      },
+    },
+    filter_chains: [
+      {
+        filters: [
+          {
+            name: 'envoy.http_connection_manager',
+            typed_config: {
+              '@type': 'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
+              access_log: [
+                {
+                  name: 'envoy.access_loggers.stdout',
+                  typed_config: {
+                    '@type': 'type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog',
+                  },
+                },
+              ],
+              codec_type: 'auto',
+              common_http_protocol_options: {
+                headers_with_underscores_action: 'REJECT_REQUEST',
+                idle_timeout: '60s',
+              },
+              http2_protocol_options: {
+                initial_connection_window_size: 1048576,
+                initial_stream_window_size: 65536,
+                max_concurrent_streams: 100,
+              },
+              http_filters: std.prune([
+                // If there's a GRPC router, enable grpc_stats.
+                if std.foldl(function(last, route) last || 'grpc' in route.match, routes, false) then
+                  {
+                    name: 'envoy.filters.http.grpc_stats',
+                    typed_config: {
+                      '@type': 'type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig',
+                      enable_upstream_stats: true,
+                      // Stats for all methods = true would let anyone on the Internet fill up the
+                      // statistics buffer with bogus RPC method names, so we have to leave it off.
+                      stats_for_all_methods: false,
+                    },
+                  } else {},
+                {
+                  name: 'envoy.filters.http.router',
+                  typed_config: {
+                    '@type': 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router',
+                  },
+                },
+              ]),
+              http_protocol_options: {
+                accept_http_10: false,
+              },
+              request_timeout: '604800s',  // Necessary to allow long file uploads.
+              stream_idle_timeout: '600s',  // Only completely idle streams are dropped after this timeout.
+              route_config: {
+                virtual_hosts: [
+                  {
+                    domains: [
+                      '*',
+                    ],
+                    name: 'any',
+                    routes: routes,
+                    retry_policy: {
+                      retry_on: 'connect-failure',
+                      num_retries: 4,
+                      host_selection_retry_max_attempts: 4,
+                    },
+                  },
+                ],
+              },
+              stat_prefix: name,
+              use_remote_address: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  defaultCluster: {
+    connect_timeout: '10s',
+    dns_lookup_family: 'V4_ONLY',
+    dns_refresh_rate: '5s',
+    dns_failure_refresh_rate: {
+      base_interval: '0.05s',
+      max_interval: '0.1s',
+    },
+    lb_policy: 'random',
+    type: 'strict_dns',
+    upstream_connection_options: {
+      tcp_keepalive: {},
+    },
+  },
+  GRPCCluster: self.defaultCluster {
+    typed_extension_protocol_options: {
+      'envoy.extensions.upstreams.http.v3.HttpProtocolOptions': {
+        '@type': 'type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions',
+        explicit_http_config: {
+          http2_protocol_options: {},
+        },
+      },
+    },
+  },
+}

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -1,0 +1,1027 @@
+{
+   "admin": {
+      "access_log": [
+         {
+            "name": "envoy.access_loggers.stderr",
+            "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StderrAccessLog"
+            }
+         }
+      ],
+      "address": {
+         "socket_address": {
+            "address": "0.0.0.0",
+            "port_value": 9901
+         }
+      }
+   },
+   "layered_runtime": {
+      "layers": [
+         {
+            "name": "static_layer_0",
+            "static_layer": {
+               "overload": {
+                  "global_downstream_max_connections": 50000
+               }
+            }
+         }
+      ]
+   },
+   "overload_manager": {
+      "actions": [
+         {
+            "name": "envoy.overload_actions.shrink_heap",
+            "triggers": [
+               {
+                  "name": "envoy.resource_monitors.fixed_heap",
+                  "threshold": {
+                     "value": 0.94999999999999996
+                  }
+               }
+            ]
+         },
+         {
+            "name": "envoy.overload_actions.stop_accepting_requests",
+            "triggers": [
+               {
+                  "name": "envoy.resource_monitors.fixed_heap",
+                  "threshold": {
+                     "value": 0.97999999999999998
+                  }
+               }
+            ]
+         }
+      ],
+      "refresh_interval": "0.25s",
+      "resource_monitors": [
+         {
+            "name": "envoy.resource_monitors.fixed_heap",
+            "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig",
+               "max_heap_size_bytes": 500000000
+            }
+         }
+      ]
+   },
+   "static_resources": {
+      "clusters": [
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "console",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "console-proxy-backend",
+                                    "port_value": 4000
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "console",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "grpc_health_check": { },
+                  "healthy_threshold": 1,
+                  "interval": "10s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-grpc",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1650
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-grpc",
+            "type": "strict_dns",
+            "typed_extension_protocol_options": {
+               "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                  "explicit_http_config": {
+                     "http2_protocol_options": { }
+                  }
+               }
+            },
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/dex/.well-known/openid-configuration"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-identity",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1658
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-identity",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [ ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-metrics",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1656
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-metrics",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [ ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-oidc",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1657
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-oidc",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [ ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-s3",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1600
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-s3",
+            "type": "strict_dns",
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         }
+      ],
+      "listeners": [
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 8080
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.grpc_stats",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                                    "enable_upstream_stats": true,
+                                    "stats_for_all_methods": false
+                                 }
+                              },
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "grpc": { },
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-grpc",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "headers": [
+                                                {
+                                                   "name": "authorization",
+                                                   "string_match": {
+                                                      "prefix": "AWS4-HMAC-SHA256"
+                                                   }
+                                                }
+                                             ],
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-s3",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "headers": [
+                                                {
+                                                   "name": "authorization",
+                                                   "string_match": {
+                                                      "prefix": "AWS "
+                                                   }
+                                                }
+                                             ],
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-s3",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/dex"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-identity",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/authorization-code/callback"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-oidc",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "console",
+                                             "idle_timeout": "600s",
+                                             "timeout": "3600s",
+                                             "upgrade_configs": [
+                                                {
+                                                   "enabled": true,
+                                                   "upgrade_type": "websocket"
+                                                }
+                                             ]
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "proxy-http",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "proxy-http",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 1600
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "headers": [
+                                                {
+                                                   "name": "authorization",
+                                                   "string_match": {
+                                                      "prefix": "AWS4-HMAC-SHA256"
+                                                   }
+                                                }
+                                             ],
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-s3",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "headers": [
+                                                {
+                                                   "name": "authorization",
+                                                   "string_match": {
+                                                      "prefix": "AWS "
+                                                   }
+                                                }
+                                             ],
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-s3",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "direct-pachd-s3",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "direct-pachd-s3",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 1650
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.grpc_stats",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                                    "enable_upstream_stats": true,
+                                    "stats_for_all_methods": false
+                                 }
+                              },
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "grpc": { },
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-grpc",
+                                             "timeout": "604800s"
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "direct-pachd-grpc",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "direct-pachd-grpc",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 1656
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-metrics",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "direct-pachd-metrics",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "direct-pachd-metrics",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 1657
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "prefix": "/authorization-code/callback"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-oidc",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "direct-pachd-oidc",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "direct-pachd-oidc",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 1658
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "prefix": "/dex"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-identity",
+                                             "idle_timeout": "60s",
+                                             "timeout": "60s"
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "direct-pachd-identity",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "direct-pachd-identity",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         },
+         {
+            "address": {
+               "socket_address": {
+                  "address": "0.0.0.0",
+                  "port_value": 4000
+               }
+            },
+            "filter_chains": [
+               {
+                  "filters": [
+                     {
+                        "name": "envoy.http_connection_manager",
+                        "typed_config": {
+                           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                           "access_log": [
+                              {
+                                 "name": "envoy.access_loggers.stdout",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                                 }
+                              }
+                           ],
+                           "codec_type": "auto",
+                           "common_http_protocol_options": {
+                              "headers_with_underscores_action": "REJECT_REQUEST",
+                              "idle_timeout": "60s"
+                           },
+                           "http2_protocol_options": {
+                              "initial_connection_window_size": 1048576,
+                              "initial_stream_window_size": 65536,
+                              "max_concurrent_streams": 100
+                           },
+                           "http_filters": [
+                              {
+                                 "name": "envoy.filters.http.router",
+                                 "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                 }
+                              }
+                           ],
+                           "http_protocol_options": {
+                              "accept_http_10": false
+                           },
+                           "request_timeout": "604800s",
+                           "route_config": {
+                              "virtual_hosts": [
+                                 {
+                                    "domains": [
+                                       "*"
+                                    ],
+                                    "name": "any",
+                                    "retry_policy": {
+                                       "host_selection_retry_max_attempts": 4,
+                                       "num_retries": 4,
+                                       "retry_on": "connect-failure"
+                                    },
+                                    "routes": [
+                                       {
+                                          "match": {
+                                             "prefix": "/"
+                                          },
+                                          "route": {
+                                             "cluster": "console",
+                                             "idle_timeout": "600s",
+                                             "timeout": "3600s",
+                                             "upgrade_configs": [
+                                                {
+                                                   "enabled": true,
+                                                   "upgrade_type": "websocket"
+                                                }
+                                             ]
+                                          }
+                                       }
+                                    ]
+                                 }
+                              ]
+                           },
+                           "stat_prefix": "direct-console",
+                           "stream_idle_timeout": "600s",
+                           "use_remote_address": true
+                        }
+                     }
+                  ]
+               }
+            ],
+            "name": "direct-console",
+            "per_connection_buffer_limit_bytes": 32768,
+            "traffic_direction": "INBOUND"
+         }
+      ]
+   }
+}

--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -46,9 +46,14 @@ http
 
 {{- define "pachyderm.issuerURI" -}}
 {{- if .Values.oidc.issuerURI -}}
+{{- if and .Values.proxy.enabled (not (hasSuffix "/dex" .Values.oidc.issuerURI)) -}}
+{{ fail (printf "With the proxy enabled, oidc.issuerURI must end with /dex, not %s" .Values.oidc.issuerURI) }}
+{{- end -}}
 {{ .Values.oidc.issuerURI }}
 {{- else if .Values.ingress.host -}}
 {{- printf "%s://%s/dex" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
+{{- else if .Values.proxy.enabled -}}
+http://pachd:30658/dex
 {{- else if not .Values.ingress.enabled -}}
 {{- if eq .Values.pachd.service.type "NodePort" -}}
 http://pachd:1658
@@ -61,7 +66,7 @@ http://pachd:30658
 {{- end }}
 
 {{- /*
-reactAppRuntimeIssuerURI: The URI without the path of the user accessible issuerURI. 
+reactAppRuntimeIssuerURI: The URI without the path of the user accessible issuerURI.
 ie. In local deployments, this is http://localhost:30658, while the issuer URI is http://pachd:30658
 In deployments where the issuerURI is user accessible (ie. Via ingress) this would be the issuerURI without the path
 */ -}}

--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - containerPort: {{ .Values.console.config.graphqlPort }}
           name: console-http
         env:
-        {{- if not .Values.ingress.enabled }}
+        {{- if and (not .Values.ingress.enabled) (not .Values.proxy.enabled) }}
         - name: REACT_APP_RUNTIME_SUBSCRIPTIONS_PREFIX
           value: ":{{ .Values.console.config.graphqlPort }}/graphql"
         {{- end }}

--- a/etc/helm/pachyderm/templates/ingress/ingress-via-proxy.yaml
+++ b/etc/helm/pachyderm/templates/ingress/ingress-via-proxy.yaml
@@ -1,0 +1,33 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if and .Values.ingress.enabled .Values.proxy.enabled -}}
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
+metadata:
+  name: "pachyderm-proxy"
+  annotations: {{ toYaml .Values.ingress.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: "pachyderm-proxy"
+    suite: "pachyderm"
+spec:
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - secretName: {{ required "if ingress.tls.enabled you must specify ingress.tls.secretName" .Values.ingress.tls.secretName }}
+      hosts:
+       - {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: pachyderm-proxy
+                port:
+                  name: http-port
+{{ end -}}

--- a/etc/helm/pachyderm/templates/ingress/ingress.yaml
+++ b/etc/helm/pachyderm/templates/ingress/ingress.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.proxy.enabled) -}}
 apiVersion: "networking.k8s.io/v1"
 kind: "Ingress"
 metadata:

--- a/etc/helm/pachyderm/templates/proxy/configmap.yaml
+++ b/etc/helm/pachyderm/templates/proxy/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: pachyderm-proxy
+    suite: pachyderm
+    {{- if .Values.proxy.labels }}
+    {{- toYaml .Values.proxy.labels | nindent 6 }}
+    {{- end }}
+  {{- if .Values.proxy.annotations }}
+  annotations:
+    {{- toYaml .Values.proxy.annotations | nindent 8 }}
+  {{- end }}
+  name: pachyderm-proxy-config
+data:
+  envoy.json: |
+    {{- .Files.Get "envoy.json" | nindent 4 }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
@@ -1,0 +1,24 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if and .Values.proxy.enabled .Values.console.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pachyderm-proxy-support
+    suite: pachyderm
+  name: console-proxy-backend
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: console-http
+    port: 4000
+    targetPort: console-http
+  selector:
+    app: console
+    suite: pachyderm
+  type: ClusterIP
+  clusterIP: None
+{{- end }}

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pachyderm-proxy
+    suite: pachyderm
+  name: pachyderm-proxy
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.proxy.replicas }}
+  selector:
+    matchLabels:
+      app: pachyderm-proxy
+      suite: pachyderm
+      {{- if .Values.proxy.labels }}
+      {{- toYaml .Values.proxy.labels | nindent 6 }}
+      {{- end }}
+  template:
+    metadata:
+      {{- if .Values.proxy.annotations }}
+      annotations:
+        {{- toYaml .Values.proxy.annotations | nindent 8 }}
+      {{- end }}
+      labels:
+        app: pachyderm-proxy
+        suite: pachyderm
+        {{- if .Values.proxy.labels }}
+        {{- toYaml .Values.proxy.labels | nindent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - pachd
+      {{- include "pachyderm.imagePullSecrets" . | indent 6 }}
+      containers:
+        - name: envoy
+          command:
+            - envoy
+          args:
+            - -c
+            - /etc/envoy/envoy.json
+            - --service-node
+            - $(MY_POD_NAME)
+            - --service-zone
+            - $(MY_NODE_NAME)
+            - --service-cluster
+            - pachyderm-envoy
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          ports:
+            - name: admin-port
+              containerPort: 9901
+            - name: http-port
+              containerPort: 8080
+            # - name: https
+            #   containerPort: 8443
+            - name: console-direct
+              containerPort: 4000
+            - name: s3-direct
+              containerPort: 1600
+            - name: grpc-direct
+              containerPort: 1650
+            - name: oidc-direct
+              containerPort: 1657
+            - name: identity-direct
+              containerPort: 1658
+            - name: metrics-direct
+              containerPort: 1656
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 9901
+          livenessProbe:
+            httpGet:
+              path: /server_info
+              port: 9901
+          {{- if .Values.proxy.resources }}
+          resources: {{ toYaml .Values.proxy.resources | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: pachyderm-proxy-config
+{{- end }}

--- a/etc/helm/pachyderm/templates/proxy/pachd-proxy-backend-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/pachd-proxy-backend-service.yaml
@@ -1,0 +1,37 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if and .Values.proxy.enabled .Values.pachd.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pachyderm-proxy-support
+    suite: pachyderm
+  name: pachd-proxy-backend
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: api-grpc-port
+    port: 1650
+    targetPort: api-grpc-port
+  - name: oidc-port
+    port: 1657
+    targetPort: oidc-port
+  - name: identity-port
+    port: 1658
+    targetPort: identity-port
+  - name: s3gateway-port
+    port: 1600
+    targetPort: s3gateway-port
+  - name: prom-metrics
+    port: 1656
+    protocol: TCP
+    targetPort: prom-metrics
+  selector:
+    app: pachd
+    suite: pachyderm
+  type: ClusterIP
+  clusterIP: None
+{{- end }}

--- a/etc/helm/pachyderm/templates/proxy/service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/service.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pachyderm-proxy
+    suite: pachyderm
+    {{- if .Values.proxy.service.labels -}}
+    {{- toYaml .Values.proxy.service.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.proxy.service.annotations }}
+  annotations:
+    {{- toYaml .Values.proxy.service.annotations | nindent 4 }}
+  {{- end }}
+  name: pachyderm-proxy
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: {{ .Values.proxy.service.type }}
+  ports:
+    - name: http-port
+      targetPort: http-port
+      port: {{ .Values.proxy.service.httpPort }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.httpNodePort }}
+      {{- end }}
+    {{ if .Values.proxy.service.legacyPorts.console }}
+    - name: console-direct
+      targetPort: console-direct
+      port: {{ .Values.proxy.service.legacyPorts.console }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.legacyPorts.console }}
+      {{- end }}
+    {{- end }}
+    {{ if .Values.proxy.service.legacyPorts.grpc }}
+    - name: grpc-direct
+      targetPort: grpc-direct
+      port: {{ .Values.proxy.service.legacyPorts.grpc }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.legacyPorts.grpc }}
+      {{- end }}
+    {{- end }}
+    {{ if .Values.proxy.service.legacyPorts.s3Gateway }}
+    - name: s3-direct
+      targetPort: s3-direct
+      port: {{ .Values.proxy.service.legacyPorts.s3Gateway }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.legacyPorts.s3Gateway }}
+      {{- end }}
+    {{- end }}
+    {{ if .Values.proxy.service.legacyPorts.oidc }}
+    - name: oidc-direct
+      targetPort: oidc-direct
+      port: {{ .Values.proxy.service.legacyPorts.oidc }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.legacyPorts.oidc }}
+      {{- end }}
+    {{- end }}
+    {{ if .Values.proxy.service.legacyPorts.identity }}
+    - name: identity-direct
+      targetPort: identity-direct
+      port: {{ .Values.proxy.service.legacyPorts.identity }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.legacyPorts.identity }}
+      {{- end }}
+    {{- end }}
+    {{ if .Values.proxy.service.legacyPorts.metrics }}
+    - name: metrics-direct
+      targetPort: metrics-direct
+      port: {{ .Values.proxy.service.legacyPorts.metrics }}
+      {{- if eq .Values.proxy.service.type "NodePort" }}
+      nodePort: {{ .Values.proxy.service.legacyPorts.metrics }}
+      {{- end }}
+    {{- end }}
+  selector:
+    app: pachyderm-proxy
+    suite: pachyderm
+    {{- if .Values.proxy.labels -}} {{/* Note that these are the pod labels. */}}
+    {{- toYaml .Values.proxy.labels | nindent 4 }}
+    {{- end }}
+  {{- if ne .Values.proxy.service.loadBalancerIP "" }}
+  loadBalancerIP: {{ .Values.proxy.service.loadBalancerIP }}
+  {{- end }}
+{{- end }}

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -37,7 +37,8 @@ global:
   imagePullSecrets: []
   # when set, the certificate file in pachd-tls-cert will be loaded as the root certificate for pachd, console, and enterprise-server pods
   customCaCerts: false
-  # Sets the HTTP/S proxy server address for console, pachd, and enteprise server
+  # Sets the HTTP/S proxy server address for console, pachd, and enterprise server.  (This is for
+  # traffic leaving the cluster, not traffic coming into the cluster.)
   proxy: ""
   # If proxy is set, this allows you to set a comma-separated list of destinations that bypass the proxy
   noProxy: ""
@@ -637,3 +638,63 @@ oidc:
   dexCredentialSecretName: ""
   mockIDP: true
   #TODO scopes:
+
+# The proxy is a service to handle all Pachyderm traffic (S3, Console, OIDC, Dex, GRPC) on a single
+# port; good for exposing directly to the Internet.
+proxy:
+  # If enabled, create a proxy deployment (based on the Envoy proxy) and a service to expose it.  If
+  # ingress is also enabled, any Ingress traffic will be routed through the proxy before being sent
+  # to pachd or Console.
+  enabled: false
+  # The number of proxy replicas to run.  1 should be fine, but if you want more for higher
+  # availability, that's perfectly reasonable.  Each replica can handle 50,000 concurrent
+  # connections.  There is an affinity rule to prefer scheduling the proxy pods on the same node as
+  # pachd, so a number here that matches the number of pachd replicas is a fine configuration.
+  # (Note that we don't guarantee to keep the proxy<->pachd traffic on-node or even in-region.)
+  replicas: 1
+  # The envoy image to pull.
+  image:
+    repository: "envoyproxy/envoy"
+    tag: "v1.22.0"
+    pullPolicy: "IfNotPresent"
+  # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's
+  # a resonable memory limit.  It doesn't need much CPU.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 512Mi
+  # Any additional labels to add to the pods.  These are also added to the deployment and service
+  # selectors.
+  labels: {}
+  # Any additional annotations to add to the pods.
+  annotations: {}
+  # Configure the service that routes traffic to the proxy.
+  service:
+    # The type of service can be ClusterIP, NodePort, or LoadBalancer.
+    type: ClusterIP
+    # If the service is a LoadBalancer, you can specify the IP address to use.
+    loadBalancerIP: ""
+    # The port to serve plain HTTP traffic on.
+    httpPort: 80
+    # The port to serve HTTPS traffic on, if enabled below.
+    httpsPort: 443 # Not implemented yet.
+    # If the service is a NodePort, you can specify the port to receive HTTP traffic on.
+    httpNodePort: 30080
+    httpsNodePort: 30443 # Not implemented yet.
+    # Any additional annotations to add.
+    annotations: {}
+    # Any additional labels to add to the service itself (not the selector!).
+    labels: {}
+    # The proxy can also serve each backend service on a numbered port, and will do so for any port
+    # not numbered 0 here.  If this service is of type NodePort, the port numbers here will be used
+    # for the node port, and will need to be in the node port range.
+    legacyPorts:
+      console: 0 # legacy 30080, conflicts with default httpNodePort
+      grpc: 0 # legacy 30650
+      s3Gateway: 0 # legacy 30600
+      oidc: 0 # legacy 30657
+      identity: 0 # legacy 30658
+      metrics: 0 # legacy 30656
+  tls: {} # Not implemented yet.

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -1,33 +1,46 @@
 deployTarget: custom
 
 global:
-  postgresql:
-    postgresqlPassword: pachyderm
-    postgresqlPostgresPassword: pachyderm
+    postgresql:
+        postgresqlPassword: pachyderm
+        postgresqlPostgresPassword: pachyderm
 
 pachd:
-  service:
-    type: NodePort
-  image:
-    tag: local
-  storage:
-    backend: MINIO
-    minio:
-      bucket: "pachyderm-test"
-      endpoint: "minio.default.svc.cluster.local:9000"
-      id: "minioadmin"
-      secret: "minioadmin"
-      secure: "false"
-      signature: ""
-  metrics:
-    enabled: false
-  resources:
-    requests:
-      cpu: 250m
-      memory: 512M
+    service:
+        type: ClusterIP
+    image:
+        tag: local
+    storage:
+        backend: MINIO
+        minio:
+            bucket: "pachyderm-test"
+            endpoint: "minio.default.svc.cluster.local:9000"
+            id: "minioadmin"
+            secret: "minioadmin"
+            secure: "false"
+            signature: ""
+    lokiDeploy: true
+    metrics:
+        enabled: false
+    resources:
+        requests:
+            cpu: 250m
+            memory: 512M
 
 etcd:
-  resources:
-    requests:
-      cpu: 250m
-      memory: 512M
+    resources:
+        requests:
+            cpu: 250m
+            memory: 512M
+
+proxy:
+    enabled: true
+    service:
+        type: NodePort
+        httpNodePort: 30650
+        legacyPorts:
+            console: 30400
+            s3Gateway: 30600
+            oidc: 30657
+            identity: 30658
+            metrics: 30656

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -19,7 +19,6 @@ pachd:
       secret: "minioadmin"
       secure: "false"
       signature: ""
-  lokiDeploy: true
   metrics:
     enabled: false
   resources:

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -8,8 +8,4 @@ source "$(dirname "$0")/env.sh"
 # deploy object storage
 kubectl apply -f etc/testing/minio.yaml
 
-helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
-
-kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
-
 pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/etc/testing/circle/launch.sh
+++ b/etc/testing/circle/launch.sh
@@ -12,8 +12,4 @@ helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 
-# Wait for loki to be deployed
-kubectl wait --for=condition=ready pod -l app=loki --timeout=5m
-kubectl wait --for=condition=ready pod -l app=promtail --timeout=5m
-
 pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/etc/testing/circle/run_load_tests.sh
+++ b/etc/testing/circle/run_load_tests.sh
@@ -19,8 +19,16 @@ helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 
-# Print client and server versions, for debugging.
-pachctl version
+# Print client and server versions, for debugging.  (Also waits for proxy to discover pachd, etc.)
+for i in $(seq 1 20); do
+    if pachctl version; then
+        echo "pachd ready after $i attempts"
+        break
+    else
+        sleep 5
+        continue
+    fi
+done
 
 # Run load tests.
 set +e
@@ -48,7 +56,7 @@ if [[ "$CIRCLE_JOB" == *"nightly_load"* ]]; then
 DURATION=$(echo "$PPS_RESPONSE_SPEC" | jq '.duration')
 DURATION=${DURATION: 1:-2}
 bq insert --ignore_unknown_values insights.load-tests << EOF
-  {"gitBranch": "$CIRCLE_BRANCH","specName": "$BUCKET","duration": $DURATION,"type": "PPS", "commit": "$CIRCLE_SHA1", "timeStamp": "$(date +%Y-%m-%dT%H:%M:%S)"} 
+  {"gitBranch": "$CIRCLE_BRANCH","specName": "$BUCKET","duration": $DURATION,"type": "PPS", "commit": "$CIRCLE_SHA1", "timeStamp": "$(date +%Y-%m-%dT%H:%M:%S)"}
 EOF
 
 fi

--- a/etc/testing/circle/run_load_tests.sh
+++ b/etc/testing/circle/run_load_tests.sh
@@ -2,6 +2,9 @@
 
 set -euxo pipefail
 
+# shellcheck disable=SC1090
+source "$(dirname "$0")/env.sh"
+
 mkdir -p "${HOME}/go/bin"
 export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
 export GOPATH="${HOME}/go"
@@ -11,6 +14,10 @@ pachctl version --client-only
 # Set version for docker builds.
 VERSION="$(pachctl version --client-only)"
 export VERSION
+
+helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
+
+kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 
 # Print client and server versions, for debugging.
 pachctl version

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -6,6 +6,16 @@ helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 
+for i in $(seq 1 20); do
+    if pachctl version; then
+        echo "pachd ready after $i attempts"
+        break
+    else
+        sleep 5
+        continue
+    fi
+done
+
 # Runs various examples to ensure they don't break. Some examples were
 # designed for older versions of pachyderm and are not used here.
 
@@ -102,14 +112,14 @@ pachctl delete repo --all
 ##        pachctl put file raw_data@master:iris.csv -f noisy_iris.csv
 ##
 ##        pushd parameters
-##            pachctl put file parameters@master -f c_parameters.txt --split line --target-file-datums 1 
+##            pachctl put file parameters@master -f c_parameters.txt --split line --target-file-datums 1
 ##            pachctl put file parameters@master -f gamma_parameters.txt --split line --target-file-datums 1
 ##        popd
 ##    popd
 ##
-##    pachctl create pipeline -f split.json 
+##    pachctl create pipeline -f split.json
 ##    pachctl create pipeline -f model.json
-##    pachctl create pipeline -f test.json 
+##    pachctl create pipeline -f test.json
 ##    pachctl create pipeline -f select.json
 ##
 ##    pachctl wait commit "select@master"

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
+
+kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
+
 # Runs various examples to ensure they don't break. Some examples were
 # designed for older versions of pachyderm and are not used here.
 

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -131,7 +131,7 @@ func localDeploymentWithMinioOptions(namespace, image string) *helm.Options {
 		SetValues: map[string]string{
 			"deployTarget": "custom",
 
-			"pachd.service.type":        exposedServiceType(),
+			"pachd.service.type":        "ClusterIP",
 			"pachd.image.tag":           image,
 			"pachd.clusterDeploymentID": "dev",
 
@@ -148,6 +148,22 @@ func localDeploymentWithMinioOptions(namespace, image string) *helm.Options {
 
 			"global.postgresql.postgresqlPassword":         "pachyderm",
 			"global.postgresql.postgresqlPostgresPassword": "pachyderm",
+
+			// For tests, traffic from outside the cluster is routed through the proxy,
+			// but we bind the internal k8s service ports to the same numbers for
+			// in-cluster traffic, like enterprise registration.
+			"proxy.enabled":                       "true",
+			"proxy.service.type":                  exposedServiceType(),
+			"proxy.service.httpNodePort":          "30650",
+			"pachd.service.apiGRPCPort":           "30650",
+			"proxy.service.legacyPorts.oidc":      "30657",
+			"pachd.service.oidcPort":              "30657",
+			"proxy.service.legacyPorts.identity":  "30658",
+			"pachd.service.identityPort":          "30658",
+			"proxy.service.legacyPorts.s3Gateway": "30600",
+			"pachd.service.s3GatewayPort":         "30600",
+			"proxy.service.legacyPorts.metrics":   "30656",
+			"pachd.service.prometheusPort":        "30656",
 		},
 		SetStrValues: map[string]string{
 			"pachd.storage.minio.signature": "",
@@ -177,11 +193,33 @@ func withPort(namespace string, port uint16) *helm.Options {
 	return &helm.Options{
 		KubectlOptions: &k8s.KubectlOptions{Namespace: namespace},
 		SetValues: map[string]string{
-			"pachd.service.apiGRPCPort":    fmt.Sprintf("%v", port),
-			"pachd.service.oidcPort":       fmt.Sprintf("%v", port+7),
-			"pachd.service.identityPort":   fmt.Sprintf("%v", port+8),
-			"pachd.service.s3GatewayPort":  fmt.Sprintf("%v", port+3),
-			"pachd.service.prometheusPort": fmt.Sprintf("%v", port+4),
+			// Run gRPC traffic through the full router.
+			"proxy.service.httpNodePort": fmt.Sprintf("%v", port),
+
+			// Let everything else use the legacy way.  We use the same mapping for
+			// internal ports, so in-cluster traffic doesn't go through the proxy, but
+			// doesn't need to confusingly use a different port number.
+			"pachd.service.apiGRPCPort":           fmt.Sprintf("%v", port),
+			"proxy.service.legacyPorts.oidc":      fmt.Sprintf("%v", port+7),
+			"pachd.service.oidcPort":              fmt.Sprintf("%v", port+7),
+			"proxy.service.legacyPorts.identity":  fmt.Sprintf("%v", port+8),
+			"pachd.service.identityPort":          fmt.Sprintf("%v", port+8),
+			"proxy.service.legacyPorts.s3Gateway": fmt.Sprintf("%v", port+3),
+			"pachd.service.s3GatewayPort":         fmt.Sprintf("%v", port+3),
+			"proxy.service.legacyPorts.metrics":   fmt.Sprintf("%v", port+4),
+			"pachd.service.prometheusPort":        fmt.Sprintf("%v", port+4),
+		},
+	}
+}
+
+// withoutProxy disables the Pachyderm proxy.  It's used to test upgrades from versions of Pachyderm
+// that didn't have the proxy.
+func withoutProxy(namespace string) *helm.Options {
+	return &helm.Options{
+		KubectlOptions: &k8s.KubectlOptions{Namespace: namespace},
+		SetValues: map[string]string{
+			"proxy.enabled":      "false",
+			"pachd.service.type": exposedServiceType(),
 		},
 	}
 }
@@ -261,6 +299,10 @@ func pachClient(t testing.TB, pachAddress *grpcutil.PachdAddress, authUser, name
 		if err != nil {
 			return errors.Wrapf(err, "failed to connect to pachd on port %v", pachAddress.Port)
 		}
+		// Ensure that pachd is really ready to receive requests.
+		if _, err := c.InspectCluster(); err != nil {
+			return errors.Wrapf(err, "failed to inspect cluster on port %v", pachAddress.Port)
+		}
 		return nil
 	}, backoff.RetryEvery(time.Second).For(50*time.Second)))
 	t.Logf("Success connecting to pachd on port: %v, in namespace: %s", pachAddress.Port, namespace)
@@ -328,6 +370,9 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 	}
 	if opts.Loki {
 		helmOpts = union(helmOpts, withLokiOptions(namespace, int(pachAddress.Port)))
+	}
+	if !(opts.Version == "" || strings.HasPrefix(opts.Version, "2.3")) {
+		helmOpts = union(helmOpts, withoutProxy(namespace))
 	}
 	if err := f(t, helmOpts, chartPath, namespace); err != nil {
 		if opts.UseLeftoverCluster {

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -40,13 +40,6 @@ func activateAuthHelper(tb testing.TB, client *client.APIClient) {
 	require.NoError(tb, err)
 }
 
-// ActivateAuth activates the auth service in the test cluster, if it isn't already enabled
-func ActivateAuth(tb testing.TB) {
-	tb.Helper()
-	client := GetPachClient(tb)
-	activateAuthHelper(tb, client)
-}
-
 // ActivateAuthClient activates the auth service in the test cluster, if it isn't already enabled
 func ActivateAuthClient(tb testing.TB, c *client.APIClient) {
 	tb.Helper()
@@ -74,51 +67,10 @@ func AuthenticatedPachClient(tb testing.TB, c *client.APIClient, subject string)
 	return AuthenticateClient(tb, c, subject)
 }
 
-// GetAuthenticatedPachClient activates auth, if it is not activated, and returns
-// an authenticated client for the specified subject.
-func GetAuthenticatedPachClient(tb testing.TB, subject string) *client.APIClient {
-	tb.Helper()
-	ActivateAuth(tb)
-	rootClient := GetUnauthenticatedPachClient(tb)
-	rootClient.SetAuthToken(RootToken)
-	if subject == auth.RootUser {
-		return rootClient
-	}
-	token, err := rootClient.GetRobotToken(rootClient.Ctx(), &auth.GetRobotTokenRequest{Robot: subject})
-	require.NoError(tb, err)
-	client := GetUnauthenticatedPachClient(tb)
-	client.SetAuthToken(token.Token)
-	return client
-}
-
 // GetUnauthenticatedPachClient returns a copy of the testing pach client with no auth token
 func UnauthenticatedPachClient(tb testing.TB, c *client.APIClient) *client.APIClient {
 	tb.Helper()
 	client := c.WithCtx(context.Background())
 	client.SetAuthToken("")
 	return client
-}
-
-// GetUnauthenticatedPachClient returns a copy of the testing pach client with no auth token
-func GetUnauthenticatedPachClient(tb testing.TB) *client.APIClient {
-	tb.Helper()
-	client := GetPachClient(tb)
-	client = client.WithCtx(context.Background())
-	client.SetAuthToken("")
-	return client
-}
-
-// DeleteAll deletes all data in the cluster. This includes deleting all auth
-// tokens, so all pachyderm clients must be recreated after calling deleteAll()
-// (it should generally be called at the beginning or end of tests, before any
-// clients have been created or after they're done being used).
-func DeleteAll(tb testing.TB) {
-	tb.Helper()
-
-	// Setting the auth token has no effect if auth is disabled. If it's enabled,
-	// the root user must be an admin so this will always succeed (unless auth was
-	// activated with an unknown root token).
-	client := GetUnauthenticatedPachClient(tb)
-	client.SetAuthToken(RootToken)
-	require.NoError(tb, client.DeleteAll())
 }

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -24,7 +24,7 @@ const DexMockConnectorEmail = `kilgore@kilgore.trout`
 // OIDCOIDCConfig is an auth config which can be used to connect to the identity service in tests
 func OIDCOIDCConfig() *auth.OIDCConfig {
 	return &auth.OIDCConfig{
-		Issuer:          "http://pachd:1658/",
+		Issuer:          "http://pachd:1658/dex",
 		ClientID:        "pachyderm",
 		ClientSecret:    "notsecret",
 		RedirectURI:     "http://pachd:1657/authorization-code/callback",
@@ -43,7 +43,7 @@ func ConfigureOIDCProvider(t *testing.T, c *client.APIClient) error {
 
 	_, err = adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
 		Config: &identity.IdentityServerConfig{
-			Issuer: "http://pachd:1658/",
+			Issuer: "http://pachd:1658/dex",
 		},
 	})
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func ConfigureOIDCProvider(t *testing.T, c *client.APIClient) error {
 		resp, err := adminClient.GetIdentityServerConfig(adminClient.Ctx(), &identity.GetIdentityServerConfigRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			"http://pachd:1658/", resp.Config.Issuer,
+			"http://pachd:1658/dex", resp.Config.Issuer,
 		)
 	}, backoff.NewTestingBackOff()))
 
@@ -148,8 +148,8 @@ func GetOIDCTokenForTrustedApp(t testing.TB, testClient *client.APIClient) strin
 		ClientSecret: "test",
 		RedirectURL:  "http://test.example.com:1657/authorization-code/callback",
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  RewriteURL(t, "http://pachd:30658/auth", DexHost(testClient)),
-			TokenURL: RewriteURL(t, "http://pachd:30658/token", DexHost(testClient)),
+			AuthURL:  RewriteURL(t, "http://pachd:30658/dex/auth", DexHost(testClient)),
+			TokenURL: RewriteURL(t, "http://pachd:30658/dex/token", DexHost(testClient)),
 		},
 		Scopes: []string{
 			"openid",

--- a/src/internal/testutil/pach_client.go
+++ b/src/internal/testutil/pach_client.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -10,34 +9,12 @@ import (
 
 const DefaultTransformImage = "pachyderm/testuser:local"
 
-var (
-	pachClient *client.APIClient
-	pachErr    error
-	clientOnce sync.Once
-)
-
-// GetPachClient gets a pachyderm client for use in tests. It works for tests
-// running both inside and outside the cluster. Note that multiple calls to
-// GetPachClient will return the same instance.
-func GetPachClient(t testing.TB) *client.APIClient {
-	clientOnce.Do(func() {
-		if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
-			pachClient, pachErr = client.NewInCluster()
-		} else {
-			pachClient, pachErr = client.NewForTest()
-		}
-	})
-	if pachErr != nil {
-		t.Fatalf("error getting Pachyderm client: %s", pachErr.Error())
-	}
-	return pachClient
-}
-
 // NewPachClient gets a pachyderm client for use in tests. It works for tests
 // running both inside and outside the cluster. Unlike GetPachClient,
 // multiple calls will return new pach client instances
 func NewPachClient(t testing.TB) *client.APIClient {
 	var c *client.APIClient
+	var pachErr error
 	if _, ok := os.LookupEnv("PACHD_PORT_1650_TCP_ADDR"); ok {
 		t.Log("creating pach client using cluster config")
 		c, pachErr = client.NewInCluster()

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -204,9 +204,9 @@ func TestCheckGetSet(t *testing.T) {
 	loginAsUser(t, c, auth.RootUser)
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth check repo {{.repo}} {{.alice}} \
-			| match "Roles: \[repoOwner\]" 
+			| match "Roles: \[repoOwner\]"
                 pachctl auth check repo {{.repo}} {{.bob}} \
-			| match "Roles: \[repoReader\]" 
+			| match "Roles: \[repoReader\]"
 		`,
 		"alice", alice,
 		"bob", bob,
@@ -228,7 +228,7 @@ func TestAdmins(t *testing.T) {
 		pachctl auth set cluster clusterAdmin robot:admin2
 		pachctl auth get cluster \
 			| match "^robot:admin2: \[clusterAdmin\]$" \
-			| match "^robot:admin: \[clusterAdmin\]$" 
+			| match "^robot:admin: \[clusterAdmin\]$"
 		pachctl auth set cluster none robot:admin
 
 		# as 'admin' is a substr of 'admin2', use '^admin$' regex...
@@ -242,7 +242,7 @@ func TestAdmins(t *testing.T) {
 	// works for non-admins)
 	loginAsUser(t, c, "robot:admin2")
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
-		pachctl auth set cluster clusterAdmin robot:admin 
+		pachctl auth set cluster clusterAdmin robot:admin
 		pachctl auth set cluster none robot:admin2
 	`).Run())
 	require.NoError(t, backoff.Retry(func() error {
@@ -279,14 +279,14 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
         pachctl auth set-config <<EOF
         {
-            "issuer": "http://pachd:1658/",
+            "issuer": "http://pachd:1658/dex",
             "localhost_issuer": true,
             "client_id": "localhost",
             "redirect_uri": "http://localhost:1650"
         }
 EOF
 		pachctl auth get-config \
-		  | match '"issuer": "http://pachd:1658/"' \
+		  | match '"issuer": "http://pachd:1658/dex"' \
 		  | match '"localhost_issuer": true' \
 		  | match '"client_id": "localhost"' \
 		  | match '"redirect_uri": "http://localhost:1650"' \
@@ -295,7 +295,7 @@ EOF
 
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth get-config -o yaml \
-		  | match 'issuer: http://pachd:1658/' \
+		  | match 'issuer: http://pachd:1658/dex' \
 		  | match 'localhost_issuer: true' \
 		  | match 'client_id: localhost' \
 		  | match 'redirect_uri: http://localhost:1650' \

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2611,16 +2611,15 @@ func TestDebug(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	tu.DeleteAll(t)
-	defer tu.DeleteAll(t)
-
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t, minikubetestenv.WaitForLokiOption)
+	tu.ActivateAuthClient(t, c)
 	// Get all the authenticated clients at the beginning of the test.
 	// GetAuthenticatedPachClient will always re-activate auth, which
 	// causes PPS to rotate all the pipeline tokens. This makes the RCs
 	// change and recreates all the pods, which used to race with collecting logs.
-	adminClient := tu.GetAuthenticatedPachClient(t, auth.RootUser)
 	alice := robot(tu.UniqueString("alice"))
-	aliceClient := tu.GetAuthenticatedPachClient(t, alice)
+	aliceClient, adminClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)
 
 	dataRepo := tu.UniqueString("TestDebug_data")
 	require.NoError(t, aliceClient.CreateRepo(dataRepo))
@@ -2634,7 +2633,7 @@ func TestDebug(t *testing.T) {
 			[]string{"bash"},
 			[]string{
 				fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo),
-				"sleep 15",
+				"sleep 45",
 			},
 			&pps.ParallelismSpec{
 				Constant: 1,
@@ -2655,33 +2654,41 @@ func TestDebug(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, len(jobInfos))
 
-	// Only admins can collect a debug dump.
-	buf := &bytes.Buffer{}
-	require.YesError(t, aliceClient.Dump(nil, 0, buf))
-	require.NoError(t, adminClient.Dump(nil, 0, buf))
-	gr, err := gzip.NewReader(buf)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, gr.Close())
-	}()
-	// Check that all of the expected files were returned.
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
+	require.YesError(t, aliceClient.Dump(nil, 0, &bytes.Buffer{}))
+
+	require.NoErrorWithinT(t, time.Minute, func() error {
+		// Only admins can collect a debug dump.
+		buf := &bytes.Buffer{}
+		require.NoError(t, adminClient.Dump(nil, 0, buf))
+		gr, err := gzip.NewReader(buf)
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			require.NoError(t, err)
+			return err //nolint:wrapcheck
 		}
-		for pattern, g := range expectedFiles {
-			if g.Match(hdr.Name) {
-				delete(expectedFiles, pattern)
-				break
+		defer func() {
+			require.NoError(t, gr.Close())
+		}()
+		// Check that all of the expected files were returned.
+		tr := tar.NewReader(gr)
+		for {
+			hdr, err := tr.Next()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err //nolint:wrapcheck
+			}
+			for pattern, g := range expectedFiles {
+				if g.Match(hdr.Name) {
+					delete(expectedFiles, pattern)
+					break
+				}
 			}
 		}
-	}
-	require.Equal(t, 0, len(expectedFiles))
+		if len(expectedFiles) > 0 {
+			return errors.Errorf("Debug dump hasn't produced the exepcted files: %v", expectedFiles)
+		}
+		return nil
+	})
 }
 
 func TestDeleteExpiredAuthTokens(t *testing.T) {

--- a/src/server/auth/server/testing/config_test.go
+++ b/src/server/auth/server/testing/config_test.go
@@ -28,7 +28,7 @@ func TestSetGetConfigBasic(t *testing.T) {
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 	// Set a configuration
 	conf := &auth.OIDCConfig{
-		Issuer:          "http://pachd:1658/",
+		Issuer:          "http://pachd:1658/dex",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
 		RedirectURI:     "http://pachd:1657/authorization-code/test",
@@ -59,14 +59,14 @@ func TestIssuerNotLocalhost(t *testing.T) {
 	// set the issuer to locahost:1658 so we don't need to set LocalhostIssuer = true
 	_, err := adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
 		Config: &identity.IdentityServerConfig{
-			Issuer: "http://localhost:1658/",
+			Issuer: "http://localhost:1658/dex",
 		},
 	})
 	require.NoError(t, err)
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
-		Issuer:          "http://localhost:1658/",
+		Issuer:          "http://localhost:1658/dex",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
 		RedirectURI:     "http://localhost:1657/authorization-code/test",
@@ -105,7 +105,7 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 
 	// Alice tries to set the current configuration and fails
 	conf := &auth.OIDCConfig{
-		Issuer:          "http://pachd:1658/",
+		Issuer:          "http://pachd:1658/dex",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
 		RedirectURI:     "http://pachd:1657/authorization-code/test",
@@ -163,7 +163,7 @@ func TestConfigRestartAuth(t *testing.T) {
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
-		Issuer:          "http://pachd:1658/",
+		Issuer:          "http://pachd:1658/dex",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
 		RedirectURI:     "http://pachd:1657/authorization-code/test",
@@ -247,7 +247,7 @@ func TestSetGetNilConfig(t *testing.T) {
 
 	// Set a configuration
 	conf := &auth.OIDCConfig{
-		Issuer:          "http://pachd:1658/",
+		Issuer:          "http://pachd:1658/dex",
 		ClientID:        "configtest",
 		ClientSecret:    "newsecret",
 		RedirectURI:     "http://pachd:1657/authorization-code/test",

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -92,7 +91,7 @@ func TestCannotAuthenticateWithExpiredLicense(t *testing.T) {
 			Expires:        ts,
 		})
 	require.NoError(t, err)
-	require.True(t, resp.GetInfo().Expires.Seconds == ts.Seconds)
+	require.Equal(t, ts.Seconds, resp.GetInfo().Expires.Seconds)
 
 	// Heartbeat forces Enterprise Service to refresh it's view of the LicenseRecord
 	_, err = adminClient.Enterprise.Heartbeat(adminClient.Ctx(), &enterprise.HeartbeatRequest{})
@@ -102,7 +101,7 @@ func TestCannotAuthenticateWithExpiredLicense(t *testing.T) {
 	_, err = testClient.Authenticate(testClient.Ctx(),
 		&auth.AuthenticateRequest{OIDCState: loginInfo.State})
 	require.YesError(t, err)
-	require.True(t, strings.Contains(err.Error(), "Pachyderm Enterprise is not active"))
+	require.Matches(t, "Pachyderm Enterprise is not active", err.Error())
 
 	// give test user the Cluster Admin Role
 	// admin grants alice cluster admin role

--- a/src/server/identity/server/api_server_test.go
+++ b/src/server/identity/server/api_server_test.go
@@ -156,7 +156,7 @@ func TestSetConfiguration(t *testing.T) {
 
 	_, err = adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
 		Config: &identity.IdentityServerConfig{
-			Issuer: "http://localhost:30658/",
+			Issuer: "http://localhost:30658/dex",
 		},
 	})
 	require.NoError(t, err)
@@ -166,16 +166,16 @@ func TestSetConfiguration(t *testing.T) {
 		resp, err := adminClient.GetIdentityServerConfig(adminClient.Ctx(), &identity.GetIdentityServerConfigRequest{})
 		require.NoError(t, err)
 		return require.EqualOrErr(
-			"http://localhost:30658/", resp.Config.Issuer,
+			"http://localhost:30658/dex", resp.Config.Issuer,
 		)
 	}, backoff.NewTestingBackOff()))
 
-	resp, err := http.Get(fmt.Sprintf("http://%v/.well-known/openid-configuration", tu.DexHost(adminClient)))
+	resp, err := http.Get(fmt.Sprintf("http://%v/dex/.well-known/openid-configuration", tu.DexHost(adminClient)))
 	require.NoError(t, err)
 
 	var oidcConfig map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&oidcConfig))
-	require.Equal(t, "http://localhost:30658/", oidcConfig["issuer"].(string))
+	require.Equal(t, "http://localhost:30658/dex", oidcConfig["issuer"].(string))
 }
 
 func TestOIDCClientCRUD(t *testing.T) {
@@ -277,7 +277,7 @@ func TestShortenIDTokenExpiry(t *testing.T) {
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 	_, err := adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
 		Config: &identity.IdentityServerConfig{
-			Issuer:              "http://pachd:1658/",
+			Issuer:              "http://pachd:1658/dex",
 			IdTokenExpiry:       "1h",
 			RotationTokenExpiry: "5h",
 		},

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4254,8 +4254,8 @@ func TestLokiLogs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c := tu.GetPachClient(t)
-	require.NoError(t, c.DeleteAll())
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t, minikubetestenv.WaitForLokiOption)
 	tu.ActivateEnterprise(t, c)
 	// create repos
 	dataRepo := tu.UniqueString("data")
@@ -9426,9 +9426,8 @@ func TestDebug(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-
-	c := tu.GetPachClient(t)
-	require.NoError(t, c.DeleteAll())
+	t.Parallel()
+	c, _ := minikubetestenv.AcquireCluster(t, minikubetestenv.WaitForLokiOption)
 
 	dataRepo := tu.UniqueString("TestDebug_data")
 	require.NoError(t, c.CreateRepo(dataRepo))
@@ -9438,7 +9437,7 @@ func TestDebug(t *testing.T) {
 	for i, p := range pipelines {
 		cmdStdin := []string{
 			fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo),
-			"sleep 3",
+			"sleep 45",
 		}
 		if i == 0 {
 			// We had a bug where generating a debug dump for failed pipelines/jobs would crash pachd.
@@ -9467,41 +9466,40 @@ func TestDebug(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 10, len(commitInfos))
 
-	buf := &bytes.Buffer{}
-	require.NoError(t, c.Dump(nil, 0, buf))
-	gr, err := gzip.NewReader(buf)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, gr.Close())
-	}()
-	// Check that all of the expected files were returned.
-	var gotFiles []string
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
+	require.NoErrorWithinT(t, time.Minute, func() error {
+		buf := &bytes.Buffer{}
+		require.NoError(t, c.Dump(nil, 0, buf))
+		gr, err := gzip.NewReader(buf)
 		if err != nil {
-			if err == io.EOF {
-				break
+			return err //nolint:wrapcheck
+		}
+		defer func() {
+			require.NoError(t, gr.Close())
+		}()
+		// Check that all of the expected files were returned.
+		var gotFiles []string
+		tr := tar.NewReader(gr)
+		for {
+			hdr, err := tr.Next()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err //nolint:wrapcheck
 			}
-			require.NoError(t, err)
-		}
-		gotFiles = append(gotFiles, hdr.Name)
-		for pattern, g := range expectedFiles {
-			if g.Match(hdr.Name) {
-				delete(expectedFiles, pattern)
-				break
+			gotFiles = append(gotFiles, hdr.Name)
+			for pattern, g := range expectedFiles {
+				if g.Match(hdr.Name) {
+					delete(expectedFiles, pattern)
+					break
+				}
 			}
 		}
-	}
-	if len(expectedFiles) > 0 {
-		t.Logf("got files: %v", gotFiles)
-		var names []string
-		for n := range expectedFiles {
-			names = append(names, n)
+		if len(expectedFiles) > 0 {
+			return errors.Errorf("Debug dump has produced %v of the exepcted files: %v", gotFiles, expectedFiles)
 		}
-		t.Logf("no files match: %v", names)
-	}
-	require.Equal(t, 0, len(expectedFiles))
+		return nil
+	})
 }
 
 func TestUpdateMultiplePipelinesInTransaction(t *testing.T) {

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -493,7 +493,6 @@ func TestS3SkippedDatums(t *testing.T) {
 	name := t.Name()
 
 	c, userToken, ns := initPachClient(t)
-	defer tu.DeleteAll(t)
 
 	t.Run("S3Inputs", func(t *testing.T) {
 		// TODO(2.0 optional): Duplicate file paths from different datums no longer allowed.


### PR DESCRIPTION
Also grabbed {Deploy Loki  in test clusters (#7591)} and {Remove Default CI Cluster (#7601)}.

Note that backporting 7601 made me delete a test that's in master but not 2.2.x.  If you try to grab that later, you will be screwed, I think.  This might be bad.