### PR TITLE
[CORE-549]remove duplicae pps env variables

### DIFF
--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -539,8 +539,6 @@ func (kd *kubeDriver) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pi
 func (kd *kubeDriver) getStorageEnvVars(pipelineInfo *pps.PipelineInfo) []v1.EnvVar {
 	vars := []v1.EnvVar{
 		{Name: UploadConcurrencyLimitEnvVar, Value: strconv.Itoa(kd.config.StorageUploadConcurrencyLimit)},
-		{Name: client.PPSProjectNameEnv, Value: pipelineInfo.Pipeline.Project.GetName()},
-		{Name: client.PPSPipelineNameEnv, Value: pipelineInfo.Pipeline.Name},
 	}
 	return vars
 }
@@ -610,13 +608,7 @@ func (kd *kubeDriver) getWorkerOptions(ctx context.Context, pipelineInfo *pps.Pi
 		userImage = DefaultUserImage
 	}
 
-	workerEnv := []v1.EnvVar{{
-		Name:  client.PPSProjectNameEnv,
-		Value: pipelineInfo.Pipeline.Project.GetName(),
-	}, {
-		Name:  client.PPSPipelineNameEnv,
-		Value: pipelineInfo.Pipeline.Name,
-	}}
+	workerEnv := []v1.EnvVar{}
 	for name, value := range transform.Env {
 		workerEnv = append(
 			workerEnv,


### PR DESCRIPTION
## Problem Summary:
https://pachyderm.atlassian.net/browse/CORE-549

Two environment variables, `PPS_PROJECT_NAME` and `PPS_PIPELINE_NAME` are being set in multiple places causing warnings from Kubernetes. You can see this issue in the pachd logs and in the pod description:
![image](https://user-images.githubusercontent.com/116583733/197873484-558c5057-bd6e-41ca-9f62-a952885565c8.png)


## Fix:
`getStorageEnvVars` and `getWorkerOptions` set these variables even though they are also set in the `commonEnv`.

These functions are only called in this file, and both are appended to commonEnv before usage, so deleting them _shouldn't_ have any side effects, and testing looks good, but this seems like the part to double check.

## Testing:

Re-ran `example/opencv` after the build and confirmed the variables are only listed once, and there was no warning in the pachd logs.

The pipeline passed, but only after a retry. I'll look more into the failure, but I believe this was flake in the load test.

After:
![image](https://user-images.githubusercontent.com/116583733/197873410-308315c5-70e8-4edc-ab96-6b77514589d2.png)
