### PR TITLE
New SQL ingest pipeline architecture design

### DIFF
--- a/src/internal/transforms/sqlingest.go
+++ b/src/internal/transforms/sqlingest.go
@@ -181,7 +181,7 @@ func RunSQLRaw(ctx context.Context, params SQLRunParams) error {
 
 	w, err := os.OpenFile(filepath.Join(params.OutputDir, params.OutputFile), os.O_WRONLY|os.O_CREATE, 0755)
 	if err != nil {
-		return err
+		return errors.EnsureStack(err)
 	}
 	defer w.Close()
 

--- a/src/internal/transforms/sqlingest.go
+++ b/src/internal/transforms/sqlingest.go
@@ -173,9 +173,9 @@ func RunSQLRaw(ctx context.Context, params SQLRunParams) error {
 	if err := func() error {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		return db.PingContext(ctx)
+		return errors.EnsureStack(db.PingContext(ctx))
 	}(); err != nil {
-		return errors.EnsureStack(err)
+		return err
 	}
 	log.Info("Connected to DB")
 

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -126,7 +126,7 @@ func sqlRun(ctx context.Context, log *logrus.Logger, args []string) error {
 	url, fileFormat, query, oFname := args[0], args[1], args[2], args[3]
 	hasHeader, err := strconv.ParseBool(args[4])
 	if err != nil {
-		return err
+		return errors.EnsureStack(err)
 	}
 
 	password, ok := os.LookupEnv(PACHYDERM_SQL_PASSWORD)

--- a/src/server/cmd/pachtf/main.go
+++ b/src/server/cmd/pachtf/main.go
@@ -49,6 +49,7 @@ func main() {
 
 type Entrypoint = func(ctx context.Context, log *logrus.Logger, args []string) error
 
+// sql-gen-queries and sql-ingest are deprecated, and users should prefer sql-run instead.
 var entrypoints = map[string]Entrypoint{
 	"sql-ingest":      sqlIngest,
 	"sql-gen-queries": sqlGenQueries,
@@ -120,8 +121,8 @@ func sqlGenQueries(ctx context.Context, log *logrus.Logger, args []string) error
 }
 
 func sqlRun(ctx context.Context, log *logrus.Logger, args []string) error {
-	if len(args) < 4 {
-		return errors.Errorf("must provide [url, fileFormat, query, outputFile, hasHeader]")
+	if len(args) < 5 {
+		return errors.Errorf("must provide url fileFormat query outputFile and hasHeader")
 	}
 	url, fileFormat, query, oFname := args[0], args[1], args[2], args[3]
 	hasHeader, err := strconv.ParseBool(args[4])

--- a/src/templates/sql_ingest_cron.jsonnet
+++ b/src/templates/sql_ingest_cron.jsonnet
@@ -1,47 +1,23 @@
-local newPipeline(name, input, transform) = {
-  pipeline: {
-    name: name,
-  },
-  transform: transform,
-  input: input,
-};
-local pachtf(args, secretName='') = {
-  cmd: ['/pach-bin/pachtf'] + args,
-  secrets: if secretName != '' then
-    [
-      {
-        name: secretName,
-        env_var: 'PACHYDERM_SQL_PASSWORD',
-        key: 'PACHYDERM_SQL_PASSWORD',
-      },
-    ]
-  else
-    null,
-};
-
-function(name, url, query, format, cronSpec, secretName, hasHeader='false')
-  local queryPipelineName = name + '_queries';
-  [
-    newPipeline(
-      name=queryPipelineName,
-      input={
-        cron: {
-          name: 'in',
-          spec: cronSpec,
-          overwrite: true,
+function(name, url, query, format, cronSpec, secretName, outputFile='0000', hasHeader='false')
+  {
+    pipeline: {
+      name: name,
+    },
+    transform: {
+      cmd: ['/pach-bin/pachtf', 'sql-run', url, format, query, outputFile, hasHeader],
+      secrets: [
+        {
+          name: secretName,
+          env_var: 'PACHYDERM_SQL_PASSWORD',
+          key: 'PACHYDERM_SQL_PASSWORD',
         },
+      ],
+    },
+    input: {
+      cron: {
+        name: 'cron',
+        spec: cronSpec,
+        overwrite: true,
       },
-      transform=pachtf(['sql-gen-queries', query]),
-    ),
-    newPipeline(
-      name=name,
-      input={
-        pfs: {
-          name: 'in',
-          repo: queryPipelineName,
-          glob: '/*',
-        },
-      },
-      transform=pachtf(['sql-ingest', url, format, hasHeader], secretName),
-    ),
-  ]
+    },
+  }


### PR DESCRIPTION
This PR simplifies the existing SQL ingestion architecture by reducing two pipelines to one. Currently, we create two pipelines, one for generating the query file triggered via cron tick, and the other for actually reading the query file and persisting the results.

The new design is simple: `cron -> [run query] -> file`, where the query is embedded in the pipeline's `transform.cmd` section. However, this means the query is no long available in PFS as a file. If a user wants to know what query the pipeline is running, then they would have to inspect the pipeline.