### PR TITLE
[CORE-1291] Default project in transactional repo creation

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -145,9 +145,7 @@ func (d *driver) createRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 	if repo == nil {
 		return errors.New("repo cannot be nil")
 	}
-	if repo.Project == nil || repo.Project.Name == "" {
-		repo.Project = &pfs.Project{Name: pfs.DefaultProjectName}
-	}
+	repo.EnsureProject()
 
 	// Check that the user is logged in (user doesn't need any access level to
 	// create a repo, but they must be authenticated if auth is active)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -145,6 +145,9 @@ func (d *driver) createRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Rep
 	if repo == nil {
 		return errors.New("repo cannot be nil")
 	}
+	if repo.Project == nil || repo.Project.Name == "" {
+		repo.Project = &pfs.Project{Name: pfs.DefaultProjectName}
+	}
 
 	// Check that the user is logged in (user doesn't need any access level to
 	// create a repo, but they must be authenticated if auth is active)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -755,6 +755,40 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, err)
 	})
 
+	suite.Run("CreateRepoWithoutProject", func(t *testing.T) {
+		t.Parallel()
+		env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+
+		repo := "repo123"
+		_, err = env.PachClient.PfsAPIClient.CreateRepo(context.Background(), &pfs.CreateRepoRequest{
+			Repo: &pfs.Repo{Name: repo},
+		})
+		require.NoError(t, err)
+
+		repoInfo, err := env.PachClient.InspectProjectRepo(pfs.DefaultProjectName, repo)
+		require.NoError(t, err)
+		require.Equal(t, repo, repoInfo.Repo.Name)
+		require.NotNil(t, repoInfo.Created)
+		require.Equal(t, 0, int(repoInfo.Details.SizeBytes))
+	})
+
+	suite.Run("CreateRepoWithEmptyProject", func(t *testing.T) {
+		t.Parallel()
+		env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+
+		repo := "repo123"
+		_, err = env.PachClient.PfsAPIClient.CreateRepo(context.Background(), &pfs.CreateRepoRequest{
+			Repo: &pfs.Repo{Project: &pfs.Project{}, Name: repo},
+		})
+		require.NoError(t, err)
+
+		repoInfo, err := env.PachClient.InspectProjectRepo(pfs.DefaultProjectName, repo)
+		require.NoError(t, err)
+		require.Equal(t, repo, repoInfo.Repo.Name)
+		require.NotNil(t, repoInfo.Created)
+		require.Equal(t, 0, int(repoInfo.Details.SizeBytes))
+	})
+
 	suite.Run("ListRepo", func(t *testing.T) {
 		t.Parallel()
 		env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -760,7 +760,7 @@ func TestPFS(suite *testing.T) {
 		env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo123"
-		_, err = env.PachClient.PfsAPIClient.CreateRepo(context.Background(), &pfs.CreateRepoRequest{
+		_, err := env.PachClient.PfsAPIClient.CreateRepo(context.Background(), &pfs.CreateRepoRequest{
 			Repo: &pfs.Repo{Name: repo},
 		})
 		require.NoError(t, err)
@@ -777,7 +777,7 @@ func TestPFS(suite *testing.T) {
 		env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
 
 		repo := "repo123"
-		_, err = env.PachClient.PfsAPIClient.CreateRepo(context.Background(), &pfs.CreateRepoRequest{
+		_, err := env.PachClient.PfsAPIClient.CreateRepo(context.Background(), &pfs.CreateRepoRequest{
 			Repo: &pfs.Repo{Project: &pfs.Project{}, Name: repo},
 		})
 		require.NoError(t, err)

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -475,8 +475,10 @@ func TestTransactions(suite *testing.T) {
 	})
 
 	suite.Run("TestProjectlessBatch", func(t *testing.T) {
-		info, err := env.PachClient.RunBatchInTransaction(func(builder *client.TransactionBuilder) error {
-			_, err := builder.PfsApiClient.CreateRepo(&pfs.CreateRepoRequest{
+		t.Parallel()
+		env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+		_, err := env.PachClient.RunBatchInTransaction(func(builder *client.TransactionBuilder) error {
+			_, err := builder.PfsAPIClient.CreateRepo(builder.Ctx(), &pfs.CreateRepoRequest{
 				Repo: &pfs.Repo{
 					Name: "someproject",
 				},

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -520,3 +520,37 @@ func TestCreatePipelineTransaction(t *testing.T) {
 	require.NoError(t, c.GetFile(commitInfo.Commit, "foo", &buf))
 	require.Equal(t, "bar", buf.String())
 }
+
+func TestCreateProjectlessPipelineTransaction(t *testing.T) {
+	c, _ := minikubetestenv.AcquireCluster(t)
+	repo := testutil.UniqueString("in")
+	pipeline := testutil.UniqueString("pipeline")
+	_, err := c.ExecuteInTransaction(func(txnClient *client.APIClient) error {
+		require.NoError(t, txnClient.CreateProjectRepo(pfs.DefaultProjectName, repo))
+		_, err := txnClient.PpsAPIClient.CreatePipeline(txnClient.Ctx(),
+			&pps.CreatePipelineRequest{
+				Pipeline: &pps.Pipeline{Name: pipeline},
+				Transform: &pps.Transform{
+					Image: testutil.DefaultTransformImage,
+					Cmd:   []string{"bash"},
+					Stdin: []string{fmt.Sprintf("cp /pfs/%s/* /pfs/out", repo)},
+				},
+				ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
+				Input:           client.NewProjectPFSInput(pfs.DefaultProjectName, repo, "/"),
+				OutputBranch:    "master",
+			})
+		require.NoError(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+
+	commit := client.NewProjectCommit(pfs.DefaultProjectName, repo, "master", "")
+	require.NoError(t, c.PutFile(commit, "foo", strings.NewReader("bar")))
+
+	commitInfo, err := c.WaitProjectCommit(pfs.DefaultProjectName, pipeline, "master", "")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, c.GetFile(commitInfo.Commit, "foo", &buf))
+	require.Equal(t, "bar", buf.String())
+}

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -473,6 +473,19 @@ func TestTransactions(suite *testing.T) {
 			}
 		}
 	})
+
+	suite.Run("TestProjectlessBatch", func(t *testing.T) {
+		info, err := env.PachClient.RunBatchInTransaction(func(builder *client.TransactionBuilder) error {
+			_, err := builder.PfsApiClient.CreateRepo(&pfs.CreateRepoRequest{
+				Repo: &pfs.Repo{
+					Name: "someproject",
+				},
+			})
+			require.NoError(t, err)
+			return nil
+		})
+		require.NoError(t, err)
+	})
 }
 
 func TestCreatePipelineTransaction(t *testing.T) {


### PR DESCRIPTION
If the project is not included or is empty, use the default project. This enables older clients to still create projects.