### PR TITLE
[2.3.x Backport] liveness probe to not use URI (#8128)

### DIFF
--- a/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pgbouncer/deployment.yaml
@@ -95,7 +95,7 @@ spec:
             command:
               - "/bin/sh"
               - "-c"
-              - psql postgresql://$POSTGRESQL_USERNAME:$POSTGRESQL_PASSWORD@127.0.0.1:$PGBOUNCER_PORT/$POSTGRESQL_DATABASE --tuples-only --command="SELECT 1;" | grep -q "1"
+              - PGPASSWORD=$POSTGRESQL_PASSWORD psql -U $POSTGRESQL_USERNAME -h 127.0.0.1 -p $PGBOUNCER_PORT -d $POSTGRESQL_DATABASE --tuples-only --command="SELECT 1;" | grep -q "1"
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 1


### PR DESCRIPTION
Switches pg bouncer liveness probe to not use URI