### PR TITLE
remove docker version spec in ci

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -845,7 +845,7 @@ jobs:
           path: ~/project
       - attach_workspace:
           at: .
-      - setup_remote_docker:
+      - setup_remote_docker
       - run:
           name: docker login
           command: echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
@@ -864,7 +864,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - setup_remote_docker:
+      - setup_remote_docker
       - run:
           name: docker login
           command: echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -559,7 +559,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: "20.10.12"
       - run:
           name: Install Goreleaser
           command: |
@@ -847,7 +846,6 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 19.03.13
       - run:
           name: docker login
           command: echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
@@ -867,7 +865,6 @@ jobs:
       - checkout:
           path: ~/project
       - setup_remote_docker:
-          version: 19.03.13
       - run:
           name: docker login
           command: echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
@@ -1065,7 +1062,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: "20.10.12"
       - run:
           name: pachydermbuildbot docker login
           command: |

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -35,7 +35,7 @@ fi
 # To get the latest minikube version:
 # curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[].tag_name | sort -V | tail -n1
 if [ ! -f cached-deps/minikube ] ; then
-    MINIKUBE_VERSION=v1.26.0 
+    MINIKUBE_VERSION=v1.27.0
     curl -L -o minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
         chmod +x ./minikube
         mv ./minikube cached-deps/minikube


### PR DESCRIPTION
use the default docker version rather than specifying one per job.