### PR TITLE
worker_rc: make the created service headless

### DIFF
--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -884,7 +884,8 @@ func (kd *kubeDriver) createWorkerSvcAndRc(ctx context.Context, pipelineInfo *pp
 			Annotations: serviceAnnotations,
 		},
 		Spec: v1.ServiceSpec{
-			Selector: options.labels,
+			Selector:  options.labels,
+			ClusterIP: "None", // headless, so as not to consume an IP address in the cluster
 			Ports: []v1.ServicePort{
 				{
 					Port: int32(kd.config.PPSWorkerPort),


### PR DESCRIPTION
This avoids consuming an IP address in the cluster, which can be expensive in certain circumstances.