### PR TITLE
Use prebuilt image in CI

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -88,6 +88,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - restore_cache:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
@@ -299,6 +300,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - run: etc/testing/circle/install.sh
       - run:
           name: Collect node stats
@@ -323,6 +325,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - restore_cache:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
@@ -350,7 +353,9 @@ jobs:
           key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
           paths:
             - /home/circleci/.gocache
-      - run: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'
+      - run: 
+          name: Run Tests
+          command: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
           command: etc/testing/circle/upload_stats.sh
           when: always

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -353,7 +353,7 @@ jobs:
           key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
           paths:
             - /home/circleci/.gocache
-      - run: 
+      - run:
           name: Run Tests
           command: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ launch-dev: check-kubectl check-kubectl-connection
 launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml
+	helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set pachd.image.sha=$(CIRCLE_SHA1)
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
 	@if [ -z $$CIRCLE_SHA1 ]; then \
-		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.sha=$(CIRCLE_SHA1)
+		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.sha=$(CIRCLE_SHA1) \
 	fi
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,9 @@ launch-dev: check-kubectl check-kubectl-connection
 launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set pachd.image.sha=$(CIRCLE_SHA1)
+	@if [ -z $$CIRCLE_SHA1 ]; then \
+		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.sha=$(CIRCLE_SHA1)
+	fi
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,8 @@ launch-dev: check-kubectl check-kubectl-connection
 launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	@if [ -n $$CIRCLE_SHA1 ]; then \
-		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.sha=$(CIRCLE_SHA1) \
+	@if [[ -n $$CIRCLE_SHA1 ]]; then \
+		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.tag=$$CIRCLE_SHA1; \
 	fi
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ launch-dev: check-kubectl check-kubectl-connection
 launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	@if [ -z $$CIRCLE_SHA1 ]; then \
+	@if [ -n $$CIRCLE_SHA1 ]; then \
 		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.sha=$(CIRCLE_SHA1) \
 	fi
 	# wait for the pachyderm to come up

--- a/etc/testing/circle/build.sh
+++ b/etc/testing/circle/build.sh
@@ -29,4 +29,6 @@ fi
 git config user.email "donotreply@pachyderm.com"
 git config user.name "anonymous"
 git tag -f -am "Circle CI test v$VERSION" v"$VERSION"
-make docker-build
+#make docker-build
+docker build -f etc/test-images/Dockerfile.testuser -t pachyderm/testuser:local .
+docker build --network=host -f etc/test-images/Dockerfile.netcat -t pachyderm/ubuntuplusnetcat:local .

--- a/etc/testing/circle/helm-upgrade.sh
+++ b/etc/testing/circle/helm-upgrade.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-helm upgrade pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
-
-kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
-
-pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -8,8 +8,6 @@ global:
 pachd:
     service:
         type: ClusterIP
-    image:
-        tag: local
     storage:
         backend: MINIO
         minio:

--- a/etc/testing/circle/helm-values.yaml
+++ b/etc/testing/circle/helm-values.yaml
@@ -8,6 +8,8 @@ global:
 pachd:
     service:
         type: ClusterIP
+    image:
+        tag: local
     storage:
         backend: MINIO
         minio:

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
+helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag=${CIRCLE_SHA1}
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-if [ -z $CIRCLE_SHA1 ]; then
+if [ -n $CIRCLE_SHA1 ]; then
     helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag=${CIRCLE_SHA1}
 fi
 

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag=${CIRCLE_SHA1}
+if [ -z $CIRCLE_SHA1 ]; then
+    helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag=${CIRCLE_SHA1}
+fi
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-if [ -n $CIRCLE_SHA1 ]; then
-    helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag=${CIRCLE_SHA1}
+if [[ -n $CIRCLE_SHA1 ]]; then
+    helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag="${CIRCLE_SHA1}"
 fi
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m


### PR DESCRIPTION
This uses the docker image built centrally instead of building pach in every CI run.