### PR TITLE
Use forward slashes for comment in input spec docs

### DIFF
--- a/doc/docs/2.2.x/reference/pipeline-spec.md
+++ b/doc/docs/2.2.x/reference/pipeline-spec.md
@@ -107,7 +107,7 @@ To see how to use a pipeline spec to create a pipeline, refer to the [create pip
         "external_port": int
       },
       "spout": {
-        \\ Optionally, you can combine a spout with a service:
+        // Optionally, you can combine a spout with a service:
         "service": {
           "internal_port": int,
           "external_port": int


### PR DESCRIPTION
It would be more usual to use forward slashes to indicate that this is a comment