### PR TITLE
[Mount Server] Prevent mounting non-existent branch in a read-only mount

### DIFF
--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hanwen/go-fuse/v2/fs"
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
@@ -1076,6 +1077,9 @@ func verifyMountRequest(mis []*MountInfo, lr ListRepoResponse) error {
 		}
 		if _, ok := lr[mi.Repo]; !ok {
 			return errors.Errorf("repo does not exist")
+		}
+		if mi.Mode == "ro" && !slices.Contains(lr[mi.Repo].Branches, mi.Branch) {
+			return errors.Errorf("cannot mount a non-existent branch in read-only mode")
 		}
 	}
 

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -1078,7 +1078,7 @@ func verifyMountRequest(mis []*MountInfo, lr ListRepoResponse) error {
 		if _, ok := lr[mi.Repo]; !ok {
 			return errors.Errorf("repo does not exist")
 		}
-		if mi.Mode == "ro" && !slices.Contains(lr[mi.Repo].Branches, mi.Branch) {
+		if mi.Mode == "ro" && lr[mi.Repo].Authorization != "none" && !slices.Contains(lr[mi.Repo].Branches, mi.Branch) {
 			return errors.Errorf("cannot mount a non-existent branch in read-only mode")
 		}
 	}


### PR DESCRIPTION
Prior to this change, mounting a non-existent branch "works", creating the corresponding repo folder in the pfs mount directory. Now, throw an error, except in the case where the mount is a read-write mount (since users can use this to add data on a new branch).

Ticket: https://linear.app/pachyderm/issue/INT-559/mounting-nonexistent-branch-silently-fails