### PR TITLE
[DOC-452] Upgrade with bundled PostgreSQL does not require to go fetch the database password on upgrades anymore

### DIFF
--- a/doc/docs/master/deploy-manage/deploy/aws-deploy-pachyderm.md
+++ b/doc/docs/master/deploy-manage/deploy/aws-deploy-pachyderm.md
@@ -217,7 +217,7 @@ etcd and PostgreSQL (metadata storage) each claim the creation of a pv.
 If you plan on using **gp2** EBS volumes:
 
 - For deployments in **production**, [go to the AWS-managed PostgreSQL deployment and setup section](#5-create-an-aws-managed-postgresql-database)
-- Otherwise, you will be using the default bundled version of PostgreSQL: [Go to the deployment of Pachyderm](#6-deploy-pachyderm) 
+- For non production deployments, you will be using the default bundled version of PostgreSQL: [Go to the deployment of Pachyderm](#6-deploy-pachyderm) 
 
 For gp3 volumes, you will need to **deploy an Amazon EBS CSI driver to your cluster as detailed below**.
 
@@ -293,6 +293,8 @@ global:
     postgresqlUsername: "username"
     postgresqlPassword: "password" 
     # The name of the database should be Pachyderm's ("pachyderm" in the example above), not "dex" 
+    # See also 
+    # postgresqlExistingSecretName: "<yoursecretname>"
     postgresqlDatabase: "databasename"
     # The postgresql database host to connect to. Defaults to postgres service in subchart
     postgresqlHost: "RDS CNAME"

--- a/doc/docs/master/deploy-manage/deploy/quickstart.md
+++ b/doc/docs/master/deploy-manage/deploy/quickstart.md
@@ -2,7 +2,7 @@
 
 On this page, you will find simplified deployment instructions and Helm values to get you started with the latest release of Pachyderm on the Kubernetes Engine of your choice (AWS (EKS), Google (GKS), and Azure (AKS)).
 
-For each cloud provider, we will give you the option to "quick deploy" Pachyderm with or without Console (Pachyderm Web UI).
+For each cloud provider, we will give you the option to "quick deploy" Pachyderm with or without an enterprise key. A quick deployment allows you to experiment with Pachyderm without having to go through any infrastructure setup. In particular, you do not need to set up any object store or PostgreSQL instance.
 
 !!! Important 
     The deployment steps highlighted in this document are **not intended for production**. For production settings, please read our [infrastructure recommendations](../ingress/). In particular, we recommend:
@@ -47,7 +47,8 @@ Select your favorite cloud provider.
 ## 2. Create Your Values.yaml
 
 !!! Note
-    For a better understanding of the additional steps and helm values needed when deploying with Console, read about the [deployment of Pachyderm with Console](../console/#deploy-in-the-cloud) page. 
+    Pachyderm comes with a [Web UI (Console)](../console/#deploy-in-the-cloud) per default.
+
 ### AWS
 
 1. Additional client installation:

--- a/doc/docs/master/deploy-manage/manage/upgrades.md
+++ b/doc/docs/master/deploy-manage/manage/upgrades.md
@@ -16,7 +16,7 @@ section of this documentation.
 
 ## 2- Update Your Helm Values
 
-This phase depends on whether you need to modify your existing configuration (for example, enter an enterprise key, plug an Identity Provider, reference an Enterprise Server, etc...).
+This phase depends on whether you need to modify your existing configuration (for example, enter an enterprise key, plug an identity provider, reference an enterprise server, etc...).
 
 In the case of a simple upgrade of version on a cluster, and provided that you do not need to change any additional configuration, no change in the values.yaml should be required. The new version of Pachyderm will be directly set in the `helm upgrade` command.
 


### PR DESCRIPTION
Not much work is needed here for two reasons:

- I had already removed the warning and command informing users to retrieve and then set their database password back before any upgrade when using a built-in Postgres.
- It is simply a better/more transparent user experience overall where upgrades are happening smoothly (when it would previously fail when you did not retrieve and set the password back into your values)