### PR TITLE
[CORE-467] add new mux for oidc and metrics

### DIFF
--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -402,8 +402,9 @@ func RunLocal() (retErr error) {
 		return errors.EnsureStack(server.ListenAndServeTLS(certPath, keyPath))
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
-		http.Handle("/metrics", promhttp.Handler())
-		return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", env.Config().PrometheusPort), nil))
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", env.Config().PrometheusPort), mux))
 	})
 	return <-errChan
 }

--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -400,6 +400,7 @@ func (a *apiServer) handleOIDCExchangeInternal(ctx context.Context, authCode, st
 
 func (a *apiServer) serveOIDC() error {
 	// serve OIDC handler to exchange the auth code
-	http.HandleFunc("/authorization-code/callback", a.handleOIDCExchange)
-	return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", a.env.Config.OidcPort), nil))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorization-code/callback", a.handleOIDCExchange)
+	return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", a.env.Config.OidcPort), mux))
 }

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -967,8 +967,9 @@ func doFullMode(config interface{}) (retErr error) {
 		return errors.EnsureStack(server.ListenAndServeTLS(certPath, keyPath))
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
-		http.Handle("/metrics", promhttp.Handler())
-		return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", env.Config().PrometheusPort), nil))
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", env.Config().PrometheusPort), mux))
 	})
 	go func(c chan os.Signal) {
 		<-c
@@ -1299,8 +1300,9 @@ func doPausedMode(config interface{}) (retErr error) {
 		return errors.EnsureStack(server.ListenAndServeTLS(certPath, keyPath))
 	})
 	go waitForError("Prometheus Server", errChan, requireNoncriticalServers, func() error {
-		http.Handle("/metrics", promhttp.Handler())
-		return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", env.Config().PrometheusPort), nil))
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		return errors.EnsureStack(http.ListenAndServe(fmt.Sprintf(":%v", env.Config().PrometheusPort), mux))
 	})
 	go func(c chan os.Signal) {
 		<-c

--- a/src/server/worker/stats/stats.go
+++ b/src/server/worker/stats/stats.go
@@ -202,9 +202,10 @@ var (
 // code, and exposes the stats on an http endpoint.
 func InitPrometheus() {
 	logrus.Infof("registering prometheus collectors")
-	http.Handle("/metrics", promhttp.Handler())
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
 	go func() {
-		if err := http.ListenAndServe(fmt.Sprintf(":%v", PrometheusPort), nil); err != nil {
+		if err := http.ListenAndServe(fmt.Sprintf(":%v", PrometheusPort), mux); err != nil {
 			logrus.Errorf("error serving prometheus metrics: %v", err)
 		}
 	}()


### PR DESCRIPTION
This prevents the prometheus handler from being served on the OIDC port and vice versa. 

Running `curl -s localhost:30657/metrics` while port forwarding now returns a 404