### PR TITLE
Fix issue with pretty printing JobInfo.Started

### DIFF
--- a/src/internal/pretty/pretty.go
+++ b/src/internal/pretty/pretty.go
@@ -32,7 +32,7 @@ func Since(timestamp *types.Timestamp) string {
 // human-readable string, and adds "ago" to the end.
 func Ago(timestamp *types.Timestamp) string {
 	if timestamp == nil {
-		return "N/A"
+		return "-"
 	}
 	since := Since(timestamp)
 	if since == "" {

--- a/src/internal/pretty/pretty.go
+++ b/src/internal/pretty/pretty.go
@@ -31,6 +31,9 @@ func Since(timestamp *types.Timestamp) string {
 // Ago pretty-prints the amount of time that has passed since timestamp as a
 // human-readable string, and adds "ago" to the end.
 func Ago(timestamp *types.Timestamp) string {
+	if timestamp == nil {
+		return "N/A"
+	}
 	since := Since(timestamp)
 	if since == "" {
 		return since

--- a/src/internal/pretty/pretty_test.go
+++ b/src/internal/pretty/pretty_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/pretty"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
 func TestCommafy(t *testing.T) {
@@ -22,4 +23,8 @@ func TestCommafy(t *testing.T) {
 	if expected, actual := "foo, bar and baz", pretty.Commafy([]string{"foo", "bar", "baz"}); expected != actual {
 		t.Errorf("expected %q; got %q", expected, actual)
 	}
+}
+
+func TestAgo(t *testing.T) {
+	require.Equal(t, "N/A", pretty.Ago(nil))
 }

--- a/src/internal/pretty/pretty_test.go
+++ b/src/internal/pretty/pretty_test.go
@@ -26,5 +26,5 @@ func TestCommafy(t *testing.T) {
 }
 
 func TestAgo(t *testing.T) {
-	require.Equal(t, "N/A", pretty.Ago(nil))
+	require.Equal(t, "-", pretty.Ago(nil))
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1784,14 +1784,11 @@ func TestProvenance(t *testing.T) {
 }
 
 // TestProvenance2 tests the following DAG:
-//
-//	 A
-//	/ \
-//
+//   A
+//  / \
 // B   C
-//
-//	\ /
-//	 D
+//  \ /
+//   D
 func TestProvenance2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -1784,11 +1784,14 @@ func TestProvenance(t *testing.T) {
 }
 
 // TestProvenance2 tests the following DAG:
-//   A
-//  / \
+//
+//	 A
+//	/ \
+//
 // B   C
-//  \ /
-//   D
+//
+//	\ /
+//	 D
 func TestProvenance2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -2496,7 +2499,7 @@ func TestPrettyPrinting(t *testing.T) {
 	jobInfos, err := c.ListJob("", nil, -1, true)
 	require.NoError(t, err)
 	require.True(t, len(jobInfos) > 0)
-	require.NoError(t, ppspretty.PrintDetailedJobInfo(os.Stdout, ppspretty.NewPrintableJobInfo(jobInfos[0])))
+	require.NoError(t, ppspretty.PrintDetailedJobInfo(os.Stdout, ppspretty.NewPrintableJobInfo(jobInfos[0], false)))
 }
 
 func TestAuthPrettyPrinting(t *testing.T) {
@@ -2555,7 +2558,7 @@ func TestAuthPrettyPrinting(t *testing.T) {
 	jobInfos, err := c.ListJob("", nil, -1, true)
 	require.NoError(t, err)
 	require.True(t, len(jobInfos) > 0)
-	require.NoError(t, ppspretty.PrintDetailedJobInfo(os.Stdout, ppspretty.NewPrintableJobInfo(jobInfos[0])))
+	require.NoError(t, ppspretty.PrintDetailedJobInfo(os.Stdout, ppspretty.NewPrintableJobInfo(jobInfos[0], false)))
 }
 
 func TestDeleteAll(t *testing.T) {

--- a/src/server/pps/pretty/pretty_test.go
+++ b/src/server/pps/pretty/pretty_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	pfsclient "github.com/pachyderm/pachyderm/v2/src/pfs"
 	ppsclient "github.com/pachyderm/pachyderm/v2/src/pps"
 	"github.com/pachyderm/pachyderm/v2/src/server/pps/pretty"
@@ -82,6 +83,21 @@ func TestJobEgressURL(t *testing.T) {
 			t.Errorf("could not find egress %s in detailed job info; expected %q", item, value)
 		}
 	}
+}
+
+func TestJobStarted(t *testing.T) {
+	jobInfo := &ppsclient.JobInfo{
+		Job: &ppsclient.Job{
+			ID:       "foo",
+			Pipeline: &ppsclient.Pipeline{Name: "Bar"},
+		},
+		Stats:   &ppsclient.ProcessStats{},
+		Details: &ppsclient.JobInfo_Details{},
+	}
+	printableJobInfo := pretty.NewPrintableJobInfo(jobInfo)
+	buf := new(bytes.Buffer)
+	require.NoError(t, pretty.PrintDetailedJobInfo(buf, printableJobInfo))
+	require.True(t, strings.Contains(buf.String(), "Started: N/A"))
 }
 
 func TestPipelineEgressTarget(t *testing.T) {

--- a/src/server/pps/pretty/pretty_test.go
+++ b/src/server/pps/pretty/pretty_test.go
@@ -42,7 +42,7 @@ func TestJobEgressTarget(t *testing.T) {
 			},
 		}
 	)
-	if err := pretty.PrintDetailedJobInfo(buf, pretty.NewPrintableJobInfo(ji)); err != nil {
+	if err := pretty.PrintDetailedJobInfo(buf, pretty.NewPrintableJobInfo(ji, false)); err != nil {
 		t.Fatal(err)
 	}
 	s := buf.String()
@@ -74,7 +74,7 @@ func TestJobEgressURL(t *testing.T) {
 			},
 		}
 	)
-	if err := pretty.PrintDetailedJobInfo(buf, pretty.NewPrintableJobInfo(ji)); err != nil {
+	if err := pretty.PrintDetailedJobInfo(buf, pretty.NewPrintableJobInfo(ji, false)); err != nil {
 		t.Fatal(err)
 	}
 	s := buf.String()
@@ -86,18 +86,36 @@ func TestJobEgressURL(t *testing.T) {
 }
 
 func TestJobStarted(t *testing.T) {
-	jobInfo := &ppsclient.JobInfo{
-		Job: &ppsclient.Job{
-			ID:       "foo",
-			Pipeline: &ppsclient.Pipeline{Name: "Bar"},
+	tests := map[string]struct {
+		full     bool
+		expected string
+	}{
+		"Full timestamp": {
+			full:     true,
+			expected: "Started: -",
 		},
-		Stats:   &ppsclient.ProcessStats{},
-		Details: &ppsclient.JobInfo_Details{},
+		"Pretty ago": {
+			full:     false,
+			expected: "Started: -",
+		},
 	}
-	printableJobInfo := pretty.NewPrintableJobInfo(jobInfo)
-	buf := new(bytes.Buffer)
-	require.NoError(t, pretty.PrintDetailedJobInfo(buf, printableJobInfo))
-	require.True(t, strings.Contains(buf.String(), "Started: N/A"))
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			jobInfo := &ppsclient.JobInfo{
+				Job: &ppsclient.Job{
+					ID:       "foo",
+					Pipeline: &ppsclient.Pipeline{Name: "Bar"},
+				},
+				Started: nil,
+				Stats:   &ppsclient.ProcessStats{},
+				Details: &ppsclient.JobInfo_Details{},
+			}
+			printableJobInfo := pretty.NewPrintableJobInfo(jobInfo, test.full)
+			buf := new(bytes.Buffer)
+			require.NoError(t, pretty.PrintDetailedJobInfo(buf, printableJobInfo))
+			require.True(t, strings.Contains(buf.String(), test.expected))
+		})
+	}
 }
 
 func TestPipelineEgressTarget(t *testing.T) {


### PR DESCRIPTION
When the user inspects a job that hasn't started yet, they get something like  `Started: 52 years ago` or `Started: nil timestamp` when `full-timestamp` is set. This is because the `JobInfo.Started` field is nil, which gets interpreted as the unix time 0. This PR addresses this issue by checking for nil timestamp, if so, returning "-".