### PR TITLE
Some adjustments to logging

### DIFF
--- a/src/internal/grpcutil/server.go
+++ b/src/internal/grpcutil/server.go
@@ -48,7 +48,7 @@ type Server struct {
 // over TLS. If either are missing this will serve GRPC traffic over
 // unencrypted HTTP,
 func NewServer(ctx context.Context, publicPortTLSAllowed bool, options ...grpc.ServerOption) (*Server, error) {
-	baseInterceptor := logging.NewBaseContextInterceptor(pctx.Child(ctx, "grpc", pctx.WithOptions(zap.WithCaller(false))))
+	baseInterceptor := logging.NewBaseContextInterceptor(pctx.Child(ctx, "grpc"))
 	opts := append([]grpc.ServerOption{
 		grpc.MaxConcurrentStreams(math.MaxUint32),
 		grpc.MaxRecvMsgSize(MaxMsgSize),

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -376,7 +376,7 @@ func getCommonLogger(ctx context.Context, service, method string) context.Contex
 		// The health check logger is rate-limited to one unique message per hour.
 		ctx = log.HealthCheckLogger(ctx)
 	}
-	return pctx.Child(ctx, "", pctx.WithFields(f...))
+	return pctx.Child(ctx, service+"/"+method, pctx.WithFields(f...))
 }
 
 func getRequestLogger(ctx context.Context, req any) context.Context {


### PR DESCRIPTION
This adds the "caller" field back to gRPC logs.  I originally disabled them because the interceptor code is always on the same line and it's annoying to look at, but of course the RPC handlers themselves get a context derived from the one in the BaseContextInterceptor, and the caller is essential there.

I also made the child logger include the name of the gRPC handler.  It reads better when you're looking at a gRPC call that does a bunch of sub operations:

```
DEBUG Dec 21 03:42:48 queryLoki: span finished ok caller:server/server.go:996 logger:grpc.debug_v2.Debug/Dump.collectAppLogs.queryLoki method:Dump peer:↑ service:↑ command:↑ x-request-id:↑ spanDuration:0.089450369 queryStr:↑ logs:10572
DEBUG Dec 21 03:42:48 collectLogsLoki: span finished ok caller:server/server.go:843 logger:grpc.debug_v2.Debug/Dump.collectAppLogs.collectLogsLoki method:↑ peer:↑ service:↑ command:↑ x-request-id:↑ spanDuration:0.103719298 container:pg-bouncer pod:pg-bouncer-746bb45867-gvtlr
DEBUG Dec 21 03:42:48 collectAppLogs: span finished ok caller:server/server.go:229 logger:grpc.debug_v2.Debug/Dump.collectAppLogs method:↑ peer:↑ service:↑ command:↑ x-request-id:↑ spanDuration:5.330222448
DEBUG Dec 21 03:42:48 collectDatabaseDump: span start caller:server/database_dump.go:23 logger:grpc.debug_v2.Debug/Dump.collectDatabaseDump method:↑ peer:↑ service:↑ command:↑ x-request-id:↑ timeout:1577.737476258
DEBUG Dec 21 03:42:48 collectDatabaseDump: span finished ok caller:server/database_dump.go:33 logger:↑ method:↑ peer:↑ service:↑ command:↑ x-request-id:↑ spanDuration:0.034103188
INFO  Dec 21 03:42:48 first message sent for debug_v2.Debug/Dump caller:logging/interceptor.go:529 logger:grpc.debug_v2.Debug/Dump method:↑ peer:↑ service:↑ grpc.code:0 response:{"firstBytes":"H4sIAAAAAAAA/+z7dVRczbYuDjfuHiCBIIEAwZum","len":1807082} command:↑ x-request-id:↑
```

`logger: grpc.collectDatabaseDump` just looks too weird to me.  It is of course redundant but I'm sure everyone is compressing their logs anyway.