### PR TITLE
Add PROJECT column to PFS pprinter

### DIFF
--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -19,7 +19,7 @@ const (
 	// RepoHeader is the header for repos.
 	RepoHeader = "PROJECT\tNAME\tCREATED\tSIZE (MASTER)\tDESCRIPTION\t\n"
 	// RepoAuthHeader is the header for repos with auth information attached.
-	RepoAuthHeader = "NAME\tCREATED\tSIZE (MASTER)\tACCESS LEVEL\t\n"
+	RepoAuthHeader = "PROJECT\tNAME\tCREATED\tSIZE (MASTER)\tACCESS LEVEL\t\n"
 	// CommitHeader is the header for commits.
 	CommitHeader = "REPO\tBRANCH\tCOMMIT\tFINISHED\tSIZE\tORIGIN\tDESCRIPTION\n"
 	// CommitSetHeader is the header for commitsets.

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -19,11 +19,11 @@ const (
 	// RepoHeader is the header for repos.
 	RepoHeader = "PROJECT\tNAME\tCREATED\tSIZE (MASTER)\tDESCRIPTION\t\n"
 	// RepoAuthHeader is the header for repos with auth information attached.
-	RepoAuthHeader = "PROJECT\tNAME\tCREATED\tSIZE (MASTER)\tACCESS LEVEL\t\n"
+	RepoAuthHeader = "PROJECT\tNAME\tCREATED\tSIZE (MASTER)\tACCESS_LEVEL\tDESCRIPTION\t\n"
 	// CommitHeader is the header for commits.
-	CommitHeader = "PROJECT\tREPO\tBRANCH\tCOMMIT\tFINISHED\tSIZE\tORIGIN\tDESCRIPTION\n"
+	CommitHeader = "PROJECT\tREPO\tBRANCH\tCOMMIT\tFINISHED\tSIZE\tORIGIN\tDESCRIPTION\t\n"
 	// CommitSetHeader is the header for commitsets.
-	CommitSetHeader = "ID\tSUBCOMMITS\tPROGRESS\tCREATED\tMODIFIED\n"
+	CommitSetHeader = "ID\tSUBCOMMITS\tPROGRESS\tCREATED\tMODIFIED\t\n"
 	// BranchHeader is the header for branches.
 	BranchHeader = "BRANCH\tHEAD\tTRIGGER\t\n"
 	// ProjectHeader is the header for the projects.
@@ -38,7 +38,13 @@ const (
 
 // PrintRepoInfo pretty-prints repo info.
 func PrintRepoInfo(w io.Writer, repoInfo *pfs.RepoInfo, fullTimestamps bool) {
-	fmt.Fprintf(w, "%s\t%s\t", repoInfo.Repo.Project.GetName(), repoInfo.Repo.Name)
+	fmt.Fprintf(w, "%s\t", repoInfo.Repo.Project)
+	// Repo.String() returns "<project>/<repo>"" but we want to print the project name as a separate column.
+	if repoInfo.Repo.Type == pfs.UserRepoType {
+		fmt.Fprintf(w, "%s\t", repoInfo.Repo.Name)
+	} else {
+		fmt.Fprintf(w, "%s.%s\t", repoInfo.Repo.Name, repoInfo.Repo.Type)
+	}
 	if fullTimestamps {
 		fmt.Fprintf(w, "%s\t", repoInfo.Created.String())
 	} else {
@@ -162,7 +168,7 @@ Description: {{ .Description}} {{end}}
 
 // PrintCommitInfo pretty-prints commit info.
 func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps bool) {
-	fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Repo.Project.GetName())
+	fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Repo.Project)
 	// Repo.String() returns "<project>/<repo>"" but we want to print the project name as a separate column.
 	if commitInfo.Commit.Branch.Repo.Type == pfs.UserRepoType {
 		fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Repo.Name)

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -21,7 +21,7 @@ const (
 	// RepoAuthHeader is the header for repos with auth information attached.
 	RepoAuthHeader = "PROJECT\tNAME\tCREATED\tSIZE (MASTER)\tACCESS LEVEL\t\n"
 	// CommitHeader is the header for commits.
-	CommitHeader = "REPO\tBRANCH\tCOMMIT\tFINISHED\tSIZE\tORIGIN\tDESCRIPTION\n"
+	CommitHeader = "PROJECT\tREPO\tBRANCH\tCOMMIT\tFINISHED\tSIZE\tORIGIN\tDESCRIPTION\n"
 	// CommitSetHeader is the header for commitsets.
 	CommitSetHeader = "ID\tSUBCOMMITS\tPROGRESS\tCREATED\tMODIFIED\n"
 	// BranchHeader is the header for branches.
@@ -162,7 +162,13 @@ Description: {{ .Description}} {{end}}
 
 // PrintCommitInfo pretty-prints commit info.
 func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps bool) {
-	fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Repo)
+	fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Repo.Project.GetName())
+	// Repo.String() returns "<project>/<repo>"" but we want to print the project name as a separate column.
+	if commitInfo.Commit.Branch.Repo.Type == pfs.UserRepoType {
+		fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Repo.Name)
+	} else {
+		fmt.Fprintf(w, "%s.%s\t", commitInfo.Commit.Branch.Repo.Name, commitInfo.Commit.Branch.Repo.Type)
+	}
 	fmt.Fprintf(w, "%s\t", commitInfo.Commit.Branch.Name)
 	fmt.Fprintf(w, "%s\t", commitInfo.Commit.ID)
 	if commitInfo.Finished == nil {


### PR DESCRIPTION
This PR adds a `PROJECT` column to the PFS pretty printer, which results in the following:
```
# with auth activated
pachctl list repos --all
PROJECT   NAME         CREATED      SIZE (MASTER) ACCESS_LEVEL                        DESCRIPTION                               
default   montage.meta 26 hours ago ≤ 1.71MiB     [clusterAdmin repoOwner]            Meta repo for pipeline montage            
default   montage.spec 26 hours ago ≤ 0B          [clusterAdmin repoOwner repoReader] Spec repo for pipeline default/montage.   
default   montage      26 hours ago ≤ 1.346MiB    [clusterAdmin repoOwner]            Output repo for pipeline default/montage. 
default   edges.meta   26 hours ago ≤ 374.4KiB    [clusterAdmin repoOwner]            Meta repo for pipeline edges              
default   edges.spec   26 hours ago ≤ 0B          [clusterAdmin repoOwner repoReader] Spec repo for pipeline default/edges.     
default   edges        26 hours ago ≤ 133.6KiB    [clusterAdmin repoOwner]            Output repo for pipeline default/edges.   
default   images       26 hours ago ≤ 238.3KiB    [clusterAdmin repoOwner]                                                                               
```

```
pachctl list commits -x
PROJECT REPO         BRANCH COMMIT                           FINISHED     SIZE     ORIGIN DESCRIPTION
default edges.spec   master d26285b3324e4848b1eefc4e6be7931e 26 hours ago 0B       ALIAS   
default images       master d26285b3324e4848b1eefc4e6be7931e 26 hours ago 238.3KiB USER    
default montage.spec master d26285b3324e4848b1eefc4e6be7931e 26 hours ago 0B       ALIAS
```