### PR TITLE
Fix swallowed error in PFS DeleteFile 

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -176,13 +176,14 @@ func NewCronInput(name string, spec string) *pps.Input {
 // It uses cron syntax to specify the schedule. The input will be exposed to
 // jobs as `/pfs/<name>/<timestamp>`. The timestamp uses the RFC 3339 format,
 // e.g. `2006-01-02T15:04:05Z07:00`. It includes all the options.
-func NewCronInputOpts(name string, repo string, spec string, overwrite bool) *pps.Input {
+func NewCronInputOpts(name string, repo string, spec string, overwrite bool, start *types.Timestamp) *pps.Input {
 	return &pps.Input{
 		Cron: &pps.CronInput{
 			Name:      name,
 			Repo:      repo,
 			Spec:      spec,
 			Overwrite: overwrite,
+			Start:     start,
 		},
 	}
 }

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -479,8 +479,7 @@ func putFileURL(ctx context.Context, uw *fileset.UnorderedWriter, dstPath, tag s
 }
 
 func deleteFile(uw *fileset.UnorderedWriter, request *pfs.DeleteFile) error {
-	uw.Delete(request.Path, request.Datum)
-	return nil
+	return uw.Delete(request.Path, request.Datum)
 }
 
 // GetFileTAR implements the protobuf pfs.GetFileTAR RPC

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -3398,10 +3398,6 @@ func TestPFS(suite *testing.T) {
 		_, err = env.PachClient.StartCommit(repo, "master")
 		require.NoError(t, err)
 
-		err = env.PachClient.DeleteFile(commit, "dir2/dir3/*")
-		require.NoError(t, err)
-		err = env.PachClient.DeleteFile(commit, "dir?/*")
-		require.NoError(t, err)
 		err = env.PachClient.DeleteFile(commit, "/")
 		require.NoError(t, err)
 		checks = func() {


### PR DESCRIPTION
This bug was discovered serendipitously while testing CronInput repo behaviour.

Currently, if you have a CronInput with `overwrite set to true`, and the existing cron timestamp falls behind PPS master's clock, such that the cron tick has to catch up quickly, then we see an accumulation of cron tick files in the repo. This is because while the parent commit is finishing (doing compaction), the child commit tries to delete the previous cron tick files, whereby the error gets swallowed, and commits the new file, outcompeting compaction. Although in the cron case, the system eventually goes back to a good state once compaction catches up, it's still an important bug to fix since other areas of the system also depends on this file deletion logic.

Thanks to @PFedak for pairing with me on this one.