### PR TITLE
add build-docker-image dependency for load tests

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -291,21 +291,17 @@ jobs:
       GOOGLE_COMPUTE_REGION: us-east1
     steps:
       - checkout
-      - when:
-          condition:
-            equal: [true, << pipeline.parameters.run_load_tests >>]
-          steps:
-            - gcp-cli/initialize
-            - go/install:
-                version: << pipeline.parameters.go-version >>
-            - run: |
-                echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
-            - run:
-                command: etc/testing/circle/run_all_load_tests.sh
-                no_output_timeout: 1h
-            - store_artifacts:
-                path: /tmp/debug-dump
-                destination: debug-dump
+      - gcp-cli/initialize
+      - go/install:
+          version: << pipeline.parameters.go-version >>
+      - run: |
+          echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
+      - run:
+          command: etc/testing/circle/run_all_load_tests.sh
+          no_output_timeout: 1h
+      - store_artifacts:
+          path: /tmp/debug-dump
+          destination: debug-dump
   rootless:
     resource_class: large
     machine:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -291,17 +291,21 @@ jobs:
       GOOGLE_COMPUTE_REGION: us-east1
     steps:
       - checkout
-      - gcp-cli/initialize
-      - go/install:
-          version: << pipeline.parameters.go-version >>
-      - run: |
-          echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
-      - run:
-          command: etc/testing/circle/run_all_load_tests.sh
-          no_output_timeout: 1h
-      - store_artifacts:
-          path: /tmp/debug-dump
-          destination: debug-dump
+      - when:
+          condition:
+            equal: [true, << pipeline.parameters.run_load_tests >>]
+          steps:
+            - gcp-cli/initialize
+            - go/install:
+                version: << pipeline.parameters.go-version >>
+            - run: |
+                echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
+            - run:
+                command: etc/testing/circle/run_all_load_tests.sh
+                no_output_timeout: 1h
+            - store_artifacts:
+                path: /tmp/debug-dump
+                destination: debug-dump
   rootless:
     resource_class: large
     machine:
@@ -668,6 +672,28 @@ workflows:
   integration-tests:
     jobs:
       - build-docker-images
+      - nightly-load:
+          requires:
+            - build-docker-images
+          matrix:
+            parameters:
+              bucket:
+                - LOAD1
+                - LOAD2
+                - LOAD3
+                - LOAD4
+                - LOAD5
+                - LOAD6
+                - LOAD7
+                - LOAD8
+                - LOAD9
+                - LOAD10
+                - LOAD11
+                - LOAD12
+                  # Disabled for now since they take too long, may consider reenabling later.
+                  #- LOAD13
+                  #- LOAD14
+                  #- LOAD15
       - build-pachctl-bin:
           version: $CIRCLE_SHA1
           upload: true
@@ -698,29 +724,6 @@ workflows:
   helm-tests:
     jobs:
       - helm-tests
-  nightly_load_tests:
-    when: << pipeline.parameters.run_load_tests >>
-    jobs:
-      - nightly-load:
-          matrix:
-            parameters:
-              bucket:
-                - LOAD1
-                - LOAD2
-                - LOAD3
-                - LOAD4
-                - LOAD5
-                - LOAD6
-                - LOAD7
-                - LOAD8
-                - LOAD9
-                - LOAD10
-                - LOAD11
-                - LOAD12
-                  # Disabled for now since they take too long, may consider reenabling later.
-                  #- LOAD13
-                  #- LOAD14
-                  #- LOAD15
   rootless-tests:
     jobs:
       - rootless

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -672,28 +672,6 @@ workflows:
   integration-tests:
     jobs:
       - build-docker-images
-      - nightly-load:
-          requires:
-            - build-docker-images
-          matrix:
-            parameters:
-              bucket:
-                - LOAD1
-                - LOAD2
-                - LOAD3
-                - LOAD4
-                - LOAD5
-                - LOAD6
-                - LOAD7
-                - LOAD8
-                - LOAD9
-                - LOAD10
-                - LOAD11
-                - LOAD12
-                  # Disabled for now since they take too long, may consider reenabling later.
-                  #- LOAD13
-                  #- LOAD14
-                  #- LOAD15
       - build-pachctl-bin:
           version: $CIRCLE_SHA1
           upload: true
@@ -724,6 +702,32 @@ workflows:
   helm-tests:
     jobs:
       - helm-tests
+  nightly_load_tests:
+    when: << pipeline.parameters.run_load_tests >>
+    jobs:
+      - build-docker-images
+      - nightly-load:
+          requires:
+            - build-docker-images
+          matrix:
+            parameters:
+              bucket:
+                - LOAD1
+                - LOAD2
+                - LOAD3
+                - LOAD4
+                - LOAD5
+                - LOAD6
+                - LOAD7
+                - LOAD8
+                - LOAD9
+                - LOAD10
+                - LOAD11
+                - LOAD12
+                  # Disabled for now since they take too long, may consider reenabling later.
+                  #- LOAD13
+                  #- LOAD14
+                  #- LOAD15
   rootless-tests:
     jobs:
       - rootless

--- a/etc/testing/circle/run_load_tests.sh
+++ b/etc/testing/circle/run_load_tests.sh
@@ -21,15 +21,12 @@ pachctl version --client-only
 VERSION="$(pachctl version --client-only)"
 export VERSION
 
-# Build and push docker images.
-make docker-build
-make docker-push
 
 JOB=$(echo "$CIRCLE_JOB" | tr '[:upper:]' '[:lower:]')
 
 # # provision a pulumi load test env
 curl -X POST -H "Authorization: Bearer ${HELIUM_API_TOKEN}" \
- -F name=commit-"${CIRCLE_SHA1:0:7}-${JOB}" -F pachdVersion="${VERSION}" -F valuesYaml=@etc/testing/circle/helm-load-env-values.yaml \
+ -F name=commit-"${CIRCLE_SHA1:0:7}-${JOB}" -F pachdVersion="${CIRCLE_SHA1}" -F valuesYaml=@etc/testing/circle/helm-load-env-values.yaml \
   https://helium.pachyderm.io/v1/api/workspace
 
 # wait for helium to kick off to pulumi before pinging it.


### PR DESCRIPTION
nightly runs are still broken since now we are building arm64 images, and requires the binfmt_misc hack. So proposing we don't rebuild docker images in different places. and only use the same job and make nightly load depend on that.

nightly load will now use same image build job instead of rebuilding in its script. we should consider using the built in requires in circle ci and get rid of `wait_for_docker_images.sh` the ci tests too


