### PR TITLE
[CORE-744] Add a simple log wrapper to Loki stream entries

### DIFF
--- a/src/internal/lokiutil/lokiutil.go
+++ b/src/internal/lokiutil/lokiutil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -47,6 +48,21 @@ func forEachLine(resp loki.QueryResponse, f func(t time.Time, line string) error
 	return nil
 }
 
+func wrapEntryLog(entry streamEntry) (streamEntry, error) {
+	if strings.HasPrefix(entry.Log, "{") {
+		return entry, nil
+	}
+	// Entries from Klog may not be in JSON and so should be wrapped to maintain structured logging.
+	wrappedLog := logWrapper{}
+	wrappedLog.Message = entry.Log
+	wrappedLogJSON, err := json.Marshal(wrappedLog)
+	if err != nil {
+		return streamEntry{}, errors.EnsureStack(err)
+	}
+	entry.Log = string(wrappedLogJSON)
+	return entry, nil
+}
+
 // QueryRange calls QueryRange on the passed loki.Client and calls f with each logline.
 func QueryRange(ctx context.Context, c *loki.Client, queryStr string, from, through time.Time, follow bool, f func(t time.Time, line string) error) error {
 	for {
@@ -58,12 +74,12 @@ func QueryRange(ctx context.Context, c *loki.Client, queryStr string, from, thro
 		if err := forEachLine(*resp, func(t time.Time, line string) error {
 			from = t
 			nMsgs++
-			var entry struct {
-				Log    string    `json:"log"`
-				Stream string    `json:"stream"`
-				Time   time.Time `json:"time"`
-			}
+			entry := streamEntry{}
 			err := json.Unmarshal([]byte(line), &entry)
+			if err != nil {
+				return errors.EnsureStack(err)
+			}
+			entry, err = wrapEntryLog(entry)
 			if err != nil {
 				return errors.EnsureStack(err)
 			}
@@ -78,7 +94,17 @@ func QueryRange(ctx context.Context, c *loki.Client, queryStr string, from, thro
 	}
 }
 
+type streamEntry struct {
+	Log    string    `json:"log"`
+	Stream string    `json:"stream"`
+	Time   time.Time `json:"time"`
+}
+
 type streamEntryPair struct {
 	entry  loki.Entry
 	labels loki.LabelSet
+}
+
+type logWrapper struct {
+	Message string `json:"message"`
 }

--- a/src/internal/lokiutil/lokiutil_test.go
+++ b/src/internal/lokiutil/lokiutil_test.go
@@ -1,0 +1,22 @@
+package lokiutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+)
+
+func TestWrapEntryLog(t *testing.T) {
+	entries := []streamEntry{
+		{Log: "W0627 19:40:45.997742\t 1 warnings.go:70] <msg> duplicate name \"PPS_PIPELINE_NAME\"\n"},
+		{Log: "{\"message\":\"started setting up External Pachd GRPC Server\",\"severity\":\"info\"}"},
+	}
+	for _, entry := range entries {
+		t.Run("test wrapEntryLog", func(t *testing.T) {
+			wrappedEntry, err := wrapEntryLog(entry)
+			require.NoError(t, err, "entries should be serializable")
+			require.True(t, strings.HasPrefix(wrappedEntry.Log, "{"), "wrappedEntry.Log should be JSON")
+		})
+	}
+}

--- a/src/internal/lokiutil/lokiutil_test.go
+++ b/src/internal/lokiutil/lokiutil_test.go
@@ -1,22 +1,22 @@
 package lokiutil
 
 import (
-	"strings"
+	"encoding/json"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
-func TestWrapEntryLog(t *testing.T) {
+func TestWrapEntryIfNotJSON(t *testing.T) {
 	entries := []streamEntry{
 		{Log: "W0627 19:40:45.997742\t 1 warnings.go:70] <msg> duplicate name \"PPS_PIPELINE_NAME\"\n"},
 		{Log: "{\"message\":\"started setting up External Pachd GRPC Server\",\"severity\":\"info\"}"},
 	}
 	for _, entry := range entries {
-		t.Run("test wrapEntryLog", func(t *testing.T) {
-			wrappedEntry, err := wrapEntryLog(entry)
+		t.Run("test wrapEntryIfNotJSON", func(t *testing.T) {
+			wrappedEntry, err := wrapEntryIfNotJSON(entry)
 			require.NoError(t, err, "entries should be serializable")
-			require.True(t, strings.HasPrefix(wrappedEntry.Log, "{"), "wrappedEntry.Log should be JSON")
+			require.NoError(t, json.Unmarshal([]byte(wrappedEntry.Log), &map[string]interface{}{}), "wrappedEntry.Log should be JSON")
 		})
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes a bug that breaks structured JSON logging when using `pachctl logs` and Loki. Some log messages written by components using `Klog` use their own format and are being forwarded as-is by Loki. We address this with a check to see if the entry is a JSON formatted string. If it is not, then we wrap it in a struct and serialize it.