### PR TITLE
Add timeout to queryLoki

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -868,11 +868,12 @@ func (s *debugServer) getWorkerPodsLoki(ctx context.Context, pipelineInfo *pps.P
 	return pods, nil
 }
 
-// This used to be 5,000 but a comment said this was too few logs, so now it's 30,000.  If it still
-// seems too small, bump it up again.  5,000 remains the maximum value of "limit" in queries that
-// Loki seems to accept.
 const (
-	maxLogs       = 30000
+	// maxLogs used to be 5,000 but a comment said this was too few logs, so now it's 30,000.
+	// If it still seems too small, bump it up again.
+	maxLogs = 30000
+	// 5,000 is the maximum value of "limit" in queries that Loki seems to accept.
+	// We set serverMaxLogs below the actual limit because of a bug in Loki where it hangs when you request too much data from it.
 	serverMaxLogs = 1000
 )
 
@@ -909,7 +910,7 @@ func (s *debugServer) queryLoki(ctx context.Context, queryStr string) ([]lokiLog
 		if err != nil {
 			// Note: the error from QueryRange has a stack.
 			if errors.Is(err, context.DeadlineExceeded) {
-				log.Debugf("query range timed out (query=%v, limit=%v, start=%v, end=%v): %v", queryStr, serverMaxLogs, start.Format(time.RFC3339), end.Format(time.RFC3339), err)
+				log.Debugf("query range timed out (query=%v, limit=%v, start=%v, end=%v): %+v", queryStr, serverMaxLogs, start.Format(time.RFC3339), end.Format(time.RFC3339), err)
 				return result, nil
 			}
 			return nil, errors.Errorf("query range (query=%v, limit=%v, start=%v, end=%v): %+v", queryStr, serverMaxLogs, start.Format(time.RFC3339), end.Format(time.RFC3339), err)

--- a/src/server/debug/server/server_test.go
+++ b/src/server/debug/server/server_test.go
@@ -147,7 +147,7 @@ func TestQueryLoki(t *testing.T) {
 			name: "all logs",
 			buildEntries: func() []loki.Entry {
 				var entries []loki.Entry
-				for i := -99; i >= 0; i++ {
+				for i := -99; i <= 0; i++ {
 					entries = append(entries, loki.Entry{
 						Timestamp: time.Now().Add(time.Duration(-1) * time.Second),
 						Line:      fmt.Sprintf("%v", i),
@@ -157,7 +157,7 @@ func TestQueryLoki(t *testing.T) {
 			},
 			buildWant: func() []int {
 				var want []int
-				for i := -99; i >= 0; i++ {
+				for i := -99; i <= 0; i++ {
 					want = append(want, i)
 				}
 				return want
@@ -208,7 +208,7 @@ func TestQueryLoki(t *testing.T) {
 			buildWant: func() []int {
 				var want []int
 				want = append(want, -2)
-				for i := 0; i < 4999; i++ {
+				for i := 0; i < serverMaxLogs-1; i++ {
 					want = append(want, -1)
 				}
 				want = append(want, 0)
@@ -230,7 +230,7 @@ func TestQueryLoki(t *testing.T) {
 						Line:      "-1",
 					})
 				}
-				for i := 0; i < 5000; i++ {
+				for i := 0; i < serverMaxLogs; i++ {
 					entries = append(entries, loki.Entry{
 						Timestamp: start,
 						Line:      "0",
@@ -241,10 +241,10 @@ func TestQueryLoki(t *testing.T) {
 			buildWant: func() []int {
 				var want []int
 				want = append(want, -2)
-				for i := 0; i < 5000; i++ {
+				for i := 0; i < serverMaxLogs; i++ {
 					want = append(want, -1)
 				}
-				for i := 0; i < 5000; i++ {
+				for i := 0; i < serverMaxLogs; i++ {
 					want = append(want, 0)
 				}
 				return want
@@ -279,7 +279,7 @@ func TestQueryLoki(t *testing.T) {
 
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf(`result differs:
-	      first |   last |    len
+          first |   last |    len
        +--------+--------+-------
    got | %6d | %6d | %6d
   want | %6d | %6d | %6d


### PR DESCRIPTION
A lot of the recent debug dump hanging issues is due to Loki queries hanging, which is a bug in Loki itself, but for now, we want to handle this by gracefully timing out so that the user can get back some results.