### PR TITLE
[FRON-472] enable console by default

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -50,7 +50,7 @@ global:
 
 console:
   # enabled controls whether the console manifests are created or not.
-  enabled: false
+  enabled: true
   annotations: {}
   image:
     # repository is the image repo to pull from; together with tag it


### PR DESCRIPTION
We'll want to merge this last to release community edition console

With the context that console's being updated to work without authentication, is there anything else that'd need to be set here?