### PR TITLE
Use external postgres secret when requested

### DIFF
--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -61,8 +61,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres # Must match secret setup by postgres subchart or postgres-secret.yaml if using external postgres
-              key: postgresql-password
+              name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
+              key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
         {{- if and .Values.enterpriseServer.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR
           value:  /pachd-tls-cert

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -58,11 +58,20 @@ spec:
           value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
         - name: POSTGRES_USER
           value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
+        {{- if .Values.global.postgresql.ssl }}
+        - name: POSTGRES_SSL
+          value: "require"
+        {{- end }}
+        {{- if .Values.cloudsqlAuthProxy.iamLogin }}
+        - name: POSTGRES_PASSWORD
+          value: "Using-iamLogin"
+        {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
               key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
+        {{- end }}
         {{- if and .Values.enterpriseServer.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR
           value:  /pachd-tls-cert

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -2,7 +2,10 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.enterpriseServer.enabled }}
+{{- if .Values.enterpriseServer.enabled -}}
+{{- if .Values.pachd.enabled -}}
+{{- fail "pachd and enterpriseServer shall not be enabled at the same time in the same namespace" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -261,4 +264,4 @@ spec:
         secret:
           secretName: {{ required "If enterpriseServer.tls.enabled, you must set enterpriseServer.tls.secretName" .Values.enterpriseServer.tls.secretName | quote }}
       {{- end }}
-{{- end }}
+{{- end -}}

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -69,8 +69,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
-              key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
+              name: {{ default "postgres" .Values.global.postgresql.postgresqlExistingSecretName }}
+              key: {{ default "postgresql-password" .Values.global.postgresql.postgresqlExistingSecretKey }}
         {{- end }}
         {{- if and .Values.enterpriseServer.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR

--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -69,8 +69,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ default "postgres" .Values.global.postgresql.postgresqlExistingSecretName }}
-              key: {{ default "postgresql-password" .Values.global.postgresql.postgresqlExistingSecretKey }}
+              name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
+              key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
         {{- end }}
         {{- if and .Values.enterpriseServer.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR

--- a/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.enterpriseServer.enabled (not .Values.postgresql.enabled) -}}
+{{- if and .Values.enterpriseServer.enabled (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
@@ -2,14 +2,14 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.enterpriseServer.enabled (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
+{{- if and .Values.enterpriseServer.enabled (not .Values.pachd.enabled) (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
     app: postgresql
     suite: pachyderm
-  name: postgres # Must match secretname specified for postgres password in pachd deployment, enterprise and pg bouncer
+  name: enterprise-postgres # Must match secretname specified for postgres password in pachd deployment, enterprise and pg bouncer
   namespace: {{ .Release.Namespace }}
 data:
   postgresql-password: {{ required "Postgres password required when using an external Postgresql server" .Values.global.postgresql.postgresqlPassword | b64enc | quote }}

--- a/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
@@ -2,14 +2,14 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.enterpriseServer.enabled (not .Values.pachd.enabled) (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
+{{- if and .Values.enterpriseServer.enabled (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
     app: postgresql
     suite: pachyderm
-  name: enterprise-postgres # Must match secretname specified for postgres password in pachd deployment, enterprise and pg bouncer
+  name: postgres # Must match secretname specified for postgres password in pachd deployment, enterprise and pg bouncer
   namespace: {{ .Release.Namespace }}
 data:
   postgresql-password: {{ required "Postgres password required when using an external Postgresql server" .Values.global.postgresql.postgresqlPassword | b64enc | quote }}

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -2,7 +2,10 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.pachd.enabled }}
+{{- if .Values.pachd.enabled -}}
+{{- if .Values.enterpriseServer.enabled -}}
+{{- fail "pachd and enterpriseServer shall not be enabled at the same time in the same namespace" -}}
+{{- end -}}
 {{- $randHostPath := printf "/var/pachyderm-%s/" (randAlphaNum 5) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -441,4 +444,4 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.oidc.dexCredentialSecretName }}
       {{- end }}
-{{- end }}
+{{- end -}}

--- a/etc/helm/pachyderm/templates/pachd/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/postgres-secret.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.pachd.enabled  (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
+{{- if and .Values.pachd.enabled (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/etc/helm/pachyderm/templates/pachd/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/postgres-secret.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.pachd.enabled (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
+{{- if and .Values.pachd.enabled  (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
This PR attempts to fix a problem with deploying enterprise servers, when `postgres` instances has other secret provisions. In addition, this addresses the issue of failing `helm template` when both `pachd` and `enterprise-server` are enabled.