### PR TITLE
makefile: protos: build proto compilation container for the host

### DIFF
--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,19 +1,21 @@
 FROM golang:1.17.3
+
 LABEL maintainer="msteffen@pachyderm.io"
 
-ENV GOPROXY https://proxy.golang.org
+ARG PROTO_COMPILER_VERSION=3.11.4
+ARG TARGETPLATFORM
 
 RUN apt-get update -yq && apt-get install -yq unzip
 
 # Install protoc
-RUN \
-  PROTO_COMPILER_VERSION=3.11.4; \
-  wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTO_COMPILER_VERSION}/protoc-${PROTO_COMPILER_VERSION}-linux-x86_64.zip" -O protoc.zip
+RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTO_COMPILER_VERSION}/protoc-${PROTO_COMPILER_VERSION}-linux-x86_64.zip" -O protoc.zip; fi
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTO_COMPILER_VERSION}/protoc-${PROTO_COMPILER_VERSION}-linux-aarch_64.zip" -O protoc.zip; fi
+
 RUN unzip protoc.zip -d /
 RUN cp -r /include /bin
 
 # if you modify the version of gogo/protobuf. you also need to update the path in run.sh
-RUN go install -v github.com/gogo/protobuf/protoc-gen-gofast@v1.3.2 github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.2 
+RUN go install -v github.com/gogo/protobuf/protoc-gen-gofast@v1.3.2 github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.2
 RUN mkdir -p ${GOPATH}/src/github.com/pachyderm/pachyderm
 RUN date +%s >/last_run_time
 


### PR DESCRIPTION
This adjusts the makefile to build the proto compiler container for the host's architecture.  I chose host instead of multi-arch because it's unlikely you would ever run this on an architecture other than your host machine.

It will totally work if you just pass in `linux/amd64,linux/arm64` instead of `linux/$(go env GOARCH)`, though.  It's just very slow to build the emulated version and unnecessary.