### PR TITLE
require scheme on userAccessibleOauthIssuerHost

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -135,7 +135,7 @@ true
 {{- define "pachyderm.userAccessibleOauthIssuerHost" -}}
 {{- if .Values.oidc.userAccessibleOauthIssuerHost -}}
   {{- if not (hasPrefix "http" .Values.oidc.userAccessibleOauthIssuerHost) -}}
-    {{ fail (printf "oidc.userAccessibleOauthIssuerHost must begin with http:// or https://, not %s" .Values.oidc.userAccessibleOauthIssuerHost) }}
+    {{- printf "%s://%s" (include "pachyderm.hostproto" .) .Values.oidc.userAccessibleOauthIssuerHost -}}
   {{- end -}}
 {{ .Values.oidc.userAccessibleOauthIssuerHost }}
 {{- else if (include "pachyderm.host" .) -}}

--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -136,8 +136,9 @@ true
 {{- if .Values.oidc.userAccessibleOauthIssuerHost -}}
   {{- if not (hasPrefix "http" .Values.oidc.userAccessibleOauthIssuerHost) -}}
     {{- printf "%s://%s" (include "pachyderm.hostproto" .) .Values.oidc.userAccessibleOauthIssuerHost -}}
+  {{- else -}}
+  {{ .Values.oidc.userAccessibleOauthIssuerHost }}
   {{- end -}}
-{{ .Values.oidc.userAccessibleOauthIssuerHost }}
 {{- else if (include "pachyderm.host" .) -}}
 {{- printf "%s://%s" (include "pachyderm.hostproto" .) (include "pachyderm.host" .) -}}
 {{- else  -}}

--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -134,11 +134,14 @@ true
 
 {{- define "pachyderm.userAccessibleOauthIssuerHost" -}}
 {{- if .Values.oidc.userAccessibleOauthIssuerHost -}}
+  {{- if not (hasPrefix "http" .Values.oidc.userAccessibleOauthIssuerHost) -}}
+    {{ fail (printf "oidc.userAccessibleOauthIssuerHost must begin with http:// or https://, not %s" .Values.oidc.userAccessibleOauthIssuerHost) }}
+  {{- end -}}
 {{ .Values.oidc.userAccessibleOauthIssuerHost }}
 {{- else if (include "pachyderm.host" .) -}}
-{{- (include "pachyderm.host" .) -}}
+{{- printf "%s://%s" (include "pachyderm.hostproto" .) (include "pachyderm.host" .) -}}
 {{- else  -}}
-localhost:30658
+http://localhost:30658
 {{- end -}}
 {{- end }}
 

--- a/src/auth/auth.pb.go
+++ b/src/auth/auth.pb.go
@@ -561,8 +561,8 @@ type OIDCConfig struct {
 	LocalhostIssuer bool `protobuf:"varint,7,opt,name=localhost_issuer,json=localhostIssuer,proto3" json:"localhost_issuer,omitempty"`
 	// user_accessible_issuer_host can be set to override the host used
 	// in the OAuth2 authorization URL in case the OIDC issuer isn't
-	// accessible outside the cluster. This is necessary to support
-	// some configurations like Minikube.
+	// accessible outside the cluster. This requires a fully formed URL with scheme of either http or https.
+	// This is necessary to support some configurations like Minikube.
 	UserAccessibleIssuerHost string   `protobuf:"bytes,8,opt,name=user_accessible_issuer_host,json=userAccessibleIssuerHost,proto3" json:"user_accessible_issuer_host,omitempty"`
 	XXX_NoUnkeyedLiteral     struct{} `json:"-"`
 	XXX_unrecognized         []byte   `json:"-"`

--- a/src/auth/auth.proto
+++ b/src/auth/auth.proto
@@ -10,8 +10,8 @@ import "google/protobuf/timestamp.proto";
  *
  * In Pachyderm, usernames are structured strings. This makes both
  * our API and our data model more flexible (at the loss of some type safety).
- * Basically, anywhere that Pachyderm refers to a subject (i.e. TokenInfo) or 
- * principal (ACL, the 'admins' collection), that username will have some 
+ * Basically, anywhere that Pachyderm refers to a subject (i.e. TokenInfo) or
+ * principal (ACL, the 'admins' collection), that username will have some
  * structured prefix.
  *
  * Note that externally-facing principals ({Get,Set}{Scope,ACL}, ModifyAdmins,
@@ -55,7 +55,7 @@ message RotateRootTokenResponse {
   string root_token = 1;
 }
 
-// Configure Pachyderm's auth system with an OIDC provider 
+// Configure Pachyderm's auth system with an OIDC provider
 message OIDCConfig{
   string issuer = 1;
   string client_id = 2 [(gogoproto.customname) = "ClientID"];
@@ -66,13 +66,13 @@ message OIDCConfig{
 
  // localhost_issuer ignores the contents of the issuer claim and makes all
  // OIDC requests to the embedded OIDC provider. This is necessary to support
- // some network configurations like Minikube. 
+ // some network configurations like Minikube.
  bool localhost_issuer = 7;
 
-  // user_accessible_issuer_host can be set to override the host used 
+  // user_accessible_issuer_host can be set to override the host used
   // in the OAuth2 authorization URL in case the OIDC issuer isn't
-  // accessible outside the cluster. This is necessary to support 
-  // some configurations like Minikube.
+  // accessible outside the cluster. This requires a fully formed URL with scheme of either http or https.
+  // This is necessary to support some configurations like Minikube.
   string user_accessible_issuer_host = 8;
 }
 
@@ -144,7 +144,7 @@ message RoleBinding {
   map<string, Roles> entries = 1;
 }
 
-// Permission represents the ability to perform a given operation on a Resource 
+// Permission represents the ability to perform a given operation on a Resource
 enum Permission {
   PERMISSION_UNKNOWN = 0;
 
@@ -232,7 +232,7 @@ enum ResourceType {
 
 // Resource represents any resource that has role-bindings in the system
 message Resource {
-  ResourceType type = 1; 
+  ResourceType type = 1;
   string name = 2;
 }
 
@@ -247,7 +247,7 @@ message Groups {
 message Role {
   string name = 1;
   repeated Permission permissions = 2;
-  repeated ResourceType resource_types = 3; 
+  repeated ResourceType resource_types = 3;
 }
 
 //// Authorization API
@@ -255,7 +255,7 @@ message Role {
 message AuthorizeRequest {
   Resource resource = 1;
 
-  // permissions are the operations the caller is attempting to perform 
+  // permissions are the operations the caller is attempting to perform
   repeated Permission permissions = 2;
 }
 
@@ -279,7 +279,7 @@ message GetPermissionsRequest {
 }
 
 // GetPermissionsForPrincipal evaluates an arbitrary principal's permissions
-// on a resource 
+// on a resource
 message GetPermissionsForPrincipalRequest {
   Resource resource = 1;
 
@@ -290,13 +290,13 @@ message GetPermissionsResponse {
   // permissions is the set of permissions the principal has
   repeated Permission permissions = 1;
 
-  // roles is the set of roles the principal has 
+  // roles is the set of roles the principal has
   repeated string roles = 2;
 }
 
 
 message ModifyRoleBindingRequest {
-  // resource is the resource to modify the role bindings on 
+  // resource is the resource to modify the role bindings on
   Resource resource = 1;
 
   // principal is the principal to modify the roles binding for
@@ -310,11 +310,11 @@ message ModifyRoleBindingRequest {
 message ModifyRoleBindingResponse {}
 
 message GetRoleBindingRequest {
-  Resource resource = 1; 
+  Resource resource = 1;
 }
 
 message GetRoleBindingResponse {
-  RoleBinding binding = 1; 
+  RoleBinding binding = 1;
 }
 
 //////////////////////////////
@@ -425,12 +425,12 @@ message GetUsersResponse {
 message ExtractAuthTokensRequest {}
 
 message ExtractAuthTokensResponse {
-  repeated TokenInfo tokens = 1; 
+  repeated TokenInfo tokens = 1;
 }
 
 // RestoreAuthToken inserts a hashed token that has previously been extracted.
 message RestoreAuthTokenRequest {
-  TokenInfo token = 1; 
+  TokenInfo token = 1;
 }
 
 message RestoreAuthTokenResponse {}

--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -167,7 +167,13 @@ func (a *apiServer) GetOIDCLoginURL(ctx context.Context) (string, string, error)
 		if err != nil {
 			return "", "", errors.Wrap(err, "could not parse Auth URL for Localhost Issuer rewrite")
 		}
-		rewriteURL.Host = config.userAccessAddress
+
+		userURL, err := url.Parse(config.userAccessAddress)
+		if err != nil {
+			return "", "", errors.Wrap(err, "could not parse User Accessible Oauth Issuer URL")
+		}
+		rewriteURL.Host = userURL.Host
+		rewriteURL.Scheme = userURL.Scheme
 		authURL = rewriteURL.String()
 	}
 	return authURL, state, nil


### PR DESCRIPTION
Setting oidc.issuerURI: "http://pachd:30658/dex" but wanting a userAccessibleOauthIssuerHost with a scheme of https is currently incompatible, as `pachctl auth login -b` would use the scheme from the oidc.issuerURI.  This is a breaking config change, where we now require a scheme to be explicitly set when configuring userAccessibleOauthIssuerHost, and a guard clause has been added to try and prevent that misconfiguration. 