### PR TITLE
[CORE-703] add oidc health check to envoy

### DIFF
--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -110,6 +110,18 @@
         },
       },
     ],
+    health_check: {
+      healthy_threshold: 1,
+      http_health_check: {
+        host: 'localhost',
+        path: '/',
+      },
+      interval: '30s',
+      timeout: '10s',
+      unhealthy_threshold: 2,
+      no_traffic_interval: '10s',
+      no_traffic_healthy_interval: '10s',
+    },
   },
   console: {
     internal_port: 4000,

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -257,7 +257,20 @@
             },
             "dns_lookup_family": "V4_ONLY",
             "dns_refresh_rate": "5s",
-            "health_checks": [ ],
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
             "lb_policy": "random",
             "load_assignment": {
                "cluster_name": "pachd-oidc",

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -257,7 +257,20 @@
             },
             "dns_lookup_family": "V4_ONLY",
             "dns_refresh_rate": "5s",
-            "health_checks": [ ],
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
             "lb_policy": "random",
             "load_assignment": {
                "cluster_name": "pachd-oidc",


### PR DESCRIPTION
This adds the envoy health check definition for the pachd-oidc service. pachd-identity already has a health check configured which checks /dex/.well-known/openid-configuration so no changes required there.