### PR TITLE
fix circle ci nightly load test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ parameters:
     type: boolean
     default: false
 
-
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,12 @@ setup: true
 orbs:
   continuation: circleci/continuation@0.1.2
 
+parameters:
+  run_load_tests:
+    type: boolean
+    default: false
+
+
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -21,6 +21,9 @@ parameters:
   go-version:
     type: string
     default: "1.19"
+  run_load_tests:
+    type: boolean
+    default: false
 
 executors:
   docker-go:
@@ -649,14 +652,7 @@ workflows:
     jobs:
       - helm-tests
   nightly_load_tests:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - 2.3.x
-                - master
+    when: << pipeline.parameters.run_load_tests >>
     jobs:
       - nightly-load:
           matrix:


### PR DESCRIPTION
Turns out scheduled nightly load test got broken when dynamic config was turned on because  [Scheduled workflows are not supported with Dynamic Configurations / Setup Workflows and, by the end of 2022, scheduled workflows will be phased out to be replaced by scheduled pipelines as the primary method of scheduling work.]( https://support.circleci.com/hc/en-us/articles/360060833331-Support-for-Scheduled-Workflows-in-Dynamic-Configurations-Setup-Workflows)

The schedules are now maintained in circle ci. Here is sample triggers that will need to be set up when this PR is merged.


![Screen Shot 2022-08-24 at 6 54 44 PM](https://user-images.githubusercontent.com/19845556/186538658-bf56974a-598e-4792-8407-248884fcb15d.png)

❗ This PR fixes this for nightly load tests. AND good news is we can actually use this for the nightly builds instead to avoid the double trigger approach in #8111, because we can store the working version in the trigger and we can bump that without source control changes and potentially toggle off the manual approval step when its a scheduled nightly release. 