### PR TITLE
[CORE-607] Add helm templates and config for kube-event-tail

### DIFF
--- a/etc/helm/pachyderm/templates/kube-event-tail/clusterRole.yaml
+++ b/etc/helm/pachyderm/templates/kube-event-tail/clusterRole.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.kubeEventTail.enabled (eq .Values.kubeEventTail.clusterScope true) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: pachyderm-kube-event-tail
+    suite: pachyderm
+  name: pachyderm-kube-event-tail-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}

--- a/etc/helm/pachyderm/templates/kube-event-tail/clusterRoleBinding.yaml
+++ b/etc/helm/pachyderm/templates/kube-event-tail/clusterRoleBinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.kubeEventTail.enabled (eq .Values.kubeEventTail.clusterScope true) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: pachyderm-kube-event-tail
+    suite: pachyderm
+  name: pachyderm-kube-event-tail-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pachyderm-kube-event-tail-reader
+subjects:
+- kind: ServiceAccount
+  name: pachyderm-kube-event-tail
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/kube-event-tail/deployment.yaml
+++ b/etc/helm/pachyderm/templates/kube-event-tail/deployment.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.kubeEventTail.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pachyderm-kube-event-tail
+    suite: pachyderm
+  name: pachyderm-kube-event-tail
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pachyderm-kube-event-tail
+      suite: pachyderm
+  template:
+    metadata:
+      labels:
+        app: pachyderm-kube-event-tail
+        suite: pachyderm
+    spec:
+    {{- include "pachyderm.imagePullSecrets" . | indent 6 }}
+      containers:
+        - name: kube-event-tail
+          env:
+            - name: DEBUG_ADDRESS
+              value: 0.0.0.0:8081
+            - name: NAMESPACE
+          {{- if eq .Values.kubeEventTail.clusterScope true }}
+              value: ""
+          {{ else }}
+              value: {{ .Release.Namespace }}
+          {{- end }}
+          image: "{{ .Values.kubeEventTail.image.repository }}:{{ .Values.kubeEventTail.image.tag }}"
+          imagePullPolicy: {{ .Values.kubeEventTail.image.pullPolicy }}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: debug
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 8081
+              name: debug
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: debug
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+        {{- if .Values.kubeEventTail.resources }}
+          resources: {{ toYaml .Values.kubeEventTail.resources | nindent 12 }}
+        {{- else }}
+          resources:
+            limits:
+              cpu: 1
+              memory: 45Mi
+            requests:
+              cpu: 100m
+              memory: 45Mi
+        {{- end }}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+    {{- if .Values.global.securityContexts.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    {{- end }}
+      serviceAccountName: pachyderm-kube-event-tail
+{{- end }}

--- a/etc/helm/pachyderm/templates/kube-event-tail/role.yaml
+++ b/etc/helm/pachyderm/templates/kube-event-tail/role.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.kubeEventTail.enabled (eq .Values.kubeEventTail.clusterScope false) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: pachyderm-kube-event-tail
+    suite: pachyderm
+  name: pachyderm-kube-event-tail-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}

--- a/etc/helm/pachyderm/templates/kube-event-tail/roleBinding.yaml
+++ b/etc/helm/pachyderm/templates/kube-event-tail/roleBinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.kubeEventTail.enabled (eq .Values.kubeEventTail.clusterScope false) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: pachyderm-kube-event-tail
+    suite: pachyderm
+  name: pachyderm-kube-event-tail-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pachyderm-kube-event-tail-reader
+subjects:
+- kind: ServiceAccount
+  name: pachyderm-kube-event-tail
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/kube-event-tail/serviceaccount.yaml
+++ b/etc/helm/pachyderm/templates/kube-event-tail/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.kubeEventTail.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: pachyderm-kube-event-tail
+    suite: pachyderm
+  name: pachyderm-kube-event-tail
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -410,6 +410,55 @@
                 }
             }
         },
+        "kubeEventTail": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "clusterScope": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "loki-stack": {
             "type": "object",
             "properties": {

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -558,6 +558,23 @@ pachd:
     # deploy.
     create: true
 
+kubeEventTail:
+  # Deploys a lightweight app that watches kubernetes events and echos them to logs.
+  enabled: true
+  # clusterScope determines whether kube-event-tail should watch all events or just events in its namespace.
+  clusterScope: false
+  image:
+    repository: "docker.io/jrockway/kube-event-tail"
+    pullPolicy: "IfNotPresent"
+    tag: "v0.0.6"
+  resources:
+    limits:
+      cpu: 1
+      memory: 45Mi
+    requests:
+      cpu: 100m
+      memory: 45Mi
+
 pgbouncer:
   service:
     type: ClusterIP


### PR DESCRIPTION
## Description
This PR adds `kube-event-tail` templates to the set of components we can deploy alongside `pachd`. Deploying `kube-event-tail` is a simple way of collecting `kubernetes events` during `pachctl debug dump` calls.  `Kube-event-tail` watches events and logs them to stdout. 

Configuration of `kube-event-tail` is controlled with a new helm object `kubeEventTail` which has three boolean fields:

- enabled: deploys kube-event-tail if true
- clusterScope: determines whether kube-event-tail logs only events in its namespace or collects and logs all events
- podMonitor: controls whether a prometheus pod monitor is deployed for kube-event-tail