### PR TITLE
Enable a bunch of linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,8 @@ linters:
     # - bodyclose
     - exhaustive
     # - gocritic
-    # - goprintffuncname
+    - goprintffuncname
+    # - gosec
 linters-settings:
   errcheck:
     exclude-functions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,10 +11,15 @@ linters:
     - nolintlint
 linters-settings:
   errcheck:
-     exclude-functions:
+    exclude-functions:
       - (*database/sql.Tx).Rollback
       - (*github.com/spf13/cobra.Command).MarkFlagCustom
       - (*github.com/spf13/cobra.Command).Usage
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: false
+    require-explanation: false
+    require-specific: true
   wrapcheck:
     ignoreSigs:
       - github.com/pachyderm/pachyderm/v2/src/internal/errors.Errorf
@@ -27,6 +32,8 @@ linters-settings:
       - .WithMessagef(
       - .WithStack(
     ignorePackageGlobs:
+      # These are packages whose return values don't have to be wrapped, not packages where the
+      # linter isn't used.
       - github.com/pachyderm/pachyderm/v2/src/*
     ignoreInterfaceRegexps:
       - ^fileset\.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,11 +18,11 @@ linters:
     - asciicheck
     - asasalint
     - bidichk
-    # - bodyclose
     - exhaustive
-    # - gocritic
     - goprintffuncname
-    # - gosec
+    # - bodyclose CORE-1317
+    # - gocritic CORE-1318
+    # - gosec CORE-1319
 linters-settings:
   errcheck:
     exclude-functions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
   enable:
     - wrapcheck
     - nolintlint
+    - gofmt
 linters-settings:
   errcheck:
     exclude-functions:
@@ -39,3 +40,6 @@ linters-settings:
       - ^fileset\.
       - ^collection\.
       - ^track\.
+  gofmt:
+    # You can check in "gofmt -s"'d code, but it's not mandatory.
+    simplify: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,5 +41,4 @@ linters-settings:
       - ^collection\.
       - ^track\.
   gofmt:
-    # You can check in "gofmt -s"'d code, but it's not mandatory.
-    simplify: false
+    simplify: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,18 @@ linters:
     - wrapcheck
     - nolintlint
     - gofmt
+    - govet
+    - gosimple
+    - errcheck
+    - ineffassign
+    - unused
+    - asciicheck
+    - asasalint
+    - bidichk
+    # - bodyclose
+    - exhaustive
+    # - gocritic
+    # - goprintffuncname
 linters-settings:
   errcheck:
     exclude-functions:
@@ -42,3 +54,10 @@ linters-settings:
       - ^track\.
   gofmt:
     simplify: true
+  exhaustive:
+    default-signifies-exhaustive: true
+    # Right now, we only allow opting into the exhaustive check due to a lot of code that makes
+    # correct use of non-exhaustive switch statements.
+    # Annotate your switch statement with //exhaustive:enforce to opt in.
+    explicit-exhaustive-switch: true
+    explicit-exhaustive-map: true

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,8 +18,8 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.48.0
-golangci-lint run --
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.50.1
+golangci-lint run --max-same-issues=1000 --
 
 # shellcheck disable=SC2046
 find . \

--- a/examples/word_count/src/map.go
+++ b/examples/word_count/src/map.go
@@ -78,9 +78,9 @@ func main() {
 	}
 
 	for word, count := range wordMap {
-		newPath := filepath.Join(outputDir,os.Getenv("PACH_DATUM_ID"))
+		newPath := filepath.Join(outputDir, os.Getenv("PACH_DATUM_ID"))
 		os.MkdirAll(newPath, os.ModePerm)
-		if err := ioutil.WriteFile(filepath.Join(newPath,word), []byte(strconv.Itoa(count)+"\n"), 0644); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(newPath, word), []byte(strconv.Itoa(count)+"\n"), 0644); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/src/client/debug.go
+++ b/src/client/debug.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (

--- a/src/client/portforwarder.go
+++ b/src/client/portforwarder.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	
+
 	"math/rand"
 	"net/http"
 	"sync"

--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 package client
 
 import (
@@ -987,10 +986,10 @@ func (c APIClient) ListPipelineHistory(pipelineName string, history int64, detai
 //
 // `history` specifies how many historical revisions to return:
 
-//   - 0: Return the current version of the pipeline or pipelines.
-//   - 1: Return the above and the next most recent version
-//   - 2: etc.
-//   - -1: Return all historical versions.
+// - 0: Return the current version of the pipeline or pipelines.
+// - 1: Return the above and the next most recent version
+// - 2: etc.
+// - -1: Return all historical versions.
 func (c APIClient) ListProjectPipelineHistory(projectName, pipelineName string, history int64, details bool) ([]*pps.PipelineInfo, error) {
 	var pipeline *pps.Pipeline
 	if pipelineName != "" {

--- a/src/client/proxy.go
+++ b/src/client/proxy.go
@@ -1,11 +1,9 @@
-//nolint:wrapcheck
 package client
 
 import (
 	"context"
 	"sync"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/proxy"
@@ -100,7 +98,7 @@ func (ppl *proxyPostgresListener) listen(notifier col.Notifier) {
 				ppl.mu.Lock()
 				if ci, ok := ppl.channelInfos[channel]; ok {
 					for _, notifier := range ci.notifiers {
-						notifier.Notify(&collection.Notification{
+						notifier.Notify(&col.Notification{
 							Channel: channel,
 							Extra:   resp.Extra,
 						})

--- a/src/internal/backoff/exponential.go
+++ b/src/internal/backoff/exponential.go
@@ -11,17 +11,17 @@ period for each retry attempt using a randomization function that grows exponent
 
 NextBackOff() is calculated using the following formula:
 
- randomized interval =
-     RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+	randomized interval =
+	    RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
 
 In other words NextBackOff() will range between the randomization factor
 percentage below and above the retry interval.
 
 For example, given the following parameters:
 
- RetryInterval = 2
- RandomizationFactor = 0.5
- Multiplier = 2
+	RetryInterval = 2
+	RandomizationFactor = 0.5
+	Multiplier = 2
 
 the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
 multiplied by the exponential, that is, between 2 and 6 seconds.
@@ -36,18 +36,18 @@ The elapsed time can be reset by calling Reset().
 Example: Given the following default arguments, for 10 tries the sequence will be,
 and assuming we go over the MaxElapsedTime on the 10th try:
 
- Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+	Request #  RetryInterval (seconds)  Randomized Interval (seconds)
 
-  1          0.5                     [0.25,   0.75]
-  2          0.75                    [0.375,  1.125]
-  3          1.125                   [0.562,  1.687]
-  4          1.687                   [0.8435, 2.53]
-  5          2.53                    [1.265,  3.795]
-  6          3.795                   [1.897,  5.692]
-  7          5.692                   [2.846,  8.538]
-  8          8.538                   [4.269, 12.807]
-  9         12.807                   [6.403, 19.210]
- 10         19.210                   backoff.Stop
+	 1          0.5                     [0.25,   0.75]
+	 2          0.75                    [0.375,  1.125]
+	 3          1.125                   [0.562,  1.687]
+	 4          1.687                   [0.8435, 2.53]
+	 5          2.53                    [1.265,  3.795]
+	 6          3.795                   [1.897,  5.692]
+	 7          5.692                   [2.846,  8.538]
+	 8          8.538                   [4.269, 12.807]
+	 9         12.807                   [6.403, 19.210]
+	10         19.210                   backoff.Stop
 
 Note: Implementation is not thread-safe.
 */
@@ -171,7 +171,8 @@ func (b *ExponentialBackOff) Reset() {
 }
 
 // NextBackOff calculates the next backoff interval using the formula:
-// 	Randomized interval = RetryInterval +/- (RandomizationFactor * RetryInterval)
+//
+//	Randomized interval = RetryInterval +/- (RandomizationFactor * RetryInterval)
 func (b *ExponentialBackOff) NextBackOff() time.Duration {
 	// Make sure we have not gone over the maximum elapsed time.
 	if b.MaxElapsedTime != 0 && b.GetElapsedTime() > b.MaxElapsedTime {
@@ -200,7 +201,8 @@ func (b *ExponentialBackOff) incrementCurrentInterval() {
 }
 
 // Returns a random value from the following interval:
-// 	[randomizationFactor * currentInterval, randomizationFactor * currentInterval].
+//
+//	[randomizationFactor * currentInterval, randomizationFactor * currentInterval].
 func GetRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
 	var delta = randomizationFactor * float64(currentInterval)
 	var minInterval = float64(currentInterval) - delta

--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -32,7 +32,7 @@ func RunFixedArgs(numArgs int, run func([]string) error) func(*cobra.Command, []
 			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
-				ErrorAndExit("%v", err)
+				ErrorAndExitf("%v", err)
 			}
 		}
 	}
@@ -47,7 +47,7 @@ func RunBoundedArgs(min int, max int, run func([]string) error) func(*cobra.Comm
 			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
-				ErrorAndExit("%v", err)
+				ErrorAndExitf("%v", err)
 			}
 		}
 	}
@@ -62,7 +62,7 @@ func RunMinimumArgs(min int, run func([]string) error) func(*cobra.Command, []st
 			cmd.Usage()
 		} else {
 			if err := run(args); err != nil {
-				ErrorAndExit("%v", err)
+				ErrorAndExitf("%v", err)
 			}
 		}
 	}
@@ -72,13 +72,13 @@ func RunMinimumArgs(min int, run func([]string) error) func(*cobra.Command, []st
 func Run(run func(args []string) error) func(*cobra.Command, []string) {
 	return func(_ *cobra.Command, args []string) {
 		if err := run(args); err != nil {
-			ErrorAndExit("%v", err)
+			ErrorAndExitf("%v", err)
 		}
 	}
 }
 
-// ErrorAndExit errors with the given format and args, and then exits.
-func ErrorAndExit(format string, args ...interface{}) {
+// ErrorAndExitf errors with the given format and args, and then exits.
+func ErrorAndExitf(format string, args ...interface{}) {
 	if errString := strings.TrimSpace(fmt.Sprintf(format, args...)); errString != "" {
 		fmt.Fprintf(os.Stderr, "%s\n", errString)
 	}

--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -114,13 +114,14 @@ func ParseRepo(project, name string) *pfs.Repo {
 // Parses the following formats, any unspecified fields will be left as empty
 // strings in the pfs.File structure.  The second return value is the number of fields parsed -
 // (1: repo only, 2: repo and branch-or-commit, 3: repo, branch, and file).
-//   repo
-//   repo@branch
-//   repo@branch:path
-//   repo@branch=commit
-//   repo@branch=commit:path
-//   repo@commit
-//   repo@commit:path
+//
+//	repo
+//	repo@branch
+//	repo@branch:path
+//	repo@branch=commit
+//	repo@branch=commit:path
+//	repo@commit
+//	repo@commit:path
 func parseFile(project, arg string) (*pfs.File, int, error) {
 	var repo, branch, commit, path string
 	parts := strings.SplitN(arg, "@", 2)

--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -37,7 +37,7 @@ func Main(ctx context.Context, do func(context.Context, interface{}) error, appE
 }
 
 func mainError(err error) {
-	ErrorAndExit("%v\n", err)
+	ErrorAndExitf("%v\n", err)
 }
 
 const (

--- a/src/internal/cmdutil/util.go
+++ b/src/internal/cmdutil/util.go
@@ -26,7 +26,7 @@ func Encoder(format string, w io.Writer) serde.Encoder {
 		serde.WithOrigName(true),
 	)
 	if err != nil {
-		ErrorAndExit("%s", err.Error())
+		ErrorAndExitf("%s", err.Error())
 	}
 	return e
 }

--- a/src/internal/collection/v2.4.0.go
+++ b/src/internal/collection/v2.4.0.go
@@ -16,7 +16,7 @@ import (
 // key, value and indices, all in one transaction which caller is responsible
 // for committing.
 //
-// DO NOT MODIFY THIS FUNCTION
+// # DO NOT MODIFY THIS FUNCTION
 //
 // IT HAS BEEN USED IN A RELEASED MIGRATION
 func MigratePostgreSQLCollection_v2_4_0(ctx context.Context, tx *pachsql.Tx, name string, indices []*Index, oldVal proto.Message, f func(oldKey string) (newKey string, newVal proto.Message, err error), opts ...Option) error {

--- a/src/internal/grpcutil/stream.go
+++ b/src/internal/grpcutil/stream.go
@@ -107,13 +107,15 @@ func (w *ChunkWriteCloser) Close() error {
 }
 
 // StreamingBytesServer represents a server for an rpc method of the form:
-//   rpc Foo(Bar) returns (stream google.protobuf.BytesValue) {}
+//
+//	rpc Foo(Bar) returns (stream google.protobuf.BytesValue) {}
 type StreamingBytesServer interface {
 	Send(bytesValue *types.BytesValue) error
 }
 
 // StreamingBytesClient represents a client for an rpc method of the form:
-//   rpc Foo(Bar) returns (stream google.protobuf.BytesValue) {}
+//
+//	rpc Foo(Bar) returns (stream google.protobuf.BytesValue) {}
 type StreamingBytesClient interface {
 	Recv() (*types.BytesValue, error)
 }

--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -21,7 +21,7 @@ import (
 	kube "k8s.io/client-go/kubernetes"
 )
 
-//Reporter is used to submit user & cluster metrics to segment
+// Reporter is used to submit user & cluster metrics to segment
 type Reporter struct {
 	router    *router
 	clusterID string
@@ -48,7 +48,7 @@ func NewReporter(env serviceenv.ServiceEnv) *Reporter {
 	return reporter
 }
 
-//ReportUserAction pushes the action into a queue for reporting,
+// ReportUserAction pushes the action into a queue for reporting,
 // and reports the start, finish, and error conditions
 func ReportUserAction(ctx context.Context, r *Reporter, action string) func(time.Time, error) {
 	if r == nil {

--- a/src/internal/obj/factory.go
+++ b/src/internal/obj/factory.go
@@ -140,9 +140,10 @@ func NewGoogleClientFromEnv() (Client, error) {
 }
 
 // NewMicrosoftClient creates a microsoft client:
+//
 //	container   - Azure Blob Container name
 //	accountName - Azure Storage Account name
-// 	accountKey  - Azure Storage Account key
+//	accountKey  - Azure Storage Account key
 func NewMicrosoftClient(container string, accountName string, accountKey string) (c Client, err error) {
 	c, err = newMicrosoftClient(container, accountName, accountKey)
 	if err != nil {
@@ -191,12 +192,13 @@ func NewMicrosoftClientFromEnv() (Client, error) {
 }
 
 // NewMinioClient creates an s3 compatible client with the following credentials:
-//   endpoint - S3 compatible endpoint
-//   bucket - S3 bucket name
-//   id     - AWS access key id
-//   secret - AWS secret access key
-//   secure - Set to true if connection is secure.
-//   isS3V2 - Set to true if client follows S3V2
+//
+//	endpoint - S3 compatible endpoint
+//	bucket - S3 bucket name
+//	id     - AWS access key id
+//	secret - AWS secret access key
+//	secure - Set to true if connection is secure.
+//	isS3V2 - Set to true if client follows S3V2
 func NewMinioClient(endpoint, bucket, id, secret string, secure, isS3V2 bool) (c Client, err error) {
 	log.Warnf("DEPRECATED: Support for the S3V2 option is being deprecated. It will be removed in a future version")
 	if isS3V2 {
@@ -210,14 +212,15 @@ func NewMinioClient(endpoint, bucket, id, secret string, secure, isS3V2 bool) (c
 }
 
 // NewAmazonClient creates an amazon client with the following credentials:
-//   bucket - S3 bucket name
-//   distribution - cloudfront distribution ID
-//   id     - AWS access key id
-//   secret - AWS secret access key
-//   token  - AWS access token
-//   region - AWS region
-//   endpoint - Custom endpoint (generally used for S3 compatible object stores)
-//   reverse - Reverse object storage paths (overwrites configured value)
+//
+//	bucket - S3 bucket name
+//	distribution - cloudfront distribution ID
+//	id     - AWS access key id
+//	secret - AWS secret access key
+//	token  - AWS access token
+//	region - AWS region
+//	endpoint - Custom endpoint (generally used for S3 compatible object stores)
+//	reverse - Reverse object storage paths (overwrites configured value)
 func NewAmazonClient(region, bucket string, creds *AmazonCreds, distribution string, endpoint string) (c Client, err error) {
 	advancedConfig := &AmazonAdvancedConfiguration{}
 	if err := cmdutil.Populate(advancedConfig); err != nil {

--- a/src/internal/obj/integrationtests/util.go
+++ b/src/internal/obj/integrationtests/util.go
@@ -16,10 +16,11 @@ import (
 // specific bucket.
 
 // LoadAmazonParameters loads the test parameters for S3 object storage:
-//  id - the key id credential
-//  secret - the key secret credential
-//  bucket - the S3 bucket to issue requests towards
-//  region - the S3 region that the bucket is in
+//
+//	id - the key id credential
+//	secret - the key secret credential
+//	bucket - the S3 bucket to issue requests towards
+//	region - the S3 region that the bucket is in
 func LoadAmazonParameters(t *testing.T) (string, string, string, string) {
 	id := os.Getenv("AMAZON_CLIENT_ID")
 	secret := os.Getenv("AMAZON_CLIENT_SECRET")
@@ -35,11 +36,12 @@ func LoadAmazonParameters(t *testing.T) (string, string, string, string) {
 
 // LoadECSParameters loads the test parameters for ECS object storage
 // (credentials can be requested for a new account from portal.ecstestdrive.com):
-//  id - the key id credential
-//  secret - the key secret credential
-//  bucket - the ECS bucket to issue requests towards
-//  region - a dummy region - some clients require this but it is unused with 'endpoint'
-//  endpoint - the S3-compatible server to send requests to
+//
+//	id - the key id credential
+//	secret - the key secret credential
+//	bucket - the ECS bucket to issue requests towards
+//	region - a dummy region - some clients require this but it is unused with 'endpoint'
+//	endpoint - the S3-compatible server to send requests to
 func LoadECSParameters(t *testing.T) (string, string, string, string, string) {
 	id := os.Getenv("ECS_CLIENT_ID")
 	secret := os.Getenv("ECS_CLIENT_SECRET")
@@ -54,8 +56,9 @@ func LoadECSParameters(t *testing.T) (string, string, string, string, string) {
 }
 
 // LoadGoogleParameters loads the test parameters for GCS object storage:
-//  bucket - the GCS bucket to issue requests towards
-//  creds - the JSON GCP credentials to use
+//
+//	bucket - the GCS bucket to issue requests towards
+//	creds - the JSON GCP credentials to use
 func LoadGoogleParameters(t *testing.T) (string, string) {
 	bucket := os.Getenv("GOOGLE_CLIENT_BUCKET")
 	creds := os.Getenv("GOOGLE_CLIENT_CREDS")
@@ -67,11 +70,12 @@ func LoadGoogleParameters(t *testing.T) (string, string) {
 
 // LoadGoogleHMACParameters loads the test parameters for GCS object storage,
 // specifically for use with S3-compatible clients:
-//  id - the key id credential
-//  secret - the key secret credential
-//  bucket - the GCS bucket to issue requests towards
-//  region - the GCS region that the bucket is in
-//  endpoint - the S3-compatible server to send requests to
+//
+//	id - the key id credential
+//	secret - the key secret credential
+//	bucket - the GCS bucket to issue requests towards
+//	region - the GCS region that the bucket is in
+//	endpoint - the S3-compatible server to send requests to
 func LoadGoogleHMACParameters(t *testing.T) (string, string, string, string, string) {
 	id := os.Getenv("GOOGLE_CLIENT_HMAC_ID")
 	secret := os.Getenv("GOOGLE_CLIENT_HMAC_SECRET")
@@ -86,9 +90,10 @@ func LoadGoogleHMACParameters(t *testing.T) (string, string, string, string, str
 }
 
 // LoadMicrosoftParameters loads the test parameters for Azure blob storage:
-//  id - the key id credential
-//  secret - the key secret credential
-//  container - the Azure blob container to issue requests towards
+//
+//	id - the key id credential
+//	secret - the key secret credential
+//	container - the Azure blob container to issue requests towards
 func LoadMicrosoftParameters(t *testing.T) (string, string, string) {
 	id := os.Getenv("MICROSOFT_CLIENT_ID")
 	secret := os.Getenv("MICROSOFT_CLIENT_SECRET")

--- a/src/internal/obj/limited_client.go
+++ b/src/internal/obj/limited_client.go
@@ -41,8 +41,10 @@ type limitedClient struct {
 }
 
 // NewLimitedClient constructs a Client which will only ever have
-//   <= maxReaders objects open for reading
-//   <= maxWriters objects open for writing
+//
+//	<= maxReaders objects open for reading
+//	<= maxWriters objects open for writing
+//
 // if either is < 1 then that constraint is ignored.
 func NewLimitedClient(client Client, maxReaders, maxWriters int) Client {
 	if maxReaders < 1 {

--- a/src/internal/obj/testsuite.go
+++ b/src/internal/obj/testsuite.go
@@ -72,10 +72,11 @@ func TestEmptyWrite(t *testing.T, client Client) {
 
 // TestInterruption
 // Interruption is currently not implemented on the Amazon, Microsoft, and Minio clients
-//  Amazon client - use *WithContext methods
-//  Microsoft client - move to github.com/Azure/azure-storage-blob-go which supports contexts
-//  Minio client - upgrade to v7 which supports contexts in all APIs
-//  Local client - interruptible file operations are not a thing in the stdlib
+//
+//	Amazon client - use *WithContext methods
+//	Microsoft client - move to github.com/Azure/azure-storage-blob-go which supports contexts
+//	Minio client - upgrade to v7 which supports contexts in all APIs
+//	Local client - interruptible file operations are not a thing in the stdlib
 func TestInterruption(t *testing.T, client Client) {
 	// Make a canceled context
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/internal/pfssync/pipe_unix.go
+++ b/src/internal/pfssync/pipe_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package pfssync

--- a/src/internal/pfssync/pipe_windows.go
+++ b/src/internal/pfssync/pipe_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package pfssync

--- a/src/internal/serde/interface.go
+++ b/src/internal/serde/interface.go
@@ -5,10 +5,10 @@
 // Similar to https://github.com/ghodss/yaml, all implementations of the Format
 // interface marshal and unmarshal data using the following pipeline:
 //
-//    Go struct/map (fully structured)
-//      <-> JSON document
-//      <-> map[string]interface{}
-//      <-> target format document
+//	Go struct/map (fully structured)
+//	  <-> JSON document
+//	  <-> map[string]interface{}
+//	  <-> target format document
 //
 // Despite the redundant round of marshalling and unmarshalling, there are two
 // main advantages to this approach:
@@ -75,8 +75,10 @@ func WithIndent(numSpaces int) func(d Encoder) {
 // the decision about what kind of encoding to use until runtime, like so:
 //
 // enc, _ := GetEncoder(outputFlag, os.Stdout,
-//     ...options to use if json...,
-//     ...options to use if yaml...,
+//
+//	...options to use if json...,
+//	...options to use if yaml...,
+//
 // )
 // enc.Encode(obj)
 func GetEncoder(encoding string, w io.Writer, opts ...EncoderOption) (Encoder, error) {

--- a/src/internal/serde/json_encoder.go
+++ b/src/internal/serde/json_encoder.go
@@ -2,10 +2,10 @@
 // approach. Because the final output is json, the steps this uses are a little
 // more redundant, but still the reverse of the steps in decoder.go (allowing
 // for future-proof reversability):
-// 1) Serialize structs to JSON using encoding/json or, in the case of
-//    protobufs, using Google's 'jsonpb' library
-// 2) Deserialize that text into a generic interface{}
-// 3) Serialize that interface using encoding/json
+//  1. Serialize structs to JSON using encoding/json or, in the case of
+//     protobufs, using Google's 'jsonpb' library
+//  2. Deserialize that text into a generic interface{}
+//  3. Serialize that interface using encoding/json
 //
 // Because the data is serialized to JSON twice, this approach seems more
 // redundant in the context of json_encoder.go, but it's symmetrical with the

--- a/src/internal/serde/yaml_encoder.go
+++ b/src/internal/serde/yaml_encoder.go
@@ -1,9 +1,9 @@
 // yaml_encoder.go is the reverse of decoder.go. It applies the same steps in
 // the opposite order:
-// 1) Serialize structs to JSON using encoding/json or, in the case of
-//    protobufs, using Google's 'jsonpb' library
-// 2) Deserialize that text into a generic interface{}
-// 3) Serialize that interface using gopkg.in/yaml.v3
+//  1. Serialize structs to JSON using encoding/json or, in the case of
+//     protobufs, using Google's 'jsonpb' library
+//  2. Deserialize that text into a generic interface{}
+//  3. Serialize that interface using gopkg.in/yaml.v3
 //
 // This allows for correct handling of timestamps and such. It also allows data
 // that has already been deserialized into a generic interface{} to be written

--- a/src/internal/serviceenv/service_env_cgo.go
+++ b/src/internal/serviceenv/service_env_cgo.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package serviceenv

--- a/src/internal/storage/fileset/fileset.go
+++ b/src/internal/storage/fileset/fileset.go
@@ -26,8 +26,8 @@ The algorithms for file and index chunking have changed throughout 2.x, and we
 must support previously written data. Here are some examples of conditions in
 past data which current code will not generate:
   - a file that is split across multiple chunks may share some of them with
-  other files (in the current code, a file split across chunks will be the only
-  file in those chunks).
+    other files (in the current code, a file split across chunks will be the only
+    file in those chunks).
   - related, even small files may be split across multiple chunks
   - an index range data reference may start part way through a chunk
 */

--- a/src/internal/storage/fileset/fileset_test.go
+++ b/src/internal/storage/fileset/fileset_test.go
@@ -208,35 +208,35 @@ func TestStableHash(t *testing.T) {
 		expected []string
 	}
 	tds := []*testData{
-		&testData{
+		{
 			seed: 1648577872380609229,
 			expected: []string{
 				"27e12145099615b6bf0364a4472452dfe0e8105e6d58d7fbc5d0c038c7a50736",
 				"5672e6f3e1841f3f1e284c2d4b7c12dc213ffc88878c9d3e2302be8acd0198ef",
 			},
 		},
-		&testData{
+		{
 			seed: 1648742949150704545,
 			expected: []string{
 				"020e7fda5b3d81b000918ac4fa808a6569fc01000d15322247206aeeea1761a2",
 				"d1842da7cfdc60c4a63c8ab58bd8eee4fa765a270743f3aa36ece6cbef786423",
 			},
 		},
-		&testData{
+		{
 			seed: 1648742961991348032,
 			expected: []string{
 				"8a801a53ba2933cccea69fdb61eb3aa04b2019eea541aa848c6b42ef4c7262d5",
 				"d578bcae30c790722048f7d698a6279049012a42b339e802da07bca269831b30",
 			},
 		},
-		&testData{
+		{
 			seed: 1648742974827637769,
 			expected: []string{
 				"70e7271fc45251fcf788175df481ab6fd090f37860fcdc63b9f25c26834adf52",
 				"b480bf9cffce51b52615a59dc254647145c6376551cf864d2eb87c63bd11344d",
 			},
 		},
-		&testData{
+		{
 			seed: 1648742988445537518,
 			expected: []string{
 				"ca46ed3b9bc6a9b090d94a71d4d308ca05580ab467681cdb236b097206feba5a",

--- a/src/internal/testutil/cmds.go
+++ b/src/internal/testutil/cmds.go
@@ -23,13 +23,15 @@ import (
 // lines of text. This is useful for long, inline commands that are indented to
 // match the surrounding code but should be interpreted without the space:
 // e.g.:
-// func() {
-//   BashCmd(`
-//     cat <<EOF
-//     This is a test
-//     EOF
-//   `)
-// }
+//
+//	func() {
+//	  BashCmd(`
+//	    cat <<EOF
+//	    This is a test
+//	    EOF
+//	  `)
+//	}
+//
 // Should evaluate:
 // $ cat <<EOF
 // > This is a test

--- a/src/internal/testutil/pach_client.go
+++ b/src/internal/testutil/pach_client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 )
 
-//
 const DefaultTransformImage = "ubuntu:20.04"
 
 // NewPachClient gets a pachyderm client for use in tests. It works for tests

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -95,12 +95,13 @@ func (tnxEnv *TransactionEnv) Initialize(
 // action directly or append an action to an existing transaction (depending on
 // if there is an active transaction in the client context metadata).  There
 // are two implementations of this interface:
-//  directTransaction: all operations will be run directly through the relevant
-//    server, all inside the same STM.
-//  appendTransaction: all operations will be appended to the active transaction
-//    which will then be dryrun so that the response for the operation can be
-//    returned.  Each operation that is appended will do a new dryrun, so this
-//    isn't as efficient as it could be.
+//
+//	directTransaction: all operations will be run directly through the relevant
+//	  server, all inside the same STM.
+//	appendTransaction: all operations will be appended to the active transaction
+//	  which will then be dryrun so that the response for the operation can be
+//	  returned.  Each operation that is appended will do a new dryrun, so this
+//	  isn't as efficient as it could be.
 type Transaction interface {
 	PfsWrites
 	PpsWrites

--- a/src/server/auth/server/testing/auth_integration_test.go
+++ b/src/server/auth/server/testing/auth_integration_test.go
@@ -126,8 +126,8 @@ func TestListDatum(t *testing.T) {
 		}
 	}
 	require.Equal(t, map[string]struct{}{
-		"file1": struct{}{},
-		"file2": struct{}{},
+		"file1": {},
+		"file2": {},
 	}, files)
 
 	// Test list datum input.

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -1547,80 +1547,80 @@ func TestModifyMembers(t *testing.T) {
 	}{
 		{
 			[]*auth.ModifyMembersRequest{
-				&auth.ModifyMembersRequest{
+				{
 					Add:   []string{alice},
 					Group: organization,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Add:   []string{alice},
 					Group: organization,
 				},
 			},
 			map[string][]string{
-				alice: []string{organization},
+				alice: {organization},
 			},
 		},
 		{
 			[]*auth.ModifyMembersRequest{
-				&auth.ModifyMembersRequest{
+				{
 					Add:   []string{bob},
 					Group: organization,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Add:   []string{alice, bob},
 					Group: engineering,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Add:   []string{bob},
 					Group: security,
 				},
 			},
 			map[string][]string{
-				alice: []string{organization, engineering},
-				bob:   []string{organization, engineering, security},
+				alice: {organization, engineering},
+				bob:   {organization, engineering, security},
 			},
 		},
 		{
 			[]*auth.ModifyMembersRequest{
-				&auth.ModifyMembersRequest{
+				{
 					Add:    []string{alice},
 					Remove: []string{bob},
 					Group:  security,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Remove: []string{bob},
 					Group:  engineering,
 				},
 			},
 			map[string][]string{
-				alice: []string{organization, engineering, security},
-				bob:   []string{organization},
+				alice: {organization, engineering, security},
+				bob:   {organization},
 			},
 		},
 		{
 			[]*auth.ModifyMembersRequest{
-				&auth.ModifyMembersRequest{
+				{
 					Remove: []string{alice, bob},
 					Group:  organization,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Remove: []string{alice, bob},
 					Group:  security,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Add:    []string{alice},
 					Remove: []string{alice},
 					Group:  organization,
 				},
-				&auth.ModifyMembersRequest{
+				{
 					Add:    []string{},
 					Remove: []string{},
 					Group:  organization,
 				},
 			},
 			map[string][]string{
-				alice: []string{engineering},
-				bob:   []string{},
+				alice: {engineering},
+				bob:   {},
 			},
 		},
 	}

--- a/src/server/cmd/pachctl/cmd/cmd_test.go
+++ b/src/server/cmd/pachctl/cmd/cmd_test.go
@@ -102,7 +102,7 @@ func testConfig(t *testing.T, pachdAddressStr string) *os.File {
 		V2: &config.ConfigV2{
 			ActiveContext: "test",
 			Contexts: map[string]*config.Context{
-				"test": &config.Context{
+				"test": {
 					PachdAddress: pachdAddress.Qualified(),
 				},
 			},

--- a/src/server/cmd/pachd/signals_unix.go
+++ b/src/server/cmd/pachd/signals_unix.go
@@ -1,3 +1,4 @@
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
 // +build aix android darwin dragonfly freebsd hurd illumos ios linux netbsd openbsd solaris
 
 // TODO: in go v1.19+, the above can simply be “unix”

--- a/src/server/cmd/pachd/signals_windows.go
+++ b/src/server/cmd/pachd/signals_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/src/server/identity/server/dex_web.go
+++ b/src/server/identity/server/dex_web.go
@@ -143,7 +143,7 @@ func (w *dexWeb) startWebServer(config *identity.IdentityServerConfig, connector
 		w.logger.Info("no idp connectors configured, using placeholder")
 		dex_server.ConnectorsConfig["placeholder"] = func() dex_server.ConnectorConfig { return new(placeholderConfig) }
 		storage = dex_storage.WithStaticConnectors(storage, []dex_storage.Connector{
-			dex_storage.Connector{
+			{
 				ID:     "placeholder",
 				Type:   "placeholder",
 				Name:   "No IDPs Configured",

--- a/src/server/pfs/cmds/mount_windows.go
+++ b/src/server/pfs/cmds/mount_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cmds

--- a/src/server/pfs/fuse/fuse_test.go
+++ b/src/server/pfs/fuse/fuse_test.go
@@ -390,7 +390,7 @@ func TestMountCommit(t *testing.T) {
 	require.NoError(t, err)
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: &pfs.File{Commit: c1},
 			},
@@ -413,7 +413,7 @@ func TestMountCommit(t *testing.T) {
 
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: &pfs.File{Commit: c2},
 			},
@@ -443,7 +443,7 @@ func TestMountFile(t *testing.T) {
 	require.NoError(t, env.PachClient.PutFile(client.NewProjectCommit(pfs.DefaultProjectName, "repo", "master", ""), "buzz", strings.NewReader("buzz")))
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: client.NewProjectFile(pfs.DefaultProjectName, "repo", "master", "master^", "/foo"),
 			},
@@ -466,7 +466,7 @@ func TestMountFile(t *testing.T) {
 
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: client.NewProjectFile(pfs.DefaultProjectName, "repo", "master", "", "/bar"),
 			},
@@ -503,7 +503,7 @@ func TestMountDir(t *testing.T) {
 	require.NoError(t, err)
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: client.NewProjectFile(pfs.DefaultProjectName, "repo", "master", "", "/dir/foo"),
 			},
@@ -531,7 +531,7 @@ func TestMountDir(t *testing.T) {
 
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: client.NewProjectFile(pfs.DefaultProjectName, "repo", "master", "", "/dir/bar"),
 			},
@@ -559,7 +559,7 @@ func TestMountDir(t *testing.T) {
 
 	withMount(t, env.PachClient, &Options{
 		RepoOptions: map[string]*RepoOptions{
-			"repo": &RepoOptions{
+			"repo": {
 				Name: "repo",
 				File: client.NewProjectFile(pfs.DefaultProjectName, "repo", "master", "", "/dir"),
 			},

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -1384,7 +1384,7 @@ func mountingState(m *MountStateMachine) StateFn {
 	// _in all cases_
 	m.transitionedTo("mounting", "")
 	// TODO: refactor this so we're not reaching into another struct's lock
-	var err error;
+	var err error
 	err = func() error {
 		m.manager.mu.Lock()
 		defer m.manager.mu.Unlock()
@@ -1412,7 +1412,7 @@ func mountingState(m *MountStateMachine) StateFn {
 		}
 		m.manager.root.commits[m.Name] = commitInfos[0].Commit.ID
 		return nil
-	}();
+	}()
 	// re-downloading the repos with an updated RepoOptions set will have the
 	// effect of causing it to pop into existence
 	if err == nil {

--- a/src/server/pfs/s3/bucket.go
+++ b/src/server/pfs/s3/bucket.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
 package s3

--- a/src/server/pfs/s3/driver.go
+++ b/src/server/pfs/s3/driver.go
@@ -1,6 +1,7 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
+//
+//nolint:wrapcheck
 package s3
 
 import (

--- a/src/server/pfs/s3/driver_test.go
+++ b/src/server/pfs/s3/driver_test.go
@@ -9,7 +9,7 @@ import (
 func TestBucketNameToProjectCommit(t *testing.T) {
 	// pattern: [commitID.][branch. | branch.type.]repoName.projectName
 	var cases = map[string]*pfs.Commit{
-		"8b234298216044d4accaf3f472175a54.testLOPed701519c9c4.default": &pfs.Commit{
+		"8b234298216044d4accaf3f472175a54.testLOPed701519c9c4.default": {
 			ID: "8b234298216044d4accaf3f472175a54",
 			Branch: &pfs.Branch{
 				Name: "master",
@@ -22,7 +22,7 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 				},
 			},
 		},
-		"8b234298216044d4accaf3f472175a54.notmaster.testLOPed701519c9c4.default": &pfs.Commit{
+		"8b234298216044d4accaf3f472175a54.notmaster.testLOPed701519c9c4.default": {
 			ID: "8b234298216044d4accaf3f472175a54",
 			Branch: &pfs.Branch{
 				Name: "notmaster",
@@ -35,7 +35,7 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 				},
 			},
 		},
-		"8b234298216044d4accaf3f472175a54.notmaster.spec.testLOPed701519c9c4.default": &pfs.Commit{
+		"8b234298216044d4accaf3f472175a54.notmaster.spec.testLOPed701519c9c4.default": {
 			ID: "8b234298216044d4accaf3f472175a54",
 			Branch: &pfs.Branch{
 				Name: "notmaster",
@@ -48,7 +48,7 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 				},
 			},
 		},
-		"notmaster.testLOPed701519c9c4.default": &pfs.Commit{
+		"notmaster.testLOPed701519c9c4.default": {
 			ID: "",
 			Branch: &pfs.Branch{
 				Name: "notmaster",
@@ -61,7 +61,7 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 				},
 			},
 		},
-		"notmaster.spec.testLOPed701519c9c4.default": &pfs.Commit{
+		"notmaster.spec.testLOPed701519c9c4.default": {
 			ID: "",
 			Branch: &pfs.Branch{
 				Name: "notmaster",
@@ -74,7 +74,7 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 				},
 			},
 		},
-		"testLOPed701519c9c4.default": &pfs.Commit{
+		"testLOPed701519c9c4.default": {
 			ID: "",
 			Branch: &pfs.Branch{
 				Name: "master",

--- a/src/server/pfs/s3/multipart.go
+++ b/src/server/pfs/s3/multipart.go
@@ -1,6 +1,7 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
+//
+//nolint:wrapcheck
 package s3
 
 import (

--- a/src/server/pfs/s3/object.go
+++ b/src/server/pfs/s3/object.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
 package s3

--- a/src/server/pfs/s3/service.go
+++ b/src/server/pfs/s3/service.go
@@ -1,4 +1,3 @@
-//nolint:wrapcheck
 // TODO: the s2 library checks the type of the error to decide how to handle it,
 // which doesn't work properly with wrapped errors
 package s3

--- a/src/server/pfs/server/driver_unix.go
+++ b/src/server/pfs/server/driver_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package server

--- a/src/server/pfs/server/driver_windows.go
+++ b/src/server/pfs/server/driver_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package server

--- a/src/server/pps/server/poller.go
+++ b/src/server/pps/server/poller.go
@@ -172,9 +172,10 @@ func (m *ppsMaster) pollPipelines(ctx context.Context) {
 }
 
 // pollPipelinePods creates a kubernetes watch, and for each event:
-//   1) Checks if the event concerns a Pod
-//   2) Checks if the Pod belongs to a pipeline (pipelineName annotation is set)
-//   3) Checks if the Pod is failing
+//  1. Checks if the event concerns a Pod
+//  2. Checks if the Pod belongs to a pipeline (pipelineName annotation is set)
+//  3. Checks if the Pod is failing
+//
 // If all three conditions are met, then the pipline (in 'pipelineName') is set
 // to CRASHING
 func (m *ppsMaster) pollPipelinePods(ctx context.Context) {
@@ -256,10 +257,10 @@ func (m *ppsMaster) pollPipelinePods(ctx context.Context) {
 // pollPipelinePods (above) observes that a pipeline is crashing and updates its
 // state in the database, the flow for starting monitorPipelineCrashing is:
 //
-//  k8s watch ─> pollPipelinePods  ╭───> watchPipelines    ╭──> m.run()
-//                      │          │            │          │      │
-//                      ↓          │            ↓          │      ↓
-//                   db write──────╯       m.eventCh ──────╯   m.step()
+//	k8s watch ─> pollPipelinePods  ╭───> watchPipelines    ╭──> m.run()
+//	                    │          │            │          │      │
+//	                    ↓          │            ↓          │      ↓
+//	                 db write──────╯       m.eventCh ──────╯   m.step()
 //
 // Most of the other poll/monitor goroutines actually go through watchPipelines
 // (by writing to the database, which is then observed by the watch below)

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -4,8 +4,9 @@
 This test is for PPS pipelines that use S3 inputs/outputs. Most of these
 pipelines use the pachyderm/s3testing image, which exists on dockerhub but can
 be built by running:
-  cd etc/testing/images/s3testing
-  make push-to-minikube
+
+	cd etc/testing/images/s3testing
+	make push-to-minikube
 */
 package server
 

--- a/src/server/worker/datum/worker.go
+++ b/src/server/worker/datum/worker.go
@@ -134,7 +134,7 @@ func processPFSTask(pachClient *client.APIClient, task *PFSTask) (*types.Any, er
 			groupBy := g.Replace(p, task.Input.GroupBy)
 			meta := &Meta{
 				Inputs: []*common.Input{
-					&common.Input{
+					{
 						FileInfo:   fi,
 						JoinOn:     joinOn,
 						OuterJoin:  task.Input.OuterJoin,

--- a/src/server/worker/driver/driver_windows.go
+++ b/src/server/worker/driver/driver_windows.go
@@ -1,9 +1,9 @@
+//go:build windows
 // +build windows
 
 package driver
 
 import (
-	
 	"os"
 	"path/filepath"
 	"syscall"

--- a/src/server/worker/logs/logger.go
+++ b/src/server/worker/logs/logger.go
@@ -74,10 +74,11 @@ func newLogger(pipelineInfo *pps.PipelineInfo) *taggedLogger {
 // client.
 //
 // TODO: the whole object api interface here is bad, there are a few shortcomings:
-//  - it's only used under the worker function when stats are enabled
-//  - 'Close' is used to end the object, but it must be explicitly called
-//  - the 'eg', 'putObjClient', 'msgCh', 'buffer', and 'objSize' don't play well
-//      with cloned loggers.
+//   - it's only used under the worker function when stats are enabled
+//   - 'Close' is used to end the object, but it must be explicitly called
+//   - the 'eg', 'putObjClient', 'msgCh', 'buffer', and 'objSize' don't play well
+//     with cloned loggers.
+//
 // Abstract this into a separate object with a more explicit lifetime?
 func NewLogger(pipelineInfo *pps.PipelineInfo, pachClient *client.APIClient) (TaggedLogger, error) {
 	result := newLogger(pipelineInfo)

--- a/src/server/worker/stats/stats_test.go
+++ b/src/server/worker/stats/stats_test.go
@@ -230,7 +230,7 @@ func TestPrometheusStats(t *testing.T) {
 }
 
 // Regression: stats commits would not close when there were no input datums.
-//For more info, see github.com/pachyderm/pachyderm/v2/issues/3337
+// For more info, see github.com/pachyderm/pachyderm/v2/issues/3337
 func TestCloseStatsCommitWithNoInputDatums(t *testing.T) {
 	c, _ := minikubetestenv.AcquireCluster(t)
 	tu.ActivateEnterprise(t, c)

--- a/src/version/client.go
+++ b/src/version/client.go
@@ -45,7 +45,6 @@ type buildInfo struct {
 	platform        string
 }
 
-//
 func getBuildInfo() buildInfo {
 	info, ok := debug.ReadBuildInfo()
 	b := buildInfo{}


### PR DESCRIPTION
I was mostly in here to mandate gofmt, but also enabled some other easy-to-enable linters and opened a ticket to do the rest.

I thought I was going crazy because I've always assumed these linters were turned on, but it was in Hub that I turned them on.  Now we can have them too.

This is CORE-1314.