### PR TITLE
bump envoy proxy stream idle timeout to 24hrs

### DIFF
--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -105,7 +105,7 @@
       codec_type: 'auto',
       common_http_protocol_options: {
         headers_with_underscores_action: 'REJECT_REQUEST',
-        idle_timeout: '3600s',
+        idle_timeout: '86400s',
       },
       http2_protocol_options: {
         initial_connection_window_size: 1048576,

--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -136,7 +136,7 @@
         accept_http_10: false,
       },
       request_timeout: '604800s',  // Necessary to allow long file uploads.
-      stream_idle_timeout: '3600s',  // Only completely idle streams are dropped after this timeout.
+      stream_idle_timeout: '86400s',  // Only completely idle streams are dropped after this timeout.
       route_config: {
         [if std.length(response_headers_to_add) > 0 then 'response_headers_to_add' else null]: [
           {

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -359,7 +359,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -443,7 +443,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -639,7 +639,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -404,7 +404,7 @@
                               ]
                            },
                            "stat_prefix": "https-redirect",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -578,7 +578,7 @@
                               ]
                            },
                            "stat_prefix": "proxy-https",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -684,7 +684,7 @@
                               ]
                            },
                            "stat_prefix": "proxy-https-cleartext",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -486,7 +486,7 @@
                               ]
                            },
                            "stat_prefix": "proxy-http",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -570,7 +570,7 @@
                               ]
                            },
                            "stat_prefix": "https-warning",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -679,7 +679,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-s3",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -770,7 +770,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-grpc",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -853,7 +853,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-metrics",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -936,7 +936,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-oidc",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -1019,7 +1019,7 @@
                               ]
                            },
                            "stat_prefix": "direct-pachd-identity",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }
@@ -1108,7 +1108,7 @@
                               ]
                            },
                            "stat_prefix": "direct-console",
-                           "stream_idle_timeout": "3600s",
+                           "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
                      }

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -359,7 +359,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -522,7 +522,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -606,7 +606,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -715,7 +715,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -806,7 +806,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -889,7 +889,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -972,7 +972,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
@@ -1055,7 +1055,7 @@
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
-                              "idle_timeout": "3600s"
+                              "idle_timeout": "86400s"
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,


### PR DESCRIPTION
nightly load test env recently started using the proxy, envs had been broken for a bit and seems we missed these errors, `rpc error: code = Unavailable desc = stream timeout` which require a longer timeout

related to #8284 