### PR TITLE
goreleaser: set the platform for the docker image description

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -386,13 +386,13 @@ jobs:
       appVersion:
         type: string
         default: "0.0.0"
+    machine:
+      image: << pipeline.parameters.machine_image >>
     resource_class: xlarge
-    executor: docker-go
     steps:
+      - go/install:
+          version: << pipeline.parameters.go-version >>
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-          version: "20.10.12"
       - run:
           name: Download utilities
           command: |
@@ -400,6 +400,8 @@ jobs:
             wget https://github.com/goreleaser/goreleaser/releases/download/v1.10.3/goreleaser_Linux_x86_64.tar.gz
             tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
             rm -rf goreleaser_Linux_x86_64.tar.gz
+            apt update
+            apt install qemu binfmt-support qemu-user-static
       - run:
           name: pachydermbuildbot docker login
           command: |

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -400,8 +400,8 @@ jobs:
             wget https://github.com/goreleaser/goreleaser/releases/download/v1.10.3/goreleaser_Linux_x86_64.tar.gz
             tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
             rm -rf goreleaser_Linux_x86_64.tar.gz
-            apt update
-            apt install qemu binfmt-support qemu-user-static
+            sudo apt update
+            sudo apt install qemu binfmt-support qemu-user-static
       - run:
           name: pachydermbuildbot docker login
           command: |

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -129,6 +129,7 @@ dockers:
           - "--network=host"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/amd64"
     - image_templates:
           - pachyderm/pachctl-amd64
           - pachyderm/pachctl-amd64:{{ .FullCommit }}
@@ -143,6 +144,7 @@ dockers:
           - "--progress=plain"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/amd64"
       extra_files:
           - LICENSE
           - licenses
@@ -160,6 +162,7 @@ dockers:
           - "--progress=plain"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/amd64"
       extra_files:
           - LICENSE
           - licenses
@@ -182,6 +185,7 @@ dockers:
           - "--progress=plain"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/amd64"
       extra_files:
           - LICENSE
           - licenses
@@ -206,6 +210,7 @@ dockers:
           - "--network=host"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/arm64"
     - image_templates:
           - pachyderm/pachctl-arm64
           - pachyderm/pachctl-arm64:{{ .FullCommit }}
@@ -220,6 +225,7 @@ dockers:
           - "--progress=plain"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/arm64"
       extra_files:
           - LICENSE
           - licenses
@@ -237,6 +243,7 @@ dockers:
           - "--progress=plain"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/arm64"
       extra_files:
           - LICENSE
           - licenses
@@ -257,6 +264,7 @@ dockers:
           - "--progress=plain"
           - "--label=version={{.Version}}"
           - "--label=release={{.Version}}"
+          - "--platform=linux/arm64"
       extra_files:
           - LICENSE
           - licenses


### PR DESCRIPTION
This is somewhat undocumented (--help doesn't know about it, but the web documentation does) and I don't know the full side effects.  But if you "docker inspect" something you built, the Architecture field is now correct.