### PR TITLE
Distributed put / get file url

### DIFF
--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -5,10 +5,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"net/http"
-	"net/url"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -20,8 +16,6 @@ import (
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
-	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
-	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsload"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
@@ -442,7 +436,7 @@ func (a *apiServer) modifyFile(ctx context.Context, uw *fileset.UnorderedWriter,
 			case *pfs.AddFile_Raw:
 				n, err = putFileRaw(ctx, uw, p, t, src.Raw)
 			case *pfs.AddFile_Url:
-				n, err = putFileURL(ctx, uw, p, t, src.Url)
+				n, err = putFileURL(ctx, a.env.TaskService, uw, p, t, src.Url)
 			default:
 				// need to write empty data to path
 				n, err = putFileRaw(ctx, uw, p, t, &types.BytesValue{})
@@ -476,55 +470,6 @@ func putFileRaw(ctx context.Context, uw *fileset.UnorderedWriter, path, tag stri
 	return int64(len(src.Value)), nil
 }
 
-func putFileURL(ctx context.Context, uw *fileset.UnorderedWriter, dstPath, tag string, src *pfs.AddFile_URLSource) (n int64, retErr error) {
-	url, err := url.Parse(src.URL)
-	if err != nil {
-		return 0, errors.EnsureStack(err)
-	}
-	switch url.Scheme {
-	case "http":
-		fallthrough
-	case "https":
-		resp, err := http.Get(src.URL)
-		if err != nil {
-			return 0, errors.EnsureStack(err)
-		} else if resp.StatusCode >= 400 {
-			return 0, errors.Errorf("error retrieving content from %q: %s", src.URL, resp.Status)
-		}
-		defer func() {
-			if err := resp.Body.Close(); retErr == nil {
-				retErr = err
-			}
-		}()
-		return 0, uw.Put(ctx, dstPath, tag, true, resp.Body)
-	default:
-		url, err := obj.ParseURL(src.URL)
-		if err != nil {
-			return 0, errors.Wrapf(err, "error parsing url %v", src)
-		}
-		objClient, err := obj.NewClientFromURLAndSecret(url, false)
-		if err != nil {
-			return 0, err
-		}
-		if src.Recursive {
-			path := strings.TrimPrefix(url.Object, "/")
-			err := objClient.Walk(ctx, path, func(name string) error {
-				return miscutil.WithPipe(func(w io.Writer) error {
-					return errors.EnsureStack(objClient.Get(ctx, name, w))
-				}, func(r io.Reader) error {
-					return uw.Put(ctx, filepath.Join(dstPath, strings.TrimPrefix(name, path)), tag, true, r)
-				})
-			})
-			return 0, errors.EnsureStack(err)
-		}
-		return 0, miscutil.WithPipe(func(w io.Writer) error {
-			return errors.EnsureStack(objClient.Get(ctx, url.Object, w))
-		}, func(r io.Reader) error {
-			return uw.Put(ctx, dstPath, tag, true, r)
-		})
-	}
-}
-
 func deleteFile(ctx context.Context, uw *fileset.UnorderedWriter, request *pfs.DeleteFile) error {
 	return uw.Delete(ctx, request.Path, request.Datum)
 }
@@ -534,12 +479,12 @@ func (a *apiServer) GetFileTAR(request *pfs.GetFileRequest, server pfs.API_GetFi
 	request.GetFile().GetCommit().GetBranch().Repo.EnsureProject()
 	return metrics.ReportRequestWithThroughput(func() (int64, error) {
 		ctx := server.Context()
+		if request.URL != "" {
+			return a.driver.getFileURL(ctx, a.env.TaskService, request.URL, request.File, request.PathRange)
+		}
 		src, err := a.driver.getFile(ctx, request.File, request.PathRange)
 		if err != nil {
 			return 0, err
-		}
-		if request.URL != "" {
-			return getFileURL(ctx, request.URL, src)
 		}
 		var bytesWritten int64
 		err = grpcutil.WithStreamingBytesWriter(server, func(w io.Writer) error {
@@ -558,12 +503,12 @@ func (a *apiServer) GetFile(request *pfs.GetFileRequest, server pfs.API_GetFileS
 	request.GetFile().GetCommit().GetBranch().GetRepo().EnsureProject()
 	return metrics.ReportRequestWithThroughput(func() (int64, error) {
 		ctx := server.Context()
+		if request.URL != "" {
+			return a.driver.getFileURL(ctx, a.env.TaskService, request.URL, request.File, request.PathRange)
+		}
 		src, err := a.driver.getFile(ctx, request.File, request.PathRange)
 		if err != nil {
 			return 0, err
-		}
-		if request.URL != "" {
-			return getFileURL(ctx, request.URL, src)
 		}
 		if err := checkSingleFile(ctx, src); err != nil {
 			return 0, err
@@ -579,34 +524,6 @@ func (a *apiServer) GetFile(request *pfs.GetFileRequest, server pfs.API_GetFileS
 		}
 		return n, nil
 	})
-}
-
-// TODO: Parallelize and decide on appropriate config.
-func getFileURL(ctx context.Context, URL string, src Source) (int64, error) {
-	parsedURL, err := obj.ParseURL(URL)
-	if err != nil {
-		return 0, err
-	}
-	objClient, err := obj.NewClientFromURLAndSecret(parsedURL, false)
-	if err != nil {
-		return 0, err
-	}
-	var bytesWritten int64
-	err = src.Iterate(ctx, func(fi *pfs.FileInfo, file fileset.File) (retErr error) {
-		if fi.FileType != pfs.FileType_FILE {
-			return nil
-		}
-		if err := miscutil.WithPipe(func(w io.Writer) error {
-			return errors.EnsureStack(file.Content(ctx, w))
-		}, func(r io.Reader) error {
-			return errors.EnsureStack(objClient.Put(ctx, filepath.Join(parsedURL.Object, fi.File.Path), r))
-		}); err != nil {
-			return err
-		}
-		bytesWritten += int64(fi.SizeBytes)
-		return nil
-	})
-	return bytesWritten, errors.EnsureStack(err)
 }
 
 func withGetFileWriter(w io.Writer, cb func(io.Writer) error) (int64, error) {
@@ -1012,19 +929,20 @@ func readCommit(srv pfs.API_ModifyFileServer) (*pfs.Commit, error) {
 }
 
 func (a *apiServer) Egress(ctx context.Context, req *pfs.EgressRequest) (*pfs.EgressResponse, error) {
-	src, err := a.driver.getFile(ctx, req.Commit.NewFile("/"), nil)
-	if err != nil {
-		return nil, err
-	}
+	file := req.Commit.NewFile("/")
 	switch target := req.Target.(type) {
 	case *pfs.EgressRequest_ObjectStorage:
-		result, err := copyToObjectStorage(ctx, src, target.ObjectStorage.Url)
+		result, err := a.driver.copyToObjectStorage(ctx, a.env.TaskService, file, target.ObjectStorage.Url)
 		if err != nil {
 			return nil, errors.EnsureStack(err)
 		}
 		return &pfs.EgressResponse{Result: &pfs.EgressResponse_ObjectStorage{ObjectStorage: result}}, nil
 
 	case *pfs.EgressRequest_SqlDatabase:
+		src, err := a.driver.getFile(ctx, file, nil)
+		if err != nil {
+			return nil, err
+		}
 		result, err := copyToSQLDB(ctx, src, target.SqlDatabase.Url, target.SqlDatabase.FileFormat)
 		if err != nil {
 			return nil, errors.EnsureStack(err)

--- a/src/server/pfs/server/egress.go
+++ b/src/server/pfs/server/egress.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/sdata"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
@@ -24,8 +25,8 @@ func getEgressPassword() (string, error) {
 	return password, nil
 }
 
-func copyToObjectStorage(ctx context.Context, src Source, destURL string) (*pfs.EgressResponse_ObjectStorageResult, error) {
-	bytesWritten, err := getFileURL(ctx, destURL, src)
+func (d *driver) copyToObjectStorage(ctx context.Context, taskService task.Service, file *pfs.File, destURL string) (*pfs.EgressResponse_ObjectStorageResult, error) {
+	bytesWritten, err := d.getFileURL(ctx, taskService, destURL, file, nil)
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}

--- a/src/server/pfs/server/pfsserver.pb.go
+++ b/src/server/pfs/server/pfsserver.pb.go
@@ -7,6 +7,7 @@ import (
 	fmt "fmt"
 	proto "github.com/gogo/protobuf/proto"
 	index "github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
+	pfs "github.com/pachyderm/pachyderm/v2/src/pfs"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -502,6 +503,226 @@ func (m *ValidateTaskResult) GetSizeBytes() int64 {
 	return 0
 }
 
+type PutFileURLTask struct {
+	Dst                  string   `protobuf:"bytes,1,opt,name=dst,proto3" json:"dst,omitempty"`
+	Datum                string   `protobuf:"bytes,2,opt,name=datum,proto3" json:"datum,omitempty"`
+	URL                  string   `protobuf:"bytes,3,opt,name=URL,proto3" json:"URL,omitempty"`
+	Paths                []string `protobuf:"bytes,4,rep,name=paths,proto3" json:"paths,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PutFileURLTask) Reset()         { *m = PutFileURLTask{} }
+func (m *PutFileURLTask) String() string { return proto.CompactTextString(m) }
+func (*PutFileURLTask) ProtoMessage()    {}
+func (*PutFileURLTask) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5a92e512e703e9c, []int{9}
+}
+func (m *PutFileURLTask) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *PutFileURLTask) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_PutFileURLTask.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *PutFileURLTask) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PutFileURLTask.Merge(m, src)
+}
+func (m *PutFileURLTask) XXX_Size() int {
+	return m.Size()
+}
+func (m *PutFileURLTask) XXX_DiscardUnknown() {
+	xxx_messageInfo_PutFileURLTask.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PutFileURLTask proto.InternalMessageInfo
+
+func (m *PutFileURLTask) GetDst() string {
+	if m != nil {
+		return m.Dst
+	}
+	return ""
+}
+
+func (m *PutFileURLTask) GetDatum() string {
+	if m != nil {
+		return m.Datum
+	}
+	return ""
+}
+
+func (m *PutFileURLTask) GetURL() string {
+	if m != nil {
+		return m.URL
+	}
+	return ""
+}
+
+func (m *PutFileURLTask) GetPaths() []string {
+	if m != nil {
+		return m.Paths
+	}
+	return nil
+}
+
+type PutFileURLTaskResult struct {
+	Id                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PutFileURLTaskResult) Reset()         { *m = PutFileURLTaskResult{} }
+func (m *PutFileURLTaskResult) String() string { return proto.CompactTextString(m) }
+func (*PutFileURLTaskResult) ProtoMessage()    {}
+func (*PutFileURLTaskResult) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5a92e512e703e9c, []int{10}
+}
+func (m *PutFileURLTaskResult) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *PutFileURLTaskResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_PutFileURLTaskResult.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *PutFileURLTaskResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PutFileURLTaskResult.Merge(m, src)
+}
+func (m *PutFileURLTaskResult) XXX_Size() int {
+	return m.Size()
+}
+func (m *PutFileURLTaskResult) XXX_DiscardUnknown() {
+	xxx_messageInfo_PutFileURLTaskResult.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PutFileURLTaskResult proto.InternalMessageInfo
+
+func (m *PutFileURLTaskResult) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+type GetFileURLTask struct {
+	URL                  string         `protobuf:"bytes,1,opt,name=URL,proto3" json:"URL,omitempty"`
+	File                 *pfs.File      `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
+	PathRange            *pfs.PathRange `protobuf:"bytes,3,opt,name=path_range,json=pathRange,proto3" json:"path_range,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
+}
+
+func (m *GetFileURLTask) Reset()         { *m = GetFileURLTask{} }
+func (m *GetFileURLTask) String() string { return proto.CompactTextString(m) }
+func (*GetFileURLTask) ProtoMessage()    {}
+func (*GetFileURLTask) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5a92e512e703e9c, []int{11}
+}
+func (m *GetFileURLTask) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetFileURLTask) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetFileURLTask.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetFileURLTask) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetFileURLTask.Merge(m, src)
+}
+func (m *GetFileURLTask) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetFileURLTask) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetFileURLTask.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetFileURLTask proto.InternalMessageInfo
+
+func (m *GetFileURLTask) GetURL() string {
+	if m != nil {
+		return m.URL
+	}
+	return ""
+}
+
+func (m *GetFileURLTask) GetFile() *pfs.File {
+	if m != nil {
+		return m.File
+	}
+	return nil
+}
+
+func (m *GetFileURLTask) GetPathRange() *pfs.PathRange {
+	if m != nil {
+		return m.PathRange
+	}
+	return nil
+}
+
+type GetFileURLTaskResult struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetFileURLTaskResult) Reset()         { *m = GetFileURLTaskResult{} }
+func (m *GetFileURLTaskResult) String() string { return proto.CompactTextString(m) }
+func (*GetFileURLTaskResult) ProtoMessage()    {}
+func (*GetFileURLTaskResult) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5a92e512e703e9c, []int{12}
+}
+func (m *GetFileURLTaskResult) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetFileURLTaskResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetFileURLTaskResult.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetFileURLTaskResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetFileURLTaskResult.Merge(m, src)
+}
+func (m *GetFileURLTaskResult) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetFileURLTaskResult) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetFileURLTaskResult.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetFileURLTaskResult proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*ShardTask)(nil), "pfsserver.ShardTask")
 	proto.RegisterType((*ShardTaskResult)(nil), "pfsserver.ShardTaskResult")
@@ -512,38 +733,49 @@ func init() {
 	proto.RegisterType((*ConcatTaskResult)(nil), "pfsserver.ConcatTaskResult")
 	proto.RegisterType((*ValidateTask)(nil), "pfsserver.ValidateTask")
 	proto.RegisterType((*ValidateTaskResult)(nil), "pfsserver.ValidateTaskResult")
+	proto.RegisterType((*PutFileURLTask)(nil), "pfsserver.PutFileURLTask")
+	proto.RegisterType((*PutFileURLTaskResult)(nil), "pfsserver.PutFileURLTaskResult")
+	proto.RegisterType((*GetFileURLTask)(nil), "pfsserver.GetFileURLTask")
+	proto.RegisterType((*GetFileURLTaskResult)(nil), "pfsserver.GetFileURLTaskResult")
 }
 
 func init() { proto.RegisterFile("server/pfs/server/pfsserver.proto", fileDescriptor_a5a92e512e703e9c) }
 
 var fileDescriptor_a5a92e512e703e9c = []byte{
-	// 417 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x53, 0x4d, 0x6f, 0x13, 0x31,
-	0x10, 0x95, 0x93, 0xb6, 0x92, 0x27, 0xe1, 0xcb, 0xaa, 0xaa, 0x15, 0x12, 0xd1, 0x62, 0x38, 0x44,
-	0x1c, 0x62, 0x29, 0x3d, 0xf4, 0xc0, 0xad, 0x15, 0x07, 0x2e, 0x08, 0xb9, 0x08, 0xa1, 0x5e, 0x22,
-	0x67, 0x77, 0x92, 0xb5, 0xba, 0x5d, 0x5b, 0xb6, 0x53, 0x08, 0x7f, 0x82, 0xbf, 0xc5, 0x91, 0x9f,
-	0x80, 0xf2, 0x4b, 0xd0, 0xae, 0x97, 0xec, 0x02, 0x82, 0x03, 0xea, 0xc5, 0x9a, 0x37, 0xcf, 0x7e,
-	0xef, 0x8d, 0x6c, 0xc3, 0x53, 0x8f, 0xee, 0x16, 0x9d, 0xb0, 0x2b, 0x2f, 0xba, 0x32, 0x56, 0x33,
-	0xeb, 0x4c, 0x30, 0x8c, 0xee, 0x1b, 0x8f, 0x5f, 0xe8, 0x2a, 0xa0, 0xab, 0x54, 0x29, 0x7c, 0x30,
-	0x4e, 0xad, 0x51, 0xac, 0x74, 0x89, 0x1e, 0x83, 0xd0, 0x55, 0x8e, 0x9f, 0xe2, 0x1a, 0x8f, 0xf1,
-	0x0f, 0x40, 0x2f, 0x0b, 0xe5, 0xf2, 0x77, 0xca, 0x5f, 0xb3, 0x13, 0x38, 0xd2, 0x95, 0xdd, 0x04,
-	0x9f, 0x90, 0x74, 0x38, 0xa5, 0xb2, 0x45, 0xec, 0x14, 0xc0, 0xaa, 0x50, 0x2c, 0x9c, 0xaa, 0xd6,
-	0x98, 0x0c, 0x52, 0x32, 0x1d, 0xcd, 0x8f, 0x67, 0x5d, 0x82, 0xb7, 0x2a, 0x14, 0xb2, 0xe6, 0x24,
-	0xb5, 0x3f, 0x4b, 0xfe, 0x06, 0x1e, 0xec, 0x95, 0x25, 0xfa, 0x4d, 0x19, 0xd8, 0x4b, 0xb8, 0x97,
-	0x99, 0x1b, 0xab, 0xb2, 0xb0, 0x08, 0xca, 0x5f, 0x47, 0x9b, 0xd1, 0xfc, 0xa4, 0x27, 0x75, 0x11,
-	0xf9, 0xe6, 0xd0, 0x38, 0xeb, 0x80, 0xe7, 0x67, 0x40, 0xf7, 0x3e, 0xec, 0x18, 0x0e, 0x4b, 0xf3,
-	0x11, 0x5d, 0x42, 0x52, 0x32, 0xa5, 0x32, 0x82, 0xba, 0xbb, 0xb1, 0x16, 0x5d, 0x13, 0x91, 0xca,
-	0x08, 0xf8, 0x15, 0x8c, 0x7a, 0xaa, 0x77, 0x3b, 0xe4, 0x33, 0x78, 0xd4, 0x4f, 0x1c, 0xc7, 0xbc,
-	0x0f, 0x03, 0x9d, 0xb7, 0xc9, 0x06, 0x3a, 0xe7, 0xcf, 0x01, 0x2e, 0x4c, 0x95, 0xa9, 0x7f, 0xfa,
-	0x73, 0x0e, 0x0f, 0xbb, 0x5d, 0x7f, 0x51, 0xba, 0x84, 0xf1, 0x7b, 0x55, 0xea, 0x5c, 0x05, 0x6c,
-	0xb4, 0x7e, 0xe3, 0xff, 0x6f, 0x86, 0x2f, 0x04, 0x58, 0x5f, 0xb5, 0xf5, 0xe6, 0x70, 0xb8, 0xd2,
-	0xce, 0x87, 0x46, 0x7e, 0x34, 0x1f, 0xcf, 0xe2, 0xb3, 0x79, 0x5d, 0xaf, 0x32, 0x52, 0x2c, 0x85,
-	0x83, 0x52, 0xf9, 0xd0, 0x3a, 0xfd, 0xba, 0xa5, 0x61, 0xea, 0x2b, 0x41, 0xe7, 0x8c, 0x4b, 0x86,
-	0xf1, 0x4a, 0x1a, 0xc0, 0x9e, 0x00, 0x78, 0xfd, 0x19, 0x17, 0xcb, 0x6d, 0x40, 0x9f, 0x1c, 0xa4,
-	0x64, 0x3a, 0x94, 0xb4, 0xee, 0x9c, 0xd7, 0x8d, 0xf3, 0x57, 0x5f, 0x77, 0x13, 0xf2, 0x6d, 0x37,
-	0x21, 0xdf, 0x77, 0x13, 0x72, 0x75, 0xb6, 0xd6, 0xa1, 0xd8, 0x2c, 0x67, 0x99, 0xb9, 0x11, 0x56,
-	0x65, 0xc5, 0x36, 0x47, 0xd7, 0xaf, 0x6e, 0xe7, 0xc2, 0xbb, 0x4c, 0xfc, 0xf1, 0x45, 0x96, 0x47,
-	0xcd, 0x13, 0x3f, 0xfd, 0x11, 0x00, 0x00, 0xff, 0xff, 0x0a, 0x65, 0x57, 0xf0, 0x3e, 0x03, 0x00,
+	// 529 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0xd1, 0x6e, 0xd3, 0x3c,
+	0x14, 0x96, 0xdb, 0x6e, 0x52, 0x4e, 0xbb, 0xfe, 0x5b, 0x54, 0x55, 0xd5, 0xa4, 0xbf, 0x0a, 0x06,
+	0xa1, 0x8a, 0x8b, 0x06, 0x75, 0x17, 0xbb, 0xe0, 0x6e, 0x13, 0x20, 0xa4, 0x09, 0x4d, 0x1e, 0x43,
+	0x68, 0x37, 0xc5, 0x4d, 0xdc, 0xc6, 0x5a, 0x9a, 0x58, 0xb6, 0x53, 0x18, 0x2f, 0xc1, 0x6b, 0x71,
+	0xc9, 0x23, 0xa0, 0x3e, 0x09, 0xb2, 0x9d, 0x36, 0xe9, 0x60, 0x5c, 0x20, 0x6e, 0xa2, 0xf3, 0x9d,
+	0x73, 0xfc, 0x7d, 0xdf, 0xf1, 0xa9, 0x0b, 0x8f, 0x14, 0x93, 0x2b, 0x26, 0x43, 0x31, 0x57, 0x61,
+	0x15, 0xba, 0x68, 0x2c, 0x64, 0xae, 0x73, 0xdf, 0xdb, 0x26, 0x8e, 0x9f, 0xf1, 0x4c, 0x33, 0x99,
+	0xd1, 0x34, 0x54, 0x3a, 0x97, 0x74, 0xc1, 0xc2, 0x39, 0x4f, 0x99, 0x62, 0x3a, 0xe4, 0x59, 0xcc,
+	0x3e, 0xbb, 0xaf, 0x3b, 0x76, 0x7c, 0x60, 0x28, 0xc5, 0x5c, 0x39, 0x88, 0x3f, 0x80, 0x77, 0x95,
+	0x50, 0x19, 0xbf, 0xa3, 0xea, 0xd6, 0xef, 0xc3, 0x3e, 0xcf, 0x44, 0xa1, 0xd5, 0x00, 0x05, 0xcd,
+	0x91, 0x47, 0x4a, 0xe4, 0x9f, 0x00, 0x08, 0xaa, 0x93, 0xa9, 0xa4, 0xd9, 0x82, 0x0d, 0x1a, 0x01,
+	0x1a, 0xb5, 0x27, 0xbd, 0x71, 0x65, 0xe8, 0x92, 0xea, 0x84, 0x98, 0x1a, 0xf1, 0xc4, 0x26, 0xc4,
+	0x6f, 0xe1, 0xbf, 0x2d, 0x33, 0x61, 0xaa, 0x48, 0xb5, 0xff, 0x02, 0x0e, 0xa2, 0x7c, 0x29, 0x68,
+	0xa4, 0xa7, 0x9a, 0xaa, 0x5b, 0x27, 0xd3, 0x9e, 0xf4, 0x6b, 0x54, 0xe7, 0xae, 0x6e, 0x0f, 0x75,
+	0xa2, 0x0a, 0x28, 0x7c, 0x0a, 0xde, 0x56, 0xc7, 0xef, 0xc1, 0x5e, 0x9a, 0x7f, 0x62, 0x72, 0x80,
+	0x02, 0x34, 0xf2, 0x88, 0x03, 0x26, 0x5b, 0x08, 0xc1, 0xa4, 0xb5, 0xe8, 0x11, 0x07, 0xf0, 0x0d,
+	0xb4, 0x6b, 0xac, 0xff, 0x76, 0xc8, 0xc7, 0x70, 0x54, 0x77, 0xec, 0xc6, 0xec, 0x42, 0x83, 0xc7,
+	0xa5, 0xb3, 0x06, 0x8f, 0xf1, 0x13, 0x80, 0xf3, 0x3c, 0x8b, 0xe8, 0x1f, 0xf5, 0x31, 0x86, 0xc3,
+	0xaa, 0xeb, 0x01, 0xa6, 0x2b, 0xe8, 0xbc, 0xa7, 0x29, 0x8f, 0xa9, 0x66, 0x96, 0xeb, 0x5e, 0xfd,
+	0xef, 0x66, 0xf8, 0x8a, 0xc0, 0xaf, 0xb3, 0x96, 0xda, 0x18, 0xf6, 0xe6, 0x5c, 0x2a, 0x6d, 0xe9,
+	0xdb, 0x93, 0xce, 0xd8, 0xfd, 0x8a, 0xde, 0x98, 0x2f, 0x71, 0x25, 0x3f, 0x80, 0x56, 0x4a, 0x95,
+	0x2e, 0x95, 0x76, 0x5b, 0x6c, 0xc5, 0xac, 0x84, 0x49, 0x99, 0xcb, 0x41, 0xd3, 0xad, 0xc4, 0x02,
+	0xff, 0x7f, 0x00, 0xc5, 0xbf, 0xb0, 0xe9, 0xec, 0x4e, 0x33, 0x35, 0x68, 0x05, 0x68, 0xd4, 0x24,
+	0x9e, 0xc9, 0x9c, 0x99, 0x04, 0xfe, 0x08, 0xdd, 0xcb, 0x42, 0xbf, 0xe2, 0x29, 0xbb, 0x26, 0x17,
+	0x76, 0xd0, 0x43, 0x68, 0xc6, 0xa5, 0x15, 0x8f, 0x98, 0xd0, 0x10, 0xc7, 0x54, 0x17, 0xcb, 0xcd,
+	0xae, 0x2d, 0x30, 0x7d, 0xd7, 0xe4, 0xa2, 0x14, 0x33, 0xa1, 0xe9, 0x33, 0xa3, 0x1a, 0x15, 0x73,
+	0xdb, 0x0e, 0xe0, 0xa7, 0xd0, 0xdb, 0x55, 0x78, 0xe0, 0xc2, 0x57, 0xd0, 0x7d, 0xcd, 0xee, 0x3b,
+	0x31, 0x0a, 0xa8, 0x52, 0x08, 0xa0, 0x65, 0x9e, 0xdb, 0xf6, 0x12, 0xc4, 0x5c, 0x4d, 0x57, 0x93,
+	0xb1, 0x39, 0x44, 0x6c, 0xc5, 0x7f, 0xbe, 0xb3, 0x96, 0xa6, 0xed, 0x3b, 0xda, 0xf4, 0xfd, 0x76,
+	0x27, 0x7d, 0xe8, 0xed, 0xea, 0x3a, 0x7f, 0x67, 0x2f, 0xbf, 0xad, 0x87, 0xe8, 0xfb, 0x7a, 0x88,
+	0x7e, 0xac, 0x87, 0xe8, 0xe6, 0x74, 0xc1, 0x75, 0x52, 0xcc, 0xc6, 0x51, 0xbe, 0x0c, 0x05, 0x8d,
+	0x92, 0xbb, 0x98, 0xc9, 0x7a, 0xb4, 0x9a, 0x84, 0x4a, 0x46, 0xe1, 0x2f, 0xff, 0x25, 0xb3, 0x7d,
+	0xfb, 0xf8, 0x4f, 0x7e, 0x06, 0x00, 0x00, 0xff, 0xff, 0x99, 0xf6, 0x0f, 0xd8, 0x67, 0x04, 0x00,
 	0x00,
 }
 
@@ -938,6 +1170,182 @@ func (m *ValidateTaskResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *PutFileURLTask) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PutFileURLTask) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *PutFileURLTask) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Paths) > 0 {
+		for iNdEx := len(m.Paths) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Paths[iNdEx])
+			copy(dAtA[i:], m.Paths[iNdEx])
+			i = encodeVarintPfsserver(dAtA, i, uint64(len(m.Paths[iNdEx])))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.URL) > 0 {
+		i -= len(m.URL)
+		copy(dAtA[i:], m.URL)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.URL)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Datum) > 0 {
+		i -= len(m.Datum)
+		copy(dAtA[i:], m.Datum)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.Datum)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Dst) > 0 {
+		i -= len(m.Dst)
+		copy(dAtA[i:], m.Dst)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.Dst)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *PutFileURLTaskResult) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PutFileURLTaskResult) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *PutFileURLTaskResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetFileURLTask) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetFileURLTask) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetFileURLTask) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.PathRange != nil {
+		{
+			size, err := m.PathRange.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintPfsserver(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.File != nil {
+		{
+			size, err := m.File.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintPfsserver(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.URL) > 0 {
+		i -= len(m.URL)
+		copy(dAtA[i:], m.URL)
+		i = encodeVarintPfsserver(dAtA, i, uint64(len(m.URL)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetFileURLTaskResult) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetFileURLTaskResult) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetFileURLTaskResult) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintPfsserver(dAtA []byte, offset int, v uint64) int {
 	offset -= sovPfsserver(v)
 	base := offset
@@ -1122,6 +1530,88 @@ func (m *ValidateTaskResult) Size() (n int) {
 	if m.SizeBytes != 0 {
 		n += 1 + sovPfsserver(uint64(m.SizeBytes))
 	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *PutFileURLTask) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Dst)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	l = len(m.Datum)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	l = len(m.URL)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if len(m.Paths) > 0 {
+		for _, s := range m.Paths {
+			l = len(s)
+			n += 1 + l + sovPfsserver(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *PutFileURLTaskResult) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetFileURLTask) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.URL)
+	if l > 0 {
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if m.File != nil {
+		l = m.File.Size()
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if m.PathRange != nil {
+		l = m.PathRange.Size()
+		n += 1 + l + sovPfsserver(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetFileURLTaskResult) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -2092,6 +2582,474 @@ func (m *ValidateTaskResult) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPfsserver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PutFileURLTask) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPfsserver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PutFileURLTask: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PutFileURLTask: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Dst", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Dst = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Datum", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Datum = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field URL", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.URL = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Paths", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Paths = append(m.Paths, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPfsserver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PutFileURLTaskResult) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPfsserver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PutFileURLTaskResult: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PutFileURLTaskResult: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPfsserver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetFileURLTask) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPfsserver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetFileURLTask: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetFileURLTask: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field URL", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.URL = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field File", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.File == nil {
+				m.File = &pfs.File{}
+			}
+			if err := m.File.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PathRange", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPfsserver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.PathRange == nil {
+				m.PathRange = &pfs.PathRange{}
+			}
+			if err := m.PathRange.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPfsserver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPfsserver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetFileURLTaskResult) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPfsserver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetFileURLTaskResult: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetFileURLTaskResult: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := skipPfsserver(dAtA[iNdEx:])

--- a/src/server/pfs/server/pfsserver.proto
+++ b/src/server/pfs/server/pfsserver.proto
@@ -4,6 +4,7 @@ package pfsserver;
 option go_package = "github.com/pachyderm/pachyderm/v2/src/server/pfs/server";
 
 import "internal/storage/fileset/index/index.proto";
+import "pfs/pfs.proto";
 
 message ShardTask {
   repeated string inputs = 1;
@@ -47,3 +48,22 @@ message ValidateTaskResult {
   string error = 3;
   int64 size_bytes = 4;
 }
+
+message PutFileURLTask {
+  string dst = 1;
+  string datum = 2;
+  string URL = 3;
+  repeated string paths = 4;
+}
+
+message PutFileURLTaskResult {
+  string id = 1;
+}
+
+message GetFileURLTask {
+  string URL = 1;
+  pfs_v2.File file = 2;
+  pfs_v2.PathRange path_range = 3;
+}
+
+message GetFileURLTaskResult {}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -12,6 +12,7 @@ func NewAPIServer(env Env) (pfsserver.APIServer, error) {
 		return nil, err
 	}
 	go a.driver.master(env.BackgroundContext)
+	go a.driver.URLWorker(env.BackgroundContext)
 	go func() { pfsload.Worker(env.GetPachClient(env.BackgroundContext), env.TaskService) }() //nolint:errcheck
 	return newValidatedAPIServer(a, env.AuthServer), nil
 }

--- a/src/server/pfs/server/url.go
+++ b/src/server/pfs/server/url.go
@@ -27,9 +27,7 @@ func putFileURL(ctx context.Context, taskService task.Service, uw *fileset.Unord
 		return 0, errors.EnsureStack(err)
 	}
 	switch url.Scheme {
-	case "http":
-		fallthrough
-	case "https":
+	case "http", "https":
 		resp, err := http.Get(src.URL)
 		if err != nil {
 			return 0, errors.EnsureStack(err)

--- a/src/server/pfs/server/url.go
+++ b/src/server/pfs/server/url.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"github.com/pachyderm/pachyderm/v2/src/internal/task"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	defaultURLTaskSize = 1000
+)
+
+func putFileURL(ctx context.Context, taskService task.Service, uw *fileset.UnorderedWriter, dstPath, tag string, src *pfs.AddFile_URLSource) (n int64, retErr error) {
+	url, err := url.Parse(src.URL)
+	if err != nil {
+		return 0, errors.EnsureStack(err)
+	}
+	switch url.Scheme {
+	case "http":
+		fallthrough
+	case "https":
+		resp, err := http.Get(src.URL)
+		if err != nil {
+			return 0, errors.EnsureStack(err)
+		} else if resp.StatusCode >= 400 {
+			return 0, errors.Errorf("error retrieving content from %q: %s", src.URL, resp.Status)
+		}
+		defer func() {
+			if err := resp.Body.Close(); retErr == nil {
+				retErr = err
+			}
+		}()
+		return 0, uw.Put(ctx, dstPath, tag, true, resp.Body)
+	default:
+		if src.Recursive {
+			return 0, putFileURLRecursive(ctx, taskService, uw, dstPath, tag, src)
+		}
+		url, err := obj.ParseURL(src.URL)
+		if err != nil {
+			return 0, errors.Wrapf(err, "error parsing url %v", src)
+		}
+		objClient, err := obj.NewClientFromURLAndSecret(url, false)
+		if err != nil {
+			return 0, err
+		}
+		return 0, miscutil.WithPipe(func(w io.Writer) error {
+			return errors.EnsureStack(objClient.Get(ctx, url.Object, w))
+		}, func(r io.Reader) error {
+			return uw.Put(ctx, dstPath, tag, true, r)
+		})
+	}
+}
+
+func putFileURLRecursive(ctx context.Context, taskService task.Service, uw *fileset.UnorderedWriter, dst, tag string, src *pfs.AddFile_URLSource) error {
+	inputChan := make(chan *types.Any)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		// TODO: Add cache?
+		doer := taskService.NewDoer(URLTaskNamespace, uuid.NewWithoutDashes(), nil)
+		err := doer.Do(ctx, inputChan, func(_ int64, output *types.Any, err error) error {
+			if err != nil {
+				return err
+			}
+			result, err := deserializePutFileURLTaskResult(output)
+			if err != nil {
+				return err
+			}
+			fsid, err := fileset.ParseID(result.Id)
+			if err != nil {
+				return err
+			}
+			return uw.AddFileSet(ctx, *fsid)
+		})
+		return errors.EnsureStack(err)
+	})
+	eg.Go(func() error {
+		url, err := obj.ParseURL(src.URL)
+		if err != nil {
+			return errors.Wrapf(err, "error parsing url %v", src)
+		}
+		objClient, err := obj.NewClientFromURLAndSecret(url, false)
+		if err != nil {
+			return err
+		}
+		var paths []string
+		createTask := func() error {
+			input, err := serializePutFileURLTask(&PutFileURLTask{
+				Dst:   dst,
+				Datum: tag,
+				URL:   src.URL,
+				Paths: paths,
+			})
+			if err != nil {
+				return err
+			}
+			select {
+			case inputChan <- input:
+			case <-ctx.Done():
+				return errors.EnsureStack(ctx.Err())
+			}
+			return nil
+		}
+		if err := objClient.Walk(ctx, url.Object, func(p string) error {
+			if len(paths) >= defaultURLTaskSize {
+				if err := createTask(); err != nil {
+					return err
+				}
+				paths = nil
+			}
+			paths = append(paths, p)
+			return nil
+		}); err != nil {
+			return errors.EnsureStack(err)
+		}
+		if len(paths) > 0 {
+			if err := createTask(); err != nil {
+				return err
+			}
+		}
+		close(inputChan)
+		return nil
+	})
+	return errors.EnsureStack(eg.Wait())
+}
+
+// TODO: Parallelize and decide on appropriate config.
+func (d *driver) getFileURL(ctx context.Context, taskService task.Service, URL string, file *pfs.File, basePathRange *pfs.PathRange) (int64, error) {
+	if basePathRange == nil {
+		basePathRange = &pfs.PathRange{}
+	}
+	inputChan := make(chan *types.Any)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		// TODO: Add cache?
+		doer := taskService.NewDoer(URLTaskNamespace, uuid.NewWithoutDashes(), nil)
+		err := doer.Do(ctx, inputChan, func(_ int64, output *types.Any, err error) error { return err })
+		return errors.EnsureStack(err)
+	})
+	var bytesWritten int64
+	eg.Go(func() error {
+		src, err := d.getFile(ctx, file, basePathRange)
+		if err != nil {
+			return err
+		}
+		pathRange := &pfs.PathRange{
+			Lower: basePathRange.Lower,
+		}
+		createTask := func() error {
+			input, err := serializeGetFileURLTask(&GetFileURLTask{
+				URL:       URL,
+				File:      file,
+				PathRange: pathRange,
+			})
+			if err != nil {
+				return err
+			}
+			select {
+			case inputChan <- input:
+			case <-ctx.Done():
+				return errors.EnsureStack(ctx.Err())
+			}
+			return nil
+		}
+		var count int64
+		if err := src.Iterate(ctx, func(fi *pfs.FileInfo, file fileset.File) error {
+			if fi.FileType != pfs.FileType_FILE {
+				return nil
+			}
+			bytesWritten += int64(fi.SizeBytes)
+			if count >= defaultURLTaskSize {
+				pathRange.Upper = file.Index().Path
+				if err := createTask(); err != nil {
+					return err
+				}
+				pathRange = &pfs.PathRange{
+					Lower: file.Index().Path,
+				}
+				count = 0
+			}
+			count++
+			return nil
+		}); err != nil {
+			return errors.EnsureStack(err)
+		}
+		pathRange.Upper = basePathRange.Upper
+		if err := createTask(); err != nil {
+			return err
+		}
+		close(inputChan)
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		return 0, errors.EnsureStack(err)
+	}
+	return bytesWritten, nil
+}

--- a/src/server/pfs/server/url_worker.go
+++ b/src/server/pfs/server/url_worker.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	URLTaskNamespace = "url"
+)
+
+func (d *driver) URLWorker(ctx context.Context) {
+	ctx = auth.AsInternalUser(ctx, "pfs-url-worker")
+	taskSource := d.env.TaskService.NewSource(URLTaskNamespace)
+	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
+		err := taskSource.Iterate(ctx, func(ctx context.Context, input *types.Any) (*types.Any, error) {
+			switch {
+			case types.Is(input, &PutFileURLTask{}):
+				putFileURLTask, err := deserializePutFileURLTask(input)
+				if err != nil {
+					return nil, err
+				}
+				return d.processPutFileURLTask(ctx, putFileURLTask)
+			case types.Is(input, &GetFileURLTask{}):
+				getFileURLTask, err := deserializeGetFileURLTask(input)
+				if err != nil {
+					return nil, err
+				}
+				return d.processGetFileURLTask(ctx, getFileURLTask)
+			default:
+				return nil, errors.Errorf("unrecognized any type (%v) in URL worker", input.TypeUrl)
+			}
+		})
+		return errors.EnsureStack(err)
+	}, backoff.NewInfiniteBackOff(), func(err error, _ time.Duration) error {
+		log.Printf("error in URL worker: %v", err)
+		return nil
+	})
+}
+
+func (d *driver) processPutFileURLTask(ctx context.Context, task *PutFileURLTask) (*types.Any, error) {
+	url, err := obj.ParseURL(task.URL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing URL %v", task.URL)
+	}
+	objClient, err := obj.NewClientFromURLAndSecret(url, false)
+	if err != nil {
+		return nil, err
+	}
+	prefix := strings.TrimPrefix(url.Object, "/")
+	result := &PutFileURLTaskResult{}
+	if err := miscutil.LogStep(ctx, log.NewEntry(log.StandardLogger()), "processing put file URL task", func() error {
+		return d.storage.WithRenewer(ctx, defaultTTL, func(ctx context.Context, renewer *fileset.Renewer) error {
+			id, err := d.withUnorderedWriter(ctx, renewer, func(uw *fileset.UnorderedWriter) error {
+				for _, path := range task.Paths {
+					if err := miscutil.WithPipe(func(w io.Writer) error {
+						return errors.EnsureStack(objClient.Get(ctx, path, w))
+					}, func(r io.Reader) error {
+						return uw.Put(ctx, filepath.Join(task.Dst, strings.TrimPrefix(path, prefix)), task.Datum, true, r)
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			result.Id = id.HexString()
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return serializePutFileURLTaskResult(result)
+}
+
+func (d *driver) processGetFileURLTask(ctx context.Context, task *GetFileURLTask) (*types.Any, error) {
+	src, err := d.getFile(ctx, task.File, task.PathRange)
+	if err != nil {
+		return nil, err
+	}
+	url, err := obj.ParseURL(task.URL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing URL %v", task.URL)
+	}
+	objClient, err := obj.NewClientFromURLAndSecret(url, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := miscutil.LogStep(ctx, log.NewEntry(log.StandardLogger()), "processing get file URL task", func() error {
+		err := src.Iterate(ctx, func(fi *pfs.FileInfo, file fileset.File) error {
+			if fi.FileType != pfs.FileType_FILE {
+				return nil
+			}
+			return miscutil.WithPipe(func(w io.Writer) error {
+				return errors.EnsureStack(file.Content(ctx, w))
+			}, func(r io.Reader) error {
+				return errors.EnsureStack(objClient.Put(ctx, filepath.Join(url.Object, fi.File.Path), r))
+			})
+		})
+		return errors.EnsureStack(err)
+	}); err != nil {
+		return nil, err
+	}
+	return serializeGetFileURLTaskResult(&GetFileURLTaskResult{})
+}
+
+func serializePutFileURLTask(task *PutFileURLTask) (*types.Any, error) {
+	data, err := proto.Marshal(task)
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return &types.Any{
+		TypeUrl: "/" + proto.MessageName(task),
+		Value:   data,
+	}, nil
+}
+
+func deserializePutFileURLTask(taskAny *types.Any) (*PutFileURLTask, error) {
+	task := &PutFileURLTask{}
+	if err := types.UnmarshalAny(taskAny, task); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return task, nil
+}
+
+func serializePutFileURLTaskResult(task *PutFileURLTaskResult) (*types.Any, error) {
+	data, err := proto.Marshal(task)
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return &types.Any{
+		TypeUrl: "/" + proto.MessageName(task),
+		Value:   data,
+	}, nil
+}
+
+func deserializePutFileURLTaskResult(taskAny *types.Any) (*PutFileURLTaskResult, error) {
+	task := &PutFileURLTaskResult{}
+	if err := types.UnmarshalAny(taskAny, task); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return task, nil
+}
+
+func serializeGetFileURLTask(task *GetFileURLTask) (*types.Any, error) {
+	data, err := proto.Marshal(task)
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return &types.Any{
+		TypeUrl: "/" + proto.MessageName(task),
+		Value:   data,
+	}, nil
+}
+
+func deserializeGetFileURLTask(taskAny *types.Any) (*GetFileURLTask, error) {
+	task := &GetFileURLTask{}
+	if err := types.UnmarshalAny(taskAny, task); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return task, nil
+}
+
+func serializeGetFileURLTaskResult(task *GetFileURLTaskResult) (*types.Any, error) {
+	data, err := proto.Marshal(task)
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return &types.Any{
+		TypeUrl: "/" + proto.MessageName(task),
+		Value:   data,
+	}, nil
+}


### PR DESCRIPTION
This PR distributes the processing of put / get file url requests through the task service. The objects / files to be imported / exported are split into batches that can be processed as tasks through the task service. For put file url, the object prefix is walked to determine the batches. For get file url, the files are iterated through to get the batches. Put file url batches are specified as a list of paths to import. Get file url batches are specified as a file and a path range to export. Both put and get file url use the task service streaming interface to mitigate the impact of stragglers. This implementation has a couple shortcomings that I intend to address in a followup PR that will change our object storage client interface (potentially to this: https://github.com/google/go-cloud). The shortcomings are:
- No path range specification for put file url tasks, which means all of the paths are stored in the task description.
- Not as much benefit for large files since they will still be downloaded serially. We would ideally be able to split large files up into byte ranges and spread them across multiple tasks.