### PR TITLE
Avoid scrubbing get file error message.

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1289,8 +1289,8 @@ $ {{alias}} foo@master:XXX -r
 			}
 			if err := c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes)); err != nil {
 				msg := err.Error()
-				if strings.Contains(msg, pfsserver.GetFileTARString) {
-					err = errors.New(strings.ReplaceAll(msg, pfsserver.GetFileTARString, "Use the -r flag instead"))
+				if strings.Contains(msg, pfsserver.GetFileTARSuggestion) {
+					err = errors.New(strings.ReplaceAll(msg, pfsserver.GetFileTARSuggestion, "Use the -r flag instead"))
 				}
 				return errors.Wrapf(err, "couldn't download %s from %s", file.Path, file.Commit)
 			}

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1204,7 +1204,7 @@ $ {{alias}} repo@branch -i http://host/path`,
 		Short: "Return the contents of a file.",
 		Long:  "Return the contents of a file.",
 		Example: `
-# get file "XXX" on branch "master" in repo "foo"
+# get a single file "XXX" on branch "master" in repo "foo"
 $ {{alias}} foo@master:XXX
 
 # get file "XXX" in the parent of the current head of branch "master"
@@ -1217,7 +1217,11 @@ $ {{alias}} foo@master^2:XXX
 
 # get file "test[].txt" on branch "master" in repo "foo"
 # the path is interpreted as a glob pattern: quote and protect regex characters
-$ {{alias}} 'foo@master:/test\[\].txt'`,
+$ {{alias}} 'foo@master:/test\[\].txt'
+
+# get all files under the directory "XXX" on branch "master" in repo "foo"
+$ {{alias}} foo@master:XXX -r
+`,
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			if !enableProgress {
 				progress.Disable()
@@ -1282,13 +1286,11 @@ $ {{alias}} 'foo@master:/test\[\].txt'`,
 				defer f.Close()
 				w = f
 			}
-			if err := c.GetFile(file.Commit, file.Path, w); err != nil {
-				return errors.Errorf("File %s not found. Command only supports file paths", file.Path)
-			}
-			return nil
+			return errors.Wrapf(c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes)),
+				"couldn't download %s from %s", file.Path, file.Commit)
 		}),
 	}
-	getFile.Flags().BoolVarP(&recursive, "recursive", "r", false, "Recursively download a directory.")
+	getFile.Flags().BoolVarP(&recursive, "recursive", "r", false, "Download multiple files, or recursively download a directory.")
 	getFile.Flags().StringVarP(&outputPath, "output", "o", "", "The path where data will be downloaded.")
 	getFile.Flags().BoolVar(&enableProgress, "progress", isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()), "{true|false} Whether or not to print the progress bars.")
 	getFile.Flags().Int64Var(&offsetBytes, "offset", 0, "The number of bytes in the file to skip ahead when reading.")

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pager"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsload"
@@ -1286,8 +1287,14 @@ $ {{alias}} foo@master:XXX -r
 				defer f.Close()
 				w = f
 			}
-			return errors.Wrapf(c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes)),
-				"couldn't download %s from %s", file.Path, file.Commit)
+			if err := c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes); err != nil {
+				msg := err.Error()
+				if strings.Contains(msg, pfsserver.GetFileTARString) {
+					err = errors.New(strings.ReplaceAll(msg, pfsserver.GetFileTARString, "Use the -r flag instead"))
+				}
+				return errors.Wrapf(err, "couldn't download %s from %s", file.Path, file.Commit)
+			}
+			return nil
 		}),
 	}
 	getFile.Flags().BoolVarP(&recursive, "recursive", "r", false, "Download multiple files, or recursively download a directory.")

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
-	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pager"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsload"
@@ -35,6 +34,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/server/cmd/pachctl/shell"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/server/pfs/pretty"
 	txncmds "github.com/pachyderm/pachyderm/v2/src/server/transaction/cmds"
 )
@@ -1287,7 +1287,7 @@ $ {{alias}} foo@master:XXX -r
 				defer f.Close()
 				w = f
 			}
-			if err := c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes); err != nil {
+			if err := c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes)); err != nil {
 				msg := err.Error()
 				if strings.Contains(msg, pfsserver.GetFileTARString) {
 					err = errors.New(strings.ReplaceAll(msg, pfsserver.GetFileTARString, "Use the -r flag instead"))

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1290,7 +1290,7 @@ $ {{alias}} foo@master:XXX -r
 			if err := c.GetFile(file.Commit, file.Path, w, client.WithOffset(offsetBytes)); err != nil {
 				msg := err.Error()
 				if strings.Contains(msg, pfsserver.GetFileTARSuggestion) {
-					err = errors.New(strings.ReplaceAll(msg, pfsserver.GetFileTARSuggestion, "Use the -r flag instead"))
+					err = errors.New(strings.ReplaceAll(msg, pfsserver.GetFileTARSuggestion, "Try again with the -r flag"))
 				}
 				return errors.Wrapf(err, "couldn't download %s from %s", file.Path, file.Commit)
 			}

--- a/src/server/pfs/cmds/cmds_test.go
+++ b/src/server/pfs/cmds/cmds_test.go
@@ -205,8 +205,8 @@ func TestGetFileError(t *testing.T) {
 	}
 	checkError("bad", "/foo", "not found")
 	checkError("master", "/bad", "not found")
-	checkError("master", "/dir", "Use -r instead")
-	checkError("master", "/dir/*", "Use -r instead")
+	checkError("master", "/dir", "Try again with the -r flag")
+	checkError("master", "/dir/*", "Try again with the -r flag")
 }
 
 // TestSynonyms walks through the command tree for each resource and verb combination defined in PPS.

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -136,6 +136,13 @@ type ErrDropWithChildren struct {
 	Commit *pfs.Commit
 }
 
+const GetFileTARString = "Use GetFileTAR instead"
+
+var (
+	ErrMatchedNonFile       = fmt.Errorf("cannot get directory or non-regular file. %s", GetFileTARString)
+	ErrMatchedMultipleFiles = fmt.Errorf("matched multiple files. %s", GetFileTARString)
+)
+
 func (e ErrFileNotFound) Error() string {
 	return fmt.Sprintf("file %v not found in repo %v at commit %v", e.File.Path, e.File.Commit.Branch.Repo, e.File.Commit.ID)
 }

--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -136,11 +136,11 @@ type ErrDropWithChildren struct {
 	Commit *pfs.Commit
 }
 
-const GetFileTARString = "Use GetFileTAR instead"
+const GetFileTARSuggestion = "Use GetFileTAR instead"
 
 var (
-	ErrMatchedNonFile       = fmt.Errorf("cannot get directory or non-regular file. %s", GetFileTARString)
-	ErrMatchedMultipleFiles = fmt.Errorf("matched multiple files. %s", GetFileTARString)
+	ErrMatchedNonFile       = fmt.Errorf("cannot get directory or non-regular file. %s", GetFileTARSuggestion)
+	ErrMatchedMultipleFiles = fmt.Errorf("matched multiple files. %s", GetFileTARSuggestion)
 )
 
 func (e ErrFileNotFound) Error() string {

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -5,11 +5,13 @@ import (
 	"path"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
-	"golang.org/x/net/context"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 )
 
 // Source iterates over FileInfos generated from a fileset.FileSet
@@ -200,13 +202,13 @@ func checkSingleFile(ctx context.Context, src Source) error {
 	var count int
 	err := src.Iterate(ctx, func(finfo *pfs.FileInfo, fsFile fileset.File) error {
 		if finfo.FileType != pfs.FileType_FILE {
-			return errors.Errorf("cannot get directory or non-regular file. Use GetFileTAR or the -r flag")
+			return errors.EnsureStack(pfsserver.ErrMatchedNonFile)
 		}
 		if count == 0 {
 			count++
 			return nil
 		}
-		return errors.Errorf("matched multiple files. Use GetFileTAR or the -r flag")
+		return errors.EnsureStack(pfsserver.ErrMatchedMultipleFiles)
 	})
 	return errors.EnsureStack(err)
 }

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -200,13 +200,13 @@ func checkSingleFile(ctx context.Context, src Source) error {
 	var count int
 	err := src.Iterate(ctx, func(finfo *pfs.FileInfo, fsFile fileset.File) error {
 		if finfo.FileType != pfs.FileType_FILE {
-			return errors.Errorf("cannot get non-regular file. Try GetFileTAR for directories")
+			return errors.Errorf("cannot get directory or non-regular file. Use GetFileTAR or the -r flag")
 		}
 		if count == 0 {
 			count++
 			return nil
 		}
-		return errors.Errorf("matched multiple files. Try GetFileTAR")
+		return errors.Errorf("matched multiple files. Use GetFileTAR or the -r flag")
 	})
 	return errors.EnsureStack(err)
 }


### PR DESCRIPTION
Mostly revert #6668, which threw away the original error message in
favor of some not-entirely-clear advice. Also point users directly to -r
in multi-file cases, and clarify the help text.