### PR TITLE
envoy: use the default idle_timeout

### DIFF
--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -105,7 +105,7 @@
       codec_type: 'auto',
       common_http_protocol_options: {
         headers_with_underscores_action: 'REJECT_REQUEST',
-        idle_timeout: '60s',
+        idle_timeout: '3600s',
       },
       http2_protocol_options: {
         initial_connection_window_size: 1048576,

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -346,7 +346,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -430,7 +430,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -626,7 +626,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -346,7 +346,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -509,7 +509,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -593,7 +593,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -702,7 +702,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -793,7 +793,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -876,7 +876,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -959,7 +959,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -1042,7 +1042,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "60s"
+                              "idle_timeout": "3600s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,


### PR DESCRIPTION
For some reason, I set a very aggressive `idle_timeout`.  This doesn't cause any harm, but it's annoying.  `debug-dump-server` polls Pachyderm every 60 seconds and it always has to create a new channel.   That doesn't cause any problems (the RPC proceeds as normal transparently), but it's kind of a waste of resources.  I feel like I'm probably not the only person who will want to keep an idle connection around for a while, so I've reverted this to the default of 1 hour:

https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts

Do note that this timeout is only for channels with no RPCs whatsoever; things like WaitCommit, PutFile, etc. are not considered idle.  So there is no harm in this being 60s, it just bugs me.
