### PR TITLE
PPS: Be more careful about k8s errors during RC updates

### DIFF
--- a/src/internal/promutil/promutil.go
+++ b/src/internal/promutil/promutil.go
@@ -62,7 +62,7 @@ func (rt *loggingRT) RoundTrip(req *http.Request) (*http.Response, error) {
 		log.WithFields(logrus.Fields{
 			"duration": time.Since(start),
 			"status":   res.Status,
-		}).Infof("outgoing http request complete")
+		}).Debugf("outgoing http request complete")
 	}
 	return res, err
 }

--- a/src/internal/promutil/promutil.go
+++ b/src/internal/promutil/promutil.go
@@ -4,10 +4,12 @@ package promutil
 import (
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -28,6 +30,43 @@ var (
 	}, []string{"client", "method"})
 )
 
+type loggingRT struct {
+	name       string
+	underlying http.RoundTripper
+}
+
+func (rt *loggingRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	log := logrus.WithFields(logrus.Fields{
+		"name":   rt.name,
+		"method": req.Method,
+		"uri":    req.URL.String(),
+	})
+
+	// Log the start of long HTTP requests.
+	timer := time.AfterFunc(10*time.Second, func() {
+		l := log
+		if dl, ok := req.Context().Deadline(); ok {
+			l = l.WithField("deadline", time.Until(dl))
+		}
+		l.WithField("duration", time.Since(start)).Info("ongoing long http request")
+	})
+	defer timer.Stop()
+
+	res, err := rt.underlying.RoundTrip(req)
+	if err != nil {
+		log.WithError(err).Info("outgoing http request completed with error")
+		return res, err
+	}
+	if res != nil {
+		log.WithFields(logrus.Fields{
+			"duration": time.Since(start),
+			"status":   res.Status,
+		}).Infof("outgoing http request complete")
+	}
+	return res, err
+}
+
 // InstrumentRoundTripper returns an http.RoundTripper that collects Prometheus metrics; delegating
 // to the underlying RoundTripper to actually make requests.
 func InstrumentRoundTripper(name string, rt http.RoundTripper) http.RoundTripper {
@@ -41,7 +80,7 @@ func InstrumentRoundTripper(name string, rt http.RoundTripper) http.RoundTripper
 			requestTimeMetric.MustCurryWith(ls),
 			promhttp.InstrumentRoundTripperCounter(
 				requestCountMetric.MustCurryWith(ls),
-				rt)))
+				&loggingRT{name: name, underlying: rt})))
 }
 
 // Adder is something that can be added to.

--- a/src/internal/promutil/promutil.go
+++ b/src/internal/promutil/promutil.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -56,7 +57,7 @@ func (rt *loggingRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := rt.underlying.RoundTrip(req)
 	if err != nil {
 		log.WithError(err).Info("outgoing http request completed with error")
-		return res, err
+		return res, errors.EnsureStack(err)
 	}
 	if res != nil {
 		log.WithFields(logrus.Fields{
@@ -64,7 +65,7 @@ func (rt *loggingRT) RoundTrip(req *http.Request) (*http.Response, error) {
 			"status":   res.Status,
 		}).Debugf("outgoing http request complete")
 	}
-	return res, err
+	return res, errors.EnsureStack(err)
 }
 
 // InstrumentRoundTripper returns an http.RoundTripper that collects Prometheus metrics; delegating

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -79,10 +79,19 @@ type stepError struct {
 }
 
 func newRetriableError(err error, message string) error {
+	retry, failPipeline := true, true
+	if errors.Is(err, context.Canceled) {
+		retry = false
+		failPipeline = false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		retry = true
+		failPipeline = false
+	}
 	return stepError{
 		error:        errors.Wrap(err, message),
-		retry:        true,
-		failPipeline: true,
+		retry:        retry,
+		failPipeline: failPipeline,
 	}
 }
 

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -60,6 +61,26 @@ const (
 	sideEffectName_CRASH_MONITOR        sideEffectName = 5
 )
 
+// String implements fmt.Stringer.
+func (s sideEffectName) String() string {
+	switch s {
+	case sideEffectName_KUBERNETES_RESOURCES:
+		return "KUBERNETES_RESOURCES"
+	case sideEffectName_FINISH_COMMITS:
+		return "FINISH_COMMITS"
+	case sideEffectName_RESTART:
+		return "RESTART"
+	case sideEffectName_SCALE_WORKERS:
+		return "SCALE_WORKERS"
+	case sideEffectName_PIPELINE_MONITOR:
+		return "PIPELINE_MONITOR"
+	case sideEffectName_CRASH_MONITOR:
+		return "CRASH_MONITOR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 type sideEffectToggle int32
 
 const (
@@ -67,6 +88,20 @@ const (
 	sideEffectToggle_UP   sideEffectToggle = 1
 	sideEffectToggle_DOWN sideEffectToggle = 2
 )
+
+// String implements fmt.Stringer.
+func (s sideEffectToggle) String() string {
+	switch s {
+	case sideEffectToggle_NONE:
+		return "NONE"
+	case sideEffectToggle_UP:
+		return "UP"
+	case sideEffectToggle_DOWN:
+		return "DOWN"
+	default:
+		return "UNKNOWN"
+	}
+}
 
 // sideEffect intends to capture a state changing operation that the pipeline controller may apply
 // NOTE: the PipelineInfo & ReplicationController arguments supplied to apply should be treated as read only copies
@@ -78,6 +113,18 @@ type sideEffect struct {
 
 func (se sideEffect) equals(o sideEffect) bool {
 	return se.name == o.name && se.toggle == o.toggle
+}
+
+// String implements fmt.Stringer.
+func (se sideEffect) String() string {
+	b := new(strings.Builder)
+	b.WriteString(se.name.String())
+	if t := se.toggle; t != sideEffectToggle_NONE {
+		b.WriteString(" (")
+		b.WriteString(t.String())
+		b.WriteString(")")
+	}
+	return b.String()
 }
 
 func ResourcesSideEffect(toggle sideEffectToggle) sideEffect {

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -471,7 +471,7 @@ func evaluate(pi *pps.PipelineInfo, rc *v1.ReplicationController) (pps.PipelineS
 func (pc *pipelineController) apply(ctx context.Context, pi *pps.PipelineInfo, rc *v1.ReplicationController, target pps.PipelineState, sideEffects []sideEffect, reason string) error {
 	for _, s := range sideEffects {
 		if err := s.apply(ctx, pc, pi, rc); err != nil {
-			return err
+			return errors.Wrapf(err, "apply side effect %s", s.String())
 		}
 	}
 	if target != pi.State {

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -626,11 +626,11 @@ func (pc *pipelineController) scaleUpPipeline(ctx context.Context, pi *pps.Pipel
 				return nil
 			})
 			// Set parallelism
-			log.Debugf("PPS master: beginning scale-up check for %q, which has %d tasks",
-				pi.Pipeline.Name, nTasks)
+			log.Debugf("PPS master: beginning scale-up check for %q, which has %d tasks and %d workers",
+				pi.Pipeline.Name, nTasks, curScale)
 			switch {
 			case err != nil || nTasks == 0:
-				if err != nil {
+				if err == nil {
 					log.Infof("PPS master: tasks remaining for %q not known (possibly still being calculated)",
 						pi.Pipeline.Name)
 				} else {
@@ -662,10 +662,11 @@ func (pc *pipelineController) scaleUpPipeline(ctx context.Context, pi *pps.Pipel
 			}()
 		}
 		if curScale == targetScale {
+			log.Debugf("PPS master: pipeline %q is at desired scale", pi.GetPipeline().GetName())
 			return false // no changes necessary
 		}
 		// Update the # of replicas
-		log.Debugf("PPS master: scale up pipeline %q from %d to %d replicas", pi.GetPipeline().GetName(), curScale, targetScale)
+		log.Debugf("PPS master: scale pipeline %q from %d to %d replicas", pi.GetPipeline().GetName(), curScale, targetScale)
 		rc.Spec.Replicas = &targetScale
 		return true
 	}))


### PR DESCRIPTION
A customer was seeing the symptom of having work-in-progress canceled, with PIPELINE_FAILED and "error updating RC: context canceled" in the "reason" field.  This can only happen if the context is canceled while talking to k8s.  Why it's canceled is unclear; the most obvious point of cancelation is the PPS master losing its lease.  But I tried that, and the symptoms are different; when the master restarts, it scales workers down to 0 (as the transition into PIPELINE_STANDBY) at the k8s level without calling StopJob (which was happening in the customer's case).  To truly understand what's going on here, we should have a reproduction that causes "context canceled" while talking to k8s.  (We don't set a deadline or anything like that.)

This PR has some preemptive fixes.  I've made "context canceled" into an error that doesn't fail the pipeline outright.  That should prevent scaling down to 0 when the context gets canceled.  I also handle "deadline exceeded" there (with retry allowed) in case we add RPC deadlines around k8s in the future; we should, because we don't want to wait "forever" on a misbehaving k8s API server, which is what we do now.

I also added a ton of logging:

* All outgoing HTTP requests are logged when they complete, or if they're taking more than 10 seconds.  The completion is DEBUG level, because PPS polls RCs constantly and it would be too many logs.  Long requests are INFO though, so we should always have those in debug dumps.  The side effect of this change is that other stuff is logged, like reads and writes from object storage.  Things like that make me want to log at INFO level (it's quite informative), but I'll skip that for now.
* When a step in the pipeline controller fails to apply, we now return a description of the step in the error message ("KUBERNETES_RESOURCES(UP)" for example).  If we had that logging for this customer issue, it would be clear exactly what operation failed.  This involves implementing fmt.Stringer for side effects.  A lot of lines but straightforward code.
* Added a bunch of log messages around scaling up and enhanced the detail in the existing ones.
* Corrected some log messages that should be prefixed with "PPS master:" to include that prefix.

Right now, this isn't a full fix of all the problems, but will give us more debugging information next time.  The user will also see more detail in the "reason" field when a pipeline transitions into the failure state because of failing-to-apply side effects.

This is a difficult one to add automated tests for.  I tested manually extensively:

* To make k8s fail with "context canceled", I made losing the PPS master into an on-demand thing (`func init() { go http.ListenAndServe(func{ cancel() })`).  This didn't reproduce the customer's issue.
* I added another similar handler to make k8s return "context canceled" without causing the PPS master to exit.  This DOES reproduce the issue when it happens during autoscaling scale up, and this PR does fix that issue.   (Submit a job, wait for it to start, make k8s slow, submit another job, note failure when k8s call fails during autoscaling up.)
* I SIGSTOP'd my API server to test the logging around long HTTP requests.  It works.