### PR TITLE
[2.2] Enterprise Server Cmd Tests against test cluster pachd instances (#7596)

### DIFF
--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -4,41 +4,49 @@ package testing
 
 import (
 	"bufio"
-	"os/exec"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 const enterpriseRootToken = "iamenterprise"
 
-func resetClusterState(t *testing.T) {
+func resetClusterState(t *testing.T, c *client.APIClient) {
 	ec, err := client.NewEnterpriseClientForTest()
 	require.NoError(t, err)
-
-	c, err := client.NewForTest()
-	require.NoError(t, err)
-
 	// Set the root token, in case a previous test failed
-	c.SetAuthToken(tu.RootToken)
 	ec.SetAuthToken(enterpriseRootToken)
-
-	require.NoError(t, c.DeleteAll())
 	require.NoError(t, ec.DeleteAllEnterprise())
+
+	require.NoError(t, tu.PachctlBashCmd(t, c, `pachctl config set context  --overwrite enterprise <<EOF
+	{
+	  "source": 1,
+	  "pachd_address": "grpc://{{ .host }}:{{ .port }}",
+	  "session_token": "{{ .token }}"
+	}
+	EOF`,
+		"host", ec.GetAddress().Host,
+		"port", fmt.Sprint(ec.GetAddress().Port),
+		"token", enterpriseRootToken,
+	).Run())
+	require.NoError(t, tu.PachctlBashCmd(t, c, "pachctl config set active-enterprise-context enterprise").Run())
 }
 
 // TestRegisterPachd tests registering a pachd with the enterprise server when auth is disabled
 func TestRegisterPachd(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
-	require.NoError(t, tu.BashCmd(`
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{.pach_address}}
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
 		  | match 'id: {{.id}}' \
@@ -46,19 +54,21 @@ func TestRegisterPachd(t *testing.T) {
 		`,
 		"id", tu.UniqueString("cluster"),
 		"license", tu.GetTestEnterpriseCode(t),
+		"pach_address", pachAddress,
 	).Run())
 }
 
 // TestRegisterAuthenticated tests registering a pachd with the enterprise server when auth is enabled
 func TestRegisterAuthenticated(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
 	cluster := tu.UniqueString("cluster")
-	require.NoError(t, tu.BashCmd(`
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 
 		pachctl enterprise get-state | match ACTIVE
 		pachctl license list-clusters \
@@ -70,18 +80,20 @@ func TestRegisterAuthenticated(t *testing.T) {
 		"id", cluster,
 		"license", tu.GetTestEnterpriseCode(t),
 		"enterprise_token", enterpriseRootToken,
+		"pach_address", pachAddress,
 	).Run())
 }
 
 // TestEnterpriseRoleBindings tests configuring role bindings for the enterprise server
 func TestEnterpriseRoleBindings(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
-	require.NoError(t, tu.BashCmd(`
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth set enterprise clusterAdmin robot:test1
 		pachctl auth get enterprise | match robot:test1
@@ -91,18 +103,20 @@ func TestEnterpriseRoleBindings(t *testing.T) {
 		"license", tu.GetTestEnterpriseCode(t),
 		"enterprise_token", enterpriseRootToken,
 		"token", tu.RootToken,
+		"pach_address", pachAddress,
 	).Run())
 }
 
 // TestGetAndUseRobotToken tests getting a robot token for the enterprise server
 func TestGetAndUseRobotToken(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
-	require.NoError(t, tu.BashCmd(`
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		pachctl auth get-robot-token --enterprise -q {{.alice}} | tail -1 | pachctl auth use-auth-token --enterprise
 		pachctl auth get-robot-token -q {{.bob}} | pachctl auth use-auth-token
@@ -115,27 +129,30 @@ func TestGetAndUseRobotToken(t *testing.T) {
 		"enterprise_token", enterpriseRootToken,
 		"alice", tu.UniqueString("alice"),
 		"bob", tu.UniqueString("bob"),
+		"pach_address", pachAddress,
 	).Run())
 }
 
 // TestConfig tests getting and setting OIDC configuration for the identity server
 func TestConfig(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
-	require.NoError(t, tu.BashCmd(`
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:31650 --pachd-address pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 			`,
 		"id", tu.UniqueString("cluster"),
 		"token", tu.RootToken,
 		"enterprise_token", enterpriseRootToken,
 		"license", tu.GetTestEnterpriseCode(t),
+		"pach_address", pachAddress,
 	).Run())
 
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth set-config --enterprise <<EOF
 {
 	"issuer": "http://pach-enterprise.enterprise:31658",
@@ -146,7 +163,7 @@ func TestConfig(t *testing.T) {
 EOF
 	`).Run())
 
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth get-config --enterprise \
 		  | match '"issuer": "http://pach-enterprise.enterprise:31658"' \
 		  | match '"localhost_issuer": true' \
@@ -158,16 +175,16 @@ EOF
 
 // TestLoginEnterprise tests logging in to the enterprise server
 func TestLoginEnterprise(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
 	ec, err := client.NewEnterpriseClientForTest()
 	require.NoError(t, err)
-
-	require.NoError(t, tu.BashCmd(`
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
@@ -175,9 +192,10 @@ func TestLoginEnterprise(t *testing.T) {
 		"token", tu.RootToken,
 		"enterprise_token", enterpriseRootToken,
 		"license", tu.GetTestEnterpriseCode(t),
+		"pach_address", pachAddress,
 	).Run())
 
-	cmd := exec.Command("pachctl", "auth", "login", "--no-browser", "--enterprise")
+	cmd := tu.PachctlBashCmd(t, c, "pachctl auth login --no-browser --enterprise")
 	out, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 
@@ -191,7 +209,7 @@ func TestLoginEnterprise(t *testing.T) {
 	}
 	cmd.Wait()
 
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami --enterprise | match user:{{.user}}
 		pachctl auth whoami | match pach:root`,
 		"user", tu.DexMockConnectorEmail,
@@ -200,19 +218,17 @@ func TestLoginEnterprise(t *testing.T) {
 
 // TestLoginPachd tests logging in to pachd
 func TestLoginPachd(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
-	c, err := client.NewForTest()
-	require.NoError(t, err)
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
 
 	ec, err := client.NewEnterpriseClientForTest()
 	require.NoError(t, err)
-
-	require.NoError(t, tu.BashCmd(`
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 		echo {{.token}} | pachctl auth activate --supply-root-token --client-id pachd2
 		echo '{"id": "test", "name": "test", "type": "mockPassword", "config": {"username": "admin", "password": "password"}}' | pachctl idp create-connector
 		`,
@@ -220,9 +236,10 @@ func TestLoginPachd(t *testing.T) {
 		"token", tu.RootToken,
 		"enterprise_token", enterpriseRootToken,
 		"license", tu.GetTestEnterpriseCode(t),
+		"pach_address", pachAddress,
 	).Run())
 
-	cmd := exec.Command("pachctl", "auth", "login", "--no-browser")
+	cmd := tu.PachctlBashCmd(t, c, "pachctl auth login --no-browser")
 	out, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 
@@ -236,7 +253,7 @@ func TestLoginPachd(t *testing.T) {
 	}
 	cmd.Wait()
 
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami | match user:{{.user}}
 		pachctl auth whoami --enterprise | match 'pach:root'`,
 		"user", tu.DexMockConnectorEmail,
@@ -245,34 +262,35 @@ func TestLoginPachd(t *testing.T) {
 
 // Tests synching contexts from the enterprise server
 func TestSyncContexts(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
 	id := tu.UniqueString("cluster")
 	clusterId := tu.UniqueString("clusterDeploymentId")
-
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
 	// register a new cluster
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650 --pachd-user-address grpc://pachd.default:1655 --cluster-deployment-id {{.clusterId}} 
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }} --pachd-user-address grpc://pachd.default:1655 --cluster-deployment-id {{.clusterId}} 
 		`,
 		"id", id,
 		"token", tu.RootToken,
 		"enterprise_token", enterpriseRootToken,
 		"license", tu.GetTestEnterpriseCode(t),
 		"clusterId", clusterId,
+		"pach_address", pachAddress,
 	).Run())
 
 	// assert the registered cluster isn't reflected in the user's config
-	require.YesError(t, tu.BashCmd(`
+	require.YesError(t, tu.PachctlBashCmd(t, c, `
 		pachctl config list context | match {{.id}}
 		`,
 		"id", id,
 	).Run())
 
 	// sync contexts and assert that the newly registered cluster is accessible
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl enterprise sync-contexts
 		pachctl config list context | match {{.id}}
 		pachctl config get context {{.id}} | match "\"pachd_address\": \"grpc://pachd.default:1655\"" 
@@ -285,7 +303,7 @@ func TestSyncContexts(t *testing.T) {
 
 	// re-register cluster with the same cluster ID and new user address
 	// the user-address should be updated on sync
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl license update-cluster --id {{.id}} --user-address {{.userAddress}}
 		pachctl enterprise sync-contexts
 		pachctl config get context {{.id}} | match "\"pachd_address\": \"{{.userAddress}}\"" 
@@ -300,7 +318,7 @@ func TestSyncContexts(t *testing.T) {
 	// the cluster id should be updated and the session token should be set to empty
 	// TODO(acohen4): set session_token so that it can be unset
 	newClusterId := tu.UniqueString("clusterDeploymentId")
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl license update-cluster --id {{.id}} --cluster-deployment-id {{.clusterId}}
 		pachctl enterprise sync-contexts
 		pachctl config get context {{.id}} | match "\"pachd_address\": \"{{.userAddress}}\"" 
@@ -315,16 +333,14 @@ func TestSyncContexts(t *testing.T) {
 	// make sure that the cluster with id = 'localhost' does not get synched, which is
 	// self referencing context record for the enterprise server.
 	// it should be filtered on the criteria of being set as an enterprise server record
-	require.YesError(t, tu.BashCmd(`pachctl config list context | match localhost`).Run())
+	require.YesError(t, tu.PachctlBashCmd(t, c, `pachctl config list context | match localhost`).Run())
 }
 
 // Tests RegisterCluster command's derived argument values if not provided
 func TestRegisterDefaultArgs(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
-	c, err := client.NewForTest()
-	require.NoError(t, err)
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
 
 	id := tu.UniqueString("cluster")
 
@@ -334,20 +350,17 @@ func TestRegisterDefaultArgs(t *testing.T) {
 	clusterId := clusterInfo.DeploymentID
 
 	host := c.GetAddress().Host
-	if host == "0.0.0.0" {
-		host = "localhost"
-	}
-
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
 	// register a new cluster
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		echo {{.enterprise_token}} | pachctl auth activate --enterprise --issuer http://pach-enterprise.enterprise:31658 --supply-root-token
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address}}
 
 		pachctl enterprise sync-contexts
 
 		pachctl config list context | match {{.id}}
-		pachctl config get context {{.id}} | match "\"pachd_address\": \"{{.pachdAddress}}"
+		pachctl config get context {{.id}} | match "\"pachd_address\": \"{{.list_pach_address}}"
 		pachctl config get context {{.id}} | match "\"cluster_deployment_id\": \"{{.clusterId}}\""
 		pachctl config get context {{.id}} | match "\"source\": \"IMPORTED\","
 		`,
@@ -355,42 +368,45 @@ func TestRegisterDefaultArgs(t *testing.T) {
 		"enterprise_token", enterpriseRootToken,
 		"license", tu.GetTestEnterpriseCode(t),
 		"clusterId", clusterId,
-		"pachdAddress", "grpc://"+host+":30650", // assert that a localhost address is registered
+		"pach_address", pachAddress,
+		"list_pach_address", fmt.Sprintf("grpc://%s:%v", host, c.GetAddress().Port), // assert that a localhost address is registered
 	).Run())
 }
 
 // tests that Cluster Registration is undone when enterprise service fails to activate in the `enterprise register` subcommand
 func TestRegisterRollback(t *testing.T) {
-	resetClusterState(t)
-	defer resetClusterState(t)
-
+	c, ns := minikubetestenv.AcquireCluster(t)
+	resetClusterState(t, c)
+	defer resetClusterState(t, c)
 	id := tu.UniqueString("cluster")
 
-	require.NoError(t, tu.BashCmd(`
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		echo {{.license}} | pachctl license activate
 		`,
 		"license", tu.GetTestEnterpriseCode(t),
 	).Run())
-
+	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
 	// passing an unreachable enterprise-server-address to the `enterprise register` command
 	// causes it to fail, and rollback cluster record creation
-	require.YesError(t, tu.BashCmd(`
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc:/bad-address:31650 --pachd-address grpc://pachd.default:30650
+	require.YesError(t, tu.PachctlBashCmd(t, c, `
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc:/bad-address:31650 --pachd-address {{ .pach_address }}
 		`,
 		"id", id,
+		"pach_address", pachAddress,
 	).Run())
 
 	// verify the cluster id is not present in the license server's registered clusters
-	require.YesError(t, tu.BashCmd(`
+	require.YesError(t, tu.PachctlBashCmd(t, c, `
 		pachctl license list-clusters \
 			| match 'id: {{.id}}' \
 		`,
 		"id", id,
 	).Run())
 
-	require.NoError(t, tu.BashCmd(`
-		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address grpc://pachd.default:30650
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
+		pachctl enterprise register --id {{.id}} --enterprise-server-address grpc://pach-enterprise.enterprise:31650 --pachd-address {{ .pach_address }}
 		`,
 		"id", id,
+		"pach_address", pachAddress,
 	).Run())
 }


### PR DESCRIPTION
* Migrate Enterprise Server Command Tests

* Run Enterprise Server Cmd Tests against test cluster pachd instances

* revert