### PR TITLE
Add Support for Plurals in Pachctl

### DIFF
--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -322,14 +322,14 @@ func CreateAlias(cmd *cobra.Command, invocation string) *cobra.Command {
 	return createAlias(cmd, invocation)
 }
 
-// CreateAliases is like CreateAlias, except it allows us to specify one or more plurals for the
+// CreateAliases is like CreateAlias, except it allows us to specify one or more synonyms for the
 // last argument in the command with the assumption that the last argument in the command is a resource
 // such as 'repo' or 'pipeline'.
-func CreateAliases(cmd *cobra.Command, invocation string, plurals ...string) *cobra.Command {
-	return createAlias(cmd, invocation, plurals...)
+func CreateAliases(cmd *cobra.Command, invocation string, synonyms ...string) *cobra.Command {
+	return createAlias(cmd, invocation, synonyms...)
 }
 
-func createAlias(cmd *cobra.Command, invocation string, plurals ...string) *cobra.Command {
+func createAlias(cmd *cobra.Command, invocation string, synonyms ...string) *cobra.Command {
 	// Create logical commands for each substring in each invocation
 	var root, prev *cobra.Command
 	args := strings.Split(invocation, " ")
@@ -348,8 +348,8 @@ func createAlias(cmd *cobra.Command, invocation string, plurals ...string) *cobr
 			}
 			cur.Example = strings.ReplaceAll(cmd.Example, "{{alias}}", fmt.Sprintf("%s %s", os.Args[0], invocation))
 
-			if len(plurals) != 0 {
-				cur.Aliases = append([]string{cur.Use}, plurals...)
+			if len(synonyms) != 0 {
+				cur.Aliases = append([]string{}, synonyms...)
 			}
 
 		} else {
@@ -419,17 +419,17 @@ func CreateDocsAlias(command *cobra.Command, invocation string, pattern string) 
 	return createDocsAlias(command, invocation, pattern)
 }
 
-// CreateDocsAliases is like CreateDocsAlias, except it allows us to specify one or more plurals for the
+// CreateDocsAliases is like CreateDocsAlias, except it allows us to specify one or more synonyms for the
 // last argument in the command with the assumption that the last argument in the command is a resource
 // such as 'repo' or 'pipeline'.
 func CreateDocsAliases(command *cobra.Command, invocation string, pattern string,
-	plurals ...string) *cobra.Command {
-	return createDocsAlias(command, invocation, pattern, plurals...)
+	synonyms ...string) *cobra.Command {
+	return createDocsAlias(command, invocation, pattern, synonyms...)
 }
 
-func createDocsAlias(command *cobra.Command, invocation string, pattern string, plurals ...string) *cobra.Command {
+func createDocsAlias(command *cobra.Command, invocation string, pattern string, synonyms ...string) *cobra.Command {
 	// This should create a linked-list-shaped tree, follow it to the one leaf
-	root := CreateAliases(command, invocation, plurals...)
+	root := CreateAliases(command, invocation, synonyms...)
 	command = root
 	for len(command.Commands()) != 0 {
 		command = command.Commands()[0]

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -546,7 +546,7 @@ func CheckRepoCmd() *cobra.Command {
 			return nil
 		}),
 	}
-	return cmdutil.CreateAlias(check, "auth check repo")
+	return cmdutil.CreateAliases(check, "auth check repo", "repos")
 }
 
 // SetRepoRoleBindingCmd returns a cobra command that sets the roles for a user on a resource
@@ -573,7 +573,7 @@ func SetRepoRoleBindingCmd() *cobra.Command {
 			return grpcutil.ScrubGRPC(err)
 		}),
 	}
-	return cmdutil.CreateAlias(setScope, "auth set repo")
+	return cmdutil.CreateAliases(setScope, "auth set repo", "repos")
 }
 
 // GetRepoRoleBindingCmd returns a cobra command that gets the role bindings for a resource
@@ -597,7 +597,7 @@ func GetRepoRoleBindingCmd() *cobra.Command {
 			return nil
 		}),
 	}
-	return cmdutil.CreateAlias(get, "auth get repo")
+	return cmdutil.CreateAliases(get, "auth get repo", "repos")
 }
 
 // SetClusterRoleBindingCmd returns a cobra command that sets the roles for a user on a resource

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -417,3 +417,41 @@ func TestRotateRootToken(t *testing.T) {
 		pachctl auth whoami | match "pach:root"
 	`).Run())
 }
+
+// TestPlurals walks through the command tree for each resource and verb combination defined in PPS.
+// A template is filled in that calls the help flag and the output is compared. It seems like 'match'
+// is unable to compare the outputs correctly, but we can use diff here which returns an exit code of 0
+// if there is no difference.
+func TestPlurals(t *testing.T) {
+	pluralCheckTemplate := `
+		pachctl auth {{VERB}} {{RESOURCE_PLURAL}} -h > plural.txt
+		pachctl auth {{VERB}} {{RESOURCE}} -h > singular.txt
+		diff plural.txt singular.txt
+		rm plural.txt singular.txt
+	`
+
+	resources := map[string][]string{
+		"repo": {"check", "set", "get"},
+	}
+
+	pluralMap := map[string]string{
+		"repo": "repos",
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	c, _ := minikubetestenv.AcquireCluster(t)
+
+	for resource, verbs := range resources {
+		withResource := strings.ReplaceAll(pluralCheckTemplate, "{{RESOURCE}}", resource)
+		withResources := strings.ReplaceAll(withResource, "{{RESOURCE_PLURAL}}", pluralMap[resource])
+
+		for _, verb := range verbs {
+			pluralCommand := strings.ReplaceAll(withResources, "{{VERB}}", verb)
+			t.Logf("Testing auth %s %s -h\n", verb, resource)
+			require.NoError(t, tu.PachctlBashCmd(t, c, pluralCommand).Run())
+		}
+	}
+}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -41,6 +41,35 @@ import (
 const (
 	// DefaultParallelism is the default parallelism used by 'get file' and 'put file'.
 	DefaultParallelism = 10
+
+	// Singular variables are used in testing.
+	branch = "branch"
+	commit = "commit"
+	file   = "file"
+	repo   = "repo"
+
+	// Plural variables are used below for user convenience.
+	branches = "branches"
+	commits  = "commits"
+	files    = "files"
+	repos    = "repos"
+
+	// Command 'verbs' are also used in testing.
+	copy      = "copy"
+	create    = "create"
+	delete    = "delete"
+	diff      = "diff"
+	finish    = "finish"
+	get       = "get"
+	glob      = "glob"
+	inspect   = "inspect"
+	list      = "list"
+	put       = "put"
+	squash    = "squash"
+	start     = "start"
+	subscribe = "subscribe"
+	update    = "update"
+	wait      = "job"
 )
 
 // Cmds returns a slice containing pfs commands.
@@ -64,7 +93,7 @@ func Cmds() []*cobra.Command {
 Repos contain version-controlled directories and files. Files can be of any size
 or type (e.g. csv, binary, images, etc).`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(repoDocs, "repo", " repo$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(repoDocs, "repo", " repo$", repos))
 
 	var description string
 	createRepo := &cobra.Command{
@@ -92,7 +121,7 @@ or type (e.g. csv, binary, images, etc).`,
 		}),
 	}
 	createRepo.Flags().StringVarP(&description, "description", "d", "", "A description of the repo.")
-	commands = append(commands, cmdutil.CreateAlias(createRepo, "create repo"))
+	commands = append(commands, cmdutil.CreateAliases(createRepo, "create repo", repos))
 
 	updateRepo := &cobra.Command{
 		Use:   "{{alias}} <repo>",
@@ -121,7 +150,7 @@ or type (e.g. csv, binary, images, etc).`,
 	}
 	updateRepo.Flags().StringVarP(&description, "description", "d", "", "A description of the repo.")
 	shell.RegisterCompletionFunc(updateRepo, shell.RepoCompletion)
-	commands = append(commands, cmdutil.CreateAlias(updateRepo, "update repo"))
+	commands = append(commands, cmdutil.CreateAliases(updateRepo, "update repo", repos))
 
 	inspectRepo := &cobra.Command{
 		Use:   "{{alias}} <repo>",
@@ -155,7 +184,7 @@ or type (e.g. csv, binary, images, etc).`,
 	inspectRepo.Flags().AddFlagSet(outputFlags)
 	inspectRepo.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(inspectRepo, shell.RepoCompletion)
-	commands = append(commands, cmdutil.CreateAlias(inspectRepo, "inspect repo"))
+	commands = append(commands, cmdutil.CreateAliases(inspectRepo, "inspect repo", repos))
 
 	var all bool
 	var repoType string
@@ -206,7 +235,7 @@ or type (e.g. csv, binary, images, etc).`,
 	listRepo.Flags().AddFlagSet(timestampFlags)
 	listRepo.Flags().BoolVar(&all, "all", false, "include system repos of all types")
 	listRepo.Flags().StringVar(&repoType, "type", "", "only include repos of the given type")
-	commands = append(commands, cmdutil.CreateAlias(listRepo, "list repo"))
+	commands = append(commands, cmdutil.CreateAliases(listRepo, "list repo", repos))
 
 	var force bool
 	deleteRepo := &cobra.Command{
@@ -246,7 +275,7 @@ or type (e.g. csv, binary, images, etc).`,
 	deleteRepo.Flags().BoolVarP(&force, "force", "f", false, "remove the repo regardless of errors; use with care")
 	deleteRepo.Flags().BoolVar(&all, "all", false, "remove all repos")
 	shell.RegisterCompletionFunc(deleteRepo, shell.RepoCompletion)
-	commands = append(commands, cmdutil.CreateAlias(deleteRepo, "delete repo"))
+	commands = append(commands, cmdutil.CreateAliases(deleteRepo, "delete repo", repos))
 
 	commitDocs := &cobra.Command{
 		Short: "Docs for commits.",
@@ -262,7 +291,7 @@ Commits become reliable (and immutable) when they are finished.
 
 Commits can be created with another commit as a parent.`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(commitDocs, "commit", " commit$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(commitDocs, "commit", " commit$", commits))
 
 	var parent string
 	startCommit := &cobra.Command{
@@ -323,7 +352,7 @@ $ {{alias}} test@fork -p XXX`,
 	startCommit.Flags().StringVarP(&description, "message", "m", "", "A description of this commit's contents")
 	startCommit.Flags().StringVar(&description, "description", "", "A description of this commit's contents (synonym for --message)")
 	shell.RegisterCompletionFunc(startCommit, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(startCommit, "start commit"))
+	commands = append(commands, cmdutil.CreateAliases(startCommit, "start commit", commits))
 
 	finishCommit := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>",
@@ -358,7 +387,7 @@ $ {{alias}} test@fork -p XXX`,
 	finishCommit.Flags().StringVar(&description, "description", "", "A description of this commit's contents (synonym for --message)")
 	finishCommit.Flags().BoolVarP(&force, "force", "f", false, "finish the commit even if it has provenance, which could break jobs; prefer 'stop job'")
 	shell.RegisterCompletionFunc(finishCommit, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(finishCommit, "finish commit"))
+	commands = append(commands, cmdutil.CreateAliases(finishCommit, "finish commit", commits))
 
 	inspectCommit := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>",
@@ -404,7 +433,7 @@ $ {{alias}} test@fork -p XXX`,
 	inspectCommit.Flags().AddFlagSet(outputFlags)
 	inspectCommit.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(inspectCommit, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(inspectCommit, "inspect commit"))
+	commands = append(commands, cmdutil.CreateAliases(inspectCommit, "inspect commit", commits))
 
 	var from string
 	var number int64
@@ -620,7 +649,7 @@ $ {{alias}} foo@master --from XXX`,
 	listCommit.Flags().AddFlagSet(outputFlags)
 	listCommit.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(listCommit, shell.RepoCompletion)
-	commands = append(commands, cmdutil.CreateAlias(listCommit, "list commit"))
+	commands = append(commands, cmdutil.CreateAliases(listCommit, "list commit", commits))
 
 	waitCommit := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>",
@@ -661,7 +690,7 @@ $ {{alias}} foo@XXX -b bar@baz`,
 	}
 	waitCommit.Flags().AddFlagSet(outputFlags)
 	waitCommit.Flags().AddFlagSet(timestampFlags)
-	commands = append(commands, cmdutil.CreateAlias(waitCommit, "wait commit"))
+	commands = append(commands, cmdutil.CreateAliases(waitCommit, "wait commit", commits))
 
 	var newCommits bool
 	subscribeCommit := &cobra.Command{
@@ -748,7 +777,7 @@ $ {{alias}} test@master --new`,
 	subscribeCommit.Flags().AddFlagSet(outputFlags)
 	subscribeCommit.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(subscribeCommit, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(subscribeCommit, "subscribe commit"))
+	commands = append(commands, cmdutil.CreateAliases(subscribeCommit, "subscribe commit", commits))
 
 	squashCommit := &cobra.Command{
 		Use:   "{{alias}} <commit-id>",
@@ -769,7 +798,7 @@ The squash will fail if it includes a commit with no children`,
 		}),
 	}
 	shell.RegisterCompletionFunc(squashCommit, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(squashCommit, "squash commit"))
+	commands = append(commands, cmdutil.CreateAliases(squashCommit, "squash commit", commits))
 
 	deleteCommit := &cobra.Command{
 		Use:   "{{alias}} <commit-id>",
@@ -790,7 +819,7 @@ This operation is only supported if none of the sub-commits have children.`,
 		}),
 	}
 	shell.RegisterCompletionFunc(deleteCommit, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(deleteCommit, "delete commit"))
+	commands = append(commands, cmdutil.CreateAliases(deleteCommit, "delete commit", commits))
 
 	branchDocs := &cobra.Command{
 		Short: "Docs for branches.",
@@ -802,7 +831,7 @@ branch, known as the HEAD commit. All commits are on exactly one branch.
 
 Any pachctl command that can take a commit, can take a branch name instead.`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(branchDocs, "branch", " branch$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(branchDocs, "branch", " branch$", branches))
 
 	var branchProvenance cmdutil.RepeatedStringArg
 	var head string
@@ -870,7 +899,7 @@ Any pachctl command that can take a commit, can take a branch name instead.`,
 	createBranch.Flags().StringVar(&trigger.Size_, "trigger-size", "", "The data size to use in triggering.")
 	createBranch.Flags().Int64Var(&trigger.Commits, "trigger-commits", 0, "The number of commits to use in triggering.")
 	createBranch.Flags().BoolVar(&trigger.All, "trigger-all", false, "Only trigger when all conditions are met, rather than when any are met.")
-	commands = append(commands, cmdutil.CreateAlias(createBranch, "create branch"))
+	commands = append(commands, cmdutil.CreateAliases(createBranch, "create branch", branches))
 
 	inspectBranch := &cobra.Command{
 		Use:   "{{alias}}  <repo>@<branch>",
@@ -906,7 +935,7 @@ Any pachctl command that can take a commit, can take a branch name instead.`,
 	inspectBranch.Flags().AddFlagSet(outputFlags)
 	inspectBranch.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(inspectBranch, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(inspectBranch, "inspect branch"))
+	commands = append(commands, cmdutil.CreateAliases(inspectBranch, "inspect branch", branches))
 
 	listBranch := &cobra.Command{
 		Use:   "{{alias}} <repo>",
@@ -945,7 +974,7 @@ Any pachctl command that can take a commit, can take a branch name instead.`,
 	}
 	listBranch.Flags().AddFlagSet(outputFlags)
 	shell.RegisterCompletionFunc(listBranch, shell.RepoCompletion)
-	commands = append(commands, cmdutil.CreateAlias(listBranch, "list branch"))
+	commands = append(commands, cmdutil.CreateAliases(listBranch, "list branch", branches))
 
 	deleteBranch := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch>",
@@ -970,7 +999,7 @@ Any pachctl command that can take a commit, can take a branch name instead.`,
 	}
 	deleteBranch.Flags().BoolVarP(&force, "force", "f", false, "remove the branch regardless of errors; use with care")
 	shell.RegisterCompletionFunc(deleteBranch, shell.BranchCompletion)
-	commands = append(commands, cmdutil.CreateAlias(deleteBranch, "delete branch"))
+	commands = append(commands, cmdutil.CreateAliases(deleteBranch, "delete branch", branches))
 
 	fileDocs := &cobra.Command{
 		Short: "Docs for files.",
@@ -980,7 +1009,7 @@ Files can be of any type (e.g. csv, binary, images, etc) or size and can be
 written to started (but not finished) commits with 'put file'. Files can be read
 from commits with 'get file'.`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(fileDocs, "file", " file$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(fileDocs, "file", " file$", files))
 
 	var filePaths []string
 	var inputFile string
@@ -1154,7 +1183,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 			}
 			return nil, shell.SameFlag(flag)
 		})
-	commands = append(commands, cmdutil.CreateAlias(putFile, "put file"))
+	commands = append(commands, cmdutil.CreateAliases(putFile, "put file", files))
 
 	copyFile := &cobra.Command{
 		Use:   "{{alias}} <src-repo>@<src-branch-or-commit>:<src-path> <dst-repo>@<dst-branch-or-commit>:<dst-path>",
@@ -1188,7 +1217,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 	}
 	copyFile.Flags().BoolVarP(&appendFile, "append", "a", false, "Append to the existing content of the file, either from previous commits or previous calls to 'put file' within this commit.")
 	shell.RegisterCompletionFunc(copyFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(copyFile, "copy file"))
+	commands = append(commands, cmdutil.CreateAliases(copyFile, "copy file", files))
 
 	var outputPath string
 	var offsetBytes int64
@@ -1288,7 +1317,7 @@ $ {{alias}} 'foo@master:/test\[\].txt'`,
 	getFile.Flags().Int64Var(&offsetBytes, "offset", 0, "The number of bytes in the file to skip ahead when reading.")
 	getFile.Flags().BoolVar(&retry, "retry", false, "{true|false} Whether to append the missing bytes to an existing file. No-op if the file doesn't exist.")
 	shell.RegisterCompletionFunc(getFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(getFile, "get file"))
+	commands = append(commands, cmdutil.CreateAliases(getFile, "get file", files))
 
 	inspectFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>:<path/in/pfs>",
@@ -1321,7 +1350,7 @@ $ {{alias}} 'foo@master:/test\[\].txt'`,
 	}
 	inspectFile.Flags().AddFlagSet(outputFlags)
 	shell.RegisterCompletionFunc(inspectFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(inspectFile, "inspect file"))
+	commands = append(commands, cmdutil.CreateAliases(inspectFile, "inspect file", files))
 
 	listFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>[:<path/in/pfs>]",
@@ -1377,7 +1406,7 @@ $ {{alias}} 'foo@master:dir\[1\]'`,
 	listFile.Flags().AddFlagSet(outputFlags)
 	listFile.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(listFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(listFile, "list file"))
+	commands = append(commands, cmdutil.CreateAliases(listFile, "list file", files))
 
 	globFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>:<pattern>",
@@ -1426,7 +1455,7 @@ $ {{alias}} "foo@master:data/*"`,
 	globFile.Flags().AddFlagSet(outputFlags)
 	globFile.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(globFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(globFile, "glob file"))
+	commands = append(commands, cmdutil.CreateAliases(globFile, "glob file", files))
 
 	var shallow bool
 	var nameOnly bool
@@ -1530,7 +1559,7 @@ $ {{alias}} foo@master:path1 bar@master:path2`,
 	diffFile.Flags().AddFlagSet(timestampFlags)
 	diffFile.Flags().AddFlagSet(pagerFlags)
 	shell.RegisterCompletionFunc(diffFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(diffFile, "diff file"))
+	commands = append(commands, cmdutil.CreateAliases(diffFile, "diff file", files))
 
 	deleteFile := &cobra.Command{
 		Use:   "{{alias}} <repo>@<branch-or-commit>:<path/in/pfs>",
@@ -1556,7 +1585,7 @@ $ {{alias}} foo@master:path1 bar@master:path2`,
 	}
 	deleteFile.Flags().BoolVarP(&recursive, "recursive", "r", false, "Recursively delete the files in a directory.")
 	shell.RegisterCompletionFunc(deleteFile, shell.FileCompletion)
-	commands = append(commands, cmdutil.CreateAlias(deleteFile, "delete file"))
+	commands = append(commands, cmdutil.CreateAliases(deleteFile, "delete file", files))
 
 	objectDocs := &cobra.Command{
 		Short: "Docs for objects.",

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -42,34 +42,11 @@ const (
 	// DefaultParallelism is the default parallelism used by 'get file' and 'put file'.
 	DefaultParallelism = 10
 
-	// Singular variables are used in testing.
-	branch = "branch"
-	commit = "commit"
-	file   = "file"
-	repo   = "repo"
-
 	// Plural variables are used below for user convenience.
 	branches = "branches"
 	commits  = "commits"
 	files    = "files"
 	repos    = "repos"
-
-	// Command 'verbs' are also used in testing.
-	copy      = "copy"
-	create    = "create"
-	delete    = "delete"
-	diff      = "diff"
-	finish    = "finish"
-	get       = "get"
-	glob      = "glob"
-	inspect   = "inspect"
-	list      = "list"
-	put       = "put"
-	squash    = "squash"
-	start     = "start"
-	subscribe = "subscribe"
-	update    = "update"
-	wait      = "job"
 )
 
 // Cmds returns a slice containing pfs commands.

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -44,6 +44,32 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	// Singular variables are used for testing.
+	datum    = "datum"
+	job      = "job"
+	pipeline = "pipeline"
+	secret   = "secret"
+
+	// Plural variables are used below for user convenience.
+	datums    = "datums"
+	jobs      = "jobs"
+	pipelines = "pipelines"
+	secrets   = "secrets"
+
+	// Command 'verbs' are also used in testing.
+	create  = "create"
+	delete  = "delete"
+	edit    = "edit"
+	inspect = "inspect"
+	list    = "list"
+	restart = "restart"
+	start   = "start"
+	stop    = "stop"
+	update  = "update"
+	wait    = "job"
+)
+
 // Cmds returns a slice containing pps commands.
 func Cmds() []*cobra.Command {
 	var commands []*cobra.Command
@@ -69,7 +95,7 @@ results will be merged together at the end.
 
 If the job fails, the output commit will not be populated with data.`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(jobDocs, "job", " job$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(jobDocs, "job", " job$", jobs))
 
 	inspectJob := &cobra.Command{
 		Use:   "{{alias}} <pipeline>@<job>",
@@ -106,7 +132,7 @@ If the job fails, the output commit will not be populated with data.`,
 	inspectJob.Flags().AddFlagSet(outputFlags)
 	inspectJob.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(inspectJob, shell.JobCompletion)
-	commands = append(commands, cmdutil.CreateAlias(inspectJob, "inspect job"))
+	commands = append(commands, cmdutil.CreateAliases(inspectJob, "inspect job", jobs))
 
 	writeJobInfos := func(out io.Writer, jobInfos []*pps.JobInfo) error {
 		if raw {
@@ -165,7 +191,7 @@ If the job fails, the output commit will not be populated with data.`,
 	waitJob.Flags().AddFlagSet(outputFlags)
 	waitJob.Flags().AddFlagSet(timestampFlags)
 	shell.RegisterCompletionFunc(waitJob, shell.JobCompletion)
-	commands = append(commands, cmdutil.CreateAlias(waitJob, "wait job"))
+	commands = append(commands, cmdutil.CreateAliases(waitJob, "wait job", jobs))
 
 	var pipelineName string
 	var inputCommitStrs []string
@@ -317,7 +343,7 @@ $ {{alias}} -p foo -i bar@YYY`,
 			}
 			return shell.JobSetCompletion(flag, text, maxCompletions)
 		})
-	commands = append(commands, cmdutil.CreateAlias(listJob, "list job"))
+	commands = append(commands, cmdutil.CreateAliases(listJob, "list job", jobs))
 
 	deleteJob := &cobra.Command{
 		Use:   "{{alias}} <pipeline>@<job>",
@@ -340,7 +366,7 @@ $ {{alias}} -p foo -i bar@YYY`,
 		}),
 	}
 	shell.RegisterCompletionFunc(deleteJob, shell.JobCompletion)
-	commands = append(commands, cmdutil.CreateAlias(deleteJob, "delete job"))
+	commands = append(commands, cmdutil.CreateAliases(deleteJob, "delete job", jobs))
 
 	stopJob := &cobra.Command{
 		Use:   "{{alias}} <pipeline>@<job>",
@@ -382,7 +408,7 @@ $ {{alias}} -p foo -i bar@YYY`,
 		}),
 	}
 	shell.RegisterCompletionFunc(stopJob, shell.JobCompletion)
-	commands = append(commands, cmdutil.CreateAlias(stopJob, "stop job"))
+	commands = append(commands, cmdutil.CreateAliases(stopJob, "stop job", jobs))
 
 	datumDocs := &cobra.Command{
 		Short: "Docs for datums.",
@@ -395,7 +421,7 @@ Datums within a job will be processed independently, sometimes distributed
 across separate workers.  A separate execution of user code will be run for
 each datum.`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(datumDocs, "datum", " datum$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(datumDocs, "datum", " datum$", datums))
 
 	restartDatum := &cobra.Command{
 		Use:   "{{alias}} <pipeline>@<job> <datum-path1>,<datum-path2>,...",
@@ -425,7 +451,7 @@ each datum.`,
 			return client.RestartDatum(job.Pipeline.Name, job.ID, datumFilter)
 		}),
 	}
-	commands = append(commands, cmdutil.CreateAlias(restartDatum, "restart datum"))
+	commands = append(commands, cmdutil.CreateAliases(restartDatum, "restart datum", datums))
 
 	var pipelineInputPath string
 	listDatum := &cobra.Command{
@@ -489,7 +515,7 @@ each datum.`,
 	listDatum.Flags().StringVarP(&pipelineInputPath, "file", "f", "", "The JSON file containing the pipeline to list datums from, the pipeline need not exist")
 	listDatum.Flags().AddFlagSet(outputFlags)
 	shell.RegisterCompletionFunc(listDatum, shell.JobCompletion)
-	commands = append(commands, cmdutil.CreateAlias(listDatum, "list datum"))
+	commands = append(commands, cmdutil.CreateAliases(listDatum, "list datum", datums))
 
 	inspectDatum := &cobra.Command{
 		Use:   "{{alias}} <pipeline>@<job> <datum>",
@@ -519,7 +545,7 @@ each datum.`,
 		}),
 	}
 	inspectDatum.Flags().AddFlagSet(outputFlags)
-	commands = append(commands, cmdutil.CreateAlias(inspectDatum, "inspect datum"))
+	commands = append(commands, cmdutil.CreateAliases(inspectDatum, "inspect datum", datums))
 
 	var (
 		jobStr      string
@@ -674,7 +700,7 @@ and launch a job to process each incoming commit.
 
 All jobs created by a pipeline will create commits in the pipeline's output repo.`,
 	}
-	commands = append(commands, cmdutil.CreateDocsAlias(pipelineDocs, "pipeline", " pipeline$"))
+	commands = append(commands, cmdutil.CreateDocsAliases(pipelineDocs, "pipeline", " pipeline$", pipelines))
 
 	var pushImages bool
 	var registry string
@@ -695,7 +721,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	createPipeline.Flags().BoolVarP(&pushImages, "push-images", "p", false, "If true, push local docker images into the docker registry.")
 	createPipeline.Flags().StringVarP(&registry, "registry", "r", "index.docker.io", "The registry to push images to.")
 	createPipeline.Flags().StringVarP(&username, "username", "u", "", "The username to push images as.")
-	commands = append(commands, cmdutil.CreateAlias(createPipeline, "create pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(createPipeline, "create pipeline", pipelines))
 
 	var reprocess bool
 	updatePipeline := &cobra.Command{
@@ -712,7 +738,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	updatePipeline.Flags().StringVarP(&registry, "registry", "r", "index.docker.io", "The registry to push images to.")
 	updatePipeline.Flags().StringVarP(&username, "username", "u", "", "The username to push images as.")
 	updatePipeline.Flags().BoolVar(&reprocess, "reprocess", false, "If true, reprocess datums that were already processed by previous version of the pipeline.")
-	commands = append(commands, cmdutil.CreateAlias(updatePipeline, "update pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(updatePipeline, "update pipeline", pipelines))
 
 	runCron := &cobra.Command{
 		Use:   "{{alias}} <pipeline>",
@@ -764,7 +790,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	}
 	inspectPipeline.Flags().AddFlagSet(outputFlags)
 	inspectPipeline.Flags().AddFlagSet(timestampFlags)
-	commands = append(commands, cmdutil.CreateAlias(inspectPipeline, "inspect pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(inspectPipeline, "inspect pipeline", pipelines))
 
 	var editor string
 	var editorArgs []string
@@ -842,7 +868,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	editPipeline.Flags().BoolVar(&reprocess, "reprocess", false, "If true, reprocess datums that were already processed by previous version of the pipeline.")
 	editPipeline.Flags().StringVar(&editor, "editor", "", "Editor to use for modifying the manifest.")
 	editPipeline.Flags().StringVarP(&output, "output", "o", "", "Output format: \"json\" or \"yaml\" (default \"json\")")
-	commands = append(commands, cmdutil.CreateAlias(editPipeline, "edit pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(editPipeline, "edit pipeline", pipelines))
 
 	var spec bool
 	listPipeline := &cobra.Command{
@@ -924,7 +950,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	listPipeline.Flags().AddFlagSet(timestampFlags)
 	listPipeline.Flags().StringVar(&history, "history", "none", "Return revision history for pipelines.")
 	listPipeline.Flags().StringArrayVar(&stateStrs, "state", []string{}, "Return only pipelines with the specified state. Can be repeated to include multiple states")
-	commands = append(commands, cmdutil.CreateAlias(listPipeline, "list pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(listPipeline, "list pipeline", pipelines))
 
 	var (
 		all      bool
@@ -964,7 +990,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	deletePipeline.Flags().BoolVar(&all, "all", false, "delete all pipelines")
 	deletePipeline.Flags().BoolVarP(&force, "force", "f", false, "delete the pipeline regardless of errors; use with care")
 	deletePipeline.Flags().BoolVar(&keepRepo, "keep-repo", false, "delete the pipeline, but keep the output repo around (the pipeline can be recreated later and use the same repo)")
-	commands = append(commands, cmdutil.CreateAlias(deletePipeline, "delete pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(deletePipeline, "delete pipeline", pipelines))
 
 	startPipeline := &cobra.Command{
 		Use:   "{{alias}} <pipeline>",
@@ -982,7 +1008,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			return nil
 		}),
 	}
-	commands = append(commands, cmdutil.CreateAlias(startPipeline, "start pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(startPipeline, "start pipeline", pipelines))
 
 	stopPipeline := &cobra.Command{
 		Use:   "{{alias}} <pipeline>",
@@ -1000,7 +1026,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			return nil
 		}),
 	}
-	commands = append(commands, cmdutil.CreateAlias(stopPipeline, "stop pipeline"))
+	commands = append(commands, cmdutil.CreateAliases(stopPipeline, "stop pipeline", pipelines))
 
 	var file string
 	createSecret := &cobra.Command{
@@ -1030,7 +1056,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 		}),
 	}
 	createSecret.Flags().StringVarP(&file, "file", "f", "", "File containing Kubernetes secret.")
-	commands = append(commands, cmdutil.CreateAlias(createSecret, "create secret"))
+	commands = append(commands, cmdutil.CreateAliases(createSecret, "create secret", secrets))
 
 	deleteSecret := &cobra.Command{
 		Short: "Delete a secret from the cluster.",
@@ -1056,7 +1082,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			return nil
 		}),
 	}
-	commands = append(commands, cmdutil.CreateAlias(deleteSecret, "delete secret"))
+	commands = append(commands, cmdutil.CreateAliases(deleteSecret, "delete secret", secrets))
 
 	inspectSecret := &cobra.Command{
 		Short: "Inspect a secret from the cluster.",
@@ -1084,7 +1110,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			return writer.Flush()
 		}),
 	}
-	commands = append(commands, cmdutil.CreateAlias(inspectSecret, "inspect secret"))
+	commands = append(commands, cmdutil.CreateAliases(inspectSecret, "inspect secret", secrets))
 
 	listSecret := &cobra.Command{
 		Short: "List all secrets from a namespace in the cluster.",
@@ -1111,7 +1137,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 			return writer.Flush()
 		}),
 	}
-	commands = append(commands, cmdutil.CreateAlias(listSecret, "list secret"))
+	commands = append(commands, cmdutil.CreateAliases(listSecret, "list secret", secrets))
 
 	var seed int64
 	runLoadTest := &cobra.Command{

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -45,29 +45,11 @@ import (
 )
 
 const (
-	// Singular variables are used for testing.
-	datum    = "datum"
-	job      = "job"
-	pipeline = "pipeline"
-	secret   = "secret"
-
 	// Plural variables are used below for user convenience.
 	datums    = "datums"
 	jobs      = "jobs"
 	pipelines = "pipelines"
 	secrets   = "secrets"
-
-	// Command 'verbs' are also used in testing.
-	create  = "create"
-	delete  = "delete"
-	edit    = "edit"
-	inspect = "inspect"
-	list    = "list"
-	restart = "restart"
-	start   = "start"
-	stop    = "stop"
-	update  = "update"
-	wait    = "job"
 )
 
 // Cmds returns a slice containing pps commands.

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -58,23 +58,23 @@ const badJSON2 = `{
 }
 `
 
-func resourcesMap() map[string][]string {
-	return map[string][]string{
-		datum:    {inspect, list, restart},
-		job:      {delete, inspect, list, stop, wait},
-		pipeline: {create, delete, edit, inspect, list, start, stop, update},
-		secret:   {create, delete, inspect, list},
-	}
-}
+const (
+	datum    = "datum"
+	job      = "job"
+	pipeline = "pipeline"
+	secret   = "secret"
 
-func pluralsMap() map[string]string {
-	return map[string]string{
-		datum:    datums,
-		job:      jobs,
-		pipeline: pipelines,
-		secret:   secrets,
-	}
-}
+	create  = "create"
+	delete  = "delete"
+	edit    = "edit"
+	inspect = "inspect"
+	list    = "list"
+	restart = "restart"
+	start   = "start"
+	stop    = "stop"
+	update  = "update"
+	wait    = "job"
+)
 
 func TestSyntaxErrorsReportedCreatePipeline(t *testing.T) {
 	if testing.Short() {
@@ -1061,66 +1061,80 @@ func TestPipelineWithSecret(t *testing.T) {
 	`, "pipeline", tu.UniqueString("p-"), "secret", secretName).Run())
 }
 
-// TestPlurals walks through the command tree for each resource and verb combination defined in PPS.
+// TestSynonyms walks through the command tree for each resource and verb combination defined in PPS.
 // A template is filled in that calls the help flag and the output is compared. It seems like 'match'
 // is unable to compare the outputs correctly, but we can use diff here which returns an exit code of 0
 // if there is no difference.
-func TestPlurals(t *testing.T) {
-	pluralCheckTemplate := `
-		pachctl {{VERB}} {{RESOURCE_PLURAL}} -h > plural.txt
-		pachctl {{VERB}} {{RESOURCE}} -h > singular.txt
-		diff plural.txt singular.txt
-		rm plural.txt singular.txt
-	`
-
-	resources := resourcesMap()
-	plurals := pluralsMap()
-
+func TestSynonyms(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c, _ := minikubetestenv.AcquireCluster(t)
+	synonymCheckTemplate := `
+		pachctl {{VERB}} {{RESOURCE_SYNONYM}} -h > synonym.txt
+		pachctl {{VERB}} {{RESOURCE}} -h > singular.txt
+		diff synonym.txt singular.txt
+		rm synonym.txt singular.txt
+	`
+
+	resources := resourcesMap()
+	synonyms := synonymsMap()
 
 	for resource, verbs := range resources {
-		withResource := strings.ReplaceAll(pluralCheckTemplate, "{{RESOURCE}}", resource)
-		withResources := strings.ReplaceAll(withResource, "{{RESOURCE_PLURAL}}", plurals[resource])
+		withResource := strings.ReplaceAll(synonymCheckTemplate, "{{RESOURCE}}", resource)
+		withResources := strings.ReplaceAll(withResource, "{{RESOURCE_SYNONYM}}", synonyms[resource])
 
 		for _, verb := range verbs {
-			pluralCommand := strings.ReplaceAll(withResources, "{{VERB}}", verb)
+			synonymCommand := strings.ReplaceAll(withResources, "{{VERB}}", verb)
 			t.Logf("Testing %s %s -h\n", verb, resource)
-			require.NoError(t, tu.PachctlBashCmd(t, c, pluralCommand).Run())
+			require.NoError(t, tu.BashCmd(synonymCommand).Run())
 		}
 	}
 }
 
-// TestPluralsDocs is like TestPlurals except it only tests commands registered by CreateDocsAliases.
-func TestPluralsDocs(t *testing.T) {
-	pluralCheckTemplate := `
-		pachctl {{RESOURCE_PLURAL}} -h > plural.txt
-		pachctl {{RESOURCE}} -h > singular.txt
-		diff plural.txt singular.txt
-		rm plural.txt singular.txt
-	`
-
-	plurals := pluralsMap()
-
+// TestSynonymsDocs is like TestSynonyms except it only tests commands registered by CreateDocsAliases.
+func TestSynonymsDocs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	c, _ := minikubetestenv.AcquireCluster(t)
+	synonymCheckTemplate := `
+		pachctl {{RESOURCE_SYNONYM}} -h > synonym.txt
+		pachctl {{RESOURCE}} -h > singular.txt
+		diff synonym.txt singular.txt
+		rm synonym.txt singular.txt
+	`
 
-	for resource := range plurals {
+	synonyms := synonymsMap()
+
+	for resource := range synonyms {
 		if resource == "secret" {
 			// no help doc defined for secret yet.
 			continue
 		}
 
-		withResource := strings.ReplaceAll(pluralCheckTemplate, "{{RESOURCE}}", resource)
-		pluralCommand := strings.ReplaceAll(withResource, "{{RESOURCE_PLURAL}}", plurals[resource])
+		withResource := strings.ReplaceAll(synonymCheckTemplate, "{{RESOURCE}}", resource)
+		synonymCommand := strings.ReplaceAll(withResource, "{{RESOURCE_SYNONYM}}", synonyms[resource])
 
 		t.Logf("Testing %s -h\n", resource)
-		require.NoError(t, tu.PachctlBashCmd(t, c, pluralCommand).Run())
+		require.NoError(t, tu.BashCmd(synonymCommand).Run())
+	}
+}
+
+func resourcesMap() map[string][]string {
+	return map[string][]string{
+		datum:    {inspect, list, restart},
+		job:      {delete, inspect, list, stop, wait},
+		pipeline: {create, delete, edit, inspect, list, start, stop, update},
+		secret:   {create, delete, inspect, list},
+	}
+}
+
+func synonymsMap() map[string]string {
+	return map[string]string{
+		datum:    datums,
+		job:      jobs,
+		pipeline: pipelines,
+		secret:   secrets,
 	}
 }


### PR DESCRIPTION
This Pull Request adds support for the plural version of resources like `pipelines` or `files`. Previously, users had to input commands in a singular form like so:
```
pachctl list repo
```

Now, a user can input:
```
pachctl list repos
```

There's no difference in the execution of these commands under the hood, the plurals are just the aliases of the original commands. 