### PR TITLE
proxy: allow helm chart to set tolerations and node selector; don't mount service account token

### DIFF
--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -29,8 +29,15 @@ spec:
         {{- toYaml .Values.proxy.labels | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: false
       {{- if .Values.proxy.priorityClassName }}
       priorityClassName: {{ .Values.proxy.priorityClassName }}
+      {{- end }}
+      {{-  if .Values.proxy.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.proxy.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{-  if .Values.proxy.tolerations }}
+      tolerations: {{ toYaml .Values.proxy.tolerations | nindent 8 }}
       {{- end }}
       affinity:
         podAffinity:

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -871,6 +871,12 @@ proxy:
   labels: {}
   # Any additional annotations to add to the pods.
   annotations: {}
+  # A nodeSelector statement for each pod in the proxy Deployment, if desired.
+  nodeSelector: {}
+  # A tolerations statement for each pod in the proxy Deployment, if desired.
+  tolerations: []
+  # A priority class name for each pod in the proxy Deployment, if desired.
+  priorityClassName: ""
   # Configure the service that routes traffic to the proxy.
   service:
     # The type of service can be ClusterIP, NodePort, or LoadBalancer.


### PR DESCRIPTION
This brings configurability up to par with other services we run.  I also explicitly added priorityClassName to the values.yaml file so people can see that they have the option.