### PR TITLE
Build Arm64 containers

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -143,6 +143,9 @@ jobs:
           name: Install minio
           command: kubectl apply -f etc/testing/minio.yaml
       - run:
+          name: Wait for docker images to be built
+          command: etc/testing/circle/wait_for_docker_images.sh
+      - run:
           no_output_timeout: 20m
           command: etc/testing/circle/run_tests.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
@@ -377,7 +380,7 @@ jobs:
       appVersion:
         type: string
         default: "0.0.0"
-    resource_class: large
+    resource_class: xlarge
     executor: docker-go
     steps:
       - checkout

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -388,7 +388,7 @@ jobs:
           name: Download utilities
           command: |
             mkdir -p /home/circleci/bin
-            wget https://github.com/goreleaser/goreleaser/releases/download/v1.4.1/goreleaser_Linux_x86_64.tar.gz
+            wget https://github.com/goreleaser/goreleaser/releases/download/v1.10.3/goreleaser_Linux_x86_64.tar.gz
             tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
             rm -rf goreleaser_Linux_x86_64.tar.gz
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -314,6 +314,9 @@ jobs:
           name: Collect node stats
           command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
+      - run:
+          name: Wait for docker images to be built
+          command: etc/testing/circle/wait_for_docker_images.sh
       - run: etc/testing/circle/rootless_test.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
           name: Dump debugging info in case of failure
@@ -361,6 +364,9 @@ jobs:
           key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
           paths:
             - /home/circleci/.gocache
+      - run:
+          name: Wait for docker images to be built
+          command: etc/testing/circle/wait_for_docker_images.sh
       - run:
           name: Run Tests
           command: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,7 @@ docker-gpu: docker-build-gpu docker-push-gpu
 docker-gpu-dev: docker-build-gpu docker-push-gpu-dev
 
 docker-push:
-	$(SKIP) docker push pachyderm/pachd:$(VERSION)
-	$(SKIP) docker push pachyderm/worker:$(VERSION)
-	$(SKIP) docker push pachyderm/pachctl:$(VERSION)
-	$(SKIP) docker push pachyderm/mount-server:$(VERSION)
+	$(SKIP) ./etc/build/push_docker_with_manifests.sh
 
 docker-pull:
 	$(SKIP) docker pull pachyderm/pachd:$(VERSION)

--- a/etc/build/push_docker_with_manifests.sh
+++ b/etc/build/push_docker_with_manifests.sh
@@ -6,19 +6,16 @@ REPO=pachyderm
 
 for product in pachd worker pachctl mount-server; do
     echo "push $product $VERSION..."
-    echo ""
-    docker push $REPO/$product-amd64:$VERSION
-    docker push $REPO/$product-arm64:$VERSION
+    docker push "$REPO/$product-amd64:$VERSION"
+    docker push "$REPO/$product-arm64:$VERSION"
 
-    docker manifest create $REPO/$product:$VERSION \
-           $REPO/$product-amd64:$VERSION \
-           $REPO/$product-arm64:$VERSION
+    docker manifest create "$REPO/$product:$VERSION" \
+           "$REPO/$product-amd64:$VERSION" \
+           "$REPO/$product-arm64:$VERSION"
 
-    docker manifest annotate $REPO/$product:$VERSION $REPO/$product-amd64:$VERSION --arch amd64
-    docker manifest annotate $REPO/$product:$VERSION $REPO/$product-arm64:$VERSION --arch arm64
+    docker manifest annotate "$REPO/$product:$VERSION" "$REPO/$product-amd64:$VERSION" --arch amd64
+    docker manifest annotate "$REPO/$product:$VERSION" "$REPO/$product-arm64:$VERSION" --arch arm64
 
-    docker manifest inspect $REPO/$product:$VERSION
-    docker manifest push $REPO/$product:$VERSION
-    echo "ok"
-    echo ""
+    docker manifest inspect "$REPO/$product:$VERSION"
+    docker manifest push "$REPO/$product:$VERSION"
 done

--- a/etc/build/push_docker_with_manifests.sh
+++ b/etc/build/push_docker_with_manifests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set +x -euo pipefail
+
+#REPO=localhost:5001/pachyderm
+REPO=pachyderm/
+
+for product in pachd worker pachctl mount-server; do
+    echo "push $product $VERSION..."
+    echo ""
+    docker push $REPO/$product-amd64:$VERSION
+    docker push $REPO/$product-arm64:$VERSION
+
+    docker manifest create --insecure $REPO/$product:$VERSION \
+           $REPO/$product-amd64:$VERSION \
+           $REPO/$product-arm64:$VERSION
+
+    docker manifest annotate $REPO/$product:$VERSION $REPO/$product-amd64:$VERSION --arch amd64
+    docker manifest annotate $REPO/$product:$VERSION $REPO/$product-arm64:$VERSION --arch arm64
+
+    docker manifest inspect $REPO/$product:$VERSION
+    docker manifest push $REPO/$product:$VERSION
+    echo "ok"
+    echo ""
+done

--- a/etc/build/push_docker_with_manifests.sh
+++ b/etc/build/push_docker_with_manifests.sh
@@ -11,7 +11,7 @@ for product in pachd worker pachctl mount-server; do
     docker push $REPO/$product-amd64:$VERSION
     docker push $REPO/$product-arm64:$VERSION
 
-    docker manifest create --insecure $REPO/$product:$VERSION \
+    docker manifest create $REPO/$product:$VERSION \
            $REPO/$product-amd64:$VERSION \
            $REPO/$product-arm64:$VERSION
 

--- a/etc/build/push_docker_with_manifests.sh
+++ b/etc/build/push_docker_with_manifests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set +x -euo pipefail
+set -euxo pipefail
 
 #REPO=localhost:5001/pachyderm
 REPO=pachyderm/

--- a/etc/build/push_docker_with_manifests.sh
+++ b/etc/build/push_docker_with_manifests.sh
@@ -2,8 +2,7 @@
 
 set -euxo pipefail
 
-#REPO=localhost:5001/pachyderm
-REPO=pachyderm/
+REPO=pachyderm
 
 for product in pachd worker pachctl mount-server; do
     echo "push $product $VERSION..."

--- a/etc/testing/circle/wait_for_docker_images.sh
+++ b/etc/testing/circle/wait_for_docker_images.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -euxo pipefail
+
 for _ in $(seq 1 120); do
-    if docker manifest inspect "pachyderm/pachd:$CIRCLE_SHA"; then
+    if docker manifest inspect "pachyderm/pachd:$CIRCLE_SHA1"; then
         echo "manifest exists"
         exit 0
     fi

--- a/etc/testing/circle/wait_for_docker_images.sh
+++ b/etc/testing/circle/wait_for_docker_images.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+for _ in $(seq 1 120); do
+    if docker manifest inspect "pachyderm/pachd:$CIRCLE_SHA"; then
+        echo "manifest exists"
+        exit 0
+    fi
+    echo "sleeping..."
+    sleep 5
+done
+
+echo "images not available after 600 seconds; giving up"
+exit 1

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -58,7 +58,6 @@ builds:
             "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
       goos:
           - linux
-          - darwin
       goarch:
           - amd64
           - arm64
@@ -73,7 +72,6 @@ builds:
             "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
       goos:
           - linux
-          - darwin
       goarch:
           - amd64
           - arm64

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -110,6 +110,8 @@ release:
 
 dockers:
     - image_templates:
+          - pachyderm/pachd
+          - pachyderm/pachd:local
           - pachyderm/pachd-amd64
           - pachyderm/pachd-amd64:local
           - "pachyderm/pachd-amd64:{{ .Version }}"
@@ -163,6 +165,8 @@ dockers:
           - LICENSE
           - licenses
     - image_templates:
+          - pachyderm/worker
+          - pachyderm/worker:local
           - pachyderm/worker-amd64
           - pachyderm/worker-amd64:local
           - "pachyderm/worker-amd64:{{ .FullCommit }}"

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -1,184 +1,261 @@
 dist: ../dist-pach/docker
 
 builds:
-  -
-    id: pachd
-    dir: src/server/cmd/pachd
-    main: main.go
-    binary: pachd
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: worker
-    dir: src/server/cmd/worker
-    main: main.go
-    binary: worker
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: worker_init
-    dir: etc/worker
-    main: init.go
-    binary: worker_init
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: pachctl
-    dir: src/server/cmd/pachctl
-    main: main.go
-    binary: pachctl
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: mount-server
-    dir: src/server/cmd/mount-server
-    main: main.go
-    binary: mount-server
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: pachtf
-    dir: src/server/cmd/pachtf
-    main: main.go
-    binary: pachtf
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
+    - id: pachd
+      dir: src/server/cmd/pachd
+      main: main.go
+      binary: pachd
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: worker
+      dir: src/server/cmd/worker
+      main: main.go
+      binary: worker
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: worker_init
+      dir: etc/worker
+      main: init.go
+      binary: worker_init
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: pachctl
+      dir: src/server/cmd/pachctl
+      main: main.go
+      binary: pachctl
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: mount-server
+      dir: src/server/cmd/mount-server
+      main: main.go
+      binary: mount-server
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: pachtf
+      dir: src/server/cmd/pachtf
+      main: main.go
+      binary: pachtf
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
 
 archives:
-  - format: binary
-    builds:
-      - pachctl
+    - format: binary
+      builds:
+          - pachctl
 
 checksum:
-  disable: true
+    disable: true
 
 changelog:
-  skip: true
+    skip: true
 
 release:
-  disable: true
+    disable: true
 
 dockers:
-  -
-    image_templates:
-      - pachyderm/pachd
-      - pachyderm/pachd:local
-      - "pachyderm/pachd:{{.Version}}"
-      - pachyderm/pachd:{{ .FullCommit }}
-    ids:
-      - pachd
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.pachd
-    extra_files:
-      - dex-assets
-      - LICENSE
-      - licenses
-    build_flag_templates:
-      - "--network=host"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-  -
-    image_templates:
-      - pachyderm/pachctl
-      - pachyderm/pachctl:{{ .FullCommit }}
-    ids:
-      - pachctl
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.pachctl
-    build_flag_templates:
-      - "--network=host"
-      - "--progress=plain"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-    extra_files:
-      - LICENSE
-      - licenses
-  -
-    image_templates:
-      - pachyderm/mount-server
-      - pachyderm/mount-server:{{ .FullCommit }}
-    ids:
-      - mount-server
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.mount-server
-    build_flag_templates:
-      - "--network=host"
-      - "--progress=plain"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-    extra_files:
-      - LICENSE
-      - licenses
-  -
-    image_templates:
-      - pachyderm/worker
-      - pachyderm/worker:local
-      - pachyderm/worker:{{ .FullCommit }}
-    ids:
-      - pachctl
-      - worker_init
-      - worker
-      - pachtf
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.worker
-    build_flag_templates:
-      - "--progress=plain"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-    extra_files:
-      - LICENSE
-      - licenses
+    - image_templates:
+          - pachyderm/pachd-amd64
+          - pachyderm/pachd-amd64:local
+          - "pachyderm/pachd-amd64:{{ .Version }}"
+          - "pachyderm/pachd-amd64:{{ .FullCommit }}"
+      ids:
+          - pachd
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.pachd
+      extra_files:
+          - dex-assets
+          - LICENSE
+          - licenses
+      build_flag_templates:
+          - "--network=host"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+    - image_templates:
+          - pachyderm/pachctl-amd64
+          - pachyderm/pachctl-amd64:{{ .FullCommit }}
+      ids:
+          - pachctl
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.pachctl
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/mount-server-amd64
+          - "pachyderm/mount-server-amd64:{{ .FullCommit }}"
+      ids:
+          - mount-server
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.mount-server
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/worker-amd64
+          - pachyderm/worker-amd64:local
+          - "pachyderm/worker-amd64:{{ .FullCommit }}"
+      ids:
+          - pachctl
+          - worker_init
+          - worker
+          - pachtf
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.worker
+      build_flag_templates:
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+
+    # arm64 builds follow
+    - image_templates:
+          - pachyderm/pachd-arm64
+          - pachyderm/pachd-arm64:local
+          - "pachyderm/pachd-arm64:{{ .Version }}"
+          - "pachyderm/pachd-arm64:{{ .FullCommit }}"
+      ids:
+          - pachd
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.pachd
+      extra_files:
+          - dex-assets
+          - LICENSE
+          - licenses
+      build_flag_templates:
+          - "--network=host"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+    - image_templates:
+          - pachyderm/pachctl-arm64
+          - pachyderm/pachctl-arm64:{{ .FullCommit }}
+      ids:
+          - pachctl
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.pachctl
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/mount-server-arm64
+          - "pachyderm/mount-server-arm64:{{ .FullCommit }}"
+      ids:
+          - mount-server
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.mount-server
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/worker-arm64
+          - pachyderm/worker-arm64:local
+          - "pachyderm/worker-arm64:{{ .FullCommit }}"
+      ids:
+          - pachctl
+          - worker_init
+          - worker
+          - pachtf
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.worker
+      build_flag_templates:
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -647,7 +647,6 @@ func (s *debugServer) collectGoInfo(tw *tar.Writer) error {
 		} else {
 			fmt.Fprint(w, "<no build info>")
 		}
-		w.Write([]byte("\n"))
 		fmt.Fprintf(w, "GOOS: %v\nGOARCH: %v\nGOMAXPROCS: %v\nNumCPU: %v\n", runtime.GOOS, runtime.GOARCH, runtime.GOMAXPROCS(0), runtime.NumCPU())
 		return nil
 	})

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -481,7 +481,7 @@ func (s *debugServer) collectPachdDumpFunc(limit int64) collectFunc {
 			return err
 		}
 		// Collect go info.
-		if err := s.collectGoInfo(tw); err != nil {
+		if err := s.collectGoInfo(tw, prefix...); err != nil {
 			return err
 		}
 		// Collect the pachd describe output.
@@ -638,7 +638,7 @@ func collectGraph(tw *tar.Writer, name, XAxisName string, series []chart.Series,
 	}, prefix...)
 }
 
-func (s *debugServer) collectGoInfo(tw *tar.Writer) error {
+func (s *debugServer) collectGoInfo(tw *tar.Writer, prefix ...string) error {
 	return collectDebugFile(tw, "go_info", "txt", func(w io.Writer) error {
 		fmt.Fprintf(w, "build info: ")
 		info, ok := runtimedebug.ReadBuildInfo()
@@ -649,7 +649,7 @@ func (s *debugServer) collectGoInfo(tw *tar.Writer) error {
 		}
 		fmt.Fprintf(w, "GOOS: %v\nGOARCH: %v\nGOMAXPROCS: %v\nNumCPU: %v\n", runtime.GOOS, runtime.GOARCH, runtime.GOMAXPROCS(0), runtime.NumCPU())
 		return nil
-	})
+	}, prefix...)
 }
 
 func (s *debugServer) collectPachdVersion(tw *tar.Writer, pachClient *client.APIClient, prefix ...string) error {
@@ -979,6 +979,10 @@ func (s *debugServer) collectJobs(tw *tar.Writer, pachClient *client.APIClient, 
 func (s *debugServer) collectWorkerDump(ctx context.Context, tw *tar.Writer, pod *v1.Pod, prefix ...string) error {
 	// Collect the worker describe output.
 	if err := s.collectDescribe(tw, pod.Name, prefix...); err != nil {
+		return err
+	}
+	// Collect go info.
+	if err := s.collectGoInfo(tw, prefix...); err != nil {
 		return err
 	}
 	// Collect the worker user and storage container logs.


### PR DESCRIPTION
Part of CORE-417

During the build phase, we build images like "pachyderm/worker-amd64" and "pachyderm/worker-arm64".  During the push phase, we assemble that into a "manifest" which contains the information needed for multi-arch pulls.

I assume that some developers run "make docker-build" to build images locally, so I've tagged the raw amd64 images for pachd and worker as `pachyderm/pachd:latest` and `pachyderm/pachd:local` in addition to the architecture-specific tags.  This way, your docker daemon will still have "pachd:local" for you to use, if that's your local development workflow. 

I added a new file, go_info.txt, to debug dumps that contains information about the Go build process and runtime, including GOARCH (so you can verify that you're running the arm64 version).  cc @seslattery who has a bug open to add debug.GetBuildInfo related stuff.

I also noticed that tests start running before the docker images have finished building, so I added an explicit wait for them.  This can be moved into minikubetestenv to allow non-k8s tests to run while waiting for those to become ready.

Finally, I removed darwin builds from the docker.yml goreleaser file.  I don't think we use those; binary releases are configured in a different file.
