### PR TITLE
[2.3.x Backport] Use external postgres secret when requested (#8138)

### DIFF
--- a/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/deployment.yaml
@@ -2,7 +2,10 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.enterpriseServer.enabled }}
+{{- if .Values.enterpriseServer.enabled -}}
+{{- if .Values.pachd.enabled -}}
+{{- fail "pachd and enterpriseServer shall not be enabled at the same time in the same namespace" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,11 +61,20 @@ spec:
           value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
         - name: POSTGRES_USER
           value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
+        {{- if .Values.global.postgresql.ssl }}
+        - name: POSTGRES_SSL
+          value: "require"
+        {{- end }}
+        {{- if .Values.cloudsqlAuthProxy.iamLogin }}
+        - name: POSTGRES_PASSWORD
+          value: "Using-iamLogin"
+        {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres # Must match secret setup by postgres subchart or postgres-secret.yaml if using external postgres
-              key: postgresql-password
+              name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
+              key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
+        {{- end }}
         {{- if and .Values.enterpriseServer.tls.enabled .Values.global.customCaCerts }}
         - name: SSL_CERT_DIR
           value:  /pachd-tls-cert
@@ -252,4 +264,4 @@ spec:
         secret:
           secretName: {{ required "If enterpriseServer.tls.enabled, you must set enterpriseServer.tls.secretName" .Values.enterpriseServer.tls.secretName | quote }}
       {{- end }}
-{{- end }}
+{{- end -}}

--- a/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
+++ b/etc/helm/pachyderm/templates/enterprise-server/postgres-secret.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.enterpriseServer.enabled (not .Values.postgresql.enabled) -}}
+{{- if and .Values.enterpriseServer.enabled (not .Values.postgresql.enabled) (not .Values.global.postgresql.postgresqlExistingSecretName) (not .Values.cloudsqlAuthProxy.iamLogin) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -2,7 +2,10 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if .Values.pachd.enabled }}
+{{- if .Values.pachd.enabled -}}
+{{- if .Values.enterpriseServer.enabled -}}
+{{- fail "pachd and enterpriseServer shall not be enabled at the same time in the same namespace" -}}
+{{- end -}}
 {{- $randHostPath := printf "/var/pachyderm-%s/" (randAlphaNum 5) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -443,4 +446,4 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.oidc.dexCredentialSecretName }}
       {{- end }}
-{{- end }}
+{{- end -}}


### PR DESCRIPTION
* use external postgres secret when requested

* skip secret creation if external postgres is set

* handle cloudproxy and tls case for postgres

* generate exactly one postgres secret when both pachd and enterprise-server are enabled

* Revert "generate exactly one postgres secret when both pachd and enterprise-server are enabled"

This reverts commit f0885876deb3f6c1c7b848bbc6b29dc31d1e9e17.

* mutually exclude deployments of pachd and enterprise-server