### PR TITLE
Fix copy url params

### DIFF
--- a/src/internal/pachsql/db.go
+++ b/src/internal/pachsql/db.go
@@ -149,6 +149,7 @@ func snowflakeDSN(u URL, password string) (string, error) {
 	// in this case, the account_identifier is my_organization-my_account
 	params := make(map[string]*string, len(u.Params))
 	for k, v := range u.Params {
+		v := v
 		params[k] = &v
 	}
 	var account, host string

--- a/src/internal/pachsql/url_test.go
+++ b/src/internal/pachsql/url_test.go
@@ -92,6 +92,8 @@ func TestSnowflakeConnection(t *testing.T) {
 		"wh":             {fmt.Sprintf("snowflake://%s@%s?warehouse=COMPUTE_WH", user, account), require.NoError},
 		"bad wh":         {fmt.Sprintf("snowflake://%s@%s?warehouse=badWH", user, account), require.YesError},
 		"role":           {fmt.Sprintf("snowflake://%s@%s?role=%s", user, account, role), require.NoError},
+		"role and my_wh": {fmt.Sprintf("snowflake://%s@%s?my_warehouse=COMPUTE_WH&role=%s", user, account, role), require.NoError},
+		"role and wh":    {fmt.Sprintf("snowflake://%s@%s?warehouse=COMPUTE_WH&role=%s", user, account, role), require.NoError},
 		"bad role":       {fmt.Sprintf("snowflake://%s@%s?role=badRole", user, account), require.YesError},
 		"host":           {fmt.Sprintf("snowflake://%s@%s", user, host), require.NoError},
 		"host with port": {fmt.Sprintf("snowflake://%s@%s:443?account=%s", user, host, account), require.NoError},


### PR DESCRIPTION
Currently, every url param would get the last param's value due to the "Go for-loop pointer bug".