### PR TITLE
pachctl: add "buildinfo" command

### DIFF
--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -2,8 +2,7 @@ dist: ../dist-pach/docker
 
 builds:
     - id: pachd
-      dir: src/server/cmd/pachd
-      main: main.go
+      main: ./src/server/cmd/pachd
       binary: pachd
       env:
           - CGO_ENABLED=0
@@ -18,8 +17,7 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: worker
-      dir: src/server/cmd/worker
-      main: main.go
+      main: ./src/server/cmd/worker
       binary: worker
       env:
           - CGO_ENABLED=0
@@ -50,9 +48,10 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: pachctl
-      dir: src/server/cmd/pachctl
-      main: main.go
+      main: ./src/server/cmd/pachctl
       binary: pachctl
+      env:
+          - CGO_ENABLED=0
       ldflags:
           - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
             "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
@@ -64,9 +63,10 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: mount-server
-      dir: src/server/cmd/mount-server
-      main: main.go
+      main: ./src/server/cmd/mount-server
       binary: mount-server
+      env:
+          - CGO_ENABLED=0
       ldflags:
           - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
             "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
@@ -78,8 +78,7 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: pachtf
-      dir: src/server/cmd/pachtf
-      main: main.go
+      main: ./src/server/cmd/pachtf
       binary: pachtf
       env:
           - CGO_ENABLED=0

--- a/goreleaser/mount-server.yml
+++ b/goreleaser/mount-server.yml
@@ -3,69 +3,65 @@ project_name: mount-server
 dist: ../dist-pach/mount-server
 
 before:
-  hooks:
-    - go mod download
-    - go generate ./...
+    hooks:
+        - go mod download
+        - go generate ./...
 
 builds:
-  -
-    id: mount-server
-    dir: src/server/cmd/mount-server
-    main: main.go
-    binary: mount-server
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }}
-    gcflags:
-      - "all=-trimpath={{.Env.GOBIN}}"
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    - id: mount-server
+      main: ./src/server/cmd/mount-server
+      binary: mount-server
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }}
+      gcflags:
+          - "all=-trimpath={{.Env.GOBIN}}"
+      env:
+          - CGO_ENABLED=0
+      goos:
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - arm64
 
 archives:
-  -
-    id: mount-server-archives
-    builds:
-      - mount-server
-    format_overrides:
-      - goos: darwin
-        format: zip
-    wrap_in_directory: true
-    files:
-      - mount-server*/mount-server
+    - id: mount-server-archives
+      builds:
+          - mount-server
+      format_overrides:
+          - goos: darwin
+            format: zip
+      wrap_in_directory: true
+      files:
+          - mount-server*/mount-server
 
 checksum:
-  disable: true
+    disable: true
 
 snapshot:
-  name_template: "{{ .Env.VERSION }}"
+    name_template: "{{ .Env.VERSION }}"
 
 changelog:
-  skip: false
+    skip: false
 
 nfpms:
-  -
-    id: mount-server-deb
-    package_name: mount-server
-    file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
-    builds:
-      - mount-server
-    replacements:
-      linux: ""
-      amd64: amd64
-    vendor: Pachyderm
-    maintainer: Pachyderm <jdoliner@pachyderm.io>
-    homepage: https://www.pachyderm.com/
-    description: "Reproducible data science"
-    formats:
-      - deb
-    bindir: /usr/bin
+    - id: mount-server-deb
+      package_name: mount-server
+      file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
+      builds:
+          - mount-server
+      replacements:
+          linux: ""
+          amd64: amd64
+      vendor: Pachyderm
+      maintainer: Pachyderm <jdoliner@pachyderm.io>
+      homepage: https://www.pachyderm.com/
+      description: "Reproducible data science"
+      formats:
+          - deb
+      bindir: /usr/bin
 
 release:
-  name_template: "{{ .Env.VERSION }}"
-  prerelease: auto
-  disable: false
+    name_template: "{{ .Env.VERSION }}"
+    prerelease: auto
+    disable: false

--- a/goreleaser/pachctl.yml
+++ b/goreleaser/pachctl.yml
@@ -3,69 +3,66 @@ project_name: pachctl
 dist: ../dist-pach/pachctl
 
 before:
-  hooks:
-    - go mod download
-    - go generate ./...
+    hooks:
+        - go mod download
+        - go generate ./...
 
 builds:
-  -
-    id: pachctl
-    dir: src/server/cmd/pachctl
-    main: main.go
-    binary: pachctl
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    gcflags:
-      - "all=-trimpath={{.Env.GOBIN}}"
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    - id: pachctl
+      main: ./src/server/cmd/pachctl
+      binary: pachctl
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      gcflags:
+          - "all=-trimpath={{.Env.GOBIN}}"
+      env:
+          - CGO_ENABLED=0
+      goos:
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - arm64
 
 archives:
-  -
-    id: pachctl-archives
-    builds:
-      - pachctl
-    format_overrides:
-      - goos: darwin
-        format: zip
-    wrap_in_directory: true
-    files:
-      - pachctl*/pachctl
+    - id: pachctl-archives
+      builds:
+          - pachctl
+      format_overrides:
+          - goos: darwin
+            format: zip
+      wrap_in_directory: true
+      files:
+          - pachctl*/pachctl
 
 checksum:
-  disable: true
+    disable: true
 
 snapshot:
-  name_template: "{{ .Env.VERSION }}"
+    name_template: "{{ .Env.VERSION }}"
 
 changelog:
-  skip: false
+    skip: false
 
 nfpms:
-  -
-    id: pachctl-deb
-    package_name: pachctl
-    file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
-    builds:
-      - pachctl
-    replacements:
-      linux: ""
-      amd64: amd64
-    vendor: Pachyderm
-    maintainer: Pachyderm <jdoliner@pachyderm.io>
-    homepage: https://www.pachyderm.com/
-    description: "Reproducible data science"
-    formats:
-      - deb
-    bindir: /usr/bin
+    - id: pachctl-deb
+      package_name: pachctl
+      file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
+      builds:
+          - pachctl
+      replacements:
+          linux: ""
+          amd64: amd64
+      vendor: Pachyderm
+      maintainer: Pachyderm <jdoliner@pachyderm.io>
+      homepage: https://www.pachyderm.com/
+      description: "Reproducible data science"
+      formats:
+          - deb
+      bindir: /usr/bin
 
 release:
-  name_template: "{{ .Env.VERSION }}"
-  prerelease: auto
-  disable: false
+    name_template: "{{ .Env.VERSION }}"
+    prerelease: auto
+    disable: false

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"syscall"
@@ -456,6 +457,18 @@ Environment variables:
 		"'pachctl version' will run on the active enterprise context.")
 	versionCmd.Flags().AddFlagSet(outputFlags)
 	subcommands = append(subcommands, cmdutil.CreateAlias(versionCmd, "version"))
+
+	buildInfo := &cobra.Command{
+		Short: "Print go buildinfo.",
+		Long:  "Print information about the build environment.",
+		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
+			info, _ := debug.ReadBuildInfo()
+			fmt.Println(info)
+			return nil
+		}),
+	}
+	subcommands = append(subcommands, cmdutil.CreateAlias(buildInfo, "buildinfo"))
+
 	exitCmd := &cobra.Command{
 		Short: "Exit the pachctl shell.",
 		Long:  "Exit the pachctl shell.",


### PR DESCRIPTION
We also statically link the docker versions of pachctl and mount-server (oversight, I think), and ask goreleaser to build with "go build ./pkg" instead of "go build ./pkg/main.go", which puts vcs info into the buildinfo.

pachctl buildinfo just prints the buildinfo:
```
$ ./pachctl buildinfo                                                                                                                                                                                                          go      go1.18.5
path    github.com/pachyderm/pachyderm/v2/src/server/cmd/pachctl
mod     github.com/pachyderm/pachyderm/v2       (devel)
...
dep     sigs.k8s.io/yaml        v1.2.0  h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
build   -compiler=gc
build   CGO_ENABLED=1
build   CGO_CFLAGS=
build   CGO_CPPFLAGS=
build   CGO_CXXFLAGS=
build   CGO_LDFLAGS=
build   GOARCH=amd64
build   GOOS=linux
build   GOAMD64=v1
build   vcs=git
build   vcs.revision=eefaca9eb552e5eed4fbc9f2b5f8d90f8732e7c2
build   vcs.time=2022-08-04T22:00:36Z
build   vcs.modified=true
```

The server includes similar information in the debug dump.