### PR TITLE
Revert "Test tweaking default shard threshold (#8230)"

### DIFF
--- a/src/internal/storage/fileset/index/reader.go
+++ b/src/internal/storage/fileset/index/reader.go
@@ -32,7 +32,7 @@ func NewReader(chunks *chunk.Storage, cache *Cache, topIdx *Index, opts ...Optio
 		topIdx: topIdx,
 		shardConfig: &ShardConfig{
 			NumFiles:  1000000,
-			SizeBytes: 10 * units.GB,
+			SizeBytes: units.GB,
 		},
 	}
 	for _, opt := range opts {

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -23,7 +23,7 @@ const (
 	DefaultMemoryThreshold = units.GB
 	// DefaultShardThreshold is the default for the size threshold that must
 	// be met before a shard is created by the shard function.
-	DefaultShardSizeThreshold  = 10 * units.GB
+	DefaultShardSizeThreshold  = units.GB
 	DefaultShardCountThreshold = 1000000
 	// DefaultCompactionFixedDelay is the default fixed delay for compaction.
 	// This is expressed as the number of primitive filesets.


### PR DESCRIPTION
This PR reverts a recent change to the default shard threshold. The default shard threshold being this high is problematic for TestTemporaryDuplicatedPath. It isn't clear whether this reflects a general issue with shards this large in resource constrained environments, so I am reverting it for now to fix master.