### PR TITLE
[Mount Server] Read from config file on startup

### DIFF
--- a/src/server/cmd/mount-server/cmd/cmd.go
+++ b/src/server/cmd/mount-server/cmd/cmd.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"os"
+	"time"
 
+	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	pfscmds "github.com/pachyderm/pachyderm/v2/src/server/pfs/cmds"
 	"github.com/pachyderm/pachyderm/v2/src/server/pfs/fuse"
@@ -25,7 +27,11 @@ func MountServerCmd() *cobra.Command {
 				MountDir: mountDir,
 			}
 			pfscmds.PrintWarning()
-			return fuse.Server(serverOpts, nil)
+			c, err := client.NewOnUserMachine("user", client.WithDialTimeout(5*time.Second))
+			if err != nil {
+				return fuse.Server(serverOpts, nil)
+			}
+			return fuse.Server(serverOpts, c)
 		}),
 	}
 	rootCmd.Flags().StringVar(&mountDir, "mount-dir", "/pfs", "Target directory for mounts e.g /pfs")

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -475,18 +475,19 @@ func (mm *MountManager) FinishAll() (retErr error) {
 	return retErr
 }
 
-func Server(sopts *ServerOptions, testClient *client.APIClient) error {
+func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 	logrus.Infof("Dynamically mounting pfs to %s", sopts.MountDir)
 
 	// This variable points to the MountManager for each connected cluster.
 	// Updated when the config is updated.
 	var mm *MountManager = &MountManager{}
-	if testClient != nil {
+	if existingClient != nil {
 		var err error
-		mm, err = CreateMount(testClient, sopts.MountDir)
+		mm, err = CreateMount(existingClient, sopts.MountDir)
 		if err != nil {
 			return err
 		}
+		logrus.Infof("Connected to %s", existingClient.GetAddress().Qualified())
 	}
 	router := mux.NewRouter()
 	router.Methods("GET").Path("/repos").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Connect to the context specified in the config file if valid on mount server startup. This prevents users from having to input cluster connection info every time they start up notebooks. Tested manually.

Jira: https://pachyderm.atlassian.net/browse/INT-650