### PR TITLE
Djanicek/projects pachctl testing

### DIFF
--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -446,8 +446,21 @@ func NoErrorWithinT(tb testing.TB, t time.Duration, f func() error, msgAndArgs .
 }
 
 // NoErrorWithinTRetry checks that 'f' finishes within time 't' and does not
-// emit an error. Unlike NoErrorWithinT if f does error, it will retry it.
+// emit an error. Unlike NoErrorWithinT if f does error, it will retry it. Uses an exponential backoff.
 func NoErrorWithinTRetry(tb testing.TB, t time.Duration, f func() error, msgAndArgs ...interface{}) {
+	tb.Helper()
+	noErrorWithinTRetry(tb, t, f, backoff.NewExponentialBackOff(), msgAndArgs...)
+}
+
+// NoErrorWithinTRetry checks that 'f' finishes within time 't' and does not
+// emit an error. Will retry at a constant specified interval rather than using exponential backoff
+func NoErrorWithinTRetryConstant(tb testing.TB, t time.Duration, f func() error, interval time.Duration, msgAndArgs ...interface{}) {
+	tb.Helper()
+	noErrorWithinTRetry(tb, t, f, backoff.NewConstantBackOff(interval), msgAndArgs...)
+}
+
+// Same as NoErrorWithinTRetry but accepts a custom backoff
+func noErrorWithinTRetry(tb testing.TB, t time.Duration, f func() error, bo backoff.BackOff, msgAndArgs ...interface{}) {
 	tb.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), t)
 	defer cancel()
@@ -458,7 +471,7 @@ func NoErrorWithinTRetry(tb testing.TB, t time.Duration, f func() error, msgAndA
 			tb.Logf("retryable: %v", userError)
 		}
 		return userError
-	}, backoff.NewExponentialBackOff(), nil)
+	}, bo, nil)
 	if err != nil {
 		fatal(tb, msgAndArgs, "operation did not finish within %s - last error: %v", t.String(), userError)
 	}

--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -452,7 +452,7 @@ func NoErrorWithinTRetry(tb testing.TB, t time.Duration, f func() error, msgAndA
 	noErrorWithinTRetry(tb, t, f, backoff.NewExponentialBackOff(), msgAndArgs...)
 }
 
-// NoErrorWithinTRetry checks that 'f' finishes within time 't' and does not
+// NoErrorWithinTRetryConstant checks that 'f' finishes within time 't' and does not
 // emit an error. Will retry at a constant specified interval rather than using exponential backoff
 func NoErrorWithinTRetryConstant(tb testing.TB, t time.Duration, f func() error, interval time.Duration, msgAndArgs ...interface{}) {
 	tb.Helper()

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4755,37 +4755,37 @@ func TestDatumStatusRestart(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	// TODO: (CORE-1015) Fix flaky test
-	t.Skip("Skipping flaky test")
-
 	t.Parallel()
 	c, _ := minikubetestenv.AcquireCluster(t)
 
+	project := tu.UniqueString("PROJECT")
+	require.NoError(t, c.CreateProject(project))
+
 	dataRepo := tu.UniqueString("TestDatumDedup_data")
-	require.NoError(t, c.CreateProjectRepo(pfs.DefaultProjectName, dataRepo))
+	require.NoError(t, c.CreateProjectRepo(project, dataRepo))
 
 	pipeline := tu.UniqueString("pipeline")
 	// This pipeline sleeps for 20 secs per datum
-	require.NoError(t, c.CreateProjectPipeline(pfs.DefaultProjectName,
+	require.NoError(t, c.CreateProjectPipeline(project,
 		pipeline,
 		"",
 		[]string{"bash"},
 		[]string{
-			"sleep 20",
+			"sleep 30",
 		},
 		nil,
-		client.NewProjectPFSInput(pfs.DefaultProjectName, dataRepo, "/*"),
+		client.NewProjectPFSInput(project, dataRepo, "/*"),
 		"",
 		false,
 	))
 
-	commit1, err := c.StartProjectCommit(pfs.DefaultProjectName, dataRepo, "master")
+	commit1, err := c.StartProjectCommit(project, dataRepo, "master")
 	require.NoError(t, err)
 	require.NoError(t, c.PutFile(commit1, "file", strings.NewReader("foo"), client.WithAppendPutFile()))
-	require.NoError(t, c.FinishProjectCommit(pfs.DefaultProjectName, dataRepo, commit1.Branch.Name, commit1.ID))
+	require.NoError(t, c.FinishProjectCommit(project, dataRepo, commit1.Branch.Name, commit1.ID))
 
 	// get the job status
-	jobs, err := c.ListProjectJob(pfs.DefaultProjectName, pipeline, nil, -1, true)
+	jobs, err := c.ListProjectJob(project, pipeline, nil, -1, true)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(jobs))
 
@@ -4794,8 +4794,9 @@ func TestDatumStatusRestart(t *testing.T) {
 	// it's called, the datum being processes was started at a new and later time
 	// (than the last time checkStatus was called)
 	checkStatus := func() {
-		require.NoErrorWithinTRetry(t, time.Minute, func() error {
-			jobInfo, err := c.InspectProjectJob(pfs.DefaultProjectName, pipeline, commit1.ID, true)
+		require.NoErrorWithinTRetryConstant(t, time.Minute, func() error {
+			jobInfo, err := c.InspectProjectJob(project, pipeline, commit1.ID, true)
+
 			require.NoError(t, err)
 			if len(jobInfo.Details.WorkerStatus) == 0 {
 				return errors.Errorf("no worker statuses")
@@ -4818,10 +4819,10 @@ func TestDatumStatusRestart(t *testing.T) {
 				return nil
 			}
 			return errors.Errorf("worker status from wrong job")
-		})
+		}, 500*time.Millisecond) // We need to check quickly. If we wait too long the datum might finish before we can restart it.
 	}
 	checkStatus()
-	require.NoError(t, c.RestartProjectDatum(pfs.DefaultProjectName, pipeline, commit1.ID, []string{"/file"}))
+	require.NoError(t, c.RestartProjectDatum(project, pipeline, commit1.ID, []string{"/file"}))
 	checkStatus()
 
 	commitInfos, err := c.WaitCommitSetAll(commit1.ID)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4761,7 +4761,7 @@ func TestDatumStatusRestart(t *testing.T) {
 	project := tu.UniqueString("PROJECT")
 	require.NoError(t, c.CreateProject(project))
 
-	dataRepo := tu.UniqueString("TestDatumDedup_data")
+	dataRepo := tu.UniqueString("dataRepo")
 	require.NoError(t, c.CreateProjectRepo(project, dataRepo))
 
 	pipeline := tu.UniqueString("pipeline")

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -4765,7 +4765,7 @@ func TestDatumStatusRestart(t *testing.T) {
 	require.NoError(t, c.CreateProjectRepo(project, dataRepo))
 
 	pipeline := tu.UniqueString("pipeline")
-	// This pipeline sleeps for 20 secs per datum
+	// This pipeline sleeps for 30 secs per datum
 	require.NoError(t, c.CreateProjectPipeline(project,
 		pipeline,
 		"",

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -164,7 +164,7 @@ If the job fails, the output commit will not be populated with data.`,
 				if err != nil {
 					return err
 				}
-				jobInfo, err := client.WaitProjectJob(pfs.DefaultProjectName, job.Pipeline.Name, job.ID, true)
+				jobInfo, err := client.WaitProjectJob(job.Pipeline.Project.GetName(), job.Pipeline.Name, job.ID, true)
 				if err != nil {
 					return errors.Wrap(err, "error from InspectJob")
 				}

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -535,11 +535,10 @@ func TestInspectWaitJob(t *testing.T) {
 			},
 			"transform": {
 				"cmd": [
-					"/bin/bash",
-					"sleep 20"
+					"/bin/bash"
 				],
 				"stdin": [
-					"cp /pfs/input/* /pfs/out"
+					"sleep 15 && cp /pfs/input/* /pfs/out"
 				]
 			}
 		}
@@ -560,7 +559,7 @@ func TestInspectWaitJob(t *testing.T) {
 	`,
 		"pipeline1", pipeline1,
 		"project", project,
-		"job", jobs[1].Job.GetID(),
+		"job", jobs[0].Job.GetID(),
 	).Run())
 }
 


### PR DESCRIPTION
This includes test changes to help reduce flake and test Projects. Related tickets:
CORE-1409 - We didn't have a test for job or inspect job, so we had a small bug. This fixes the bug and adds a cmd test.
CORE-1015 - The only test I could find for datum restart was flaky. I added projects and de-flaked it. I beleieve the cap for the exponential backoff was too high and was causing test failures.

Additionally, for increased test coverage I updated TestPFS/SubscribeCommit to include projects.