### PR TITLE
[CORE-1136] Adjust pachctl list jobs -x output

### DIFF
--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/gogo/protobuf/types"
 	"github.com/juju/ansiterm"
+
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pretty"
@@ -68,7 +69,11 @@ func PrintJobInfo(w io.Writer, jobInfo *ppsclient.JobInfo, fullTimestamps bool) 
 	if jobInfo.Reason != "" {
 		fmt.Fprintf(w, "%s: %s\t", JobState(jobInfo.State), safeTrim(jobInfo.Reason, jobReasonLen))
 	} else {
-		fmt.Fprintf(w, "%s\t", JobState(jobInfo.State))
+		if jobInfo.State == ppsclient.JobState_JOB_SUCCESS && jobInfo.DataSkipped == jobInfo.DataTotal {
+			fmt.Fprintf(w, "%s\t", color.New(color.FgGreen).SprintFunc()("success: there were no datums to process"))
+		} else {
+			fmt.Fprintf(w, "%s\t", JobState(jobInfo.State))
+		}
 	}
 	fmt.Fprintln(w)
 }


### PR DESCRIPTION
## Description
This PR adjusts the output of `pachctl list jobs -x` to add an extra descriptive tag to the state of successful jobs that did not process any datums because they were just initialized or because new files in a commit did not match the defined glob pattern.

For example:

```
PIPELINE ID                               STARTED            DURATION           RESTART PROGRESS  DL       UL       STATE
edges    d6b9206f98344fd095334369b7d7b5de 10 seconds ago     Less than a second 0       0 + 3 / 3 0B       0B       success: there were no datums to process
edges    b1bb0119080c432380ef49aac30fb375 About a minute ago 2 seconds          0       2 + 1 / 3 181.1KiB 111.4KiB success
edges    675c00df5af14944ac08f7f9f51b6da0 About a minute ago 1 second           0       1 + 0 / 1 57.27KiB 22.22KiB success
edges    e6042e73d7dd4b4db8ab89dd0c1fcd7e About a minute ago Less than a second 0       0 + 0 / 0 0B       0B       success: there were no datums to process
```
To generate this output, I ran just the edges pipeline from `opencv` but adjusted the glob pattern to `/*.jpg`. The first run doesn't process anything and is a no-op, which triggers the state to be ` success: there were no datums to process`

The last/most recent run is generated by adding a file that is not a .jpg. This file is then ignored by the next pipeline run. Because no new files were processed, the state is output as `success: there were no datums to process`

These changes are all in client-side printing.