### PR TITLE
Upgrade gosnowflake to handle TIMESTAMP_LTZ

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -232,7 +232,7 @@ require (
 	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect
-	github.com/snowflakedb/gosnowflake v1.6.7
+	github.com/snowflakedb/gosnowflake v1.6.11
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1241,8 +1241,8 @@ github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUr
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/snowflakedb/gosnowflake v1.6.7 h1:BTUIJIgxHqyYcZ7oGW8jf6i+9tWNFv0wknMeL0H1dKg=
-github.com/snowflakedb/gosnowflake v1.6.7/go.mod h1:2wS1J12a0mCwY2PJpObLD2MWNzC7wIwVknUuO2xRLV0=
+github.com/snowflakedb/gosnowflake v1.6.11 h1:iA8BO+CstFArdfMw3OoXZnn/F8oFluX64KOGg1wVQtU=
+github.com/snowflakedb/gosnowflake v1.6.11/go.mod h1:BoZ0gnLERaUEiziH4Dumim10LN8cvoaCKovsAfhxzrE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=


### PR DESCRIPTION
The version of gosnowflake we were using had a bug that didn't handle timestamp_ltz well when run in containers that don't have the locale file specified. This bug was fixed in https://github.com/snowflakedb/gosnowflake/pull/571.