### PR TITLE
Many Loki improvements

### DIFF
--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -70,6 +70,7 @@ case "${BUCKET}" in
     make test-transaction
     make test-s3gateway-unit
     make test-worker
+    bash -ceo pipefail "go test -p 1 -count 1 ./src/server/debug/... ${TESTFLAGS}"
     # these tests require secure env vars to run, which aren't available
     # when the PR is coming from an outside contributor - so we just
     # disable them

--- a/src/internal/lokiutil/client/client.go
+++ b/src/internal/lokiutil/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -78,9 +77,9 @@ func (c *Client) doRequest(ctx context.Context, path, query string, quiet bool, 
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			body = append(body, []byte(fmt.Sprintf("\nreading body: %v", err))...)
+			return errors.EnsureStack(errors.Errorf("error response from loki: %v (body: %q); additionally, reading body: %v", resp.Status, body, err))
 		}
-		return errors.EnsureStack(errors.Errorf("error response from loki: %v (body: %s)", resp.Status, body))
+		return errors.EnsureStack(errors.Errorf("error response from loki: %v (body: %q)", resp.Status, body))
 	}
 	return errors.EnsureStack(json.NewDecoder(resp.Body).Decode(out))
 }

--- a/src/internal/lokiutil/client/client.go
+++ b/src/internal/lokiutil/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -71,8 +73,15 @@ func (c *Client) doRequest(ctx context.Context, path, query string, quiet bool, 
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-
 	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			body = append(body, []byte(fmt.Sprintf("\nreading body: %v", err))...)
+		}
+		return errors.EnsureStack(errors.Errorf("error response from loki: %v (body: %s)", resp.Status, body))
+	}
 	return errors.EnsureStack(json.NewDecoder(resp.Body).Decode(out))
 }
 

--- a/src/internal/middleware/auth/interceptor.go
+++ b/src/internal/middleware/auth/interceptor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 // authHandlers is a mapping of RPCs to authorization levels required to access them.
@@ -279,6 +280,13 @@ type Interceptor struct {
 	getAuthServer func() authserver.APIServer
 }
 
+func peerName(ctx context.Context) string {
+	if p, ok := peer.FromContext(ctx); ok {
+		return p.Addr.String()
+	}
+	return "<unknown ip>"
+}
+
 // InterceptUnary applies authentication rules to unary RPCs
 func (i *Interceptor) InterceptUnary(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	a, ok := authHandlers[info.FullMethod]
@@ -290,7 +298,7 @@ func (i *Interceptor) InterceptUnary(ctx context.Context, req interface{}, info 
 	username, err := a(ctx, i.getAuthServer(), info.FullMethod)
 
 	if err != nil {
-		logrus.WithError(err).Errorf("denied unary call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
+		logrus.WithError(err).Errorf("denied unary call %q to user %v@%v", info.FullMethod, nameOrUnauthenticated(username), peerName(ctx))
 		return nil, err
 	}
 
@@ -313,7 +321,7 @@ func (i *Interceptor) InterceptStream(srv interface{}, stream grpc.ServerStream,
 	username, err := a(ctx, i.getAuthServer(), info.FullMethod)
 
 	if err != nil {
-		logrus.WithError(err).Errorf("denied streaming call %q to user %v\n", info.FullMethod, nameOrUnauthenticated(username))
+		logrus.WithError(err).Errorf("denied streaming call %q to user %v@%v", info.FullMethod, nameOrUnauthenticated(username), peerName(ctx))
 		return err
 	}
 

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -649,17 +649,18 @@ func (s *debugServer) collectLogsLoki(ctx context.Context, tw *tar.Writer, pod, 
 		}
 
 		var cursor *loki.LabelSet
-		for _, entry := range logs {
+		for i, entry := range logs {
 			// Print the stream labels in %v format whenever they are different from the
 			// previous line.  The pointer comparison is a fast path to avoid
 			// reflect.DeepEqual when both log lines are from the same chunk of logs
 			// returned by Loki.
 			if cursor != entry.Labels && !reflect.DeepEqual(cursor, entry.Labels) {
-				cursor = entry.Labels
-				if _, err := fmt.Fprintf(w, "%v\n", cursor); err != nil {
+				if _, err := fmt.Fprintf(w, "%v\n", entry.Labels); err != nil {
 					return errors.EnsureStack(err)
 				}
 			}
+			cursor = entry.Labels
+
 			// Then the line itself.
 			if _, err := fmt.Fprintf(w, "%s\n", entry.Entry.Line); err != nil {
 				return errors.EnsureStack(err)

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -363,7 +363,7 @@ func (s *debugServer) Binary(request *debug.BinaryRequest, server debug.Debug_Bi
 		collectBinary,
 		nil,
 		nil,
-		redirectBinaryFunc,
+		redirectBinary,
 		collectBinary,
 		false,
 	)
@@ -385,7 +385,7 @@ func collectBinary(_ context.Context, tw *tar.Writer, _ *client.APIClient, prefi
 	}, prefix...)
 }
 
-func redirectBinaryFunc(ctx context.Context, c debug.DebugClient, filter *debug.Filter) (io.Reader, error) {
+func redirectBinary(ctx context.Context, c debug.DebugClient, filter *debug.Filter) (io.Reader, error) {
 	binaryC, err := c.Binary(ctx, &debug.BinaryRequest{Filter: filter})
 	if err != nil {
 		return nil, errors.EnsureStack(err)
@@ -405,7 +405,7 @@ func (s *debugServer) Dump(request *debug.DumpRequest, server debug.Debug_DumpSe
 		s.collectPachdDumpFunc(request.Limit),
 		s.collectPipelineDumpFunc(request.Limit),
 		s.collectWorkerDump,
-		redirectDumpFunc,
+		redirectDump,
 		collectDump,
 		true,
 	)
@@ -869,7 +869,7 @@ func (s *debugServer) collectWorkerDump(ctx context.Context, tw *tar.Writer, pod
 	return s.collectLogs(ctx, tw, pod.Name, client.PPSWorkerSidecarContainerName, sidecarPrefix)
 }
 
-func redirectDumpFunc(ctx context.Context, c debug.DebugClient, filter *debug.Filter) (io.Reader, error) {
+func redirectDump(ctx context.Context, c debug.DebugClient, filter *debug.Filter) (io.Reader, error) {
 	dumpC, err := c.Dump(ctx, &debug.DumpRequest{Filter: filter})
 	if err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -649,7 +649,7 @@ func (s *debugServer) collectLogsLoki(ctx context.Context, tw *tar.Writer, pod, 
 		}
 
 		var cursor *loki.LabelSet
-		for i, entry := range logs {
+		for _, entry := range logs {
 			// Print the stream labels in %v format whenever they are different from the
 			// previous line.  The pointer comparison is a fast path to avoid
 			// reflect.DeepEqual when both log lines are from the same chunk of logs

--- a/src/server/debug/server/server_test.go
+++ b/src/server/debug/server/server_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+)
+
+type lokiResult struct {
+	Stream map[string]string `json:"stream"`
+	Values [][2]string       `json:"values"`
+}
+
+type data struct {
+	ResultType string       `json:"resultType"`
+	Result     []lokiResult `json:"result"`
+}
+type response struct {
+	Status string `json:"status"`
+	Data   data   `json:"data"`
+}
+
+func mustParseQuerystringInt64(r *http.Request, field string) int64 {
+	x, err := strconv.ParseInt(r.URL.Query().Get(field), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return x
+}
+
+func TestQueryLoki(t *testing.T) {
+	start := time.Now()
+	var entries []loki.Entry
+	for i := -49999; i <= 0; i++ {
+		entries = append(entries, loki.Entry{
+			Timestamp: start.Add(time.Duration(i) * time.Second),
+			Line:      fmt.Sprintf("%v", i),
+		})
+	}
+	handleQuery := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		direction := r.URL.Query().Get("direction")
+		start := time.Unix(0, mustParseQuerystringInt64(r, "start"))
+		end := time.Unix(0, mustParseQuerystringInt64(r, "end"))
+		limit := int(mustParseQuerystringInt64(r, "limit"))
+
+		if end.Before(start) {
+			panic("end is before start")
+		}
+		if end.Sub(start) >= 721*time.Hour { // Not documented, but what a local Loki rejects.
+			panic("query range too long")
+		}
+
+		var match []loki.Entry
+
+		// From the logcli docs:
+		// --from=FROM          Start looking for logs at this absolute time (inclusive)
+		// --to=TO              Stop looking for logs at this absolute time (exclusive)
+		// To is "end" and From is "start", so end is exclusive and start is inclusive.
+		inRange := func(e loki.Entry) bool {
+			return (e.Timestamp.After(start) || e.Timestamp.Equal(start)) && e.Timestamp.Before(end)
+		}
+
+		switch direction {
+		case "FORWARD":
+			for _, e := range entries {
+				if inRange(e) {
+					if len(match) >= limit {
+						break
+					}
+					match = append(match, e)
+				}
+			}
+		case "BACKWARD":
+			for i := len(entries) - 1; i >= 0; i-- {
+				e := entries[i]
+				if inRange(e) {
+					if len(match) >= limit {
+						break
+					}
+					match = append(match, e)
+				}
+			}
+		default:
+			panic("invalid direction")
+		}
+
+		result := response{
+			Status: "success",
+			Data: data{
+				ResultType: "streams",
+				Result: []lokiResult{
+					{
+						Stream: map[string]string{"test": "stream"},
+						Values: [][2]string{},
+					},
+				},
+			},
+		}
+		for _, e := range match {
+			result.Data.Result[0].Values = append(result.Data.Result[0].Values, [2]string{
+				strconv.FormatInt(e.Timestamp.UnixNano(), 10),
+				e.Line,
+			})
+		}
+
+		content, err := json.Marshal(&result)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(content); err != nil {
+			panic(err)
+		}
+	})
+	s := httptest.NewServer(handleQuery)
+	d := &debugServer{
+		env: &serviceenv.TestServiceEnv{
+			LokiClient: &loki.Client{Address: s.URL},
+		},
+	}
+
+	var want []int
+	for i := -29999; i <= 0; i++ {
+		want = append(want, i)
+	}
+
+	var got []int
+	out, err := d.queryLoki(context.Background(), `{foo="bar"}`)
+	if err != nil {
+		t.Fatalf("query loki: %v", err)
+	}
+	for i, l := range out {
+		x, err := strconv.ParseInt(l.Entry.Line, 10, 64)
+		if err != nil {
+			t.Errorf("parse log line %d: %v", i, err)
+		}
+		got = append(got, int(x))
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf(`result differs:
+	  first |   last |    len
+       +--------+--------+-------
+   got | %6d | %6d | %6d
+  want | %6d | %6d | %6d
+
+slice samples:
+   got: %v ... %v
+  want: %v ... %v`,
+			got[0], got[len(got)-1], len(got),
+			want[0], want[len(want)-1], len(want),
+			got[:4], got[len(got)-4:],
+			want[:4], want[len(want)-4:])
+
+		if testing.Verbose() {
+			t.Logf("returned lines:\n%v", diff)
+		}
+	}
+}

--- a/src/server/debug/server/server_test.go
+++ b/src/server/debug/server/server_test.go
@@ -37,119 +37,235 @@ func mustParseQuerystringInt64(r *http.Request, field string) int64 {
 	return x
 }
 
-func TestQueryLoki(t *testing.T) {
-	start := time.Now()
-	var entries []loki.Entry
-	for i := -49999; i <= 0; i++ {
-		entries = append(entries, loki.Entry{
-			Timestamp: start.Add(time.Duration(i) * time.Second),
-			Line:      fmt.Sprintf("%v", i),
-		})
+type fakeLoki struct {
+	entries []loki.Entry // Must be sorted by time ascending.
+}
+
+func (l *fakeLoki) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	direction := r.URL.Query().Get("direction")
+	start := time.Unix(0, mustParseQuerystringInt64(r, "start"))
+	end := time.Unix(0, mustParseQuerystringInt64(r, "end"))
+	limit := int(mustParseQuerystringInt64(r, "limit"))
+
+	if end.Before(start) {
+		panic("end is before start")
 	}
-	handleQuery := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		direction := r.URL.Query().Get("direction")
-		start := time.Unix(0, mustParseQuerystringInt64(r, "start"))
-		end := time.Unix(0, mustParseQuerystringInt64(r, "end"))
-		limit := int(mustParseQuerystringInt64(r, "limit"))
+	if end.Sub(start) >= 721*time.Hour { // Not documented, but what a local Loki rejects.
+		panic("query range too long")
+	}
 
-		if end.Before(start) {
-			panic("end is before start")
-		}
-		if end.Sub(start) >= 721*time.Hour { // Not documented, but what a local Loki rejects.
-			panic("query range too long")
-		}
+	var match []loki.Entry
 
-		var match []loki.Entry
+	// From the logcli docs:
+	// --from=FROM          Start looking for logs at this absolute time (inclusive)
+	// --to=TO              Stop looking for logs at this absolute time (exclusive)
+	// To is "end" and From is "start", so end is exclusive and start is inclusive.
+	inRange := func(e loki.Entry) bool {
+		return (e.Timestamp.After(start) || e.Timestamp.Equal(start)) && e.Timestamp.Before(end)
+	}
 
-		// From the logcli docs:
-		// --from=FROM          Start looking for logs at this absolute time (inclusive)
-		// --to=TO              Stop looking for logs at this absolute time (exclusive)
-		// To is "end" and From is "start", so end is exclusive and start is inclusive.
-		inRange := func(e loki.Entry) bool {
-			return (e.Timestamp.After(start) || e.Timestamp.Equal(start)) && e.Timestamp.Before(end)
-		}
-
-		switch direction {
-		case "FORWARD":
-			for _, e := range entries {
-				if inRange(e) {
-					if len(match) >= limit {
-						break
-					}
-					match = append(match, e)
+	switch direction {
+	case "FORWARD":
+		for _, e := range l.entries {
+			if inRange(e) {
+				if len(match) >= limit {
+					break
 				}
+				match = append(match, e)
 			}
-		case "BACKWARD":
-			for i := len(entries) - 1; i >= 0; i-- {
-				e := entries[i]
-				if inRange(e) {
-					if len(match) >= limit {
-						break
-					}
-					match = append(match, e)
-				}
-			}
-		default:
-			panic("invalid direction")
 		}
+	case "BACKWARD":
+		for i := len(l.entries) - 1; i >= 0; i-- {
+			e := l.entries[i]
+			if inRange(e) {
+				if len(match) >= limit {
+					break
+				}
+				match = append(match, e)
+			}
+		}
+	default:
+		panic("invalid direction")
+	}
 
-		result := response{
-			Status: "success",
-			Data: data{
-				ResultType: "streams",
-				Result: []lokiResult{
-					{
-						Stream: map[string]string{"test": "stream"},
-						Values: [][2]string{},
-					},
+	result := response{
+		Status: "success",
+		Data: data{
+			ResultType: "streams",
+			Result: []lokiResult{
+				{
+					Stream: map[string]string{"test": "stream"},
+					Values: [][2]string{},
 				},
 			},
-		}
-		for _, e := range match {
-			result.Data.Result[0].Values = append(result.Data.Result[0].Values, [2]string{
-				strconv.FormatInt(e.Timestamp.UnixNano(), 10),
-				e.Line,
-			})
-		}
+		},
+	}
+	for _, e := range match {
+		result.Data.Result[0].Values = append(result.Data.Result[0].Values, [2]string{
+			strconv.FormatInt(e.Timestamp.UnixNano(), 10),
+			e.Line,
+		})
+	}
 
-		content, err := json.Marshal(&result)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(content); err != nil {
-			panic(err)
-		}
-	})
-	s := httptest.NewServer(handleQuery)
-	d := &debugServer{
-		env: &serviceenv.TestServiceEnv{
-			LokiClient: &loki.Client{Address: s.URL},
+	content, err := json.Marshal(&result)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(content); err != nil {
+		panic(err)
+	}
+}
+
+func TestQueryLoki(t *testing.T) {
+	testData := []struct {
+		name         string
+		buildEntries func() []loki.Entry
+		buildWant    func() []int
+	}{
+		{
+			name:         "no logs to return",
+			buildEntries: func() []loki.Entry { return nil },
+			buildWant:    func() []int { return nil },
+		},
+		{
+			name: "all logs",
+			buildEntries: func() []loki.Entry {
+				var entries []loki.Entry
+				for i := -99; i >= 0; i++ {
+					entries = append(entries, loki.Entry{
+						Timestamp: time.Now().Add(time.Duration(-1) * time.Second),
+						Line:      fmt.Sprintf("%v", i),
+					})
+				}
+				return entries
+			},
+			buildWant: func() []int {
+				var want []int
+				for i := -99; i >= 0; i++ {
+					want = append(want, i)
+				}
+				return want
+			},
+		},
+		{
+			name: "too many logs",
+			buildEntries: func() []loki.Entry {
+				start := time.Now()
+				var entries []loki.Entry
+				for i := -49999; i <= 0; i++ {
+					entries = append(entries, loki.Entry{
+						Timestamp: start.Add(time.Duration(i) * time.Second),
+						Line:      fmt.Sprintf("%v", i),
+					})
+				}
+				return entries
+			},
+			buildWant: func() []int {
+				var want []int
+				for i := -29999; i <= 0; i++ {
+					want = append(want, i)
+				}
+				return want
+			},
+		},
+		{
+			name: "big chunk of unchanging timestamps",
+			buildEntries: func() []loki.Entry {
+				start := time.Now()
+				var entries []loki.Entry
+				entries = append(entries, loki.Entry{
+					Timestamp: start.Add(-2 * time.Second),
+					Line:      "-2",
+				})
+				for i := 0; i < 40000; i++ {
+					entries = append(entries, loki.Entry{
+						Timestamp: start.Add(-1 * time.Second),
+						Line:      "-1",
+					})
+				}
+				entries = append(entries, loki.Entry{
+					Timestamp: start,
+					Line:      "0",
+				})
+				return entries
+			},
+			buildWant: func() []int {
+				var want []int
+				want = append(want, -2)
+				for i := 0; i < 4999; i++ {
+					want = append(want, -1)
+				}
+				want = append(want, 0)
+				return want
+			},
+		},
+		{
+			name: "big chunk of unchanging timestamps at chunk boundary",
+			buildEntries: func() []loki.Entry {
+				start := time.Now()
+				var entries []loki.Entry
+				entries = append(entries, loki.Entry{
+					Timestamp: start.Add(-2 * time.Second),
+					Line:      "-2",
+				})
+				for i := 0; i < 40000; i++ {
+					entries = append(entries, loki.Entry{
+						Timestamp: start.Add(-1 * time.Second),
+						Line:      "-1",
+					})
+				}
+				for i := 0; i < 5000; i++ {
+					entries = append(entries, loki.Entry{
+						Timestamp: start,
+						Line:      "0",
+					})
+				}
+				return entries
+			},
+			buildWant: func() []int {
+				var want []int
+				want = append(want, -2)
+				for i := 0; i < 5000; i++ {
+					want = append(want, -1)
+				}
+				for i := 0; i < 5000; i++ {
+					want = append(want, 0)
+				}
+				return want
+			},
 		},
 	}
 
-	var want []int
-	for i := -29999; i <= 0; i++ {
-		want = append(want, i)
-	}
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			entries := test.buildEntries()
+			want := test.buildWant()
 
-	var got []int
-	out, err := d.queryLoki(context.Background(), `{foo="bar"}`)
-	if err != nil {
-		t.Fatalf("query loki: %v", err)
-	}
-	for i, l := range out {
-		x, err := strconv.ParseInt(l.Entry.Line, 10, 64)
-		if err != nil {
-			t.Errorf("parse log line %d: %v", i, err)
-		}
-		got = append(got, int(x))
-	}
+			s := httptest.NewServer(&fakeLoki{entries: entries})
+			d := &debugServer{
+				env: &serviceenv.TestServiceEnv{
+					LokiClient: &loki.Client{Address: s.URL},
+				},
+			}
 
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf(`result differs:
-	  first |   last |    len
+			var got []int
+			out, err := d.queryLoki(context.Background(), `{foo="bar"}`)
+			if err != nil {
+				t.Fatalf("query loki: %v", err)
+			}
+			for i, l := range out {
+				x, err := strconv.ParseInt(l.Entry.Line, 10, 64)
+				if err != nil {
+					t.Errorf("parse log line %d: %v", i, err)
+				}
+				got = append(got, int(x))
+			}
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf(`result differs:
+	      first |   last |    len
        +--------+--------+-------
    got | %6d | %6d | %6d
   want | %6d | %6d | %6d
@@ -157,13 +273,15 @@ func TestQueryLoki(t *testing.T) {
 slice samples:
    got: %v ... %v
   want: %v ... %v`,
-			got[0], got[len(got)-1], len(got),
-			want[0], want[len(want)-1], len(want),
-			got[:4], got[len(got)-4:],
-			want[:4], want[len(want)-4:])
+					got[0], got[len(got)-1], len(got),
+					want[0], want[len(want)-1], len(want),
+					got[:4], got[len(got)-4:],
+					want[:4], want[len(want)-4:])
 
-		if testing.Verbose() {
-			t.Logf("returned lines:\n%v", diff)
-		}
+				if testing.Verbose() {
+					t.Logf("returned lines:\n%v", diff)
+				}
+			}
+		})
 	}
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1416,13 +1416,13 @@ func parseLokiLine(inputLine string, msg *pps.LogMessage) error {
 	parseDocker := func(line string) error {
 		var result struct{ Log string }
 		if err := json.Unmarshal([]byte(line), &result); err != nil {
-			return fmt.Errorf("outer json: %w", err)
+			return errors.Errorf("outer json: %v", err)
 		}
 		if result.Log == "" {
 			return errors.New("log field is empty")
 		}
 		if err := parseNative(result.Log); err != nil {
-			return fmt.Errorf("native json (%q): %w", result.Log, err)
+			return errors.Errorf("native json (%q): %v", result.Log, err)
 		}
 		return nil
 	}
@@ -1439,7 +1439,7 @@ func parseLokiLine(inputLine string, msg *pps.LogMessage) error {
 		}
 		l := string(b[i:])
 		if err := parseNative(l); err != nil {
-			return fmt.Errorf("native json (%q): %w", l, err)
+			return errors.Errorf("native json (%q): %v", l, err)
 		}
 		return nil
 	}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1365,16 +1365,18 @@ func (a *apiServer) getLogsLoki(request *pps.GetLogsRequest, apiGetLogsServer pp
 		query += contains(filter)
 	}
 	return lokiutil.QueryRange(apiGetLogsServer.Context(), loki, query, time.Now().Add(-since), time.Now(), request.Follow, func(t time.Time, line string) error {
-		msg := &pps.LogMessage{}
+		msg := new(pps.LogMessage)
+		if err := parseLokiLine(line, msg); err != nil {
+			logrus.WithField("line", line).WithError(err).Debug("get logs (loki): unparseable log line")
+			return nil
+		}
+
 		// These filters are almost always unnecessary because we apply
 		// them in the Loki request, but many of them are just done with
 		// string matching so there technically could be some false
 		// positive matches (although it's pretty unlikely), checking here
 		// just makes sure we don't accidentally intersperse unrelated log
 		// messages.
-		if err := jsonpb.Unmarshal(strings.NewReader(line), msg); err != nil {
-			return nil
-		}
 		if request.Pipeline != nil && request.Pipeline.Name != msg.PipelineName {
 			return nil
 		}
@@ -1393,6 +1395,89 @@ func (a *apiServer) getLogsLoki(request *pps.GetLogsRequest, apiGetLogsServer pp
 		msg.Message = strings.TrimSuffix(msg.Message, "\n")
 		return errors.EnsureStack(apiGetLogsServer.Send(msg))
 	})
+}
+
+func parseLokiLine(inputLine string, msg *pps.LogMessage) error {
+	// There are three possible log formats in Loki, depending on the underlying formatting done
+	// by the container runtime.  Under ideal circumstances, the user of Loki has configured
+	// promtail to remove the runtime-specific logs, but it's quite easy to miss this
+	// configuration aspect, so we correct for it here.  (See:
+	// https://grafana.com/docs/loki/latest/clients/promtail/stages/cri/ and
+	// https://grafana.com/docs/loki/latest/clients/promtail/stages/docker/)
+
+	// Receives a raw chunk of JSON from Loki, which is our logged pps.LogMessage object.
+	parseNative := func(line string) error {
+		return errors.EnsureStack(jsonpb.UnmarshalString(line, msg))
+	}
+
+	// Receives the raw Docker log line, which is a JSON object containing a time, stream, and
+	// log field.  The log contains what our program actually logged, so we parse that with
+	// parseNative after extracting it.
+	parseDocker := func(line string) error {
+		var result struct{ Log string }
+		if err := json.Unmarshal([]byte(line), &result); err != nil {
+			return fmt.Errorf("outer json: %w", err)
+		}
+		if result.Log == "" {
+			return errors.New("log field is empty")
+		}
+		if err := parseNative(result.Log); err != nil {
+			return fmt.Errorf("native json (%q): %w", result.Log, err)
+		}
+		return nil
+	}
+
+	// Receives the raw CRI-format (used by containerd and cri-o) log line, which is a line of
+	// text formatted like: <RFC3339 time> <stream name> <maybe flags> <log message>.  Because
+	// this format is not actually parseable (the log message could start with a flag, but there
+	// are no flags), we just seek to the first { and feed that to the native parser.
+	parseCRI := func(line string) error {
+		b := []byte(line)
+		i := bytes.IndexByte(b, '{')
+		if i < 0 {
+			return errors.New("line does not contain {")
+		}
+		l := string(b[i:])
+		if err := parseNative(l); err != nil {
+			return fmt.Errorf("native json (%q): %w", l, err)
+		}
+		return nil
+	}
+
+	// Try each driver; if one results in a valid message, then we're done.
+	errs := make(map[string]error)
+	parsers := map[string]func(string) error{
+		// The order here is important, because native and docker messages are ambiguous.
+		// It is unfortunate that we can't happy-path native.
+		"cri":    parseCRI,
+		"docker": parseDocker,
+		"native": parseNative,
+	}
+	for driver, parser := range parsers {
+		if err := parser(inputLine); err != nil {
+			errs[driver] = err
+			continue
+		}
+		// This driver worked, so give up!
+		return nil
+	}
+
+	if len(errs) == 0 {
+		// This can't happen, because there are 3 iterations of the loop and each iteration
+		// either returns or populates errs.
+		return errors.EnsureStack(errors.New("impossible: did not succeed, but also did not error"))
+	}
+
+	// None of the drivers worked; explain why each failed.
+	errMsg := new(strings.Builder)
+	errMsg.WriteString("interpret loki line as json:")
+	for parser, err := range errs {
+		errMsg.WriteString("\n\t")
+		errMsg.WriteString(parser)
+		errMsg.WriteString(": ")
+		errMsg.WriteString(err.Error())
+	}
+	return errors.EnsureStack(errors.New(errMsg.String()))
 }
 
 func contains(s string) string {
@@ -2988,23 +3073,23 @@ fileSources:
   - name: "random"
     random:
       directory:
-        depth: 
+        depth:
           min: 0
           max: 3
         run: 3
       sizes:
         - min: 1000
           max: 10000
-          prob: 30 
+          prob: 30
         - min: 10000
           max: 100000
-          prob: 30 
+          prob: 30
         - min: 1000000
           max: 10000000
-          prob: 30 
+          prob: 30
         - min: 10000000
           max: 100000000
-          prob: 10 
+          prob: 10
 validator: {}
 `}
 

--- a/src/server/pps/server/api_server_test.go
+++ b/src/server/pps/server/api_server_test.go
@@ -67,3 +67,104 @@ func newServer(t testing.TB) pps.APIServer {
 func newConfig(testing.TB) serviceenv.Configuration {
 	return *serviceenv.ConfigFromOptions()
 }
+
+func TestParseLokiLine(t *testing.T) {
+	testData := []struct {
+		name        string
+		line        string
+		wantMessage string
+		wantErr     bool
+	}{
+		{
+			name:    "empty",
+			line:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			line:    "{this is not json}",
+			wantErr: true,
+		},
+		{
+			name:        "useless json",
+			line:        "{}",
+			wantMessage: "",
+		},
+		{
+			name:        "docker json",
+			line:        `{"log":"{\"message\":\"ok\"}"}`,
+			wantMessage: "ok",
+		},
+		{
+			name:    "docker with invalid json inside",
+			line:    `{"log":"{this is not json}"}`,
+			wantErr: true,
+		},
+		{
+			name:        "native json",
+			line:        `{"message":"ok"}`,
+			wantMessage: "ok",
+		},
+		{
+			name:        "empty native json",
+			line:        `{"master":false}`,
+			wantMessage: "",
+		},
+		{
+			name:        "cri format with flags and valid message",
+			line:        `2022-01-01T00:00:00.1234 stdout F {"message":"ok"}`,
+			wantMessage: "ok",
+		},
+		{
+			name:        "cri format without flags and valid message",
+			line:        `2022-01-01T00:00:00.1234 stdout {"message":"ok"}`,
+			wantMessage: "ok",
+		},
+		{
+			name:    "cri format with flags and EOF",
+			line:    `2022-01-01T00:00:00.1234 stdout F`,
+			wantErr: true,
+		},
+		{
+			name:    "cri format without flags and EOF",
+			line:    `2022-01-01T00:00:00.1234 stdout`,
+			wantErr: true,
+		},
+		{
+			name:    "cri format with flags and invalid json",
+			line:    `2022-01-01T00:00:00.1234 stdout F this is not json`,
+			wantErr: true,
+		},
+		{
+			name:    "cri format without flags and invalid json",
+			line:    `2022-01-01T00:00:00.1234 stdout this is not json`,
+			wantErr: true,
+		},
+		{
+			name:    "cri format with flags and EOF right after {",
+			line:    `2022-01-01T00:00:00.1234 stdout F {`,
+			wantErr: true,
+		},
+		{
+			name:    "cri format without flags and EOF right after {",
+			line:    `2022-01-01T00:00:00.1234 stdout {`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			var msg pps.LogMessage
+			err := parseLokiLine(test.line, &msg)
+			t.Logf("err: %v", err)
+			if test.wantErr && err == nil {
+				t.Fatal("parse: got success, want error")
+			} else if !test.wantErr && err != nil {
+				t.Fatalf("parse: unexpected error: %v", err)
+			}
+			if got, want := msg.Message, test.wantMessage; got != want {
+				t.Fatalf("parse: message:\n  got: %v\n want: %v", got, want)
+			}
+		})
+	}
+}

--- a/src/server/worker/stats/stats.go
+++ b/src/server/worker/stats/stats.go
@@ -201,7 +201,6 @@ var (
 // InitPrometheus sets up the default datum stats collectors for use by worker
 // code, and exposes the stats on an http endpoint.
 func InitPrometheus() {
-	logrus.Infof("registering prometheus collectors")
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	go func() {


### PR DESCRIPTION
This PR is Quite The Thing.  I can't vouch for the sanity of the changes because I may have consumed some alcohol and listened to the same 5 seconds of a song on repeat while writing this.  Note to self: delete this tomorrow morning.

With that in mind...

1. I noticed while reviewing loki logs in a debug dump that they weren't separated by newlines.  This adds a newline between lines.  
2. I saw a TODO in the code that we should really pass a context to the Loki client.  Good idea.  Refactored to do that.  (I went a little overboard here; relying on explicit contexts instead of the one contained by server.env.pachClient.  We have to use the context from pachClient.WithContext(ctx).Ctx() in order to pass auth credentials internally, so that still gets a context, but we pass an explicit context around as a general best practice; I didn't want to do different things in different methods, and I didn't want to use pachClient as a budget context.Context.)  I tested Control-C-ing pachctl debug dump, and it cancels everything now.  No goroutine leaks while a user is trying to debug stuff!
4. Did you see the parenthetical remark in that last one about auth?  Yeah, I know that because I didn't do that first.  I noticed some access denied errors in the logs and wanted to see where they were coming from, so I made all access denied errors also log the client IP.  When it's 127.0.0.1 you know you messed up.  (At some point in the future, people will probably want x-forwarded-for from Envoy or their ingress controller, instead of the IP of the ingress controller.  We can do that when someone asks.  Already VERY out of scope for this PR.)
5. I saw a TODO in the code that we should retrieve more than 5000 log lines from Loki.  Extremely good idea.  Now we get 30,000.  The code tried to do this before, but the loop conditions were wrong, and I fixed those, so now it works!  I extensively tested this; there is and was a bug where a container has stdout and stderr streams, logs may appear out of order if one chunk of 5000 logs has both streams in the same chunk.  -We should probably load all 30,000 lines into a slice and sort by time.  That felt horrible to me this evening so I didn't do it, but it's probably a max of 6MB of RAM per log file, so not a big deal.- We do the sorting now, and output in a new format that preserves the Loki stream information.
6. The original thing that prompted me to fix item number 1 (not to be confused with bug #1) was a confusing error message in an `error.txt` from Loki in the debug dump.  I made the Loki client return correct errors, instead of the error from trying to parse the plain-text error as JSON!  Instead of a JSON parse error, you'll get the plain text that the Loki server responded with now.
7. I noticed a while ago on hub that "pachctl logs" didn't work.  This is because we silently discard JSON parse errors from worker logs.   If they aren't valid JSON, we throw them away without even warning about it.  The JSON parse errors are actually a change between Docker and containerd/cri-o container runtimes; Loki expects the raw log file on the host to be in Docker format (configurable!), but if you're using containerd/cri-o, then they're not, and you don't actually get JSON from loki.  Because our code assumes that every record returned from Loki is valid JSON, if you use containerd "pachctl logs" basically stops working.  I estimate this affects 100% of users, because Docker mysteriously disappeared from Kubernetes and was replaced with containerd or cri-o, but nobody edited their promtail configuration to account for this.  Users can of course fix this log parsing (see Slack thread), but I know they won't, so I adjusted the Loki log parsing to handle all 3 possible formats (native/correct promtail config, incorrectly configured Docker logs, incorrectly configured containerd/cri-o logs).  I also now warn when we delete a malformed line, so at least you can look at pachd logs and see that we're throwing away your worker logs.
8. Speaking of malformed lines, we initialized prometheus in the workers before the log format has been set to JSON, but logged a line saying that we're starting up prometheus.  The log format thing turns out to be ... not fixable (circular dependencies) ... so I just deleted that log line to avoid a spurious log parsing error.
9. I added a test to ensure that we get the 30,000 most recent logs, instead of the 30,000 least recent logs.
10. While working on the profiling stuff, I noticed that profile/binary dumps also contain suite=pachyderm logs.  I fixed that issue here.

The new log format looks something like this; the logs are sorted by time, and whenever the stream info changes, we emit a header that captures all the information Loki returned:
```
&map[app:pg-bouncer container:pg-bouncer filename:/var/log/pods/default_pg-bouncer-66d8b86c4-zwhhk_d954f97d-d92e-4fbb-a626-7b42a428cc8a/pg-bouncer/0.log job:default/pg-bouncer namespace:default pod:pg-bouncer-66d8b86c4-zwhhk pod_template_hash:66d8b86c4 suite:pachyderm]
2022-05-26T20:01:05.667064575Z stderr F pgbouncer 20:01:05.66
2022-05-26T20:01:05.668233301Z stderr F pgbouncer 20:01:05.66 Welcome to the Bitnami pgbouncer container
...
2022-05-26T21:12:22.988920326Z stderr F 2022-05-26 21:12:22.988 UTC [1] LOG stats: 25 xacts/s, 45 queries/s, in 5684 B/s, out 11994 B/s, xact 520 us, query 215 us, wait 0 us
&map[app:pg-bouncer container:pg-bouncer filename:/var/log/pods/default_pg-bouncer-66d8b86c4-zwhhk_d954f97d-d92e-4fbb-a626-7b42a428cc8a/pg-bouncer/0.log job:default/pg-bouncer namespace:default pod:pg-bouncer-66d8b86c4-zwhhk pod_template_hash:66d8b86c4 stream:stderr suite:pachyderm]
2022-05-26 21:13:22.987 UTC [1] LOG stats: 25 xacts/s, 45 queries/s, in 5691 B/s, out 11997 B/s, xact 515 us, query 213 us, wait 0 us
2022-05-26 21:13:49.380 UTC [1] LOG C-0x55e6ebf012d0: pachyderm/pachyderm@10.244.0.20:39982 login attempt: db=pachyderm user=pachyderm tls=no
...
```
(In this example, it's because Loki was reconfigured to properly retain the stream name; but this basically happens most often when an app logs to both stdout and stderr.  pachyderm-proxy does that, for example.)

The stream headers always start with '&map[', so you can grep those out.

-We should open a ticket to write some tests for the debug dump that ensure 100% of the logs are in the loki-logs.txt file.  I think we should just run a pipeline, print some stuff (30,000 lines of stuff, or 5001 lines at a minimum), and then see if it's in the debug dump.  That will allow people to edit this code without breaking it.  I might remember to do this.- I sort of did this.  It's not the real Loki, but at least we can add tests for the log-getting code now.

Good evening and good night.  This was fun.  I don't remember what I was supposed to do today, but this is what I did.