### PR TITLE
Reintroduce UPGRADE_NO_OP (#8113)

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -88,6 +88,10 @@ spec:
             secretKeyRef:
               name: {{ .Values.console.config.oauthClientSecretSecretName | default "pachyderm-console-secret"}}
               key: OAUTH_CLIENT_SECRET
+        {{- if .Release.IsUpgrade }}
+        - name: UPGRADE_NO_OP
+          value: {{ randAlphaNum 32 }}
+        {{- end }}
         {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
         - name: NODE_EXTRA_CA_CERTS
           value:  /pach-tls/certs/root.crt

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -180,6 +180,10 @@ spec:
               name: pachyderm-console-secret
               key: OAUTH_CLIENT_SECRET
         {{- end }}
+        {{- if .Release.IsUpgrade }}
+        - name: UPGRADE_NO_OP
+          value: {{ randAlphaNum 32 }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: pachyderm-deployment-id-secret

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -313,6 +313,10 @@ spec:
         - name: IDENTITY_SERVER_DATABASE
           value: {{ .Values.global.postgresql.identityDatabaseFullNameOverride }}
         {{ end }}
+        {{- if .Release.IsUpgrade }}
+        - name: UPGRADE_NO_OP
+          value: {{ randAlphaNum 32 }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: pachyderm-storage-secret


### PR DESCRIPTION
env-var to ease 'helm upgrade' auto-restarting pods to consume new secrets. This is a stop gap until we migrate secrets to volumes, and watch their inodes to restart (#8113)