### PR TITLE
dlock: add logging around lock acquisition and release

### DIFF
--- a/src/internal/consistenthashing/etcd.go
+++ b/src/internal/consistenthashing/etcd.go
@@ -280,7 +280,6 @@ func (ring *Ring) Lock(ctx context.Context, key string) (context.Context, error)
 					ctx:  pctx.Child(ctx, "lock", pctx.WithFields(zap.String("lock", key))),
 				}
 				ring.node.locks[key] = l
-				log.Info(l.ctx, "claimed lock")
 				return lockCtx, nil
 			}
 		}

--- a/src/server/pachw/server/pachw.go
+++ b/src/server/pachw/server/pachw.go
@@ -41,17 +41,14 @@ func (p *pachW) run(ctx context.Context) {
 	ctx = auth.AsInternalUser(ctx, "pachw-controller")
 	backoff.RetryUntilCancel(ctx, func() (retErr error) { //nolint:errcheck
 		lock := dlock.NewDLock(p.env.EtcdClient, path.Join(p.env.EtcdPrefix, "pachw-controller-lock"))
-		log.Debug(ctx, "attempting to take pachw-controller lock")
 		ctx, err := lock.Lock(ctx)
 		if err != nil {
 			return errors.Wrap(err, "locking pachw-controller lock")
 		}
-		log.Debug(ctx, "got pachw-controller lock")
 		defer func() {
 			if err := lock.Unlock(ctx); err != nil {
 				retErr = multierror.Append(retErr, errors.Wrap(err, "error unlocking"))
 			}
-			log.Debug(ctx, "relinquished pachw-controller role", zap.Error(retErr))
 		}()
 		var replicas int
 		var scaleDownCount int


### PR DESCRIPTION
It's often interesting to have information about when locks are acquired or lost, so this adds it around all uses of DLock.  The actual calls to Lock/TryLock/Unlock are wrapped in a span, reporting how long it took to acquire or release the lock, and any errors that might have occurred.  The time spent waiting for the lock is reported as the `spanDuration` on the `DLock.Lock` (etc.) span, and all messages that are logged using the returned context have a `withLock` and `locked` field, to make it clear where the context came from.  (The lock timing spans also have a `withLock` field, but `locked` isn't set until the lock is actually acquired.)

Here's what the chunk GC looks like starting up:

![Capture](https://user-images.githubusercontent.com/2367/208828244-54243bb8-26d1-4610-aa1c-be497f92b029.JPG)

From this, we can see that we waited 21.86 seconds to take the lock, and that several GC runs have occurred while holding that lock.  (If there was an error, that would also be logged.)

The span only tracks time spent actually interacting with the locking machinery; the total time the lock was held is reported at the end though.

When unlocking, we identify the lock by the `prefix` field instead of `withLock`.  That's so that you can compare the two and see which context is being used to gate the unlocking operation vs. which lock is being unlocked. 
