### PR TITLE
Djanicek/performance pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ parameters:
   run-perf-tests:
     type: boolean
     default: false
+  pachd-latest-version:
+    type: string
+    default: ""
 # our defined job, and its steps
 jobs:
   setup:
@@ -132,7 +135,7 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
       PACHD_VERSION: << parameters.version >>
-      PACHD_LATEST_VERSION: ""
+      PACHD_LATEST_VERSION: << pipeline.parameters.pachd-latest-version >>
     parallelism: 1
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ parameters:
     # may not always be in sync with pgbouncer-base-image-version
     # i.e any entrypoint.sh wrapper updates
     default: "1.16.1"
+  run-perf-tests:
+    type: boolean
+    default: false
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,10 @@ workflows:
     jobs:
       - release-pgbouncer
   nightly-api-performance:
-    when: << pipeline.parameters.run-perf-tests >>
+    when:
+      and:
+        - not: << pipeline.parameters.run_nightly_tag >>
+        - equal: [true, << pipeline.parameters.run-perf-tests >>]
     jobs:
       - api-performance-test:
           matrix:
@@ -231,4 +234,3 @@ workflows:
               version:
                 - v2.4.0
                 - latest
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             docker buildx create --name pgb --driver docker-container --use buildx-build
             docker buildx build --builder pgb --build-arg VERSION=<< pipeline.parameters.pgbouncer-base-image-version >> --platform=linux/amd64,linux/arm64 -f Dockerfile.pgbouncer -t pachyderm/pgbouncer:<< pipeline.parameters.pgbouncer-image-tag >> --push ./etc/pgbouncer
   api-performance-test:
-    resource_class: large
+    resource_class: xlarge
     parameters:
       version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,12 @@ setup: true
 orbs:
   continuation: circleci/continuation@0.1.2
   path-filtering: circleci/path-filtering@0.1.3
+  gh: circleci/github-cli@2.1
 
 parameters:
+  machine_image:
+    type: string
+    default: ubuntu-2004:2022.07.1
   run_load_tests:
     type: boolean
     default: false
@@ -118,6 +122,61 @@ jobs:
             docker context create buildx-build
             docker buildx create --name pgb --driver docker-container --use buildx-build
             docker buildx build --builder pgb --build-arg VERSION=<< pipeline.parameters.pgbouncer-base-image-version >> --platform=linux/amd64,linux/arm64 -f Dockerfile.pgbouncer -t pachyderm/pgbouncer:<< pipeline.parameters.pgbouncer-image-tag >> --push ./etc/pgbouncer
+  api-performance-test:
+    resource_class: large
+    parameters:
+      version:
+        type: string
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    environment:
+      TEST_RESULTS: /tmp/test-results
+      PACHD_VERSION: << parameters.version >>
+    parallelism: 1
+    steps:
+      - checkout
+      - run:
+          name: Collect node stats
+          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
+          background: true
+      - run: mkdir -p ${TEST_RESULTS}
+      - run:
+          name: Clone Locust tests
+          command: |
+            git clone https://github.com/pachyderm/locust-pachyderm.git locust-pachyderm
+      - run:
+          name: setup env vars
+          command: |
+            echo 'export GOCACHE=/home/circleci/.gocache' >> $BASH_ENV
+            echo 'export GOPATH=/home/circleci/.go_workspace' >> $BASH_ENV
+
+            echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
+            echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+      - restore_cache:
+          keys:
+            - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
+      - run: etc/testing/circle/install.sh
+      - gh/setup:
+          version: 2.20.2
+      - run:
+          name: Start minikube
+          command: etc/testing/circle/start-minikube.sh
+          background: true
+      - run: etc/testing/circle/wait-minikube.sh
+      - run:
+          name: Install minio
+          command: kubectl apply -f etc/testing/minio.yaml
+      - run:
+          name: run api performance benchmark
+          no_output_timeout: 20m
+          command: |
+            etc/testing/circle/run_api_performance_tests.sh
+      - run:
+          name: Dump debugging info in case of failure
+          when: on_fail
+          command: etc/testing/circle/kube_debug.sh
+      - store_artifacts:
+          path: /tmp/test-results
 
 # our single workflow, that triggers the setup job defined above
 workflows:
@@ -127,6 +186,7 @@ workflows:
         - not: << pipeline.parameters.run_nightly_tag >>
         - not: << pipeline.parameters.release-pgbouncer >>
         - not: << pipeline.parameters.release-etcd >>
+        - not: << pipeline.parameters.run-perf-tests >>
     jobs:
       - path-filtering/filter:
           name: check-updated-files
@@ -162,3 +222,13 @@ workflows:
         - equal: [true, << pipeline.parameters.release-pgbouncer >>]
     jobs:
       - release-pgbouncer
+  nightly-api-performance:
+    when: << pipeline.parameters.run-perf-tests >>
+    jobs:
+      - api-performance-test:
+          matrix:
+            parameters:
+              version:
+                - v2.4.0
+                - latest
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
       PACHD_VERSION: << parameters.version >>
+      PACHD_LATEST_VERSION: ""
     parallelism: 1
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,4 +233,5 @@ workflows:
             parameters:
               version:
                 - v2.4.0
+                - v2.5.0-alpha.1
                 - latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1218,61 +1218,7 @@ jobs:
             index=${#prefix}
             additional=${v:index}
             ./etc/build/update_homebrew.sh ${CIRCLE_TAG:1} ${additional}
-  api-performance-test:
-    resource_class: xlarge
-    parameters:
-      version:
-        type: string
-    machine:
-      image: << pipeline.parameters.machine_image >>
-    environment:
-      TEST_RESULTS: /tmp/test-results
-      PACHD_VERSION: << parameters.version >>
-    parallelism: 1
-    steps:
-      - checkout
-      - run:
-          name: Collect node stats
-          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
-          background: true
-      - run: mkdir -p ${TEST_RESULTS}
-      - run:
-          name: Clone Locust tests
-          command: |
-            git clone https://github.com/pachyderm/locust-pachyderm.git locust-pachyderm
-      - run:
-          name: setup env vars
-          command: |
-            echo 'export GOCACHE=/home/circleci/.gocache' >> $BASH_ENV
-            echo 'export GOPATH=/home/circleci/.go_workspace' >> $BASH_ENV
 
-            echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
-            echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-      - restore_cache:
-          keys:
-            - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
-      - run: etc/testing/circle/install.sh
-      - gh/setup:
-          version: 2.20.2
-      - run:
-          name: Start minikube
-          command: etc/testing/circle/start-minikube.sh
-          background: true
-      - run: etc/testing/circle/wait-minikube.sh
-      - run:
-          name: Install minio
-          command: kubectl apply -f etc/testing/minio.yaml
-      - run:
-          name: run api performance benchmark
-          no_output_timeout: 20m
-          command: |
-            etc/testing/circle/run_api_performance_tests.sh
-      - run:
-          name: Dump debugging info in case of failure
-          when: on_fail
-          command: etc/testing/circle/kube_debug.sh
-      - store_artifacts:
-          path: /tmp/test-results
 workflows:
   integration-tests:
     when:
@@ -1597,15 +1543,6 @@ workflows:
           filters: *only-nightly-tags
           requires:
             - gcp-prerelease-testing
-  nightly-api-performance:
-    when: << pipeline.parameters.run-perf-tests >>
-    jobs:
-      - api-performance-test:
-          matrix:
-            parameters:
-              version:
-                - v2.4.0
-                - latest
 
 commands:
   install-jupyter-test-deps:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -41,6 +41,9 @@ parameters:
   run-core-jobs:
     type: boolean
     default: false
+  run-perf-tests:
+    type: boolean
+    default: false
 
 executors:
   docker-go:
@@ -1215,6 +1218,55 @@ jobs:
             index=${#prefix}
             additional=${v:index}
             ./etc/build/update_homebrew.sh ${CIRCLE_TAG:1} ${additional}
+  api-performance-test:
+    resource_class: xlarge
+    parameters:
+      version:
+        type: string
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    environment:
+      TEST_RESULTS: /tmp/test-results
+      PACHD_VERSION: << parameters.version >>
+    parallelism: 8
+    steps:
+      - checkout
+      - run:
+          name: Collect node stats
+          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
+          background: true
+      - run: mkdir -p ${TEST_RESULTS}
+      - run:
+          name: setup env vars
+          command: |
+            echo 'export GOCACHE=/home/circleci/.gocache' >> $BASH_ENV
+            echo 'export GOPATH=/home/circleci/.go_workspace' >> $BASH_ENV
+
+            echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
+            echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+      - restore_cache:
+          keys:
+            - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
+      - run: etc/testing/circle/install.sh
+      - run:
+          name: Start minikube
+          command: etc/testing/circle/start-minikube.sh
+          background: true
+      - run: etc/testing/circle/wait-minikube.sh
+      - run:
+          name: Install minio
+          command: kubectl apply -f etc/testing/minio.yaml
+      - run:
+          name: run api performance benchmark
+          no_output_timeout: 20m
+          command: |
+            echo "workflow test $PACHD_VERSION"
+      - run:
+          name: Dump debugging info in case of failure
+          when: on_fail
+          command: etc/testing/circle/kube_debug.sh
+      - store_artifacts:
+          path: /tmp/test-results
 workflows:
   integration-tests:
     when:
@@ -1539,6 +1591,15 @@ workflows:
           filters: *only-nightly-tags
           requires:
             - gcp-prerelease-testing
+  nightly-api-performance:
+    when: << pipeline.parameters.run-perf-tests >>
+    jobs:
+      - api-performance-test:
+          matrix:
+            parameters:
+              version:
+                - v2.4.0
+                - latest
 
 commands:
   install-jupyter-test-deps:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1228,7 +1228,7 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
       PACHD_VERSION: << parameters.version >>
-    parallelism: 8
+    parallelism: 1
     steps:
       - checkout
       - run:
@@ -1236,6 +1236,10 @@ jobs:
           command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
           background: true
       - run: mkdir -p ${TEST_RESULTS}
+      - run:
+          name: Clone Locust tests
+          command: |
+            git clone https://github.com/pachyderm/locust-pachyderm.git locust-pachyderm
       - run:
           name: setup env vars
           command: |
@@ -1248,6 +1252,8 @@ jobs:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
       - run: etc/testing/circle/install.sh
+      - gh/setup:
+          version: 2.20.2
       - run:
           name: Start minikube
           command: etc/testing/circle/start-minikube.sh
@@ -1260,7 +1266,7 @@ jobs:
           name: run api performance benchmark
           no_output_timeout: 20m
           command: |
-            echo "workflow test $PACHD_VERSION"
+            etc/testing/circle/run_api_performance_tests.sh
       - run:
           name: Dump debugging info in case of failure
           when: on_fail

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -41,9 +41,6 @@ parameters:
   run-core-jobs:
     type: boolean
     default: false
-  run-perf-tests:
-    type: boolean
-    default: false
 
 executors:
   docker-go:

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 pachctl_tag=$PACHD_VERSION 
 if [ "$PACHD_VERSION" == "latest" ]; then
-    pachctl_tag="v2.5.0-alpha.1" #$(git tag --sort=taggerdate | tail -1) Hard code for the moment until nightly docker images are deploying
+    pachctl_tag=$(git tag --sort=taggerdate | tail -1) # the latest tag should be the nightly
 fi
 image_tag=$(echo "$pachctl_tag" | sed s/v//) #removing v from the front for the image
 
@@ -30,6 +30,4 @@ pip3 install -r requirements.txt
 locust --version
 locust -f locustfile.py --headless --users 50 --spawn-rate 1 --run-time 3m \
     --csv /tmp/test-results/api-perf \
-    --html /tmp/test-results/api-perf-stats.html \
-    --exit-code-on-error 0 # we should remove this eventually, but for now closing the connnectioncauses an error if an rpc is currently running
-
+    --html /tmp/test-results/api-perf-stats.html 

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -12,7 +12,7 @@ then
         pachctl_tag="$PACHD_LATEST_VERSION"
     fi
 fi
-image_tag=$(echo "${pachctl_tag//v/}") #removing v from the front for the image
+image_tag="${pachctl_tag//v/}" #removing v from the front for the image
 
 # Install pachctl
 gh release download "$pachctl_tag" --pattern "pachctl_${image_tag}_amd64.deb" --repo pachyderm/pachyderm --output /tmp/pachctl.deb

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -36,5 +36,5 @@ pip3 install -r requirements.txt
 locust --version
 locust -f locustfile.py --headless --users 50 --spawn-rate 1 --run-time 3m \
     --csv /tmp/test-results/api-perf \
-    --html /tmp/test-results/api-perf-stats.html 
+    --html /tmp/test-results/api-perf-stats.html \
     --exit-code-on-error 0 # errors are reported in the artifacts, if the test finishes the pipeline ran successfully

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+pachctl_tag=$PACHD_VERSION 
+if [ "$PACHD_VERSION" == "latest" ]; then
+    pachctl_tag="v2.5.0-alpha.1" #$(git tag --sort=taggerdate | tail -1) Hard code for the moment until nightly docker images are deploying
+fi
+image_tag=$(echo "$pachctl_tag" | sed s/v//) #removing v from the front for the image
+
+# Install pachctl
+gh release download "$pachctl_tag" --pattern "pachctl_${image_tag}_amd64.deb" --repo pachyderm/pachyderm --output /tmp/pachctl.deb
+sudo dpkg -i /tmp/pachctl.deb
+
+kubectl config use-context minikube
+# create Pachyderm deployment
+helm install pachyderm etc/helm/pachyderm \
+    -f etc/testing/circle/helm-values.yaml \
+    --set pachd.image.tag="$image_tag"
+kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
+
+pachctl config import-kube perftest
+echo $ENT_ACT_CODE | pachctl license activate
+pachctl version
+nohup pachctl port-forward &
+
+# Run locust tests
+cd locust-pachyderm
+pip3 install -r requirements.txt
+locust --version
+locust -f locustfile.py --headless --users 50 --spawn-rate 1 --run-time 3m \
+    --csv /tmp/test-results/api-perf \
+    --html /tmp/test-results/api-perf-stats.html \
+    --exit-code-on-error 0 # we should remove this eventually, but for now closing the connnectioncauses an error if an rpc is currently running
+

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -12,7 +12,7 @@ then
         pachctl_tag="$PACHD_LATEST_VERSION"
     fi
 fi
-image_tag=$(echo "$pachctl_tag" | sed s/v//) #removing v from the front for the image
+image_tag=$(echo "${pachctl_tag//v/}") #removing v from the front for the image
 
 # Install pachctl
 gh release download "$pachctl_tag" --pattern "pachctl_${image_tag}_amd64.deb" --repo pachyderm/pachyderm --output /tmp/pachctl.deb
@@ -26,7 +26,7 @@ helm install pachyderm etc/helm/pachyderm \
 kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 
 pachctl config import-kube perftest
-echo $ENT_ACT_CODE | pachctl license activate
+echo "$ENT_ACT_CODE" | pachctl license activate
 pachctl version
 nohup pachctl port-forward &
 

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 pachctl_tag=$PACHD_VERSION 
 if [ "$PACHD_VERSION" == "latest" ]
 then 
-    if [ -n "$PACHD_LATEST_VERSION" ]
+    if [ -z "$PACHD_LATEST_VERSION" ]
     then 
         pachctl_tag=$(git tag --sort=taggerdate | tail -1) # the latest tag should be the nightly
     else

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -3,8 +3,14 @@
 set -euxo pipefail
 
 pachctl_tag=$PACHD_VERSION 
-if [ "$PACHD_VERSION" == "latest" ]; then
-    pachctl_tag=$(git tag --sort=taggerdate | tail -1) # the latest tag should be the nightly
+if [ "$PACHD_VERSION" == "latest" ]
+then 
+    if [ -n "$PACHD_LATEST_VERSION" ]
+    then 
+        pachctl_tag=$(git tag --sort=taggerdate | tail -1) # the latest tag should be the nightly
+    else
+        pachctl_tag="$PACHD_LATEST_VERSION"
+    fi
 fi
 image_tag=$(echo "$pachctl_tag" | sed s/v//) #removing v from the front for the image
 

--- a/etc/testing/circle/run_api_performance_tests.sh
+++ b/etc/testing/circle/run_api_performance_tests.sh
@@ -37,3 +37,4 @@ locust --version
 locust -f locustfile.py --headless --users 50 --spawn-rate 1 --run-time 3m \
     --csv /tmp/test-results/api-perf \
     --html /tmp/test-results/api-perf-stats.html 
+    --exit-code-on-error 0 # errors are reported in the artifacts, if the test finishes the pipeline ran successfully


### PR DESCRIPTION
This change adds a CI pipeline and sh script to trigger the Locust performance tests in circle-ci. It runs the tests against a minikube deployment in the circle-ci runner. Once this is merged, I'll set up a nightly test to run these everynight.

to trigger the performance tests, set the pipeline environment variable `run-perf-tests` to true. Here's an example pipeline job: https://app.circleci.com/pipelines/github/pachyderm/pachyderm/16553/workflows/7a0a53ca-91b1-4a2e-bb6f-a994be4137fa

