### PR TITLE
Adjust envoy default stream window to increase upload throughput

### DIFF
--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -109,7 +109,7 @@
       },
       http2_protocol_options: {
         initial_connection_window_size: 1048576,
-        initial_stream_window_size: 65536,
+        initial_stream_window_size: 524288,
         max_concurrent_streams: 100,
       },
       http_filters: std.prune([

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -363,7 +363,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -447,7 +447,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -643,7 +643,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -363,7 +363,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -526,7 +526,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -610,7 +610,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -719,7 +719,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -810,7 +810,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -893,7 +893,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -976,7 +976,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [
@@ -1059,7 +1059,7 @@
                            },
                            "http2_protocol_options": {
                               "initial_connection_window_size": 1048576,
-                              "initial_stream_window_size": 65536,
+                              "initial_stream_window_size": 524288,
                               "max_concurrent_streams": 100
                            },
                            "http_filters": [

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -867,7 +867,7 @@ proxy:
   # The envoy image to pull.
   image:
     repository: "envoyproxy/envoy"
-    tag: "v1.22.0"
+    tag: "v1.24.0"
     pullPolicy: "IfNotPresent"
   # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's
   # a resonable memory limit.  It doesn't need much CPU.


### PR DESCRIPTION
I don't really know why gRPC flow control is so broken, but this is the most minimal change to work around it.  I chose 512KiB intead of the default 64KiB because 512KiB is faster than 256KiB, but 1024KiB is not faster than 512KiB.   I think the actual buffer size is less important than it not being the default; it triggers different RTT estimation code in gRPC.

I tested various uploads with: https://github.com/pachyderm/pachyderm/blob/jonathan/test-scripts/etc/benchmark-uploads/main.go

We should test this on a connection with latency;  performance with both the proxy and `kubectl port-forward` is abysmal with `sudo tc qdisc add dev lo root netem delay 60ms` (on the order of 2MB/s compared to 140MB/s without).

I also upgraded Envoy here, but it's not critical to this change.

CORE-1315