### PR TITLE
Fix several goroutine leaks when closing a service environment

### DIFF
--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachtmpl"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsfile"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsload"
@@ -278,6 +279,7 @@ func validateTransform(transform *pps.Transform) error {
 }
 
 func (a *apiServer) validateKube(ctx context.Context) {
+	ctx = pctx.Child(ctx, "validateKube")
 	errors := false
 	kubeClient := a.env.KubeClient
 

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -76,7 +76,7 @@ func NewAPIServer(env Env) (ppsiface.APIServer, error) {
 	}
 	apiServer := (srv).(*apiServer)
 	if env.Config.EnablePreflightChecks {
-		apiServer.validateKube(pctx.Child(apiServer.env.BackgroundContext, "validateKube"))
+		apiServer.validateKube(env.BackgroundContext)
 	} else {
 		log.Error(env.BackgroundContext, "Preflight checks are disabled. This is not recommended.")
 	}


### PR DESCRIPTION
This PR fixes several goroutine leaks when closing a service environment. This is particularly problematic for the PFS tests since they set up a new environment for each test. This hasn't been an issue up to now because the PFS tests did not set up the PPS, Auth, and Enterprise services, which contain the leaks.