### PR TITLE
pfs_file: return errors from close along with errors from callbacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -258,8 +258,8 @@ require (
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.19.0
 	golang.org/x/image v0.0.0-20210216034530-4410531fe030 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1413,6 +1413,8 @@ go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/automaxprocs v1.4.0 h1:CpDZl6aOlLhReez+8S3eEotD7Jx0Os++lemPlMULQP0=
 go.uber.org/automaxprocs v1.4.0/go.mod h1:/mTEdr7LvHhs0v7mjdxDreTz1OG5zdZGqgOnhWiR/+Q=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
@@ -1423,6 +1425,8 @@ go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=


### PR DESCRIPTION
Fixes CORE-774.

This fixes an issue where pipelines that write filenames not representable in PFS (like `foo?bar`) fail with the error `EOF`.  

`EOF` comes from the logic in ModifyFileClient.  Files are uploaded by calling PutFileTAR on a ModifyFileClient.  ModifyFileClient implement PutFileTAR by writing `SendMsg(AddFile{...})` to the client streaming RPC call.  `SendMsg` can't return an error from the server at the time that you send an invalid record; it's a unidirectional stream, not a bidirectional stream.  What happens when you send an invalid record is that the server just closes the stream without telling anyone.  Subsequent calls to `SendMsg` succeed until a client-side buffer is full, at which point GRPC realizes the stream is closed, and returns `io.EOF`. 

Additionally, each write to the stream (PutFile/DeleteFile/CopyFile/etc.) is wrapped with a `maybeError` function that only calls the requested method if previous methods didn't return an error.  (When one of those methods returns an error, it retains that and returns it each time you call one of those methods.).  This is not a problem in and of itself, except that `Close` is also wrapped with the same logic (return the previous  error instead of calling the Close function), so that means once we hit an error we can no longer close the stream. 

Finally, `WithModifyFileClient`/`WithCreateFileSetClient` only call `CloseAndRecv` if the callback passed to those functions doesn't error.  Since, when this bug is in effect, we return EOF from that callback, we never call Close and get the chance to receive the real error message from the server.

Sometimes you do get the error message from the server despite all of this.  That's because `SendMsg` returns no error even if the filename is invalid; it's `Close` that returns the error from the server.  This case happens when the faulty file is uploaded before the stream buffer fills up (so, "zzz?bar" is likely to return the error, "000?bar" is likely not to because a subsequent file upload is likely to fill up the buffer).  If you have a pipeline that produces a single file and it's invalid, you'll get a good error message.  If you have a pipeline which produces hundreds of files, then you might not get the real error.   Thus, the bug was quite difficult to track down ;)

Anyway, the fix for this is twofold.  

First, we no longer gate closing the stream on the WithModifyFileClient (etc.) callback not returning an error.  We close no matter what.  The Close functions were gated by `maybeError`, which means even if we didn't have the don't-call logic in the With* functions, we'd still not call it.  I've rewritten the Close functions to Close no matter what, but also return the error that was retained inside the ModifyFileClient (to prevent any changes to the outward API; that error would be returned INSTEAD of closing before this change).  I used `multierr.Combine` to return both errors.  If Close succeeds but the stream broke earlier, you'll just get the raw retained error.  Similarly, if `Close` fails but there was no prior error, you'll only get the error from close.  So all code that consumes this API should receive similar behavior (err != nil never changes), but we always close the stream and always return the error from the server now.

The side effect of this is that most failures of the class described in CORE-744 end up with three error messages, two EOFs and one "hey that filename was invalid".  This is ugly, but it's the only way to not suppress errors to Close and still maintain the contract of our Close wrappers in the client.  (I could be persuaded to break this in 2.3, of course.)  One EOF error is the error returned from user code, the other EOF error is the error retained by ModifyFileClient, and the last error is the message from the server that we actually care about.

Regarding multierr... wrapping io.EOF is always scary because the standard library uses the raw non-wrapped value as a sentinel, and so does gRPC.  We never use ModifyFileClient as an io.Reader or io.Writer, and we do our wrapping after gRPC has inspected the errors, so this shouldn't be a problem.  But we should be careful about `multierr.Combine` in general (as with errors.Wrap and friends, of course; only EnsureStack maintains the io.EOF sentinel as a special case), because wrapping io.EOF can be dangerous in general.
