### PR TITLE
[CORE-813] Consolidate the kube-event-tail and pgbouncer images.

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -568,7 +568,7 @@ kubeEventTail:
   # clusterScope determines whether kube-event-tail should watch all events or just events in its namespace.
   clusterScope: false
   image:
-    repository: "docker.io/jrockway/kube-event-tail"
+    repository: pachyderm/kube-event-tail
     pullPolicy: "IfNotPresent"
     tag: "v0.0.6"
   resources:
@@ -587,7 +587,7 @@ pgbouncer:
   nodeSelector: {}
   tolerations: []
   image:
-    repository: bitnami/pgbouncer
+    repository: pachyderm/pgbouncer
     tag: 1.16.1-debian-10-r82
   resources:
     {}


### PR DESCRIPTION
## Description
This PR repoints the `values.yaml` to images consolidated to the pachyderm user. In the future, when we want to update these images, the plan is to add a `dynamic config` section to our `.circleci` config and run the related steps if one of the images are updated. This way, an engineer can update a vendor image we point to, then run those steps on a push of their local branch.