### PR TITLE
helm: add a startup probe for pachd

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -263,7 +263,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: "pachyderm-enterprise-config"
-              key: "enterprise-cluster" 
+              key: "enterprise-cluster"
         {{- end }}
         {{ if .Values.global.postgresql.identityDatabaseFullNameOverride }}
         - name: IDENTITY_SERVER_DATABASE
@@ -316,6 +316,13 @@ spec:
             command:
             - /pachd
             - --readiness
+        startupProbe:
+          exec:
+            command:
+            - /pachd
+            - --readiness
+          failureThreshold: 10
+          timeoutSeconds: 30
         {{- if .Values.pachd.resources }}
         resources: {{ toYaml .Values.pachd.resources | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
This gives pachd 300 seconds to connect to the database (and apply migrations, etc.) before k8s will consider killing it due to liveness check failure.  We will fail liveness checks until the RPC server starts up, which happens after DB initialization.

One might be aware of a "test connection" helm hook; that just connects to pachd after deployment and is the condition for unblocking "helm install".  We don't do any sequencing around postgres -> pgbouncer -> pachd; they are all applied at once and we hope for the best, which is fine.