### PR TITLE
Add a test to ensure that the proxy multiplexing works

### DIFF
--- a/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
@@ -2,7 +2,8 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.proxy.enabled .Values.console.enabled -}}
+{{- /* Deploy even if console is disabled, so the lack of endpoints is more easily apparent. */ -}}
+{{- if and .Values.proxy.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -427,6 +427,9 @@ func NoErrorWithinTRetry(tb testing.TB, t time.Duration, f func() error, msgAndA
 	var userError error
 	err := backoff.RetryUntilCancel(ctx, func() error {
 		userError = f()
+		if userError != nil {
+			tb.Logf("retryable: %v", userError)
+		}
 		return userError
 	}, backoff.NewExponentialBackOff(), nil)
 	if err != nil {

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/minio/minio-go/v6"
+	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+func get(t *testing.T, url string) error {
+	t.Helper()
+	hc := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	ctx, c := context.WithTimeout(context.Background(), 5*time.Second)
+	defer c()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return errors.Errorf("create http request for %v: %w", url, err)
+	}
+
+	res, err := hc.Do(req)
+	if err != nil {
+		return errors.Errorf("execute http request for %v: %w", url, err)
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Logf("warning: get %v: problem reading body: %v", url, err)
+	}
+	if got, want := res.StatusCode, http.StatusOK; got != want {
+		t.Logf("get %v: body:\n%s", url, body)
+		return errors.Errorf("get %v: response code\n  got: %v\n want: %v", url, got, want)
+	}
+	return nil
+}
+
+func proxyTest(t *testing.T, c *client.APIClient, secure bool) {
+	t.Helper()
+	httpPrefix := "http://"
+	if secure {
+		httpPrefix = "https://"
+	}
+	addr := fmt.Sprintf("%v:%d", c.GetAddress().Host, c.GetAddress().Port)
+
+	// Test console.
+	t.Run("TestConsole", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			return get(t, httpPrefix+addr+"/")
+		}, "should be able to load console")
+	})
+
+	// Test OIDC.
+	t.Run("TestOIDC", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			return get(t, httpPrefix+addr+"/dex/.well-known/openid-configuration")
+		}, "should be able to load openid config")
+	})
+
+	testText := []byte("this is a test\n")
+	for i := 0; i < 8*1024*1024; i++ {
+		// Make sure the file doesn't fit in a single message.  Default message size is 4MB,
+		// so 8MiB is comfortably large enough to ensure that both pachd and Envoy agree on
+		// that it won't fit in a single message.
+		testText = append(testText, (byte(i)%26)+'A')
+	}
+
+	// Test GRPC API.
+	t.Run("TestGRPC", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			if err := c.CreateRepo("test"); err != nil {
+				return errors.Errorf("create repo: %w", err)
+			}
+			if err := c.PutFile(client.NewRepo("test").NewCommit("master", ""), "test.txt", bytes.NewReader(testText)); err != nil {
+				return errors.Errorf("put file: %w", err)
+			}
+			return nil
+		}, "should be able to upload a file over grpc")
+	})
+
+	// Test S3 API.
+	t.Run("TestS3", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
+			s3v4, err := minio.NewV4(addr, c.AuthToken(), c.AuthToken(), secure)
+			if err != nil {
+				return errors.Errorf("get s3v4 client: %w", err)
+			}
+			s3v2, err := minio.NewV2(addr, c.AuthToken(), c.AuthToken(), secure)
+			if err != nil {
+				return errors.Errorf("get s3v2 client: %w", err)
+			}
+
+			for name, client := range map[string]interface {
+				GetObject(string, string, minio.GetObjectOptions) (*minio.Object, error)
+			}{"v4": s3v4, "v2": s3v2} {
+				obj, err := client.GetObject("master.test", "test.txt", minio.GetObjectOptions{})
+				if err != nil {
+					return errors.Errorf("s3%v: get object: %w", name, err)
+				}
+				got, err := io.ReadAll(obj)
+				if err != nil {
+					return errors.Errorf("s3%v: read all: %w", name, err)
+				}
+				want := testText
+				if diff := cmp.Diff(got, want); diff != "" {
+					return errors.Errorf("s3%v: content:\n%v", name, diff)
+				}
+			}
+			return nil
+		}, "should be able to retrieve files over S3")
+	})
+}
+
+func deployFakeConsole(t *testing.T, ns string) {
+	t.Helper()
+	ctx := context.Background()
+	c := testutil.GetKubeClient(t)
+	lbl := map[string]string{
+		"app":   "console",
+		"suite": "pachyderm",
+	}
+	aopts := metav1.ApplyOptions{
+		FieldManager: "proxy_test",
+	}
+
+	cm := applyv1.ConfigMap("fake-console-html", ns)
+	cm.Data = map[string]string{
+		"index.html": "<html><head><title>Hi</title></head><body><p>Hello from console!</p></body></html>",
+	}
+	_, err := c.CoreV1().ConfigMaps(ns).Apply(ctx, cm, aopts)
+	require.NoError(t, err, "should create a configmap for the fake console HTML files")
+
+	cm = applyv1.ConfigMap("fake-console-config", ns)
+	cm.Data = map[string]string{
+		"default.conf": `server {
+			listen       4000;
+			server_name  localhost;
+
+			access_log  /dev/stdout  main;
+
+			location / {
+			    root   /usr/share/nginx/html;
+			    index  index.html;
+			}
+		    }`,
+	}
+	_, err = c.CoreV1().ConfigMaps(ns).Apply(ctx, cm, aopts)
+	require.NoError(t, err, "should create a configmap for the fake console config files")
+
+	dep := applyappsv1.Deployment("console", ns)
+	dep.ObjectMetaApplyConfiguration.Labels = lbl
+	dep.Spec = applyappsv1.DeploymentSpec().WithReplicas(1).WithSelector(applymetav1.LabelSelector().WithMatchLabels(lbl))
+	dep.Spec.Template = applyv1.PodTemplateSpec()
+	dep.Spec.Template.ObjectMetaApplyConfiguration = applymetav1.ObjectMeta().WithName("console").WithNamespace(ns).WithLabels(lbl)
+	dep.Spec.Template.Spec = applyv1.PodSpec().
+		WithContainers(applyv1.Container().
+			WithName("console").
+			WithImage("nginx:latest").
+			WithPorts(applyv1.ContainerPort().WithContainerPort(4000).WithName("console-http").WithProtocol(v1.ProtocolTCP)).
+			WithVolumeMounts(
+				applyv1.VolumeMount().WithName("html").WithMountPath("/usr/share/nginx/html"),
+				applyv1.VolumeMount().WithName("config").WithMountPath("/etc/nginx/conf.d"),
+			).
+			WithReadinessProbe(applyv1.Probe().WithHTTPGet(
+				applyv1.HTTPGetAction().WithPort(intstr.FromInt(4000)).WithPath("/")))).
+		WithVolumes(
+			applyv1.Volume().WithName("html").WithConfigMap(applyv1.ConfigMapVolumeSource().WithName("fake-console-html")),
+			applyv1.Volume().WithName("config").WithConfigMap(applyv1.ConfigMapVolumeSource().WithName("fake-console-config")),
+		)
+	_, err = c.AppsV1().Deployments(ns).Apply(ctx, dep, aopts)
+	require.NoError(t, err, "should create a 'console' deployment")
+
+	t.Log("waiting for the console backend service to have endpoints")
+	var ok bool
+	for i := 0; i < 30; i++ {
+		ep, err := c.CoreV1().Endpoints(ns).Get(ctx, "console-proxy-backend", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("get console service endpoints: %v", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		if ss := ep.Subsets; len(ss) > 0 {
+			t.Logf("console endpoints: %v", ss)
+			ok = true
+			break
+		}
+		t.Log("no endpoints yet")
+		time.Sleep(time.Second)
+	}
+	if !ok {
+		t.Fatal("never got console endpoints")
+	}
+}
+
+func TestTrafficThroughProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	c, ns := minikubetestenv.AcquireCluster(t)
+	deployFakeConsole(t, ns)
+	testutil.ActivateAuthClient(t, c)
+	testutil.ConfigureOIDCProvider(t, c)
+	proxyTest(t, c, false)
+}


### PR DESCRIPTION
This PR adds a test that tests all operations through the multiplexed port.  It was part of the TLS work (we wanted to test that better), but it's simpler if we add this test first, since a bit of refactoring is required to get the TLS secrets into minikubetestenv clusters, and the PR was becoming large.  (The non-TLS case adds some additional assurances that the proxy works correctly, though.  This isn't stub code that will be useful in the future, but is useful right now.)

The way I add "console" into the cluster (actually nginx just serving a static page) is by applying it after minikubetestenv starts.  That means when this namespace is used again, it's still there.  This isn't a problem for the test, since I used the server-side apply API instead of a straight 'Create'.  But that is potentially unclean if people started doing it in general, so maybe not the best idea.

Finally, I initially wrote my own retry logic to get incremental error messages after each retry and before the test ended, and decided it would be better to add that feature to the main `require.NoErrorWithinTRetry`.  You are welcome to object to this change, it's pretty out of scope for this PR, but was better than using a non-standard retryer.  (I wrote it that way first, but decided it would be best to retry all the tests and not just the HTTP-GET-based tests.  So using NoErrorWithinTRetry for every case seemed cleanest.)