### PR TITLE
[CORE-1347] Fix pachctl verbose logging

### DIFF
--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -80,7 +80,7 @@ func NewGRPCLogWriter(logger *logrus.Logger, source string) *GRPCLogWriter {
 // Write allows `GRPCInfoWriter` to implement the `io.Writer` interface. This
 // will take gRPC logs, which look something like this:
 // ```
-// INFO: 2019/02/18 12:21:54 ClientConn switching balancer to "pick_first"
+// 2019/02/18 12:21:54 INFO: ClientConn switching balancer to "pick_first"
 // ```
 // strip out redundant content, and print the message at the appropriate log
 // level in logrus. Any parse errors of the log message will be reported in

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -90,11 +90,11 @@ func (l *GRPCLogWriter) Write(p []byte) (int, error) {
 	entry := l.logger.WithField("source", l.source)
 
 	if len(parts) == 4 {
-		// parts[1] and parts[2] contain the date and time, but logrus already
+		// parts[0] and parts[1] contain the date and time, but logrus already
 		// adds this under the `time` entry field, so it's not needed (though
 		// the time will presumably be marginally ahead of the original log
 		// message)
-		level := parts[0]
+		level := parts[2]
 		message := strings.TrimSpace(parts[3])
 
 		if level == "INFO:" {


### PR DESCRIPTION
picks the correct string that has the error level