### PR TITLE
proxy: set the default stream idle timeout to 1h instead of 10m

### DIFF
--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -136,7 +136,7 @@
         accept_http_10: false,
       },
       request_timeout: '604800s',  // Necessary to allow long file uploads.
-      stream_idle_timeout: '600s',  // Only completely idle streams are dropped after this timeout.
+      stream_idle_timeout: '3600s',  // Only completely idle streams are dropped after this timeout.
       route_config: {
         [if std.length(response_headers_to_add) > 0 then 'response_headers_to_add' else null]: [
           {

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -404,7 +404,7 @@
                               ]
                            },
                            "stat_prefix": "https-redirect",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -578,7 +578,7 @@
                               ]
                            },
                            "stat_prefix": "proxy-https",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -684,7 +684,7 @@
                               ]
                            },
                            "stat_prefix": "proxy-https-cleartext",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -486,7 +486,7 @@
                               ]
                            },
                            "stat_prefix": "proxy-http",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -570,7 +570,7 @@
                               ]
                            },
                            "stat_prefix": "https-warning",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -679,7 +679,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-s3",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -770,7 +770,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-grpc",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -853,7 +853,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-metrics",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -936,7 +936,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-oidc",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -1019,7 +1019,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-identity",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }
@@ -1108,7 +1108,7 @@
                               ]
                            },
                            "stat_prefix": "direct-console",
-                           "stream_idle_timeout": "600s",
+                           "stream_idle_timeout": "3600s",
                            "use_remote_address": true
                         }
                      }


### PR DESCRIPTION
This is necessary for the load test.  I think we tested this with "pachctl wait commit" a while back and it never timed out, but that's also a unary RPC, so I'm not sure what the difference is.

How this was tested:
* Ran load test, after 10 minutes, got Unavailable "stream idle timeout" and SI in the envoy logs.
* Made this change, after 1200s, the load test completed.

Maybe we want an even longer timeout than 3600s though.