### PR TITLE
[2.3.x] Backport ARM64 builds

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -88,6 +88,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - restore_cache:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
@@ -299,6 +300,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - run: etc/testing/circle/install.sh
       - run:
           name: Collect node stats
@@ -323,6 +325,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - restore_cache:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
@@ -350,7 +353,9 @@ jobs:
           key: pach-go-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
           paths:
             - /home/circleci/.gocache
-      - run: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'
+      - run:
+          name: Run Tests
+          command: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
           command: etc/testing/circle/upload_stats.sh
           when: always

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -140,6 +140,9 @@ jobs:
           name: Install minio
           command: kubectl apply -f etc/testing/minio.yaml
       - run:
+          name: Wait for docker images to be built
+          command: etc/testing/circle/wait_for_docker_images.sh
+      - run:
           no_output_timeout: 20m
           command: etc/testing/circle/run_tests.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
@@ -306,6 +309,9 @@ jobs:
           name: Collect node stats
           command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
+      - run:
+          name: Wait for docker images to be built
+          command: etc/testing/circle/wait_for_docker_images.sh
       - run: etc/testing/circle/rootless_test.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
           name: Dump debugging info in case of failure
@@ -354,6 +360,9 @@ jobs:
           paths:
             - /home/circleci/.gocache
       - run:
+          name: Wait for docker images to be built
+          command: etc/testing/circle/wait_for_docker_images.sh
+      - run:
           name: Run Tests
           command: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'
       - run:
@@ -372,7 +381,7 @@ jobs:
       appVersion:
         type: string
         default: "0.0.0"
-    resource_class: large
+    resource_class: xlarge
     executor: docker-go
     steps:
       - checkout
@@ -383,7 +392,7 @@ jobs:
           name: Download utilities
           command: |
             mkdir -p /home/circleci/bin
-            wget https://github.com/goreleaser/goreleaser/releases/download/v1.4.1/goreleaser_Linux_x86_64.tar.gz
+            wget https://github.com/goreleaser/goreleaser/releases/download/v1.10.3/goreleaser_Linux_x86_64.tar.gz
             tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
             rm -rf goreleaser_Linux_x86_64.tar.gz
       - run:

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,7 @@ docker-gpu: docker-build-gpu docker-push-gpu
 docker-gpu-dev: docker-build-gpu docker-push-gpu-dev
 
 docker-push:
-	$(SKIP) docker push pachyderm/pachd:$(VERSION)
-	$(SKIP) docker push pachyderm/worker:$(VERSION)
-	$(SKIP) docker push pachyderm/pachctl:$(VERSION)
-	$(SKIP) docker push pachyderm/mount-server:$(VERSION)
+	$(SKIP) ./etc/build/push_docker_with_manifests.sh
 
 docker-pull:
 	$(SKIP) docker pull pachyderm/pachd:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,9 @@ launch-dev: check-kubectl check-kubectl-connection
 launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -
-	helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml
+	@if [[ -n $$CIRCLE_SHA1 ]]; then \
+		helm install enterprise etc/helm/pachyderm --namespace enterprise -f etc/helm/examples/enterprise-dev.yaml --set enterpriseServer.image.tag=$$CIRCLE_SHA1; \
+	fi
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pach-enterprise --namespace enterprise --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/etc/build/push_docker_with_manifests.sh
+++ b/etc/build/push_docker_with_manifests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+REPO=pachyderm
+
+for product in pachd worker pachctl mount-server; do
+    echo "push $product $VERSION..."
+    docker push "$REPO/$product-amd64:$VERSION"
+    docker push "$REPO/$product-arm64:$VERSION"
+
+    docker manifest create "$REPO/$product:$VERSION" \
+           "$REPO/$product-amd64:$VERSION" \
+           "$REPO/$product-arm64:$VERSION"
+
+    docker manifest annotate "$REPO/$product:$VERSION" "$REPO/$product-amd64:$VERSION" --arch amd64
+    docker manifest annotate "$REPO/$product:$VERSION" "$REPO/$product-arm64:$VERSION" --arch arm64
+
+    docker manifest inspect "$REPO/$product:$VERSION"
+    docker manifest push "$REPO/$product:$VERSION"
+done

--- a/etc/testing/circle/build.sh
+++ b/etc/testing/circle/build.sh
@@ -29,4 +29,6 @@ fi
 git config user.email "donotreply@pachyderm.com"
 git config user.name "anonymous"
 git tag -f -am "Circle CI test v$VERSION" v"$VERSION"
-make docker-build
+#make docker-build
+docker build -f etc/test-images/Dockerfile.testuser -t pachyderm/testuser:local .
+docker build --network=host -f etc/test-images/Dockerfile.netcat -t pachyderm/ubuntuplusnetcat:local .

--- a/etc/testing/circle/helm-upgrade.sh
+++ b/etc/testing/circle/helm-upgrade.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-helm upgrade pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
-
-kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
-
-pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/etc/testing/circle/wait_for_docker_images.sh
+++ b/etc/testing/circle/wait_for_docker_images.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+for _ in $(seq 1 120); do
+    if docker manifest inspect "pachyderm/pachd:$CIRCLE_SHA1"; then
+        echo "manifest exists"
+        exit 0
+    fi
+    echo "sleeping..."
+    sleep 5
+done
+
+echo "images not available after 600 seconds; giving up"
+exit 1

--- a/etc/testing/examples.sh
+++ b/etc/testing/examples.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml
+if [[ -n $CIRCLE_SHA1 ]]; then
+    helm install pachyderm etc/helm/pachyderm -f etc/testing/circle/helm-values.yaml --set pachd.image.tag="${CIRCLE_SHA1}"
+fi
 
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -1,184 +1,263 @@
 dist: ../dist-pach/docker
 
 builds:
-  -
-    id: pachd
-    dir: src/server/cmd/pachd
-    main: main.go
-    binary: pachd
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: worker
-    dir: src/server/cmd/worker
-    main: main.go
-    binary: worker
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: worker_init
-    dir: etc/worker
-    main: init.go
-    binary: worker_init
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: pachctl
-    dir: src/server/cmd/pachctl
-    main: main.go
-    binary: pachctl
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: mount-server
-    dir: src/server/cmd/mount-server
-    main: main.go
-    binary: mount-server
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
-  -
-    id: pachtf
-    dir: src/server/cmd/pachtf
-    main: main.go
-    binary: pachtf
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    gcflags:
-      - "all=-trimpath={{.Env.PWD}}"
+    - id: pachd
+      dir: src/server/cmd/pachd
+      main: main.go
+      binary: pachd
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: worker
+      dir: src/server/cmd/worker
+      main: main.go
+      binary: worker
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: worker_init
+      dir: etc/worker
+      main: init.go
+      binary: worker_init
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: pachctl
+      dir: src/server/cmd/pachctl
+      main: main.go
+      binary: pachctl
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: mount-server
+      dir: src/server/cmd/mount-server
+      main: main.go
+      binary: mount-server
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
+    - id: pachtf
+      dir: src/server/cmd/pachtf
+      main: main.go
+      binary: pachtf
+      env:
+          - CGO_ENABLED=0
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      goos:
+          - linux
+      goarch:
+          - amd64
+          - arm64
+      gcflags:
+          - "all=-trimpath={{.Env.PWD}}"
 
 archives:
-  - format: binary
-    builds:
-      - pachctl
+    - format: binary
+      builds:
+          - pachctl
 
 checksum:
-  disable: true
+    disable: true
 
 changelog:
-  skip: true
+    skip: true
 
 release:
-  disable: true
+    disable: true
 
 dockers:
-  -
-    image_templates:
-      - pachyderm/pachd
-      - pachyderm/pachd:local
-      - "pachyderm/pachd:{{.Version}}"
-      - pachyderm/pachd:{{ .FullCommit }}
-    ids:
-      - pachd
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.pachd
-    extra_files:
-      - dex-assets
-      - LICENSE
-      - licenses
-    build_flag_templates:
-      - "--network=host"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-  -
-    image_templates:
-      - pachyderm/pachctl
-      - pachyderm/pachctl:{{ .FullCommit }}
-    ids:
-      - pachctl
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.pachctl
-    build_flag_templates:
-      - "--network=host"
-      - "--progress=plain"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-    extra_files:
-      - LICENSE
-      - licenses
-  -
-    image_templates:
-      - pachyderm/mount-server
-      - pachyderm/mount-server:{{ .FullCommit }}
-    ids:
-      - mount-server
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.mount-server
-    build_flag_templates:
-      - "--network=host"
-      - "--progress=plain"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-    extra_files:
-      - LICENSE
-      - licenses
-  -
-    image_templates:
-      - pachyderm/worker
-      - pachyderm/worker:local
-      - pachyderm/worker:{{ .FullCommit }}
-    ids:
-      - pachctl
-      - worker_init
-      - worker
-      - pachtf
-    goos: linux
-    goarch: amd64
-    skip_push: false
-    dockerfile: Dockerfile.worker
-    build_flag_templates:
-      - "--progress=plain"
-      - "--label=version={{.Version}}"
-      - "--label=release={{.Version}}"
-    extra_files:
-      - LICENSE
-      - licenses
+    - image_templates:
+          - pachyderm/pachd
+          - pachyderm/pachd:local
+          - pachyderm/pachd-amd64
+          - pachyderm/pachd-amd64:local
+          - "pachyderm/pachd-amd64:{{ .Version }}"
+          - "pachyderm/pachd-amd64:{{ .FullCommit }}"
+      ids:
+          - pachd
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.pachd
+      extra_files:
+          - dex-assets
+          - LICENSE
+          - licenses
+      build_flag_templates:
+          - "--network=host"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+    - image_templates:
+          - pachyderm/pachctl-amd64
+          - pachyderm/pachctl-amd64:{{ .FullCommit }}
+      ids:
+          - pachctl
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.pachctl
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/mount-server-amd64
+          - "pachyderm/mount-server-amd64:{{ .FullCommit }}"
+      ids:
+          - mount-server
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.mount-server
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/worker
+          - pachyderm/worker:local
+          - pachyderm/worker-amd64
+          - pachyderm/worker-amd64:local
+          - "pachyderm/worker-amd64:{{ .FullCommit }}"
+      ids:
+          - pachctl
+          - worker_init
+          - worker
+          - pachtf
+      goos: linux
+      goarch: amd64
+      skip_push: false
+      dockerfile: Dockerfile.worker
+      build_flag_templates:
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+
+    # arm64 builds follow
+    - image_templates:
+          - pachyderm/pachd-arm64
+          - pachyderm/pachd-arm64:local
+          - "pachyderm/pachd-arm64:{{ .Version }}"
+          - "pachyderm/pachd-arm64:{{ .FullCommit }}"
+      ids:
+          - pachd
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.pachd
+      extra_files:
+          - dex-assets
+          - LICENSE
+          - licenses
+      build_flag_templates:
+          - "--network=host"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+    - image_templates:
+          - pachyderm/pachctl-arm64
+          - pachyderm/pachctl-arm64:{{ .FullCommit }}
+      ids:
+          - pachctl
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.pachctl
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/mount-server-arm64
+          - "pachyderm/mount-server-arm64:{{ .FullCommit }}"
+      ids:
+          - mount-server
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.mount-server
+      build_flag_templates:
+          - "--network=host"
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses
+    - image_templates:
+          - pachyderm/worker-arm64
+          - pachyderm/worker-arm64:local
+          - "pachyderm/worker-arm64:{{ .FullCommit }}"
+      ids:
+          - pachctl
+          - worker_init
+          - worker
+          - pachtf
+      goos: linux
+      goarch: arm64
+      skip_push: false
+      dockerfile: Dockerfile.worker
+      build_flag_templates:
+          - "--progress=plain"
+          - "--label=version={{.Version}}"
+          - "--label=release={{.Version}}"
+      extra_files:
+          - LICENSE
+          - licenses

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -2,8 +2,7 @@ dist: ../dist-pach/docker
 
 builds:
     - id: pachd
-      dir: src/server/cmd/pachd
-      main: main.go
+      main: ./src/server/cmd/pachd
       binary: pachd
       env:
           - CGO_ENABLED=0
@@ -18,8 +17,7 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: worker
-      dir: src/server/cmd/worker
-      main: main.go
+      main: ./src/server/cmd/worker
       binary: worker
       env:
           - CGO_ENABLED=0
@@ -50,9 +48,10 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: pachctl
-      dir: src/server/cmd/pachctl
-      main: main.go
+      main: ./src/server/cmd/pachctl
       binary: pachctl
+      env:
+          - CGO_ENABLED=0
       ldflags:
           - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
             "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
@@ -64,9 +63,10 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: mount-server
-      dir: src/server/cmd/mount-server
-      main: main.go
+      main: ./src/server/cmd/mount-server
       binary: mount-server
+      env:
+          - CGO_ENABLED=0
       ldflags:
           - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
             "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
@@ -78,8 +78,7 @@ builds:
       gcflags:
           - "all=-trimpath={{.Env.PWD}}"
     - id: pachtf
-      dir: src/server/cmd/pachtf
-      main: main.go
+      main: ./src/server/cmd/pachtf
       binary: pachtf
       env:
           - CGO_ENABLED=0

--- a/goreleaser/mount-server.yml
+++ b/goreleaser/mount-server.yml
@@ -3,69 +3,65 @@ project_name: mount-server
 dist: ../dist-pach/mount-server
 
 before:
-  hooks:
-    - go mod download
-    - go generate ./...
+    hooks:
+        - go mod download
+        - go generate ./...
 
 builds:
-  -
-    id: mount-server
-    dir: src/server/cmd/mount-server
-    main: main.go
-    binary: mount-server
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }}
-    gcflags:
-      - "all=-trimpath={{.Env.GOBIN}}"
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    - id: mount-server
+      main: ./src/server/cmd/mount-server
+      binary: mount-server
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }}
+      gcflags:
+          - "all=-trimpath={{.Env.GOBIN}}"
+      env:
+          - CGO_ENABLED=0
+      goos:
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - arm64
 
 archives:
-  -
-    id: mount-server-archives
-    builds:
-      - mount-server
-    format_overrides:
-      - goos: darwin
-        format: zip
-    wrap_in_directory: true
-    files:
-      - mount-server*/mount-server
+    - id: mount-server-archives
+      builds:
+          - mount-server
+      format_overrides:
+          - goos: darwin
+            format: zip
+      wrap_in_directory: true
+      files:
+          - mount-server*/mount-server
 
 checksum:
-  disable: true
+    disable: true
 
 snapshot:
-  name_template: "{{ .Env.VERSION }}"
+    name_template: "{{ .Env.VERSION }}"
 
 changelog:
-  skip: false
+    skip: false
 
 nfpms:
-  -
-    id: mount-server-deb
-    package_name: mount-server
-    file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
-    builds:
-      - mount-server
-    replacements:
-      linux: ""
-      amd64: amd64
-    vendor: Pachyderm
-    maintainer: Pachyderm <jdoliner@pachyderm.io>
-    homepage: https://www.pachyderm.com/
-    description: "Reproducible data science"
-    formats:
-      - deb
-    bindir: /usr/bin
+    - id: mount-server-deb
+      package_name: mount-server
+      file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
+      builds:
+          - mount-server
+      replacements:
+          linux: ""
+          amd64: amd64
+      vendor: Pachyderm
+      maintainer: Pachyderm <jdoliner@pachyderm.io>
+      homepage: https://www.pachyderm.com/
+      description: "Reproducible data science"
+      formats:
+          - deb
+      bindir: /usr/bin
 
 release:
-  name_template: "{{ .Env.VERSION }}"
-  prerelease: auto
-  disable: false
+    name_template: "{{ .Env.VERSION }}"
+    prerelease: auto
+    disable: false

--- a/goreleaser/pachctl.yml
+++ b/goreleaser/pachctl.yml
@@ -3,69 +3,66 @@ project_name: pachctl
 dist: ../dist-pach/pachctl
 
 before:
-  hooks:
-    - go mod download
-    - go generate ./...
+    hooks:
+        - go mod download
+        - go generate ./...
 
 builds:
-  -
-    id: pachctl
-    dir: src/server/cmd/pachctl
-    main: main.go
-    binary: pachctl
-    ldflags:
-      - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
-    gcflags:
-      - "all=-trimpath={{.Env.GOBIN}}"
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    - id: pachctl
+      main: ./src/server/cmd/pachctl
+      binary: pachctl
+      ldflags:
+          - -X {{ .Env.CLIENT_ADDITIONAL_VERSION }} -X
+            "github.com/pachyderm/pachyderm/v2/src/version.AppVersion={{ .Env.VERSION }}"
+      gcflags:
+          - "all=-trimpath={{.Env.GOBIN}}"
+      env:
+          - CGO_ENABLED=0
+      goos:
+          - linux
+          - darwin
+      goarch:
+          - amd64
+          - arm64
 
 archives:
-  -
-    id: pachctl-archives
-    builds:
-      - pachctl
-    format_overrides:
-      - goos: darwin
-        format: zip
-    wrap_in_directory: true
-    files:
-      - pachctl*/pachctl
+    - id: pachctl-archives
+      builds:
+          - pachctl
+      format_overrides:
+          - goos: darwin
+            format: zip
+      wrap_in_directory: true
+      files:
+          - pachctl*/pachctl
 
 checksum:
-  disable: true
+    disable: true
 
 snapshot:
-  name_template: "{{ .Env.VERSION }}"
+    name_template: "{{ .Env.VERSION }}"
 
 changelog:
-  skip: false
+    skip: false
 
 nfpms:
-  -
-    id: pachctl-deb
-    package_name: pachctl
-    file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
-    builds:
-      - pachctl
-    replacements:
-      linux: ""
-      amd64: amd64
-    vendor: Pachyderm
-    maintainer: Pachyderm <jdoliner@pachyderm.io>
-    homepage: https://www.pachyderm.com/
-    description: "Reproducible data science"
-    formats:
-      - deb
-    bindir: /usr/bin
+    - id: pachctl-deb
+      package_name: pachctl
+      file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Arch }}"
+      builds:
+          - pachctl
+      replacements:
+          linux: ""
+          amd64: amd64
+      vendor: Pachyderm
+      maintainer: Pachyderm <jdoliner@pachyderm.io>
+      homepage: https://www.pachyderm.com/
+      description: "Reproducible data science"
+      formats:
+          - deb
+      bindir: /usr/bin
 
 release:
-  name_template: "{{ .Env.VERSION }}"
-  prerelease: auto
-  disable: false
+    name_template: "{{ .Env.VERSION }}"
+    prerelease: auto
+    disable: false

--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"syscall"
@@ -456,6 +457,18 @@ Environment variables:
 		"'pachctl version' will run on the active enterprise context.")
 	versionCmd.Flags().AddFlagSet(outputFlags)
 	subcommands = append(subcommands, cmdutil.CreateAlias(versionCmd, "version"))
+
+	buildInfo := &cobra.Command{
+		Short: "Print go buildinfo.",
+		Long:  "Print information about the build environment.",
+		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
+			info, _ := debug.ReadBuildInfo()
+			fmt.Println(info)
+			return nil
+		}),
+	}
+	subcommands = append(subcommands, cmdutil.CreateAlias(buildInfo, "buildinfo"))
+
 	exitCmd := &cobra.Command{
 		Short: "Exit the pachctl shell.",
 		Long:  "Exit the pachctl shell.",


### PR DESCRIPTION
3 changes here:

1) Build docker containers only once during CI.
2) Arm64 builds and mult-arch manifests during docker push.
3) "pachctl buildinfo".