### PR TITLE
[CORE-950] Use service environment interface

### DIFF
--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -56,6 +56,7 @@ type ServiceEnv interface {
 	SetIdentityServer(identity.APIServer)
 	SetPfsServer(pfs_server.APIServer)
 	SetPpsServer(pps_server.APIServer)
+	SetEnterpriseServer(enterprise_server.APIServer)
 
 	Config() *Configuration
 	GetPachClient(ctx context.Context) *client.APIClient
@@ -66,6 +67,7 @@ type ServiceEnv interface {
 	GetDBClient() *pachsql.DB
 	GetDirectDBClient() *pachsql.DB
 	GetPostgresListener() col.PostgresListener
+	InitDexDB()
 	GetDexDB() dex_storage.Storage
 	ClusterID() string
 	Context() context.Context

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -172,3 +172,6 @@ func (env *TestServiceEnv) EnterpriseServer() enterprise_server.APIServer {
 func (env *TestServiceEnv) SetEnterpriseServer(s enterprise_server.APIServer) {
 	env.Enterprise = s
 }
+
+// InitDexDB implements the ServiceEnv interface.
+func (end *TestServiceEnv) InitDexDB() {}

--- a/src/internal/testpachd/real_env.go
+++ b/src/internal/testpachd/real_env.go
@@ -91,7 +91,7 @@ func NewRealEnv(t testing.TB, customOpts ...serviceenv.ConfigOption) *RealEnv {
 	txnEnv := txnenv.New()
 	// AUTH
 	realEnv.AuthServer = &authtesting.InactiveAPIServer{}
-	realEnv.ServiceEnv.(*serviceenv.NonblockingServiceEnv).SetAuthServer(realEnv.AuthServer)
+	realEnv.ServiceEnv.SetAuthServer(realEnv.AuthServer)
 
 	// PFS
 	pfsEnv, err := pfsserver.EnvFromServiceEnv(realEnv.ServiceEnv, txnEnv)
@@ -99,11 +99,11 @@ func NewRealEnv(t testing.TB, customOpts ...serviceenv.ConfigOption) *RealEnv {
 	pfsEnv.EtcdPrefix = ""
 	realEnv.PFSServer, err = pfsserver.NewAPIServer(*pfsEnv)
 	require.NoError(t, err)
-	realEnv.ServiceEnv.(*serviceenv.NonblockingServiceEnv).SetPfsServer(realEnv.PFSServer)
+	realEnv.ServiceEnv.SetPfsServer(realEnv.PFSServer)
 
 	// PPS
 	realEnv.MockPPSTransactionServer = NewMockPPSTransactionServer()
-	realEnv.ServiceEnv.(*serviceenv.NonblockingServiceEnv).SetPpsServer(&realEnv.MockPPSTransactionServer.api)
+	realEnv.ServiceEnv.SetPpsServer(&realEnv.MockPPSTransactionServer.api)
 	realEnv.MockPPSTransactionServer.InspectPipelineInTransaction.
 		Use(func(txnctx *txncontext.TransactionContext, name string) (*pps.PipelineInfo, error) {
 			return nil, col.ErrNotFound{

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -154,7 +154,7 @@ func newExternalServer(ctx context.Context, authInterceptor *authmw.Interceptor,
 	)
 }
 
-func setup(config interface{}, service string) (env *serviceenv.NonblockingServiceEnv, err error) {
+func setup(config interface{}, service string) (env serviceenv.ServiceEnv, err error) {
 	switch logLevel := os.Getenv("LOG_LEVEL"); logLevel {
 	case "debug":
 		log.SetLevel(log.DebugLevel)
@@ -186,7 +186,7 @@ func setup(config interface{}, service string) (env *serviceenv.NonblockingServi
 	return env, err
 }
 
-func setupDB(ctx context.Context, env *serviceenv.NonblockingServiceEnv) error {
+func setupDB(ctx context.Context, env serviceenv.ServiceEnv) error {
 	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
 	if err := dbutil.WaitUntilReady(context.Background(), log.StandardLogger(), env.GetDBClient()); err != nil {
 		return err


### PR DESCRIPTION
Use the interface rather than the concrete type outside of package `servicenv`.