### PR TITLE
[CORE-946] Plumb a context through cmdutil.Main

### DIFF
--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"strconv"
@@ -25,11 +26,11 @@ func Populate(object interface{}, decoders ...Decoder) error {
 // Main runs the common functionality needed in a go main function.
 // appEnv will be populated and passed to do, defaultEnv can be nil
 // if there is an error, os.Exit(1) will be called.
-func Main(do func(interface{}) error, appEnv interface{}, decoders ...Decoder) {
+func Main(ctx context.Context, do func(context.Context, interface{}) error, appEnv interface{}, decoders ...Decoder) {
 	if err := Populate(appEnv, decoders...); err != nil {
 		mainError(err)
 	}
-	if err := do(appEnv); err != nil {
+	if err := do(ctx, appEnv); err != nil {
 		mainError(err)
 	}
 	os.Exit(0)

--- a/src/server/cmd/pachctl-doc/main.go
+++ b/src/server/cmd/pachctl-doc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
@@ -13,10 +14,10 @@ import (
 type appEnv struct{}
 
 func main() {
-	cmdutil.Main(do, &appEnv{})
+	cmdutil.Main(context.Background(), do, &appEnv{})
 }
 
-func do(appEnvObj interface{}) error {
+func do(ctx context.Context, appEnvObj interface{}) error {
 	// Set 'os.Args[0]' so that examples use the expected command name
 	os.Args[0] = "pachctl"
 

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -84,31 +84,32 @@ func main() {
 	log.SetFormatter(logutil.FormatterFunc(logutil.JSONPretty))
 	// set GOMAXPROCS to the container limit & log outcome to stdout
 	maxprocs.Set(maxprocs.Logger(log.Printf)) //nolint:errcheck
+	ctx := context.Background()
 
 	switch {
 	case readiness:
-		cmdutil.Main(doReadinessCheck, &serviceenv.GlobalConfiguration{})
+		cmdutil.Main(ctx, doReadinessCheck, &serviceenv.GlobalConfiguration{})
 	case mode == "full", mode == "", mode == "$(MODE)":
 		// Because of the way Kubernetes environment substitution works,
 		// a reference to an unset variable is not replaced with the
 		// empty string, but instead the reference is passed unchanged;
 		// because of this, '$(MODE)' should be recognized as an unset —
 		// i.e., default — mode.
-		cmdutil.Main(doFullMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, doFullMode, &serviceenv.PachdFullConfiguration{})
 	case mode == "enterprise":
-		cmdutil.Main(doEnterpriseMode, &serviceenv.EnterpriseServerConfiguration{})
+		cmdutil.Main(ctx, doEnterpriseMode, &serviceenv.EnterpriseServerConfiguration{})
 	case mode == "sidecar":
-		cmdutil.Main(doSidecarMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, doSidecarMode, &serviceenv.PachdFullConfiguration{})
 	case mode == "paused":
-		cmdutil.Main(doPausedMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, doPausedMode, &serviceenv.PachdFullConfiguration{})
 	default:
 		fmt.Printf("unrecognized mode: %s\n", mode)
 	}
 }
 
-func newInternalServer(authInterceptor *authmw.Interceptor, loggingInterceptor *loggingmw.LoggingInterceptor) (*grpcutil.Server, error) {
+func newInternalServer(ctx context.Context, authInterceptor *authmw.Interceptor, loggingInterceptor *loggingmw.LoggingInterceptor) (*grpcutil.Server, error) {
 	return grpcutil.NewServer(
-		context.Background(),
+		ctx,
 		false,
 		grpc.ChainUnaryInterceptor(
 			errorsmw.UnaryServerInterceptor,
@@ -125,9 +126,9 @@ func newInternalServer(authInterceptor *authmw.Interceptor, loggingInterceptor *
 	)
 }
 
-func newExternalServer(authInterceptor *authmw.Interceptor, loggingInterceptor *loggingmw.LoggingInterceptor) (*grpcutil.Server, error) {
+func newExternalServer(ctx context.Context, authInterceptor *authmw.Interceptor, loggingInterceptor *loggingmw.LoggingInterceptor) (*grpcutil.Server, error) {
 	return grpcutil.NewServer(
-		context.Background(),
+		ctx,
 		true,
 		// Add an UnknownServiceHandler to catch the case where the user has a client with the wrong major version.
 		// Weirdly, GRPC seems to run the interceptor stack before the UnknownServiceHandler, so this is never called
@@ -199,12 +200,12 @@ func setupDB(ctx context.Context, env *serviceenv.NonblockingServiceEnv) error {
 	return nil
 }
 
-func doReadinessCheck(config interface{}) error {
+func doReadinessCheck(ctx context.Context, config interface{}) error {
 	env := serviceenv.InitPachOnlyEnv(serviceenv.NewConfiguration(config))
-	return env.GetPachClient(context.Background()).Health()
+	return env.GetPachClient(ctx).Health()
 }
 
-func doEnterpriseMode(config interface{}) (retErr error) {
+func doEnterpriseMode(ctx context.Context, config interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			log.WithError(retErr).Print("failed to start server")
@@ -216,7 +217,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if err := setupDB(context.Background(), env); err != nil {
+	if err := setupDB(ctx, env); err != nil {
 		return err
 	}
 	if !env.Config().EnterpriseMember {
@@ -226,12 +227,12 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	// Setup External Pachd GRPC Server.
 	authInterceptor := authmw.NewInterceptor(env.AuthServer)
 	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger(), loggingmw.WithLogFormat(env.Config().LogFormat))
-	externalServer, err := newExternalServer(authInterceptor, loggingInterceptor)
+	externalServer, err := newExternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}
 	// Setup Internal Pachd GRPC Server.
-	internalServer, err := newInternalServer(authInterceptor, loggingInterceptor)
+	internalServer, err := newInternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}
@@ -331,7 +332,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 			return err
 		}
 		for _, b := range bootstrappers {
-			if err := b.EnvBootstrap(context.Background()); err != nil {
+			if err := b.EnvBootstrap(ctx); err != nil {
 				return errors.EnsureStack(err)
 			}
 		}
@@ -356,7 +357,7 @@ func doEnterpriseMode(config interface{}) (retErr error) {
 	return <-errChan
 }
 
-func doSidecarMode(config interface{}) (retErr error) {
+func doSidecarMode(ctx context.Context, config interface{}) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			pprof.Lookup("goroutine").WriteTo(os.Stderr, 2) //nolint:errcheck
@@ -368,7 +369,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 	}
 	authInterceptor := authmw.NewInterceptor(env.AuthServer)
 	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger())
-	server, err := newInternalServer(authInterceptor, loggingInterceptor)
+	server, err := newInternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}
@@ -477,8 +478,7 @@ func doSidecarMode(config interface{}) (retErr error) {
 	return server.Wait()
 }
 
-func doFullMode(config interface{}) (retErr error) {
-	var ctx = context.Background()
+func doFullMode(ctx context.Context, config interface{}) (retErr error) {
 	interruptChan := make(chan os.Signal, 1)
 	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer func() {
@@ -490,7 +490,7 @@ func doFullMode(config interface{}) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if err := setupDB(context.Background(), env); err != nil {
+	if err := setupDB(ctx, env); err != nil {
 		return err
 	}
 	if !env.Config().EnterpriseMember {
@@ -504,12 +504,12 @@ func doFullMode(config interface{}) (retErr error) {
 	// Setup External Pachd GRPC Server.
 	authInterceptor := authmw.NewInterceptor(env.AuthServer)
 	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger())
-	externalServer, err := newExternalServer(authInterceptor, loggingInterceptor)
+	externalServer, err := newExternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}
 	// Setup Internal Pachd GRPC Server.
-	internalServer, err := newInternalServer(authInterceptor, loggingInterceptor)
+	internalServer, err := newInternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func doFullMode(config interface{}) (retErr error) {
 			return err
 		}
 		for _, b := range bootstrappers {
-			if err := b.EnvBootstrap(context.Background()); err != nil {
+			if err := b.EnvBootstrap(ctx); err != nil {
 				return errors.EnsureStack(err)
 			}
 		}
@@ -741,8 +741,7 @@ func doFullMode(config interface{}) (retErr error) {
 	return <-errChan
 }
 
-func doPausedMode(config interface{}) (retErr error) {
-	var ctx = context.Background()
+func doPausedMode(ctx context.Context, config interface{}) (retErr error) {
 	interruptChan := make(chan os.Signal, 1)
 	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer func() {
@@ -755,7 +754,7 @@ func doPausedMode(config interface{}) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if err := setupDB(context.Background(), env); err != nil {
+	if err := setupDB(ctx, env); err != nil {
 		return err
 	}
 	if !env.Config().EnterpriseMember {
@@ -765,12 +764,12 @@ func doPausedMode(config interface{}) (retErr error) {
 	// Setup External Pachd GRPC Server.
 	authInterceptor := authmw.NewInterceptor(env.AuthServer)
 	loggingInterceptor := loggingmw.NewLoggingInterceptor(env.Logger())
-	externalServer, err := newExternalServer(authInterceptor, loggingInterceptor)
+	externalServer, err := newExternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}
 	// Setup Internal Pachd GRPC Server.
-	internalServer, err := newInternalServer(authInterceptor, loggingInterceptor)
+	internalServer, err := newInternalServer(ctx, authInterceptor, loggingInterceptor)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is not a huge improvement on its own; it lays the groundwork for handling termination in a unified manner later.