### PR TITLE
[2.3.x] use localhostIssuer=true even when network routing allows it to be false

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -117,10 +117,8 @@ pachd-peer.{{ .Release.Namespace }}.svc.cluster.local:30653
   {{- end -}}
 {{- else if .Values.pachd.activateEnterpriseMember -}}
 false
-{{- else if not .Values.ingress.enabled -}}
+{{- else -}}
 true
-{{- else if .Values.ingress.host -}}
-false
 {{- end -}}
 {{- end }}
 


### PR DESCRIPTION
This is due to the readiness check interfering with the ability to contact local pachd via k8s services.

CORE-968