### PR TITLE
helm: Add a setting to prevent console/pachd from using the external network for OAuth

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -88,11 +88,7 @@ assume some logic about the auth activation (namely that the suffix on issuerURI
 serve dex).
 */ -}}
 {{- define "pachyderm.dexBaseURI" -}}
-{{ (dict
-    "scheme" "http"
-    "host" (printf "pachd:%v" .Values.pachd.service.identityPort)
-    "path" (get (include "pachyderm.issuerURI" . | urlParse) "path")
-) | urlJoin }}
+{{ (dict "scheme" "http" "host" (printf "pachd:%v" .Values.pachd.service.identityPort) "path" (get (include "pachyderm.issuerURI" . | urlParse) "path") ) | urlJoin }}
 {{- end }}
 
 {{- define "pachyderm.consoleRedirectURI" -}}

--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           value: {{ include "pachyderm.issuerURI" . | quote}}
         - name: REACT_APP_RUNTIME_ISSUER_URI
           value: {{ include "pachyderm.reactAppRuntimeIssuerURI" . | quote}}
+        {{- if .Values.oidc.avoidExternalNetwork }}
+        - name: DEX_BASE_URI
+          value: {{ include "pachyderm.dexBaseURI" . | quote}}
+        {{- end }}
         - name: REACT_APP_RUNTIME_DISABLE_TELEMETRY
           value: {{ .Values.console.config.disableTelemetry | quote}}
         - name: OAUTH_REDIRECT_URI

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -522,6 +522,9 @@
                 "RotationTokenExpiry": {
                     "type": "string"
                 },
+                "avoidExternalNetwork": {
+                    "type": "boolean"
+                },
                 "dexCredentialSecretName": {
                     "type": "string"
                 },
@@ -1165,7 +1168,18 @@
                     }
                 },
                 "tls": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "secret": {
+                            "type": "object"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         }

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -662,6 +662,10 @@ oidc:
   RotationTokenExpiry: 48h
   # (Optional) Only set in cases where the issuerURI is not user accessible (ie. localhost install)
   userAccessibleOauthIssuerHost: ""
+  # If true, avoid making any OIDC requests from console (etc.) over the external network.  This is
+  # good if you have some sort of authenticating proxy or firewall rule in front of the
+  # publicly-available issuer URL.
+  avoidExternalNetwork: false
   ## to set up upstream IDPs, set pachd.mockIDP to false,
   ## and populate the pachd.upstreamIDPs with an array of Dex Connector configurations.
   ## See the example below or https://dexidp.io/docs/connectors/


### PR DESCRIPTION
This is the helm side of https://github.com/pachyderm/haberdashery/pull/658

Basically with this enabled `pachd` and `console` will always do oauth things over the internal network.  You can still have the actual Issuer be external, of course, but only a human user with their browser will ever use that URL.  A new setting that defaults to false enables this (overriding localhostIssuer if explicitly set).

There are probably some missing special cases (enterprise server only on the internal network, proxies that map company.com/pachyderm/dex to pachd:1658/dex), but I want to hold off on adding a config key to set these.   I'd like to gradually remove most of this explicit configuration and have one that just works.  But it will be a while.

I also regenerated the values schema to pick up a couple of recent changes.