### PR TITLE
debug: print debug dump download progress information in pachctl

### DIFF
--- a/src/server/debug/cmds/cmds.go
+++ b/src/server/debug/cmds/cmds.go
@@ -1,10 +1,15 @@
 package cmds
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/pachyderm/pachyderm/v2/src/server/debug/shell"
 
 	"github.com/gogo/protobuf/types"
@@ -47,8 +52,8 @@ func Cmds() []*cobra.Command {
 			if err != nil {
 				return err
 			}
-			return withFile(args[1], func(f *os.File) error {
-				return client.Profile(p, filter, f)
+			return withFile(os.Stderr, args[1], func(w io.Writer) error {
+				return client.Profile(p, filter, w)
 			})
 		}),
 	}
@@ -72,8 +77,8 @@ func Cmds() []*cobra.Command {
 			if err != nil {
 				return err
 			}
-			return withFile(args[0], func(f *os.File) error {
-				return client.Binary(filter, f)
+			return withFile(os.Stderr, args[0], func(w io.Writer) error {
+				return client.Binary(filter, w)
 			})
 		}),
 	}
@@ -97,8 +102,8 @@ func Cmds() []*cobra.Command {
 			if err != nil {
 				return err
 			}
-			return withFile(args[0], func(f *os.File) error {
-				return client.Dump(filter, limit, f)
+			return withFile(os.Stderr, args[0], func(w io.Writer) error {
+				return client.Dump(filter, limit, w)
 			})
 		}),
 	}
@@ -156,7 +161,64 @@ func createFilter(pachd, database bool, pipeline, worker string) (*debug.Filter,
 	return f, nil
 }
 
-func withFile(file string, cb func(*os.File) error) (retErr error) {
+// progressWriter is an io.Writer that logs a progress update after each write.  The output is in
+// the form "1.2KiB 42%" with a spinner that changes with each write even if the number doesn't.
+// The updates occur in-place and the progress update is replaced with "done." when done.
+type progressWriter struct {
+	log                          io.Writer
+	wrote                        string
+	spinnerState, current, total int
+}
+
+// Write implements io.Writer.
+func (w *progressWriter) Write(buf []byte) (n int, err error) {
+	w.spinnerState++
+	w.current += len(buf)
+
+	backspaces, msg, clear := new(strings.Builder), new(strings.Builder), new(strings.Builder)
+	for i := 0; i < len(w.wrote); i++ {
+		// Backspace over the last write.
+		backspaces.WriteByte('\b')
+	}
+
+	// Print current number of bytes downloaded.
+	msg.WriteString(humanize.IBytes(uint64(w.current)))
+
+	if w.current == w.total {
+		// Print "done."
+		msg.WriteString(" done.")
+	} else {
+		// Print the % indicator.
+		fmt.Fprintf(msg, "%3.f%% ", 100*float64(w.current)/float64(w.total))
+
+		// Print the spinner.
+		switch w.spinnerState % 4 {
+		case 0:
+			msg.WriteByte('|')
+		case 1:
+			msg.WriteByte('/')
+		case 2:
+			msg.WriteByte('-')
+		case 3:
+			msg.WriteByte('\\')
+		}
+	}
+
+	// Clear any bytes remaining at the end of the line.
+	for _, b := range []byte{' ', '\b'} {
+		for i := msg.Len(); i < len(w.wrote); i++ {
+			clear.WriteByte(b)
+		}
+	}
+
+	fmt.Fprintf(w.log, "%s%s%s", backspaces.String(), msg.String(), clear.String())
+	w.wrote = msg.String()
+
+	return len(buf), nil
+}
+
+func withFile(log io.Writer, file string, cb func(io.Writer) error) (retErr error) {
+	// Create the named file on disk.
 	f, err := os.Create(file)
 	if err != nil {
 		return errors.EnsureStack(err)
@@ -166,5 +228,52 @@ func withFile(file string, cb func(*os.File) error) (retErr error) {
 			retErr = err
 		}
 	}()
-	return cb(f)
+
+	// This syncronization allows tests to ensure we do not keep the reader running forever,
+	// which would result in lost data in real life.
+	doneCh := make(chan struct{})
+	defer func() { <-doneCh }()
+
+	// Create a pipe which will let the progress producer see the bytes written to the
+	// callback's writer (a MultiWriter between f and w).
+	r, w := io.Pipe()
+	defer w.Close()
+
+	// In the background, print progress information as tar.gz bytes arrive.
+	go func() {
+		defer close(doneCh)
+		// Consume all bytes even if we error out.
+		defer io.Copy(io.Discard, r) //nolint:errcheck
+
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			fmt.Fprintf(log, "debug: problem creating gzip reader: %v\n", err)
+			return
+		}
+		defer gr.Close()
+
+		tr := tar.NewReader(gr)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(log, "debug: problem reading tar header: %v\n", err)
+				return
+			}
+
+			fmt.Fprintf(log, "debug: receiving sub-file %s (%s): ", hdr.Name, humanize.IBytes(uint64(hdr.Size)))
+			pw := &progressWriter{
+				total: int(hdr.Size),
+				log:   log,
+			}
+			if _, err := io.Copy(pw, tr); err != nil {
+				fmt.Fprintf(log, "\ndebug: problem reading sub-file %s: %v", hdr.Name, err)
+			}
+			fmt.Fprintln(log, "")
+		}
+	}()
+
+	return cb(io.MultiWriter(f, w))
 }

--- a/src/server/debug/cmds/cmds_test.go
+++ b/src/server/debug/cmds/cmds_test.go
@@ -1,0 +1,111 @@
+package cmds
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+)
+
+func TestWithFile(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    []byte
+		wantLogs *regexp.Regexp
+	}{
+		{
+			name:     "empty",
+			wantLogs: regexp.MustCompile("problem creating gzip reader: EOF"),
+		},
+		{
+			name:     "not_gzipped",
+			input:    []byte("this is an ordinary file\n"),
+			wantLogs: regexp.MustCompile("problem creating gzip reader"),
+		},
+		{
+			name: "not_tarred",
+			input: func() []byte {
+				buf := new(bytes.Buffer)
+				gw := gzip.NewWriter(buf)
+				if _, err := fmt.Fprintf(gw, "this text will be compressed\n"); err != nil {
+					panic(err)
+				}
+				if err := gw.Close(); err != nil {
+					panic(err)
+				}
+				return buf.Bytes()
+			}(),
+			wantLogs: regexp.MustCompile("problem reading tar header"),
+		},
+		{
+			name: "tgz",
+			input: func() []byte {
+				buf := new(bytes.Buffer)
+				gw := gzip.NewWriter(buf)
+				tw := tar.NewWriter(gw)
+				for _, file := range []string{"foo", "bar", "baz", "quux"} {
+					if err := tw.WriteHeader(&tar.Header{
+						Name: file,
+						Size: int64(100000 * (len(file) + 1)),
+					}); err != nil {
+						panic(err)
+					}
+					for i := 0; i < 100000; i++ {
+						if _, err := fmt.Fprintf(tw, "%s\n", file); err != nil {
+							panic(err)
+						}
+					}
+				}
+				if err := tw.Close(); err != nil {
+					panic(err)
+				}
+				if err := gw.Close(); err != nil {
+					panic(err)
+				}
+				return buf.Bytes()
+			}(),
+			wantLogs: regexp.MustCompile("(?s)receiving sub-file foo.*done.*receiving sub-file bar.*done"),
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			name := filepath.Join(t.TempDir(), test.name)
+			logs := new(bytes.Buffer)
+			err := withFile(logs, name, func(w io.Writer) error {
+				_, err := io.Copy(w, bytes.NewReader(test.input))
+				return errors.EnsureStack(err)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(got, test.input, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("downloaded file content:\n%s", diff)
+			}
+
+			if test.wantLogs != nil {
+				if !test.wantLogs.MatchString(logs.String()) {
+					t.Error("logs did not match regexp")
+					for _, l := range strings.Split(logs.String(), "\n") {
+						t.Log(l)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR modifies pachctl to decode the content of a debug dump as it's streamed to the client and display how far along it is.  If it gets stuck, there's something to paste in so that we can attempt to debug debug dumping, which has unfortunately become necessary recently.

I have taken great pains to preserve the downloaded bytes even if they aren't .tgz (see tests), and to not interfere with downloading even if tgz decoding fails midway through the file.

Here's a demo!!

https://user-images.githubusercontent.com/2367/195169881-36d698e4-88a1-4868-a2ac-78e2cb79d4e9.mp4

Part of CORE-1125.
