### PR TITLE
fix alias filter

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -10,7 +10,7 @@ aliases:
       only: /^v\d+\.\d+\.\d+(-(?!nightly)[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
   - &only-nightly-tags
     branches:
-      only: master
+      ignore: /.*/
     tags:
       only: /^v\d+\.\d+\.\d+-(nightly)+(\.[0-9A-Za-z-]+)*?$/
   - &only-alpha-tags


### PR DESCRIPTION
`only master` apparently will also trigger on any push to master, but should only be on tag