### PR TITLE
Deal with subprocesses cleanly in the worker

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -7,7 +7,12 @@ COPY LICENSE /LICENSE
 COPY licenses /licenses
 
 WORKDIR /app
-COPY worker . 
+# etc/worker/init.go copies the dumb-init for the right architecture into the user container and
+# makes it executable.  This is to avoid needing a shell in this container to run
+# `if [ $TARGETPLATFORM = "linux/amd64 "]; ...`
+ADD --chown=1000:1000 https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /app/dumb-init-amd64
+ADD --chown=1000:1000 https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_aarch64 /app/dumb-init-arm64
+COPY worker .
 COPY worker_init init
 COPY pachctl .
 COPY pachtf .

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -173,7 +173,7 @@ func TestPipelineWithSubprocesses(t *testing.T) {
 	c, _ := minikubetestenv.AcquireCluster(t)
 	c = c.WithDefaultTransformUser("1000")
 
-	projectName := tu.UniqueString("project")
+	projectName := tu.UniqueString("p")
 	require.NoError(t, c.CreateProject(projectName))
 	dataRepoName := tu.UniqueString("TestPipelineWithSubprocesses_data")
 	require.NoError(t, c.CreateProjectRepo(projectName, dataRepoName))
@@ -184,7 +184,7 @@ func TestPipelineWithSubprocesses(t *testing.T) {
 	require.NoError(t, c.PutFile(commit1, "bar", strings.NewReader("bar"), client.WithAppendPutFile()))
 	require.NoError(t, c.FinishProjectCommit(projectName, dataRepoName, commit1.Branch.Name, commit1.ID))
 
-	pipeline := tu.UniqueString("TestPipelineWithSubprocesses")
+	pipeline := tu.UniqueString("TestPipelineWS")
 	_, err = c.PpsAPIClient.CreatePipeline(
 		c.Ctx(),
 		&pps.CreatePipelineRequest{
@@ -217,8 +217,12 @@ func TestPipelineWithSubprocesses(t *testing.T) {
 	}
 	require.NotNil(t, output, "output commit should have been found (got: %#v)", commitInfos)
 
-	require.NoError(t, c.GetFile(output.Commit, "foo", io.Discard), "should get foo without error")
-	require.NoError(t, c.GetFile(output.Commit, "bar", io.Discard), "should get bar without error")
+	buf := new(bytes.Buffer)
+	require.NoError(t, c.GetFile(output.Commit, "foo", buf), "should get foo without error")
+	require.Equal(t, "foo", buf.String(), "content should be correct")
+	buf.Reset()
+	require.NoError(t, c.GetFile(output.Commit, "bar", buf), "should get bar without error")
+	require.Equal(t, "bar", buf.String(), "content should be correct")
 }
 
 func TestCrossProjectPipeline(t *testing.T) {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -431,7 +431,7 @@ func (kd *kubeDriver) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pi
 			{
 				Name:            client.PPSWorkerUserContainerName,
 				Image:           options.userImage,
-				Command:         []string{"/pach-bin/worker"},
+				Command:         []string{"/pach-bin/dumb-init", "--", "/pach-bin/worker"},
 				ImagePullPolicy: v1.PullPolicy(pullPolicy),
 				Env:             workerEnv,
 				Resources: v1.ResourceRequirements{

--- a/src/server/worker/driver/block_linux.go
+++ b/src/server/worker/driver/block_linux.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+package driver
+
+import (
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+const _P_PID = 1
+
+// blockUntilWaitable attempts to block until a call to Wait4(pid) will succeed immediately, and
+// reports whether it has done so.  It does not actually call Wait4.  Incorrect results will be
+// returned if pid has not been started at the time of the call.  This code is modified slightly
+// from os/wait_waitid.go in the Go source code.
+func blockUntilWaitable(pid int) (bool, error) {
+	// The waitid system call expects a pointer to a siginfo_t,
+	// which is 128 bytes on all Linux systems.
+	// On darwin/amd64, it requires 104 bytes.
+	// We don't care about the values it returns.
+	var siginfo [16]uint64
+	psig := &siginfo[0]
+	var e syscall.Errno
+	for {
+		_, _, e = syscall.Syscall6(syscall.SYS_WAITID, _P_PID, uintptr(pid), uintptr(unsafe.Pointer(psig)), syscall.WEXITED|syscall.WNOWAIT, 0, 0)
+		if e != syscall.EINTR {
+			break
+		}
+	}
+	runtime.KeepAlive(pid)
+	if e != 0 {
+		if e == syscall.ECHILD {
+			// This means there is no process with that ID, so we can assume it's gone.
+			return true, e
+		}
+		return false, e
+	}
+	return true, nil
+}

--- a/src/server/worker/driver/block_nonlinux.go
+++ b/src/server/worker/driver/block_nonlinux.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package driver
+
+// On OSes other than Linux, waitid(2) is too broken to use, or not implemented at all.
+func blockUntilWaitable(pid int) (bool, error) {
+	return false, nil
+}

--- a/src/server/worker/driver/driver_unix.go
+++ b/src/server/worker/driver/driver_unix.go
@@ -1,9 +1,10 @@
-//go:build !windows
-// +build !windows
+//go:build unix
+// +build unix
 
 package driver
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,16 +13,50 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/common"
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
 )
 
-func makeCmdCredentials(uid uint32, gid uint32) *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Uid:         uid,
-			Gid:         gid,
-			NoSetGroups: true,
-		},
+func makeSysProcAttr(uid *uint32, gid *uint32) *syscall.SysProcAttr {
+	attr := &syscall.SysProcAttr{
+		// We create a process group so that we can later send SIGKILL to all child
+		// processes created by the user code.
+		Setpgid: true,
 	}
+	if uid != nil && gid != nil {
+		attr.Credential = &syscall.Credential{
+			Uid:         *uid,
+			Gid:         *gid,
+			NoSetGroups: true,
+		}
+	}
+	return attr
+}
+
+// makeProcessGroupKiller creates a background goroutine that kills all processes assosciated with
+// the provided process group when the root context expires or the returned cancellation function is
+// called.  Even though we pass a negative number to syscall.Kill, pgid should be positive.
+//
+// For the driver specifically, we always run this no matter what.  If the context times out, we
+// kill all subprocesses including the parent (the non-zero exit there will fail the job, as
+// expected).  If user code exits 0, but has child processes in the background, we still kill those,
+// but the job will succeed.  If user code wants to fail when its children hang, it will have to
+// implement that logic itself (by calling waitpid on the children; "wait" in bash).
+func makeProcessGroupKiller(rctx context.Context, l logs.TaggedLogger, pgid int) func() {
+	ctx, c := context.WithCancel(rctx)
+	go func() {
+		<-ctx.Done()
+		l.Logf("killing remaining children") // XXX: delete
+		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+			// ESRCH means that the process group is gone, because everything
+			// has already exited on its own (or there was only one process in
+			// the process group, and it's already gone).
+			if err == syscall.ESRCH {
+				return
+			}
+			l.Logf("warning: problem killing user code process group #%v: %v", pgid, err)
+		}
+	}()
+	return c
 }
 
 // WithActiveData is implemented differently in unix vs windows because of how

--- a/src/server/worker/driver/driver_unix.go
+++ b/src/server/worker/driver/driver_unix.go
@@ -45,7 +45,7 @@ func makeProcessGroupKiller(rctx context.Context, l logs.TaggedLogger, pgid int)
 	ctx, c := context.WithCancel(rctx)
 	go func() {
 		<-ctx.Done()
-		l.Logf("killing remaining children") // XXX: delete
+		logRunningProcesses(l, pgid)
 		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
 			// ESRCH means that the process group is gone, because everything
 			// has already exited on its own (or there was only one process in

--- a/src/server/worker/driver/driver_windows.go
+++ b/src/server/worker/driver/driver_windows.go
@@ -1,9 +1,9 @@
+//go:build windows
 // +build windows
 
 package driver
 
 import (
-	
 	"os"
 	"path/filepath"
 	"syscall"
@@ -15,8 +15,14 @@ import (
 
 // Note: these are stubs only meant for tests - the worker does not run on windows
 
-func makeCmdCredentials(uid uint32, gid uint32) *syscall.SysProcAttr {
+func makeSysProcAttr(uid *uint32, gid *uint32) *syscall.SysProcAttr {
 	return nil
+}
+
+func makeProcessGroupKiller(rctx context.Context, l logs.TaggedLogger, p *os.Process) func() {
+	return func() {
+		l.Logf("warning: not killing user code's children: unsupported OS")
+	}
 }
 
 // WithActiveData is implemented differently in unix vs windows because of how

--- a/src/server/worker/driver/ps_linux.go
+++ b/src/server/worker/driver/ps_linux.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package driver
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
+)
+
+// logRunningProcesses will print the cmdline of processes that we'd kill if we killed the provided
+// process group.  Looking at these logs will let users know that they might be doing something
+// interesting accidentally.
+func logRunningProcesses(l logs.TaggedLogger, pgid int) {
+	err := filepath.WalkDir("/proc", func(path string, d fs.DirEntry, err error) error {
+		if path == "/proc" {
+			return nil
+		}
+		if !d.IsDir() {
+			return filepath.SkipDir
+		}
+		if err != nil {
+			return err
+		}
+
+		pid, err := strconv.Atoi(d.Name())
+		if err != nil {
+			// Not a PID directory.
+			return filepath.SkipDir
+		}
+		stat, err := os.ReadFile(filepath.Join(path, "stat"))
+		if err != nil {
+			l.Logf("warning: unable to read stat: %v", err)
+			return filepath.SkipDir
+		}
+		// From proc(5):
+		// /proc/[pid]/stat
+		//
+		//     Status information about the process.  This is used by ps(1).  It is defined
+		//     in the kernel source file fs/proc/array.c.
+		//         (1) pid  %d
+		//         The process ID.
+		//         (2) comm  %s
+		//         The  filename of the executable, in parentheses.
+		//         ...
+		//         (5) pgrp  %d
+		//         The process group ID of the process.
+		//
+		// That man page is 1-indexed.
+		var comm string
+		statParts := bytes.SplitN(stat, []byte{' '}, 6)
+		if len(statParts) > 4 {
+			pgrp, err := strconv.Atoi(string(statParts[4]))
+			if err != nil {
+				l.Logf("warning: unable to parse %v/stat[4]: %v", path, err)
+				return filepath.SkipDir
+			}
+			if pgrp != pgid {
+				// Not something we're going to try and kill; ignore.
+				return filepath.SkipDir
+			}
+			comm = string(statParts[1])
+		}
+
+		cmdline, err := os.ReadFile(filepath.Join(path, "cmdline"))
+		if err != nil {
+			l.Logf("warning: unable to read cmdline: %v", err)
+		}
+		cmdlineParts := bytes.Split(cmdline, []byte{0})
+
+		l.Logf("note: about to kill unexpectedly-remaining subprocess of the user code: pid=%v comm=%v cmdline=%s", pid, comm, bytes.Join(cmdlineParts, []byte{' '}))
+		return filepath.SkipDir
+	})
+	if err != nil {
+		l.Logf("warning: unable to walk /proc (to provide debug information about orphaned child processes): %v", err)
+	}
+}

--- a/src/server/worker/driver/ps_linux_test.go
+++ b/src/server/worker/driver/ps_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package driver
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
+)
+
+type testLogger struct {
+	logs.TaggedLogger
+	entries []string
+}
+
+func (l *testLogger) Logf(format string, args ...any) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
+}
+
+func TestLogRunningProcesses(t *testing.T) {
+	l := new(testLogger)
+	logRunningProcesses(l, syscall.Getpgrp())
+	t.Logf("entries:\n\t%v", strings.Join(l.entries, "\n\t"))
+	if len(l.entries) < 1 {
+		t.Errorf("expected logs")
+	}
+	for _, ent := range l.entries {
+		if strings.HasPrefix(ent, "warning: ") {
+			t.Errorf("unexpected warning: %q", ent)
+		}
+	}
+}

--- a/src/server/worker/driver/ps_nonlinux.go
+++ b/src/server/worker/driver/ps_nonlinux.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package driver
+
+import "github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
+
+func logRunningProcesses(l logs.TaggedLogger, pgid int) {
+	l.Logf("warning: listing processes on this OS is not supported; you won't see debug information about which child processes we're about to kill")
+}


### PR DESCRIPTION
This fixes 2 things.

## Zombies (CORE-1279)

If user code spawns a background process and it exits without the user code calling `waitpid` on it before the user code exits, we end up with a zombie process that takes up a slot in the process table forever.  We now run the worker through dumb-init to reap these zombies, preventing the process table from filling up when user code behaves like this.   Fixing this is not a huge deal in practice, but it's good for correctness.  Setting DUMB_INIT_DEBUG=1 will print something whenever a zombie is reaped.  A pipeline that runs a bash script like `sleep 30 & touch /pfs/out/foo` is an example of how to produce a zombie prior to this change. 

## Subprocesses that don't exit (CORE-1016, CORE-1280):

If user code spawns a background process that DOES NOT exit, then we have big problems.  It could hold stdout open forever, which means we wait forever reading that inside `cmd.Wait()`, even if the user code is killed because of a context timeout.  We had a workaround prior to #8066, but it didn't go far enough.  A case it ignores is where a child of the user code doesn't read STDOUT but uses some other resource on the system, like a TCP port.  Issue #8375 is an example of something that does this.  This PR fixes that case by running the user code in a process group, and sending SIGKILL to the process group when the user code exits (leaving around background processes) or is killed (because of an expiring context).  This means that everything the user code spawned gets SIGKILL'd and is guaranteed to terminate, releasing any file descriptors we were reading (STDOUT) or other resources (TCP ports).  

We make a best effort to log when we're about to do this (find /proc/... races with processes exiting on their own before we call kill); so the logs look something like this running the opencv example as a bash script like `sleep infinity & python3 /edges.py`:

```
Nov 22 22:43:24 beginning to run user code pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:[{"hash":"q4zXe15LED6ufrTyMlNYCP+dN/coyuQPAQ/KoY7n9iQ=","path":"/1VqcWw9.jpg"}] datumId:aa7e5b5ee2d9e78cfd714209d5d591078f86671e53e1710f1e658e353813cc25
Nov 22 22:43:24 /usr/local/lib/python3.4/dist-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment. pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:↑ datumId:↑ user:true
Nov 22 22:43:24   warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.') pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:↑ datumId:↑ user:↑
Nov 22 22:43:24 /usr/local/lib/python3.4/dist-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment. pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:↑ datumId:↑ user:↑
Nov 22 22:43:24   warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.') pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:↑ datumId:↑ user:↑
Nov 22 22:43:24 note: about to kill unexpectedly-remaining subprocess of the user code: pid=35 comm=(sleep) cmdline=sleep infinity  pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:↑ datumId:↑
Nov 22 22:43:24 finished running user code after 598.008993ms pipelineName:↑ projectName:↑ workerId:↑ jobId:↑ data:↑ datumId:↑
```                                                                                                              

A process can leave the process group and they will have the same problems (stdout stuck open) as before.  You have to go out of your way to leave the process group, but if a user does that, we have no way of fixing that.  (For that, we'd have to create a PID namespace with unshare, but that requires root or at least CAP_SYSADMIN.)

Anyway, this bug is fairly common; if you've ever run "stop job" and it didn't stop, or if you see something taking longer than the DatumTimeout, you hit this bug.  I've seen it quite a bit but didn't recognize the cause until looking into this in detail.  `sleep infinity & touch /pfs/out/foo` is an example of a script that used to break, but now works.

`TestService` in pachyderm_test would be broken by this bug, but they found a workaround for this issue: `exec python ...` instead of `python ...`.  I've made that test do it "wrong" now, acting as a test for this fix.  Now users don't have to be UNIX wizards to have a working web server for files in a repo!

One reason this bug is problematic in general is that we use SIGKILL (via a hard-coded default in exec.Cmd); if the user code has cleanup code to terminate it subprocesses, it can't run it because SIGKILL is not something it can catch.  SIGTERM + grace period + SIGKILL would be more polite and less likely to cause problems; a well-behaved app would catch SIGTERM and kill its children.  The ideal solution here is to run the user code in a new PID namespace and let it be pid 1; then user code could use dumb-init to remap SIGKILL to SIGTERM if it felt like it.  But creating a PID namespace requires root, which we try to avoid, so I didn't pursue that route.

Finally, *this is technically a breaking change*.  If you had a pipeline like `do_actual_work & sleep 10` and `do_actual_work` runs longer than 10 seconds, that would work in the past, but won't work now.  Worse, the job will be marked successful because bash will exit 0 after the sleep 10.  In the past, we would wait indefinitely for `do_actual_work` to close stdout, but now we SIGKILL it instantly.  Something we'll have to watch out for as users upgrade.

## How I tested this

I ran TestPipelineWithSubprocess with and without this PR -- without, it hangs forever; with, it passes.

I ran (this PR's version of) TestService with and without this PR -- without, the first version of the server never gets killed and the test times out; with, it works as expected.  Some logs:
```
Nov 22 21:22:23 beginning to run user code master:true pipelineName:pipelineservice47fafd305644 projectName:default workerId:pipeline-default-pipelineservice47fafd305644-v1-5jpzk data:[{"hash":"tzUlQiTOsvaBavGE0GHMNpn5FVUqne/23Cvboctq8pw=","path":"/"}] datumId:17f6ef2602f33a7faa8e4fe5eca9730c4851f2132fb97dd67c1d48cecf82a1c7

Nov 22 21:22:28 10.244.0.1 - - [23/Nov/2022 02:22:28] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:true
Nov 22 21:22:28 canceling previous service, new job ready master:true pipelineName:↑ projectName:↑ workerId:↑
Nov 22 21:22:29 10.244.0.1 - - [23/Nov/2022 02:22:29] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:[{"hash":"tzUlQiTOsvaBavGE0GHMNpn5FVUqne/23Cvboctq8pw=","path":"/"}] datumId:17f6ef2602f33a7faa8e4fe5eca9730c4851f2132fb97dd67c1d48cecf82a1c7 user:true
Nov 22 21:22:29 10.244.0.1 - - [23/Nov/2022 02:22:29] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:30 10.244.0.1 - - [23/Nov/2022 02:22:30] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:32 10.244.0.1 - - [23/Nov/2022 02:22:32] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:33 10.244.0.1 - - [23/Nov/2022 02:22:33] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:35 10.244.0.1 - - [23/Nov/2022 02:22:35] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:40 10.244.0.1 - - [23/Nov/2022 02:22:40] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:43 10.244.0.1 - - [23/Nov/2022 02:22:43] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:46 10.244.0.1 - - [23/Nov/2022 02:22:46] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:49 10.244.0.1 - - [23/Nov/2022 02:22:49] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:53 10.244.0.1 - - [23/Nov/2022 02:22:53] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:22:58 10.244.0.1 - - [23/Nov/2022 02:22:58] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:05 10.244.0.1 - - [23/Nov/2022 02:23:05] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:08 10.244.0.1 - - [23/Nov/2022 02:23:08] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:13 10.244.0.1 - - [23/Nov/2022 02:23:13] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:17 10.244.0.1 - - [23/Nov/2022 02:23:17] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:22 10.244.0.1 - - [23/Nov/2022 02:23:22] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:26 10.244.0.1 - - [23/Nov/2022 02:23:26] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
Nov 22 21:23:30 10.244.0.1 - - [23/Nov/2022 02:23:30] "GET /TestService_data9eabed90410e/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:↑
```
(Note how we keep serving the wrong content after "canceling previous service, new job ready"; the requests for file1 at increasing intervals is the backoff loop waiting for the content to change.)

With this change, the logs are much more in line with what we expect:
```
Nov 22 21:29:51 beginning to run user code master:true pipelineName:pipelineservice6c2a4335d762 projectName:default workerId:pipeline-default-pipelineservice6c2a4335d762-v1-pljn6 data:[{"hash":"tzUlQiTOsvaBavGE0GHMNpn5FVUqne/23Cvboctq8pw=","path":"/"}] datumId:f69008bc94305836b09b32cedafbbc3544a97d1d1ac08da93cef0b8b4c93dafc
Nov 22 21:29:56 10.244.0.1 - - [23/Nov/2022 02:29:56] "GET /TestService_data23806d8940d0/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:true
Nov 22 21:29:56 canceling previous service, new job ready master:true pipelineName:↑ projectName:↑ workerId:↑
Nov 22 21:29:56 killing remaining children master:↑ pipelineName:↑ projectName:↑ workerId:↑ data:[{"hash":"tzUlQiTOsvaBavGE0GHMNpn5FVUqne/23Cvboctq8pw=","path":"/"}] datumId:f69008bc94305836b09b32cedafbbc3544a97d1d1ac08da93cef0b8b4c93dafcNov 22 21:29:56 errored running user code after 5.124852286s: signal: killed master:↑ pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑
Nov 22 21:29:56 starting new service, job: 073c5aa44d0f4d959f342f16dadae57b master:↑ pipelineName:↑ projectName:↑ workerId:↑
Nov 22 21:29:57 beginning to run user code master:true pipelineName:pipelineservice6c2a4335d762 projectName:default workerId:pipeline-default-pipelineservice6c2a4335d762-v1-pljn6 data:[{"hash":"NXAbkRl+Dg9yqP1d97rKGS/hekrlWOTEN8Tqj8pi+dg=","path":"/"}] datumId:f69008bc94305836b09b32cedafbbc3544a97d1d1ac08da93cef0b8b4c93dafc
Nov 22 21:29:57 10.244.0.1 - - [23/Nov/2022 02:29:57] "GET /TestService_data23806d8940d0/file1 HTTP/1.1" 200 - pipelineName:↑ projectName:↑ workerId:↑ data:↑ datumId:↑ user:true
```