### PR TITLE
Remove default controlplane tolerations from promtail

### DIFF
--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -642,6 +642,9 @@
                                     "type": "integer"
                                 }
                             }
+                        },
+                        "tolerations": {
+                            "type": "object"
                         }
                     }
                 }

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -644,7 +644,7 @@
                             }
                         },
                         "tolerations": {
-                            "type": "object"
+                            "type": "array"
                         }
                     }
                 }

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -343,7 +343,7 @@ loki-stack:
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
     # Tolerations for promtail pods. Promtail must run on any node where pachyderm resources will run or you won't get any logs for them
-    # For example, GKE gpu nodes have a default tail of nvidia.com/gpu=present:NoSchedule so if you use GPUs we wouldn't have logs
+    # For example, GKE gpu nodes have a default taint of nvidia.com/gpu=present:NoSchedule so if you use GPUs we wouldn't have logs
     tolerations: {}
     livenessProbe:
       failureThreshold: 5

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -344,7 +344,7 @@ loki-stack:
             regex: __meta_kubernetes_pod_label_(.+)
     # Tolerations for promtail pods. Promtail must run on any node where pachyderm resources will run or you won't get any logs for them
     # For example, GKE gpu nodes have a default taint of nvidia.com/gpu=present:NoSchedule so if you use GPUs we wouldn't have logs
-    tolerations: {}
+    tolerations: []
     livenessProbe:
       failureThreshold: 5
       tcpSocket:

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -342,6 +342,9 @@ loki-stack:
           # this gets all kubernetes labels as well
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
+    # Tolerations for promtail pods. Promtail must run on any node where pachyderm resources will run or you won't get any logs for them
+    # For example, GKE gpu nodes have a default tail of nvidia.com/gpu=present:NoSchedule so if you use GPUs we wouldn't have logs
+    tolerations: {}
     livenessProbe:
       failureThreshold: 5
       tcpSocket:


### PR DESCRIPTION
by default, promtail has tolerations for controlplane/master taints. This removes those default tolerations, and adds some notes for users to configure tolerations for any taints where pachyderm resources are running.