### PR TITLE
helm: make upgrades idempotent with respect to the Values dictionary

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -27,9 +27,11 @@ spec:
         {{- end }}
       name: console
       namespace: {{ .Release.Namespace }}
-      {{- if .Values.console.annotations }}
-      annotations: {{ toYaml .Values.console.annotations | nindent 4 }}
-      {{- end }}
+      annotations:
+        checksum/helm-values: {{ toJson .Values | sha256sum }}
+        {{- if .Values.console.annotations -}}
+        {{ toYaml .Values.console.annotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.console.priorityClassName }}
       priorityClassName: {{ .Values.console.priorityClassName }}
@@ -86,10 +88,6 @@ spec:
             secretKeyRef:
               name: {{ .Values.console.config.oauthClientSecretSecretName | default "pachyderm-console-secret"}}
               key: OAUTH_CLIENT_SECRET
-        {{- if .Release.IsUpgrade }}
-        - name: UPGRADE_NO_OP
-          value: {{ randAlphaNum 32 }}
-        {{- end }}
         {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
         - name: NODE_EXTRA_CA_CERTS
           value:  /pach-tls/certs/root.crt

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -28,9 +28,11 @@ spec:
         {{- end }}
       name: pach-enterprise
       namespace: {{ .Release.Namespace }}
-      {{- if .Values.enterpriseServer.annotations }}
-      annotations: {{ toYaml .Values.enterpriseServer.annotations | nindent 4 }}
-      {{- end }}
+      annotations:
+        checksum/helm-values: {{ toJson .Values | sha256sum }}
+        {{- if .Values.enterpriseServer.annotations }}
+        {{ toYaml .Values.enterpriseServer.annotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.enterpriseServer.priorityClassName }}
       priorityClassName: {{ .Values.enterpriseServer.priorityClassName }}
@@ -177,10 +179,6 @@ spec:
             secretKeyRef:
               name: pachyderm-console-secret
               key: OAUTH_CLIENT_SECRET
-        {{- end }}
-        {{- if .Release.IsUpgrade }}
-        - name: UPGRADE_NO_OP
-          value: {{ randAlphaNum 32 }}
         {{- end }}
         envFrom:
           - secretRef:

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/helm-values: {{ toJson .Values | sha256sum }}
         checksum/storage-secret: {{ include (print $.Template.BasePath "/pachd/storage-secret.yaml") . | sha256sum }}
         {{- if .Values.pachd.annotations -}}
         {{ toYaml .Values.pachd.annotations | nindent 8 }}
@@ -307,10 +308,6 @@ spec:
         - name: IDENTITY_SERVER_DATABASE
           value: {{ .Values.global.postgresql.identityDatabaseFullNameOverride }}
         {{ end }}
-        {{- if .Release.IsUpgrade }}
-        - name: UPGRADE_NO_OP
-          value: {{ randAlphaNum 32 }}
-        {{- end }}
         envFrom:
           - secretRef:
               name: pachyderm-storage-secret


### PR DESCRIPTION
also fix console annotations, I think.  not sure how indenting 4 ever worked there.  (i have tested the current version with custom annotations and it does work now.)