### PR TITLE
helm: enable proxy by default; add NOTE about externalService deprecation

### DIFF
--- a/etc/helm/examples/enterprise-dev.yaml
+++ b/etc/helm/examples/enterprise-dev.yaml
@@ -1,6 +1,6 @@
 oidc:
   mockIDP: true
-  issuerURI: "http://pach-enterprise.enterprise.svc.cluster.local:31658"
+  issuerURI: "http://pach-enterprise.enterprise.svc.cluster.local:31658/dex"
   userAccessibleOauthIssuerHost: localhost:31658
 
 console:

--- a/etc/helm/pachyderm/templates/NOTES.txt
+++ b/etc/helm/pachyderm/templates/NOTES.txt
@@ -18,7 +18,7 @@ WARNING: Your cluster is configured with a default login of admin:password
 WARNING: You have pachd.enterpriseRootToken or pachd.enterpriseRootTokenSecretName set. These values are being replaced by pachd.enterpriseServerToken and pachd.enterpriseServerTokenSecretName which you can set now. The deprecated values will be removed in version 2.4.0.
 {{- end -}}
 
-{{ if .Values.pachd.externalService.enabled and (eq .Values.proxy.service.type "ClusterIP")}}
+{{ if and .Values.pachd.externalService.enabled (eq .Values.proxy.service.type "ClusterIP")}}
 WARNING: pachd.externalService is deprecated in favor of proxy.enabled.  You can transparently
 migrate by exposing the proxy and removing the external service:
 

--- a/etc/helm/pachyderm/templates/NOTES.txt
+++ b/etc/helm/pachyderm/templates/NOTES.txt
@@ -64,3 +64,20 @@ and then visiting http://localhost in the browser (or grpc://localhost:80 with p
 Your deployment's security posture will improve by enabling the proxy.  It is hardened against
 malicious traffic, and writes out extensive audit logs for all requests to Pachyderm.
 {{- end -}}
+
+
+{{- if and .Values.proxy.enabled (ne .Values.proxy.service.type "ClusterIP") (ne .Values.proxy.host "")}}
+{{- if .Values.proxy.tls.enabled }}
+Start using your Pachyderm deployment by visiting the Console at https://{{.Values.proxy.host}} in you browser.
+
+Connect pachctl by running:
+
+    echo '{"pachd_address":"grpc://{{ .Values.proxy.host }}:443"}' | pachctl config set context {{ .Release.Name }} --overwrite && pachctl config set active-context {{ .Release.Name }}
+{{- else }}
+Start using your Pachyderm deployment by visiting the Console at http://{{.Values.proxy.host}} in your browser.
+
+Connect pachctl by running:
+
+    echo '{"pachd_address":"grpc://{{ .Values.proxy.host }}:80"}' | pachctl config set context {{ .Release.Name}} --overwrite && pachctl config set active-context {{ .Release.Name }}
+{{- end }}
+{{- end -}}

--- a/etc/helm/pachyderm/templates/NOTES.txt
+++ b/etc/helm/pachyderm/templates/NOTES.txt
@@ -18,7 +18,7 @@ WARNING: Your cluster is configured with a default login of admin:password
 WARNING: You have pachd.enterpriseRootToken or pachd.enterpriseRootTokenSecretName set. These values are being replaced by pachd.enterpriseServerToken and pachd.enterpriseServerTokenSecretName which you can set now. The deprecated values will be removed in version 2.4.0.
 {{- end -}}
 
-{{ if .Values.pachd.externalService and (eq .Values.proxy.service.type "ClusterIP")}}
+{{ if .Values.pachd.externalService.enabled and (eq .Values.proxy.service.type "ClusterIP")}}
 WARNING: pachd.externalService is deprecated in favor of proxy.enabled.  You can transparently
 migrate by exposing the proxy and removing the external service:
 

--- a/etc/helm/pachyderm/templates/NOTES.txt
+++ b/etc/helm/pachyderm/templates/NOTES.txt
@@ -27,15 +27,15 @@ migrate by exposing the proxy and removing the external service:
 
   proxy:
     enabled: true
-    host: <the DNS name attached to the provided loadBalancerIP>
+    host: {{ or .Values.proxy.host "<the DNS name attached to the provided loadBalancerIP>" }}
     service:
       type: LoadBalancer
-      loadBalancerIP: "{{ .Values.pachd.externalService.loadBalancerIP }}"
+      loadBalancerIP: "{{ or .Values.pachd.externalService.loadBalancerIP .Values.proxy.service.loadBalancerIP "<the IP provisioned for the load balancer; not setting this is OK if you don't know it>"}}"
       legacyPorts:
-        grpc: {{ .Values.pachd.externalService.apiGRPCPort }}
-        s3Gateway: {{ .Values.pachd.externalService.s3GatewayPort }}
-        oidcPort: {{ .Values.pachd.externalService.oidcPort }}
-        identityPort: {{ .Values.pachd.externalService.identityPort }}
+        grpc: {{ or .Values.pachd.externalService.apiGRPCPort 0 }}
+        s3Gateway: {{ or .Values.pachd.externalService.s3GatewayPort 0 }}
+        oidcPort: {{ or .Values.pachd.externalService.oidcPort 0 }}
+        identityPort: {{ or .Values.pachd.externalService.identityPort 0 }}
 
 Please see values.yaml for a full list of configuration options, including SSL/TLS/HTTPS support.
 
@@ -47,10 +47,19 @@ otherwise (grpcs://<proxy.host>:443, https://<proxy.host>).
 
 As of 2.5.0, the proxy is enabled by default, but not exposed to the Internet.  You can test it out
 with:
+{{- if .Values.proxy.tls.enabled }}
+
+    kubectl port-forward svc/pachyderm-proxy 443
+
+and then visiting https://localhost in the browser (or grpcs://localhost:443 with pachctl).  You may
+have to ignore certificate validation warnings until the URL you type into the browser contains the
+host that the TLS certificate was provisioned with.
+{{- else }}
 
     kubectl port-forward svc/pachyderm-proxy 80
 
 and then visiting http://localhost in the browser (or grpc://localhost:80 with pachctl).
+{{- end }}
 
 Your deployment's security posture will improve by enabling the proxy.  It is hardened against
 malicious traffic, and writes out extensive audit logs for all requests to Pachyderm.

--- a/etc/helm/pachyderm/templates/NOTES.txt
+++ b/etc/helm/pachyderm/templates/NOTES.txt
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
 
-{{- if and (not .Values.ingress.enabled) (not .Values.pachd.externalService.enabled)  -}}
+{{- if and (not .Values.ingress.enabled) (not .Values.pachd.externalService.enabled) (not .Values.proxy.enabled) (eq .Values.proxy.service.type "ClusterIP") -}}
 To connect to your new pachyderm instance, run:
 pachctl config import-kube local --overwrite
 pachctl config set active-context local
@@ -18,3 +18,40 @@ WARNING: Your cluster is configured with a default login of admin:password
 WARNING: You have pachd.enterpriseRootToken or pachd.enterpriseRootTokenSecretName set. These values are being replaced by pachd.enterpriseServerToken and pachd.enterpriseServerTokenSecretName which you can set now. The deprecated values will be removed in version 2.4.0.
 {{- end -}}
 
+{{ if .Values.pachd.externalService and (eq .Values.proxy.service.type "ClusterIP")}}
+WARNING: pachd.externalService is deprecated in favor of proxy.enabled.  You can transparently
+migrate by exposing the proxy and removing the external service:
+
+  pachd:
+    externalService: false
+
+  proxy:
+    enabled: true
+    host: <the DNS name attached to the provided loadBalancerIP>
+    service:
+      type: LoadBalancer
+      loadBalancerIP: "{{ .Values.pachd.externalService.loadBalancerIP }}"
+      legacyPorts:
+        grpc: {{ .Values.pachd.externalService.apiGRPCPort }}
+        s3Gateway: {{ .Values.pachd.externalService.s3GatewayPort }}
+        oidcPort: {{ .Values.pachd.externalService.oidcPort }}
+        identityPort: {{ .Values.pachd.externalService.identityPort }}
+
+Please see values.yaml for a full list of configuration options, including SSL/TLS/HTTPS support.
+
+The legacy ports are not strictly necessary except for compatability with your existing
+configuration.  The proxy inspects traffic arriving on normal http or https ports (80 and 443) and
+automatically routes it to the right service.  pachd, console, S3, oidc, and identity will be
+available on port 80 (grpc://<proxy.host>:80, http://<proxy.host>) if TLS is disabled, or port 443
+otherwise (grpcs://<proxy.host>:443, https://<proxy.host>).
+
+As of 2.5.0, the proxy is enabled by default, but not exposed to the Internet.  You can test it out
+with:
+
+    kubectl port-forward svc/pachyderm-proxy 80
+
+and then visiting http://localhost in the browser (or grpc://localhost:80 with pachctl).
+
+Your deployment's security posture will improve by enabling the proxy.  It is hardened against
+malicious traffic, and writes out extensive audit logs for all requests to Pachyderm.
+{{- end -}}

--- a/etc/helm/pachyderm/templates/NOTES.txt
+++ b/etc/helm/pachyderm/templates/NOTES.txt
@@ -72,7 +72,7 @@ Start using your Pachyderm deployment by visiting the Console at https://{{.Valu
 
 Connect pachctl by running:
 
-    echo '{"pachd_address":"grpc://{{ .Values.proxy.host }}:443"}' | pachctl config set context {{ .Release.Name }} --overwrite && pachctl config set active-context {{ .Release.Name }}
+    echo '{"pachd_address":"grpcs://{{ .Values.proxy.host }}:443"}' | pachctl config set context {{ .Release.Name }} --overwrite && pachctl config set active-context {{ .Release.Name }}
 {{- else }}
 Start using your Pachyderm deployment by visiting the Console at http://{{.Values.proxy.host}} in your browser.
 

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -870,7 +870,7 @@ proxy:
   # The envoy image to pull.
   image:
     repository: "envoyproxy/envoy"
-    tag: "v1.24.0"
+    tag: "v1.24.1"
     pullPolicy: "IfNotPresent"
   # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's
   # a resonable memory limit.  It doesn't need much CPU.

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -869,7 +869,7 @@ proxy:
   replicas: 1
   # The envoy image to pull.
   image:
-    repository: "envoyproxy/envoy"
+    repository: "envoyproxy/envoy-distroless"
     tag: "v1.24.1"
     pullPolicy: "IfNotPresent"
   # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -856,7 +856,7 @@ proxy:
   # If enabled, create a proxy deployment (based on the Envoy proxy) and a service to expose it.  If
   # ingress is also enabled, any Ingress traffic will be routed through the proxy before being sent
   # to pachd or Console.
-  enabled: false
+  enabled: true
   # The external hostname (including port if nonstandard) that the proxy will be reachable at.
   # If you have ingress enabled and an ingress hostname defined, the proxy will use that.
   # Ingress will be deprecated in the future so configuring the proxy host instead is recommended.

--- a/etc/helm/test/pachyderm_helm_test.go
+++ b/etc/helm/test/pachyderm_helm_test.go
@@ -23,7 +23,7 @@ func TestConsoleImageAndConfigTag(t *testing.T) {
 
 	helmChartPath := "../pachyderm"
 
-	expectedIssuerURI := "http://foo.bar"
+	expectedIssuerURI := "http://foo.bar/dex"
 	expectedOauthRedirectURI := "http://foo.bar/oauth"
 	options := &helm.Options{
 		SetValues: map[string]string{

--- a/etc/helm/test/tls_test.go
+++ b/etc/helm/test/tls_test.go
@@ -94,6 +94,7 @@ func TestEnableconsoleTLSExistingSecret(t *testing.T) {
 	expectedSecretName := "blah"
 	options := &helm.Options{
 		SetValues: map[string]string{
+			"proxy.enabled":          "false",
 			"deployTarget":           "LOCAL",
 			"console.enabled":        "true",
 			"ingress.tls.enabled":    "true",


### PR DESCRIPTION
This is CORE-1307.

The NOTE might be too long, but it seems helpful to me.  If you are migrating from external service, it will print:

```
WARNING: pachd.externalService is deprecated in favor of proxy.enabled.  You can transparently
migrate by exposing the proxy and removing the external service:

  pachd:
    externalService: false

  proxy:
    enabled: true
    host: 192.168.1.70
    service:
      type: LoadBalancer
      loadBalancerIP: "<the IP provisioned for the load balancer; not setting this is OK if you don't know it>"
      legacyPorts:
        grpc: 30650
        s3Gateway: 30600
        oidcPort: 0
        identityPort: 0

Please see values.yaml for a full list of configuration options, including SSL/TLS/HTTPS support.

The legacy ports are not strictly necessary except for compatability with your existing
configuration.  The proxy inspects traffic arriving on normal http or https ports (80 and 443) and
automatically routes it to the right service.  pachd, console, S3, oidc, and identity will be
available on port 80 (grpc://<proxy.host>:80, http://<proxy.host>) if TLS is disabled, or port 443
otherwise (grpcs://<proxy.host>:443, https://<proxy.host>).

As of 2.5.0, the proxy is enabled by default, but not exposed to the Internet.  You can test it out
with:

    kubectl port-forward svc/pachyderm-proxy 80

and then visiting http://localhost in the browser (or grpc://localhost:80 with pachctl).

Your deployment's security posture will improve by enabling the proxy.  It is hardened against
malicious traffic, and writes out extensive audit logs for all requests to Pachyderm.
```

(Everything that can be pre-filled from existing values is pre-filled there.  We hard code LoadBalancer because the old externalService did.)

After you adjust your configuration to have a working proxy setup, you get:

```
Start using your Pachyderm deployment by visiting the Console at http://192.168.1.70 in your browser.

Connect pachctl by running:

    echo '{"pachd_address":"grpc://192.168.1.70:80"}' | pachctl config set context pachyderm --overwrite && pachctl config set active-context pachyderm
```

If your helm release name is `$(rm / -rf)` i guess you're gonna have a bad time if you copypaste that, but I'm sure helm won't let you do that 😛 

The messages adjust depending on `proxy.tls.enabled`.

One sticky bit here is that if users manually configure issuerURI and the URL doesn't end in /dex, their working configuration will stop working (rather they won't be able to helm upgrade).  Any thoughts on that @tybritten?