### PR TITLE
Improve random data generation speed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.5
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/exp v0.0.0-20221019170559-20944726eadf
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f

--- a/go.sum
+++ b/go.sum
@@ -1576,8 +1576,9 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
-golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221019170559-20944726eadf h1:nFVjjKDgNY37+ZSYCJmtYf7tOlfQswHqplG2eosjOMg=
+golang.org/x/exp v0.0.0-20221019170559-20944726eadf/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/src/internal/miscutil/math.go
+++ b/src/internal/miscutil/math.go
@@ -1,15 +1,9 @@
 package miscutil
 
-// Min returns the smaller of a and b.
-func Min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
+import "golang.org/x/exp/constraints"
 
-// MinInt64 returns the smaller of a and b.
-func MinInt64(a, b int64) int64 {
+// Min returns the smaller of a and b.
+func Min[T constraints.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}

--- a/src/internal/randutil/rand.go
+++ b/src/internal/randutil/rand.go
@@ -32,7 +32,7 @@ func NewBytesReader(random *rand.Rand, n int64) *bytesReader {
 }
 
 func (br *bytesReader) Read(data []byte) (int, error) {
-	size := int(miscutil.MinInt64(br.n, int64(len(data))))
+	size := int(miscutil.Min(br.n, int64(len(data))))
 	for i := 0; i < size; i++ {
 		data[i] = letters[br.random.Intn(len(letters))]
 	}

--- a/src/internal/randutil/rand.go
+++ b/src/internal/randutil/rand.go
@@ -14,7 +14,7 @@ func Bytes(random *rand.Rand, n int) []byte {
 	bs := make([]byte, n)
 	random.Read(bs) // Cannot return an error.
 	for i, b := range bs {
-		bs[i] = letters[(52*uint16(b))>>8]
+		bs[i] = letters[(uint16(len(letters))*uint16(b))>>8]
 	}
 	return bs
 }
@@ -36,7 +36,7 @@ func (br *bytesReader) Read(data []byte) (int, error) {
 	size := int(miscutil.Min(br.n, int64(len(data))))
 	br.random.Read(data[:size])
 	for i := 0; i < size; i++ {
-		data[i] = letters[52*uint16(data[i])>>8]
+		data[i] = letters[uint16(len(letters))*uint16(data[i])>>8]
 	}
 	br.n -= int64(size)
 	if br.n <= 0 {

--- a/src/internal/randutil/rand.go
+++ b/src/internal/randutil/rand.go
@@ -12,8 +12,9 @@ var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 // Bytes generates random bytes (n is number of bytes)
 func Bytes(random *rand.Rand, n int) []byte {
 	bs := make([]byte, n)
-	for i := range bs {
-		bs[i] = letters[random.Intn(len(letters))]
+	random.Read(bs) // Cannot return an error.
+	for i, b := range bs {
+		bs[i] = letters[(52*uint16(b))>>8]
 	}
 	return bs
 }
@@ -33,11 +34,12 @@ func NewBytesReader(random *rand.Rand, n int64) *bytesReader {
 
 func (br *bytesReader) Read(data []byte) (int, error) {
 	size := int(miscutil.Min(br.n, int64(len(data))))
+	br.random.Read(data[:size])
 	for i := 0; i < size; i++ {
-		data[i] = letters[br.random.Intn(len(letters))]
+		data[i] = letters[52*uint16(data[i])>>8]
 	}
 	br.n -= int64(size)
-	if br.n == 0 {
+	if br.n <= 0 {
 		return size, io.EOF
 	}
 	return size, nil

--- a/src/internal/randutil/rand_test.go
+++ b/src/internal/randutil/rand_test.go
@@ -24,6 +24,11 @@ func BenchmarkReader(b *testing.B) {
 	}
 }
 
+// testLetters ensures that every expected letter appears in the generated output.  There is some
+// probability that this won't happen, and we don't pick a seed that guarantees it happens.  Rather,
+// we assume with a large enough input, there should be at least one of every letter.  1000 seems to
+// be enough for 52 letters, but if you ever find the test being flaky, the options are to pick a
+// seed at the `var random` declaration above, or to produce more than 1000 letters.
 func testLetters(t *testing.T, buf []byte) {
 	t.Helper()
 	got := map[byte]int{}

--- a/src/internal/randutil/rand_test.go
+++ b/src/internal/randutil/rand_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
+var random = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+
 func BenchmarkReader(b *testing.B) {
-	seed := time.Now().UTC().UnixNano()
-	random := rand.New(rand.NewSource(seed))
 	b.SetBytes(100 * units.MB)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -22,4 +22,28 @@ func BenchmarkReader(b *testing.B) {
 		_, err := io.Copy(buf, r)
 		require.NoError(b, err)
 	}
+}
+
+func testLetters(t *testing.T, buf []byte) {
+	t.Helper()
+	got := map[byte]int{}
+	for _, b := range buf {
+		got[byte(b)]++
+	}
+	for _, letter := range letters {
+		if n := got[letter]; n < 1 {
+			t.Errorf("letter %s never appears", string(letter))
+		}
+	}
+}
+
+func TestBytes(t *testing.T) {
+	testLetters(t, Bytes(random, 1000))
+}
+
+func TestBytesReader(t *testing.T) {
+	r := NewBytesReader(random, 1000)
+	buf, err := io.ReadAll(r)
+	require.NoError(t, err, "should have read bytes from BytesReader")
+	testLetters(t, buf)
 }

--- a/src/internal/storage/fileset/fileset_test.go
+++ b/src/internal/storage/fileset/fileset_test.go
@@ -249,11 +249,11 @@ func TestStableHash(t *testing.T) {
 		output, err := pachhash.ParseHex([]byte(td.expected[0]))
 		require.NoError(t, err)
 		random := rand.New(rand.NewSource(td.seed))
-		testStableHash(t, randutil.Bytes(random, 100*units.KB), output[:], msg)
+		testStableHash(t, oldRandomBytes(random, 100*units.KB), output[:], msg)
 		output, err = pachhash.ParseHex([]byte(td.expected[1]))
 		require.NoError(t, err)
 		random = rand.New(rand.NewSource(td.seed))
-		testStableHash(t, randutil.Bytes(random, 100*units.MB), output[:], msg)
+		testStableHash(t, oldRandomBytes(random, 100*units.MB), output[:], msg)
 	}
 }
 
@@ -263,6 +263,18 @@ func TestStableHashFuzz(t *testing.T) {
 	random := rand.New(rand.NewSource(seed))
 	testStableHash(t, randutil.Bytes(random, 100*units.KB), nil, msg)
 	testStableHash(t, randutil.Bytes(random, 100*units.MB), nil, msg)
+}
+
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// This is an older way of generating random bytes; what randutil.Bytes used to do.  The algorithm
+// it uses has changed in favor of a faster one, but breaks the above test.
+func oldRandomBytes(random *rand.Rand, n int) []byte {
+	bs := make([]byte, n)
+	for i := range bs {
+		bs[i] = letters[random.Intn(len(letters))]
+	}
+	return bs
 }
 
 func testStableHash(t *testing.T, data, expected []byte, msg string) {


### PR DESCRIPTION
This adjusts randutil.Bytes/BytesReader to use a faster reduction algorithm than `random.Intn`.  random.Intn does a very slow divide to avoid any bias; we do `len(letters)*uint16(byte) >> 8` which is much faster for the CPU to actually execute, and doesn't introduce too much bias.  See https://lemire.me/blog/2016/06/30/fast-random-shuffling for details.  I added some tests to make sure each letter does show up in the output with enough rolls of the dice.

Before this change, BytesReader could generate data at about 70MB/s.  Now it does 530MB/s.  (Without doing any mapping from bytes to letter, you can get about 630MB/s.)

I also got rid of the `miscutil.MinInt64` function, and made `miscutil.Min` generic.

One downside is that some tests depend on randutil.Bytes always producing the same output; this algorithm changes the output for a given seed.  I think it's just one set of tests, though, so I ported the old code into that test for it to use in isolation.