### PR TITLE
worker_rc: set default requests if resource_requests and resource_limits are both empty

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -342,6 +342,18 @@ spec:
         - name: GC_PERCENT
           value: {{ .Values.pachd.gcPercent | quote }}
         {{- end }}
+        {{- if ne .Values.pachd.defaultPipelineCPURequest "" }}
+        - name: PIPELINE_DEFAULT_CPU_REQUEST
+          value: {{ .Values.pachd.defaultPipelineCPURequest | quote }}
+        {{- end }}
+        {{- if ne .Values.pachd.defaultPipelineMemoryRequest "" }}
+        - name: PIPELINE_DEFAULT_MEMORY_REQUEST
+          value: {{ .Values.pachd.defaultPipelineMemoryRequest | quote }}
+        {{- end }}
+        {{- if ne .Values.pachd.defaultPipelineStorageRequest "" }}
+        - name: PIPELINE_DEFAULT_STORAGE_REQUEST
+          value: {{ .Values.pachd.defaultPipelineStorageRequest | quote }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: pachyderm-storage-secret

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -782,6 +782,15 @@
                 "goMemLimit": {
                     "type": "string"
                 },
+                "defaultPipelineCPURequest": {
+                    "type": "string"
+                },
+                "defaultPipelineMemoryRequest": {
+                    "type": "string"
+                },
+                "defaultPipelineStorageRequest": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -660,7 +660,11 @@ pachd:
     # Setting it to false is analogous to passing --no-rbac to pachctl
     # deploy.
     create: true
-
+  # Set up default resources for pipelines that don't include any requests or limits.  The values
+  # are k8s resource quantities, so "1Gi", "2", etc.  Set to "0" to disable setting any defaults.
+  defaultPipelineCPURequest: ""
+  defaultPipelineMemoryRequest: ""
+  defaultPipelineStorageRequest: ""
 kubeEventTail:
   # Deploys a lightweight app that watches kubernetes events and echos them to logs.
   enabled: true

--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Decoder decodes an env file.
@@ -49,6 +50,13 @@ const (
 	invalidTagErr               = "invalid tag, must be KEY,{required},{default=DEFAULT_VALUE}"
 )
 
+// These are structs types that we unmarshal directly, without recursing into them.
+var knownStructs = map[reflect.Type]func(string) (any, error){
+	reflect.TypeOf(resource.Quantity{}): func(x string) (any, error) {
+		return resource.ParseQuantity(x)
+	},
+}
+
 func populate(object interface{}, decoders []Decoder) error {
 	decoderMap, err := getDecoderMap(decoders)
 	if err != nil {
@@ -66,14 +74,17 @@ func populateInternal(reflectValue reflect.Value, decoderMap map[string]string, 
 	if reflectValue.Type().Kind() != reflect.Struct {
 		return errors.Errorf("%s: %v", expectedStructErr, reflectValue.Type())
 	}
+
 	for i := 0; i < reflectValue.NumField(); i++ {
 		structField := reflectValue.Type().Field(i)
 		ptrToStruct := structField.Type.Kind() == reflect.Ptr && structField.Type.Elem().Kind() == reflect.Struct
 		if structField.Type.Kind() == reflect.Struct || ptrToStruct {
-			if err := populateInternal(reflectValue.Field(i), decoderMap, true); err != nil {
-				return err
+			if _, ok := knownStructs[structField.Type]; !ok {
+				if err := populateInternal(reflectValue.Field(i), decoderMap, true); err != nil {
+					return err
+				}
+				continue
 			}
-			continue
 		}
 		envTag, err := getEnvTag(structField)
 		if err != nil {
@@ -114,14 +125,17 @@ func populateDefaultsInternal(reflectValue reflect.Value, recursive bool) error 
 	if reflectValue.Type().Kind() != reflect.Struct {
 		return errors.Errorf("%s: %v", expectedStructErr, reflectValue.Type())
 	}
+
 	for i := 0; i < reflectValue.NumField(); i++ {
 		structField := reflectValue.Type().Field(i)
 		ptrToStruct := structField.Type.Kind() == reflect.Ptr && structField.Type.Elem().Kind() == reflect.Struct
 		if structField.Type.Kind() == reflect.Struct || ptrToStruct {
-			if err := populateDefaultsInternal(reflectValue.Field(i), true); err != nil {
-				return err
+			if _, ok := knownStructs[structField.Type]; !ok {
+				if err := populateDefaultsInternal(reflectValue.Field(i), true); err != nil {
+					return err
+				}
+				continue
 			}
-			continue
 		}
 		envTag, err := getEnvTag(structField)
 		if err != nil {
@@ -287,8 +301,18 @@ func parseField(structField reflect.StructField, value string) (interface{}, err
 			return nil, errors.Wrapf(err, cannotParseErr)
 		}
 		return float64(parsedValue), nil
+
 	case reflect.String:
 		return value, nil
+
+	case reflect.Struct:
+		// Already checked by the caller.
+		parser := knownStructs[structField.Type]
+		v, err := parser(value)
+		if err != nil {
+			return nil, errors.Wrapf(err, cannotParseErr)
+		}
+		return v, nil
 	default:
 		return nil, errors.Errorf("%s: %v", fieldTypeNotAllowedErr, fieldKind)
 	}

--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -53,7 +53,7 @@ const (
 // These are structs types that we unmarshal directly, without recursing into them.
 var knownStructs = map[reflect.Type]func(string) (any, error){
 	reflect.TypeOf(resource.Quantity{}): func(x string) (any, error) {
-		return resource.ParseQuantity(x)
+		return resource.ParseQuantity(x) //nolint:wrapcheck
 	},
 }
 

--- a/src/internal/cmdutil/env_test.go
+++ b/src/internal/cmdutil/env_test.go
@@ -1,0 +1,53 @@
+package cmdutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type Cornucopia struct {
+	String   string            `env:"STRING,default=hello"`
+	Int      int               `env:"INT,default=42"`
+	Resource resource.Quantity `env:"RESOURCE,default=1Gi"`
+}
+
+func TestPopulate(t *testing.T) {
+	os.Setenv("STRING", "string")
+	os.Setenv("RESOURCE", "1Mi")
+	t.Cleanup(func() {
+		os.Unsetenv("STRING")
+		os.Unsetenv("RESOURCE")
+	})
+	want := Cornucopia{
+		String:   "string",
+		Int:      42,
+		Resource: resource.MustParse("1Mi"),
+	}
+
+	var got Cornucopia
+	if err := Populate(&got); err != nil {
+		t.Errorf("populate: %v", err)
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("parsed value:\n%s", diff)
+	}
+}
+
+func TestPopulateDefaults(t *testing.T) {
+	want := Cornucopia{
+		String:   "hello",
+		Int:      42,
+		Resource: resource.MustParse("1Gi"),
+	}
+
+	var got Cornucopia
+	if err := PopulateDefaults(&got); err != nil {
+		t.Errorf("populate: %v", err)
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("parsed value:\n%s", diff)
+	}
+}

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -171,12 +171,15 @@ func withBase(namespace string) *helm.Options {
 	return &helm.Options{
 		KubectlOptions: &k8s.KubectlOptions{Namespace: namespace},
 		SetValues: map[string]string{
-			"pachd.clusterDeploymentID":       "dev",
-			"pachd.resources.requests.cpu":    "250m",
-			"pachd.resources.requests.memory": "512M",
-			"etcd.resources.requests.cpu":     "250m",
-			"etcd.resources.requests.memory":  "512M",
-			"console.enabled":                 "false",
+			"pachd.clusterDeploymentID":           "dev",
+			"pachd.resources.requests.cpu":        "250m",
+			"pachd.resources.requests.memory":     "512M",
+			"etcd.resources.requests.cpu":         "250m",
+			"etcd.resources.requests.memory":      "512M",
+			"pachd.defaultPipelineCPURequest":     "100m",
+			"pachd.defaultPipelineMemoryRequest":  "64M",
+			"pachd.defaultPipelineStorageRequest": "100Mi",
+			"console.enabled":                     "false",
 		},
 	}
 }

--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -1,5 +1,7 @@
 package serviceenv
 
+import "k8s.io/apimachinery/pkg/api/resource"
+
 // Configuration is the generic configuration structure used to access configuration fields.
 type Configuration struct {
 	*GlobalConfiguration
@@ -76,10 +78,18 @@ type GlobalConfiguration struct {
 	// The number of concurrent requests that the PPS Master can make against kubernetes
 	PPSMaxConcurrentK8sRequests int `env:"PPS_MAX_CONCURRENT_K8S_REQUESTS,default=10"`
 
-	// These are automatically injected into pachd by Kubernetes.  They should not be set by
+	// These are automatically injected into pachd by Kubernetes so that Go's GC can be tuned to
+	// take advantage of the memory made available to the container.  They should not be set by
 	// users manually; use GOMEMLIMIT directly instead.
 	K8sMemoryLimit   int64 `env:"K8S_MEMORY_LIMIT,default=0"`
 	K8sMemoryRequest int64 `env:"K8S_MEMORY_REQUEST,default=0"`
+
+	// Users tend to have a bad experience when they request 0 resources from k8s.  These are
+	// the defaults for piplines that don't supply any requests or limits.  (As soon as you
+	// supply and request or limit, even an empty request or limit, then these are all ignored.)
+	PipelineDefaultMemoryRequest  resource.Quantity `env:"PIPELINE_DEFAULT_MEMORY_REQUEST,default=256Mi"`
+	PipelineDefaultCPURequest     resource.Quantity `env:"PIPELINE_DEFAULT_CPU_REQUEST,default=1"`
+	PipelineDefaultStorageRequest resource.Quantity `env:"PIPELINE_DEFAULT_STORAGE_REQUEST,default=1Gi"`
 }
 
 // PachdFullConfiguration contains the full pachd configuration.

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -435,10 +435,7 @@ func (kd *kubeDriver) workerPodSpec(options *workerOptions, pipelineInfo *pps.Pi
 				ImagePullPolicy: v1.PullPolicy(pullPolicy),
 				Env:             workerEnv,
 				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceCPU:    cpuZeroQuantity,
-						v1.ResourceMemory: memDefaultQuantity,
-					},
+					Requests: v1.ResourceList{},
 				},
 				VolumeMounts:    userVolumeMounts,
 				SecurityContext: userSecurityCtx,
@@ -607,14 +604,18 @@ func (kd *kubeDriver) getWorkerOptions(ctx context.Context, pipelineInfo *pps.Pi
 			return nil, errors.Wrapf(err, "could not determine resource limit")
 		}
 	}
-	// If there are no resources specified then assume the user wants 1 CPU.  Users are often
-	// surprised when their jobs that claim to require 0 CPU are scheduled to a node with no
-	// free CPU resources.  They are still free to set ResourceRequests.Cpu = 0 to avoid this
-	// automatic generation.
+	// Users are often surprised when their jobs that claim to require 0 CPU are scheduled to a
+	// node with no free CPU resources.  This avoids that; if resources are completely omitted
+	// in the pipeline spec, then we supply some reasonable defaults.  You can supply an empty
+	// ResrouceRequests in your pipeline to avoid these defaults; this will explicitly request
+	// the old behavior of not making any requests.
 	if pipelineInfo.Details.ResourceRequests == nil && pipelineInfo.Details.ResourceLimits == nil {
 		resourceRequests = &v1.ResourceList{
-			v1.ResourceCPU: resource.MustParse("1"),
+			v1.ResourceCPU:              kd.config.PipelineDefaultCPURequest,
+			v1.ResourceMemory:           kd.config.PipelineDefaultMemoryRequest,
+			v1.ResourceEphemeralStorage: kd.config.PipelineDefaultStorageRequest,
 		}
+		log.WithField("requests", resourceRequests).Infof("PPS master: setting default resource requests on pipeline %q; supply an empty resource request ('resource_requests: {}') to opt out", pipelineInfo.GetPipeline().GetName())
 	}
 	if pipelineInfo.Details.SidecarResourceLimits != nil {
 		var err error

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -607,6 +607,15 @@ func (kd *kubeDriver) getWorkerOptions(ctx context.Context, pipelineInfo *pps.Pi
 			return nil, errors.Wrapf(err, "could not determine resource limit")
 		}
 	}
+	// If there are no resources specified then assume the user wants 1 CPU.  Users are often
+	// surprised when their jobs that claim to require 0 CPU are scheduled to a node with no
+	// free CPU resources.  They are still free to set ResourceRequests.Cpu = 0 to avoid this
+	// automatic generation.
+	if pipelineInfo.Details.ResourceRequests == nil && pipelineInfo.Details.ResourceLimits == nil {
+		resourceRequests = &v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("1"),
+		}
+	}
 	if pipelineInfo.Details.SidecarResourceLimits != nil {
 		var err error
 		sidecarResourceLimits, err = ppsutil.GetLimitsResourceList(pipelineInfo.Details.SidecarResourceLimits)


### PR DESCRIPTION
I tested this by upgrading to this version on a cluster that had some pipelines with no resources setup; they all restarted with 1 CPU.  I then edited a pipeline to explicitly say:

```json
"resource_requests": {},
```
and that worker was restarted with a request for 0 CPUs.  (ResourceSpec.Cpu is a float64, so 0 == empty.  Fortunately, the containing message can distinguish between empty and unset!) 

Since the original version of this PR, I've added defaults for memory and ephemeral storage, made those defaults configurable via helm, added a log message to warn the user that defaults are being set for them (with instructions on how to opt out), and completely replaced our previous version of this hack (cpu: 0, mem: 64M) with this method.  (You can now really disable all resource requests; that wasn't actually possible before.)

Nothing changes about the storage container, or pipelines that specify any sort of resource request or limit.