### PR TITLE
testutils and password tests

### DIFF
--- a/examples/word_count/Makefile
+++ b/examples/word_count/Makefile
@@ -3,6 +3,7 @@ DOCKER_ACCOUNT := pachyderm
 CONTAINER_NAME := example-wordcount
 CONTAINER_VERSION := 2.0.3
 CONTAINER_TAG := $(DOCKER_ACCOUNT)/$(CONTAINER_NAME):$(CONTAINER_VERSION)
+PROJECT ?= default
 
 docker-image:
 	@docker buildx build --platform linux/amd64 -t $(CONTAINER_TAG)-amd64 .
@@ -15,20 +16,20 @@ docker-image:
 
 
 wordcount:
-	pachctl create repo urls
-	cd data && pachctl put file urls@master -f Wikipedia
-	pachctl create pipeline -f pipelines/scraper.json
-	pachctl create pipeline -f pipelines/map.json
-	pachctl create pipeline -f pipelines/reduce.json
+	pachctl create repo urls --project $(PROJECT)
+	cd data && pachctl put file urls@master -f Wikipedia --project $(PROJECT)
+	pachctl create pipeline -f pipelines/scraper.json --project $(PROJECT)
+	pachctl create pipeline -f pipelines/map.json --project $(PROJECT)
+	pachctl create pipeline -f pipelines/reduce.json --project $(PROJECT)
 
 clean:
-	pachctl delete pipeline reduce
-	pachctl delete pipeline map
-	pachctl delete pipeline scraper
-	pachctl delete repo urls
-	pachctl delete repo scraper	
-	pachctl delete repo map	
-	pachctl delete repo reduce
+	pachctl delete pipeline reduce --project $(PROJECT)
+	pachctl delete pipeline map --project $(PROJECT)
+	pachctl delete pipeline scraper --project $(PROJECT)
+	pachctl delete repo urls --project $(PROJECT)
+	pachctl delete repo scraper	--project $(PROJECT)
+	pachctl delete repo map	--project $(PROJECT)
+	pachctl delete repo reduce --project $(PROJECT)
 
 
 .PHONY:

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -149,7 +149,7 @@ func PipelineNames(t *testing.T, c *client.APIClient, project string) []string {
 	t.Helper()
 	ps, err := c.ListPipeline(false)
 	require.NoError(t, err)
-	result := make([]string, len(ps))
+	var result []string
 	if project == "" {
 		project = pfs.DefaultProjectName
 	}

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -144,16 +144,16 @@ func CommitCnt(t *testing.T, c *client.APIClient, repo *pfs.Repo) int {
 }
 
 // PipelineNames returns the names of all pipelines that 'c' gets from
-// ListPipeline.
-//
-// TODO(CORE-1100): replace with version which knows about projects.
-func PipelineNames(t *testing.T, c *client.APIClient) []string {
+// ListPipeline in the specified project. "" project name means get all pipelines.
+func PipelineNames(t *testing.T, c *client.APIClient, project string) []string {
 	t.Helper()
 	ps, err := c.ListPipeline(false)
 	require.NoError(t, err)
 	result := make([]string, len(ps))
 	for i, p := range ps {
-		result[i] = p.Pipeline.Name
+		if project == "" || project == p.Pipeline.Project.Name {
+			result[i] = p.Pipeline.Name
+		}
 	}
 	return result
 }

--- a/src/internal/testutil/auth.go
+++ b/src/internal/testutil/auth.go
@@ -144,15 +144,18 @@ func CommitCnt(t *testing.T, c *client.APIClient, repo *pfs.Repo) int {
 }
 
 // PipelineNames returns the names of all pipelines that 'c' gets from
-// ListPipeline in the specified project. "" project name means get all pipelines.
+// ListPipeline in the specified project.
 func PipelineNames(t *testing.T, c *client.APIClient, project string) []string {
 	t.Helper()
 	ps, err := c.ListPipeline(false)
 	require.NoError(t, err)
 	result := make([]string, len(ps))
-	for i, p := range ps {
-		if project == "" || project == p.Pipeline.Project.Name {
-			result[i] = p.Pipeline.Name
+	if project == "" {
+		project = pfs.DefaultProjectName
+	}
+	for _, p := range ps {
+		if project == p.GetPipeline().GetProject().GetName() {
+			result = append(result, p.GetPipeline().GetName())
 		}
 	}
 	return result

--- a/src/server/auth/server/testing/auth_integration_test.go
+++ b/src/server/auth/server/testing/auth_integration_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 // works with global.postgresql.postgresqlAuthType: md5, which is default in values file.
-var default_test_opts = minikubetestenv.WithValueOverrides(map[string]string{
+var defaultTestOptions = minikubetestenv.WithValueOverrides(map[string]string{
 	"global.postgresql.postgresqlPassword": "-strong-password!@#$%^&*(){}[]|\\:\"'<>?,./_+=0123A",
 })
 
@@ -46,7 +46,7 @@ func TestListDatum(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	alice, bob := tu.Robot(tu.UniqueString("alice")), tu.Robot(tu.UniqueString("bob"))
 	aliceClient, bobClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, bob)
@@ -136,7 +136,7 @@ func TestS3GatewayAuthRequests(t *testing.T) {
 	}
 	t.Parallel()
 
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	// generate auth credentials
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
@@ -186,7 +186,7 @@ func TestDebug(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	// Get all the authenticated clients at the beginning of the test.
 	// GetAuthenticatedPachClient will always re-activate auth, which
@@ -271,7 +271,7 @@ func TestGetPachdLogsRequiresPerm(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 
@@ -493,7 +493,7 @@ func TestPipelineRevoke(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	alice, bob := tu.Robot(tu.UniqueString("alice")), tu.Robot(tu.UniqueString("bob"))
 	aliceClient, bobClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, bob)
@@ -608,7 +608,7 @@ func TestDeleteRCInStandby(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, ns := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, ns := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	c = tu.AuthenticateClient(t, c, alice)
@@ -668,7 +668,7 @@ func TestPreActivationCronPipelinesKeepRunningAfterActivation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	aliceClient, rootClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)
@@ -757,7 +757,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	aliceClient, rootClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)
@@ -845,7 +845,7 @@ func TestDeleteAllAfterDeactivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
+	c, _ := minikubetestenv.AcquireCluster(t, defaultTestOptions)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	aliceClient, rootClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)

--- a/src/server/auth/server/testing/auth_integration_test.go
+++ b/src/server/auth/server/testing/auth_integration_test.go
@@ -32,6 +32,11 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
+// works with global.postgresql.postgresqlAuthType: md5, which is default in values file.
+var default_test_opts = minikubetestenv.WithValueOverrides(map[string]string{
+	"global.postgresql.postgresqlPassword": "-strong-password!@#$%^&*(){}[]|\\:\"'<>?,./_+=0123A",
+})
+
 // TODO(Fahad): Potentially convert these to unit tests by using Jon's fake kube apiserver
 
 // TestListDatum tests that you must have READER access to all of job's
@@ -41,7 +46,7 @@ func TestListDatum(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	alice, bob := tu.Robot(tu.UniqueString("alice")), tu.Robot(tu.UniqueString("bob"))
 	aliceClient, bobClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, bob)
@@ -130,7 +135,8 @@ func TestS3GatewayAuthRequests(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t)
+
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	// generate auth credentials
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
@@ -180,7 +186,7 @@ func TestDebug(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	// Get all the authenticated clients at the beginning of the test.
 	// GetAuthenticatedPachClient will always re-activate auth, which
@@ -265,7 +271,7 @@ func TestGetPachdLogsRequiresPerm(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	adminClient := tu.AuthenticateClient(t, c, auth.RootUser)
 
@@ -487,7 +493,7 @@ func TestPipelineRevoke(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	alice, bob := tu.Robot(tu.UniqueString("alice")), tu.Robot(tu.UniqueString("bob"))
 	aliceClient, bobClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, bob)
@@ -602,7 +608,7 @@ func TestDeleteRCInStandby(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, ns := minikubetestenv.AcquireCluster(t)
+	c, ns := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	c = tu.AuthenticateClient(t, c, alice)
@@ -662,7 +668,7 @@ func TestPreActivationCronPipelinesKeepRunningAfterActivation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	aliceClient, rootClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)
@@ -751,7 +757,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	aliceClient, rootClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)
@@ -773,7 +779,7 @@ func TestPipelinesRunAfterExpiration(t *testing.T) {
 		"",    // default output branch: master
 		false, // no update
 	))
-	require.OneOfEquals(t, pipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, pipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 	// check that alice owns the output repo too,
 	require.Equal(t, tu.BuildBindings(alice, auth.RepoOwnerRole, tu.Pl(pfs.DefaultProjectName, pipeline), auth.RepoWriterRole), tu.GetRepoRoleBinding(t, aliceClient, pfs.DefaultProjectName, pipeline))
 
@@ -839,7 +845,7 @@ func TestDeleteAllAfterDeactivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
-	c, _ := minikubetestenv.AcquireCluster(t)
+	c, _ := minikubetestenv.AcquireCluster(t, default_test_opts)
 	tu.ActivateAuthClient(t, c)
 	alice := tu.Robot(tu.UniqueString("alice"))
 	aliceClient, rootClient := tu.AuthenticateClient(t, c, alice), tu.AuthenticateClient(t, c, auth.RootUser)

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -414,7 +414,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 		name:   pipeline,
 		repo:   dataRepo,
 	}))
-	require.OneOfEquals(t, pipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, pipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 	// check that alice owns the output repo too)
 	require.Equal(t,
 		tu.BuildBindings(alice, auth.RepoOwnerRole, tu.Pl(pfs.DefaultProjectName, pipeline), auth.RepoWriterRole), tu.GetRepoRoleBinding(t, aliceClient, pfs.DefaultProjectName, pipeline))
@@ -437,7 +437,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.NoneEquals(t, badPipeline, tu.PipelineNames(t, aliceClient))
+	require.NoneEquals(t, badPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 
 	// alice adds bob as a reader of the input repo
 	require.NoError(t, aliceClient.ModifyProjectRepoRoleBinding(pfs.DefaultProjectName, dataRepo, bob, []string{auth.RepoReaderRole}))
@@ -449,7 +449,7 @@ func TestCreateAndUpdatePipeline(t *testing.T) {
 		name:   goodPipeline,
 		repo:   dataRepo,
 	}))
-	require.OneOfEquals(t, goodPipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, goodPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 	// check that bob owns the output repo too)
 	require.Equal(t,
 		tu.BuildBindings(bob, auth.RepoOwnerRole, tu.Pl(pfs.DefaultProjectName, goodPipeline), auth.RepoWriterRole), tu.GetRepoRoleBinding(t, bobClient, pfs.DefaultProjectName, goodPipeline))
@@ -612,7 +612,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 			client.NewProjectPFSInput(pfs.DefaultProjectName, dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, aliceCrossPipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, aliceCrossPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 	// check that alice owns the output repo too)
 	require.Equal(t,
 		tu.BuildBindings(alice, auth.RepoOwnerRole, tu.Pl(pfs.DefaultProjectName, aliceCrossPipeline), auth.RepoWriterRole), tu.GetRepoRoleBinding(t, aliceClient, pfs.DefaultProjectName, aliceCrossPipeline))
@@ -627,7 +627,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 			client.NewProjectPFSInput(pfs.DefaultProjectName, dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, aliceUnionPipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, aliceUnionPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 	// check that alice owns the output repo too)
 	require.Equal(t,
 		tu.BuildBindings(alice, auth.RepoOwnerRole, tu.Pl(pfs.DefaultProjectName, aliceUnionPipeline), auth.RepoWriterRole), tu.GetRepoRoleBinding(t, aliceClient, pfs.DefaultProjectName, aliceUnionPipeline))
@@ -647,7 +647,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.NoneEquals(t, bobCrossPipeline, tu.PipelineNames(t, aliceClient))
+	require.NoneEquals(t, bobCrossPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 
 	// bob cannot create a union-pipeline with both inputs
 	bobUnionPipeline := tu.UniqueString("bob-union")
@@ -661,7 +661,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 	})
 	require.YesError(t, err)
 	require.Matches(t, "not authorized", err.Error())
-	require.NoneEquals(t, bobUnionPipeline, tu.PipelineNames(t, aliceClient))
+	require.NoneEquals(t, bobUnionPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 
 	// alice adds bob as a writer of her pipeline's output
 	require.NoError(t, aliceClient.ModifyProjectRepoRoleBinding(pfs.DefaultProjectName, aliceCrossPipeline, bob, []string{auth.RepoWriterRole}))
@@ -729,7 +729,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 			client.NewProjectPFSInput(pfs.DefaultProjectName, dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, bobCrossPipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, bobCrossPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 
 	// bob can create a union-pipeline with both inputs
 	require.NoError(t, createPipeline(createArgs{
@@ -740,7 +740,7 @@ func TestPipelineMultipleInputs(t *testing.T) {
 			client.NewProjectPFSInput(pfs.DefaultProjectName, dataRepo2, "/*"),
 		),
 	}))
-	require.OneOfEquals(t, bobUnionPipeline, tu.PipelineNames(t, aliceClient))
+	require.OneOfEquals(t, bobUnionPipeline, tu.PipelineNames(t, aliceClient, pfs.DefaultProjectName))
 
 }
 

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -995,7 +995,7 @@ All jobs created by a pipeline will create commits in the pipeline's output repo
 	listPipeline.Flags().StringVar(&history, "history", "none", "Return revision history for pipelines.")
 	listPipeline.Flags().StringVarP(&commit, "commit", "c", "", "List the pipelines as they existed at this commit.")
 	listPipeline.Flags().StringArrayVar(&stateStrs, "state", []string{}, "Return only pipelines with the specified state. Can be repeated to include multiple states")
-	listPipeline.Flags().StringVar(&project, "project", pfs.DefaultProjectName, "Project containing projects.")
+	listPipeline.Flags().StringVar(&project, "project", pfs.DefaultProjectName, "Project containing pipelines.")
 	commands = append(commands, cmdutil.CreateAliases(listPipeline, "list pipeline", pipelines))
 
 	var commitSet string


### PR DESCRIPTION
### Tickets: 

CORE-1100
CORE-714

### Summary

I'm adding project awareness to auth tests. This doesn't handle adding new tests, but sets us up to do so in the future.

I'm adding tests to check for weird characters(specifically ") in passwords by just making it the default pg password in the auth tests.

I added project awareness to the makefile for the word_count example as a bonus to help with tesitng as that project moves forward.

**I changed cmds.go since I think there was a typo, but let me know if I misunderstood.**

### Testing:

Ran both the auth_test.go and auth_integration_test.go locally and confirmed all passing.
Ran the word count example and confirmed passing.