### PR TITLE
tests: no need to run "internal" tests in a bucket anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,6 @@ workflows:
                 - PPS8
                 - PPS_AUTH
                 - EXAMPLES
-                - INTERNAL
   helm:
     when:
       and:

--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -76,10 +76,6 @@ case "${BUCKET}" in
     # disable them
     # make test-tls
     ;;
-  INTERNAL)
-    go install -v ./src/testing/match
-    bash -ceo pipefail "go test -p 1 -count 1 ./src/internal/... ${TESTFLAGS}"
-    ;;
   EXAMPLES)
     echo "Running the example test suite"
     ./etc/testing/examples.sh


### PR DESCRIPTION
`go test ./...` run by the `test-go` rule handles these tests now.