### PR TITLE
[2.2.x Backport] Enterprise Members shouldn't run the Identity/Dex Service (#7701)

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/config-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/config-secret.yaml
@@ -81,7 +81,13 @@ stringData:
   idps: |
     {{ include "pachyderm.idps" . }}
   {{- end }}
-  
+
+  # identityServiceConfig configures the OIDC provider
+  # id_token_expiry, and rotation_token_expiry value is parsed into golang's time.Duration: https://pkg.go.dev/time#example-ParseDuration
+  identityServiceConfig: |  
+    issuer: {{ include "pachyderm.issuerURI" . }}
+    id_token_expiry: {{ .Values.oidc.IDTokenExpiry }}
+    rotation_token_expiry: {{ .Values.oidc.RotationTokenExpiry }}
   {{- end }}
   
   {{- if .Values.pachd.enterpriseLicenseKeySecretName }}
@@ -113,12 +119,6 @@ stringData:
     - groups
     - openid 
 
-  # identityServiceConfig configures the OIDC provider
-  # id_token_expiry, and rotation_token_expiry value is parsed into golang's time.Duration: https://pkg.go.dev/time#example-ParseDuration
-  identityServiceConfig: |  
-    issuer: {{ include "pachyderm.issuerURI" . }}
-    id_token_expiry: {{ .Values.oidc.IDTokenExpiry }}
-    rotation_token_expiry: {{ .Values.oidc.RotationTokenExpiry }}
 
   # oidcClients is the set of OIDC clients registered with the OIDC provider
   # the config-pod (job that sets up pachyderm using this data) resolves oidcClient 

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -192,6 +192,8 @@ spec:
           value: {{ .Values.pachd.securityContext.enabled | quote }}
         - name: UNPAUSED_MODE
           value: "full"
+        - name: ENTERPRISE_MEMBER
+          value: {{ .Values.pachd.activateEnterpriseMember | quote }}
         {{ if .Values.global.postgresql.identityDatabaseFullNameOverride }}
         - name: IDENTITY_SERVER_DATABASE
           value: {{ .Values.global.postgresql.identityDatabaseFullNameOverride }}

--- a/src/internal/minikubetestenv/client_factory.go
+++ b/src/internal/minikubetestenv/client_factory.go
@@ -22,13 +22,18 @@ const (
 )
 
 type acquireSettings struct {
-	WaitForLoki bool
+	WaitForLoki      bool
+	EnterpriseMember bool
 }
 
 type Option func(*acquireSettings)
 
 var WaitForLokiOption = func(ds *acquireSettings) {
 	ds.WaitForLoki = true
+}
+
+var EnterpriseMemberOption = func(ds *acquireSettings) {
+	ds.EnterpriseMember = true
 }
 
 var (

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -48,9 +48,11 @@ type DeployOpts struct {
 	// Because NodePorts are cluster-wide, we use a PortOffset to
 	// assign separate ports per deployment.
 	// NOTE: it might make more sense to declare port instead of offset
-	PortOffset  uint16
-	Loki        bool
-	WaitSeconds int
+	PortOffset       uint16
+	Loki             bool
+	WaitSeconds      int
+	EnterpriseMember bool
+	ValueOverrides   map[string]string
 }
 
 type helmPutE func(t terraTest.TestingT, options *helm.Options, chart string, releaseName string) error
@@ -331,6 +333,9 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 	if opts.Enterprise {
 		createSecretEnterpriseKeySecret(t, ctx, kubeClient, namespace)
 		helmOpts = union(helmOpts, withEnterprise(namespace, pachAddress))
+	}
+	if opts.EnterpriseMember {
+		helmOpts = union(helmOpts, &helm.Options{SetValues: map[string]string{"pachd.enterpriseMember": "true"}})
 	}
 	if opts.Loki {
 		helmOpts = union(helmOpts, withLokiOptions(namespace, int(pachAddress.Port)))

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -5,6 +5,7 @@ type Configuration struct {
 	*GlobalConfiguration
 	*PachdSpecificConfiguration
 	*WorkerSpecificConfiguration
+	*EnterpriseSpecificConfiguration
 }
 
 // GlobalConfiguration contains the global configuration.
@@ -79,6 +80,7 @@ type GlobalConfiguration struct {
 type PachdFullConfiguration struct {
 	GlobalConfiguration
 	PachdSpecificConfiguration
+	EnterpriseSpecificConfiguration
 }
 
 // PachdSpecificConfiguration contains the pachd specific configuration.
@@ -100,6 +102,20 @@ type PachdSpecificConfiguration struct {
 	PachdPodName                 string `env:"PACHD_POD_NAME,required"`
 	EnableWorkerSecurityContexts bool   `env:"ENABLE_WORKER_SECURITY_CONTEXTS,default=true"`
 	TLSCertSecretName            string `env:"TLS_CERT_SECRET_NAME,default="`
+}
+
+// EnterpriseServerConfiguration contains the full configuration for an enterprise server
+type EnterpriseServerConfiguration struct {
+	GlobalConfiguration
+	EnterpriseSpecificConfiguration
+}
+
+// EnterpriseSpecificConfiguration contains the configuration required for enterprise features
+type EnterpriseSpecificConfiguration struct {
+	AuthRootToken    string `env:"AUTH_ROOT_TOKEN,default="`
+	LicenseKey       string `env:"LICENSE_KEY,default="`
+	EnterpriseSecret string `env:"ENTERPRISE_SECRET,default="`
+	EnterpriseMember bool   `env:"ENTERPRISE_MEMBER,default=false"`
 }
 
 // StorageConfiguration contains the storage configuration.
@@ -153,10 +169,15 @@ func NewConfiguration(config interface{}) *Configuration {
 	case *PachdFullConfiguration:
 		configuration.GlobalConfiguration = &v.GlobalConfiguration
 		configuration.PachdSpecificConfiguration = &v.PachdSpecificConfiguration
+		configuration.EnterpriseSpecificConfiguration = &v.EnterpriseSpecificConfiguration
 		return configuration
 	case *WorkerFullConfiguration:
 		configuration.GlobalConfiguration = &v.GlobalConfiguration
 		configuration.WorkerSpecificConfiguration = &v.WorkerSpecificConfiguration
+		return configuration
+	case *EnterpriseServerConfiguration:
+		configuration.GlobalConfiguration = &v.GlobalConfiguration
+		configuration.EnterpriseSpecificConfiguration = &v.EnterpriseSpecificConfiguration
 		return configuration
 	default:
 		return nil

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -112,10 +112,7 @@ type EnterpriseServerConfiguration struct {
 
 // EnterpriseSpecificConfiguration contains the configuration required for enterprise features
 type EnterpriseSpecificConfiguration struct {
-	AuthRootToken    string `env:"AUTH_ROOT_TOKEN,default="`
-	LicenseKey       string `env:"LICENSE_KEY,default="`
-	EnterpriseSecret string `env:"ENTERPRISE_SECRET,default="`
-	EnterpriseMember bool   `env:"ENTERPRISE_MEMBER,default=false"`
+	EnterpriseMember bool `env:"ENTERPRISE_MEMBER,default=false"`
 }
 
 // StorageConfiguration contains the storage configuration.

--- a/src/internal/serviceenv/option.go
+++ b/src/internal/serviceenv/option.go
@@ -25,9 +25,10 @@ func ApplyOptions(config *Configuration, opts ...ConfigOption) {
 // config with certain default values overridden via options.
 func ConfigFromOptions(opts ...ConfigOption) *Configuration {
 	result := &Configuration{
-		GlobalConfiguration:         &GlobalConfiguration{},
-		PachdSpecificConfiguration:  &PachdSpecificConfiguration{},
-		WorkerSpecificConfiguration: &WorkerSpecificConfiguration{},
+		GlobalConfiguration:             &GlobalConfiguration{},
+		PachdSpecificConfiguration:      &PachdSpecificConfiguration{},
+		WorkerSpecificConfiguration:     &WorkerSpecificConfiguration{},
+		EnterpriseSpecificConfiguration: &EnterpriseSpecificConfiguration{},
 	}
 	ApplyOptions(result, opts...)
 	return result

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -40,7 +40,7 @@ func resetClusterState(t *testing.T, c *client.APIClient) {
 
 // TestRegisterPachd tests registering a pachd with the enterprise server when auth is disabled
 func TestRegisterPachd(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
@@ -60,7 +60,7 @@ func TestRegisterPachd(t *testing.T) {
 
 // TestRegisterAuthenticated tests registering a pachd with the enterprise server when auth is enabled
 func TestRegisterAuthenticated(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	cluster := tu.UniqueString("cluster")
@@ -86,7 +86,7 @@ func TestRegisterAuthenticated(t *testing.T) {
 
 // TestEnterpriseRoleBindings tests configuring role bindings for the enterprise server
 func TestEnterpriseRoleBindings(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
@@ -109,7 +109,7 @@ func TestEnterpriseRoleBindings(t *testing.T) {
 
 // TestGetAndUseRobotToken tests getting a robot token for the enterprise server
 func TestGetAndUseRobotToken(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
@@ -135,7 +135,7 @@ func TestGetAndUseRobotToken(t *testing.T) {
 
 // TestConfig tests getting and setting OIDC configuration for the identity server
 func TestConfig(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	pachAddress := fmt.Sprintf("grpc://pachd.%s:%v", ns, c.GetAddress().Port)
@@ -175,7 +175,7 @@ EOF
 
 // TestLoginEnterprise tests logging in to the enterprise server
 func TestLoginEnterprise(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	ec, err := client.NewEnterpriseClientForTest()
@@ -218,7 +218,7 @@ func TestLoginEnterprise(t *testing.T) {
 
 // TestLoginPachd tests logging in to pachd
 func TestLoginPachd(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 
@@ -262,7 +262,7 @@ func TestLoginPachd(t *testing.T) {
 
 // Tests synching contexts from the enterprise server
 func TestSyncContexts(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	id := tu.UniqueString("cluster")
@@ -338,7 +338,7 @@ func TestSyncContexts(t *testing.T) {
 
 // Tests RegisterCluster command's derived argument values if not provided
 func TestRegisterDefaultArgs(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 
@@ -375,7 +375,7 @@ func TestRegisterDefaultArgs(t *testing.T) {
 
 // tests that Cluster Registration is undone when enterprise service fails to activate in the `enterprise register` subcommand
 func TestRegisterRollback(t *testing.T) {
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, minikubetestenv.EnterpriseMemberOption)
 	resetClusterState(t, c)
 	defer resetClusterState(t, c)
 	id := tu.UniqueString("cluster")


### PR DESCRIPTION
* Enterprise Members shouldn't run the Identity/Dex Service

* Include EnterpriseMember in tests

* only configure identity server for embedded-enterprise or enterprise server