### PR TITLE
[CORE-591] Deflake TestUpdatePipelineRunningJob

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3080,7 +3080,6 @@ func TestUpdatePipelineRunningJob(t *testing.T) {
 	require.NoError(t, c.FinishCommit(dataRepo, commit2.Branch.Name, commit2.ID))
 
 	b := backoff.NewTestingBackOff()
-	b.MaxElapsedTime = 30 * time.Second
 	require.NoError(t, backoff.Retry(func() error {
 		jobInfos, err := c.ListJob(pipelineName, nil, -1, true)
 		if err != nil {


### PR DESCRIPTION
Occasionally, the job doesn't get started in time. This change increases the max elapsed time for the testing backoff from 30s (override) to 60s (default)