### PR TITLE
Fix service pipelines not picking up new jobs.

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7117,7 +7117,7 @@ func TestService(t *testing.T) {
 	}()
 
 	go func() {
-		iter := c.GetLogs(pipeline, "", nil, "", true, true, 0)
+		iter := c.GetLogs(pipeline, "", nil, "", true, true, 10*time.Minute)
 		for iter.Next() {
 			t.Log(iter.Message().Message)
 		}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	
+
 	"math"
 	"net"
 	"net/http"
@@ -7043,7 +7043,7 @@ func TestService(t *testing.T) {
 
 	commit1, err := c.StartCommit(dataRepo, "master")
 	require.NoError(t, err)
-	require.NoError(t, c.PutFile(commit1, "file1", strings.NewReader("foo"), client.WithAppendPutFile()))
+	require.NoError(t, c.PutFile(commit1, "file1", strings.NewReader("foo")))
 	require.NoError(t, c.FinishCommit(dataRepo, commit1.Branch.Name, commit1.ID))
 
 	annotations := map[string]string{"foo": "bar"}
@@ -7119,24 +7119,30 @@ func TestService(t *testing.T) {
 	httpClient := &http.Client{
 		Timeout: 3 * time.Second,
 	}
-	require.NoError(t, backoff.Retry(func() error {
-		resp, err := httpClient.Get(fmt.Sprintf("http://%s/%s/file1", serviceAddr, dataRepo))
-		if err != nil {
-			return errors.EnsureStack(err)
-		}
-		if resp.StatusCode != 200 {
-			return errors.Errorf("GET returned %d", resp.StatusCode)
-		}
-		content, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return errors.EnsureStack(err)
-		}
-		if string(content) != "foo" {
-			return errors.Errorf("wrong content for file1: expected foo, got %s", string(content))
-		}
-		return nil
-	}, backoff.NewTestingBackOff()))
+	checkFile := func(expected string) {
+		require.NoError(t, backoff.Retry(func() error {
+			resp, err := httpClient.Get(fmt.Sprintf("http://%s/%s/file1", serviceAddr, dataRepo))
+			if err != nil {
+				return errors.EnsureStack(err)
+			}
+			if resp.StatusCode != 200 {
+				return errors.Errorf("GET returned %d", resp.StatusCode)
+			}
+			content, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return errors.EnsureStack(err)
+			}
+			if string(content) != expected {
+				return errors.Errorf("wrong content for file1: expected %s, got %s", expected, string(content))
+			}
+			return nil
+		}, backoff.NewTestingBackOff()))
+	}
+	checkFile("foo")
 
+	// overwrite file, and check that we can access the new contents
+	require.NoError(t, c.PutFile(client.NewCommit(dataRepo, "master", ""), "file1", strings.NewReader("bar")))
+	checkFile("bar")
 }
 
 func TestServiceEnvVars(t *testing.T) {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7115,14 +7115,6 @@ func TestService(t *testing.T) {
 		require.NotEqual(t, "", address)
 		return address
 	}()
-
-	go func() {
-		iter := c.GetLogs(pipeline, "", nil, "", true, true, 10*time.Minute)
-		for iter.Next() {
-			t.Log(iter.Message().Message)
-		}
-	}()
-
 	httpClient := &http.Client{
 		Timeout: 3 * time.Second,
 	}
@@ -7132,12 +7124,12 @@ func TestService(t *testing.T) {
 			if err != nil {
 				return errors.EnsureStack(err)
 			}
-			if resp.StatusCode != 200 {
-				return errors.Errorf("GET returned %d", resp.StatusCode)
-			}
 			defer func() {
 				_ = resp.Body.Close()
 			}()
+			if resp.StatusCode != 200 {
+				return errors.Errorf("GET returned %d", resp.StatusCode)
+			}
 			content, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return errors.EnsureStack(err)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7128,6 +7128,9 @@ func TestService(t *testing.T) {
 			if resp.StatusCode != 200 {
 				return errors.Errorf("GET returned %d", resp.StatusCode)
 			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
 			content, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return errors.EnsureStack(err)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -7116,6 +7116,13 @@ func TestService(t *testing.T) {
 		return address
 	}()
 
+	go func() {
+		iter := c.GetLogs(pipeline, "", nil, "", true, true, 0)
+		for iter.Next() {
+			t.Log(iter.Message().Message)
+		}
+	}()
+
 	httpClient := &http.Client{
 		Timeout: 3 * time.Second,
 	}


### PR DESCRIPTION
A context wasn't respected after a refactor, and finish job would fail due to the absence of a meta repo. 

Also expand the existing test to hit the job switching logic, and skip `FINISHING` jobs like we do in normal transforms (maybe the subscribe logic should skip those automatically).