### PR TITLE
[CORE-1014] Set AWS creds env vars in sidecar-s3-gateway-enabled pipelines

### DIFF
--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -119,7 +119,7 @@ func TestS3PipelineErrors(t *testing.T) {
 	require.Matches(t, "join", err.Error())
 }
 
-func testS3Input(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
+func testS3Input(t *testing.T, c *client.APIClient, ns, projectName string) {
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, repo))
 	masterCommit := client.NewProjectCommit(projectName, repo, "master", "")
@@ -137,10 +137,6 @@ func testS3Input(t *testing.T, c *client.APIClient, userToken, ns, projectName s
 				"ls -R /pfs >/pfs/out/pfs_files",
 				"aws --endpoint=${S3_ENDPOINT} s3 ls >/pfs/out/s3_buckets",
 				"aws --endpoint=${S3_ENDPOINT} s3 ls s3://input_repo >/pfs/out/s3_files",
-			},
-			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     userToken,
-				"AWS_SECRET_ACCESS_KEY": userToken,
 			},
 		},
 		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -209,21 +205,18 @@ func TestS3Input(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, userToken, ns := initPachClient(t)
-	if userToken == "" {
-		userToken = "abc123"
-	}
+	c, _, ns := initPachClient(t)
 	t.Run("DefaultProject", func(t *testing.T) {
-		testS3Input(t, c, userToken, ns, pfs.DefaultProjectName)
+		testS3Input(t, c, ns, pfs.DefaultProjectName)
 	})
 	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3Input(t, c, userToken, ns, projectName)
+		testS3Input(t, c, ns, projectName)
 	})
 }
 
-func testS3Chain(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
+func testS3Chain(t *testing.T, c *client.APIClient, ns, projectName string) {
 	dataRepo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, dataRepo))
 	dataCommit := client.NewProjectCommit(projectName, dataRepo, "master", "")
@@ -246,10 +239,6 @@ func testS3Chain(t *testing.T, c *client.APIClient, userToken, ns, projectName s
 						"aws --endpoint=${S3_ENDPOINT} s3 cp s3://s3g_in/file /tmp/s3in",
 						"echo '1' >> /tmp/s3in",
 						"aws --endpoint=${S3_ENDPOINT} s3 cp /tmp/s3in s3://out/file",
-					},
-					Env: map[string]string{
-						"AWS_ACCESS_KEY_ID":     userToken,
-						"AWS_SECRET_ACCESS_KEY": userToken,
 					},
 				},
 				ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -286,17 +275,14 @@ func TestS3Chain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, userToken, ns := initPachClient(t)
-	if userToken == "" {
-		userToken = "abc123"
-	}
+	c, _, ns := initPachClient(t)
 	t.Run("DefaultProject", func(t *testing.T) {
-		testS3Chain(t, c, userToken, ns, pfs.DefaultProjectName)
+		testS3Chain(t, c, ns, pfs.DefaultProjectName)
 	})
 	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3Chain(t, c, userToken, ns, projectName)
+		testS3Chain(t, c, ns, projectName)
 	})
 }
 
@@ -349,7 +335,7 @@ func TestNamespaceInEndpoint(t *testing.T) {
 	require.True(t, strings.Contains(buf.String(), "."+ns))
 }
 
-func testS3Output(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
+func testS3Output(t *testing.T, c *client.APIClient, ns, projectName string) {
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, repo))
 	masterCommit := client.NewProjectCommit(projectName, repo, "master", "")
@@ -366,10 +352,6 @@ func testS3Output(t *testing.T, c *client.APIClient, userToken, ns, projectName 
 			Stdin: []string{
 				"ls -R /pfs | aws --endpoint=${S3_ENDPOINT} s3 cp - s3://out/pfs_files",
 				"aws --endpoint=${S3_ENDPOINT} s3 ls | aws --endpoint=${S3_ENDPOINT} s3 cp - s3://out/s3_buckets",
-			},
-			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     userToken,
-				"AWS_SECRET_ACCESS_KEY": userToken,
 			},
 		},
 		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -433,21 +415,18 @@ func TestS3Output(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, userToken, ns := initPachClient(t)
-	if userToken == "" {
-		userToken = "abc123"
-	}
+	c, _, ns := initPachClient(t)
 	t.Run("DefaultProject", func(t *testing.T) {
-		testS3Output(t, c, userToken, ns, pfs.DefaultProjectName)
+		testS3Output(t, c, ns, pfs.DefaultProjectName)
 	})
 	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3Output(t, c, userToken, ns, projectName)
+		testS3Output(t, c, ns, projectName)
 	})
 }
 
-func testFullS3(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
+func testFullS3(t *testing.T, c *client.APIClient, ns, projectName string) {
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, repo))
 	masterCommit := client.NewProjectCommit(projectName, repo, "master", "")
@@ -464,10 +443,6 @@ func testFullS3(t *testing.T, c *client.APIClient, userToken, ns, projectName st
 			Stdin: []string{
 				"ls -R /pfs | aws --endpoint=${S3_ENDPOINT} s3 cp - s3://out/pfs_files",
 				"aws --endpoint=${S3_ENDPOINT} s3 ls | aws --endpoint=${S3_ENDPOINT} s3 cp - s3://out/s3_buckets",
-			},
-			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     userToken,
-				"AWS_SECRET_ACCESS_KEY": userToken,
 			},
 		},
 		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -532,22 +507,19 @@ func TestFullS3(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, userToken, ns := initPachClient(t)
-	if userToken == "" {
-		userToken = "abc123"
-	}
+	c, _, ns := initPachClient(t)
 	t.Run("DefaultProject", func(t *testing.T) {
-		testFullS3(t, c, userToken, ns, pfs.DefaultProjectName)
+		testFullS3(t, c, ns, pfs.DefaultProjectName)
 	})
 	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testFullS3(t, c, userToken, ns, projectName)
+		testFullS3(t, c, ns, projectName)
 	})
 }
 
 // repoBucket returns the bucket name for a repo.
-func testS3SkippedDatums(t *testing.T, c *client.APIClient, userToken, ns, projectName string, repoBucket func(project, repo string) string) {
+func testS3SkippedDatums(t *testing.T, c *client.APIClient, ns, projectName string, repoBucket func(project, repo string) string) {
 	t.Run("S3Inputs", func(t *testing.T) {
 		// TODO(2.0 optional): Duplicate file paths from different datums no longer allowed.
 		t.Skip("Duplicate file paths from different datums no longer allowed.")
@@ -582,10 +554,6 @@ func testS3SkippedDatums(t *testing.T, c *client.APIClient, userToken, ns, proje
 					"aws --endpoint=${S3_ENDPOINT} s3 cp s3://s3g_in/file /tmp/s3in",
 					"cat /pfs/pfs_in/* >/tmp/pfsin",
 					"echo \"$(cat /tmp/bg) $(cat /tmp/pfsin) $(cat /tmp/s3in)\" >/pfs/out/out",
-				},
-				Env: map[string]string{
-					"AWS_ACCESS_KEY_ID":     userToken,
-					"AWS_SECRET_ACCESS_KEY": userToken,
 				},
 			},
 			ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -751,10 +719,6 @@ func testS3SkippedDatums(t *testing.T, c *client.APIClient, userToken, ns, proje
 					// outputs, we should only see one such file in every job's output.
 					"aws --endpoint=${S3_ENDPOINT} s3 cp /tmp/bg s3://out/bg/\"$(cat /tmp/bg)\"",
 				},
-				Env: map[string]string{
-					"AWS_ACCESS_KEY_ID":     userToken,
-					"AWS_SECRET_ACCESS_KEY": userToken,
-				},
 			},
 			ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
 			Input: &pps.Input{
@@ -824,17 +788,14 @@ func TestS3SkippedDatums(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, userToken, ns := initPachClient(t)
-	if userToken == "" {
-		userToken = "abc123"
-	}
+	c, _, ns := initPachClient(t)
 	t.Run("DefaultProject", func(t *testing.T) {
-		testS3SkippedDatums(t, c, userToken, ns, pfs.DefaultProjectName, func(p, r string) string { return r })
+		testS3SkippedDatums(t, c, ns, pfs.DefaultProjectName, func(p, r string) string { return r })
 	})
 	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3SkippedDatums(t, c, userToken, ns, projectName, func(p, r string) string { return r + "." + p })
+		testS3SkippedDatums(t, c, ns, projectName, func(p, r string) string { return r + "." + p })
 	})
 }
 

--- a/src/server/worker/pipeline/service/service.go
+++ b/src/server/worker/pipeline/service/service.go
@@ -65,7 +65,7 @@ func Run(driver driver.Driver, logger logs.TaggedLogger) error {
 			return datum.WithSet(cacheClient, storageRoot, func(s *datum.Set) error {
 				inputs := meta.Inputs
 				logger = logger.WithData(inputs)
-				env := driver.UserCodeEnv(logger.JobID(), jobInfo.OutputCommit, inputs)
+				env := driver.UserCodeEnv(logger.JobID(), jobInfo.OutputCommit, inputs, pipelineInfo.GetAuthToken())
 				return s.WithDatum(meta, func(d *datum.Datum) error {
 					err := driver.WithActiveData(inputs, d.PFSStorageRoot(), func() error {
 						return d.Run(ctx, func(runCtx context.Context) error {

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -97,8 +97,8 @@ func (td *testDriver) WithContext(ctx context.Context) driver.Driver {
 func (td *testDriver) WithActiveData(inputs []*common.Input, dir string, cb func() error) error {
 	return errors.EnsureStack(td.inner.WithActiveData(inputs, dir, cb))
 }
-func (td *testDriver) UserCodeEnv(jobID string, commit *pfs.Commit, inputs []*common.Input) []string {
-	return td.inner.UserCodeEnv(jobID, commit, inputs)
+func (td *testDriver) UserCodeEnv(jobID string, commit *pfs.Commit, inputs []*common.Input, authToken string) []string {
+	return td.inner.UserCodeEnv(jobID, commit, inputs, authToken)
 }
 func (td *testDriver) RunUserCode(ctx context.Context, logger logs.TaggedLogger, env []string) error {
 	return errors.EnsureStack(td.inner.RunUserCode(ctx, logger, env))

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -389,7 +389,7 @@ func forEachDatum(ctx context.Context, driver driver.Driver, baseLogger logs.Tag
 			meta.ImageId = userImageID
 			inputs := meta.Inputs
 			logger := baseLogger.WithData(inputs)
-			env := driver.UserCodeEnv(logger.JobID(), task.OutputCommit, inputs)
+			env := driver.UserCodeEnv(logger.JobID(), task.OutputCommit, inputs, driver.PipelineInfo().GetAuthToken())
 			opts := []datum.Option{datum.WithEnv(env)}
 			if driver.PipelineInfo().Details.DatumTimeout != nil {
 				timeout, err := types.DurationFromProto(driver.PipelineInfo().Details.DatumTimeout)


### PR DESCRIPTION
Sidecar-s3-gateway-enabled pipelines often trigger other, external pipeline systems. When auth is enabled, this is nearly impossible to do correctly, because the user code that is triggering the external pipeline doesn't have the auth token that the external pipeline would need in order to read/write data. This PR fixes the issue by setting the usual AWS env vars, which users can pass to their non-pachyderm pipelines, allowing them to read/write the sidecar S3 gateway.

Jira: [CORE-1014], [INT-735], [FREQQ-56]

[CORE-1014]: https://pachyderm.atlassian.net/browse/CORE-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[INT-735]: https://pachyderm.atlassian.net/browse/INT-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FREQQ-56]: https://pachyderm.atlassian.net/browse/FREQQ-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ