### PR TITLE
[FREQQ-105] Emit JSON logs by default, for GCP

### DIFF
--- a/doc/docs/2.2.x/reference/helm-values.md
+++ b/doc/docs/2.2.x/reference/helm-values.md
@@ -161,6 +161,8 @@ This section is to configure the pachd deployment.
 
 - `pachd.image` sets the image to use for pachd. This can be left at the defaults unless instructed.
 
+- `pachd.logFormat` sets the logging format (`text` or `json`). `text` is default.
+
 - `pachd.logLevel` sets the logging level. `info` is default.
 
 - `pachd.lokiLogging` enables Loki logging if set.

--- a/doc/docs/master/reference/helm-values.md
+++ b/doc/docs/master/reference/helm-values.md
@@ -161,6 +161,8 @@ This section is to configure the pachd deployment.
 
 - `pachd.image` sets the image to use for pachd. This can be left at the defaults unless instructed.
 
+- `pachd.logFormat` sets the logging format (`text` or `json`). `json` is default.
+-
 - `pachd.logLevel` sets the logging level. `info` is default.
 
 - `pachd.lokiLogging` enables Loki logging if set.

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -125,6 +125,8 @@ spec:
         - name: GOMAXPROCS # Needs to be PR'd to 2.0
           value: {{ .Values.pachd.goMaxProcs | quote }}
         {{- end }}
+        - name: LOG_FORMAT
+          value: {{ .Values.pachd.logFormat }}
         - name: LOG_LEVEL
           value: {{ .Values.pachd.logLevel }}
         - name: PACH_NAMESPACE

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -611,6 +611,9 @@
                 "localhostIssuer": {
                     "type": "string"
                 },
+                "logFormat": {
+                    "type": "string"
+                },
                 "logLevel": {
                     "type": "string"
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -280,6 +280,7 @@ pachd:
     # tag defaults to the chart’s specified appVersion.
     # This sets the worker image tag as well (they should be kept in lock step)
     tag: ""
+  logFormat: "json"
   logLevel: "info"
   # If lokiDeploy is true, a Pachyderm-specific instance of Loki will
   # be deployed.

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -55,7 +55,18 @@ func Pretty(entry *logrus.Entry) ([]byte, error) {
 	return serialized, nil
 }
 
-var jsonFormatter = &logrus.JSONFormatter{}
+var jsonFormatter = &logrus.JSONFormatter{
+	// Use GCP's field name conventions (absent any better alternative)
+	// https://cloud.google.com/logging/docs/agent/logging/configuration
+	FieldMap: logrus.FieldMap{
+		logrus.FieldKeyTime:  "time",
+		logrus.FieldKeyLevel: "severity",
+		logrus.FieldKeyMsg:   "message",
+	},
+
+	// https://github.com/sirupsen/logrus/pull/162/files
+	TimestampFormat: time.RFC3339Nano,
+}
 
 // JSONPretty is similar to Pretty() above, but it formats logrus log entries as
 // valid JSON objects. This is required by GCP (or else it misunderstands

--- a/src/internal/miscutil/log.go
+++ b/src/internal/miscutil/log.go
@@ -13,9 +13,12 @@ func LogStep(name string, cb func() error) (retErr error) {
 	defer func() {
 		duration := time.Since(start)
 		if retErr != nil {
-			log.Errorf("errored %v: %v (duration: %v)", name, retErr, duration)
+			log.WithFields(log.Fields{
+				"duration": duration,
+				"error":    retErr,
+			}).Errorf("errored %v", name)
 		} else {
-			log.Infof("finished %v (duration: %v)", name, duration)
+			log.WithField("duration", duration).Infof("finished %v", name)
 		}
 	}()
 	return cb()

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -44,6 +44,7 @@ type GlobalConfiguration struct {
 
 	EtcdPrefix           string `env:"ETCD_PREFIX,default="`
 	DeploymentID         string `env:"CLUSTER_DEPLOYMENT_ID,default="`
+	LogFormat            string `env:"LOG_FORMAT,default=json"`
 	LogLevel             string `env:"LOG_LEVEL,default=info"`
 	EnterpriseEtcdPrefix string `env:"PACHYDERM_ENTERPRISE_ETCD_PREFIX,default=pachyderm_enterprise"`
 	Metrics              bool   `env:"METRICS,default=true"`

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -54,6 +54,7 @@ import (
 	transactionclient "github.com/pachyderm/pachyderm/v2/src/transaction"
 	"github.com/pachyderm/pachyderm/v2/src/version"
 	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -79,6 +80,8 @@ func init() {
 
 func main() {
 	log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
+	// set GOMAXPROCS to the container limit & log outcome to stdout
+	maxprocs.Set(maxprocs.Logger(log.Printf))
 
 	switch {
 	case readiness:

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -54,7 +54,6 @@ import (
 	transactionclient "github.com/pachyderm/pachyderm/v2/src/transaction"
 	"github.com/pachyderm/pachyderm/v2/src/version"
 	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
-	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -79,8 +78,7 @@ func init() {
 }
 
 func main() {
-	log.SetFormatter(&log.JSONFormatter{})
-	maxprocs.Set(maxprocs.Logger(log.Printf))
+	log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
 
 	switch {
 	case readiness:
@@ -161,7 +159,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 
 	// Setup External Pachd GRPC Server.
 	authInterceptor := authmw.NewInterceptor(env.AuthServer)
-	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger())
+	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger(), loggingmw.WithLogFormat(env.Config().LogFormat))
 	externalServer, err := grpcutil.NewServer(
 		context.Background(),
 		true,

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -79,7 +79,7 @@ func init() {
 }
 
 func main() {
-	log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	log.SetFormatter(&log.JSONFormatter{})
 	maxprocs.Set(maxprocs.Logger(log.Printf))
 
 	switch {
@@ -137,6 +137,10 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	profileutil.StartCloudProfiler("pachyderm-pachd-enterprise", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
+
+	if env.Config().LogFormat == "text" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	}
 
 	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
 	if err := dbutil.WaitUntilReady(context.Background(), log.StandardLogger(), env.GetDBClient()); err != nil {
@@ -433,6 +437,11 @@ func doSidecarMode(config interface{}) (retErr error) {
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	profileutil.StartCloudProfiler("pachyderm-pachd-sidecar", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
+
+	if env.Config().LogFormat == "text" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	}
+
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}
@@ -591,6 +600,11 @@ func doFullMode(config interface{}) (retErr error) {
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	profileutil.StartCloudProfiler("pachyderm-pachd-full", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
+
+	if env.Config().LogFormat == "text" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	}
+
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -26,11 +26,8 @@ import (
 )
 
 func main() {
-	log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
-
 	// append pachyderm bins to path to allow use of pachctl
 	os.Setenv("PATH", os.Getenv("PATH")+":/pach-bin")
-
 	cmdutil.Main(do, &serviceenv.WorkerFullConfiguration{})
 }
 
@@ -38,6 +35,11 @@ func do(config interface{}) error {
 	// must run InstallJaegerTracer before InitWithKube/pach client initialization
 	tracing.InstallJaegerTracerFromEnv()
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
+
+	log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
+	if env.Config().LogFormat == "text" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	}
 
 	// Enable cloud profilers if the configuration allows.
 	profileutil.StartCloudProfiler("pachyderm-worker", env.Config())


### PR DESCRIPTION
This was requested as part of an oncall issue. See https://pachyderm.slack.com/archives/CSELV66P5/p1653413270247859 for context, as well as the referenced issue in the title.

#7683 makes a similar change in the 2.2.x branch, but leaves `text` as the default logging format. By making `json` the default only in master, I hope to give everyone lots of time to adjust to the new format and switch the default back to `text` if appropriate.