### PR TITLE
Backport CORE-1123 to Pachyderm 2.3

### DIFF
--- a/doc/docs/2.3.x/deploy-manage/deploy/loki.md
+++ b/doc/docs/2.3.x/deploy-manage/deploy/loki.md
@@ -74,7 +74,15 @@ loki-stack:
        
          ![Container logs](../images/grafana_user_logs.png)
 
-
+## Using Loki in Another Namespace
+Instead of deploying a local loki instance in your pachyderm namespace, you can configure pachyderm to use a loki running in another namespace. To do so, you must
+set `lokiHost` and `lokiPort`. You should also set `lokiDeploy: false` to prevent the chart from deploying a local loki instance.:
+```yaml
+pachd:
+  lokiDeploy: false
+  lokiHost: "<loki-namespace>.<loki-service-name>.svc.cluster.local."
+  lokiPort: 3100
+```
     
 ## References
 

--- a/doc/docs/master/deploy-manage/deploy/loki.md
+++ b/doc/docs/master/deploy-manage/deploy/loki.md
@@ -74,7 +74,15 @@ loki-stack:
        
          ![Container logs](../images/grafana_user_logs.png)
 
-
+## Using Loki in Another Namespace
+Instead of deploying a local loki instance in your pachyderm namespace, you can configure pachyderm to use a loki running in another namespace. To do so, you must
+set `lokiHost` and `lokiPort`. You should also set `lokiDeploy: false` to prevent the chart from deploying a local loki instance.:
+```yaml
+pachd:
+  lokiDeploy: false
+  lokiHost: "<loki-namespace>.<loki-service-name>.svc.cluster.local."
+  lokiPort: 3100
+```
     
 ## References
 

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -81,11 +81,17 @@ spec:
           value: "5432" # Must match pbouncer service port
         - name: LOKI_LOGGING
           value: {{ .Values.pachd.lokiLogging | quote}}
-        {{- if .Values.pachd.lokiDeploy }}
-        - name: LOKI_SERVICE_HOST_VAR
-          value: "{{ snakecase .Release.Name | upper }}_LOKI_SERVICE_HOST"
-        - name: LOKI_SERVICE_PORT_VAR
-          value: "{{ snakecase .Release.Name | upper }}_LOKI_SERVICE_PORT"
+        - name: LOKI_SERVICE_HOST
+        {{- if .Values.pachd.lokiHost }}
+          value:  {{ .Values.pachd.lokiHost }}
+        {{ else }}
+          value: "$({{ snakecase .Release.Name | upper }}_LOKI_SERVICE_HOST)"
+        {{- end }}
+        - name: LOKI_SERVICE_PORT
+        {{- if .Values.pachd.lokiPort }}
+          value:  {{ .Values.pachd.lokiPort | quote}}
+        {{ else }}
+          value: "$({{ snakecase .Release.Name | upper }}_LOKI_SERVICE_PORT)"
         {{- end }}
         - name: PACH_ROOT
           value: "/pach"

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -763,6 +763,12 @@
                 "lokiLogging": {
                     "type": "boolean"
                 },
+                "lokiPort": {
+                    "type": "integer"
+                },
+                "lokiHost": {
+                    "type": "string"
+                },
                 "metrics": {
                     "type": "object",
                     "properties": {

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -22,8 +22,8 @@ type GlobalConfiguration struct {
 	Namespace                      string `env:"PACH_NAMESPACE,default=default"`
 	StorageRoot                    string `env:"PACH_ROOT,default=/pach"`
 	GCPercent                      int    `env:"GC_PERCENT,default=50"`
-	LokiHostVar                    string `env:"LOKI_SERVICE_HOST_VAR,default=LOKI_SERVICE_HOST"`
-	LokiPortVar                    string `env:"LOKI_SERVICE_PORT_VAR,default=LOKI_SERVICE_PORT"`
+	LokiHost                       string `env:"LOKI_SERVICE_HOST"`
+	LokiPort                       string `env:"LOKI_SERVICE_PORT"`
 	OidcPort                       uint16 `env:"OIDC_PORT,default=1657"`
 	PGBouncerHost                  string `env:"PG_BOUNCER_HOST,required"`
 	PGBouncerPort                  int    `env:"PG_BOUNCER_PORT,required"`

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -169,7 +169,7 @@ func InitServiceEnv(config *Configuration) *NonblockingServiceEnv {
 		env.dbEg.Go(env.initDirectDBClient)
 	}
 	env.listener = env.newListener()
-	if lokiHost, lokiPort := os.Getenv(env.config.LokiHostVar), os.Getenv(env.config.LokiPortVar); lokiHost != "" && lokiPort != "" {
+	if lokiHost, lokiPort := env.config.LokiHost, env.config.LokiPort; lokiHost != "" && lokiPort != "" {
 		env.lokiClient = &loki.Client{
 			Address: fmt.Sprintf("http://%s", net.JoinHostPort(lokiHost, lokiPort)),
 		}

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/types"
+
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/internal/clientsdk"
@@ -709,7 +710,7 @@ func (s *debugServer) collectLogs(ctx context.Context, tw *tar.Writer, pod, cont
 }
 
 func (s *debugServer) collectLogsLoki(ctx context.Context, tw *tar.Writer, pod, container string, prefix ...string) error {
-	if os.Getenv(s.env.Config().LokiHostVar) == "" {
+	if s.env.Config().LokiHost == "" {
 		return nil
 	}
 	return collectDebugFile(tw, "logs-loki", "txt", func(w io.Writer) error {
@@ -774,7 +775,7 @@ func (s *debugServer) collectPipelineDumpFunc(limit int64) collectPipelineFunc {
 		if err := s.collectJobs(tw, pachClient, pipelineInfo.Pipeline.Name, limit, prefix...); err != nil {
 			return err
 		}
-		if os.Getenv(s.env.Config().LokiHostVar) != "" {
+		if s.env.Config().LokiHost != "" {
 			if err := s.forEachWorkerLoki(ctx, pipelineInfo, func(pod string) error {
 				workerPrefix := join(podPrefix, pod)
 				if len(prefix) > 0 {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
 	client "github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -19,12 +26,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	workerstats "github.com/pachyderm/pachyderm/v2/src/server/worker/stats"
 	"github.com/pachyderm/pachyderm/v2/src/version"
-	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -150,11 +151,11 @@ func (kd *kubeDriver) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pi
 		Name:  client.PPSPipelineNameEnv,
 		Value: pipelineInfo.Pipeline.Name,
 	}, {
-		Name:  "LOKI_SERVICE_HOST_VAR",
-		Value: kd.config.LokiHostVar,
+		Name:  "LOKI_SERVICE_HOST",
+		Value: kd.config.LokiHost,
 	}, {
-		Name:  "LOKI_SERVICE_PORT_VAR",
-		Value: kd.config.LokiPortVar,
+		Name:  "LOKI_SERVICE_PORT",
+		Value: kd.config.LokiPort,
 	},
 		// These are set explicitly below to prevent kubernetes from setting them to the service host and port.
 		{


### PR DESCRIPTION
## Description

This PR backports a feature to 2.3 which allows a user to configure `lokiHost` and `lokiPort` in pachyderm directly. This allows them to use a loki instance in another namespace. The existing `lokiDeploy` flag sets the above variables using variable substitutions to point to the pachyderm-loki service that is created by default. 