### PR TITLE
Fix upgrade for 2.2.x to 2.2.3+ without console

### DIFF
--- a/etc/helm/pachyderm/templates/console/secret.yaml
+++ b/etc/helm/pachyderm/templates/console/secret.yaml
@@ -12,9 +12,9 @@ metadata:
   name: pachyderm-console-secret
   namespace: {{ .Release.Namespace }}
 data:
-{{ if .Release.IsUpgrade }}
+{{- if and .Release.IsUpgrade .Values.pachd.activateAuth .Values.pachd.activateEnterprise }}
   OAUTH_CLIENT_SECRET: {{ required "For an upgrade release, a value is required for console.config.oauthClientSecret" .Values.console.config.oauthClientSecret | toString | b64enc | quote }}
-{{ else }}
+{{- else }}
   OAUTH_CLIENT_SECRET: {{ default (randAlphaNum 32) .Values.console.config.oauthClientSecret | toString | b64enc | quote }}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
Users on 2.x with console and auth disabled won't have a console secret, but 2.2.3 enables console, so now its expecting an existing console oauth secret. This checks to see if auth was enabled first.