### PR TITLE
[CORE-1042] Cache Symlink Commit Uploads

### DIFF
--- a/src/internal/pfssync/cache_client.go
+++ b/src/internal/pfssync/cache_client.go
@@ -4,6 +4,9 @@ import (
 	io "io"
 	"sync"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pfsload"
+
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
@@ -65,4 +68,46 @@ func (cc *CacheClient) put(key string, commit *pfs.Commit) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
 	cc.cache.Add(key, commit)
+}
+
+func (cc *CacheClient) WithCreateFileSetClient(cb func(client.ModifyFile) error) (*pfs.CreateFileSetResponse, error) {
+	pachClient := pfsload.NewPachClient(cc.APIClient)
+	resp, err := pachClient.WithCreateFileSetClient(cc.Ctx(), func(mf client.ModifyFile) error {
+		ccfsc := &cacheCreateFileSetClient{
+			ModifyFile:  mf,
+			CacheClient: cc,
+		}
+		if err := cb(ccfsc); err != nil {
+			return err
+		}
+		return nil
+	})
+	return resp, errors.EnsureStack(err)
+}
+
+type cacheCreateFileSetClient struct {
+	client.ModifyFile
+	*CacheClient
+}
+
+func (ccfsc *cacheCreateFileSetClient) CopyFile(dst string, src *pfs.File, opts ...client.CopyFileOption) error {
+	newSrc := &pfs.File{
+		Path:  src.Path,
+		Datum: src.Datum,
+	}
+	key := pfsdb.CommitKey(src.Commit)
+	if c, ok := ccfsc.get(key); ok {
+		newSrc.Commit = c
+		return errors.EnsureStack(ccfsc.ModifyFile.CopyFile(dst, newSrc, opts...))
+	}
+	id, err := ccfsc.APIClient.GetFileSet(src.Commit.Branch.Repo.Name, src.Commit.Branch.Name, src.Commit.ID)
+	if err != nil {
+		return err
+	}
+	if err := ccfsc.CacheClient.renewer.Add(ccfsc.APIClient.Ctx(), id); err != nil {
+		return err
+	}
+	newSrc.Commit = client.NewCommit(client.FileSetsRepoName, "", id)
+	ccfsc.put(key, newSrc.Commit)
+	return errors.EnsureStack(ccfsc.ModifyFile.CopyFile(dst, newSrc, opts...))
 }

--- a/src/internal/pfssync/cache_client.go
+++ b/src/internal/pfssync/cache_client.go
@@ -4,11 +4,9 @@ import (
 	io "io"
 	"sync"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pfsload"
-
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -71,16 +69,12 @@ func (cc *CacheClient) put(key string, commit *pfs.Commit) {
 }
 
 func (cc *CacheClient) WithCreateFileSetClient(cb func(client.ModifyFile) error) (*pfs.CreateFileSetResponse, error) {
-	pachClient := pfsload.NewPachClient(cc.APIClient)
-	resp, err := pachClient.WithCreateFileSetClient(cc.Ctx(), func(mf client.ModifyFile) error {
+	resp, err := cc.APIClient.WithCreateFileSetClient(func(mf client.ModifyFile) error {
 		ccfsc := &cacheCreateFileSetClient{
 			ModifyFile:  mf,
 			CacheClient: cc,
 		}
-		if err := cb(ccfsc); err != nil {
-			return err
-		}
-		return nil
+		return cb(ccfsc)
 	})
 	return resp, errors.EnsureStack(err)
 }

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -264,16 +264,16 @@ func handleDatumSet(driver driver.Driver, logger logs.TaggedLogger, task *DatumS
 	stats := &datum.Stats{ProcessStats: &pps.ProcessStats{}}
 	if err := pachClient.WithRenewer(func(ctx context.Context, renewer *renew.StringSet) error {
 		// Setup file operation client for output meta commit.
-		resp, err := pachClient.WithCreateFileSetClient(func(mfMeta client.ModifyFile) error {
+		pachClient := pachClient.WithCtx(ctx)
+		cacheClient := pfssync.NewCacheClient(pachClient, renewer)
+		resp, err := cacheClient.WithCreateFileSetClient(func(mfMeta client.ModifyFile) error {
 			// Setup file operation client for output PFS commit.
-			resp, err := pachClient.WithCreateFileSetClient(func(mfPFS client.ModifyFile) (retErr error) {
+			resp, err := cacheClient.WithCreateFileSetClient(func(mfPFS client.ModifyFile) (retErr error) {
 				opts := []datum.SetOption{
 					datum.WithMetaOutput(mfMeta),
 					datum.WithPFSOutput(mfPFS),
 					datum.WithStats(stats),
 				}
-				pachClient := pachClient.WithCtx(ctx)
-				cacheClient := pfssync.NewCacheClient(pachClient, renewer)
 				// TODO: Can this just be refactored into the datum package such that we don't need to specify a storage root for the sets?
 				// The sets would just create a temporary directory under /tmp.
 				storageRoot := filepath.Join(driver.InputDir(), client.PPSScratchSpace, uuid.NewWithoutDashes())

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -263,9 +263,9 @@ func handleDatumSet(driver driver.Driver, logger logs.TaggedLogger, task *DatumS
 	var outputFileSetID, metaFileSetID string
 	stats := &datum.Stats{ProcessStats: &pps.ProcessStats{}}
 	if err := pachClient.WithRenewer(func(ctx context.Context, renewer *renew.StringSet) error {
-		// Setup file operation client for output meta commit.
 		pachClient := pachClient.WithCtx(ctx)
 		cacheClient := pfssync.NewCacheClient(pachClient, renewer)
+		// Setup file operation client for output meta commit.
 		resp, err := cacheClient.WithCreateFileSetClient(func(mfMeta client.ModifyFile) error {
 			// Setup file operation client for output PFS commit.
 			resp, err := cacheClient.WithCreateFileSetClient(func(mfPFS client.ModifyFile) (retErr error) {


### PR DESCRIPTION
## Description
This PR resolves a bug reported in CORE-1042 by expanding the cacheClient to wrap the ModifyFile client's copyFile(). Instead of copying files in a commit, a commit ID is put into a cache and a fileSet is generated for each commit. This saves time by bypassing calls to Postgres and Auth. 