### PR TITLE
[DO NOT MERGE] Minimal breakage example

### DIFF
--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -440,7 +440,7 @@ func GetWorkerPipelineInfo(pachClient *client.APIClient, db *pachsql.DB, l colle
 	return pipelineInfo, nil
 }
 
-func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, txnEnv transactionenv.TransactionEnv, pipeline string) (*pfs.Commit, error) {
+func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, txnEnv transactionenv.TransactionEnv, pipeline *pps.Pipeline) (*pfs.Commit, error) {
 	var commit *pfs.Commit
 	if err := txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) (err error) {
 		commit, err = FindPipelineSpecCommitInTransaction(txnCtx, pfsServer, pipeline, "")
@@ -453,8 +453,8 @@ func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, 
 
 // FindPipelineSpecCommitInTransaction finds the spec commit corresponding to the pipeline version present in the commit given
 // by startID. If startID is blank, find the current pipeline version
-func FindPipelineSpecCommitInTransaction(txnCtx *txncontext.TransactionContext, pfsServer pfsServer.APIServer, pipeline, startID string) (*pfs.Commit, error) {
-	curr := client.NewSystemRepo(pipeline, pfs.SpecRepoType).NewCommit("master", startID)
+func FindPipelineSpecCommitInTransaction(txnCtx *txncontext.TransactionContext, pfsServer pfsServer.APIServer, pipeline *pps.Pipeline, startID string) (*pfs.Commit, error) {
+	curr := client.NewSystemRepo(pipeline.Name, pfs.SpecRepoType).NewCommit("master", startID)
 	commitInfo, err := pfsServer.InspectCommitInTransaction(txnCtx,
 		&pfs.InspectCommitRequest{Commit: curr})
 	if err != nil {

--- a/src/internal/testpachd/mock_transaction.go
+++ b/src/internal/testpachd/mock_transaction.go
@@ -67,7 +67,7 @@ func (mock *mockCreatePipelineInTransaction) Use(cb createPipelineInTransactionF
 	mock.handler = cb
 }
 
-type inspectPipelineInTransactionFunc func(*txncontext.TransactionContext, string) (*pps.PipelineInfo, error)
+type inspectPipelineInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
 
 type mockInspectPipelineInTransaction struct {
 	handler inspectPipelineInTransactionFunc
@@ -163,7 +163,7 @@ func (api *ppsTransactionAPI) CreatePipelineInTransaction(txnCtx *txncontext.Tra
 	return errors.Errorf("unhandled pachd mock: pps.CreatePipelineInTransaction")
 }
 
-func (api *ppsTransactionAPI) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, pipeline string) (*pps.PipelineInfo, error) {
+func (api *ppsTransactionAPI) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 	if api.mock.InspectPipelineInTransaction.handler != nil {
 		return api.mock.InspectPipelineInTransaction.handler(txnCtx, pipeline)
 	}

--- a/src/internal/testpachd/real_env.go
+++ b/src/internal/testpachd/real_env.go
@@ -105,10 +105,11 @@ func NewRealEnv(t testing.TB, customOpts ...serviceenv.ConfigOption) *RealEnv {
 	realEnv.MockPPSTransactionServer = NewMockPPSTransactionServer()
 	realEnv.ServiceEnv.SetPpsServer(&realEnv.MockPPSTransactionServer.api)
 	realEnv.MockPPSTransactionServer.InspectPipelineInTransaction.
-		Use(func(txnctx *txncontext.TransactionContext, name string) (*pps.PipelineInfo, error) {
+		Use(func(txnctx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 			return nil, col.ErrNotFound{
 				Type: "pipelines",
-				Key:  name,
+				// FIXME: add project
+				Key: pipeline.Name,
 			}
 		})
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -346,7 +346,11 @@ func (d *driver) deleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 	}
 
 	if !force {
-		if _, err := d.env.GetPPSServer().InspectPipelineInTransaction(txnCtx, repo.Name); err == nil {
+		pipeline := &pps.Pipeline{
+			Project: repo.Project,
+			Name:    repo.Name,
+		}
+		if _, err := d.env.GetPPSServer().InspectPipelineInTransaction(txnCtx, pipeline); err == nil {
 			return errors.Errorf("cannot delete a repo associated with a pipeline - delete the pipeline instead")
 		} else if err != nil && !errutil.IsNotFoundError(err) {
 			return errors.EnsureStack(err)
@@ -609,9 +613,11 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 		return errors.Errorf("cannot finish an alias commit: %s", commitInfo.Commit)
 	}
 	if !force && len(commitInfo.DirectProvenance) > 0 {
-		if info, err := d.env.GetPPSServer().InspectPipelineInTransaction(txnCtx,
-			commit.Branch.Repo.Name,
-		); err != nil && !errutil.IsNotFoundError(err) {
+		pipeline := &pps.Pipeline{
+			Project: commit.Branch.Repo.Project,
+			Name:    commit.Branch.Repo.Name,
+		}
+		if info, err := d.env.GetPPSServer().InspectPipelineInTransaction(txnCtx, pipeline); err != nil && !errutil.IsNotFoundError(err) {
 			return errors.EnsureStack(err)
 		} else if err == nil && info.Type == pps.PipelineInfo_PIPELINE_TYPE_TRANSFORM {
 			return errors.Errorf("cannot finish a pipeline output or meta commit, use 'stop job' instead")

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -2,6 +2,7 @@ package pps
 
 import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
 	pps_client "github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
@@ -18,6 +19,6 @@ type APIServer interface {
 	StopJobInTransaction(*txncontext.TransactionContext, *pps_client.StopJobRequest) error
 	UpdateJobStateInTransaction(*txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
 	CreatePipelineInTransaction(*txncontext.TransactionContext, *pps_client.CreatePipelineRequest) error
-	InspectPipelineInTransaction(*txncontext.TransactionContext, string) (*pps_client.PipelineInfo, error)
+	InspectPipelineInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (*pps_client.PipelineInfo, error)
 	ActivateAuthInTransaction(*txncontext.TransactionContext, *pps_client.ActivateAuthRequest) (*pps_client.ActivateAuthResponse, error)
 }

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -278,7 +278,8 @@ func (pc *pipelineController) step(timestamp time.Time) (isDelete bool, retErr e
 	}
 	defer tracing.FinishAnySpan(span, "err", retErr)
 	// derive the latest pipelineInfo with a corresponding auth'd context
-	pi, ctx, err := pc.psDriver.FetchState(pc.ctx, pc.pipeline)
+	pipeline := client.NewPipeline(pc.pipeline)
+	pi, ctx, err := pc.psDriver.FetchState(pc.ctx, pipeline)
 	if err != nil {
 		// if we fail to create a new step, there was an error querying the pipeline info, and there's nothing we can do
 		log.Errorf("PPS master: failed to set up step data to handle event for pipeline '%s': %v", pc.pipeline, errors.Wrapf(err, "failing pipeline %q", pc.pipeline))

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -29,7 +29,7 @@ import (
 type PipelineStateDriver interface {
 	// returns PipelineInfo corresponding to the latest pipeline state, a context loaded with the pipeline's auth info, and error
 	// NOTE: returns nil, nil, nil if the step is found to be a delete operation
-	FetchState(ctx context.Context, pipeline string) (*pps.PipelineInfo, context.Context, error)
+	FetchState(ctx context.Context, pipeline *pps.Pipeline) (*pps.PipelineInfo, context.Context, error)
 	// setPipelineState set's pc's state in the collection to 'state'. This will trigger a
 	// collection watch event and cause step() to eventually run again.
 	SetState(ctx context.Context, specCommit *pfs.Commit, state pps.PipelineState, reason string) error
@@ -64,7 +64,7 @@ func newPipelineStateDriver(
 }
 
 // takes pc.ctx
-func (sd *stateDriver) FetchState(ctx context.Context, pipeline string) (*pps.PipelineInfo, context.Context, error) {
+func (sd *stateDriver) FetchState(ctx context.Context, pipeline *pps.Pipeline) (*pps.PipelineInfo, context.Context, error) {
 	// query pipelineInfo
 	var pi *pps.PipelineInfo
 	var err error
@@ -131,7 +131,7 @@ func (sd *stateDriver) GetPipelineInfo(ctx context.Context, name string, version
 	return &pipelineInfo, nil
 }
 
-func (sd *stateDriver) tryLoadLatestPipelineInfo(ctx context.Context, pipeline string) (*pps.PipelineInfo, error) {
+func (sd *stateDriver) tryLoadLatestPipelineInfo(ctx context.Context, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 	pi := &pps.PipelineInfo{}
 	errCnt := 0
 	err := backoff.RetryNotify(func() error {
@@ -153,7 +153,7 @@ func (sd *stateDriver) tryLoadLatestPipelineInfo(ctx context.Context, pipeline s
 	return pi, err
 }
 
-func (sd *stateDriver) loadLatestPipelineInfo(ctx context.Context, pipeline string, message *pps.PipelineInfo) error {
+func (sd *stateDriver) loadLatestPipelineInfo(ctx context.Context, pipeline *pps.Pipeline, message *pps.PipelineInfo) error {
 	specCommit, err := ppsutil.FindPipelineSpecCommit(ctx, sd.pfsApi, *sd.txEnv, pipeline)
 	if err != nil {
 		return errors.Wrapf(err, "could not find spec commit for pipeline %q", pipeline)


### PR DESCRIPTION
This is an example of (what I believe to be) the minimal changes necessary to make `TestPipelineAncestry` fail. The changes replace the use of a string to identify a pipeline with a Pipeline message.

I suspect that the issue is a pun on pipeline or commit somewhere, but have not yet isolate it.