### PR TITLE
[Mount Server] Upload mount server binary for each commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,19 +238,23 @@ jobs:
           command: |
             echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run:
-          name: Build Docker
+          name: Build docker
           command: make docker-build VERSION=$CIRCLE_SHA1
       - run:
           name: Push docker
           command: make docker-push VERSION=$CIRCLE_SHA1
       - run:
-          name: Make release
-          command: make release-pachctl GORELSNAP=--snapshot VERSION=$CIRCLE_SHA1
+          name: Make releases
+          command: |
+            make release-pachctl GORELSNAP=--snapshot VERSION=$CIRCLE_SHA1
+            make release-mount-server GORELSNAP=--snapshot VERSION=$CIRCLE_SHA1
       - run:
-          name: Upload Pachctl Release
+          name: Upload releases
           command: |
             echo $PACHCTL_GOOGLE_UPLOAD_CREDS > /home/circleci/gcpcreds.json
             cd /home/circleci/dist-pach/pachctl/
+            gcsupload -b pachyderm-builds -f `find * -name \*amd64.tar.gz` -k /home/circleci/gcpcreds.json
+            cd /home/circleci/dist-pach/mount-server/
             gcsupload -b pachyderm-builds -f `find * -name \*amd64.tar.gz` -k /home/circleci/gcpcreds.json
             rm /home/circleci/gcpcreds.json
   release_job:

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ release-docker-images:
 release-pachctl:
 	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --rm-dist -f goreleaser/pachctl.yml
 
+release-mount-server:
+	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --rm-dist -f goreleaser/mount-server.yml
+
 docker-build:
 	docker build -f etc/test-images/Dockerfile.testuser -t pachyderm/testuser:local .
 	docker build --network=host -f etc/test-images/Dockerfile.netcat -t pachyderm/ubuntuplusnetcat:local .

--- a/goreleaser/mount-server.yml
+++ b/goreleaser/mount-server.yml
@@ -1,0 +1,71 @@
+project_name: mount-server
+
+dist: ../dist-pach/mount-server
+
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+
+builds:
+  -
+    id: mount-server
+    dir: src/server/cmd/mount-server
+    main: main.go
+    binary: mount-server
+    ldflags:
+      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }}
+    gcflags:
+      - "all=-trimpath={{.Env.GOBIN}}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  -
+    id: mount-server-archives
+    builds:
+      - mount-server
+    format_overrides:
+      - goos: darwin
+        format: zip
+    wrap_in_directory: true
+    files:
+      - mount-server*/mount-server
+
+checksum:
+  disable: true
+
+snapshot:
+  name_template: "{{ .Env.VERSION }}"
+
+changelog:
+  skip: false
+
+nfpms:
+  -
+    id: mount-server-deb
+    package_name: mount-server
+    file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
+    builds:
+      - mount-server
+    replacements:
+      linux: ""
+      amd64: amd64
+    vendor: Pachyderm
+    maintainer: Pachyderm <jdoliner@pachyderm.io>
+    homepage: https://www.pachyderm.com/
+    description: "Reproducible data science"
+    formats:
+      - deb
+    bindir: /usr/bin
+
+release:
+  name_template: "{{ .Env.VERSION }}"
+  prerelease: auto
+  disable: false


### PR DESCRIPTION
Builds and uploads a mount server binary to object storage for each commit in a PR, similar to what we're currently doing for pachctl.

Jira: [INT-630]

[INT-630]: https://pachyderm.atlassian.net/browse/INT-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ