### PR TITLE
[Partial Backport] Update RCs unconditionally.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9707,6 +9707,8 @@ func TestPipelineAutoscaling(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	_, err = c.WaitCommit(pipeline, "master", "")
+	require.NoError(t, err)
 
 	fileIndex := 0
 	commitNFiles := func(n int) {
@@ -10227,16 +10229,21 @@ func monitorReplicas(t testing.TB, c *client.APIClient, namespace, pipeline stri
 	rcName := ppsutil.PipelineRcName(pipeline, 1)
 	enoughReplicas := false
 	tooManyReplicas := false
+	var maxSeen int
 	require.NoErrorWithinTRetry(t, 180*time.Second, func() error {
 		for {
 			scale, err := kc.CoreV1().ReplicationControllers(namespace).GetScale(context.Background(), rcName, metav1.GetOptions{})
 			if err != nil {
 				return errors.EnsureStack(err)
 			}
-			if int(scale.Spec.Replicas) >= n {
+			replicas := int(scale.Spec.Replicas)
+			if replicas >= n {
 				enoughReplicas = true
 			}
-			if int(scale.Spec.Replicas) > n {
+			if replicas > n {
+				if replicas > maxSeen {
+					maxSeen = replicas
+				}
 				tooManyReplicas = true
 			}
 			ci, err := c.InspectCommit(pipeline, "master", "")
@@ -10248,7 +10255,7 @@ func monitorReplicas(t testing.TB, c *client.APIClient, namespace, pipeline stri
 		}
 	})
 	require.True(t, enoughReplicas, "didn't get enough replicas, looking for: %d", n)
-	require.False(t, tooManyReplicas, "got too many replicas, looking for: %d", n)
+	require.False(t, tooManyReplicas, "got too many replicas (%d), looking for: %d", maxSeen, n)
 }
 
 func TestLoad(t *testing.T) {

--- a/src/server/pps/server/kube_driver.go
+++ b/src/server/pps/server/kube_driver.go
@@ -134,6 +134,12 @@ func (kd *kubeDriver) ReadReplicationController(ctx context.Context, pi *pps.Pip
 func (kd *kubeDriver) UpdateReplicationController(ctx context.Context, old *v1.ReplicationController, update func(rc *v1.ReplicationController) bool) error {
 	// Apply op's update to rc
 	rc := old.DeepCopy()
+	// clearing resourceVersion effectively tells k8s to ignore concurrent modifications.
+	// While this has a chance of overwriting a direct change to the RC outside of pachyderm,
+	// the most likely source of conflict is replica state changes, which can be safely ignored.
+	// Ensuring an uninterrupted update would require changing our retry logic,
+	// as currently a failure here leads to failing the pipeline
+	rc.ResourceVersion = ""
 	if update(rc) {
 		// write updated RC to k8s
 		kd.limiter.Acquire()


### PR DESCRIPTION
Partial 2.2.x version of #7619, leaving out the task counting part as it relies on more recent changes