### PR TITLE
alpha.0 fixes

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -50,11 +50,11 @@ http
 {{ fail (printf "With the proxy enabled, oidc.issuerURI must end with /dex, not %s" .Values.oidc.issuerURI) }}
 {{- end -}}
 {{ .Values.oidc.issuerURI }}
-{{- else if .Values.ingress.host -}}
+{{- else if and .Values.ingress.host .Values.ingress.enabled -}}
 {{- printf "%s://%s/dex" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
 {{- else if .Values.proxy.enabled -}}
 http://pachd:30658/dex
-{{- else if not .Values.ingress.enabled -}}
+{{- else -}}
 {{- if eq .Values.pachd.service.type "NodePort" -}}
 http://pachd:1658
 {{- else -}}
@@ -129,7 +129,9 @@ false
 {{- define "pachyderm.userAccessibleOauthIssuerHost" -}}
 {{- if .Values.oidc.userAccessibleOauthIssuerHost -}}
 {{ .Values.oidc.userAccessibleOauthIssuerHost }}
-{{- else if not .Values.ingress.enabled -}}
+{{- else if .Values.ingress.host -}}
+{{- printf "%s://%s" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
+{{- else  -}}
 localhost:30658
 {{- end -}}
 {{- end }}

--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -60,8 +60,6 @@ http://pachd:1658
 {{- else -}}
 http://pachd:30658
 {{- end -}}
-{{- else -}}
-{{ fail "For Authentication, an OIDC Issuer for this pachd must be set." }}
 {{- end -}}
 {{- end }}
 

--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -110,6 +110,8 @@ spec:
         resources: {{ toYaml .Values.console.resources | nindent 10 }}
         {{- end }}
         volumeMounts:
+        - mountPath: /home/
+          name: tmp
         {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
         - mountPath: /pach-tls/certs
           name: pachd-tls-cert
@@ -136,6 +138,8 @@ spec:
       tolerations: {{ toYaml .Values.console.tolerations | nindent 8 }}
       {{- end }}
       volumes:
+      - emptyDir: {}
+        name: tmp
       {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
       - name: pachd-tls-cert
         secret:

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -231,7 +231,7 @@ spec:
         - name: CONSOLE_OAUTH_SECRET
           valueFrom:
             secretKeyRef:
-              name: pachyderm-console-secret
+              name: {{ default ("pachyderm-console-secret") .Values.console.config.oauthClientSecretSecretName  }}
               key: OAUTH_CLIENT_SECRET
         {{- end }}
         {{ if .Values.global.proxy }}


### PR DESCRIPTION
- Fixes existing secret support for console oauth on pachd
- fix console readonlyrootfilesystem (add emptydir for `/home`)
- Fix auth URI settings (using `ingress.host` and proxy configures all the URIs properly while setting issuer to `http://pachd:30658/dex`