### PR TITLE
[INT-614] Refactor to use serviceenv.GetPachClient

### DIFF
--- a/src/server/pfs/s3/s3.go
+++ b/src/server/pfs/s3/s3.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"golang.org/x/net/context"
 
 	"github.com/pachyderm/s2"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
This is the 2.x version of #7633