### PR TITLE
[CORE-860] Implement chunk prefetcher

### DIFF
--- a/src/internal/storage/chunk/reader.go
+++ b/src/internal/storage/chunk/reader.go
@@ -11,18 +11,16 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
-	"golang.org/x/sync/semaphore"
 )
 
 // Reader reads data from chunk storage.
 type Reader struct {
-	ctx           context.Context
-	client        Client
-	memCache      kv.GetPut
-	deduper       *miscutil.WorkDeduper
-	dataRefs      []*DataRef
-	offsetBytes   int64
-	prefetchLimit int
+	ctx         context.Context
+	client      Client
+	memCache    kv.GetPut
+	deduper     *miscutil.WorkDeduper
+	dataRefs    []*DataRef
+	offsetBytes int64
 }
 
 type ReaderOption func(*Reader)
@@ -33,14 +31,13 @@ func WithOffsetBytes(offsetBytes int64) ReaderOption {
 	}
 }
 
-func newReader(ctx context.Context, client Client, memCache kv.GetPut, deduper *miscutil.WorkDeduper, prefetchLimit int, dataRefs []*DataRef, opts ...ReaderOption) *Reader {
+func newReader(ctx context.Context, client Client, memCache kv.GetPut, deduper *miscutil.WorkDeduper, dataRefs []*DataRef, opts ...ReaderOption) *Reader {
 	r := &Reader{
-		ctx:           ctx,
-		client:        client,
-		memCache:      memCache,
-		deduper:       deduper,
-		prefetchLimit: prefetchLimit,
-		dataRefs:      dataRefs,
+		ctx:      ctx,
+		client:   client,
+		memCache: memCache,
+		deduper:  deduper,
+		dataRefs: dataRefs,
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -56,41 +53,15 @@ func newReader(ctx context.Context, client Client, memCache kv.GetPut, deduper *
 }
 
 // Get writes the concatenation of the data referenced by the data references.
-func (r *Reader) Get(w io.Writer) (retErr error) {
-	if len(r.dataRefs) == 0 {
-		return nil
-	}
-	if len(r.dataRefs) == 1 {
-		_, err := io.Copy(w, newDataReader(r.ctx, r.client, r.memCache, r.deduper, r.dataRefs[0], r.offsetBytes))
-		return errors.EnsureStack(err)
-	}
-	ctx, cancel := context.WithCancel(r.ctx)
-	defer cancel()
-	taskChain := NewTaskChain(ctx, semaphore.NewWeighted(int64(r.prefetchLimit)))
-	defer func() {
-		if retErr != nil {
-			cancel()
-		}
-		if err := taskChain.Wait(); retErr == nil {
-			retErr = err
-		}
-	}()
+func (r *Reader) Get(w io.Writer) error {
 	for i, dataRef := range r.dataRefs {
 		var offset int64
 		if i == 0 {
 			offset = r.offsetBytes
 		}
 		dr := newDataReader(r.ctx, r.client, r.memCache, r.deduper, dataRef, offset)
-		if err := taskChain.CreateTask(func(ctx context.Context) (func() error, error) {
-			if err := dr.fetchData(); err != nil {
-				return nil, err
-			}
-			return func() error {
-				_, err := io.Copy(w, dr)
-				return errors.EnsureStack(err)
-			}, nil
-		}); err != nil {
-			return err
+		if _, err := io.Copy(w, dr); err != nil {
+			return errors.EnsureStack(err)
 		}
 	}
 	return nil

--- a/src/internal/storage/chunk/storage.go
+++ b/src/internal/storage/chunk/storage.go
@@ -3,7 +3,6 @@ package chunk
 import (
 	"bytes"
 	"context"
-	"io"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -62,14 +61,13 @@ func (s *Storage) NewReader(ctx context.Context, dataRefs []*DataRef, opts ...Re
 	return newReader(ctx, client, s.memCache, s.deduper, s.prefetchLimit, dataRefs, opts...)
 }
 
-func (s *Storage) NewDataReader(ctx context.Context, dataRef *DataRef) io.Reader {
+func (s *Storage) NewDataReader(ctx context.Context, dataRef *DataRef) *DataReader {
 	client := NewClient(s.store, s.db, s.tracker, nil)
 	return newDataReader(ctx, client, s.memCache, s.deduper, dataRef, 0)
 }
 
 func (s *Storage) PrefetchData(ctx context.Context, dataRef *DataRef) error {
-	client := NewClient(s.store, s.db, s.tracker, nil)
-	return newDataReader(ctx, client, s.memCache, s.deduper, dataRef, 0).fetchData()
+	return s.NewDataReader(ctx, dataRef).fetchData()
 }
 
 // List lists all of the chunks in object storage.

--- a/src/internal/storage/chunk/util.go
+++ b/src/internal/storage/chunk/util.go
@@ -22,8 +22,8 @@ func NewTestStorage(t testing.TB, db *pachsql.DB, tr track.Tracker, opts ...Stor
 	return objC, NewStorage(objC, kv.NewMemCache(10), db, tr, opts...)
 }
 
-// Reference creates a data reference for the full chunk referenced by a data reference.
-func Reference(dataRef *DataRef) *DataRef {
+// FullRef creates a data reference for the full chunk referenced by a data reference.
+func FullRef(dataRef *DataRef) *DataRef {
 	chunkDataRef := &DataRef{}
 	chunkDataRef.Ref = dataRef.Ref
 	chunkDataRef.SizeBytes = dataRef.Ref.SizeBytes

--- a/src/internal/storage/fileset/compaction.go
+++ b/src/internal/storage/fileset/compaction.go
@@ -80,6 +80,7 @@ func (s *Storage) Compact(ctx context.Context, ids []ID, ttl time.Duration, opts
 	if err != nil {
 		return nil, err
 	}
+	// TODO: Consider adding prefetching here.
 	if err := CopyDeletedFiles(ctx, w, fs, opts...); err != nil {
 		return nil, err
 	}

--- a/src/internal/storage/fileset/fileset_test.go
+++ b/src/internal/storage/fileset/fileset_test.go
@@ -57,10 +57,10 @@ func checkFile(t *testing.T, f File, tf *testFile) {
 
 // newTestStorage creates a storage object with a test db and test tracker
 // both of those components are kept hidden, so this is only appropriate for testing this package.
-func newTestStorage(t *testing.T) *Storage {
-	db := dockertestenv.NewTestDB(t)
-	tr := track.NewTestTracker(t, db)
-	return NewTestStorage(t, db, tr)
+func newTestStorage(tb testing.TB) *Storage {
+	db := dockertestenv.NewTestDB(tb)
+	tr := track.NewTestTracker(tb, db)
+	return NewTestStorage(tb, db, tr)
 }
 
 func TestWriteThenRead(t *testing.T) {

--- a/src/internal/storage/fileset/prefetcher.go
+++ b/src/internal/storage/fileset/prefetcher.go
@@ -89,15 +89,11 @@ func (p *prefetcher) Iterate(ctx context.Context, cb func(File) error, opts ...i
 			files = append(files, f)
 			return nil
 		}
-		// Handle first chunk.
-		if ref == nil {
-			ref = chunk.FullRef(dataRefs[0])
-		}
 		// Handle files that are fully contained within one chunk.
 		// Buffer the file if it is in the same chunk as the current chunk.
 		// Otherwise, fetch the current chunk, then set up the new current chunk and buffered files.
 		if len(dataRefs) == 1 {
-			if bytes.Equal(dataRefs[0].Ref.Id, ref.Ref.Id) {
+			if ref != nil && bytes.Equal(dataRefs[0].Ref.Id, ref.Ref.Id) {
 				files = append(files, f)
 				return nil
 			}

--- a/src/internal/storage/fileset/prefetcher.go
+++ b/src/internal/storage/fileset/prefetcher.go
@@ -1,0 +1,122 @@
+package fileset
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
+	"golang.org/x/sync/semaphore"
+)
+
+// prefetcher prefetches chunks for the files emitted by the wrapped file set.
+// The prefetching applies at chunk boundaries rather than file boundaries, so
+// it handles the prefetching of chunks that contain the content of many small
+// files as well as chunks that contain the content of a larger file. This is
+// handled by buffering file metadata up to chunk boundaries, then kicking off
+// concurrent tasks to prefetch the chunks and emit the files associated with
+// the chunks.
+type prefetcher struct {
+	FileSet
+	storage *Storage
+}
+
+func NewPrefetcher(storage *Storage, fileSet FileSet) FileSet {
+	return &prefetcher{
+		FileSet: fileSet,
+		storage: storage,
+	}
+}
+
+func (p *prefetcher) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	taskChain := chunk.NewTaskChain(ctx, semaphore.NewWeighted(int64(p.storage.prefetchLimit)))
+	fetchChunk := func(ref *chunk.DataRef, files []File) error {
+		return taskChain.CreateTask(func(ctx context.Context) (func() error, error) {
+			if ref != nil {
+				if err := p.storage.ChunkStorage().PrefetchData(ctx, ref); err != nil {
+					return nil, err
+				}
+			}
+			return func() error {
+				for _, f := range files {
+					if err := cb(f); err != nil {
+						return err
+					}
+				}
+				return nil
+			}, nil
+		})
+	}
+	var ref *chunk.DataRef
+	var files []File
+	maxFilesBuf := p.storage.shardCountThreshold / int64(p.storage.prefetchLimit)
+	if err := p.FileSet.Iterate(ctx, func(f File) error {
+		// Emit the files if a large number are buffered.
+		if int64(len(files)) >= maxFilesBuf {
+			if err := fetchChunk(ref, files); err != nil {
+				return err
+			}
+			ref = nil
+			files = nil
+		}
+		dataRefs := f.Index().File.DataRefs
+		// Handle empty files.
+		// It does not matter which chunk they get emitted with,
+		// just that they are emitted in the correct order.
+		if len(dataRefs) == 0 {
+			files = append(files, f)
+			return nil
+		}
+		// Handle first chunk.
+		if ref == nil {
+			ref = chunk.FullRef(dataRefs[0])
+		}
+		// Handle files that are fully contained within one chunk.
+		// Buffer the file if it is in the same chunk as the current chunk.
+		// Otherwise, fetch the current chunk, then set up the new current chunk and buffered files.
+		if len(dataRefs) == 1 {
+			if bytes.Equal(dataRefs[0].Ref.Id, ref.Ref.Id) {
+				files = append(files, f)
+				return nil
+			}
+			if err := fetchChunk(ref, files); err != nil {
+				return err
+			}
+			ref = chunk.FullRef(dataRefs[0])
+			files = []File{f}
+			return nil
+		}
+		// Handle files that span multiple chunks.
+		// Fetch the curent chunk first.
+		if err := fetchChunk(ref, files); err != nil {
+			return err
+		}
+		// Fetch the first chunk if it is different from the current chunk.
+		// It will be fetched by the above fetchChunk if it is the same.
+		if !bytes.Equal(dataRefs[0].Ref.Id, ref.Ref.Id) {
+			if err := fetchChunk(chunk.FullRef(dataRefs[0]), nil); err != nil {
+				return err
+			}
+		}
+		// Fetch the full chunks that the file spans.
+		for i := 1; i < len(dataRefs)-1; i++ {
+			if err := fetchChunk(chunk.FullRef(dataRefs[i]), nil); err != nil {
+				return err
+			}
+		}
+		// Set the current chunk to the last chunk and buffer the file.
+		// The file will be emitted when the last chunk has been fetched.
+		ref = chunk.FullRef(dataRefs[len(dataRefs)-1])
+		files = []File{f}
+		return nil
+	}, opts...); err != nil {
+		return err
+	}
+	// Emit the last buffered files.
+	if err := fetchChunk(ref, files); err != nil {
+		return err
+	}
+	return taskChain.Wait()
+}

--- a/src/internal/storage/fileset/prefetcher_test.go
+++ b/src/internal/storage/fileset/prefetcher_test.go
@@ -1,0 +1,101 @@
+package fileset
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	units "github.com/docker/go-units"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+)
+
+func createTestFileSet(tb testing.TB, ctx context.Context, s *Storage, numFiles int, fileSize int, random *rand.Rand) FileSet {
+	w := s.NewWriter(ctx)
+	for i := 0; i < numFiles; i++ {
+		data := randutil.Bytes(random, fileSize)
+		require.NoError(tb, w.Add(fmt.Sprintf("%08d", i), DefaultFileDatum, bytes.NewReader(data)))
+	}
+	id, err := w.Close()
+	require.NoError(tb, err)
+	fs, err := s.Open(ctx, []ID{*id})
+	require.NoError(tb, err)
+	return fs
+}
+
+func TestPrefetcher(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStorage(t)
+	seed := int64(1648577872380609229)
+	random := rand.New(rand.NewSource(seed))
+	tests := []struct {
+		name     string
+		numFiles int
+		fileSize int
+	}{
+		{"0B", 1000000, 0},
+		{"1KB", 100000, units.KB},
+		{"100KB", 1000, 100 * units.KB},
+		{"10MB", 10, 10 * units.MB},
+		{"100MB", 1, 100 * units.MB},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := createTestFileSet(t, ctx, s, test.numFiles, test.fileSize, random)
+			fs = NewPrefetcher(s, fs)
+			var i int
+			require.NoError(t, fs.Iterate(ctx, func(f File) error {
+				p, err := strconv.Atoi(f.Index().Path)
+				require.NoError(t, err)
+				require.Equal(t, i, p)
+				i++
+				return nil
+			}))
+			require.Equal(t, test.numFiles, i)
+		})
+	}
+}
+
+func BenchmarkNoPrefetcher(b *testing.B) {
+	benchmarkPrefetcher(b, false)
+}
+
+func BenchmarkPrefetcher(b *testing.B) {
+	benchmarkPrefetcher(b, true)
+}
+
+func benchmarkPrefetcher(b *testing.B, prefetch bool) {
+	ctx := context.Background()
+	s := newTestStorage(b)
+	seed := int64(1648577872380609229)
+	random := rand.New(rand.NewSource(seed))
+	benchmarks := []struct {
+		name     string
+		numFiles int
+		fileSize int
+	}{
+		{"1KB", 100000, units.KB},
+		{"100KB", 1000, 100 * units.KB},
+		{"10MB", 10, 10 * units.MB},
+		{"100MB", 1, 100 * units.MB},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			fs := createTestFileSet(b, ctx, s, benchmark.numFiles, benchmark.fileSize, random)
+			if prefetch {
+				fs = NewPrefetcher(s, fs)
+			}
+			b.SetBytes(int64(benchmark.numFiles * benchmark.fileSize))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				require.NoError(b, fs.Iterate(ctx, func(f File) error {
+					return f.Content(ctx, io.Discard)
+				}))
+			}
+		})
+	}
+}

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -197,9 +197,10 @@ func (d *driver) getFile(ctx context.Context, file *pfs.File, pathRange *pfs.Pat
 		return nil, err
 	}
 	opts = append(opts, WithFilter(func(fs fileset.FileSet) fileset.FileSet {
-		return fileset.NewIndexFilter(fs, func(idx *index.Index) bool {
+		fs = fileset.NewIndexFilter(fs, func(idx *index.Index) bool {
 			return mf(idx.Path)
 		}, true)
+		return fileset.NewPrefetcher(d.storage, fs)
 	}))
 	s := NewSource(commitInfo, fs, opts...)
 	return NewErrOnEmpty(s, &pfsserver.ErrFileNotFound{File: file}), nil


### PR DESCRIPTION
This PR implements a file set layer chunk prefetcher that is used when getting small / medium (KB/MB) files from PFS. Prior to this, chunk prefetching would only be effective for larger files (~100MB+), which meant that getting large batches of small / medium files would be subject to serially downloading and processing the chunks.