### PR TITLE
Add errcheck to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,6 @@ run:
 linters:
   enable:
     - wrapcheck
-  disable:
-    - errcheck
 linters-settings:
   wrapcheck:
     ignoreSigs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,12 +9,9 @@ linters:
 linters-settings:
   errcheck:
      exclude-functions:
-      - io.Copy
-      - github.com/pachyderm/pachyderm/v2/src/internal/backoff.Retry
-      - github.com/pachyderm/pachyderm/v2/src/internal/backoff.RetryNotify
-      - github.com/pachyderm/pachyderm/v2/src/internal/backoff.RetryUntilCancel
       - (*database/sql.Tx).Rollback
       - (*github.com/spf13/cobra.Command).MarkFlagCustom
+      - (*github.com/spf13/cobra.Command).Usage
   wrapcheck:
     ignoreSigs:
       - github.com/pachyderm/pachyderm/v2/src/internal/errors.Errorf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,14 @@ linters:
     - wrapcheck
     - nolintlint
 linters-settings:
+  errcheck:
+     exclude-functions:
+      - io.Copy
+      - github.com/pachyderm/pachyderm/v2/src/internal/backoff.Retry
+      - github.com/pachyderm/pachyderm/v2/src/internal/backoff.RetryNotify
+      - github.com/pachyderm/pachyderm/v2/src/internal/backoff.RetryUntilCancel
+      - (*database/sql.Tx).Rollback
+      - (*github.com/spf13/cobra.Command).MarkFlagCustom
   wrapcheck:
     ignoreSigs:
       - github.com/pachyderm/pachyderm/v2/src/internal/errors.Errorf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
 linters:
   enable:
     - wrapcheck
+    - nolintlint
 linters-settings:
   wrapcheck:
     ignoreSigs:
@@ -19,3 +20,8 @@ linters-settings:
       - .WithStack(
     ignorePackageGlobs:
       - github.com/pachyderm/pachyderm/v2/src/*
+issues:
+  exclude-rules:
+    - path: _test\.go # disable some linters for test files
+      linters:
+        - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,3 @@ linters-settings:
       - .WithStack(
     ignorePackageGlobs:
       - github.com/pachyderm/pachyderm/v2/src/*
-issues:
-  exclude-rules:
-    - path: _test\.go # disable some linters for test files
-      linters:
-        - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ run:
   timeout: 5m
   skip-dirs:
     - cached-deps
+  build-tags:
+    - k8s
 linters:
   enable:
     - wrapcheck

--- a/etc/proto/pachgen/transaction_client.go
+++ b/etc/proto/pachgen/transaction_client.go
@@ -48,8 +48,7 @@ var funcs = map[string]interface{}{
 	"goPkgName": func(proto *descriptor.FileDescriptorProto) string {
 		return path.Base(*proto.Options.GoPackage)
 	},
-	// nolint:staticcheck
-	"title": strings.Title,
+	"title": strings.Title, //nolint:staticcheck
 	"typeName": func(t *string) string {
 		parts := strings.Split(*t, ".")
 		if len(parts) == 4 && parts[1] == "google" && parts[2] == "protobuf" {
@@ -60,8 +59,7 @@ var funcs = map[string]interface{}{
 		return strings.Join(parts[1:], ".")
 	},
 	"clientName": func(t string) string {
-		// nolint:staticcheck
-		return fmt.Sprintf("unsupported%sBuilderClient", strings.Title(t))
+		return fmt.Sprintf("unsupported%sBuilderClient", strings.Title(t)) //nolint:staticcheck
 	},
 }
 

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,8 +18,8 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.0
-./bin/golangci-lint run --timeout 10m
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.0
+golangci-lint run --
 
 # shellcheck disable=SC2046
 find . \

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,7 +18,7 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.47.0
 golangci-lint run --
 
 # shellcheck disable=SC2046

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.4
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838
-	golang.org/x/net v0.0.0-20220708220712-1185a9018129
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
@@ -83,6 +82,8 @@ require (
 	k8s.io/client-go v0.23.1
 	k8s.io/kubectl v0.23.1
 )
+
+require golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
 
 require (
 	cloud.google.com/go v0.102.0 // indirect

--- a/src/client/admin.go
+++ b/src/client/admin.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/client/auth.go
+++ b/src/client/auth.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -36,7 +36,7 @@ func TestInterceptors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server: %v", err)
 	}
-	defer server.Wait()
+	defer server.Wait() //nolint:errcheck
 
 	listener, err := server.ListenTCP("localhost", 0)
 	if err != nil {

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -37,6 +37,7 @@ func TestInterceptors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server: %v", err)
 	}
+	// nolint:errcheck
 	defer server.Wait()
 
 	listener, err := server.ListenTCP("localhost", 0)

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (
@@ -37,7 +36,6 @@ func TestInterceptors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server: %v", err)
 	}
-	// nolint:errcheck
 	defer server.Wait()
 
 	listener, err := server.ListenTCP("localhost", 0)

--- a/src/client/godoc_test.go
+++ b/src/client/godoc_test.go
@@ -1,6 +1,5 @@
 //go:build k8s
 
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/client/health.go
+++ b/src/client/health.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/client/option.go
+++ b/src/client/option.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import "github.com/pachyderm/pachyderm/v2/src/pfs"

--- a/src/client/transaction.go
+++ b/src/client/transaction.go
@@ -163,7 +163,7 @@ func (c APIClient) ExecuteInTransaction(f func(c *APIClient) error) (*transactio
 		return nil, err
 	}
 	if err := f(c.WithTransaction(txn)); err != nil {
-		// We ignore the delete error, because we are more interested in the error from the callback.
+		// nolint:errcheck // We ignore the delete error, because we are more interested in the error from the callback.
 		c.DeleteTransaction(txn)
 		return nil, err
 	}

--- a/src/client/transaction.go
+++ b/src/client/transaction.go
@@ -163,6 +163,7 @@ func (c APIClient) ExecuteInTransaction(f func(c *APIClient) error) (*transactio
 	}
 	if err := f(c.WithTransaction(txn)); err != nil {
 		// We ignore the delete error, because we are more interested in the error from the callback.
+		// TODO multierr
 		_ = c.DeleteTransaction(txn)
 		return nil, err
 	}

--- a/src/client/transaction.go
+++ b/src/client/transaction.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (
@@ -163,8 +162,8 @@ func (c APIClient) ExecuteInTransaction(f func(c *APIClient) error) (*transactio
 		return nil, err
 	}
 	if err := f(c.WithTransaction(txn)); err != nil {
-		// nolint:errcheck // We ignore the delete error, because we are more interested in the error from the callback.
-		c.DeleteTransaction(txn)
+		// We ignore the delete error, because we are more interested in the error from the callback.
+		_ = c.DeleteTransaction(txn)
 		return nil, err
 	}
 	return c.FinishTransaction(txn)

--- a/src/client/version.go
+++ b/src/client/version.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/internal/backoff/retry_test.go
+++ b/src/internal/backoff/retry_test.go
@@ -44,7 +44,7 @@ func TestRetry(t *testing.T) {
 func TestRetryUntilCancel(t *testing.T) {
 	var results []int
 	ctx, cancel := context.WithCancel(context.Background())
-	backoff.RetryUntilCancel(ctx, func() error {
+	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		results = append(results, len(results))
 		if len(results) >= 3 {
 			cancel()
@@ -59,7 +59,7 @@ func TestRetryUntilCancel(t *testing.T) {
 func TestRetryUntilCancelZeroBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	first := true
-	backoff.RetryUntilCancel(ctx, func() error {
+	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		if first {
 			first = false
 		} else {
@@ -95,7 +95,7 @@ func (m *mustResetBackOff) Reset() {
 func TestRetryUntilCancelResetsOnErrContinue(t *testing.T) {
 	var b mustResetBackOff = 0
 	var results []int
-	backoff.RetryUntilCancel(context.Background(), func() error {
+	backoff.RetryUntilCancel(context.Background(), func() error { //nolint:errcheck
 		results = append(results, len(results)+1)
 		if len(results) < 3 {
 			return backoff.ErrContinue
@@ -108,7 +108,7 @@ func TestRetryUntilCancelResetsOnErrContinue(t *testing.T) {
 func TestNotifyContinue(t *testing.T) {
 	t.Run("NotifyContinueWithNil", func(t *testing.T) {
 		var results []int
-		backoff.RetryNotify(func() error {
+		backoff.RetryNotify(func() error { //nolint:errcheck
 			results = append(results, len(results))
 			if len(results) < 3 {
 				return backoff.ErrContinue // notify fn below will be elided by NotifyContinue
@@ -120,7 +120,7 @@ func TestNotifyContinue(t *testing.T) {
 
 	t.Run("NotifyContinueWithNotify", func(t *testing.T) {
 		var results []int
-		backoff.RetryNotify(func() error {
+		backoff.RetryNotify(func() error { //nolint:errcheck
 			results = append(results, len(results))
 			if len(results) < 3 {
 				return backoff.ErrContinue // notify fn below will be elided by NotifyContinue
@@ -135,7 +135,7 @@ func TestNotifyContinue(t *testing.T) {
 
 	t.Run("NotifyContinueWithFunction", func(t *testing.T) {
 		var results []int
-		backoff.RetryNotify(func() error {
+		backoff.RetryNotify(func() error { //nolint:errcheck
 			results = append(results, len(results))
 			if len(results) < 3 {
 				return backoff.ErrContinue // notify fn below will be elided by NotifyContinue
@@ -154,7 +154,7 @@ func TestNotifyContinue(t *testing.T) {
 		defer log.SetOutput(os.Stdout)
 		var results []int
 		ctx, cancel := context.WithCancel(context.Background())
-		backoff.RetryUntilCancel(ctx, func() error {
+		backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 			results = append(results, len(results))
 			if len(results) < 3 {
 				return backoff.ErrContinue // causes NotifyContinue to re-run
@@ -172,7 +172,7 @@ func TestNotifyContinue(t *testing.T) {
 func TestMustLoop(t *testing.T) {
 	var results []int
 	ctx, cancel := context.WithCancel(context.Background())
-	backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error {
+	backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error { //nolint:errcheck
 		results = append(results, len(results)+1)
 		switch len(results) {
 		case 1:

--- a/src/internal/backoff/retry_test.go
+++ b/src/internal/backoff/retry_test.go
@@ -44,7 +44,6 @@ func TestRetry(t *testing.T) {
 func TestRetryUntilCancel(t *testing.T) {
 	var results []int
 	ctx, cancel := context.WithCancel(context.Background())
-	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		results = append(results, len(results))
 		if len(results) >= 3 {
@@ -60,7 +59,6 @@ func TestRetryUntilCancel(t *testing.T) {
 func TestRetryUntilCancelZeroBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	first := true
-	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		if first {
 			first = false
@@ -97,7 +95,6 @@ func (m *mustResetBackOff) Reset() {
 func TestRetryUntilCancelResetsOnErrContinue(t *testing.T) {
 	var b mustResetBackOff = 0
 	var results []int
-	// nolint:errcheck
 	backoff.RetryUntilCancel(context.Background(), func() error {
 		results = append(results, len(results)+1)
 		if len(results) < 3 {
@@ -111,7 +108,6 @@ func TestRetryUntilCancelResetsOnErrContinue(t *testing.T) {
 func TestNotifyContinue(t *testing.T) {
 	t.Run("NotifyContinueWithNil", func(t *testing.T) {
 		var results []int
-		// nolint:errcheck
 		backoff.RetryNotify(func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -124,7 +120,6 @@ func TestNotifyContinue(t *testing.T) {
 
 	t.Run("NotifyContinueWithNotify", func(t *testing.T) {
 		var results []int
-		// nolint:errcheck
 		backoff.RetryNotify(func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -140,7 +135,6 @@ func TestNotifyContinue(t *testing.T) {
 
 	t.Run("NotifyContinueWithFunction", func(t *testing.T) {
 		var results []int
-		// nolint:errcheck
 		backoff.RetryNotify(func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -160,7 +154,6 @@ func TestNotifyContinue(t *testing.T) {
 		defer log.SetOutput(os.Stdout)
 		var results []int
 		ctx, cancel := context.WithCancel(context.Background())
-		// nolint:errcheck
 		backoff.RetryUntilCancel(ctx, func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -179,7 +172,6 @@ func TestNotifyContinue(t *testing.T) {
 func TestMustLoop(t *testing.T) {
 	var results []int
 	ctx, cancel := context.WithCancel(context.Background())
-	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error {
 		results = append(results, len(results)+1)
 		switch len(results) {

--- a/src/internal/backoff/retry_test.go
+++ b/src/internal/backoff/retry_test.go
@@ -44,6 +44,7 @@ func TestRetry(t *testing.T) {
 func TestRetryUntilCancel(t *testing.T) {
 	var results []int
 	ctx, cancel := context.WithCancel(context.Background())
+	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		results = append(results, len(results))
 		if len(results) >= 3 {
@@ -59,6 +60,7 @@ func TestRetryUntilCancel(t *testing.T) {
 func TestRetryUntilCancelZeroBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	first := true
+	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		if first {
 			first = false
@@ -95,6 +97,7 @@ func (m *mustResetBackOff) Reset() {
 func TestRetryUntilCancelResetsOnErrContinue(t *testing.T) {
 	var b mustResetBackOff = 0
 	var results []int
+	// nolint:errcheck
 	backoff.RetryUntilCancel(context.Background(), func() error {
 		results = append(results, len(results)+1)
 		if len(results) < 3 {
@@ -108,6 +111,7 @@ func TestRetryUntilCancelResetsOnErrContinue(t *testing.T) {
 func TestNotifyContinue(t *testing.T) {
 	t.Run("NotifyContinueWithNil", func(t *testing.T) {
 		var results []int
+		// nolint:errcheck
 		backoff.RetryNotify(func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -120,6 +124,7 @@ func TestNotifyContinue(t *testing.T) {
 
 	t.Run("NotifyContinueWithNotify", func(t *testing.T) {
 		var results []int
+		// nolint:errcheck
 		backoff.RetryNotify(func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -135,6 +140,7 @@ func TestNotifyContinue(t *testing.T) {
 
 	t.Run("NotifyContinueWithFunction", func(t *testing.T) {
 		var results []int
+		// nolint:errcheck
 		backoff.RetryNotify(func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -154,6 +160,7 @@ func TestNotifyContinue(t *testing.T) {
 		defer log.SetOutput(os.Stdout)
 		var results []int
 		ctx, cancel := context.WithCancel(context.Background())
+		// nolint:errcheck
 		backoff.RetryUntilCancel(ctx, func() error {
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -172,6 +179,7 @@ func TestNotifyContinue(t *testing.T) {
 func TestMustLoop(t *testing.T) {
 	var results []int
 	ctx, cancel := context.WithCancel(context.Background())
+	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error {
 		results = append(results, len(results)+1)
 		switch len(results) {

--- a/src/internal/cert/cert_test.go
+++ b/src/internal/cert/cert_test.go
@@ -52,14 +52,14 @@ func TestTLS(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			b, err := ioutil.ReadAll(req.Body)
 			if err != nil {
-				w.Write([]byte("err: " + err.Error()))
+				w.Write([]byte("err: " + err.Error())) //nolint:errcheck
 				return
 			}
-			w.Write(b)
+			w.Write(b) //nolint:errcheck
 		}),
 	}
 	// Note: no need to provide cert/key files, as they're set in the TLSConfig
-	go server.ServeTLS(l, "", "")
+	go server.ServeTLS(l, "", "") //nolint:errcheck
 
 	// Create a client for the server above
 	c := http.Client{

--- a/src/internal/cert/cert_test.go
+++ b/src/internal/cert/cert_test.go
@@ -52,16 +52,13 @@ func TestTLS(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			b, err := ioutil.ReadAll(req.Body)
 			if err != nil {
-				// nolint:errcheck
 				w.Write([]byte("err: " + err.Error()))
 				return
 			}
-			// nolint:errcheck
 			w.Write(b)
 		}),
 	}
 	// Note: no need to provide cert/key files, as they're set in the TLSConfig
-	// nolint:errcheck
 	go server.ServeTLS(l, "", "")
 
 	// Create a client for the server above

--- a/src/internal/cert/cert_test.go
+++ b/src/internal/cert/cert_test.go
@@ -52,14 +52,18 @@ func TestTLS(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			b, err := ioutil.ReadAll(req.Body)
 			if err != nil {
-				w.Write([]byte("err: " + err.Error()))
+				_, err := w.Write([]byte("err: " + err.Error()))
+				require.NoError(t, err)
 				return
 			}
-			w.Write(b)
+			_, err = w.Write(b)
+			require.NoError(t, err)
 		}),
 	}
 	// Note: no need to provide cert/key files, as they're set in the TLSConfig
-	go server.ServeTLS(l, "", "")
+	go func() {
+		require.NoError(t, server.ServeTLS(l, "", ""))
+	}()
 
 	// Create a client for the server above
 	c := http.Client{

--- a/src/internal/cert/cert_test.go
+++ b/src/internal/cert/cert_test.go
@@ -52,18 +52,17 @@ func TestTLS(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			b, err := ioutil.ReadAll(req.Body)
 			if err != nil {
-				_, err := w.Write([]byte("err: " + err.Error()))
-				require.NoError(t, err)
+				// nolint:errcheck
+				w.Write([]byte("err: " + err.Error()))
 				return
 			}
-			_, err = w.Write(b)
-			require.NoError(t, err)
+			// nolint:errcheck
+			w.Write(b)
 		}),
 	}
 	// Note: no need to provide cert/key files, as they're set in the TLSConfig
-	go func() {
-		require.NoError(t, server.ServeTLS(l, "", ""))
-	}()
+	// nolint:errcheck
+	go server.ServeTLS(l, "", "")
 
 	// Create a client for the server above
 	c := http.Client{

--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -29,6 +29,7 @@ func RunFixedArgs(numArgs int, run func([]string) error) func(*cobra.Command, []
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != numArgs {
 			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
+			// nolint:errcheck
 			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
@@ -45,6 +46,7 @@ func RunCmdFixedArgs(numArgs int, run func(*cobra.Command, []string) error) func
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != numArgs {
 			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
+			// nolint:errcheck
 			cmd.Usage()
 		} else {
 			if err := run(cmd, args); err != nil {
@@ -60,6 +62,7 @@ func RunBoundedArgs(min int, max int, run func([]string) error) func(*cobra.Comm
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min || len(args) > max {
 			fmt.Printf("expected %d to %d arguments, got %d\n\n", min, max, len(args))
+			// nolint:errcheck
 			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
@@ -75,6 +78,7 @@ func RunMinimumArgs(min int, run func([]string) error) func(*cobra.Command, []st
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min {
 			fmt.Printf("expected at least %d arguments, got %d\n\n", min, len(args))
+			// nolint:errcheck
 			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {

--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -29,8 +29,7 @@ func RunFixedArgs(numArgs int, run func([]string) error) func(*cobra.Command, []
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != numArgs {
 			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
-			// nolint:errcheck
-			cmd.Usage()
+			cmd.Usage() //nolint:errcheck
 		} else {
 			if err := run(args); err != nil {
 				ErrorAndExit("%v", err)
@@ -46,8 +45,7 @@ func RunCmdFixedArgs(numArgs int, run func(*cobra.Command, []string) error) func
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != numArgs {
 			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
-			// nolint:errcheck
-			cmd.Usage()
+			cmd.Usage() //nolint:errcheck
 		} else {
 			if err := run(cmd, args); err != nil {
 				ErrorAndExit("%v", err)
@@ -62,8 +60,7 @@ func RunBoundedArgs(min int, max int, run func([]string) error) func(*cobra.Comm
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min || len(args) > max {
 			fmt.Printf("expected %d to %d arguments, got %d\n\n", min, max, len(args))
-			// nolint:errcheck
-			cmd.Usage()
+			cmd.Usage() //nolint:errcheck
 		} else {
 			if err := run(args); err != nil {
 				ErrorAndExit("%v", err)
@@ -78,8 +75,7 @@ func RunMinimumArgs(min int, run func([]string) error) func(*cobra.Command, []st
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min {
 			fmt.Printf("expected at least %d arguments, got %d\n\n", min, len(args))
-			// nolint:errcheck
-			cmd.Usage()
+			cmd.Usage() //nolint:errcheck
 		} else {
 			if err := run(args); err != nil {
 				ErrorAndExit("%v", err)

--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -29,7 +29,7 @@ func RunFixedArgs(numArgs int, run func([]string) error) func(*cobra.Command, []
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != numArgs {
 			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
-			cmd.Usage() //nolint:errcheck
+			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
 				ErrorAndExit("%v", err)
@@ -45,7 +45,7 @@ func RunCmdFixedArgs(numArgs int, run func(*cobra.Command, []string) error) func
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) != numArgs {
 			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
-			cmd.Usage() //nolint:errcheck
+			cmd.Usage()
 		} else {
 			if err := run(cmd, args); err != nil {
 				ErrorAndExit("%v", err)
@@ -60,7 +60,7 @@ func RunBoundedArgs(min int, max int, run func([]string) error) func(*cobra.Comm
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min || len(args) > max {
 			fmt.Printf("expected %d to %d arguments, got %d\n\n", min, max, len(args))
-			cmd.Usage() //nolint:errcheck
+			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
 				ErrorAndExit("%v", err)
@@ -75,7 +75,7 @@ func RunMinimumArgs(min int, run func([]string) error) func(*cobra.Command, []st
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min {
 			fmt.Printf("expected at least %d arguments, got %d\n\n", min, len(args))
-			cmd.Usage() //nolint:errcheck
+			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
 				ErrorAndExit("%v", err)

--- a/src/internal/collection/collection_test.go
+++ b/src/internal/collection/collection_test.go
@@ -499,7 +499,7 @@ func collectionTests(
 						return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", oobID)
 					}
 
-					rw.DeleteAll()
+					require.NoError(t, rw.DeleteAll())
 
 					for _, id := range idRange(0, defaultCollectionSize) {
 						if err := rw.Get(id, testProto); !col.IsErrNotFound(err) {

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -604,62 +604,59 @@ func (c *etcdReadOnlyCollection) WatchByIndex(index *Index, val string, opts ...
 	if err != nil {
 		return nil, err
 	}
-	go func() (retErr error) {
-		defer func() {
-			if retErr != nil {
-				eventCh <- &watch.Event{
-					Type: watch.EventError,
-					Err:  retErr,
+	go func() {
+		watchForEvents := func() error {
+			for {
+				var ev *watch.Event
+				var ok bool
+				select {
+				case ev, ok = <-watcher.Watch():
+				case <-done:
+					watcher.Close()
+					return nil
 				}
-				watcher.Close()
-			}
-			close(eventCh)
-		}()
-		for {
-			var ev *watch.Event
-			var ok bool
-			select {
-			case ev, ok = <-watcher.Watch():
-			case <-done:
-				watcher.Close()
-				return nil
-			}
-			if !ok {
-				watcher.Close()
-				return nil
-			}
+				if !ok {
+					watcher.Close()
+					return nil
+				}
 
-			var directEv *watch.Event
-			switch ev.Type {
-			case watch.EventError:
-				// pass along the error
-				return ev.Err
-			case watch.EventPut:
-				resp, err := c.get(c.path(path.Base(string(ev.Key))))
-				if err != nil {
-					return err
+				var directEv *watch.Event
+				switch ev.Type {
+				case watch.EventError:
+					// pass along the error
+					return ev.Err
+				case watch.EventPut:
+					resp, err := c.get(c.path(path.Base(string(ev.Key))))
+					if err != nil {
+						return err
+					}
+					if len(resp.Kvs) == 0 {
+						// this happens only if the item was deleted shortly after
+						// we receive this event.
+						continue
+					}
+					directEv = &watch.Event{
+						Key:      []byte(path.Base(string(ev.Key))),
+						Value:    resp.Kvs[0].Value,
+						Type:     ev.Type,
+						Template: c.template,
+					}
+				case watch.EventDelete:
+					directEv = &watch.Event{
+						Key:      []byte(path.Base(string(ev.Key))),
+						Type:     ev.Type,
+						Template: c.template,
+					}
 				}
-				if len(resp.Kvs) == 0 {
-					// this happens only if the item was deleted shortly after
-					// we receive this event.
-					continue
-				}
-				directEv = &watch.Event{
-					Key:      []byte(path.Base(string(ev.Key))),
-					Value:    resp.Kvs[0].Value,
-					Type:     ev.Type,
-					Template: c.template,
-				}
-			case watch.EventDelete:
-				directEv = &watch.Event{
-					Key:      []byte(path.Base(string(ev.Key))),
-					Type:     ev.Type,
-					Template: c.template,
-				}
+				eventCh <- directEv
 			}
-			eventCh <- directEv
 		}
-	}() //nolint:errcheck
+		if err := watchForEvents(); err != nil {
+			eventCh <- &watch.Event{Type: watch.EventError, Err: err}
+			watcher.Close()
+		}
+		close(eventCh)
+	}()
 	return watch.MakeEtcdWatcher(eventCh, done), nil
 }
 

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -651,11 +651,11 @@ func (c *etcdReadOnlyCollection) WatchByIndex(index *Index, val string, opts ...
 				eventCh <- directEv
 			}
 		}
+		defer close(eventCh)
 		if err := watchForEvents(); err != nil {
 			eventCh <- &watch.Event{Type: watch.EventError, Err: err}
 			watcher.Close()
 		}
-		close(eventCh)
 	}()
 	return watch.MakeEtcdWatcher(eventCh, done), nil
 }

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -604,7 +604,6 @@ func (c *etcdReadOnlyCollection) WatchByIndex(index *Index, val string, opts ...
 	if err != nil {
 		return nil, err
 	}
-	// nolint:errcheck
 	go func() (retErr error) {
 		defer func() {
 			if retErr != nil {
@@ -660,7 +659,7 @@ func (c *etcdReadOnlyCollection) WatchByIndex(index *Index, val string, opts ...
 			}
 			eventCh <- directEv
 		}
-	}()
+	}() //nolint:errcheck
 	return watch.MakeEtcdWatcher(eventCh, done), nil
 }
 

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -604,6 +604,7 @@ func (c *etcdReadOnlyCollection) WatchByIndex(index *Index, val string, opts ...
 	if err != nil {
 		return nil, err
 	}
+	// nolint:errcheck
 	go func() (retErr error) {
 		defer func() {
 			if retErr != nil {

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -103,10 +103,18 @@ func TestDeletePrefix(t *testing.T) {
 
 	_, err := col.NewSTM(context.Background(), env.EtcdClient, func(stm col.STM) error {
 		rw := jobInfos.ReadWrite(stm)
-		rw.Put(ppsdb.JobKey(j1.Job), j1)
-		rw.Put(ppsdb.JobKey(j2.Job), j2)
-		rw.Put(ppsdb.JobKey(j3.Job), j3)
-		rw.Put(ppsdb.JobKey(j4.Job), j4)
+		if err := rw.Put(ppsdb.JobKey(j1.Job), j1); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if err := rw.Put(ppsdb.JobKey(j2.Job), j2); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if err := rw.Put(ppsdb.JobKey(j3.Job), j3); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if err := rw.Put(ppsdb.JobKey(j4.Job), j4); err != nil {
+			return errors.EnsureStack(err)
+		}
 		return nil
 	})
 	require.NoError(t, err)
@@ -115,7 +123,9 @@ func TestDeletePrefix(t *testing.T) {
 		job := &pps.JobInfo{}
 		rw := jobInfos.ReadWrite(stm)
 
-		rw.DeleteAllPrefix("p@prefix/suffix")
+		if err := rw.DeleteAllPrefix("p@prefix/suffix"); err != nil {
+			return errors.EnsureStack(err)
+		}
 		if err := rw.Get(ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j1.Job.ID)
 		}
@@ -129,7 +139,9 @@ func TestDeletePrefix(t *testing.T) {
 			return errors.EnsureStack(err)
 		}
 
-		rw.DeleteAllPrefix("p@prefix")
+		if err := rw.DeleteAllPrefix("p@prefix"); err != nil {
+			return errors.EnsureStack(err)
+		}
 		if err := rw.Get(ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j1.Job.ID)
 		}
@@ -143,17 +155,23 @@ func TestDeletePrefix(t *testing.T) {
 			return errors.EnsureStack(err)
 		}
 
-		rw.Put(ppsdb.JobKey(j1.Job), j1)
+		if err := rw.Put(ppsdb.JobKey(j1.Job), j1); err != nil {
+			return errors.EnsureStack(err)
+		}
 		if err := rw.Get(ppsdb.JobKey(j1.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
 
-		rw.DeleteAllPrefix("p@prefix/suffix")
+		if err := rw.DeleteAllPrefix("p@prefix/suffix"); err != nil {
+			return errors.EnsureStack(err)
+		}
 		if err := rw.Get(ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j1.Job.ID)
 		}
 
-		rw.Put(ppsdb.JobKey(j2.Job), j2)
+		if err := rw.Put(ppsdb.JobKey(j2.Job), j2); err != nil {
+			return errors.EnsureStack(err)
+		}
 		if err := rw.Get(ppsdb.JobKey(j2.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
@@ -190,9 +208,15 @@ func TestIndex(t *testing.T) {
 	}
 	_, err := col.NewSTM(context.Background(), env.EtcdClient, func(stm col.STM) error {
 		rw := jobInfos.ReadWrite(stm)
-		rw.Put(ppsdb.JobKey(j1.Job), j1)
-		rw.Put(ppsdb.JobKey(j2.Job), j2)
-		rw.Put(ppsdb.JobKey(j3.Job), j3)
+		if err := rw.Put(ppsdb.JobKey(j1.Job), j1); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if err := rw.Put(ppsdb.JobKey(j2.Job), j2); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if err := rw.Put(ppsdb.JobKey(j3.Job), j3); err != nil {
+			return errors.EnsureStack(err)
+		}
 		return nil
 	})
 	require.NoError(t, err)
@@ -247,8 +271,12 @@ func TestBoolIndex(t *testing.T) {
 	}
 	_, err := col.NewSTM(context.Background(), env.EtcdClient, func(stm col.STM) error {
 		boolValues := boolValues.ReadWrite(stm)
-		boolValues.Put("true", r1)
-		boolValues.Put("false", r2)
+		if err := boolValues.Put("true", r1); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if err := boolValues.Put("false", r2); err != nil {
+			return errors.EnsureStack(err)
+		}
 		return nil
 	})
 	require.NoError(t, err)

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -580,14 +580,18 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 	}); err != nil && !errors.Is(err, errutil.ErrBreak) {
 		// Ignore any additional error here - we're already attempting to send an error to the user
 		// and use a background context in case we failed with context cancelled
+		// nolint:errcheck
 		watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err})
+		// nolint:errcheck
 		watcher.listener.Unregister(watcher)
 		return
 	}
 
 	if bufEvent != nil {
 		if err := watcher.sendInitial(c.ctx, bufEvent.WatchEvent(c.ctx, watcher.db, watcher.template)); err != nil {
+			// nolint:errcheck
 			watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err})
+			// nolint:errcheck
 			watcher.listener.Unregister(watcher)
 			return
 		}

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -578,21 +578,16 @@ func (c *postgresReadOnlyCollection) watchRoutine(watcher *postgresWatcher, opti
 			Rev:      m.UpdatedAt.Unix(),
 		})
 	}); err != nil && !errors.Is(err, errutil.ErrBreak) {
-		// Ignore any additional error here - we're already attempting to send an error to the user
-		// and use a background context in case we failed with context cancelled
-		// nolint:errcheck
-		watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err})
-		// nolint:errcheck
-		watcher.listener.Unregister(watcher)
+		// use a background context in case we failed with context cancelled
+		watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err}) //nolint:errcheck // already sending the error from c.list()
+		watcher.listener.Unregister(watcher)                                                      //nolint:errcheck
 		return
 	}
 
 	if bufEvent != nil {
 		if err := watcher.sendInitial(c.ctx, bufEvent.WatchEvent(c.ctx, watcher.db, watcher.template)); err != nil {
-			// nolint:errcheck
-			watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err})
-			// nolint:errcheck
-			watcher.listener.Unregister(watcher)
+			watcher.sendInitial(context.Background(), &watch.Event{Type: watch.EventError, Err: err}) //nolint:errcheck
+			watcher.listener.Unregister(watcher)                                                      //nolint:errcheck
 			return
 		}
 	}

--- a/src/internal/collection/postgres_listener.go
+++ b/src/internal/collection/postgres_listener.go
@@ -103,6 +103,7 @@ func (pw *postgresWatcher) Close() {
 	pw.closer.Do(func() {
 		// Close the 'done' channel to interrupt any waiting writes
 		close(pw.done)
+		// nolint:errcheck
 		pw.listener.Unregister(pw)
 	})
 }
@@ -123,6 +124,7 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 				// unregister the watcher and stop forwarding notifications.
 				select {
 				case pw.c <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}:
+					// nolint:errcheck
 					pw.listener.Unregister(pw)
 				case <-pw.done:
 				}
@@ -136,6 +138,7 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 			// unregister the watcher and stop forwarding notifications.
 			select {
 			case pw.c <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}:
+				// nolint:errcheck
 				pw.listener.Unregister(pw)
 			case <-pw.done:
 			}
@@ -192,6 +195,7 @@ func (pw *postgresWatcher) send(event *postgresEvent) {
 		go func() {
 			// Unregister the watcher first, so we stop attempting to send it events
 			// (this will happen again in pw.Close(), but it will be a no-op).
+			// nolint:errcheck
 			pw.listener.Unregister(pw)
 
 			select {
@@ -379,7 +383,7 @@ func (l *postgresListener) reset(err error) {
 	l.channels = make(map[string]notifierSet)
 	l.channelMu.Unlock()
 	if !l.closed {
-		// `reset` is only ever called in the case of an error, so it should be fine to discard this error
+		// nolint:errcheck // `reset` is only ever called in the case of an error, so it should be fine to discard this error
 		l.getPQL().UnlistenAll()
 	}
 }

--- a/src/internal/collection/postgres_listener.go
+++ b/src/internal/collection/postgres_listener.go
@@ -103,8 +103,7 @@ func (pw *postgresWatcher) Close() {
 	pw.closer.Do(func() {
 		// Close the 'done' channel to interrupt any waiting writes
 		close(pw.done)
-		// nolint:errcheck
-		pw.listener.Unregister(pw)
+		pw.listener.Unregister(pw) //nolint:errcheck
 	})
 }
 
@@ -124,8 +123,7 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 				// unregister the watcher and stop forwarding notifications.
 				select {
 				case pw.c <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}:
-					// nolint:errcheck
-					pw.listener.Unregister(pw)
+					pw.listener.Unregister(pw) //nolint:errcheck
 				case <-pw.done:
 				}
 				return
@@ -138,8 +136,7 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 			// unregister the watcher and stop forwarding notifications.
 			select {
 			case pw.c <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}:
-				// nolint:errcheck
-				pw.listener.Unregister(pw)
+				pw.listener.Unregister(pw) //nolint:errcheck
 			case <-pw.done:
 			}
 			return
@@ -195,8 +192,7 @@ func (pw *postgresWatcher) send(event *postgresEvent) {
 		go func() {
 			// Unregister the watcher first, so we stop attempting to send it events
 			// (this will happen again in pw.Close(), but it will be a no-op).
-			// nolint:errcheck
-			pw.listener.Unregister(pw)
+			pw.listener.Unregister(pw) //nolint:errcheck
 
 			select {
 			case pw.buf <- &postgresEvent{err: errors.New("watcher buffer is full, aborting watch")}:
@@ -383,8 +379,7 @@ func (l *postgresListener) reset(err error) {
 	l.channels = make(map[string]notifierSet)
 	l.channelMu.Unlock()
 	if !l.closed {
-		// nolint:errcheck // `reset` is only ever called in the case of an error, so it should be fine to discard this error
-		l.getPQL().UnlistenAll()
+		l.getPQL().UnlistenAll() //nolint:errcheck // `reset` is only ever called in the case of an error
 	}
 }
 

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -227,7 +227,7 @@ func watchTests(
 			defer cancel()
 			reader, writer := newCollection(context.Background(), t)
 			row := makeProto(makeID(4))
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(ctx, t, reader))
 			tester.ExpectEvent(TestEvent{watch.EventPut, row.ID, row})
@@ -246,7 +246,7 @@ func watchTests(
 			defer cancel()
 			reader, writer := newCollection(context.Background(), t)
 			for i := 0; i < 10; i++ {
-				writer(context.Background(), putItem(makeProto(makeID(i))))
+				require.NoError(t, writer(context.Background(), putItem(makeProto(makeID(i)))))
 			}
 
 			watcher := makeWatcher(ctx, t, reader)
@@ -273,7 +273,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(context.Background(), t)
 			row := makeProto(makeID(1))
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader))
 			tester.ExpectEvent(TestEvent{watch.EventPut, row.ID, row})
@@ -288,8 +288,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -323,7 +323,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(context.Background(), t)
 			row := makeProto(makeID(1), originalValue)
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader))
 			tester.ExpectEvent(TestEvent{watch.EventPut, row.ID, row})
@@ -343,7 +343,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(context.Background(), t)
 			watchRead := reader(canceledContext())
-			writer(context.Background(), putItem(makeProto(makeID(3))))
+			require.NoError(t, writer(context.Background(), putItem(makeProto(makeID(3)))))
 			testInterruptionPreemptive(t, func() (watch.Watcher, error) {
 				res, err := watchRead.Watch()
 				return res, errors.EnsureStack(err)
@@ -365,7 +365,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(context.Background(), t)
 			watchRead := reader(canceledContext())
-			writer(context.Background(), putItem(makeProto(makeID(1))))
+			require.NoError(t, writer(context.Background(), putItem(makeProto(makeID(1)))))
 
 			events := []*watch.Event{}
 			err := watchRead.WatchF(func(ev *watch.Event) error {
@@ -383,8 +383,8 @@ func watchTests(
 			watchRead := reader(context.Background())
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			events := []TestEvent{}
 			err := watchRead.WatchF(func(ev *watch.Event) error {
@@ -429,7 +429,7 @@ func watchTests(
 			defer cancel()
 			reader, writer := newCollection(context.Background(), t)
 			row := makeProto(makeID(4))
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(ctx, t, reader, row.ID))
 			tester.ExpectEvent(TestEvent{watch.EventPut, row.ID, row})
@@ -447,8 +447,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, rowA.ID))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -465,8 +465,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, rowA.ID))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -496,8 +496,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2))
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, rowA.ID))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -522,7 +522,7 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			watchRead := reader(canceledContext())
 			row := makeProto(makeID(1))
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 			testInterruptionPreemptive(t, func() (watch.Watcher, error) {
 				res, err := watchRead.WatchOne(row.ID)
 				return res, errors.EnsureStack(err)
@@ -545,7 +545,7 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			watchRead := reader(canceledContext())
 			row := makeProto(makeID(1))
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			events := []*watch.Event{}
 			err := watchRead.WatchOneF(row.ID, func(ev *watch.Event) error {
@@ -562,8 +562,8 @@ func watchTests(
 			watchRead := reader(context.Background())
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			events := []TestEvent{}
 			err := watchRead.WatchOneF(rowA.ID, func(ev *watch.Event) error {
@@ -588,7 +588,7 @@ func watchTests(
 			defer cancel()
 			reader, writer := newCollection(context.Background(), t)
 			row := makeProto(makeID(4), originalValue)
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(ctx, t, reader, originalValue))
 			tester.ExpectEvent(TestEvent{watch.EventPut, row.ID, row})
@@ -621,8 +621,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), changedValue)
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, originalValue))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -639,8 +639,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), changedValue)
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, originalValue))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -657,8 +657,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), changedValue)
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, originalValue))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -673,8 +673,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), changedValue)
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, originalValue))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -690,8 +690,8 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), changedValue)
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			tester := NewWatchTester(t, writer, makeWatcher(context.Background(), t, reader, originalValue))
 			tester.ExpectEvent(TestEvent{watch.EventPut, rowA.ID, rowA})
@@ -711,7 +711,7 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			watchRead := reader(canceledContext())
 			row := makeProto(makeID(1), originalValue)
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 			testInterruptionPreemptive(t, func() (watch.Watcher, error) {
 				res, err := watchRead.WatchByIndex(TestSecondaryIndex, originalValue)
 				return res, errors.EnsureStack(err)
@@ -734,7 +734,7 @@ func watchTests(
 			reader, writer := newCollection(context.Background(), t)
 			watchRead := reader(canceledContext())
 			row := makeProto(makeID(1), originalValue)
-			writer(context.Background(), putItem(row))
+			require.NoError(t, writer(context.Background(), putItem(row)))
 
 			events := []*watch.Event{}
 			err := watchRead.WatchByIndexF(TestSecondaryIndex, originalValue, func(ev *watch.Event) error {
@@ -751,8 +751,8 @@ func watchTests(
 			watchRead := reader(context.Background())
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), originalValue)
-			writer(context.Background(), putItem(rowA))
-			writer(context.Background(), putItem(rowB))
+			require.NoError(t, writer(context.Background(), putItem(rowA)))
+			require.NoError(t, writer(context.Background(), putItem(rowB)))
 
 			events := []TestEvent{}
 			err := watchRead.WatchByIndexF(TestSecondaryIndex, originalValue, func(ev *watch.Event) error {

--- a/src/internal/errutil/errutil.go
+++ b/src/internal/errutil/errutil.go
@@ -62,6 +62,5 @@ func IsInvalidPathError(err error) bool {
 // IsNetRetryable returns true if the error is a temporary network error.
 func IsNetRetryable(err error) bool {
 	var netErr net.Error
-	// nolint:staticcheck
-	return errors.As(err, &netErr) && netErr.Temporary()
+	return errors.As(err, &netErr) && netErr.Temporary() //nolint:staticcheck
 }

--- a/src/internal/exec/exec.go
+++ b/src/internal/exec/exec.go
@@ -172,6 +172,7 @@ func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
 // two interfaces with non-comparable underlying types.
 func interfaceEqual(a, b interface{}) bool {
 	defer func() {
+		// nolint:errcheck
 		recover()
 	}()
 	return a == b
@@ -391,6 +392,7 @@ func (c *Cmd) Start() error {
 		go func() {
 			select {
 			case <-c.ctx.Done():
+				// nolint:errcheck
 				c.Process.Kill()
 			case <-c.waitDone:
 			}

--- a/src/internal/exec/exec.go
+++ b/src/internal/exec/exec.go
@@ -172,8 +172,7 @@ func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
 // two interfaces with non-comparable underlying types.
 func interfaceEqual(a, b interface{}) bool {
 	defer func() {
-		// nolint:errcheck
-		recover()
+		recover() //nolint:errcheck
 	}()
 	return a == b
 }
@@ -392,8 +391,7 @@ func (c *Cmd) Start() error {
 		go func() {
 			select {
 			case <-c.ctx.Done():
-				// nolint:errcheck
-				c.Process.Kill()
+				c.Process.Kill() //nolint:errcheck
 			case <-c.waitDone:
 			}
 		}()

--- a/src/internal/grpcutil/server.go
+++ b/src/internal/grpcutil/server.go
@@ -91,7 +91,9 @@ func (s *Server) ListenSocket(path string) error {
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	go s.Server.Serve(listener)
+	s.eg.Go(func() error {
+		return errors.EnsureStack(s.Server.Serve(listener))
+	})
 	return nil
 }
 

--- a/src/internal/keycache/cache.go
+++ b/src/internal/keycache/cache.go
@@ -38,7 +38,7 @@ func NewCache(ctx context.Context, readOnly col.ReadOnlyCollection, key string, 
 
 // Watch should be called in a goroutine to start the watcher
 func (c *Cache) Watch() {
-	backoff.RetryNotify(func() error {
+	backoff.RetryNotify(func() error { //nolint:errcheck
 		err := c.readOnly.WatchOneF(c.key, func(ev *watch.Event) error {
 			switch ev.Type {
 			case watch.EventPut:

--- a/src/internal/keycache/cache.go
+++ b/src/internal/keycache/cache.go
@@ -38,7 +38,6 @@ func NewCache(ctx context.Context, readOnly col.ReadOnlyCollection, key string, 
 
 // Watch should be called in a goroutine to start the watcher
 func (c *Cache) Watch() {
-	//nolint:errcheck
 	backoff.RetryNotify(func() error {
 		err := c.readOnly.WatchOneF(c.key, func(ev *watch.Event) error {
 			switch ev.Type {

--- a/src/internal/keycache/cache.go
+++ b/src/internal/keycache/cache.go
@@ -38,7 +38,7 @@ func NewCache(ctx context.Context, readOnly col.ReadOnlyCollection, key string, 
 
 // Watch should be called in a goroutine to start the watcher
 func (c *Cache) Watch() {
-	// nolint:errcheck
+	//nolint:errcheck
 	backoff.RetryNotify(func() error {
 		err := c.readOnly.WatchOneF(c.key, func(ev *watch.Event) error {
 			switch ev.Type {

--- a/src/internal/keycache/cache.go
+++ b/src/internal/keycache/cache.go
@@ -38,6 +38,7 @@ func NewCache(ctx context.Context, readOnly col.ReadOnlyCollection, key string, 
 
 // Watch should be called in a goroutine to start the watcher
 func (c *Cache) Watch() {
+	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		err := c.readOnly.WatchOneF(c.key, func(ev *watch.Event) error {
 			switch ev.Type {

--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -148,6 +148,7 @@ func (r *Reporter) reportClusterMetrics() {
 		time.Sleep(reportingInterval)
 		metrics := &Metrics{}
 		r.internalMetrics(metrics)
+		// nolint:errcheck
 		externalMetrics(r.env.GetKubeClient(), metrics)
 		metrics.ClusterID = r.clusterID
 		metrics.PodID = uuid.NewWithoutDashes()

--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -148,8 +148,7 @@ func (r *Reporter) reportClusterMetrics() {
 		time.Sleep(reportingInterval)
 		metrics := &Metrics{}
 		r.internalMetrics(metrics)
-		// nolint:errcheck
-		externalMetrics(r.env.GetKubeClient(), metrics)
+		externalMetrics(r.env.GetKubeClient(), metrics) //nolint:errcheck
 		metrics.ClusterID = r.clusterID
 		metrics.PodID = uuid.NewWithoutDashes()
 		metrics.Version = version.PrettyPrintVersion(version.Version)

--- a/src/internal/metrics/segment.go
+++ b/src/internal/metrics/segment.go
@@ -23,6 +23,7 @@ func newSegmentClient() *analytics.Client {
 func reportClusterMetricsToSegment(client *analytics.Client, metrics *Metrics) {
 	// We're intentionally ignoring an error here because metrics code is
 	// non-critical
+	// nolint:errcheck
 	client.Track(&analytics.Track{
 		Event:       "cluster.metrics",
 		AnonymousId: metrics.ClusterID,
@@ -86,7 +87,7 @@ before every `Track()` call containing user data.
 */
 func identifyUser(client *analytics.Client, userID string) {
 	// We're intentionally ignoring an error here because metrics code is
-	// non-critical
+	// nolint:errcheck // non-critical
 	client.Identify(&analytics.Identify{
 		UserId: userID,
 	})
@@ -100,6 +101,7 @@ func reportUserMetricsToSegment(client *analytics.Client, userID string, prefix 
 	properties[action] = value
 	// We're intentionally ignoring an error here because metrics code is
 	// non-critical
+	// nolint:errcheck
 	client.Track(&analytics.Track{
 		Event:      fmt.Sprintf("%v.usage", prefix),
 		UserId:     userID,

--- a/src/internal/metrics/segment.go
+++ b/src/internal/metrics/segment.go
@@ -21,9 +21,7 @@ func newSegmentClient() *analytics.Client {
 }
 
 func reportClusterMetricsToSegment(client *analytics.Client, metrics *Metrics) {
-	// We're intentionally ignoring an error here because metrics code is
-	// non-critical
-	// nolint:errcheck
+	//nolint:errcheck // ignoring error because metrics code is non-critical
 	client.Track(&analytics.Track{
 		Event:       "cluster.metrics",
 		AnonymousId: metrics.ClusterID,
@@ -86,9 +84,7 @@ We have no way of knowing if a user has previously been identified, so we call t
 before every `Track()` call containing user data.
 */
 func identifyUser(client *analytics.Client, userID string) {
-	// We're intentionally ignoring an error here because metrics code is
-	// nolint:errcheck // non-critical
-	client.Identify(&analytics.Identify{
+	client.Identify(&analytics.Identify{ //nolint:errcheck // ignoring error because metrics code is non-critical
 		UserId: userID,
 	})
 }
@@ -99,10 +95,7 @@ func reportUserMetricsToSegment(client *analytics.Client, userID string, prefix 
 		"ClusterID": clusterID,
 	}
 	properties[action] = value
-	// We're intentionally ignoring an error here because metrics code is
-	// non-critical
-	// nolint:errcheck
-	client.Track(&analytics.Track{
+	client.Track(&analytics.Track{ //nolint:errcheck // ignoring error because metrics code is non-critical
 		Event:      fmt.Sprintf("%v.usage", prefix),
 		UserId:     userID,
 		Properties: properties,

--- a/src/internal/metrics/segment.go
+++ b/src/internal/metrics/segment.go
@@ -21,8 +21,7 @@ func newSegmentClient() *analytics.Client {
 }
 
 func reportClusterMetricsToSegment(client *analytics.Client, metrics *Metrics) {
-	//nolint:errcheck // ignoring error because metrics code is non-critical
-	client.Track(&analytics.Track{
+	client.Track(&analytics.Track{ //nolint:errcheck // ignoring error because metrics code is non-critical
 		Event:       "cluster.metrics",
 		AnonymousId: metrics.ClusterID,
 		Properties: map[string]interface{}{

--- a/src/internal/middleware/errors/interceptor.go
+++ b/src/internal/middleware/errors/interceptor.go
@@ -39,7 +39,7 @@ func errorForGRPC(err error) error {
 	}
 	if _, ok := status.FromError(cursor); ok {
 		// handles nil as well
-		return cursor //nolint:wrapcheck
+		return cursor
 	}
 	code := codes.Unknown
 	for cursor != nil {
@@ -52,7 +52,7 @@ func errorForGRPC(err error) error {
 	return &gRPCStatusError{
 		code: code,
 		err:  err,
-	} //nolint:wrapcheck
+	}
 }
 
 type gRPCStatusError struct {

--- a/src/internal/miscutil/miscutil.go
+++ b/src/internal/miscutil/miscutil.go
@@ -16,9 +16,7 @@ func WithPipe(wcb func(w io.Writer) error, rcb func(r io.Reader) error) error {
 	pr, pw := io.Pipe()
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		err := wcb(pw)
-		pw.CloseWithError(err)
-		return errors.EnsureStack(err)
+		return errors.EnsureStack(pw.CloseWithError(wcb(pw)))
 	})
 	eg.Go(func() error {
 		err := rcb(pr)

--- a/src/internal/miscutil/miscutil.go
+++ b/src/internal/miscutil/miscutil.go
@@ -16,7 +16,9 @@ func WithPipe(wcb func(w io.Writer) error, rcb func(r io.Reader) error) error {
 	pr, pw := io.Pipe()
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		return errors.EnsureStack(pw.CloseWithError(wcb(pw)))
+		err := wcb(pw)
+		pw.CloseWithError(err)
+		return errors.EnsureStack(err)
 	})
 	eg.Go(func() error {
 		err := rcb(pr)

--- a/src/internal/obj/amazon_client.go
+++ b/src/internal/obj/amazon_client.go
@@ -216,7 +216,6 @@ func (c *amazonClient) Get(ctx context.Context, name string, w io.Writer) (retEr
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-		// nolint:errcheck
 		backoff.RetryNotify(func() (retErr error) {
 			span, _ := tracing.AddSpanToAnyExisting(ctx, "/Amazon.Cloudfront/Get")
 			defer func() {

--- a/src/internal/obj/amazon_client.go
+++ b/src/internal/obj/amazon_client.go
@@ -216,7 +216,7 @@ func (c *amazonClient) Get(ctx context.Context, name string, w io.Writer) (retEr
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-		backoff.RetryNotify(func() (retErr error) {
+		backoff.RetryNotify(func() (retErr error) { //nolint:errcheck
 			span, _ := tracing.AddSpanToAnyExisting(ctx, "/Amazon.Cloudfront/Get")
 			defer func() {
 				tracing.FinishAnySpan(span, "err", retErr)

--- a/src/internal/obj/amazon_client.go
+++ b/src/internal/obj/amazon_client.go
@@ -216,7 +216,7 @@ func (c *amazonClient) Get(ctx context.Context, name string, w io.Writer) (retEr
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-
+		// nolint:errcheck
 		backoff.RetryNotify(func() (retErr error) {
 			span, _ := tracing.AddSpanToAnyExisting(ctx, "/Amazon.Cloudfront/Get")
 			defer func() {

--- a/src/internal/pachsql/table_info.go
+++ b/src/internal/pachsql/table_info.go
@@ -33,7 +33,6 @@ func GetTableInfo(ctx context.Context, db *DB, tableName string) (*TableInfo, er
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}
-	// nolint:errcheck
 	defer tx.Rollback()
 	ti, err := GetTableInfoTx(tx, tableName)
 	if err != nil {

--- a/src/internal/pachsql/table_info.go
+++ b/src/internal/pachsql/table_info.go
@@ -33,6 +33,7 @@ func GetTableInfo(ctx context.Context, db *DB, tableName string) (*TableInfo, er
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}
+	// nolint:errcheck
 	defer tx.Rollback()
 	ti, err := GetTableInfoTx(tx, tableName)
 	if err != nil {

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -255,8 +255,7 @@ func SetPipelineState(ctx context.Context, db *pachsql.DB, pipelinesCollection c
 func JobInput(pipelineInfo *pps.PipelineInfo, outputCommit *pfs.Commit) *pps.Input {
 	commitsetID := outputCommit.ID
 	jobInput := proto.Clone(pipelineInfo.Details.Input).(*pps.Input)
-	// nolint:errcheck
-	pps.VisitInput(jobInput, func(input *pps.Input) error {
+	pps.VisitInput(jobInput, func(input *pps.Input) error { //nolint:errcheck
 		if input.Pfs != nil {
 			input.Pfs.Commit = commitsetID
 		}
@@ -380,8 +379,7 @@ func MetaCommit(commit *pfs.Commit) *pfs.Commit {
 // 'S3' set to true. Any pipelines with s3 inputs lj
 func ContainsS3Inputs(in *pps.Input) bool {
 	var found bool
-	// nolint:errcheck
-	pps.VisitInput(in, func(in *pps.Input) error {
+	pps.VisitInput(in, func(in *pps.Input) error { //nolint:errcheck
 		if in.Pfs != nil && in.Pfs.S3 {
 			found = true
 			return errutil.ErrBreak

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -255,6 +255,7 @@ func SetPipelineState(ctx context.Context, db *pachsql.DB, pipelinesCollection c
 func JobInput(pipelineInfo *pps.PipelineInfo, outputCommit *pfs.Commit) *pps.Input {
 	commitsetID := outputCommit.ID
 	jobInput := proto.Clone(pipelineInfo.Details.Input).(*pps.Input)
+	// nolint:errcheck
 	pps.VisitInput(jobInput, func(input *pps.Input) error {
 		if input.Pfs != nil {
 			input.Pfs.Commit = commitsetID
@@ -379,6 +380,7 @@ func MetaCommit(commit *pfs.Commit) *pfs.Commit {
 // 'S3' set to true. Any pipelines with s3 inputs lj
 func ContainsS3Inputs(in *pps.Input) bool {
 	var found bool
+	// nolint:errcheck
 	pps.VisitInput(in, func(in *pps.Input) error {
 		if in.Pfs != nil && in.Pfs.S3 {
 			found = true

--- a/src/internal/progress/progress.go
+++ b/src/internal/progress/progress.go
@@ -162,9 +162,11 @@ func (f *File) monitorProgress(stop chan struct{}) {
 	for {
 		select {
 		case <-stop:
+			// nolint:errcheck
 			f.checkProgress()
 			return
 		case <-time.After(refreshRate):
+			// nolint:errcheck
 			f.checkProgress()
 		}
 	}

--- a/src/internal/progress/progress.go
+++ b/src/internal/progress/progress.go
@@ -162,12 +162,10 @@ func (f *File) monitorProgress(stop chan struct{}) {
 	for {
 		select {
 		case <-stop:
-			// nolint:errcheck
-			f.checkProgress()
+			f.checkProgress() //nolint:errcheck
 			return
 		case <-time.After(refreshRate):
-			// nolint:errcheck
-			f.checkProgress()
+			f.checkProgress() //nolint:errcheck
 		}
 	}
 }

--- a/src/internal/sdata/csv/writer.go
+++ b/src/internal/sdata/csv/writer.go
@@ -61,7 +61,9 @@ func (w *Writer) Write(record []*string) error {
 
 		// Additional logic to write null value as blank in CSV
 		if field == nil {
-			w.w.WriteString("")
+			if _, err := w.w.WriteString(""); err != nil {
+				return errors.EnsureStack(err)
+			}
 			continue
 		}
 
@@ -69,7 +71,9 @@ func (w *Writer) Write(record []*string) error {
 
 		// special-case empty string as ""
 		if fieldVal == "" {
-			w.w.WriteString(`""`)
+			if _, err := w.w.WriteString(`""`); err != nil {
+				return errors.EnsureStack(err)
+			}
 			continue
 		}
 

--- a/src/internal/sdata/sdata_test.go
+++ b/src/internal/sdata/sdata_test.go
@@ -259,6 +259,7 @@ func TestSQLTupleWriter(t *testing.T) {
 
 			tx, err := db.Beginx()
 			require.NoError(t, err)
+			// nolint:errcheck
 			defer tx.Rollback()
 
 			// Generate fake data
@@ -297,7 +298,7 @@ func TestCSVNull(t *testing.T) {
 		&sql.NullString{String: "", Valid: true},
 	}
 	expected := `null,"""""",,""` + "\n"
-	w.WriteTuple(row)
+	require.NoError(t, w.WriteTuple(row))
 	w.Flush()
 	require.Equal(t, expected, buf.String())
 

--- a/src/internal/sdata/sdata_test.go
+++ b/src/internal/sdata/sdata_test.go
@@ -259,7 +259,6 @@ func TestSQLTupleWriter(t *testing.T) {
 
 			tx, err := db.Beginx()
 			require.NoError(t, err)
-			// nolint:errcheck
 			defer tx.Rollback()
 
 			// Generate fake data

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -202,6 +202,7 @@ func (env *NonblockingServiceEnv) initClusterID() error {
 		if resp.Count == 0 {
 			// This might error if it races with another pachd trying to set the
 			// cluster id so we ignore the error.
+			// nolint:errcheck
 			client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes())
 		} else if err != nil {
 			return errors.EnsureStack(err)

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -202,8 +202,7 @@ func (env *NonblockingServiceEnv) initClusterID() error {
 		if resp.Count == 0 {
 			// This might error if it races with another pachd trying to set the
 			// cluster id so we ignore the error.
-			// nolint:errcheck
-			client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes())
+			client.Put(context.Background(), clusterIDKey, uuid.NewWithoutDashes()) //nolint:errcheck
 		} else if err != nil {
 			return errors.EnsureStack(err)
 		} else {

--- a/src/internal/storage/chunk/chunk_test.go
+++ b/src/internal/storage/chunk/chunk_test.go
@@ -50,7 +50,8 @@ func BenchmarkRollingHash(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		hash.Reset()
-		hash.Write(initialWindow)
+		_, err := hash.Write(initialWindow)
+		require.NoError(b, err)
 		for _, bt := range data {
 			hash.Roll(bt)
 			// nolint:staticcheck // benchmark is simulating exact usecase

--- a/src/internal/storage/chunk/chunk_test.go
+++ b/src/internal/storage/chunk/chunk_test.go
@@ -54,7 +54,7 @@ func BenchmarkRollingHash(b *testing.B) {
 		require.NoError(b, err)
 		for _, bt := range data {
 			hash.Roll(bt)
-			// nolint:staticcheck // benchmark is simulating exact usecase
+			//nolint:staticcheck // benchmark is simulating exact usecase
 			if hash.Sum64()&splitMask == 0 {
 			}
 		}

--- a/src/internal/storage/chunk/chunker.go
+++ b/src/internal/storage/chunk/chunker.go
@@ -67,6 +67,5 @@ func ComputeChunks(r io.Reader, cb func([]byte) error) error {
 
 func resetHash(hash *buzhash64.Buzhash64) {
 	hash.Reset()
-	// nolint:errcheck
-	hash.Write(initialWindow)
+	hash.Write(initialWindow) //nolint:errcheck
 }

--- a/src/internal/storage/chunk/chunker.go
+++ b/src/internal/storage/chunk/chunker.go
@@ -67,5 +67,6 @@ func ComputeChunks(r io.Reader, cb func([]byte) error) error {
 
 func resetHash(hash *buzhash64.Buzhash64) {
 	hash.Reset()
+	// nolint:errcheck
 	hash.Write(initialWindow)
 }

--- a/src/internal/storage/fileset/index/reader.go
+++ b/src/internal/storage/fileset/index/reader.go
@@ -94,8 +94,7 @@ func (r *Reader) Iterate(ctx context.Context, cb func(*Index) error) error {
 func (r *Reader) topLevel() pbutil.Reader {
 	buf := bytes.Buffer{}
 	pbw := pbutil.NewWriter(&buf)
-	// nolint:errcheck
-	pbw.Write(r.topIdx)
+	pbw.Write(r.topIdx) //nolint:errcheck
 	return pbutil.NewReader(&buf)
 }
 

--- a/src/internal/storage/fileset/index/reader.go
+++ b/src/internal/storage/fileset/index/reader.go
@@ -94,6 +94,7 @@ func (r *Reader) Iterate(ctx context.Context, cb func(*Index) error) error {
 func (r *Reader) topLevel() pbutil.Reader {
 	buf := bytes.Buffer{}
 	pbw := pbutil.NewWriter(&buf)
+	// nolint:errcheck
 	pbw.Write(r.topIdx)
 	return pbutil.NewReader(&buf)
 }

--- a/src/internal/tabwriter/tabwriter.go
+++ b/src/internal/tabwriter/tabwriter.go
@@ -31,8 +31,7 @@ func NewWriter(w io.Writer, header string) *Writer {
 		panic("header must end in a new line")
 	}
 	tabwriter := ansiterm.NewTabWriter(w, 0, 1, 1, ' ', 0)
-	// nolint:errcheck
-	tabwriter.Write([]byte(header))
+	tabwriter.Write([]byte(header)) //nolint:errcheck
 	return &Writer{
 		w:      tabwriter,
 		lines:  1, // 1 because we just printed the header

--- a/src/internal/tabwriter/tabwriter.go
+++ b/src/internal/tabwriter/tabwriter.go
@@ -31,6 +31,7 @@ func NewWriter(w io.Writer, header string) *Writer {
 		panic("header must end in a new line")
 	}
 	tabwriter := ansiterm.NewTabWriter(w, 0, 1, 1, ' ', 0)
+	// nolint:errcheck
 	tabwriter.Write([]byte(header))
 	return &Writer{
 		w:      tabwriter,

--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -126,6 +126,7 @@ func (ed *etcdDoer) Do(ctx context.Context, inputChan chan *types.Any, cb Collec
 		ctx, cancel := context.WithCancel(ctx)
 		defer func() {
 			cancel()
+			// nolint:errcheck
 			eg.Wait()
 		}()
 		eg.Go(func() error {

--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -126,8 +126,7 @@ func (ed *etcdDoer) Do(ctx context.Context, inputChan chan *types.Any, cb Collec
 		ctx, cancel := context.WithCancel(ctx)
 		defer func() {
 			cancel()
-			// nolint:errcheck
-			eg.Wait()
+			eg.Wait() //nolint:errcheck
 		}()
 		eg.Go(func() error {
 			err := ed.taskCol.ReadOnly(ctx).WatchOneF(prefix, func(e *watch.Event) error {

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -29,7 +29,7 @@ func activateAuthHelper(tb testing.TB, client *client.APIClient) {
 	if err != nil && !strings.HasSuffix(err.Error(), "already activated") {
 		tb.Fatalf("could not activate auth service: %v", err.Error())
 	}
-	config.WritePachTokenToConfig(RootToken, false)
+	require.NoError(tb, config.WritePachTokenToConfig(RootToken, false))
 
 	// Activate auth for PPS
 	client = client.WithCtx(context.Background())

--- a/src/internal/testutil/cmds.go
+++ b/src/internal/testutil/cmds.go
@@ -115,7 +115,9 @@ which match >/dev/null || {
 	buf.WriteRune('\n')
 
 	// do the substitution
-	template.Must(template.New("").Parse(dedent(cmd))).Execute(buf, subsMap)
+	if err := template.Must(template.New("").Parse(dedent(cmd))).Execute(buf, subsMap); err != nil {
+		panic(err)
+	}
 	return buf
 }
 
@@ -135,7 +137,8 @@ func PachctlBashCmd(t *testing.T, c *client.APIClient, cmd string, subs ...strin
 	t.Helper()
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(bashCmd(cmd, subs...))
+	_, err := buf.ReadFrom(bashCmd(cmd, subs...))
+	require.NoError(t, err)
 
 	config := fmt.Sprintf("test-pach-config-%s.json", t.Name())
 	if _, err := os.Open(config); err != nil {

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -53,7 +53,9 @@ import (
 
 func RunLocal() (retErr error) {
 	config := &serviceenv.PachdFullConfiguration{}
-	cmdutil.Populate(config)
+	if err := cmdutil.Populate(config); err != nil {
+		return err
+	}
 
 	config.PostgresSSL = "disable"
 
@@ -67,6 +69,7 @@ func RunLocal() (retErr error) {
 	defer func() {
 		if retErr != nil {
 			log.Errorf("error: %v", retErr)
+			// nolint:errcheck
 			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
 		}
 	}()

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -69,8 +69,7 @@ func RunLocal() (retErr error) {
 	defer func() {
 		if retErr != nil {
 			log.Errorf("error: %v", retErr)
-			// nolint:errcheck
-			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck
 		}
 	}()
 	switch logLevel := os.Getenv("LOG_LEVEL"); logLevel {

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -49,7 +49,10 @@ func New(ctx context.Context, sqlTx *pachsql.Tx, authServer identifier) (*Transa
 		}
 	}
 	var currTime time.Time
-	sqlTx.GetContext(ctx, &currTime, "select CURRENT_TIMESTAMP as Timestamp")
+	if err := sqlTx.GetContext(ctx, &currTime, "select CURRENT_TIMESTAMP as Timestamp"); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+
 	ts, err := types.TimestampProto(currTime)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting transaction timestamp")

--- a/src/internal/uuid/uuid.go
+++ b/src/internal/uuid/uuid.go
@@ -14,7 +14,7 @@ import (
 // New returns a new uuid.
 func New() string {
 	var result string
-	backoff.RetryNotify(func() error {
+	backoff.RetryNotify(func() error { //nolint:errcheck
 		uuid, err := uuid.NewV4()
 		if err != nil {
 			return errors.EnsureStack(err)

--- a/src/internal/uuid/uuid.go
+++ b/src/internal/uuid/uuid.go
@@ -14,6 +14,7 @@ import (
 // New returns a new uuid.
 func New() string {
 	var result string
+	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		uuid, err := uuid.NewV4()
 		if err != nil {

--- a/src/internal/uuid/uuid.go
+++ b/src/internal/uuid/uuid.go
@@ -14,7 +14,6 @@ import (
 // New returns a new uuid.
 func New() string {
 	var result string
-	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		uuid, err := uuid.NewV4()
 		if err != nil {

--- a/src/internal/watch/watch.go
+++ b/src/internal/watch/watch.go
@@ -102,7 +102,6 @@ func NewEtcdWatcher(ctx context.Context, client *etcd.Client, trimPrefix, prefix
 
 	rch := internalWatcher.Watch(ctx, prefix, watchOptions(nextRevision)...)
 
-	// nolint:errcheck
 	go func() (retErr error) {
 		defer func() {
 			if retErr != nil {
@@ -183,7 +182,7 @@ func NewEtcdWatcher(ctx context.Context, client *etcd.Client, trimPrefix, prefix
 			}
 			nextRevision = resp.Header.Revision + 1
 		}
-	}()
+	}() //nolint:errcheck
 
 	return &etcdWatcher{
 		eventCh: eventCh,

--- a/src/internal/watch/watch.go
+++ b/src/internal/watch/watch.go
@@ -102,6 +102,7 @@ func NewEtcdWatcher(ctx context.Context, client *etcd.Client, trimPrefix, prefix
 
 	rch := internalWatcher.Watch(ctx, prefix, watchOptions(nextRevision)...)
 
+	// nolint:errcheck
 	go func() (retErr error) {
 		defer func() {
 			if retErr != nil {

--- a/src/pps/util.go
+++ b/src/pps/util.go
@@ -95,6 +95,7 @@ func InputName(input *Input) string {
 
 // SortInput sorts an Input.
 func SortInput(input *Input) {
+	// nolint:errcheck
 	VisitInput(input, func(input *Input) error {
 		SortInputs := func(inputs []*Input) {
 			sort.SliceStable(inputs, func(i, j int) bool { return InputName(inputs[i]) < InputName(inputs[j]) })
@@ -116,6 +117,7 @@ func SortInput(input *Input) {
 // InputBranches returns the branches in an Input.
 func InputBranches(input *Input) []*pfs.Branch {
 	var result []*pfs.Branch
+	// nolint:errcheck
 	VisitInput(input, func(input *Input) error {
 		if input.Pfs != nil {
 			result = append(result, &pfs.Branch{

--- a/src/pps/util.go
+++ b/src/pps/util.go
@@ -95,8 +95,7 @@ func InputName(input *Input) string {
 
 // SortInput sorts an Input.
 func SortInput(input *Input) {
-	// nolint:errcheck
-	VisitInput(input, func(input *Input) error {
+	VisitInput(input, func(input *Input) error { //nolint:errcheck
 		SortInputs := func(inputs []*Input) {
 			sort.SliceStable(inputs, func(i, j int) bool { return InputName(inputs[i]) < InputName(inputs[j]) })
 		}
@@ -117,8 +116,7 @@ func SortInput(input *Input) {
 // InputBranches returns the branches in an Input.
 func InputBranches(input *Input) []*pfs.Branch {
 	var result []*pfs.Branch
-	// nolint:errcheck
-	VisitInput(input, func(input *Input) error {
+	VisitInput(input, func(input *Input) error { //nolint:errcheck
 		if input.Pfs != nil {
 			result = append(result, &pfs.Branch{
 				Repo: &pfs.Repo{

--- a/src/server/auth/cmds/cmds.go
+++ b/src/server/auth/cmds/cmds.go
@@ -550,8 +550,7 @@ func UseAuthTokenCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrapf(err, "error reading token")
 			}
-			config.WritePachTokenToConfig(strings.TrimSpace(token), enterprise) // drop trailing newline
-			return nil
+			return config.WritePachTokenToConfig(strings.TrimSpace(token), enterprise) // drop trailing newline
 		}),
 	}
 	useAuthToken.PersistentFlags().BoolVar(&enterprise, "enterprise", false, "Use the token for the enterprise context")

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -128,7 +128,7 @@ func TestLogin(t *testing.T) {
 			break
 		}
 	}
-	require.NoError(cmd.Wait())
+	require.NoError(t, cmd.Wait())
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami | match user:{{.user}}`,
 		"user", tu.DexMockConnectorEmail,

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -49,7 +49,7 @@ func executeCmdAndGetLastWord(t *testing.T, cmd *exec.Cmd) string {
 			token = tmp
 		}
 	}
-	cmd.Wait()
+	require.NoError(t, cmd.Wait())
 	return token
 }
 
@@ -113,7 +113,7 @@ func TestLogin(t *testing.T) {
 	tu.ActivateAuthClient(t, c)
 
 	// Configure OIDC login
-	tu.ConfigureOIDCProvider(t, tu.AuthenticateClient(t, c, auth.RootUser))
+	require.NoError(t, tu.ConfigureOIDCProvider(t, tu.AuthenticateClient(t, c, auth.RootUser)))
 
 	cmd := tu.PachctlBashCmd(t, c, "pachctl auth login --no-browser")
 	out, err := cmd.StdoutPipe()

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -23,14 +23,14 @@ import (
 func loginAsUser(t *testing.T, c *client.APIClient, user string) {
 	configPath := executeCmdAndGetLastWord(t, tu.PachctlBashCmd(t, c, `echo $PACH_CONFIG`))
 	if user == auth.RootUser {
-		config.WritePachTokenToConfigPath(tu.RootToken, configPath, false)
+		require.NoError(t, config.WritePachTokenToConfigPath(tu.RootToken, configPath, false))
 		return
 	}
 	rootClient := tu.AuthenticatedPachClient(t, c, auth.RootUser)
 	robot := strings.TrimPrefix(user, auth.RobotPrefix)
 	token, err := rootClient.GetRobotToken(rootClient.Ctx(), &auth.GetRobotTokenRequest{Robot: robot})
 	require.NoError(t, err)
-	config.WritePachTokenToConfigPath(token.Token, configPath, false)
+	require.NoError(t, config.WritePachTokenToConfigPath(token.Token, configPath, false))
 }
 
 // this function executes the command and returns the last word
@@ -128,7 +128,7 @@ func TestLogin(t *testing.T) {
 			break
 		}
 	}
-	cmd.Wait()
+	require.NoError(cmd.Wait())
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami | match user:{{.user}}`,
 		"user", tu.DexMockConnectorEmail,
@@ -143,7 +143,7 @@ func TestLoginIDToken(t *testing.T) {
 	tu.ActivateAuthClient(t, c)
 	c = tu.AuthenticateClient(t, c, auth.RootUser)
 	// Configure OIDC login
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	// Get an ID token for a trusted peer app
 	token := tu.GetOIDCTokenForTrustedApp(t, c)
@@ -276,7 +276,7 @@ func TestConfig(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	c = tu.AuthenticatedPachClient(t, c, auth.RootUser)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
         pachctl auth set-config <<EOF

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -506,10 +506,15 @@ func (a *apiServer) rotateRootTokenInTransaction(txCtx *txncontext.TransactionCo
 // Deactivate implements the protobuf auth.Deactivate RPC
 func (a *apiServer) Deactivate(ctx context.Context, req *auth.DeactivateRequest) (resp *auth.DeactivateResponse, retErr error) {
 	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *pachsql.Tx) error {
+		// nolint:errcheck
 		a.roleBindings.ReadWrite(sqlTx).DeleteAll()
+		// nolint:errcheck
 		a.deleteAllAuthTokens(ctx, sqlTx)
+		// nolint:errcheck
 		a.members.ReadWrite(sqlTx).DeleteAll()
+		// nolint:errcheck
 		a.groups.ReadWrite(sqlTx).DeleteAll()
+		// nolint:errcheck
 		a.authConfig.ReadWrite(sqlTx).DeleteAll()
 		return nil
 	}); err != nil {
@@ -1114,6 +1119,7 @@ func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequ
 
 // RevokeAuthToken implements the protobuf auth.RevokeAuthToken RPC
 func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
+	// nolint:errcheck
 	a.env.TxnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		resp, retErr = a.RevokeAuthTokenInTransaction(txnCtx, req)
 		return retErr
@@ -1554,6 +1560,7 @@ func (a *apiServer) deleteExpiredTokensRoutine() {
 	go func(ctx context.Context) {
 		for {
 			time.Sleep(time.Duration(cleanupIntervalHours) * time.Hour)
+			// nolint:errcheck
 			a.DeleteExpiredAuthTokens(ctx, &auth.DeleteExpiredAuthTokensRequest{})
 		}
 	}(context.Background())

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -506,16 +506,11 @@ func (a *apiServer) rotateRootTokenInTransaction(txCtx *txncontext.TransactionCo
 // Deactivate implements the protobuf auth.Deactivate RPC
 func (a *apiServer) Deactivate(ctx context.Context, req *auth.DeactivateRequest) (resp *auth.DeactivateResponse, retErr error) {
 	if err := dbutil.WithTx(ctx, a.env.DB, func(sqlTx *pachsql.Tx) error {
-		// nolint:errcheck
-		a.roleBindings.ReadWrite(sqlTx).DeleteAll()
-		// nolint:errcheck
-		a.deleteAllAuthTokens(ctx, sqlTx)
-		// nolint:errcheck
-		a.members.ReadWrite(sqlTx).DeleteAll()
-		// nolint:errcheck
-		a.groups.ReadWrite(sqlTx).DeleteAll()
-		// nolint:errcheck
-		a.authConfig.ReadWrite(sqlTx).DeleteAll()
+		a.roleBindings.ReadWrite(sqlTx).DeleteAll() //nolint:errcheck
+		a.deleteAllAuthTokens(ctx, sqlTx)           //nolint:errcheck
+		a.members.ReadWrite(sqlTx).DeleteAll()      //nolint:errcheck
+		a.groups.ReadWrite(sqlTx).DeleteAll()       //nolint:errcheck
+		a.authConfig.ReadWrite(sqlTx).DeleteAll()   //nolint:errcheck
 		return nil
 	}); err != nil {
 		return nil, err
@@ -1119,7 +1114,7 @@ func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequ
 
 // RevokeAuthToken implements the protobuf auth.RevokeAuthToken RPC
 func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
-	// nolint:errcheck
+	//nolint:errcheck
 	a.env.TxnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		resp, retErr = a.RevokeAuthTokenInTransaction(txnCtx, req)
 		return retErr
@@ -1560,8 +1555,7 @@ func (a *apiServer) deleteExpiredTokensRoutine() {
 	go func(ctx context.Context) {
 		for {
 			time.Sleep(time.Duration(cleanupIntervalHours) * time.Hour)
-			// nolint:errcheck
-			a.DeleteExpiredAuthTokens(ctx, &auth.DeleteExpiredAuthTokensRequest{})
+			a.DeleteExpiredAuthTokens(ctx, &auth.DeleteExpiredAuthTokensRequest{}) //nolint:errcheck
 		}
 	}(context.Background())
 }

--- a/src/server/auth/server/testing/config_test.go
+++ b/src/server/auth/server/testing/config_test.go
@@ -26,7 +26,7 @@ func TestSetGetConfigBasic(t *testing.T) {
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
 	// Configure OIDC login
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 	// Set a configuration
 	conf := &auth.OIDCConfig{
@@ -54,7 +54,7 @@ func TestIssuerNotLocalhost(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 
@@ -128,7 +128,7 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, proto.Equal(&authserver.DefaultOIDCConfig, configResp.Configuration))
 
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	// Modify the configuration and make sure alice can't read it, but admin can
 	_, err = adminClient.SetConfiguration(adminClient.Ctx(),
@@ -159,7 +159,7 @@ func TestConfigRestartAuth(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 
@@ -243,7 +243,7 @@ func TestSetGetNilConfig(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -23,7 +23,7 @@ func TestOIDCAuthCodeFlow(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	testClient := tu.UnauthenticatedPachClient(t, c)
 	loginInfo, err := testClient.GetOIDCLogin(testClient.Ctx(), &auth.GetOIDCLoginRequest{})
@@ -49,7 +49,7 @@ func TestOIDCTrustedApp(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 	testClient := tu.UnauthenticatedPachClient(t, c)
 
 	token := tu.GetOIDCTokenForTrustedApp(t, c)
@@ -75,7 +75,7 @@ func TestCannotAuthenticateWithExpiredLicense(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 
 	testClient := tu.UnauthenticatedPachClient(t, c)
 	loginInfo, err := testClient.GetOIDCLogin(testClient.Ctx(), &auth.GetOIDCLoginRequest{})

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -101,6 +101,7 @@ func (s *shell) executor(in string) {
 	cmd.Stdin = strings.NewReader("pachctl " + in)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// nolint:errcheck
 	cmd.Run()
 }
 

--- a/src/server/cmd/pachctl/shell/shell.go
+++ b/src/server/cmd/pachctl/shell/shell.go
@@ -101,8 +101,7 @@ func (s *shell) executor(in string) {
 	cmd.Stdin = strings.NewReader("pachctl " + in)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	// nolint:errcheck
-	cmd.Run()
+	cmd.Run() //nolint:errcheck
 }
 
 func (s *shell) suggestor(in prompt.Document) []prompt.Suggest {

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -83,8 +83,7 @@ func init() {
 func main() {
 	log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
 	// set GOMAXPROCS to the container limit & log outcome to stdout
-	// nolint:errcheck
-	maxprocs.Set(maxprocs.Logger(log.Printf))
+	maxprocs.Set(maxprocs.Logger(log.Printf)) //nolint:errcheck
 
 	switch {
 	case readiness:
@@ -209,8 +208,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			log.WithError(retErr).Print("failed to start server")
-			// nolint:errcheck
-			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck // already logging error above
 		}
 	}()
 
@@ -361,8 +359,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 func doSidecarMode(config interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
-			// nolint:errcheck
-			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck
 		}
 	}()
 	env, err := setup(config, "pachyderm-pachd-sidecar")
@@ -486,8 +483,7 @@ func doFullMode(config interface{}) (retErr error) {
 	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer func() {
 		if retErr != nil {
-			// nolint:errcheck
-			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck
 		}
 	}()
 	env, err := setup(config, "pachyderm-pachd-full")
@@ -751,8 +747,7 @@ func doPausedMode(config interface{}) (retErr error) {
 	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer func() {
 		if retErr != nil {
-			// nolint:errcheck
-			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck
 		}
 	}()
 	log.Println("starting up in paused mode")

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -208,7 +208,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			log.WithError(retErr).Print("failed to start server")
-			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck // already logging error above
+			_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) // swallow error, not much we can do if we can't write to stderr
 		}
 	}()
 

--- a/src/server/debug/server/database_dump.go
+++ b/src/server/debug/server/database_dump.go
@@ -124,8 +124,7 @@ func (s *debugServer) writeRowsToJSON(rows *sql.Rows, w io.Writer) error {
 	if err := rows.Err(); err != nil {
 		truncation := fmt.Sprintf("\n\t{\"message\": \"result set was truncated.\", \"error\":%q}\n]",
 			err.Error())
-		// nolint:errcheck
-		w.Write([]byte(truncation))
+		w.Write([]byte(truncation)) //nolint:errcheck
 		return nil
 	}
 	if _, err := w.Write([]byte("\n]")); err != nil {

--- a/src/server/debug/server/database_dump.go
+++ b/src/server/debug/server/database_dump.go
@@ -124,6 +124,7 @@ func (s *debugServer) writeRowsToJSON(rows *sql.Rows, w io.Writer) error {
 	if err := rows.Err(); err != nil {
 		truncation := fmt.Sprintf("\n\t{\"message\": \"result set was truncated.\", \"error\":%q}\n]",
 			err.Error())
+		// nolint:errcheck
 		w.Write([]byte(truncation))
 		return nil
 	}

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -310,7 +310,7 @@ func TestPauseUnpause(t *testing.T) {
 	_, err := client.Enterprise.Pause(client.Ctx(), &enterprise.PauseRequest{})
 	require.NoError(t, err)
 	bo := backoff.NewExponentialBackOff()
-	backoff.Retry(func() error {
+	backoff.Retry(func() error { //nolint:errcheck
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {
 			return errors.Errorf("could not get pause status %w", err)
@@ -328,7 +328,7 @@ func TestPauseUnpause(t *testing.T) {
 	_, err = client.Enterprise.Unpause(client.Ctx(), &enterprise.UnpauseRequest{})
 	require.NoError(t, err)
 	bo.Reset()
-	backoff.Retry(func() error {
+	backoff.Retry(func() error { //nolint:errcheck
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {
 			return errors.Errorf("could not get pause status %v", err)
@@ -356,7 +356,7 @@ func TestPauseUnpauseNoWait(t *testing.T) {
 	_, err = client.Enterprise.Unpause(client.Ctx(), &enterprise.UnpauseRequest{})
 	require.NoError(t, err)
 	bo := backoff.NewExponentialBackOff()
-	backoff.Retry(func() error {
+	backoff.Retry(func() error { //nolint:errcheck
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {
 			return errors.Errorf("could not get pause status %v", err)
@@ -387,7 +387,7 @@ func TestDoublePauseUnpause(t *testing.T) {
 	_, err = client.Enterprise.Pause(client.Ctx(), &enterprise.PauseRequest{})
 	require.NoError(t, err)
 	bo := backoff.NewExponentialBackOff()
-	backoff.Retry(func() error {
+	backoff.Retry(func() error { //nolint:errcheck
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {
 			return errors.Errorf("could not get pause status %v", err)
@@ -403,7 +403,7 @@ func TestDoublePauseUnpause(t *testing.T) {
 	_, err = client.Enterprise.Unpause(client.Ctx(), &enterprise.UnpauseRequest{})
 	require.NoError(t, err)
 	bo = backoff.NewExponentialBackOff()
-	backoff.Retry(func() error {
+	backoff.Retry(func() error { //nolint:errcheck
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {
 			return errors.Errorf("could not get pause status %v", err)

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -356,6 +356,7 @@ func TestPauseUnpauseNoWait(t *testing.T) {
 	_, err = client.Enterprise.Unpause(client.Ctx(), &enterprise.UnpauseRequest{})
 	require.NoError(t, err)
 	bo := backoff.NewExponentialBackOff()
+	// nolint:errcheck
 	backoff.Retry(func() error {
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -356,7 +356,6 @@ func TestPauseUnpauseNoWait(t *testing.T) {
 	_, err = client.Enterprise.Unpause(client.Ctx(), &enterprise.UnpauseRequest{})
 	require.NoError(t, err)
 	bo := backoff.NewExponentialBackOff()
-	// nolint:errcheck
 	backoff.Retry(func() error {
 		resp, err := client.Enterprise.PauseStatus(client.Ctx(), &enterprise.PauseStatusRequest{})
 		if err != nil {

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -209,7 +209,7 @@ func TestLoginEnterprise(t *testing.T) {
 			break
 		}
 	}
-	cmd.Wait()
+	require.NoError(t, cmd.Wait())
 
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami --enterprise | match user:{{.user}}

--- a/src/server/enterprise/testing/cmd_test.go
+++ b/src/server/enterprise/testing/cmd_test.go
@@ -253,7 +253,7 @@ func TestLoginPachd(t *testing.T) {
 			break
 		}
 	}
-	cmd.Wait()
+	require.NoError(t, cmd.Wait())
 
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami | match user:{{.user}}

--- a/src/server/identity/server/api_server.go
+++ b/src/server/identity/server/api_server.go
@@ -52,7 +52,9 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 		if err := yaml.Unmarshal([]byte(a.env.Config.IdentityConfig), &config); err != nil {
 			return errors.Wrapf(err, "unmarshal IdentityConfig with value: %q", a.env.Config.IdentityConfig)
 		}
-		a.setIdentityServerConfig(ctx, &identity.SetIdentityServerConfigRequest{Config: &config})
+		if _, err := a.setIdentityServerConfig(ctx, &identity.SetIdentityServerConfigRequest{Config: &config}); err != nil {
+			return errors.Wrapf(err, "failed to set identity server config")
+		}
 		a.env.Logger.Info("Successfully configured identity server config via environment")
 	}
 	if a.env.Config.IdentityConnectors != "" {

--- a/src/server/identity/server/api_server_test.go
+++ b/src/server/identity/server/api_server_test.go
@@ -282,7 +282,7 @@ func TestShortenIDTokenExpiry(t *testing.T) {
 	}
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 	_, err := adminClient.SetIdentityServerConfig(adminClient.Ctx(), &identity.SetIdentityServerConfigRequest{
 		Config: &identity.IdentityServerConfig{

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -607,12 +607,12 @@ func TestMultipleInputsFromTheSameRepoDifferentBranches(t *testing.T) {
 	commitA, err := c.StartCommit(dataRepo, branchA)
 	require.NoError(t, err)
 	c.PutFile(commitA, "/file", strings.NewReader("data A\n"), client.WithAppendPutFile())
-	require.NoError(c.FinishCommit(dataRepo, commitA.Branch.Name, commitA.ID))
+	require.NoError(t, c.FinishCommit(dataRepo, commitA.Branch.Name, commitA.ID))
 
 	commitB, err := c.StartCommit(dataRepo, branchB)
 	require.NoError(t, err)
 	c.PutFile(commitB, "/file", strings.NewReader("data B\n"), client.WithAppendPutFile())
-	require.NoError(c.FinishCommit(dataRepo, commitB.Branch.Name, commitB.ID))
+	require.NoError(t, c.FinishCommit(dataRepo, commitB.Branch.Name, commitB.ID))
 
 	commitInfos, err := c.WaitCommitSetAll(commitB.ID)
 	require.NoError(t, err)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -606,12 +606,12 @@ func TestMultipleInputsFromTheSameRepoDifferentBranches(t *testing.T) {
 
 	commitA, err := c.StartCommit(dataRepo, branchA)
 	require.NoError(t, err)
-	c.PutFile(commitA, "/file", strings.NewReader("data A\n"), client.WithAppendPutFile())
+	require.NoError(t, c.PutFile(commitA, "/file", strings.NewReader("data A\n"), client.WithAppendPutFile()))
 	require.NoError(t, c.FinishCommit(dataRepo, commitA.Branch.Name, commitA.ID))
 
 	commitB, err := c.StartCommit(dataRepo, branchB)
 	require.NoError(t, err)
-	c.PutFile(commitB, "/file", strings.NewReader("data B\n"), client.WithAppendPutFile())
+	require.NoError(t, c.PutFile(commitB, "/file", strings.NewReader("data B\n"), client.WithAppendPutFile()))
 	require.NoError(t, c.FinishCommit(dataRepo, commitB.Branch.Name, commitB.ID))
 
 	commitInfos, err := c.WaitCommitSetAll(commitB.ID)
@@ -3392,7 +3392,7 @@ func TestAutoscalingStandby(t *testing.T) {
 			}
 			return nil
 		})
-		eg.Wait()
+		require.NoError(t, eg.Wait())
 	})
 	t.Run("ManyCommits", func(t *testing.T) {
 		require.NoError(t, c.DeleteAll())
@@ -6581,6 +6581,7 @@ func TestCronPipeline(t *testing.T) {
 			_, err := c.PpsAPIClient.RunCron(context.Background(), &pps.RunCronRequest{Pipeline: client.NewPipeline(pipeline7)})
 			require.NoError(t, err)
 			_, err = c.WaitCommit(repo, "master", "")
+			require.NoError(t, err)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
@@ -7079,7 +7080,7 @@ func TestService(t *testing.T) {
 		// via internal cluster IP, but we don't know what that is
 		var address string
 		kubeClient := tu.GetKubeClient(t)
-		backoff.Retry(func() error {
+		backoff.Retry(func() error { //nolint:errcheck
 			svcs, err := kubeClient.CoreV1().Services(ns).List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
 			for _, svc := range svcs.Items {
@@ -7190,7 +7191,7 @@ func TestServiceEnvVars(t *testing.T) {
 		// via internal cluster IP, but we don't know what that is
 		var address string
 		kubeClient := tu.GetKubeClient(t)
-		backoff.Retry(func() error {
+		backoff.Retry(func() error { //nolint:errcheck
 			svcs, err := kubeClient.CoreV1().Services(ns).List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
 			for _, svc := range svcs.Items {
@@ -7258,7 +7259,7 @@ func TestDatumSetSpec(t *testing.T) {
 
 	t.Run("number", func(t *testing.T) {
 		pipeline := tu.UniqueString("TestDatumSetSpec")
-		c.PpsAPIClient.CreatePipeline(context.Background(),
+		_, err := c.PpsAPIClient.CreatePipeline(context.Background(),
 			&pps.CreatePipelineRequest{
 				Pipeline: client.NewPipeline(pipeline),
 				Transform: &pps.Transform{
@@ -7270,6 +7271,7 @@ func TestDatumSetSpec(t *testing.T) {
 				Input:        client.NewPFSInput(dataRepo, "/*"),
 				DatumSetSpec: &pps.DatumSetSpec{Number: 1},
 			})
+		require.NoError(t, err)
 
 		commitInfo, err := c.WaitCommit(pipeline, "master", "")
 		require.NoError(t, err)
@@ -7282,7 +7284,7 @@ func TestDatumSetSpec(t *testing.T) {
 	})
 	t.Run("size", func(t *testing.T) {
 		pipeline := tu.UniqueString("TestDatumSetSpec")
-		c.PpsAPIClient.CreatePipeline(context.Background(),
+		_, err := c.PpsAPIClient.CreatePipeline(context.Background(),
 			&pps.CreatePipelineRequest{
 				Pipeline: client.NewPipeline(pipeline),
 				Transform: &pps.Transform{
@@ -7294,6 +7296,7 @@ func TestDatumSetSpec(t *testing.T) {
 				Input:        client.NewPFSInput(dataRepo, "/*"),
 				DatumSetSpec: &pps.DatumSetSpec{SizeBytes: 5},
 			})
+		require.NoError(t, err)
 
 		commitInfo, err := c.WaitCommit(pipeline, "master", "")
 		require.NoError(t, err)
@@ -7643,7 +7646,7 @@ func TestCommitDescription(t *testing.T) {
 		Description: "test commit description in 'start commit'",
 	})
 	require.NoError(t, err)
-	c.FinishCommit(dataRepo, commit.Branch.Name, commit.ID)
+	require.NoError(t, c.FinishCommit(dataRepo, commit.Branch.Name, commit.ID))
 	commitInfo, err := c.InspectCommit(dataRepo, commit.Branch.Name, commit.ID)
 	require.NoError(t, err)
 	require.Equal(t, "test commit description in 'start commit'", commitInfo.Description)
@@ -7652,10 +7655,11 @@ func TestCommitDescription(t *testing.T) {
 	// Test putting a message in FinishCommit
 	commit, err = c.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	c.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
+	_, err = c.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
 		Commit:      commit,
 		Description: "test commit description in 'finish commit'",
 	})
+	require.NoError(t, err)
 	commitInfo, err = c.InspectCommit(dataRepo, commit.Branch.Name, commit.ID)
 	require.NoError(t, err)
 	require.Equal(t, "test commit description in 'finish commit'", commitInfo.Description)
@@ -7667,10 +7671,11 @@ func TestCommitDescription(t *testing.T) {
 		Description: "test commit description in 'start commit'",
 	})
 	require.NoError(t, err)
-	c.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
+	_, err = c.PfsAPIClient.FinishCommit(ctx, &pfs.FinishCommitRequest{
 		Commit:      commit,
 		Description: "test commit description in 'finish commit' that overwrites",
 	})
+	require.NoError(t, err)
 	commitInfo, err = c.InspectCommit(dataRepo, commit.Branch.Name, commit.ID)
 	require.NoError(t, err)
 	require.Equal(t, "test commit description in 'finish commit' that overwrites", commitInfo.Description)
@@ -8547,12 +8552,12 @@ func TestDeferredCross(t *testing.T) {
 	headCommit, err := c.InspectCommit(dataSet, "master", "")
 	require.NoError(t, err)
 
-	pps.VisitInput(jobInfo.Details.Input, func(i *pps.Input) error {
+	require.NoError(t, pps.VisitInput(jobInfo.Details.Input, func(i *pps.Input) error {
 		if i.Pfs != nil && i.Pfs.Repo == dataSet {
 			require.Equal(t, i.Pfs.Commit, headCommit.Commit.ID)
 		}
 		return nil
-	})
+	}))
 }
 
 func TestDeferredProcessing(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -607,12 +607,12 @@ func TestMultipleInputsFromTheSameRepoDifferentBranches(t *testing.T) {
 	commitA, err := c.StartCommit(dataRepo, branchA)
 	require.NoError(t, err)
 	c.PutFile(commitA, "/file", strings.NewReader("data A\n"), client.WithAppendPutFile())
-	c.FinishCommit(dataRepo, commitA.Branch.Name, commitA.ID)
+	require.NoError(c.FinishCommit(dataRepo, commitA.Branch.Name, commitA.ID))
 
 	commitB, err := c.StartCommit(dataRepo, branchB)
 	require.NoError(t, err)
 	c.PutFile(commitB, "/file", strings.NewReader("data B\n"), client.WithAppendPutFile())
-	c.FinishCommit(dataRepo, commitB.Branch.Name, commitB.ID)
+	require.NoError(c.FinishCommit(dataRepo, commitB.Branch.Name, commitB.ID))
 
 	commitInfos, err := c.WaitCommitSetAll(commitB.ID)
 	require.NoError(t, err)

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -326,7 +326,6 @@ $ {{alias}} test@fork -p XXX`,
 		}),
 	}
 	startCommit.Flags().StringVarP(&parent, "parent", "p", "", "The parent of the new commit, unneeded if branch is specified and you want to use the previous head of the branch as the parent.")
-	// nolint:errcheck
 	startCommit.MarkFlagCustom("parent", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	startCommit.Flags().StringVarP(&description, "message", "m", "", "A description of this commit's contents")
 	startCommit.Flags().StringVar(&description, "description", "", "A description of this commit's contents (synonym for --message)")
@@ -621,7 +620,6 @@ $ {{alias}} foo@master --from XXX`,
 	}
 	listCommit.Flags().StringVarP(&from, "from", "f", "", "list all commits since this commit")
 	listCommit.Flags().Int64VarP(&number, "number", "n", 0, "list only this many commits; if set to zero, list all commits")
-	// nolint:errcheck
 	listCommit.MarkFlagCustom("from", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	listCommit.Flags().BoolVar(&all, "all", false, "return all types of commits, including aliases")
 	listCommit.Flags().BoolVarP(&expand, "expand", "x", false, "show one line for each sub-commmit and include more columns")
@@ -750,7 +748,6 @@ $ {{alias}} test@master --new`,
 		}),
 	}
 	subscribeCommit.Flags().StringVar(&from, "from", "", "subscribe to all commits since this commit")
-	// nolint:errcheck
 	subscribeCommit.MarkFlagCustom("from", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	subscribeCommit.Flags().BoolVar(&newCommits, "new", false, "subscribe to only new commits created from now on")
 	subscribeCommit.Flags().BoolVar(&all, "all", false, "return all types of commits, including aliases")
@@ -872,10 +869,8 @@ Any pachctl command that can take a commit, can take a branch name instead.`,
 		}),
 	}
 	createBranch.Flags().VarP(&branchProvenance, "provenance", "p", "The provenance for the branch. format: <repo>@<branch>")
-	// nolint:errcheck
 	createBranch.MarkFlagCustom("provenance", "__pachctl_get_repo_commit")
 	createBranch.Flags().StringVarP(&head, "head", "", "", "The head of the newly created branch. Either pass the commit with format: <branch-or-commit>, or fully-qualified as <repo>@<branch>=<id>")
-	// nolint:errcheck
 	createBranch.MarkFlagCustom("head", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	createBranch.Flags().StringVarP(&trigger.Branch, "trigger", "t", "", "The branch to trigger this branch on.")
 	createBranch.Flags().StringVar(&trigger.CronSpec, "trigger-cron", "", "The cron spec to use in triggering.")

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -326,6 +326,7 @@ $ {{alias}} test@fork -p XXX`,
 		}),
 	}
 	startCommit.Flags().StringVarP(&parent, "parent", "p", "", "The parent of the new commit, unneeded if branch is specified and you want to use the previous head of the branch as the parent.")
+	// nolint:errcheck
 	startCommit.MarkFlagCustom("parent", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	startCommit.Flags().StringVarP(&description, "message", "m", "", "A description of this commit's contents")
 	startCommit.Flags().StringVar(&description, "description", "", "A description of this commit's contents (synonym for --message)")
@@ -620,6 +621,7 @@ $ {{alias}} foo@master --from XXX`,
 	}
 	listCommit.Flags().StringVarP(&from, "from", "f", "", "list all commits since this commit")
 	listCommit.Flags().Int64VarP(&number, "number", "n", 0, "list only this many commits; if set to zero, list all commits")
+	// nolint:errcheck
 	listCommit.MarkFlagCustom("from", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	listCommit.Flags().BoolVar(&all, "all", false, "return all types of commits, including aliases")
 	listCommit.Flags().BoolVarP(&expand, "expand", "x", false, "show one line for each sub-commmit and include more columns")
@@ -748,6 +750,7 @@ $ {{alias}} test@master --new`,
 		}),
 	}
 	subscribeCommit.Flags().StringVar(&from, "from", "", "subscribe to all commits since this commit")
+	// nolint:errcheck
 	subscribeCommit.MarkFlagCustom("from", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	subscribeCommit.Flags().BoolVar(&newCommits, "new", false, "subscribe to only new commits created from now on")
 	subscribeCommit.Flags().BoolVar(&all, "all", false, "return all types of commits, including aliases")
@@ -869,8 +872,10 @@ Any pachctl command that can take a commit, can take a branch name instead.`,
 		}),
 	}
 	createBranch.Flags().VarP(&branchProvenance, "provenance", "p", "The provenance for the branch. format: <repo>@<branch>")
+	// nolint:errcheck
 	createBranch.MarkFlagCustom("provenance", "__pachctl_get_repo_commit")
 	createBranch.Flags().StringVarP(&head, "head", "", "", "The head of the newly created branch. Either pass the commit with format: <branch-or-commit>, or fully-qualified as <repo>@<branch>=<id>")
+	// nolint:errcheck
 	createBranch.MarkFlagCustom("head", "__pachctl_get_commit $(__parse_repo ${nouns[0]})")
 	createBranch.Flags().StringVarP(&trigger.Branch, "trigger", "t", "", "The branch to trigger this branch on.")
 	createBranch.Flags().StringVar(&trigger.CronSpec, "trigger-cron", "", "The cron spec to use in triggering.")

--- a/src/server/pfs/cmds/mount_unix.go
+++ b/src/server/pfs/cmds/mount_unix.go
@@ -94,6 +94,7 @@ func mountCmds() []*cobra.Command {
 	mount.Flags().BoolVarP(&write, "write", "w", false, "Allow writing to pfs through the mount.")
 	mount.Flags().BoolVarP(&debug, "debug", "d", false, "Turn on debug messages.")
 	mount.Flags().VarP(&repoOpts, "repos", "r", "Repos and branches / commits to mount, arguments should be of the form \"repo[@branch=commit][+w]\", where the trailing flag \"+w\" indicates write. You can omit the branch when specifying a commit unless the same commit ID is on multiple branches in the repo.")
+	// nolint:errcheck
 	mount.MarkFlagCustom("repos", "__pachctl_get_repo_branch")
 	commands = append(commands, cmdutil.CreateAlias(mount, "mount"))
 

--- a/src/server/pfs/cmds/mount_unix.go
+++ b/src/server/pfs/cmds/mount_unix.go
@@ -94,7 +94,6 @@ func mountCmds() []*cobra.Command {
 	mount.Flags().BoolVarP(&write, "write", "w", false, "Allow writing to pfs through the mount.")
 	mount.Flags().BoolVarP(&debug, "debug", "d", false, "Turn on debug messages.")
 	mount.Flags().VarP(&repoOpts, "repos", "r", "Repos and branches / commits to mount, arguments should be of the form \"repo[@branch=commit][+w]\", where the trailing flag \"+w\" indicates write. You can omit the branch when specifying a commit unless the same commit ID is on multiple branches in the repo.")
-	// nolint:errcheck
 	mount.MarkFlagCustom("repos", "__pachctl_get_repo_branch")
 	commands = append(commands, cmdutil.CreateAlias(mount, "mount"))
 

--- a/src/server/pfs/fuse/fuse.go
+++ b/src/server/pfs/fuse/fuse.go
@@ -105,8 +105,7 @@ func Mount(c *client.APIClient, target string, opts *Options) (retErr error) {
 		case <-sigChan:
 		case <-opts.getUnmount():
 		}
-		// nolint:errcheck
-		server.Unmount()
+		server.Unmount() //nolint:errcheck
 	}()
 	server.Wait()
 	mfcs := make(map[string]*client.ModifyFileClient)

--- a/src/server/pfs/fuse/fuse.go
+++ b/src/server/pfs/fuse/fuse.go
@@ -105,6 +105,7 @@ func Mount(c *client.APIClient, target string, opts *Options) (retErr error) {
 		case <-sigChan:
 		case <-opts.getUnmount():
 		}
+		// nolint:errcheck
 		server.Unmount()
 	}()
 	server.Wait()

--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -168,8 +168,7 @@ func (n *loopbackNode) Mknod(ctx context.Context, name string, mode, rdev uint32
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
-		// nolint:errcheck
-		syscall.Rmdir(p)
+		syscall.Rmdir(p) //nolint:errcheck
 		return nil, fs.ToErrno(err)
 	}
 
@@ -195,8 +194,7 @@ func (n *loopbackNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
-		// nolint:errcheck
-		syscall.Rmdir(p)
+		syscall.Rmdir(p) //nolint:errcheck // favour outter error instead
 		return nil, fs.ToErrno(err)
 	}
 
@@ -329,8 +327,7 @@ func (n *loopbackNode) Symlink(ctx context.Context, target, name string, out *fu
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
-		// nolint:errcheck
-		syscall.Unlink(p)
+		syscall.Unlink(p) //nolint:errcheck // favour outter error instead
 		return nil, fs.ToErrno(err)
 	}
 	node := &loopbackNode{}
@@ -363,8 +360,7 @@ func (n *loopbackNode) Link(ctx context.Context, target fs.InodeEmbedder, name s
 	}()
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
-		// nolint:errcheck
-		syscall.Unlink(p)
+		syscall.Unlink(p) //nolint:errcheck
 		return nil, fs.ToErrno(err)
 	}
 	node := &loopbackNode{}

--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -194,7 +194,7 @@ func (n *loopbackNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
-		syscall.Rmdir(p) //nolint:errcheck // favour outter error instead
+		syscall.Rmdir(p) //nolint:errcheck // favour outer error instead
 		return nil, fs.ToErrno(err)
 	}
 
@@ -327,7 +327,7 @@ func (n *loopbackNode) Symlink(ctx context.Context, target, name string, out *fu
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
-		syscall.Unlink(p) //nolint:errcheck // favour outter error instead
+		syscall.Unlink(p) //nolint:errcheck // favour outer error instead
 		return nil, fs.ToErrno(err)
 	}
 	node := &loopbackNode{}

--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -168,6 +168,7 @@ func (n *loopbackNode) Mknod(ctx context.Context, name string, mode, rdev uint32
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
+		// TODO multierr
 		syscall.Rmdir(p) //nolint:errcheck
 		return nil, fs.ToErrno(err)
 	}
@@ -194,6 +195,7 @@ func (n *loopbackNode) Mkdir(ctx context.Context, name string, mode uint32, out 
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
+		// TODO multierr
 		syscall.Rmdir(p) //nolint:errcheck // favour outer error instead
 		return nil, fs.ToErrno(err)
 	}
@@ -327,6 +329,7 @@ func (n *loopbackNode) Symlink(ctx context.Context, target, name string, out *fu
 	}
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
+		// TODO multierr
 		syscall.Unlink(p) //nolint:errcheck // favour outer error instead
 		return nil, fs.ToErrno(err)
 	}
@@ -360,6 +363,7 @@ func (n *loopbackNode) Link(ctx context.Context, target fs.InodeEmbedder, name s
 	}()
 	st := syscall.Stat_t{}
 	if err := syscall.Lstat(p, &st); err != nil {
+		// TODO multierr
 		syscall.Unlink(p) //nolint:errcheck
 		return nil, fs.ToErrno(err)
 	}

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -450,9 +450,11 @@ func (mm *MountManager) Run() error {
 	}
 	go func() {
 		<-mm.opts.getUnmount()
+		// nolint:errcheck
 		server.Unmount()
 	}()
 	server.Wait()
+	// nolint:errcheck
 	defer mm.FinishAll()
 	err = mm.uploadFiles("")
 	if err != nil {
@@ -507,6 +509,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("GET").Path("/mounts").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -526,6 +529,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("PUT").
@@ -593,7 +597,9 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			w.Write(marshalled)
+			if _, err := w.Write(marshalled); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 		})
 	router.Methods("PUT").
 		Queries("name", "{name}").
@@ -635,6 +641,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("PUT").
@@ -677,6 +684,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("PUT").Path("/repos/_unmount").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -701,6 +709,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("GET").Path("/config").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -723,6 +732,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("PUT").Path("/config").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -769,6 +779,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 	router.Methods("PUT").Path("/auth/_login").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -798,6 +809,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 
 		go func() {
@@ -806,6 +818,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			// nolint:errcheck
 			config.WritePachTokenToConfig(resp.PachToken, false)
 			mm.Client.SetAuthToken(resp.PachToken)
 		}()
@@ -834,6 +847,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 		}
 
 		context.SessionToken = ""
+		// nolint:errcheck
 		cfg.Write()
 		mm.Client.SetAuthToken("")
 	})
@@ -844,6 +858,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// nolint:errcheck
 		w.Write(marshalled)
 	})
 
@@ -863,6 +878,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			close(mm.opts.getUnmount())
 			<-mm.Cleanup
 		}
+		// nolint:errcheck
 		srv.Shutdown(context.Background())
 	}()
 

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -450,12 +450,10 @@ func (mm *MountManager) Run() error {
 	}
 	go func() {
 		<-mm.opts.getUnmount()
-		// nolint:errcheck
-		server.Unmount()
+		server.Unmount() //nolint:errcheck
 	}()
 	server.Wait()
-	// nolint:errcheck
-	defer mm.FinishAll()
+	defer mm.FinishAll() //nolint:errcheck
 	err = mm.uploadFiles("")
 	if err != nil {
 		return err
@@ -509,8 +507,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("GET").Path("/mounts").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		errMsg, webCode := initialChecks(mm, true)
@@ -529,8 +526,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("PUT").
 		Path("/repos/{key:.+}/_mount").
@@ -641,8 +637,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("PUT").
 		Queries("name", "{name}").
@@ -684,8 +679,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("PUT").Path("/repos/_unmount").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		errMsg, webCode := initialChecks(mm, true)
@@ -709,8 +703,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("GET").Path("/config").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		errMsg, webCode := initialChecks(mm, false)
@@ -732,8 +725,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("PUT").Path("/config").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		mm.configMu.Lock()
@@ -779,8 +771,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 	router.Methods("PUT").Path("/auth/_login").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		errMsg, webCode := initialChecks(mm, false)
@@ -809,8 +800,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 
 		go func() {
 			resp, err := mm.Client.Authenticate(mm.Client.Ctx(), &auth.AuthenticateRequest{OIDCState: state})
@@ -818,8 +808,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			// nolint:errcheck
-			config.WritePachTokenToConfig(resp.PachToken, false)
+			config.WritePachTokenToConfig(resp.PachToken, false) //nolint:errcheck
 			mm.Client.SetAuthToken(resp.PachToken)
 		}()
 	})
@@ -847,8 +836,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 		}
 
 		context.SessionToken = ""
-		// nolint:errcheck
-		cfg.Write()
+		cfg.Write() //nolint:errcheck
 		mm.Client.SetAuthToken("")
 	})
 	router.Methods("GET").Path("/health").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -858,8 +846,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// nolint:errcheck
-		w.Write(marshalled)
+		w.Write(marshalled) //nolint:errcheck
 	})
 
 	// TODO: switch http server for gRPC server and bind to a unix socket not a
@@ -878,8 +865,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			close(mm.opts.getUnmount())
 			<-mm.Cleanup
 		}
-		// nolint:errcheck
-		srv.Shutdown(context.Background())
+		srv.Shutdown(context.Background()) //nolint:errcheck
 	}()
 
 	return errors.EnsureStack(srv.ListenAndServe())

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -78,7 +78,7 @@ func TestBasicServerSameNames(t *testing.T) {
 
 		defer resp.Body.Close()
 		repoResp := &ListRepoResponse{}
-		json.NewDecoder(resp.Body).Decode(repoResp)
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(repoResp))
 		require.Equal(t, "repo", (*repoResp)["repo"].Name)
 		require.Equal(t, "master", (*repoResp)["repo"].Branches["master"].Name)
 
@@ -190,7 +190,7 @@ func TestRepoAccess(t *testing.T) {
 		require.NoError(t, err)
 
 		reposResp := &ListRepoResponse{}
-		json.NewDecoder(resp.Body).Decode(reposResp)
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(reposResp))
 		require.Equal(t, (*reposResp)["repo1"].Authorization, "write")
 	})
 
@@ -199,7 +199,7 @@ func TestRepoAccess(t *testing.T) {
 		require.NoError(t, err)
 
 		reposResp := &ListRepoResponse{}
-		json.NewDecoder(resp.Body).Decode(reposResp)
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(reposResp))
 		require.Equal(t, (*reposResp)["repo1"].Authorization, "none")
 
 		resp, _ = put("repos/repo1/master/_mount?name=repo1&mode=ro", nil)
@@ -235,7 +235,7 @@ func TestUnmountAll(t *testing.T) {
 
 		defer resp.Body.Close()
 		unmountResp := &ListRepoResponse{}
-		json.NewDecoder(resp.Body).Decode(unmountResp)
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(unmountResp))
 		require.Equal(t, 2, len(*unmountResp))
 
 		repos, err = ioutil.ReadDir(mountPoint)
@@ -259,7 +259,7 @@ func TestConfig(t *testing.T) {
 		invalidCfg := &Config{ClusterStatus: "INVALID", PachdAddress: "bad_address"}
 		m := map[string]string{"pachd_address": invalidCfg.PachdAddress}
 		b := new(bytes.Buffer)
-		json.NewEncoder(b).Encode(m)
+		require.NoError(t, json.NewEncoder(b).Encode(m))
 
 		putResp, err := put("config", b)
 		require.NoError(t, err)
@@ -268,14 +268,14 @@ func TestConfig(t *testing.T) {
 		cfg := &Config{ClusterStatus: "AUTH_ENABLED", PachdAddress: c.GetAddress().Qualified()}
 		m = map[string]string{"pachd_address": cfg.PachdAddress}
 		b = new(bytes.Buffer)
-		json.NewEncoder(b).Encode(m)
+		require.NoError(t, json.NewEncoder(b).Encode(m))
 
 		putResp, err = put("config", b)
 		require.NoError(t, err)
 		defer putResp.Body.Close()
 
 		putConfig := &Config{}
-		json.NewDecoder(putResp.Body).Decode(putConfig)
+		require.NoError(t, json.NewDecoder(putResp.Body).Decode(putConfig))
 
 		cfgParsedPachdAddress, err := grpcutil.ParsePachdAddress(cfg.PachdAddress)
 		require.NoError(t, err)
@@ -290,7 +290,7 @@ func TestConfig(t *testing.T) {
 		defer getResp.Body.Close()
 
 		getConfig := &Config{}
-		json.NewDecoder(getResp.Body).Decode(getConfig)
+		require.NoError(t, json.NewDecoder(getResp.Body).Decode(getConfig))
 
 		require.Equal(t, cfg.ClusterStatus, getConfig.ClusterStatus)
 		require.Equal(t, cfg.PachdAddress, getConfig.PachdAddress)
@@ -300,7 +300,7 @@ func TestConfig(t *testing.T) {
 func TestAuthLoginLogout(t *testing.T) {
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateAuthClient(t, c)
-	tu.ConfigureOIDCProvider(t, c)
+	require.NoError(t, tu.ConfigureOIDCProvider(t, c))
 	c = tu.UnauthenticatedPachClient(t, c)
 
 	withServerMount(t, c, nil, func(mountPoint string) {
@@ -312,7 +312,7 @@ func TestAuthLoginLogout(t *testing.T) {
 			AuthUrl string `json:"auth_url"`
 		}
 		getAuthLogin := &AuthLoginResp{}
-		json.NewDecoder(authResp.Body).Decode(getAuthLogin)
+		require.NoError(t, json.NewDecoder(authResp.Body).Decode(getAuthLogin))
 
 		tu.DoOAuthExchange(t, c, c, getAuthLogin.AuthUrl)
 		time.Sleep(1 * time.Second)

--- a/src/server/pfs/s3/auth.go
+++ b/src/server/pfs/s3/auth.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
 package s3

--- a/src/server/pfs/s3/s3.go
+++ b/src/server/pfs/s3/s3.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
 package s3

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -138,7 +138,7 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 	require.NoError(t, err)
 
 	go func() {
-		server.Serve(listener)
+		server.Serve(listener) //nolint:errcheck
 	}()
 
 	port := listener.Addr().(*net.TCPAddr).Port

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -138,7 +138,6 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 	require.NoError(t, err)
 
 	go func() {
-		// nolint:errcheck
 		server.Serve(listener)
 	}()
 

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -137,9 +137,7 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 
-	go func() {
-		server.Serve(listener) //nolint:errcheck
-	}()
+	go server.Serve(listener) //nolint:errcheck
 
 	port := listener.Addr().(*net.TCPAddr).Port
 

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -138,6 +138,7 @@ func testRunner(t *testing.T, pachClient *client.APIClient, group string, driver
 	require.NoError(t, err)
 
 	go func() {
+		// nolint:errcheck
 		server.Serve(listener)
 	}()
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -129,6 +129,7 @@ func newDriver(env Env) (*driver, error) {
 	d.storage = fileset.NewStorage(fileset.NewPostgresStore(env.DB), tracker, chunkStorage, fileset.StorageOptions(&storageConfig)...)
 	// Set up compaction worker.
 	taskSource := env.TaskService.NewSource(storageTaskNamespace)
+	// nolint:errcheck
 	go compactionWorker(env.BackgroundContext, taskSource, d.storage)
 	d.commitStore = newPostgresCommitStore(env.DB, tracker, d.storage)
 	// TODO: Make the cache max size configurable.
@@ -1871,9 +1872,11 @@ func (d *driver) listBranch(ctx context.Context, reverse bool, cb func(*pfs.Bran
 
 	lastRev := int64(-1)
 	branchInfo := &pfs.BranchInfo{}
-	listCallback := func(key string, createRev int64) error {
+	listCallback := func(_ string, createRev int64) error {
 		if createRev != lastRev {
-			sendBis()
+			if err := sendBis(); err != nil {
+				return errors.EnsureStack(err)
+			}
 			lastRev = createRev
 		}
 		bis = append(bis, proto.Clone(branchInfo).(*pfs.BranchInfo))

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -129,8 +129,7 @@ func newDriver(env Env) (*driver, error) {
 	d.storage = fileset.NewStorage(fileset.NewPostgresStore(env.DB), tracker, chunkStorage, fileset.StorageOptions(&storageConfig)...)
 	// Set up compaction worker.
 	taskSource := env.TaskService.NewSource(storageTaskNamespace)
-	// nolint:errcheck
-	go compactionWorker(env.BackgroundContext, taskSource, d.storage)
+	go compactionWorker(env.BackgroundContext, taskSource, d.storage) //nolint:errcheck
 	d.commitStore = newPostgresCommitStore(env.DB, tracker, d.storage)
 	// TODO: Make the cache max size configurable.
 	d.cache = fileset.NewCache(env.DB, tracker, 10000)

--- a/src/server/pfs/server/egress.go
+++ b/src/server/pfs/server/egress.go
@@ -56,6 +56,7 @@ func copyToSQLDB(ctx context.Context, src Source, destURL string, fileFormat *pf
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}
+	// nolint:errcheck
 	defer tx.Rollback()
 
 	// cache tableInfos because multiple files can belong to the same table

--- a/src/server/pfs/server/egress.go
+++ b/src/server/pfs/server/egress.go
@@ -56,7 +56,6 @@ func copyToSQLDB(ctx context.Context, src Source, destURL string, fileFormat *pf
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}
-	// nolint:errcheck
 	defer tx.Rollback()
 
 	// cache tableInfos because multiple files can belong to the same table

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -32,14 +32,12 @@ const (
 func (d *driver) master(ctx context.Context) {
 	ctx = auth.AsInternalUser(ctx, "pfs-master")
 	masterLock := dlock.NewDLock(d.etcdClient, path.Join(d.prefix, masterLockPath))
-	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		masterCtx, err := masterLock.Lock(ctx)
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-		// nolint:errcheck
-		defer masterLock.Unlock(masterCtx)
+		defer masterLock.Unlock(masterCtx) //nolint:errcheck
 		eg, ctx := errgroup.WithContext(masterCtx)
 		trackerPeriod := time.Second * time.Duration(d.env.StorageConfig.StorageGCPeriod)
 		if trackerPeriod <= 0 {
@@ -97,7 +95,6 @@ func (d *driver) finishCommits(ctx context.Context) error {
 		ctx, cancel := context.WithCancel(ctx)
 		repos[key] = cancel
 		go func() {
-			// nolint:errcheck
 			backoff.RetryUntilCancel(ctx, func() error {
 				return d.finishRepoCommits(ctx, compactor, key)
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -32,11 +32,13 @@ const (
 func (d *driver) master(ctx context.Context) {
 	ctx = auth.AsInternalUser(ctx, "pfs-master")
 	masterLock := dlock.NewDLock(d.etcdClient, path.Join(d.prefix, masterLockPath))
+	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		masterCtx, err := masterLock.Lock(ctx)
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
+		// nolint:errcheck
 		defer masterLock.Unlock(masterCtx)
 		eg, ctx := errgroup.WithContext(masterCtx)
 		trackerPeriod := time.Second * time.Duration(d.env.StorageConfig.StorageGCPeriod)
@@ -95,6 +97,7 @@ func (d *driver) finishCommits(ctx context.Context) error {
 		ctx, cancel := context.WithCancel(ctx)
 		repos[key] = cancel
 		go func() {
+			// nolint:errcheck
 			backoff.RetryUntilCancel(ctx, func() error {
 				return d.finishRepoCommits(ctx, compactor, key)
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -32,7 +32,7 @@ const (
 func (d *driver) master(ctx context.Context) {
 	ctx = auth.AsInternalUser(ctx, "pfs-master")
 	masterLock := dlock.NewDLock(d.etcdClient, path.Join(d.prefix, masterLockPath))
-	backoff.RetryUntilCancel(ctx, func() error {
+	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		masterCtx, err := masterLock.Lock(ctx)
 		if err != nil {
 			return errors.EnsureStack(err)
@@ -95,7 +95,7 @@ func (d *driver) finishCommits(ctx context.Context) error {
 		ctx, cancel := context.WithCancel(ctx)
 		repos[key] = cancel
 		go func() {
-			backoff.RetryUntilCancel(ctx, func() error {
+			backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 				return d.finishRepoCommits(ctx, compactor, key)
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 				log.Errorf("error finishing commits for repo %v: %v, retrying in %v", key, err, d)

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -12,6 +12,7 @@ func NewAPIServer(env Env) (pfsserver.APIServer, error) {
 		return nil, err
 	}
 	go a.driver.master(env.BackgroundContext)
+	// nolint:errcheck
 	go func() { pfsload.Worker(env.GetPachClient(env.BackgroundContext), env.TaskService) }()
 	return newValidatedAPIServer(a, env.AuthServer), nil
 }

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -12,8 +12,7 @@ func NewAPIServer(env Env) (pfsserver.APIServer, error) {
 		return nil, err
 	}
 	go a.driver.master(env.BackgroundContext)
-	// nolint:errcheck
-	go func() { pfsload.Worker(env.GetPachClient(env.BackgroundContext), env.TaskService) }()
+	go func() { pfsload.Worker(env.GetPachClient(env.BackgroundContext), env.TaskService) }() //nolint:errcheck
 	return newValidatedAPIServer(a, env.AuthServer), nil
 }
 

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4913,7 +4913,7 @@ func TestPFS(suite *testing.T) {
 			return fmt.Sprint("seed: ", strconv.FormatInt(seed, 10))
 		}
 		monkeyRetry := func(t *testing.T, f func() error, errMsg string) {
-			backoff.Retry(func() error {
+			backoff.Retry(func() error { //nolint:errcheck
 				err := f()
 				if err != nil {
 					require.True(t, obj.IsMonkeyError(err), "Expected monkey error (%s), %s", err.Error(), errMsg)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4340,16 +4340,16 @@ func TestPFS(suite *testing.T) {
 
 		var readyCommitsB, readyCommitsC int64
 		go func() {
-			require.NoError(t, pachClient.SubscribeCommit(client.NewRepo("B"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
+			_ = pachClient.SubscribeCommit(client.NewRepo("B"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
 				atomic.AddInt64(&readyCommitsB, 1)
 				return nil
-			}))
+			})
 		}()
 		go func() {
-			require.NoError(t, pachClient.SubscribeCommit(client.NewRepo("C"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
+			_ = pachClient.SubscribeCommit(client.NewRepo("C"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
 				atomic.AddInt64(&readyCommitsC, 1)
 				return nil
-			}))
+			})
 		}()
 		_, err := pachClient.StartCommit("A", "master")
 		require.NoError(t, err)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4913,7 +4913,6 @@ func TestPFS(suite *testing.T) {
 			return fmt.Sprint("seed: ", strconv.FormatInt(seed, 10))
 		}
 		monkeyRetry := func(t *testing.T, f func() error, errMsg string) {
-			// nolint:errcheck
 			backoff.Retry(func() error {
 				err := f()
 				if err != nil {

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -3490,7 +3490,7 @@ func TestPFS(suite *testing.T) {
 		for i := 0; i < 25; i++ {
 			next := fmt.Sprintf("%d,%d,%d,%d\n", 4*i, (4*i)+1, (4*i)+2, (4*i)+3)
 			expected.WriteString(next)
-			env.PachClient.PutFile(commit, fmt.Sprintf("/data/%010d", i), strings.NewReader(next))
+			require.NoError(t, env.PachClient.PutFile(commit, fmt.Sprintf("/data/%010d", i), strings.NewReader(next)))
 		}
 		require.NoError(t, finishCommit(env.PachClient, repo, commit.Branch.Name, commit.ID))
 
@@ -3933,7 +3933,7 @@ func TestPFS(suite *testing.T) {
 		bCommit1 := inspect("B", "master", "")
 		commit3, err = env.PachClient.StartCommit("A", "master")
 		require.NoError(t, err)
-		finishCommit(env.PachClient, "A", commit3.Branch.Name, commit3.ID)
+		require.NoError(t, finishCommit(env.PachClient, "A", commit3.Branch.Name, commit3.ID))
 		// Re-inspect bCommit1, which has been updated by StartCommit
 		bCommit1, bCommit2 := inspect("B", bCommit1.Commit.Branch.Name, bCommit1.Commit.ID), inspect("B", "master", "")
 		require.Equal(t, bCommit1.Commit.ID, bCommit2.ParentCommit.ID)
@@ -3963,7 +3963,7 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.CreateRepo("A"))
 		commit, err := env.PachClient.StartCommit("A", "master")
 		require.NoError(t, err)
-		finishCommit(env.PachClient, "A", commit.Branch.Name, commit.ID)
+		require.NoError(t, finishCommit(env.PachClient, "A", commit.Branch.Name, commit.ID))
 		commit2, err := env.PachClient.PfsAPIClient.StartCommit(env.PachClient.Ctx(), &pfs.StartCommitRequest{
 			Branch: client.NewBranch("A", "master2"),
 			Parent: client.NewCommit("A", "master", ""),
@@ -4340,16 +4340,16 @@ func TestPFS(suite *testing.T) {
 
 		var readyCommitsB, readyCommitsC int64
 		go func() {
-			pachClient.SubscribeCommit(client.NewRepo("B"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
+			require.NoError(t, pachClient.SubscribeCommit(client.NewRepo("B"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
 				atomic.AddInt64(&readyCommitsB, 1)
 				return nil
-			})
+			}))
 		}()
 		go func() {
-			pachClient.SubscribeCommit(client.NewRepo("C"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
+			require.NoError(t, pachClient.SubscribeCommit(client.NewRepo("C"), "master", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
 				atomic.AddInt64(&readyCommitsC, 1)
 				return nil
-			})
+			}))
 		}()
 		_, err := pachClient.StartCommit("A", "master")
 		require.NoError(t, err)
@@ -4913,6 +4913,7 @@ func TestPFS(suite *testing.T) {
 			return fmt.Sprint("seed: ", strconv.FormatInt(seed, 10))
 		}
 		monkeyRetry := func(t *testing.T, f func() error, errMsg string) {
+			// nolint:errcheck
 			backoff.Retry(func() error {
 				err := f()
 				if err != nil {

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -307,10 +307,8 @@ $ {{alias}} -p foo -i bar@YYY`,
 		}),
 	}
 	listJob.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "Limit to jobs made by pipeline.")
-	// nolint:errcheck
 	listJob.MarkFlagCustom("pipeline", "__pachctl_get_pipeline")
 	listJob.Flags().StringSliceVarP(&inputCommitStrs, "input", "i", []string{}, "List jobs with a specific set of input commits. format: <repo>@<branch-or-commit>")
-	// nolint:errcheck
 	listJob.MarkFlagCustom("input", "__pachctl_get_repo_commit")
 	listJob.Flags().BoolVarP(&expand, "expand", "x", false, "Show one line for each sub-job and include more columns")
 	listJob.Flags().AddFlagSet(outputFlags)
@@ -646,11 +644,9 @@ each datum.`,
 	}
 	getLogs.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "Filter the log "+
 		"for lines from this pipeline (accepts pipeline name)")
-	// nolint:errcheck
 	getLogs.MarkFlagCustom("pipeline", "__pachctl_get_pipeline")
 	getLogs.Flags().StringVarP(&jobStr, "job", "j", "", "Filter for log lines from "+
 		"this job (accepts job ID)")
-	// nolint:errcheck
 	getLogs.MarkFlagCustom("job", "__pachctl_get_job")
 	getLogs.Flags().StringVar(&datumID, "datum", "", "Filter for log lines for this datum (accepts datum ID)")
 	getLogs.Flags().StringVar(&commaInputs, "inputs", "", "Filter for log lines "+

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -307,8 +307,10 @@ $ {{alias}} -p foo -i bar@YYY`,
 		}),
 	}
 	listJob.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "Limit to jobs made by pipeline.")
+	// nolint:errcheck
 	listJob.MarkFlagCustom("pipeline", "__pachctl_get_pipeline")
 	listJob.Flags().StringSliceVarP(&inputCommitStrs, "input", "i", []string{}, "List jobs with a specific set of input commits. format: <repo>@<branch-or-commit>")
+	// nolint:errcheck
 	listJob.MarkFlagCustom("input", "__pachctl_get_repo_commit")
 	listJob.Flags().BoolVarP(&expand, "expand", "x", false, "Show one line for each sub-job and include more columns")
 	listJob.Flags().AddFlagSet(outputFlags)
@@ -644,9 +646,11 @@ each datum.`,
 	}
 	getLogs.Flags().StringVarP(&pipelineName, "pipeline", "p", "", "Filter the log "+
 		"for lines from this pipeline (accepts pipeline name)")
+	// nolint:errcheck
 	getLogs.MarkFlagCustom("pipeline", "__pachctl_get_pipeline")
 	getLogs.Flags().StringVarP(&jobStr, "job", "j", "", "Filter for log lines from "+
 		"this job (accepts job ID)")
+	// nolint:errcheck
 	getLogs.MarkFlagCustom("job", "__pachctl_get_job")
 	getLogs.Flags().StringVar(&datumID, "datum", "", "Filter for log lines for this datum (accepts datum ID)")
 	getLogs.Flags().StringVar(&commaInputs, "inputs", "", "Filter for log lines "+

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1654,8 +1654,7 @@ func (a *apiServer) validatePipeline(pipelineInfo *pps.PipelineInfo) error {
 
 func branchProvenance(input *pps.Input) []*pfs.Branch {
 	var result []*pfs.Branch
-	// nolint:errcheck
-	pps.VisitInput(input, func(input *pps.Input) error {
+	pps.VisitInput(input, func(input *pps.Input) error { //nolint:errcheck
 		if input.Pfs != nil {
 			result = append(result, client.NewBranch(input.Pfs.Repo, input.Pfs.Branch))
 		}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -760,9 +760,13 @@ func (a *apiServer) listJob(
 		if jqCode != nil {
 			jsonBuffer.Reset()
 			// convert jobInfo to a map[string]interface{} for use with gojq
-			enc.EncodeProto(jobInfo)
+			if err := enc.EncodeProto(jobInfo); err != nil {
+				return errors.EnsureStack(err)
+			}
 			var jobInterface interface{}
-			json.Unmarshal(jsonBuffer.Bytes(), &jobInterface)
+			if err := json.Unmarshal(jsonBuffer.Bytes(), &jobInterface); err != nil {
+				return errors.EnsureStack(err)
+			}
 			iter := jqCode.Run(jobInterface)
 			// treat either jq false-y value as rejection
 			if v, _ := iter.Next(); v == false || v == nil {
@@ -1650,6 +1654,7 @@ func (a *apiServer) validatePipeline(pipelineInfo *pps.PipelineInfo) error {
 
 func branchProvenance(input *pps.Input) []*pfs.Branch {
 	var result []*pfs.Branch
+	// nolint:errcheck
 	pps.VisitInput(input, func(input *pps.Input) error {
 		if input.Pfs != nil {
 			result = append(result, client.NewBranch(input.Pfs.Repo, input.Pfs.Branch))
@@ -1670,7 +1675,7 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 	// Figure out which repos 'pipeline' might no longer be using
 	if prevPipelineInfo != nil {
 		pipelineName = prevPipelineInfo.Pipeline.Name
-		pps.VisitInput(prevPipelineInfo.Details.Input, func(input *pps.Input) error {
+		if err := pps.VisitInput(prevPipelineInfo.Details.Input, func(input *pps.Input) error {
 			var repo string
 			switch {
 			case input.Pfs != nil:
@@ -1682,7 +1687,9 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 			}
 			remove[repo] = struct{}{}
 			return nil
-		})
+		}); err != nil {
+			return errors.EnsureStack(err)
+		}
 	}
 
 	// Figure out which repos 'pipeline' is using
@@ -1698,7 +1705,7 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 
 		// collect inputs (remove redundant inputs from 'remove', but don't
 		// bother authorizing 'pipeline' twice)
-		pps.VisitInput(pipelineInfo.Details.Input, func(input *pps.Input) error {
+		if err := pps.VisitInput(pipelineInfo.Details.Input, func(input *pps.Input) error {
 			var repo string
 			switch {
 			case input.Pfs != nil:
@@ -1717,7 +1724,9 @@ func (a *apiServer) fixPipelineInputRepoACLsInTransaction(txnCtx *txncontext.Tra
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			return errors.EnsureStack(err)
+		}
 	}
 	if pipelineName == "" {
 		return errors.Errorf("fixPipelineInputRepoACLs called with both current and " +
@@ -2167,7 +2176,7 @@ func setPipelineDefaults(pipelineInfo *pps.PipelineInfo) error {
 func setInputDefaults(pipelineName string, input *pps.Input) {
 	now := time.Now()
 	nCreatedBranches := make(map[string]int)
-	pps.VisitInput(input, func(input *pps.Input) error {
+	if err := pps.VisitInput(input, func(input *pps.Input) error {
 		if input.Pfs != nil {
 			if input.Pfs.Branch == "" {
 				if input.Pfs.Trigger != nil {
@@ -2201,7 +2210,9 @@ func setInputDefaults(pipelineName string, input *pps.Input) {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		logrus.Errorf("error while visiting inputs: %v", err)
+	}
 }
 
 func (a *apiServer) stopAllJobsInPipeline(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) error {
@@ -2375,9 +2386,13 @@ func (a *apiServer) listPipeline(ctx context.Context, request *pps.ListPipelineR
 		if jqCode != nil {
 			jsonBuffer.Reset()
 			// convert pipelineInfo to a map[string]interface{} for use with gojq
-			enc.EncodeProto(pipelineInfo)
+			if err := enc.EncodeProto(pipelineInfo); err != nil {
+				logrus.Errorf("error encoding pipelineInfo to JSON: %v", err)
+			}
 			var pipelineInterface interface{}
-			json.Unmarshal(jsonBuffer.Bytes(), &pipelineInterface)
+			if err := json.Unmarshal(jsonBuffer.Bytes(), &pipelineInterface); err != nil {
+				logrus.Errorf("error parsing JSON encoded pipeline info: %v", err)
+			}
 			iter := jqCode.Run(pipelineInterface)
 			// treat either jq false-y value as rejection
 			if v, _ := iter.Next(); v == false || v == nil {
@@ -2710,12 +2725,14 @@ func (a *apiServer) RunCron(ctx context.Context, request *pps.RunCronRequest) (r
 
 	// find any cron inputs
 	var crons []*pps.CronInput
-	pps.VisitInput(pipelineInfo.Details.Input, func(in *pps.Input) error {
+	if err := pps.VisitInput(pipelineInfo.Details.Input, func(in *pps.Input) error {
 		if in.Cron != nil {
 			crons = append(crons, in.Cron)
 		}
 		return nil
-	})
+	}); err != nil {
+		return nil, errors.Errorf("error visiting pps inputs: %v", err)
+	}
 
 	if len(crons) < 1 {
 		return nil, errors.Errorf("pipeline doesn't have a cron input")

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -103,7 +103,6 @@ func newMaster(ctx context.Context, env Env, etcdPrefix string, kd InfraDriver, 
 // pipelines are created/removed.
 func (a *apiServer) master() {
 	masterLock := dlock.NewDLock(a.env.EtcdClient, path.Join(a.etcdPrefix, masterLockPath))
-	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		ctx, cancel := context.WithCancel(context.Background())
 		// set internal auth for basic operations
@@ -113,8 +112,7 @@ func (a *apiServer) master() {
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-		// nolint:errcheck
-		defer masterLock.Unlock(ctx)
+		defer masterLock.Unlock(ctx) //nolint:errcheck
 		log.Infof("PPS master: launching master process")
 		kd := newKubeDriver(a.env.KubeClient, a.env.Config, a.env.Logger)
 		sd := newPipelineStateDriver(a.env.DB, a.pipelines, a.txnEnv, a.env.PFSServer)

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -103,6 +103,7 @@ func newMaster(ctx context.Context, env Env, etcdPrefix string, kd InfraDriver, 
 // pipelines are created/removed.
 func (a *apiServer) master() {
 	masterLock := dlock.NewDLock(a.env.EtcdClient, path.Join(a.etcdPrefix, masterLockPath))
+	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		ctx, cancel := context.WithCancel(context.Background())
 		// set internal auth for basic operations
@@ -112,6 +113,7 @@ func (a *apiServer) master() {
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
+		// nolint:errcheck
 		defer masterLock.Unlock(ctx)
 		log.Infof("PPS master: launching master process")
 		kd := newKubeDriver(a.env.KubeClient, a.env.Config, a.env.Logger)

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -103,7 +103,7 @@ func newMaster(ctx context.Context, env Env, etcdPrefix string, kd InfraDriver, 
 // pipelines are created/removed.
 func (a *apiServer) master() {
 	masterLock := dlock.NewDLock(a.env.EtcdClient, path.Join(a.etcdPrefix, masterLockPath))
-	backoff.RetryNotify(func() error {
+	backoff.RetryNotify(func() error { //nolint:errcheck
 		ctx, cancel := context.WithCancel(context.Background())
 		// set internal auth for basic operations
 		ctx = middleware_auth.AsInternalUser(ctx, "pps-master")

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -88,8 +88,7 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 	pipeline := pipelineInfo.Pipeline.Name
 	log.Printf("PPS master: monitoring pipeline %q", pipeline)
 	var eg errgroup.Group
-	// nolint:errcheck
-	pps.VisitInput(pipelineInfo.Details.Input, func(in *pps.Input) error {
+	pps.VisitInput(pipelineInfo.Details.Input, func(in *pps.Input) error { //nolint:errcheck
 		if in.Cron != nil {
 			eg.Go(func() error {
 				return backoff.RetryNotify(func() error {

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -88,6 +88,7 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 	pipeline := pipelineInfo.Pipeline.Name
 	log.Printf("PPS master: monitoring pipeline %q", pipeline)
 	var eg errgroup.Group
+	// nolint:errcheck
 	pps.VisitInput(pipelineInfo.Details.Input, func(in *pps.Input) error {
 		if in.Cron != nil {
 			eg.Go(func() error {

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -69,9 +69,9 @@ func waitForPipelineState(t testing.TB, stateDriver *mockStateDriver, pipeline s
 func mockJobRunning(mockPachd *testpachd.MockPachd, taskCount, commitCount int) (done chan struct{}) {
 	mockPachd.PPS.ListTask.Use(func(_ *task.ListTaskRequest, srv pps.API_ListTaskServer) error {
 		for i := 0; i < taskCount; i++ {
-			srv.Send(&task.TaskInfo{
-				State: task.State_RUNNING,
-			})
+			if err := srv.Send(&task.TaskInfo{State: task.State_RUNNING}); err != nil {
+				return errors.EnsureStack(err)
+			}
 		}
 		return nil
 	})
@@ -81,9 +81,9 @@ func mockJobRunning(mockPachd *testpachd.MockPachd, taskCount, commitCount int) 
 	testDone := make(chan struct{})
 	mockPachd.PFS.SubscribeCommit.Use(func(req *pfs.SubscribeCommitRequest, server pfs.API_SubscribeCommitServer) error {
 		for i := 0; i < commitCount; i++ {
-			server.Send(&pfs.CommitInfo{
-				Commit: client.NewCommit(req.Repo.Name, "", uuid.NewWithoutDashes()),
-			})
+			if err := server.Send(&pfs.CommitInfo{Commit: client.NewCommit(req.Repo.Name, "", uuid.NewWithoutDashes())}); err != nil {
+				return errors.EnsureStack(err)
+			}
 		}
 		<-testDone
 		return nil

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -69,7 +69,6 @@ func waitForPipelineState(t testing.TB, stateDriver *mockStateDriver, pipeline s
 func mockJobRunning(mockPachd *testpachd.MockPachd, taskCount, commitCount int) (done chan struct{}) {
 	mockPachd.PPS.ListTask.Use(func(_ *task.ListTaskRequest, srv pps.API_ListTaskServer) error {
 		for i := 0; i < taskCount; i++ {
-			// nolint:errcheck
 			srv.Send(&task.TaskInfo{
 				State: task.State_RUNNING,
 			})
@@ -82,7 +81,6 @@ func mockJobRunning(mockPachd *testpachd.MockPachd, taskCount, commitCount int) 
 	testDone := make(chan struct{})
 	mockPachd.PFS.SubscribeCommit.Use(func(req *pfs.SubscribeCommitRequest, server pfs.API_SubscribeCommitServer) error {
 		for i := 0; i < commitCount; i++ {
-			// nolint:errcheck
 			server.Send(&pfs.CommitInfo{
 				Commit: client.NewCommit(req.Repo.Name, "", uuid.NewWithoutDashes()),
 			})

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -67,8 +67,9 @@ func waitForPipelineState(t testing.TB, stateDriver *mockStateDriver, pipeline s
 }
 
 func mockJobRunning(mockPachd *testpachd.MockPachd, taskCount, commitCount int) (done chan struct{}) {
-	mockPachd.PPS.ListTask.Use(func(req *task.ListTaskRequest, srv pps.API_ListTaskServer) error {
+	mockPachd.PPS.ListTask.Use(func(_ *task.ListTaskRequest, srv pps.API_ListTaskServer) error {
 		for i := 0; i < taskCount; i++ {
+			// nolint:errcheck
 			srv.Send(&task.TaskInfo{
 				State: task.State_RUNNING,
 			})
@@ -81,6 +82,7 @@ func mockJobRunning(mockPachd *testpachd.MockPachd, taskCount, commitCount int) 
 	testDone := make(chan struct{})
 	mockPachd.PFS.SubscribeCommit.Use(func(req *pfs.SubscribeCommitRequest, server pfs.API_SubscribeCommitServer) error {
 		for i := 0; i < commitCount; i++ {
+			// nolint:errcheck
 			server.Send(&pfs.CommitInfo{
 				Commit: client.NewCommit(req.Repo.Name, "", uuid.NewWithoutDashes()),
 			})

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -121,7 +121,7 @@ func (s *sidecarS3G) createK8sServices() {
 	logrus.Infof("Launching sidecar s3 gateway master process")
 	// createK8sServices goes through master election so that only one k8s service
 	// is created per pachyderm job running sidecar s3 gateway
-	backoff.RetryNotify(func() error {
+	backoff.RetryNotify(func() error { //nolint:errcheck
 		masterLock := dlock.NewDLock(s.apiServer.env.EtcdClient,
 			path.Join(s.apiServer.etcdPrefix,
 				s3gSidecarLockPath,
@@ -293,7 +293,7 @@ func (h *handleJobsCtx) start() {
 	}()
 	for { // reestablish watch in a loop, in case there's a watch error
 		var watcher watch.Watcher
-		backoff.Retry(func() error {
+		backoff.Retry(func() error { //nolint:errcheck
 			var err error
 			watcher, err = h.s.apiServer.jobs.ReadOnly(context.Background()).WatchByIndex(
 				ppsdb.JobsPipelineIndex, h.s.pipelineInfo.Pipeline.Name)

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -121,7 +121,6 @@ func (s *sidecarS3G) createK8sServices() {
 	logrus.Infof("Launching sidecar s3 gateway master process")
 	// createK8sServices goes through master election so that only one k8s service
 	// is created per pachyderm job running sidecar s3 gateway
-	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		masterLock := dlock.NewDLock(s.apiServer.env.EtcdClient,
 			path.Join(s.apiServer.etcdPrefix,
@@ -294,7 +293,6 @@ func (h *handleJobsCtx) start() {
 	}()
 	for { // reestablish watch in a loop, in case there's a watch error
 		var watcher watch.Watcher
-		// nolint:errcheck
 		backoff.Retry(func() error {
 			var err error
 			watcher, err = h.s.apiServer.jobs.ReadOnly(context.Background()).WatchByIndex(

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -221,7 +221,7 @@ func TestTrafficThroughProxy(t *testing.T) {
 	c, ns := minikubetestenv.AcquireCluster(t)
 	deployFakeConsole(t, ns)
 	testutil.ActivateAuthClient(t, c)
-	testutil.ConfigureOIDCProvider(t, c)
+	require.NoError(t, testutil.ConfigureOIDCProvider(t, c))
 	proxyTest(t, http.DefaultClient, c, false)
 }
 
@@ -290,7 +290,7 @@ func TestTrafficThroughProxyTLS(t *testing.T) {
 	deployFakeConsole(t, ns)
 
 	testutil.ActivateAuthClient(t, c)
-	testutil.ConfigureOIDCProvider(t, c)
+	require.NoError(t, testutil.ConfigureOIDCProvider(t, c))
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -465,7 +465,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 		// Write a tar stream with a single file to
 		// the tcp connection of the pipeline service's
 		// external port.
-		backoff.Retry(func() error {
+		backoff.Retry(func() error { //nolint:errcheck
 			raddr, err := net.ResolveTCPAddr("tcp", serviceAddr)
 			if err != nil {
 				return errors.EnsureStack(err)

--- a/src/server/transaction/cmds/cmds.go
+++ b/src/server/transaction/cmds/cmds.go
@@ -216,7 +216,9 @@ transaction' or cancelled with 'delete transaction'.`,
 			if isActive {
 				// The active transaction was successfully deleted, clean it up so the
 				// user doesn't need to manually 'stop transaction' it.
-				ClearActiveTransaction()
+				if err := ClearActiveTransaction(); err != nil {
+					return err
+				}
 			}
 			return nil
 		}),

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -495,7 +495,7 @@ func TestCreatePipelineTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	commit := client.NewCommit(repo, "master", "")
-	c.PutFile(commit, "foo", strings.NewReader("bar"))
+	require.NoError(t, c.PutFile(commit, "foo", strings.NewReader("bar")))
 
 	commitInfo, err := c.WaitCommit(pipeline, "master", "")
 	require.NoError(t, err)

--- a/src/server/worker/common/common.go
+++ b/src/server/worker/common/common.go
@@ -42,23 +42,15 @@ func IsDone(ctx context.Context) bool {
 func DatumID(inputs []*Input) string {
 	hash := pfs.NewHash()
 	for _, input := range inputs {
-		// nolint:errcheck
 		hash.Write([]byte(input.Name))
-		// nolint:errcheck
-		binary.Write(hash, binary.BigEndian, int64(len(input.Name)))
+		binary.Write(hash, binary.BigEndian, int64(len(input.Name))) //nolint:errcheck
 		file := input.FileInfo.File
-		// nolint:errcheck
 		hash.Write([]byte(file.Commit.Branch.Repo.Name))
-		// nolint:errcheck
-		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Repo.Name)))
-		// nolint:errcheck
+		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Repo.Name))) //nolint:errcheck
 		hash.Write([]byte(file.Commit.Branch.Name))
-		// nolint:errcheck
-		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Name)))
-		// nolint:errcheck
+		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Name))) //nolint:errcheck
 		hash.Write([]byte(input.FileInfo.File.Path))
-		// nolint:errcheck
-		binary.Write(hash, binary.BigEndian, int64(len(input.FileInfo.File.Path)))
+		binary.Write(hash, binary.BigEndian, int64(len(input.FileInfo.File.Path))) //nolint:errcheck
 	}
 	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/src/server/worker/common/common.go
+++ b/src/server/worker/common/common.go
@@ -42,14 +42,22 @@ func IsDone(ctx context.Context) bool {
 func DatumID(inputs []*Input) string {
 	hash := pfs.NewHash()
 	for _, input := range inputs {
+		// nolint:errcheck
 		hash.Write([]byte(input.Name))
+		// nolint:errcheck
 		binary.Write(hash, binary.BigEndian, int64(len(input.Name)))
 		file := input.FileInfo.File
+		// nolint:errcheck
 		hash.Write([]byte(file.Commit.Branch.Repo.Name))
+		// nolint:errcheck
 		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Repo.Name)))
+		// nolint:errcheck
 		hash.Write([]byte(file.Commit.Branch.Name))
+		// nolint:errcheck
 		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Name)))
+		// nolint:errcheck
 		hash.Write([]byte(input.FileInfo.File.Path))
+		// nolint:errcheck
 		binary.Write(hash, binary.BigEndian, int64(len(input.FileInfo.File.Path)))
 	}
 	return hex.EncodeToString(hash.Sum(nil))

--- a/src/server/worker/common/common.go
+++ b/src/server/worker/common/common.go
@@ -43,14 +43,14 @@ func DatumID(inputs []*Input) string {
 	hash := pfs.NewHash()
 	for _, input := range inputs {
 		hash.Write([]byte(input.Name))
-		binary.Write(hash, binary.BigEndian, int64(len(input.Name))) //nolint:errcheck
+		_ = binary.Write(hash, binary.BigEndian, int64(len(input.Name)))
 		file := input.FileInfo.File
 		hash.Write([]byte(file.Commit.Branch.Repo.Name))
-		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Repo.Name))) //nolint:errcheck
+		_ = binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Repo.Name)))
 		hash.Write([]byte(file.Commit.Branch.Name))
-		binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Name))) //nolint:errcheck
+		_ = binary.Write(hash, binary.BigEndian, int64(len(file.Commit.Branch.Name)))
 		hash.Write([]byte(input.FileInfo.File.Path))
-		binary.Write(hash, binary.BigEndian, int64(len(input.FileInfo.File.Path))) //nolint:errcheck
+		_ = binary.Write(hash, binary.BigEndian, int64(len(input.FileInfo.File.Path)))
 	}
 	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/src/server/worker/datum/iterator.go
+++ b/src/server/worker/datum/iterator.go
@@ -364,7 +364,9 @@ func computeDatumKeyFilesets(pachClient *client.APIClient, renewer *renew.String
 			if err != nil {
 				return err
 			}
-			renewer.Add(ctx, resp.FileSetId)
+			if err := renewer.Add(ctx, resp.FileSetId); err != nil {
+				return err
+			}
 			filesets[i] = resp.FileSetId
 			return nil
 		})

--- a/src/server/worker/logs/testing.go
+++ b/src/server/worker/logs/testing.go
@@ -47,6 +47,7 @@ func (ml *MockLogger) Logf(formatString string, args ...interface{}) {
 		params := []interface{}{time.Now().Format(time.StampMilli), ml.Job, ml.Data, ml.UserCode}
 		params = append(params, args...)
 		str := fmt.Sprintf("LOGF %s (%v, %v, %v): "+formatString+"\n", params...)
+		// nolint:errcheck
 		ml.Writer.Write([]byte(str))
 	}
 }
@@ -57,6 +58,7 @@ func (ml *MockLogger) Errf(formatString string, args ...interface{}) {
 		params := []interface{}{time.Now().Format(time.StampMilli), ml.Job, ml.Data, ml.UserCode}
 		params = append(params, args...)
 		str := fmt.Sprintf("ERRF %s (%v, %v, %v): "+formatString+"\n", params...)
+		// nolint:errcheck
 		ml.Writer.Write([]byte(str))
 	}
 }

--- a/src/server/worker/logs/testing.go
+++ b/src/server/worker/logs/testing.go
@@ -47,8 +47,7 @@ func (ml *MockLogger) Logf(formatString string, args ...interface{}) {
 		params := []interface{}{time.Now().Format(time.StampMilli), ml.Job, ml.Data, ml.UserCode}
 		params = append(params, args...)
 		str := fmt.Sprintf("LOGF %s (%v, %v, %v): "+formatString+"\n", params...)
-		// nolint:errcheck
-		ml.Writer.Write([]byte(str))
+		ml.Writer.Write([]byte(str)) //nolint:errcheck
 	}
 }
 
@@ -58,8 +57,7 @@ func (ml *MockLogger) Errf(formatString string, args ...interface{}) {
 		params := []interface{}{time.Now().Format(time.StampMilli), ml.Job, ml.Data, ml.UserCode}
 		params = append(params, args...)
 		str := fmt.Sprintf("ERRF %s (%v, %v, %v): "+formatString+"\n", params...)
-		// nolint:errcheck
-		ml.Writer.Write([]byte(str))
+		ml.Writer.Write([]byte(str)) //nolint:errcheck
 	}
 }
 

--- a/src/server/worker/pipeline/transform/pending_job.go
+++ b/src/server/worker/pipeline/transform/pending_job.go
@@ -40,7 +40,9 @@ func (pj *pendingJob) saveJobStats(stats *datum.Stats) {
 	if pj.ji.Stats == nil {
 		pj.ji.Stats = &pps.ProcessStats{}
 	}
-	datum.MergeProcessStats(pj.ji.Stats, stats.ProcessStats)
+	if err := datum.MergeProcessStats(pj.ji.Stats, stats.ProcessStats); err != nil {
+		pj.logger.Logf("errored merging process stats: %v", err)
+	}
 	pj.ji.DataProcessed += stats.Processed
 	pj.ji.DataSkipped += stats.Skipped
 	pj.ji.DataFailed += stats.Failed

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -152,7 +152,9 @@ func (reg *registry) startJob(jobInfo *pps.JobInfo) (retErr error) {
 		if pj.ji.Details.JobTimeout != nil {
 			pj.logger.Logf("cancelling job at: %+v", afterTime)
 			timer := time.AfterFunc(afterTime, func() {
-				reg.killJob(pj, "job timed out") //nolint:errcheck
+				if err := reg.killJob(pj, " jobtimed out"); err != nil {
+					pj.logger.Logf("error killing job: %v", err)
+				}
 			})
 			defer timer.Stop()
 		}

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -152,6 +152,7 @@ func (reg *registry) startJob(jobInfo *pps.JobInfo) (retErr error) {
 		if pj.ji.Details.JobTimeout != nil {
 			pj.logger.Logf("cancelling job at: %+v", afterTime)
 			timer := time.AfterFunc(afterTime, func() {
+				// nolint:errcheck
 				reg.killJob(pj, "job timed out")
 			})
 			defer timer.Stop()

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -152,8 +152,7 @@ func (reg *registry) startJob(jobInfo *pps.JobInfo) (retErr error) {
 		if pj.ji.Details.JobTimeout != nil {
 			pj.logger.Logf("cancelling job at: %+v", afterTime)
 			timer := time.AfterFunc(afterTime, func() {
-				// nolint:errcheck
-				reg.killJob(pj, "job timed out")
+				reg.killJob(pj, "job timed out") //nolint:errcheck
 			})
 			defer timer.Stop()
 		}

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -60,6 +60,7 @@ func NewWorker(
 	}
 
 	if pipelineInfo.Details.Transform.Image != "" && pipelineInfo.Details.Transform.Cmd == nil {
+		// nolint:errcheck
 		ppsutil.FailPipeline(env.Context(), env.GetDBClient(), driver.Pipelines(),
 			pipelineInfo.SpecCommit,
 			"nothing to run: no transform.cmd")
@@ -80,7 +81,7 @@ func NewWorker(
 func (w *Worker) worker() {
 	ctx := w.driver.PachClient().Ctx()
 	logger := logs.NewStatlessLogger(w.driver.PipelineInfo())
-
+	// nolint:errcheck
 	backoff.RetryUntilCancel(ctx, func() error {
 		eg, ctx := errgroup.WithContext(ctx)
 		driver := w.driver.WithContext(ctx)
@@ -117,6 +118,7 @@ func (w *Worker) master(env serviceenv.ServiceEnv) {
 	// retry interval, the master would be deleted before it gets a chance
 	// to restart.
 	b.InitialInterval = 10 * time.Second
+	// nolint:errcheck
 	backoff.RetryNotify(func() error {
 		// We use pachClient.Ctx here because it contains auth information.
 		ctx, cancel := context.WithCancel(w.driver.PachClient().Ctx())
@@ -125,6 +127,7 @@ func (w *Worker) master(env serviceenv.ServiceEnv) {
 		if err != nil {
 			return errors.Wrap(err, "locking master lock")
 		}
+		// nolint:errcheck
 		defer masterLock.Unlock(ctx)
 
 		// Create a new driver that uses a new cancelable pachClient

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -85,7 +85,7 @@ func NewWorker(
 func (w *Worker) worker() {
 	ctx := w.driver.PachClient().Ctx()
 	logger := logs.NewStatlessLogger(w.driver.PipelineInfo())
-	backoff.RetryUntilCancel(ctx, func() error {
+	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		eg, ctx := errgroup.WithContext(ctx)
 		driver := w.driver.WithContext(ctx)
 
@@ -121,7 +121,7 @@ func (w *Worker) master(env serviceenv.ServiceEnv) {
 	// retry interval, the master would be deleted before it gets a chance
 	// to restart.
 	b.InitialInterval = 10 * time.Second
-	backoff.RetryNotify(func() error {
+	backoff.RetryNotify(func() error { //nolint:errcheck
 		// We use pachClient.Ctx here because it contains auth information.
 		ctx, cancel := context.WithCancel(w.driver.PachClient().Ctx())
 		defer cancel() // make sure that everything this loop might spawn gets cleaned up

--- a/src/testing/match/match.go
+++ b/src/testing/match/match.go
@@ -63,10 +63,7 @@ func main() {
 	}
 	if matchFound || *invert {
 		// Success--dump inputBuf (with guaranteed newline @ end)
-		// Note: we must ignore errors here--os.Stdout might be closed if a
-		// downstream cmd has already finished, but we don't want to cause a test to
-		// fail because of that
-		io.Copy(os.Stdout, strings.NewReader(strings.TrimSuffix(inputBuf.String(), "\n")))
+		io.Copy(os.Stdout, strings.NewReader(strings.TrimSuffix(inputBuf.String(), "\n"))) //nolint:errcheck // stdout might be closed if a downstream cmd has already finished, but we don't want to cause a test to fail because of that
 		os.Stdout.Write([]byte{'\n'})
 		os.Exit(0)
 	} else if !*invert {

--- a/src/testing/match/match.go
+++ b/src/testing/match/match.go
@@ -66,7 +66,6 @@ func main() {
 		// Note: we must ignore errors here--os.Stdout might be closed if a
 		// downstream cmd has already finished, but we don't want to cause a test to
 		// fail because of that
-		// nolint:errcheck
 		io.Copy(os.Stdout, strings.NewReader(strings.TrimSuffix(inputBuf.String(), "\n")))
 		os.Stdout.Write([]byte{'\n'})
 		os.Exit(0)

--- a/src/testing/match/match.go
+++ b/src/testing/match/match.go
@@ -66,6 +66,7 @@ func main() {
 		// Note: we must ignore errors here--os.Stdout might be closed if a
 		// downstream cmd has already finished, but we don't want to cause a test to
 		// fail because of that
+		// nolint:errcheck
 		io.Copy(os.Stdout, strings.NewReader(strings.TrimSuffix(inputBuf.String(), "\n")))
 		os.Stdout.Write([]byte{'\n'})
 		os.Exit(0)


### PR DESCRIPTION
The goal of this PR is to detect unchecked errors in our code, and prevent them in the future. To accomplish this, we enable `errcheck` in golangci-lint.

In general, these are the types of changes:
- basic `//nolint:errcheck` comment to ignore errcheck
- errors that obviously should be returned are returned now
- log previously swallowed errors where returning is impossible
- gingerly use  `_ = funcThatErrors()` to explicitly ignore the error with code, and let the reader know that we are intentionally swallowing the error