### PR TITLE
driver: avoid an unlikely-to-succeed call to setgroups() when running non-root user code

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9889,6 +9889,7 @@ func TestNonrootPipeline(t *testing.T) {
 			Transform: &pps.Transform{
 				Cmd:   []string{"bash"},
 				Stdin: []string{fmt.Sprintf("cp /pfs/%s/* /pfs/out/", dataRepo)},
+				User:  "65534", // This is "nobody" on the default ubuntu:20.04 container, but it works.
 			},
 			ParallelismSpec: &pps.ParallelismSpec{
 				Constant: 1,
@@ -9898,7 +9899,7 @@ func TestNonrootPipeline(t *testing.T) {
 			Update:       false,
 			PodPatch: `[
 				{"op": "add",  "path": "/securityContext",  "value": {}},
-				{"op": "add",  "path": "/securityContext/runAsUser",  "value": 1000}
+				{"op": "add",  "path": "/securityContext/runAsUser",  "value": 65534}
 			]`,
 			Autoscaling: false,
 		},

--- a/src/server/worker/driver/driver_unix.go
+++ b/src/server/worker/driver/driver_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package driver
@@ -16,8 +17,9 @@ import (
 func makeCmdCredentials(uid uint32, gid uint32) *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
-			Uid: uid,
-			Gid: gid,
+			Uid:         uid,
+			Gid:         gid,
+			NoSetGroups: true,
 		},
 	}
 }


### PR DESCRIPTION
I adjusted the test to exercise this case.

Basically, the only way the user container can be run with a security context is to set `transform.user` in the pipeline spec.  I tried this in the tests and with a custom container built to run as not-root, and I couldn't get it to ever work.  I `strace`'d it and found that `os/exec` calls `Setgroups(0, NULL)` and gets  `EPERM`.  It turns out that we told `exec` to do this, and it's incorrect in the rootless security context, so I made it stop doing that.

The test I changed fails without the change in `driver_unix.go` and passes with my change.