### PR TITLE
[CORE-788] Disable Automount at the ServiceAccount Level

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -384,6 +384,7 @@ spec:
       {{-  if .Values.pachd.tolerations }}
       tolerations: {{ toYaml .Values.pachd.tolerations | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: true
       volumes:
       - name: tmp
         emptyDir: {}

--- a/etc/helm/pachyderm/templates/pachd/rbac/serviceaccount.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/serviceaccount.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 {{ if and .Values.pachd.serviceAccount.create .Values.pachd.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: false
 metadata:
   {{- if .Values.pachd.serviceAccount.additionalAnnotations }}
   annotations: {{ toYaml .Values.pachd.serviceAccount.additionalAnnotations | nindent 3 }}

--- a/etc/helm/pachyderm/templates/pachd/rbac/worker-serviceaccount.yaml
+++ b/etc/helm/pachyderm/templates/pachd/rbac/worker-serviceaccount.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 {{ if and .Values.pachd.worker.serviceAccount.create .Values.pachd.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: false
 metadata:
   {{- if .Values.pachd.worker.serviceAccount.additionalAnnotations }}
   annotations: {{ toYaml .Values.pachd.worker.serviceAccount.additionalAnnotations | nindent 3 }}

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -452,6 +452,7 @@ func (kd *kubeDriver) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pi
 			},
 		},
 		ServiceAccountName:            workerServiceAccountName,
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 		RestartPolicy:                 "Always",
 		Volumes:                       options.volumes,
 		ImagePullSecrets:              options.imagePullSecrets,


### PR DESCRIPTION
Disable ServiceAccount automounting for pachd at the SA level, enable at the pod level.