### PR TITLE
[Jupyter] Fix deleting a mounted repo error

### DIFF
--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
@@ -28,7 +28,7 @@ const ListUnmount: React.FC<ListUnmountProps> = ({item, open, updateData}) => {
   useEffect(() => {
     if (hasBranches) {
       const found = item.branches.find((branch) => branch === 'master');
-      setSelectedBranch(found ? found : item.branches[0]);
+      setSelectedBranch(found ? found : item.branches.sort()[0]);
       setDisabled(false);
     }
   }, [item]);
@@ -125,7 +125,7 @@ const ListUnmount: React.FC<ListUnmountProps> = ({item, open, updateData}) => {
                 onChange={onChange}
                 data-testid="ListItem__select"
               >
-                {item.branches.map((branch) => {
+                {item.branches.sort().map((branch) => {
                   return (
                     <option key={branch} value={branch}>
                       {branch}

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -201,21 +201,25 @@ func (mm *MountManager) ListByMounts() (ListMountResponse, error) {
 		mr.Unmounted[repo.Repo.Name] = rr
 	}
 
-	// Go through mounts and populate data to show in Mounted section
+	// Unmount mounted repos that were deleted
 	for name, msm := range mm.States {
 		if msm.State == "mounted" {
-			// Check if mount that was deleted still exists in mm.States
 			_, ok := repoBranches[msm.Repo]
 			if !ok {
 				mm.unmountDeletedRepos(name)
 				continue
 			}
 			_, ok = repoBranches[msm.Repo][msm.Branch]
-			if !ok {
+			if !ok && msm.Mode == "ro" {
 				mm.unmountDeletedRepos(name)
 				continue
 			}
+		}
+	}
 
+	// Go through mounts and populate data to show in Mounted section
+	for name, msm := range mm.States {
+		if msm.State == "mounted" {
 			if err := msm.RefreshMountState(); err != nil {
 				return mr, err
 			}

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -587,3 +587,58 @@ func TestHealth(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestDeletingMountedRepo(t *testing.T) {
+	env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	require.NoError(t, env.PachClient.CreateProjectRepo(pfs.DefaultProjectName, "repo"))
+
+	commit := client.NewProjectCommit(pfs.DefaultProjectName, "repo", "b1", "")
+	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	commit = client.NewProjectCommit(pfs.DefaultProjectName, "repo", "b2", "")
+	err = env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
+		mr := MountRequest{
+			Mounts: []*MountInfo{
+				{
+					Name:   "repo_b1",
+					Repo:   "repo",
+					Branch: "b1",
+					Mode:   "ro",
+				},
+				{
+					Name:   "repo_b2",
+					Repo:   "repo",
+					Branch: "b2",
+					Mode:   "ro",
+				},
+			},
+		}
+		b := new(bytes.Buffer)
+		require.NoError(t, json.NewEncoder(b).Encode(mr))
+		_, err := put("_mount", b)
+		require.NoError(t, err)
+
+		env.PachClient.DeleteProjectBranch(pfs.DefaultProjectName, "repo", "b1", false)
+		resp, err := get("mounts")
+		require.NoError(t, err)
+
+		mountResp := &ListMountResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(mountResp))
+		require.Equal(t, 1, len((*mountResp).Mounted))
+		require.Equal(t, "b2", (*mountResp).Mounted["repo_b2"].Branch)
+		require.Equal(t, 1, len((*mountResp).Unmounted))
+
+		env.PachClient.DeleteProjectRepo(pfs.DefaultProjectName, "repo", false)
+		resp, err = get("mounts")
+		require.NoError(t, err)
+
+		mountResp = &ListMountResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(mountResp))
+		require.Equal(t, 0, len((*mountResp).Mounted))
+		require.Equal(t, 0, len((*mountResp).Unmounted))
+	})
+}

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -610,6 +610,12 @@ func TestDeletingMountedRepo(t *testing.T) {
 					Mode:   "ro",
 				},
 				{
+					Name:   "repo_b1_dup",
+					Repo:   "repo",
+					Branch: "b1",
+					Mode:   "ro",
+				},
+				{
 					Name:   "repo_b2",
 					Repo:   "repo",
 					Branch: "b2",


### PR DESCRIPTION
In notebooks, when a mounted repo/branch is deleted, the extension crashes. This prevents the error by removing any trace of that mount from the mounted/unmounted repos list and from the file browser, leaving notebooks in a usable state.

Jira: https://pachyderm.atlassian.net/browse/INT-536