### PR TITLE
[2.2.x backport] avoid using 31800 for all nodeports, give each test a unique port 

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6958,7 +6958,7 @@ func TestServiceEnvVars(t *testing.T) {
 			Update: false,
 			Service: &pps.Service{
 				InternalPort: 8000,
-				ExternalPort: 31800,
+				ExternalPort: 31801,
 			},
 		})
 	require.NoError(t, err)
@@ -6969,7 +6969,7 @@ func TestServiceEnvVars(t *testing.T) {
 		if _, ok := os.LookupEnv("KUBERNETES_PORT"); !ok {
 			// Outside cluster: Re-use external IP and external port defined above
 			host := c.GetAddress().Host
-			return net.JoinHostPort(host, "31800")
+			return net.JoinHostPort(host, "31801")
 		}
 		// Get k8s service corresponding to pachyderm service above--must access
 		// via internal cluster IP, but we don't know what that is

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -441,7 +441,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 				Spout: &pps.Spout{
 					Service: &pps.Service{
 						InternalPort: 8000,
-						ExternalPort: 31800,
+						ExternalPort: 31803,
 					},
 				},
 			})
@@ -449,7 +449,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 		time.Sleep(20 * time.Second)
 
 		host := c.GetAddress().Host
-		serviceAddr := net.JoinHostPort(host, "31800")
+		serviceAddr := net.JoinHostPort(host, "31803")
 
 		// Write a tar stream with a single file to
 		// the tcp connection of the pipeline service's


### PR DESCRIPTION
Backport some flakiness fixing test improvements (#7559)