### PR TITLE
[2.2.x backport] [FREQQ-105] Support JSON logs, for GCP

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -134,6 +134,8 @@ spec:
         - name: GOMAXPROCS # Needs to be PR'd to 2.0
           value: {{ .Values.pachd.goMaxProcs | quote }}
         {{- end }}
+        - name: LOG_FORMAT
+          value: {{ .Values.pachd.logFormat }}
         - name: LOG_LEVEL
           value: {{ .Values.pachd.logLevel }}
         - name: PACH_NAMESPACE

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -570,6 +570,9 @@
                 "localhostIssuer": {
                     "type": "string"
                 },
+                "logFormat": {
+                    "type": "string"
+                },
                 "logLevel": {
                     "type": "string"
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -226,6 +226,7 @@ pachd:
     # tag defaults to the chart’s specified appVersion.
     # This sets the worker image tag as well (they should be kept in lock step)
     tag: ""
+  logFormat: "text"
   logLevel: "info"
   lokiDeploy: false
   # lokiLogging enables Loki logging if set.

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -55,7 +55,18 @@ func Pretty(entry *logrus.Entry) ([]byte, error) {
 	return serialized, nil
 }
 
-var jsonFormatter = &logrus.JSONFormatter{}
+var jsonFormatter = &logrus.JSONFormatter{
+	// Use GCP's field name conventions (absent any better alternative)
+	// https://cloud.google.com/logging/docs/agent/logging/configuration
+	FieldMap: logrus.FieldMap{
+		logrus.FieldKeyTime:  "time",
+		logrus.FieldKeyLevel: "severity",
+		logrus.FieldKeyMsg:   "message",
+	},
+
+	// https://github.com/sirupsen/logrus/pull/162/files
+	TimestampFormat: time.RFC3339Nano,
+}
 
 // JSONPretty is similar to Pretty() above, but it formats logrus log entries as
 // valid JSON objects. This is required by GCP (or else it misunderstands

--- a/src/internal/middleware/logging/util.go
+++ b/src/internal/middleware/logging/util.go
@@ -15,6 +15,22 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type config struct {
+	// valid values are only "text" and "json", where "text" is default
+	format string
+}
+
+type Option func(*config)
+
+func WithLogFormat(fmt string) func(*config) {
+	return func(cfg *config) {
+		if fmt != "json" {
+			cfg.format = "text"
+		}
+		cfg.format = fmt
+	}
+}
+
 // This needs to be a global var, not a field on the logger, because multiple servers
 // create new loggers, and the prometheus registration uses a global namespace
 var reportDurationGauge prometheus.Gauge
@@ -28,8 +44,16 @@ type LoggingInterceptor struct {
 }
 
 // NewLoggingInterceptor creates a new interceptor that logs method start and end
-func NewLoggingInterceptor(logger *logrus.Logger) *LoggingInterceptor {
+func NewLoggingInterceptor(logger *logrus.Logger, opts ...Option) *LoggingInterceptor {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
 	logger.Formatter = log.FormatterFunc(log.Pretty)
+	if cfg.format == "json" {
+		logger.Formatter = log.FormatterFunc(log.JSONPretty)
+	}
+
 	interceptor := &LoggingInterceptor{
 		logger,
 		make(map[string]*prometheus.HistogramVec),

--- a/src/internal/miscutil/log.go
+++ b/src/internal/miscutil/log.go
@@ -13,9 +13,12 @@ func LogStep(name string, cb func() error) (retErr error) {
 	defer func() {
 		duration := time.Since(start)
 		if retErr != nil {
-			log.Errorf("errored %v: %v (duration: %v)", name, retErr, duration)
+			log.WithFields(log.Fields{
+				"duration": duration,
+				"error":    retErr,
+			}).Errorf("errored %v", name)
 		} else {
-			log.Infof("finished %v (duration: %v)", name, duration)
+			log.WithField("duration", duration).Infof("finished %v", name)
 		}
 	}()
 	return cb()

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -43,6 +43,7 @@ type GlobalConfiguration struct {
 
 	EtcdPrefix           string `env:"ETCD_PREFIX,default="`
 	DeploymentID         string `env:"CLUSTER_DEPLOYMENT_ID,default="`
+	LogFormat            string `env:"LOG_FORMAT,default=text"`
 	LogLevel             string `env:"LOG_LEVEL,default=info"`
 	EnterpriseEtcdPrefix string `env:"PACHYDERM_ENTERPRISE_ETCD_PREFIX,default=pachyderm_enterprise"`
 	Metrics              bool   `env:"METRICS,default=true"`

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -137,6 +137,10 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	profileutil.StartCloudProfiler("pachyderm-pachd-enterprise", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
 
+	if env.Config().LogFormat == "json" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
+	}
+
 	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
 	if err := dbutil.WaitUntilReady(context.Background(), log.StandardLogger(), env.GetDBClient()); err != nil {
 		return err
@@ -424,6 +428,11 @@ func doSidecarMode(config interface{}) (retErr error) {
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	profileutil.StartCloudProfiler("pachyderm-pachd-sidecar", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
+
+	if env.Config().LogFormat == "json" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
+	}
+
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}
@@ -582,6 +591,11 @@ func doFullMode(config interface{}) (retErr error) {
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
 	profileutil.StartCloudProfiler("pachyderm-pachd-full", env.Config())
 	debug.SetGCPercent(env.Config().GCPercent)
+
+	if env.Config().LogFormat == "json" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
+	}
+
 	if env.Config().EtcdPrefix == "" {
 		env.Config().EtcdPrefix = col.DefaultPrefix
 	}

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -159,7 +159,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 
 	// Setup External Pachd GRPC Server.
 	authInterceptor := authmw.NewInterceptor(env.AuthServer)
-	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger())
+	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger(), loggingmw.WithLogFormat(env.Config().LogFormat))
 	externalServer, err := grpcutil.NewServer(
 		context.Background(),
 		true,

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -79,6 +79,7 @@ func init() {
 
 func main() {
 	log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	// set GOMAXPROCS to the container limit & log outcome to stdout
 	maxprocs.Set(maxprocs.Logger(log.Printf))
 
 	switch {

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -26,11 +26,8 @@ import (
 )
 
 func main() {
-	log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
-
 	// append pachyderm bins to path to allow use of pachctl
 	os.Setenv("PATH", os.Getenv("PATH")+":/pach-bin")
-
 	cmdutil.Main(do, &serviceenv.WorkerFullConfiguration{})
 }
 
@@ -38,6 +35,11 @@ func do(config interface{}) error {
 	// must run InstallJaegerTracer before InitWithKube/pach client initialization
 	tracing.InstallJaegerTracerFromEnv()
 	env := serviceenv.InitWithKube(serviceenv.NewConfiguration(config))
+
+	log.SetFormatter(logutil.FormatterFunc(logutil.Pretty))
+	if env.Config().LogFormat == "json" {
+		log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
+	}
 
 	// Enable cloud profilers if the configuration allows.
 	profileutil.StartCloudProfiler("pachyderm-worker", env.Config())


### PR DESCRIPTION
This is similar to #7682, but for the 2.2.x branch. Because this must be a
patch-release-compatible change, it uses text logs by default and only enables
JSON logs if requested.