### PR TITLE
Adds Proxy.host 

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -36,13 +36,23 @@ imagePullSecrets:
 {{- end }}
 {{- end -}}
 
-{{- define "pachyderm.ingressproto" -}}
+{{- define "pachyderm.hostproto" -}}
 {{- if or .Values.ingress.tls.enabled .Values.proxy.tls.enabled .Values.ingress.uriHttpsProtoOverride -}}
 https
 {{- else -}}
 http
 {{- end -}}
 {{- end }}
+
+{{- define "pachyderm.host" -}}
+{{- if .Values.ingress.enabled -}}
+{{ required "if ingress is enabled, an ingress.host is required" .Values.ingress.host }}
+{{- else if .Values.proxy.enabled -}}
+{{ required "if proxy is enable and ingress isn't, a proxy.host is required" .Values.proxy.host }}
+{{- end -}}
+{{- end }}
+
+
 
 {{- define "pachyderm.issuerURI" -}}
 {{- if .Values.oidc.issuerURI -}}
@@ -51,7 +61,7 @@ http
 {{- end -}}
 {{ .Values.oidc.issuerURI }}
 {{- else if and .Values.ingress.host .Values.ingress.enabled -}}
-{{- printf "%s://%s/dex" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
+{{- printf "%s://%s/dex" (include "pachyderm.hostproto" .) .Values.ingress.host -}}
 {{- else if .Values.proxy.enabled -}}
 http://pachd:30658/dex
 {{- else -}}
@@ -71,8 +81,8 @@ In deployments where the issuerURI is user accessible (ie. Via ingress) this wou
 {{- define "pachyderm.reactAppRuntimeIssuerURI" -}}
 {{- if .Values.console.config.reactAppRuntimeIssuerURI -}}
 {{ .Values.console.config.reactAppRuntimeIssuerURI }}
-{{- else if .Values.ingress.host -}}
-{{- printf "%s://%s" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
+{{- else if (include "pachyderm.host" .) -}}
+{{- printf "%s://%s" (include "pachyderm.hostproto" .) (include "pachyderm.host" .) -}}
 {{- else if not .Values.ingress.enabled -}}
 http://localhost:30658
 {{- end }}
@@ -81,8 +91,8 @@ http://localhost:30658
 {{- define "pachyderm.consoleRedirectURI" -}}
 {{- if .Values.console.config.oauthRedirectURI -}}
 {{ .Values.console.config.oauthRedirectURI }}
-{{- else if .Values.ingress.host -}}
-{{- printf "%s://%s/oauth/callback/?inline=true" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
+{{- else if (include "pachyderm.host" .) -}}
+{{- printf "%s://%s/oauth/callback/?inline=true" (include "pachyderm.hostproto" .) (include "pachyderm.host" .) -}}
 {{- else if not .Values.ingress.enabled -}}
 http://localhost:4000/oauth/callback/?inline=true
 {{- else -}}
@@ -93,8 +103,8 @@ http://localhost:4000/oauth/callback/?inline=true
 {{- define "pachyderm.pachdRedirectURI" -}}
 {{- if .Values.pachd.oauthRedirectURI -}}
 {{ .Values.pachd.oauthRedirectURI -}}
-{{- else if .Values.ingress.host -}}
-{{- printf "%s://%s/authorization-code/callback" (include "pachyderm.ingressproto" .) .Values.ingress.host -}}
+{{- else if (include "pachyderm.host" .) -}}
+{{- printf "%s://%s/authorization-code/callback" (include "pachyderm.hostproto" .) (include "pachyderm.host" .) -}}
 {{- else if not .Values.ingress.enabled -}}
 http://localhost:30657/authorization-code/callback
 {{- else -}}
@@ -117,18 +127,16 @@ pachd-peer.{{ .Release.Namespace }}.svc.cluster.local:30653
   {{- end -}}
 {{- else if .Values.pachd.activateEnterpriseMember -}}
 false
-{{- else if not .Values.ingress.enabled -}}
+{{- else -}}
 true
-{{- else if .Values.ingress.host -}}
-false
 {{- end -}}
 {{- end }}
 
 {{- define "pachyderm.userAccessibleOauthIssuerHost" -}}
 {{- if .Values.oidc.userAccessibleOauthIssuerHost -}}
 {{ .Values.oidc.userAccessibleOauthIssuerHost }}
-{{- else if .Values.ingress.host -}}
-{{- .Values.ingress.host -}}
+{{- else if (include "pachyderm.host" .) -}}
+{{- (include "pachyderm.host" .) -}}
 {{- else  -}}
 localhost:30658
 {{- end -}}

--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -48,7 +48,7 @@ http
 {{- if .Values.ingress.enabled -}}
 {{ required "if ingress is enabled, an ingress.host is required" .Values.ingress.host }}
 {{- else if .Values.proxy.enabled -}}
-{{ required "if proxy is enable and ingress isn't, a proxy.host is required" .Values.proxy.host }}
+{{ .Values.proxy.host }}
 {{- end -}}
 {{- end }}
 

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -1198,6 +1198,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "host": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -831,6 +831,10 @@ proxy:
   # ingress is also enabled, any Ingress traffic will be routed through the proxy before being sent
   # to pachd or Console.
   enabled: false
+  # The external hostname (including port if nonstandard) that the proxy will be reachable at.
+  # If you have ingress enabled and an ingress hostname defined, the proxy will use that.
+  # Ingress will be deprecated in the future so configuring the proxy host instead is recommended.
+  host: ""
   # The number of proxy replicas to run.  1 should be fine, but if you want more for higher
   # availability, that's perfectly reasonable.  Each replica can handle 50,000 concurrent
   # connections.  There is an affinity rule to prefer scheduling the proxy pods on the same node as

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -227,7 +227,7 @@ func withEnterprise(host, rootToken string, issuerPort, clientPort int) *helm.Op
 			// TODO: make these ports configurable to support IDP Login in parallel deployments
 			"oidc.userAccessibleOauthIssuerHost": fmt.Sprintf("%s:%v", host, issuerPort),
 			"oidc.issuerURI":                     fmt.Sprintf("http://pachd:%v/dex", issuerPort),
-			"ingress.host":                       fmt.Sprintf("%s:%v", host, clientPort),
+			"proxy.host":                       fmt.Sprintf("%s:%v", host, clientPort),
 			// to test that the override works
 			"global.postgresql.identityDatabaseFullNameOverride": "dexdb",
 		},


### PR DESCRIPTION
For users leveraging the proxy only, they can configure `proxy.host` with the externally reachable name of the proxy.

Configuration combinations work in this order:
1. If ingress is enabled, an ingress hostname is required. This is the external address, whether the proxy is enabled or not. This matches the current behavior.
2. If the proxy is enabled but ingress isn't, `proxy.host` is used to set the external address. If the host isn't set, it still enabled the proxy but falls back to the localhost ports as it does today.
3. if neither are enabled, the current behavior of falling back to localhost ports and port-forward still applies.

This allows users to orderly transition from ingress to proxy while the proxy is optional and then prevents any breaking changes to proxy users when ingress is depricated. 