### PR TITLE
CODEOWNERS Init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@
 
 # Integrations
 /src/integrations/                         @pachyderm/INT
-/src/integrations/connectors/snowflake/    @robert-uhl
+/src/integrations/connectors/snowflake/    @pachyderm/INT @albscui
 /src/templates/                            @pachyderm/INT
 
 # Internal
@@ -48,13 +48,13 @@
 /src/internal/collection/            @brycemcanally @acohen4 @robert-uhl
 /src/internal/clusterstate/          @jrockway @brycemcanally
 /src/internal/migrations/            @brendoncarroll
-/src/interna/consistenthashing/      @FahadBSyed
+/src/internal/consistenthashing/      @FahadBSyed
 /src/internal/dockertestenv/         @brendoncarroll
-/src/interna/minikubetestenv/        @acohen4
+/src/internal/minikubetestenv/        @acohen4
 /src/internal/obj/                   @pachyderm/PFS
-/src/interna/pachhash/               @pachyderm/PFS
-/src/interna/pachsql/                @albscui @brendoncarroll
-/src/interna/pachtmpl/               @albscui @brendoncarroll @pachyderm/INT
+/src/internal/pachhash/               @pachyderm/PFS
+/src/internal/pachsql/                @albscui @brendoncarroll
+/src/internal/pachtmpl/               @albscui @brendoncarroll @pachyderm/INT
 /src/internal/pfsdb/                 @pachyderm/PFS
 /src/internal/pfsfile/               @pachyderm/PFS
 /src/internal/pfssync/               @pachyderm/PFS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,68 @@
+# Default match everything to the CORE team.
+# This means that items can be intentionally excluded below by using a match pattern without a group
+/* @pachyderm/CORE
+
+# Docs
+/doc/ @lb
+
+# Helm
+/etc/helm/ @jrockway @seanslattery @rob-uhl @armaan @chainlink
+
+# Services with individual owners
+/src/auth/               @alon @jrockway
+/src/server/auth/        @alon @jrockway
+
+/src/debug/              @jrockway @bryce
+/src/server/debug/       @jrockway @bryce
+
+/src/enterprise/         @alon
+/src/server/enterprise/  @alon
+
+/src/identity/           @jrockway @alon
+/src/server/identity/    @jrockway @alon
+
+/src/license/            @alon
+/src/server/license/     @alon
+
+/src/pfs/                @pachyderm/PFS
+/src/server/pfs/         @pachyderm/PFS
+
+/src/pps/                @bryce @alon
+/src/server/pps/         @bryce @alon
+
+/src/task/               @bryce
+
+# Integrations
+/src/integrations/ @pachyderm/INT
+/src/integrations/connectors/snowflake/ @bob-uhl
+/src/templates/ @pachyderm/INT
+
+# Internal
+# Add all the teams, so anyone can make, or change internal libraries by default.
+/src/internal/ @pachyderm/CORE @pachyderm/PFS @pachyderm/INT
+
+# Individuals for specific packages
+/src/internal/collection/            @bryce @alon @bob
+/src/internal/clusterstate/          @jrockway @bryce
+/src/internal/migrations/            @brendoncarrolla
+/src/interna/consistenthashing/      @fahad
+/src/internal/dockertestenv/         @brendoncarroll
+/src/interna/minikubetestenv/        @alon
+/src/internal/obj/                   @pachyderm/PFS
+/src/interna/pachhash/               @pachyderm/PFS
+/src/interna/pachsql/                @albert @brendoncarroll
+/src/interna/pachtmpl/               @albert @brendoncarroll @pachyderm/INT
+/src/internal/pfsdb/                 @pachyderm/PFS
+/src/internal/pfsfile/               @pachyderm/PFS
+/src/internal/pfssync/               @pachyderm/PFS
+/src/internal/pfsload/               @bryce
+/src/internal/ppsdb/                 @bryce
+/src/internal/ppsload/               @bryce 
+/src/internal/storage/               @pachyderm/PFS
+/src/internal/stream/                @bryce
+/src/internal/task/                  @bryce
+/src/internal/testsnowflake/         @albert
+/src/internal/transforms/            @albert @brendoncarroll
+
+# internal/middleware
+/src/internal/middleware/auth/       @alon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,10 @@
 * @pachyderm/CORE
 
 # Docs
-/doc/ @lbliii
+/doc/ @pachyderm/DOC
+
+# etc
+/etc/ @pachyderm/BRE @pachyderm/CORE
 
 # Helm
 /etc/helm/ @jrockway @seslattery @robert-uhl @armaanv @chainlink
@@ -38,7 +41,7 @@
 /src/templates/                            @pachyderm/INT
 
 # Internal
-# Add all the teams, so anyone can make, or change internal libraries by default.
+# Add all the teams, so anyone can make or change internal libraries by default.
 /src/internal/ @pachyderm/CORE @pachyderm/PFS @pachyderm/INT
 
 # Individuals for specific packages

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,10 @@
 /etc/ @pachyderm/BRE @pachyderm/CORE
 
 # Helm
-/etc/helm/ @jrockway @seslattery @robert-uhl @armaanv @chainlink
+/etc/helm/ @jrockway @seslattery @robert-uhl @armaanv @chainlink @tybritten @BOsterbuhr
+
+# Examples
+/examples/ @pachyderm/DOC @tybritten @JimmyWhitaker @BOsterbuhr
 
 # Services with individual owners
 /src/auth/               @acohen4 @jrockway
@@ -36,9 +39,10 @@
 /src/task/               @brycemcanally
 
 # Integrations
-/src/integrations/                         @pachyderm/INT
-/src/integrations/connectors/snowflake/    @pachyderm/INT @albscui
-/src/templates/                            @pachyderm/INT
+/src/integrations/                          @pachyderm/INT
+/src/integrations/connectors/snowflake/     @pachyderm/INT @albscui @robert-uhl
+/src/templates/                             @pachyderm/INT
+/src/server/pfs/s3/                          @pachyderm/INT
 
 # Internal
 # Add all the teams, so anyone can make or change internal libraries by default.
@@ -47,14 +51,14 @@
 # Individuals for specific packages
 /src/internal/collection/            @brycemcanally @acohen4 @robert-uhl
 /src/internal/clusterstate/          @jrockway @brycemcanally
-/src/internal/migrations/            @brendoncarroll
-/src/internal/consistenthashing/      @FahadBSyed
+/src/internal/consistenthashing/     @FahadBSyed
 /src/internal/dockertestenv/         @brendoncarroll
-/src/internal/minikubetestenv/        @acohen4
+/src/internal/migrations/            @brendoncarroll
+/src/internal/minikubetestenv/       @acohen4
 /src/internal/obj/                   @pachyderm/PFS
-/src/internal/pachhash/               @pachyderm/PFS
-/src/internal/pachsql/                @albscui @brendoncarroll
-/src/internal/pachtmpl/               @albscui @brendoncarroll @pachyderm/INT
+/src/internal/pachhash/              @pachyderm/PFS
+/src/internal/pachsql/               @albscui @brendoncarroll
+/src/internal/pachtmpl/              @albscui @brendoncarroll @pachyderm/INT
 /src/internal/pfsdb/                 @pachyderm/PFS
 /src/internal/pfsfile/               @pachyderm/PFS
 /src/internal/pfssync/               @pachyderm/PFS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,38 +3,38 @@
 /* @pachyderm/CORE
 
 # Docs
-/doc/ @lb
+/doc/ @lbliii
 
 # Helm
-/etc/helm/ @jrockway @seanslattery @rob-uhl @armaan @chainlink
+/etc/helm/ @jrockway @seanslattery @robert-uhl @armaanv @chainlink
 
 # Services with individual owners
-/src/auth/               @alon @jrockway
-/src/server/auth/        @alon @jrockway
+/src/auth/               @acohen4 @jrockway
+/src/server/auth/        @acohen4 @jrockway
 
-/src/debug/              @jrockway @bryce
-/src/server/debug/       @jrockway @bryce
+/src/debug/              @jrockway @brycemcanally
+/src/server/debug/       @jrockway @brycemcanally
 
-/src/enterprise/         @alon
-/src/server/enterprise/  @alon
+/src/enterprise/         @acohen4
+/src/server/enterprise/  @acohen4
 
-/src/identity/           @jrockway @alon
-/src/server/identity/    @jrockway @alon
+/src/identity/           @jrockway @acohen4
+/src/server/identity/    @jrockway @acohen4
 
-/src/license/            @alon
-/src/server/license/     @alon
+/src/license/            @acohen4
+/src/server/license/     @acohen4
 
 /src/pfs/                @pachyderm/PFS
 /src/server/pfs/         @pachyderm/PFS
 
-/src/pps/                @bryce @alon
-/src/server/pps/         @bryce @alon
+/src/pps/                @brycemcanally @acohen4
+/src/server/pps/         @brycemcanally @acohen4
 
-/src/task/               @bryce
+/src/task/               @brycemcanally
 
 # Integrations
 /src/integrations/ @pachyderm/INT
-/src/integrations/connectors/snowflake/ @bob-uhl
+/src/integrations/connectors/snowflake/ @robert-uhl
 /src/templates/ @pachyderm/INT
 
 # Internal
@@ -42,27 +42,27 @@
 /src/internal/ @pachyderm/CORE @pachyderm/PFS @pachyderm/INT
 
 # Individuals for specific packages
-/src/internal/collection/            @bryce @alon @bob
-/src/internal/clusterstate/          @jrockway @bryce
+/src/internal/collection/            @brycemcanally @acohen4 @robert-uhl
+/src/internal/clusterstate/          @jrockway @brycemcanally
 /src/internal/migrations/            @brendoncarrolla
 /src/interna/consistenthashing/      @fahad
 /src/internal/dockertestenv/         @brendoncarroll
-/src/interna/minikubetestenv/        @alon
+/src/interna/minikubetestenv/        @acohen4
 /src/internal/obj/                   @pachyderm/PFS
 /src/interna/pachhash/               @pachyderm/PFS
-/src/interna/pachsql/                @albert @brendoncarroll
-/src/interna/pachtmpl/               @albert @brendoncarroll @pachyderm/INT
+/src/interna/pachsql/                @albscui @brendoncarroll
+/src/interna/pachtmpl/               @albscui @brendoncarroll @pachyderm/INT
 /src/internal/pfsdb/                 @pachyderm/PFS
 /src/internal/pfsfile/               @pachyderm/PFS
 /src/internal/pfssync/               @pachyderm/PFS
-/src/internal/pfsload/               @bryce
-/src/internal/ppsdb/                 @bryce
-/src/internal/ppsload/               @bryce 
+/src/internal/pfsload/               @brycemcanally
+/src/internal/ppsdb/                 @brycemcanally
+/src/internal/ppsload/               @brycemcanally 
 /src/internal/storage/               @pachyderm/PFS
-/src/internal/stream/                @bryce
-/src/internal/task/                  @bryce
-/src/internal/testsnowflake/         @albert
-/src/internal/transforms/            @albert @brendoncarroll
+/src/internal/stream/                @brycemcanally
+/src/internal/task/                  @brycemcanally
+/src/internal/testsnowflake/         @albscui
+/src/internal/transforms/            @albscui @brendoncarroll
 
 # internal/middleware
-/src/internal/middleware/auth/       @alon
+/src/internal/middleware/auth/       @acohen4

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default match everything to the CORE team.
 # This means that items can be intentionally excluded below by using a match pattern without a group
-/ @pachyderm/CORE
+* @pachyderm/CORE
 
 # Docs
 /doc/ @lbliii

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default match everything to the CORE team.
 # This means that items can be intentionally excluded below by using a match pattern without a group
-/* @pachyderm/CORE
+/ @pachyderm/CORE
 
 # Docs
 /doc/ @lbliii
 
 # Helm
-/etc/helm/ @jrockway @seanslattery @robert-uhl @armaanv @chainlink
+/etc/helm/ @jrockway @seslattery @robert-uhl @armaanv @chainlink
 
 # Services with individual owners
 /src/auth/               @acohen4 @jrockway
@@ -33,9 +33,9 @@
 /src/task/               @brycemcanally
 
 # Integrations
-/src/integrations/ @pachyderm/INT
-/src/integrations/connectors/snowflake/ @robert-uhl
-/src/templates/ @pachyderm/INT
+/src/integrations/                         @pachyderm/INT
+/src/integrations/connectors/snowflake/    @robert-uhl
+/src/templates/                            @pachyderm/INT
 
 # Internal
 # Add all the teams, so anyone can make, or change internal libraries by default.
@@ -44,8 +44,8 @@
 # Individuals for specific packages
 /src/internal/collection/            @brycemcanally @acohen4 @robert-uhl
 /src/internal/clusterstate/          @jrockway @brycemcanally
-/src/internal/migrations/            @brendoncarrolla
-/src/interna/consistenthashing/      @fahad
+/src/internal/migrations/            @brendoncarroll
+/src/interna/consistenthashing/      @FahadBSyed
 /src/internal/dockertestenv/         @brendoncarroll
 /src/interna/minikubetestenv/        @acohen4
 /src/internal/obj/                   @pachyderm/PFS


### PR DESCRIPTION
This is the first attempt at introducing a CODEOWNERS file to the repo.

There are 3 groups referenced in the owners file: `@pachyderm/core @pachyderm/pfs @pachyderm/int`.  They match the project names in JIRA.

The proposal is to give default ownership to the CORE team, and then carve out exceptions to that general rule throughout the codebase.  e.g. `/src/server/pfs/ @pachyderm/pfs`.

This is intended to be a collaborative PR; I figured it would work better than a Google Doc for this use case.  Please add comments where you would like yourself or others to be added or removed.
