### PR TITLE
Try running CI without awscli

### DIFF
--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -27,7 +27,7 @@ sudo chown root:root /etc/fuse.conf
 
 # Install aws CLI (for TLS test)
 pip3 install --upgrade --user wheel
-pip3 install --upgrade --user awscli s3transfer==0.3.4
+#pip3 install --upgrade --user awscli s3transfer==0.3.4
 
 # Install kubectl
 # To get the latest kubectl version:


### PR DESCRIPTION
Shaves 1m off the install.sh portion of the test (which gets run on every bucket) 