### PR TITLE
Fix: allow restarting spout pipelines

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2702,11 +2702,13 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 			return errors.EnsureStack(err)
 		}
 		// restore same provenance to meta repo
-		if err := a.env.PFSServer.CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
-			Branch:     client.NewSystemProjectRepo(pipelineInfo.Pipeline.Project.GetName(), pipelineInfo.Pipeline.Name, pfs.MetaRepoType).NewBranch(pipelineInfo.Details.OutputBranch),
-			Provenance: provenance,
-		}); err != nil {
-			return errors.EnsureStack(err)
+		if pipelineInfo.Details.Spout == nil {
+			if err := a.env.PFSServer.CreateBranchInTransaction(txnCtx, &pfs.CreateBranchRequest{
+				Branch:     client.NewSystemProjectRepo(pipelineInfo.Pipeline.Project.GetName(), pipelineInfo.Pipeline.Name, pfs.MetaRepoType).NewBranch(pipelineInfo.Details.OutputBranch),
+				Provenance: provenance,
+			}); err != nil {
+				return errors.EnsureStack(err)
+			}
 		}
 
 		newPipelineInfo := &pps.PipelineInfo{}


### PR DESCRIPTION
The `StartPipeline` command attempts to restore provenance to the pipeline's meta repo, but spout pipelines don't have meta repos. This adds a check to only look for a meta repo if the pipeline isn't of the spout type. Mirrors the behavior of `StopPipeline`.

Fixes #8303 