### PR TITLE
[PFS-10] Fix Misleading Version Check Logic

### DIFF
--- a/src/client/admin.go
+++ b/src/client/admin.go
@@ -2,15 +2,16 @@ package client
 
 import (
 	"github.com/gogo/protobuf/types"
+
 	"github.com/pachyderm/pachyderm/v2/src/admin"
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 )
 
 // InspectCluster retrieves cluster state
 func (c APIClient) InspectCluster() (*admin.ClusterInfo, error) {
 	clusterInfo, err := c.AdminAPIClient.InspectCluster(c.Ctx(), &types.Empty{})
 	if err != nil {
-		return nil, grpcutil.ScrubGRPC(err)
+		return nil, errors.Wrap(err, "failed to inspect cluster")
 	}
 	return clusterInfo, nil
 }

--- a/src/internal/pachd/builder.go
+++ b/src/internal/pachd/builder.go
@@ -176,13 +176,6 @@ func (b *builder) initExternalServer(ctx context.Context) error {
 	b.daemon.external, err = grpcutil.NewServer(
 		ctx,
 		true,
-		// Add an UnknownServiceHandler to catch the case where the user has a client with the wrong major version.
-		// Weirdly, GRPC seems to run the interceptor stack before the UnknownServiceHandler, so this is never called
-		// (because the version_middleware interceptor throws an error, or the auth interceptor does).
-		grpc.UnknownServiceHandler(func(srv interface{}, stream grpc.ServerStream) error {
-			method, _ := grpc.MethodFromServerStream(stream)
-			return errors.Errorf("unknown service %v", method)
-		}),
 		grpc.ChainUnaryInterceptor(
 			errorsmw.UnaryServerInterceptor,
 			version_middleware.UnaryServerInterceptor,

--- a/src/server/admin/cmds/cmds.go
+++ b/src/server/admin/cmds/cmds.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,7 @@ func Cmds() []*cobra.Command {
 			defer c.Close()
 			ci, err := c.InspectCluster()
 			if err != nil {
-				return err
+				return grpcutil.ScrubGRPC(err)
 			}
 			fmt.Println(ci.ID)
 			return nil


### PR DESCRIPTION
This PR updates the version check logic:

- Previously, if an error was returned from inspect cluster and the error was scrubbed, pachctl would display an error saying the version is different, which was incorrect.
- Pachctl now attempts to get the version of pachd and display the actual version mismatch