### PR TITLE
Consult RC when un-crashing pipeline.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-pfs-server:
 test-pps: launch-stats docker-build-spout-test
 	@# Use the count flag to disable test caching for this test suite.
 	PROM_PORT=$$(kubectl --namespace=monitoring get svc/prometheus -o json | jq -r .spec.ports[0].nodePort) \
-	  go test -v -count=1 ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) $(RUN) $(TESTFLAGS)
+	  go test -v -count=20 ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) -run MissingSecretFailure $(TESTFLAGS)
 
 test-cmds:
 	go install -v ./src/testing/match

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-pfs-server:
 test-pps: launch-stats docker-build-spout-test
 	@# Use the count flag to disable test caching for this test suite.
 	PROM_PORT=$$(kubectl --namespace=monitoring get svc/prometheus -o json | jq -r .spec.ports[0].nodePort) \
-	  go test -v -count=20 ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) -run MissingSecretFailure $(TESTFLAGS)
+	  go test -v -count=1 ./src/server -parallel $(PARALLELISM) -timeout $(TIMEOUT) $(RUN) $(TESTFLAGS)
 
 test-cmds:
 	go install -v ./src/testing/match


### PR DESCRIPTION
The missing secrets test was flaking due to the crashing monitor taking
it out of the crashing state prematurely. The logic was wrong in both
directions: it required the maximum number of pods to be present, even
if the RC requested fewer, and could include workers in its count which
were going to be terminated.

While it seems like checking the RC's status should be sufficient, I've
left the worker status check in place to capture e.g. a failure in
networking in the worker service which the worker pod itself doesn't
care about.