### PR TITLE
minikubetestenv: add a flag to use whatever you have currently setup

### DIFF
--- a/src/internal/minikubetestenv/client_factory.go
+++ b/src/internal/minikubetestenv/client_factory.go
@@ -29,6 +29,7 @@ var (
 	poolSize            *int  = flag.Int("clusters.pool", 3, "maximum size of managed pachyderm clusters")
 	useLeftoverClusters *bool = flag.Bool("clusters.reuse", false, "reuse leftover pachyderm clusters if available")
 	cleanupDataAfter    *bool = flag.Bool("clusters.data.cleanup", true, "cleanup the data following each test")
+	forceLocal          *bool = flag.Bool("clusters.local", false, "use whatever is in your pachyderm context as the target")
 )
 
 type acquireSettings struct {
@@ -176,9 +177,26 @@ func ClaimCluster(t testing.TB) (string, uint16) {
 	return assigned, portOffset
 }
 
+var (
+	localLock       sync.Mutex
+	localLockHolder string
+)
+
 // AcquireCluster returns a pachyderm APIClient from one of a pool of managed pachyderm
 // clusters deployed in separate namespace, along with the associated namespace
 func AcquireCluster(t testing.TB, opts ...Option) (*client.APIClient, string) {
+	t.Helper()
+	if *forceLocal {
+		c, err := client.NewOnUserMachine("")
+		if err != nil {
+			t.Fatalf("create local client: %v", err)
+		}
+		t.Log("waiting for local cluster lock")
+		localLock.Lock()
+		t.Log("got local cluster lock")
+		t.Cleanup(localLock.Unlock)
+		return c, ""
+	}
 	setup.Do(func() {
 		clusterFactory = &ClusterFactory{
 			managedClusters:   map[string]*managedCluster{},

--- a/src/internal/minikubetestenv/client_factory.go
+++ b/src/internal/minikubetestenv/client_factory.go
@@ -177,10 +177,7 @@ func ClaimCluster(t testing.TB) (string, uint16) {
 	return assigned, portOffset
 }
 
-var (
-	localLock       sync.Mutex
-	localLockHolder string
-)
+var localLock sync.Mutex
 
 // AcquireCluster returns a pachyderm APIClient from one of a pool of managed pachyderm
 // clusters deployed in separate namespace, along with the associated namespace


### PR DESCRIPTION
I'm not sure if this duplicates existing functionality.  I hacked it in one evening and it works great for me (yeah, some tests that use NodePorts or that inspect k8s fail; TestAutoscaling, TestService, etc. but it wasn't too burdensome to temporarily modify those as I was working on them).