### PR TITLE
Add runAsUser/Group to all containers

### DIFF
--- a/etc/helm/pachyderm/templates/cloudsqlAuthProxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/cloudsqlAuthProxy/deployment.yaml
@@ -45,6 +45,8 @@ spec:
         resources: {{ toYaml .Values.cloudsqlAuthProxy.resources | nindent 10 }}
       {{- if .Values.global.securityContexts.enabled }}
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -118,6 +118,8 @@ spec:
         {{- end }}
       {{- if .Values.global.securityContexts.enabled }}
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -203,6 +203,8 @@ spec:
         {{- end }}
       {{- if .Values.global.securityContexts.enabled }}
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/etc/helm/pachyderm/templates/etcd/statefulset.yaml
+++ b/etc/helm/pachyderm/templates/etcd/statefulset.yaml
@@ -98,6 +98,8 @@ spec:
           name: etcd-storage
       {{- if .Values.global.securityContexts.enabled }}
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -357,6 +357,8 @@ spec:
         runAsUser: 0 # Need to run as root local for hostpath support
       {{- else }}
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -125,6 +125,8 @@ spec:
         {{- end }}
       {{- if .Values.global.securityContexts.enabled }}
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -108,6 +108,8 @@ spec:
             {{- end }}
      {{- if .Values.global.securityContexts.enabled }}
           securityContext:
+            runAsUser: 101
+            runAsGroup: 101
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/etc/testing/opa-constraints.yaml
+++ b/etc/testing/opa-constraints.yaml
@@ -68,8 +68,12 @@ spec:
         matchLabels:
           suite: pachyderm
     kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
+      - apiGroups: [ "" ]
+        kinds: [ "Pod", "ReplicationController" ]
+      - apiGroups: [ "apps" ]
+        kinds: [ "Deployment", "ReplicaSet",  "StatefulSet", "DaemonSet" ]
+      - apiGroups: [ "batch" ]
+        kinds: [ "Job", "CronJob" ]
   parameters:
     runAsUser:
       rule: MustRunAs # MustRunAsNonRoot # RunAsAny 


### PR DESCRIPTION
If OPA policies are applied up the stack (deployment, replication controller, etc) they will fail if they're only applied to the pod. This adds the runAsUser/Group to the containers explicitly as well.