### PR TITLE
[CORE-701] Backport egress of CSVs with headers

### DIFF
--- a/src/internal/miscutil/miscutil.go
+++ b/src/internal/miscutil/miscutil.go
@@ -25,7 +25,10 @@ func WithPipe(wcb func(w io.Writer) error, rcb func(r io.Reader) error) error {
 		pr.CloseWithError(err)
 		return errors.EnsureStack(err)
 	})
-	return errors.EnsureStack(eg.Wait())
+	if err := eg.Wait(); err != nil {
+		return errors.EnsureStack(err)
+	}
+	return nil
 }
 
 // Iterator provides functionality for generic imperative iteration.

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -56,6 +57,14 @@ func sqlIngest(ctx context.Context, log *logrus.Logger, args []string) error {
 		return errors.Errorf("must provide db url and format")
 	}
 	urlStr, formatName := args[0], args[1]
+	var hasHeader bool
+	if len(args) > 2 {
+		var err error
+		hasHeader, err = strconv.ParseBool(args[2])
+		if err != nil {
+			return errors.EnsureStack(err)
+		}
+	}
 	password, ok := os.LookupEnv(passwordEnvar)
 	if !ok {
 		return errors.Errorf("must set %v", passwordEnvar)
@@ -79,9 +88,10 @@ func sqlIngest(ctx context.Context, log *logrus.Logger, args []string) error {
 		InputDir:  inputDir,
 		OutputDir: outputDir,
 
-		URL:      *u,
-		Password: secrets.Secret(password),
-		Format:   formatName,
+		URL:       *u,
+		Password:  secrets.Secret(password),
+		Format:    formatName,
+		HasHeader: hasHeader,
 	})
 }
 

--- a/src/server/pfs/server/egress.go
+++ b/src/server/pfs/server/egress.go
@@ -91,9 +91,11 @@ func copyToSQLDB(ctx context.Context, src Source, destURL string, fileFormat *pf
 				var tr sdata.TupleReader
 				switch fileFormat.Type {
 				case pfs.SQLDatabaseEgress_FileFormat_CSV:
-					tr = sdata.NewCSVParser(r)
+					tr = sdata.NewCSVParser(r).WithHeaderFields(fileFormat.Columns)
 				case pfs.SQLDatabaseEgress_FileFormat_JSON:
 					tr = sdata.NewJSONParser(r, fileFormat.Columns)
+				default:
+					return errors.Errorf("unknown file format %v", fileFormat.Type)
 				}
 				tw := sdata.NewSQLTupleWriter(tx, tableInfo)
 				tuple, err := sdata.NewTupleFromTableInfo(tableInfo)

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -75,7 +75,10 @@ func (s *source) Iterate(ctx context.Context, cb func(*pfs.FileInfo, fileset.Fil
 			fi.Hash = computedFi.Hash
 		}
 		// TODO: Figure out how to remove directory infos from cache when they are no longer needed.
-		return cb(fi, f)
+		if err := cb(fi, f); err != nil {
+			return errors.EnsureStack(err)
+		}
+		return nil
 	})
 	return errors.EnsureStack(err)
 }

--- a/src/templates/sql_ingest_cron.jsonnet
+++ b/src/templates/sql_ingest_cron.jsonnet
@@ -1,50 +1,48 @@
 local newPipeline(name, input, transform) = {
-	pipeline: {
-		name: name,
-	},
-	transform: transform,
-	input: input,	
+  pipeline: {
+    name: name,
+  },
+  transform: transform,
+  input: input,
 };
-local pachtf(args, secretName="") = {
-	image: "pachyderm/pachtf:2.2.1",
-	cmd: ["/app/pachtf"] + args,
-	secrets: if secretName != "" then
-		[
-			{
-				name: secretName,
-				env_var: "PACHYDERM_SQL_PASSWORD",
-				key: "PACHYDERM_SQL_PASSWORD",
-			}
-		]
-	else
-		null
-	,
+local pachtf(args, secretName='') = {
+  image: 'pachyderm/pachtf:latest',
+  cmd: ['/app/pachtf'] + args,
+  secrets: if secretName != '' then
+    [
+      {
+        name: secretName,
+        env_var: 'PACHYDERM_SQL_PASSWORD',
+        key: 'PACHYDERM_SQL_PASSWORD',
+      },
+    ]
+  else
+    null,
 };
 
-function (name, url, query, format, cronSpec, secretName)
-	local queryPipelineName = name + "_queries";
-	[
-	newPipeline(
-		name=queryPipelineName,
-	 	input={
-			cron: {
-				name: "in",
-				spec: cronSpec,
-				overwrite: true,
-			}
-	  },
-	  transform=pachtf(["sql-gen-queries", query]),
-	),
-	newPipeline(
-		name=name,
-		input={
-			pfs: {
-				name: "in",
-				repo: queryPipelineName,
-				glob: "/*",
-			},
-		},
-		transform=pachtf(["sql-ingest", url, format], secretName),
-	)
-	]
-
+function(name, url, query, format, cronSpec, secretName, hasHeader='false')
+  local queryPipelineName = name + '_queries';
+  [
+    newPipeline(
+      name=queryPipelineName,
+      input={
+        cron: {
+          name: 'in',
+          spec: cronSpec,
+          overwrite: true,
+        },
+      },
+      transform=pachtf(['sql-gen-queries', query]),
+    ),
+    newPipeline(
+      name=name,
+      input={
+        pfs: {
+          name: 'in',
+          repo: queryPipelineName,
+          glob: '/*',
+        },
+      },
+      transform=pachtf(['sql-ingest', url, format, hasHeader], secretName),
+    ),
+  ]


### PR DESCRIPTION
* Working version of CSV egress with headers

Header row is implied by the presence of named columns. Column ordering is detected from the header row.  Headerless CSV files still must match the order of columns in the table being egressed to.

* add header info to pachtf

* make hasHeader optional