### PR TITLE
Add Ability to Override Default ServiceType Behavior in Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #### VARIABLES
-# TESTFLAGS: flags for test
+# TESTFLAGS: flags for test.
+#   you can set -proxy.service.type to ether "LoadBalancer" or "NodePort" to override testing behavior
 # KUBECTLFLAGS: flags for kubectl
 # DOCKER_BUILD_FLAGS: flags for 'docker build'
 ####

--- a/src/internal/minikubetestenv/client_factory.go
+++ b/src/internal/minikubetestenv/client_factory.go
@@ -39,9 +39,10 @@ var EnterpriseMemberOption = func(ds *acquireSettings) {
 var (
 	clusterFactory      *ClusterFactory
 	setup               sync.Once
-	poolSize            *int  = flag.Int("clusters.pool", 6, "maximum size of managed pachyderm clusters")
-	useLeftoverClusters *bool = flag.Bool("clusters.reuse", false, "reuse leftover pachyderm clusters if available")
-	cleanupDataAfter    *bool = flag.Bool("clusters.data.cleanup", true, "cleanup the data following each test")
+	poolSize            *int    = flag.Int("clusters.pool", 6, "maximum size of managed pachyderm clusters")
+	useLeftoverClusters *bool   = flag.Bool("clusters.reuse", false, "reuse leftover pachyderm clusters if available")
+	cleanupDataAfter    *bool   = flag.Bool("clusters.data.cleanup", true, "cleanup the data following each test")
+	serviceTypeOverride *string = flag.String("proxy.service.type", "", "overrides the default service used, which is determined by your OS")
 )
 
 type ClusterFactory struct {

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -98,6 +98,10 @@ func getPachAddress(t testing.TB) *grpcutil.PachdAddress {
 }
 
 func exposedServiceType() string {
+	if *serviceTypeOverride != "" {
+		return *serviceTypeOverride
+	}
+
 	os := runtime.GOOS
 	serviceType := ""
 	switch os {


### PR DESCRIPTION
## Description
This Pull Request allows an engineer to explicitly select the `proxyServiceType` for their `pachd-proxy-service` when running tests locally. Normally the service type is chosen based on your `GOOS` variable. This flag is handy if you would like to use something other than the default for your operating system.