### PR TITLE
Fix file set renewal in new compaction algorithm

### DIFF
--- a/src/internal/storage/fileset/compaction_test.go
+++ b/src/internal/storage/fileset/compaction_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestCompactLevelBasedFuzz(t *testing.T) {
@@ -72,7 +73,7 @@ func TestCompactLevelBasedFuzz(t *testing.T) {
 	}
 	logger := log.StandardLogger()
 	logger.SetOutput(io.Discard)
-	id, err := s.CompactLevelBased(ctx, log.NewEntry(logger), ids, maxFanIn, track.NoTTL, compact)
+	id, err := s.CompactLevelBased(ctx, log.NewEntry(logger), ids, maxFanIn, time.Minute, compact)
 	require.NoError(t, err)
 	// Check the compaction score of the final file set to ensure no file sets were lost.
 	prims, err := s.flattenPrimitives(ctx, []ID{*id})
@@ -85,4 +86,69 @@ func TestCompactLevelBasedFuzz(t *testing.T) {
 	// Check that compact was called the expected number of times.
 	numCompactions := (numFileSets - 1) / (maxFanIn - 1)
 	require.Equal(t, numCompactions, count)
+}
+
+func TestCompactLevelBasedRenewal(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStorage(t)
+	ttl := 100 * time.Millisecond
+	gc := s.NewGC(ttl)
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var eg *errgroup.Group
+	eg, ctx = errgroup.WithContext(cancelCtx)
+	eg.Go(func() error {
+		err := gc.RunForever(ctx)
+		if errors.Is(cancelCtx.Err(), context.Canceled) {
+			err = nil
+		}
+		return err
+	})
+	numFileSets := 1000
+	maxFanIn := 10
+	var id *ID
+	eg.Go(func() error {
+		defer cancel()
+		var ids []ID
+		for i := 0; i < numFileSets; i++ {
+			prim := &Primitive{
+				Additive: &index.Index{
+					NumFiles: 1,
+				},
+			}
+			id, err := s.newPrimitive(ctx, prim, track.NoTTL)
+			if err != nil {
+				return err
+			}
+			ids = append(ids, *id)
+		}
+		compact := func(ctx context.Context, _ *log.Entry, ids []ID, ttl time.Duration) (*ID, error) {
+			time.Sleep(3 * ttl)
+			additive := &index.Index{}
+			for _, id := range ids {
+				prim, err := s.getPrimitive(ctx, id)
+				if err != nil {
+					return nil, err
+				}
+				additive.NumFiles += prim.Additive.NumFiles
+			}
+			return s.newPrimitive(ctx, &Primitive{
+				Additive: additive,
+			}, ttl)
+		}
+		logger := log.StandardLogger()
+		logger.SetOutput(io.Discard)
+		var err error
+		id, err = s.CompactLevelBased(ctx, log.NewEntry(logger), ids, maxFanIn, ttl, compact)
+		return err
+	})
+	require.NoError(t, eg.Wait())
+	ctx = context.Background()
+	prims, err := s.flattenPrimitives(ctx, []ID{*id})
+	require.NoError(t, err)
+	var numFiles int64
+	for _, prim := range prims {
+		numFiles += prim.Additive.NumFiles
+	}
+	require.Equal(t, int64(numFileSets), numFiles)
 }


### PR DESCRIPTION
This PR fixes file set renewal in the new compaction algorithm. The intermediary file sets during the level based compaction were not getting renewed, so they would get garbage collected during longer compactions. This PR also adds a test that simulates this scenario by running the garbage collector and lowering the ttl for file sets such that they are less than the run time for a test compactor.