### PR TITLE
bump pach versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,6 +486,7 @@ workflows:
               only:
                 - 2.1.x
                 - 2.2.x
+                - master
   red_hat:
     jobs:
       - push_redhat:

--- a/etc/helm/pachyderm/Chart.yaml
+++ b/etc/helm/pachyderm/Chart.yaml
@@ -21,14 +21,14 @@ type: application
 # each time you make changes to the chart and its templates, including
 # the app version.  Versions are expected to follow Semantic
 # Versioning (https://semver.org/)
-version: 2.3.0-nightly.1
+version: 2.3.0-alpha.1
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to
 # the application. Versions are not expected to follow Semantic
 # Versioning. They should reflect the version the application is
 # using.
-appVersion: 2.3.0-nightly.1
+appVersion: 2.3.0-alpha.1
 
 kubeVersion: ">= 1.16.0-0"
 

--- a/etc/helm/pachyderm/Chart.yaml
+++ b/etc/helm/pachyderm/Chart.yaml
@@ -21,21 +21,21 @@ type: application
 # each time you make changes to the chart and its templates, including
 # the app version.  Versions are expected to follow Semantic
 # Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.3.0-nightly.1
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to
 # the application. Versions are not expected to follow Semantic
 # Versioning. They should reflect the version the application is
 # using.
-appVersion: 2.1.0
+appVersion: 2.3.0-nightly.1
 
 kubeVersion: ">= 1.16.0-0"
 
 icon: https://www.pachyderm.com/wp-content/themes/pachyderm/dist/img/favicons/favicon-32x32.png
 
 annotations:
-  artifacthub.io/prerelease: "false" # NOTE: update prior to releasing
+  artifacthub.io/prerelease: "true" # NOTE: update prior to releasing
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/links: |
     - name: "Pachyderm"

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -63,7 +63,7 @@ console:
     pullPolicy: "IfNotPresent"
     # tag is the image repo to pull from; together with repository it
     # replicates the --console-image argument to pachctl deploy.
-    tag: "2.3.0-nightly.1"
+    tag: "2.2.3"
   priorityClassName: ""
   nodeSelector: {}
   tolerations: []

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -63,7 +63,7 @@ console:
     pullPolicy: "IfNotPresent"
     # tag is the image repo to pull from; together with repository it
     # replicates the --console-image argument to pachctl deploy.
-    tag: "2.1.0-1"
+    tag: "2.3.0-nightly.1"
   priorityClassName: ""
   nodeSelector: {}
   tolerations: []

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -63,7 +63,7 @@ console:
     pullPolicy: "IfNotPresent"
     # tag is the image repo to pull from; together with repository it
     # replicates the --console-image argument to pachctl deploy.
-    tag: "2.2.3"
+    tag: "2.3.0-alpha.1"
   priorityClassName: ""
   nodeSelector: {}
   tolerations: []

--- a/src/version/client.go
+++ b/src/version/client.go
@@ -12,7 +12,7 @@ const (
 	// MajorVersion is the current major version for pachyderm.
 	MajorVersion = 2
 	// MinorVersion is the current minor version for pachyderm.
-	MinorVersion = 2
+	MinorVersion = 3
 	// MicroVersion is the patch number for pachyderm.
 	MicroVersion = 0
 )


### PR DESCRIPTION
<s>bumping pach versions for first `2.3.0-nightly.1` release, temporarily done manually. </s>

bumping pach versions for first `2.3.0-alpha.1` release, temporarily done manually. 