### PR TITLE
[Jupyter] Fix deleted mount error that crashes extension

### DIFF
--- a/jupyter-extension/infra/main.go
+++ b/jupyter-extension/infra/main.go
@@ -104,7 +104,7 @@ func main() {
 								"extra_containers": pulumi.MapArray{
 									pulumi.Map{
 										"name":    pulumi.String("mount-server-manager"),
-										"image":   pulumi.String("pachyderm/mount-server:7d2471590000c6ac847a64a77e3f6c0687e64f01"),
+										"image":   pulumi.String("pachyderm/mount-server:" + sha),
 										"command": pulumi.StringArray{pulumi.String("/bin/bash"), pulumi.String("-c"), pulumi.String("mount-server")},
 										"securityContext": pulumi.Map{
 											"privileged": pulumi.Bool(true),

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -184,7 +184,7 @@ def test_mount(pachyderm_resources, dev_server):
             list(os.walk(os.path.join(PFS_MOUNT_DIR, mount_info["name"])))[0][2]
         ) == sorted(files)
     assert len(resp["unmounted"]) == 3
-    assert len(resp["unmounted"][repos[1]]["branches"]) == 1
+    assert len(resp["unmounted"][repos[1]]["branches"]) == 2
     assert len(resp["unmounted"][repos[2]]["branches"]) == 2
 
     r = requests.put(
@@ -233,7 +233,7 @@ def test_unmount(pachyderm_resources, dev_server):
     assert r.status_code == 200
     assert len(r.json()["mounted"]) == 1
     assert len(r.json()["unmounted"]) == 3
-    assert len(r.json()["unmounted"][repos[0]]["branches"]) == 1
+    assert len(r.json()["unmounted"][repos[0]]["branches"]) == 2
 
     r = requests.put(
         f"{BASE_URL}/_unmount",

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -9,7 +9,7 @@ type DatumProps = {
   setShowDatum: (shouldShow: boolean) => void;
   keepMounted: boolean;
   setKeepMounted: (keep: boolean) => void;
-  refresh: (path: string) => void;
+  open: (path: string) => void;
   pollRefresh: () => Promise<void>;
   currentDatumInfo?: CurrentDatumResponse;
 };
@@ -26,7 +26,7 @@ const Datum: React.FC<DatumProps> = ({
   keepMounted,
   setKeepMounted,
   currentDatumInfo,
-  refresh,
+  open,
   pollRefresh,
 }) => {
   const {
@@ -40,7 +40,7 @@ const Datum: React.FC<DatumProps> = ({
     callMountDatums,
     callUnmountAll,
     errorMessage,
-  } = useDatum(showDatum, keepMounted, refresh, pollRefresh, currentDatumInfo);
+  } = useDatum(showDatum, keepMounted, open, pollRefresh, currentDatumInfo);
 
   return (
     <div className="pachyderm-mount-datum-base">

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -36,7 +36,7 @@ describe('datum screen', () => {
           setShowDatum={setShowDatum}
           keepMounted={false}
           setKeepMounted={setKeepMounted}
-          refresh={jest.fn()}
+          open={jest.fn()}
           pollRefresh={jest.fn()}
         />,
       );
@@ -82,7 +82,7 @@ describe('datum screen', () => {
           setShowDatum={setShowDatum}
           keepMounted={false}
           setKeepMounted={setKeepMounted}
-          refresh={jest.fn()}
+          open={jest.fn()}
           pollRefresh={jest.fn()}
         />,
       );
@@ -127,7 +127,7 @@ describe('datum screen', () => {
           setShowDatum={setShowDatum}
           keepMounted={false}
           setKeepMounted={setKeepMounted}
-          refresh={jest.fn()}
+          open={jest.fn()}
           pollRefresh={jest.fn()}
         />,
       );
@@ -157,7 +157,7 @@ describe('datum screen', () => {
           setShowDatum={setShowDatum}
           keepMounted={false}
           setKeepMounted={setKeepMounted}
-          refresh={jest.fn()}
+          open={jest.fn()}
           pollRefresh={jest.fn()}
         />,
       );
@@ -185,7 +185,7 @@ describe('datum screen', () => {
           setShowDatum={setShowDatum}
           keepMounted={false}
           setKeepMounted={setKeepMounted}
-          refresh={jest.fn()}
+          open={jest.fn()}
           pollRefresh={jest.fn()}
         />,
       );
@@ -209,7 +209,7 @@ describe('datum screen', () => {
           setShowDatum={setShowDatum}
           keepMounted={false}
           setKeepMounted={setKeepMounted}
-          refresh={jest.fn()}
+          open={jest.fn()}
           pollRefresh={jest.fn()}
         />,
       );

--- a/jupyter-extension/src/plugins/mount/components/Datum/hooks/useDatum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/hooks/useDatum.tsx
@@ -25,7 +25,7 @@ export type useDatumResponse = {
 export const useDatum = (
   showDatum: boolean,
   keepMounted: boolean,
-  refresh: (path: string) => void,
+  open: (path: string) => void,
   pollRefresh: () => Promise<void>,
   currentDatumInfo?: CurrentDatumResponse,
 ): useDatumResponse => {
@@ -81,7 +81,7 @@ export const useDatum = (
       const res = await requestAPI<MountDatumResponse>('_mount_datums', 'PUT', {
         input: input,
       });
-      refresh('');
+      open('');
       setCurrIdx(0);
       setCurrDatum(res);
       setShouldShowCycler(true);
@@ -110,7 +110,7 @@ export const useDatum = (
         `_show_datum?idx=${currIdx}`,
         'PUT',
       );
-      refresh('');
+      open('');
       setCurrDatum(res);
     } catch (e) {
       console.log(e);
@@ -123,9 +123,9 @@ export const useDatum = (
     setLoading(true);
 
     try {
-      refresh('');
+      open('');
       await requestAPI<ListMountsResponse>('_unmount_all', 'PUT');
-      refresh('');
+      open('');
       await pollRefresh();
       setCurrIdx(-1);
       setCurrDatum({id: '', idx: -1, num_datums: 0});

--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListMount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListMount.tsx
@@ -38,7 +38,6 @@ const ListMount: React.FC<ListMountProps> = ({item, open, updateData}) => {
         mounts: [`${item.name}`],
       });
       updateData(data);
-      open('');
     } catch {
       console.log('error unmounting repo');
     }

--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
@@ -10,14 +10,12 @@ export const DISABLED_STATES: mountState[] = [
 
 type ListUnmountProps = {
   item: Repo;
-  open: (path: string) => void;
   updateData: (data: ListMountsResponse) => void;
   mountedItems: Mount[];
 };
 
 const ListUnmount: React.FC<ListUnmountProps> = ({
   item,
-  open,
   updateData,
   mountedItems,
 }) => {
@@ -71,7 +69,6 @@ const ListUnmount: React.FC<ListUnmountProps> = ({
         });
         updateData(data);
       }
-      open('');
     } catch {
       console.log('error mounting or unmounting repo');
     }

--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
@@ -28,7 +28,7 @@ const ListUnmount: React.FC<ListUnmountProps> = ({item, open, updateData}) => {
   useEffect(() => {
     if (hasBranches) {
       const found = item.branches.find((branch) => branch === 'master');
-      setSelectedBranch(found ? found : item.branches[0]);
+      setSelectedBranch(found ? found : item.branches.sort()[0]);
       setDisabled(false);
     }
   }, [item]);
@@ -125,7 +125,7 @@ const ListUnmount: React.FC<ListUnmountProps> = ({item, open, updateData}) => {
                 onChange={onChange}
                 data-testid="ListItem__select"
               >
-                {item.branches.map((branch) => {
+                {item.branches.sort().map((branch) => {
                   return (
                     <option key={branch} value={branch}>
                       {branch}

--- a/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
@@ -9,6 +9,7 @@ type SortableListProps = {
   items: Mount[] | Repo[];
   open: (path: string) => void;
   updateData: (data: ListMountsResponse) => void;
+  mountedItems: Mount[];
 };
 
 const nameComparator = {
@@ -21,6 +22,7 @@ const SortableList: React.FC<SortableListProps> = ({
   open,
   items,
   updateData,
+  mountedItems,
 }) => {
   const {sortedData, setComparator, reversed} = useSort<Mount | Repo>({
     data: items,
@@ -61,6 +63,7 @@ const SortableList: React.FC<SortableListProps> = ({
                 key={item.repo}
                 open={open}
                 updateData={updateData}
+                mountedItems={mountedItems}
               />
             ),
           )}

--- a/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
@@ -61,7 +61,6 @@ const SortableList: React.FC<SortableListProps> = ({
               <ListUnmount
                 item={item}
                 key={item.repo}
-                open={open}
                 updateData={updateData}
                 mountedItems={mountedItems}
               />

--- a/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
@@ -438,4 +438,48 @@ describe('sortable list components', () => {
     const commitBehindnessText = getByTestId('ListItem__commitBehindness');
     expect(commitBehindnessText.textContent).toContain('2 commits behind');
   });
+
+  it('should grey out mount button for selected branches in dropdown that are already mounted', async () => {
+    const mountedItems: Mount[] = [
+      {
+        name: 'edges',
+        repo: 'edges',
+        branch: 'mounted_branch',
+        commit: null,
+        glob: null,
+        mode: null,
+        state: 'mounted',
+        status: 'all is well, la la la',
+        mountpoint: null,
+        how_many_commits_behind: 2,
+        actual_mounted_commit: 'a1b2c3',
+        latest_commit: 'a1b2c3',
+      },
+    ];
+
+    const items: Repo[] = [
+      {
+        repo: 'edges',
+        authorization: 'off',
+        branches: ['dev', 'master', 'mounted_branch'],
+      },
+    ];
+
+    const {getByTestId} = render(
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={mountedItems}
+      />,
+    );
+
+    fireEvent.change(getByTestId('ListItem__select'), {
+      target: {value: 'mounted_branch'},
+    });
+    expect(getByTestId('ListItem__mount')).toBeDisabled();
+
+    fireEvent.change(getByTestId('ListItem__select'), {target: {value: 'dev'}});
+    expect(getByTestId('ListItem__mount')).not.toBeDisabled();
+  });
 });

--- a/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
@@ -28,15 +28,17 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     const listItem = getByTestId('ListItem__noBranches');
     expect(listItem).toHaveTextContent('images');
     expect(listItem).toHaveTextContent('No branches');
-    expect(listItem).toHaveAttribute(
-      'title',
-      "Either all branches are mounted or the repo doesn't have a branch",
-    );
+    expect(listItem).toHaveAttribute('title', "Repo doesn't have a branch");
   });
 
   it('should disable mount for repo with no access', async () => {
@@ -49,7 +51,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     const listItem = getByTestId('ListItem__unauthorized');
     expect(listItem).toHaveTextContent('images');
@@ -75,7 +82,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByText, getAllByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     let listItems = getAllByTestId('ListItem__noBranches');
     expect(listItems.length).toEqual(2);
@@ -100,7 +112,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     const listItem = getByTestId('ListItem__branches');
     const mountButton = getByTestId('ListItem__mount');
@@ -144,7 +161,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     const listItem = getByTestId('ListItem__branches');
     const unmountButton = getByTestId('ListItem__unmount');
@@ -186,7 +208,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByText} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     getByText('images').click();
     expect(open).toHaveBeenCalledWith('images');
@@ -202,7 +229,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByText, getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     const select = getByTestId('ListItem__select') as HTMLSelectElement;
 
@@ -241,7 +273,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
 
     const statusIcon = getByTestId('ListItem__statusIcon');
@@ -296,7 +333,12 @@ describe('sortable list components', () => {
       },
     ];
     const {getAllByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
     const unmountButtons = getAllByTestId('ListItem__unmount');
     expect(unmountButtons[0]).toBeDisabled();
@@ -323,7 +365,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
 
     const commitBehindnessText = getByTestId('ListItem__commitBehindness');
@@ -349,7 +396,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
 
     const commitBehindnessText = getByTestId('ListItem__commitBehindness');
@@ -375,7 +427,12 @@ describe('sortable list components', () => {
     ];
 
     const {getByTestId} = render(
-      <SortableList open={open} items={items} updateData={updateData} />,
+      <SortableList
+        open={open}
+        items={items}
+        updateData={updateData}
+        mountedItems={[]}
+      />,
     );
 
     const commitBehindnessText = getByTestId('ListItem__commitBehindness');

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -25,7 +25,7 @@ const createCustomFileBrowser = (
   const browser = factory.createFileBrowser('jupyterlab-pachyderm-browser', {
     driveName: drive.name,
     state: null,
-    refreshInterval: 10000,
+    refreshInterval: 3000,
   });
 
   try {

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -25,7 +25,7 @@ const createCustomFileBrowser = (
   const browser = factory.createFileBrowser('jupyterlab-pachyderm-browser', {
     driveName: drive.name,
     state: null,
-    refreshInterval: 3000,
+    refreshInterval: 10000,
   });
 
   try {

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -251,15 +251,12 @@ export class MountPlugin implements IMountPlugin {
     });
   };
 
-  refresh = async (
-    _sender: PollMounts,
-    _data: Mount[] | Repo[],
-  ): Promise<void> => {
+  refresh = async (_: PollMounts, _data: Mount[] | Repo[]): Promise<void> => {
     await this._mountBrowser.model.refresh();
   };
 
   // Change back to root directory if in a mount that no longer exists
-  verifyBrowserPath = (_sender: PollMounts, mounted: Mount[]): void => {
+  verifyBrowserPath = (_: PollMounts, mounted: Mount[]): void => {
     if (this._mountBrowser.model.path === this._mountBrowser.model.rootPath) {
       return;
     }

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -62,6 +62,8 @@ export class MountPlugin implements IMountPlugin {
       }
     });
 
+    // TODO: If unmounted list changes, check file browser path if it exists in unmounted repos list
+
     // This is used to detect if the user becomes unauthenticated of there are errors on the server
     this._poller.statusSignal.connect((_, status) => {
       if (status.code === 500) {
@@ -144,6 +146,7 @@ export class MountPlugin implements IMountPlugin {
               open={this.open}
               items={mounted ? mounted : this._poller.mounted}
               updateData={this._poller.updateData}
+              mountedItems={[]}
             />
           </div>
         )}
@@ -162,6 +165,7 @@ export class MountPlugin implements IMountPlugin {
               open={this.open}
               items={unmounted ? unmounted : this._poller.unmounted}
               updateData={this._poller.updateData}
+              mountedItems={this._poller.mounted}
             />
           </div>
         )}


### PR DESCRIPTION
- If file browser is in a mounted directory that no longer exists, change to root directory
- Go back to showing all of a repo's branches in the "Unmounted Repositories" section but disable the "Mount" button for branches that are already mounted
- Remove hardcoded mount-server sidecar Docker tag from Jupyter preview Pulumi build
- Fix python integration tests with respect to changes in mount server

Ticket: https://linear.app/pachyderm/issue/INT-536/deleting-a-mounted-repo-breaks-extension 