### PR TITLE
[doc-88] helm guidelines for yaml

### DIFF
--- a/doc/docs/1.13.x/contributing/coding-conventions.md
+++ b/doc/docs/1.13.x/contributing/coding-conventions.md
@@ -34,6 +34,10 @@ See the [Effective Go Style Guide](https://go.dev/doc/effective_go) for standard
 - Go dependencies are managed with go modules.
 - Use `go get foo` to add or update a package; for more specific versions, use  `go get foo@v1.2.3`, `go get foo@master`, or `go get foo@e3702bed2`.
 
+### YAML
+
+- See the [Helm Best Practices](https://helm.sh/docs/chart_best_practices/conventions/) guide series. 
+
 ---
 
 ## Review

--- a/doc/docs/2.0.x/contributing/coding-conventions.md
+++ b/doc/docs/2.0.x/contributing/coding-conventions.md
@@ -34,6 +34,10 @@ See the [Effective Go Style Guide](https://go.dev/doc/effective_go) for standard
 - Go dependencies are managed with go modules.
 - Use `go get foo` to add or update a package; for more specific versions, use  `go get foo@v1.2.3`, `go get foo@master`, or `go get foo@e3702bed2`.
 
+### YAML
+
+- See the [Helm Best Practices](https://helm.sh/docs/chart_best_practices/conventions/) guide series. 
+
 ---
 
 ## Review

--- a/doc/docs/2.1.x/contributing/coding-conventions.md
+++ b/doc/docs/2.1.x/contributing/coding-conventions.md
@@ -34,6 +34,10 @@ See the [Effective Go Style Guide](https://go.dev/doc/effective_go) for standard
 - Go dependencies are managed with go modules.
 - Use `go get foo` to add or update a package; for more specific versions, use  `go get foo@v1.2.3`, `go get foo@master`, or `go get foo@e3702bed2`.
 
+### YAML
+
+- See the [Helm Best Practices](https://helm.sh/docs/chart_best_practices/conventions/) guide series. 
+
 ---
 
 ## Review

--- a/doc/docs/2.2.x/contributing/coding-conventions.md
+++ b/doc/docs/2.2.x/contributing/coding-conventions.md
@@ -34,6 +34,10 @@ See the [Effective Go Style Guide](https://go.dev/doc/effective_go) for standard
 - Go dependencies are managed with go modules.
 - Use `go get foo` to add or update a package; for more specific versions, use  `go get foo@v1.2.3`, `go get foo@master`, or `go get foo@e3702bed2`.
 
+### YAML
+
+- See the [Helm Best Practices](https://helm.sh/docs/chart_best_practices/conventions/) guide series. 
+
 ---
 
 ## Review

--- a/doc/docs/master/contributing/coding-conventions.md
+++ b/doc/docs/master/contributing/coding-conventions.md
@@ -34,6 +34,10 @@ See the [Effective Go Style Guide](https://go.dev/doc/effective_go) for standard
 - Go dependencies are managed with go modules.
 - Use `go get foo` to add or update a package; for more specific versions, use  `go get foo@v1.2.3`, `go get foo@master`, or `go get foo@e3702bed2`.
 
+### YAML
+
+- See the [Helm Best Practices](https://helm.sh/docs/chart_best_practices/conventions/) guide series. 
+
 ---
 
 ## Review


### PR DESCRIPTION
Added link to helm guidelines for writing yaml under YAML header on the coding conventions page.