### PR TITLE
[Jupyter] Fix datums-related error message when notebooks starts up

### DIFF
--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -424,15 +424,17 @@ export class MountPlugin implements IMountPlugin {
           this._poller.status.code !== 200,
       );
 
-      try {
-        const res = await requestAPI<CurrentDatumResponse>('datums', 'GET');
-        if (res['num_datums'] > 0) {
-          this._keepMounted = true;
-          this._currentDatumInfo = res;
-          await this.setShowDatum(true);
+      if (this._poller.status.code === 200) {
+        try {
+          const res = await requestAPI<CurrentDatumResponse>('datums', 'GET');
+          if (res['num_datums'] > 0) {
+            this._keepMounted = true;
+            this._currentDatumInfo = res;
+            await this.setShowDatum(true);
+          }
+        } catch (e) {
+          console.log(e);
         }
-      } catch (e) {
-        console.log(e);
       }
     }
     this._loader.setHidden(true);


### PR DESCRIPTION
Make datums request at notebooks startup only when connected to a cluster and logged in if auth enabled (when mount server response is `200`).

Ticket: https://linear.app/pachyderm/issue/INT-760/error-message-when-starting-up-notebooks

JIRA: [INT-782]

[INT-782]: https://pachyderm.atlassian.net/browse/INT-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ