### PR TITLE
Djanicek/add coverage projects

### DIFF
--- a/src/internal/testutil/kubeclient.go
+++ b/src/internal/testutil/kubeclient.go
@@ -2,19 +2,14 @@ package testutil
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
 	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -43,87 +38,6 @@ func GetKubeClient(t testing.TB) *kube.Clientset {
 	k, err := kube.NewForConfig(config)
 	require.NoError(t, err)
 	return k
-}
-
-// Deletes a pod and then blocks until there is a delete event, and the pod is recreated and running.
-// However, the pod may not be in a "ready" state when control is unblocked. Use WaitForFirstPodReady
-// to block until the pod to begins accepting requests.
-func DeletePod(t testing.TB, app, ns string) {
-	kubeClient := GetKubeClient(t)
-	podList, err := kubeClient.CoreV1().Pods(ns).List(
-		context.Background(),
-		metav1.ListOptions{
-			LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
-				map[string]string{"app": app, "suite": "pachyderm"},
-			)),
-		})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(podList.Items))
-	require.NoError(t, kubeClient.CoreV1().Pods(ns).Delete(
-		context.Background(),
-		podList.Items[0].ObjectMeta.Name, metav1.DeleteOptions{}))
-
-	// Make sure the pod goes down
-	startTime := time.Now()
-	require.NoError(t, backoff.Retry(func() error {
-		podList, err := kubeClient.CoreV1().Pods(ns).List(
-			context.Background(),
-			metav1.ListOptions{
-				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
-					map[string]string{"app": app, "suite": "pachyderm"},
-				)),
-			})
-		waitForPodEvent(t, app, ns, watch.Deleted)
-		if err != nil {
-			return errors.EnsureStack(err)
-		}
-
-		if len(podList.Items) == 0 {
-			return nil
-		}
-		if time.Since(startTime) > 60*time.Second {
-			return nil
-		}
-		return errors.Errorf("waiting for old %v pod to be killed", app)
-	}, backoff.NewTestingBackOff()))
-
-	// Make sure the pod comes back up
-	require.NoErrorWithinTRetry(t, 30*time.Second, func() error {
-		podList, err := kubeClient.CoreV1().Pods(ns).List(
-			context.Background(),
-			metav1.ListOptions{
-				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
-					map[string]string{"app": app, "suite": "pachyderm"},
-				)),
-			})
-		if err != nil {
-			return errors.EnsureStack(err)
-		}
-		if len(podList.Items) == 0 {
-			return errors.Errorf("no %v pod up yet", app)
-		}
-		return nil
-	})
-
-	require.NoErrorWithinTRetry(t, 120*time.Second, func() error {
-		podList, err := kubeClient.CoreV1().Pods(ns).List(
-			context.Background(),
-			metav1.ListOptions{
-				LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(
-					map[string]string{"app": app, "suite": "pachyderm"},
-				)),
-			})
-		if err != nil {
-			return errors.EnsureStack(err)
-		}
-		if len(podList.Items) == 0 {
-			return errors.Errorf("no %v pod up yet", app)
-		}
-		if podList.Items[0].Status.Phase != v1.PodRunning {
-			return errors.Errorf("%v not running yet", app)
-		}
-		return nil
-	})
 }
 
 // DeletePipelineRC deletes the RC belonging to the pipeline 'pipeline'. This
@@ -160,120 +74,4 @@ func DeletePipelineRC(t testing.TB, pipeline, namespace string) {
 		}
 		return nil
 	})
-}
-
-// PachdDeployment finds the corresponding deployment for pachd in the
-// kubernetes namespace and returns it.
-func PachdDeployment(t testing.TB, namespace string) *apps.Deployment {
-	return GetDeployment(t, "pachd", namespace)
-}
-
-// GetDeployment finds the deployment with the corresponding app name like "pachd"
-func GetDeployment(t testing.TB, appName string, namespace string) *apps.Deployment {
-	k := GetKubeClient(t)
-	result, err := k.AppsV1().Deployments(namespace).Get(context.Background(), appName, metav1.GetOptions{})
-	require.NoError(t, err)
-	return result
-}
-
-// podRunning AndReady takes a watch event returned by v1.PodInterface.Watch and
-// returns true iff the pod is in Running phase, all of the pod's containers statuses are Ready,
-// and the pod condition "Ready" is true.
-func podRunningAndReady(e watch.Event) (bool, error) {
-	if e.Type == watch.Deleted {
-		return false, errors.New("received DELETE while watching pods")
-	}
-	pod, ok := e.Object.(*v1.Pod)
-	if !ok {
-		return false, errors.Errorf("unexpected object type in watch.Event")
-	}
-	containersReady := true
-	for _, cs := range pod.Status.ContainerStatuses {
-		if !cs.Ready {
-			containersReady = false
-			break
-		}
-	}
-	podReady := true
-	for _, c := range pod.Status.Conditions {
-		if c.Type == v1.PodReady && c.Status != v1.ConditionTrue {
-			podReady = false
-			break
-		}
-	}
-	return pod.Status.Phase == v1.PodRunning && containersReady && podReady, nil
-}
-
-// WaitForPachdReady finds the pachd pods within the kubernetes namespace and
-// blocks until they are all ready.
-// WaitForPachdReady finds the pachd pods within the kubernetes namespace and
-// blocks until they are all ready.
-func WaitForPachdReady(t testing.TB, namespace string) {
-	WaitForDeploymentReady(t, "pachd", namespace)
-}
-
-func WaitForDeploymentReady(t testing.TB, appName string, namespace string) {
-	k := GetKubeClient(t)
-	deployment := GetDeployment(t, appName, namespace)
-	for {
-		newDeployment, err := k.AppsV1().Deployments(namespace).Get(context.Background(), deployment.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		if newDeployment.Status.ObservedGeneration >= deployment.Generation && newDeployment.Status.Replicas == *newDeployment.Spec.Replicas {
-			break
-		}
-		time.Sleep(time.Second * 5)
-	}
-	watch, err := k.CoreV1().Pods(namespace).Watch(context.Background(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", appName),
-	})
-	defer watch.Stop()
-	require.NoError(t, err)
-	readyPods := make(map[string]bool)
-	for event := range watch.ResultChan() {
-		ready, err := podRunningAndReady(event)
-		require.NoError(t, err)
-		if ready {
-			pod, ok := event.Object.(*v1.Pod)
-			if !ok {
-				t.Fatal("event.Object should be an object")
-			}
-			readyPods[pod.Name] = true
-			if len(readyPods) == int(*deployment.Spec.Replicas) {
-				break
-			}
-		}
-	}
-}
-
-// Wait deployment only works for deployments and checks every pod.
-// This function is simpler and just unblocks as soon as 1 pod is read.
-// It can be used on non-Deployment objects like StatefulSets.
-func WaitForFirstPodReady(t testing.TB, appName string, namespace string) {
-	k := GetKubeClient(t)
-	watch, err := k.CoreV1().Pods(namespace).Watch(context.Background(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", appName),
-	})
-	defer watch.Stop()
-	require.NoError(t, err)
-	for event := range watch.ResultChan() {
-		ready, err := podRunningAndReady(event)
-		require.NoError(t, err)
-		if ready {
-			break
-		}
-	}
-}
-
-func waitForPodEvent(t testing.TB, appName string, namespace string, eventType watch.EventType) {
-	k := GetKubeClient(t)
-	watch, err := k.CoreV1().Pods(namespace).Watch(context.Background(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", appName),
-	})
-	defer watch.Stop()
-	require.NoError(t, err)
-	for event := range watch.ResultChan() {
-		if event.Type == eventType {
-			break
-		}
-	}
 }

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10880,7 +10880,7 @@ func TestDatumSetCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		ticker := time.NewTimer(35 * time.Second)
+		ticker := time.NewTimer(50 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
@@ -10895,7 +10895,7 @@ func TestDatumSetCache(t *testing.T) {
 				case <-ctx.Done():
 					return
 				default:
-					ticker = time.NewTimer(35 * time.Second)
+					ticker = time.NewTimer(50 * time.Second)
 				}
 			}
 		}

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -3791,14 +3791,16 @@ func TestPFS(suite *testing.T) {
 		if testing.Short() {
 			t.Skip("Skipping integration tests in short mode")
 		}
+		project := tu.UniqueString("prj-")
+		require.NoError(t, env.PachClient.CreateProject(project))
 
 		repo := "test"
-		require.NoError(t, env.PachClient.CreateProjectRepo(pfs.DefaultProjectName, repo))
-		commit := client.NewProjectCommit(pfs.DefaultProjectName, repo, "master", "")
+		require.NoError(t, env.PachClient.CreateProjectRepo(project, repo))
+		commit := client.NewProjectCommit(project, repo, "master", "")
 
 		// Write foo
 		numFiles := 100
-		_, err := env.PachClient.StartProjectCommit(pfs.DefaultProjectName, repo, "master")
+		_, err := env.PachClient.StartProjectCommit(project, repo, "master")
 		require.NoError(t, err)
 
 		require.NoError(t, env.PachClient.WithModifyFileClient(commit, func(mf client.ModifyFile) error {
@@ -3887,7 +3889,7 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, finishCommit(env.PachClient, repo, "master", ""))
 		checks()
 
-		_, err = env.PachClient.StartProjectCommit(pfs.DefaultProjectName, repo, "master")
+		_, err = env.PachClient.StartProjectCommit(project, repo, "master")
 		require.NoError(t, err)
 
 		err = env.PachClient.DeleteFile(commit, "/")

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -2815,8 +2815,8 @@ func TestPFS(suite *testing.T) {
 		require.Equal(t, len(expectedBranches), len(branchInfos))
 		for i, branchInfo := range branchInfos {
 			// branches should return in newest-first order
-			require.Equal(t, expectedBranches[len(branchInfos)-i-1], branchInfo.Branch.Name)
-			require.Equal(t, project, branchInfo.Branch.Repo.Project.GetName())
+			require.Equal(t, expectedBranches[len(branchInfos)-i-1], branchInfo.GetBranch().GetName())
+			require.Equal(t, project, branchInfo.GetBranch().GetRepo().GetProject().GetName())
 			// each branch should have a different commit id (from the transaction
 			// that moved the branch head)
 			headCommit := expectedCommits[len(branchInfos)-i-1]

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -3886,7 +3886,7 @@ func TestPFS(suite *testing.T) {
 			require.YesError(t, err)
 		}
 		checks()
-		require.NoError(t, finishCommit(env.PachClient, repo, "master", ""))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, repo, "master", ""))
 		checks()
 
 		_, err = env.PachClient.StartProjectCommit(project, repo, "master")
@@ -3900,7 +3900,7 @@ func TestPFS(suite *testing.T) {
 			require.Equal(t, 0, len(fileInfos))
 		}
 		checks()
-		require.NoError(t, finishCommit(env.PachClient, repo, "master", ""))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, repo, "master", ""))
 		checks()
 	})
 
@@ -4650,10 +4650,10 @@ func TestPFS(suite *testing.T) {
 		// commit to both inputs
 		_, err := env.PachClient.StartProjectCommit(project, "upstream1", "master")
 		require.NoError(t, err)
-		require.NoError(t, finishCommit(env.PachClient, "upstream1", "master", ""))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "upstream1", "master", ""))
 		_, err = env.PachClient.StartProjectCommit(project, "upstream2", "master")
 		require.NoError(t, err)
-		require.NoError(t, finishCommit(env.PachClient, "upstream2", "master", ""))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "upstream2", "master", ""))
 
 		// Create main repo (will have the commit graphs above)
 		require.NoError(t, env.PachClient.CreateProjectRepo(project, "repo"))
@@ -4667,7 +4667,7 @@ func TestPFS(suite *testing.T) {
 		aInfo, err := env.PachClient.InspectProjectCommit(project, "repo", "master", "")
 		require.NoError(t, err)
 		a := aInfo.Commit
-		require.NoError(t, finishCommit(env.PachClient, "repo", a.Branch.Name, a.ID))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "repo", a.Branch.Name, a.ID))
 
 		// Create 'd'
 		resp, err := env.PachClient.PfsAPIClient.StartCommit(env.PachClient.Ctx(), &pfs.StartCommitRequest{
@@ -4676,18 +4676,18 @@ func TestPFS(suite *testing.T) {
 		})
 		require.NoError(t, err)
 		d := client.NewProjectCommit(project, "repo", resp.Branch.Name, resp.ID)
-		require.NoError(t, finishCommit(env.PachClient, "repo", resp.Branch.Name, resp.ID))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "repo", resp.Branch.Name, resp.ID))
 
 		// Create 'b'
 		// (a & b have same prov commit in upstream2, so this is the commit that will
 		// be deleted, as both b and c are provenant on it)
 		squashMeCommit, err := env.PachClient.StartProjectCommit(project, "upstream1", "master")
 		require.NoError(t, err)
-		require.NoError(t, finishCommit(env.PachClient, "upstream1", "master", ""))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "upstream1", "master", ""))
 		bInfo, err := env.PachClient.InspectProjectCommit(project, "repo", "master", "")
 		require.NoError(t, err)
 		b := bInfo.Commit
-		require.NoError(t, finishCommit(env.PachClient, "repo", b.Branch.Name, b.ID))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "repo", b.Branch.Name, b.ID))
 		require.Equal(t, b.ID, squashMeCommit.ID)
 
 		// Create 'e'
@@ -4697,16 +4697,16 @@ func TestPFS(suite *testing.T) {
 		})
 		require.NoError(t, err)
 		e := client.NewProjectCommit(project, "repo", resp.Branch.Name, resp.ID)
-		require.NoError(t, finishCommit(env.PachClient, "repo", resp.Branch.Name, resp.ID))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "repo", resp.Branch.Name, resp.ID))
 
 		// Create 'c'
 		_, err = env.PachClient.StartProjectCommit(project, "upstream2", "master")
 		require.NoError(t, err)
-		require.NoError(t, finishCommit(env.PachClient, "upstream2", "master", ""))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "upstream2", "master", ""))
 		cInfo, err := env.PachClient.InspectProjectCommit(project, "repo", "master", "")
 		require.NoError(t, err)
 		c := cInfo.Commit
-		require.NoError(t, finishCommit(env.PachClient, "repo", c.Branch.Name, c.ID))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "repo", c.Branch.Name, c.ID))
 
 		// Create 'f'
 		resp, err = env.PachClient.PfsAPIClient.StartCommit(env.PachClient.Ctx(), &pfs.StartCommitRequest{
@@ -4715,7 +4715,7 @@ func TestPFS(suite *testing.T) {
 		})
 		require.NoError(t, err)
 		f := client.NewProjectCommit(project, "repo", resp.Branch.Name, resp.ID)
-		require.NoError(t, finishCommit(env.PachClient, "repo", resp.Branch.Name, resp.ID))
+		require.NoError(t, finishProjectCommit(env.PachClient, project, "repo", resp.Branch.Name, resp.ID))
 
 		// Make sure child/parent relationships are as shown in first diagram
 		commits, err := env.PachClient.ListCommit(repoProto, nil, nil, 0)

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -125,9 +125,10 @@ func TestRawFullPipelineInfo(t *testing.T) {
 		yes | pachctl delete all
 	`).Run())
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
-		pachctl create repo data
-		pachctl put file data@master:/file <<<"This is a test"
-		pachctl create pipeline <<EOF
+		pachctl create project my_project
+		pachctl create repo data --project my_project
+		pachctl put file data@master:/file <<<"This is a test" --project my_project
+		pachctl create pipeline --project my_project <<EOF
 		  {
 		    "pipeline": {"name": "{{.pipeline}}"},
 		    "input": {
@@ -145,10 +146,10 @@ func TestRawFullPipelineInfo(t *testing.T) {
 		`,
 		"pipeline", tu.UniqueString("p-")).Run())
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
-		pachctl wait commit data@master
+		pachctl wait commit data@master --project my_project
 
 		# make sure the results have the full pipeline info, including version
-		pachctl list job --raw \
+		pachctl list job --raw --project my_project \
 			| match "pipeline_version"
 		`).Run())
 }
@@ -380,14 +381,18 @@ func TestYAMLPipelineSpec(t *testing.T) {
 	// wouldn't parse otherwise)
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		yes | pachctl delete all
-		pachctl create repo input
+		pachctl create project P
+		pachctl create repo input --project P
 		pachctl create pipeline -f - <<EOF
 		pipeline:
 		  name: first
+		  project: 
+		    name: P
 		input:
 		  pfs:
 		    glob: /*
 		    repo: input
+		    project: P
 		transform:
 		  cmd: [ /bin/bash ]
 		  stdin:
@@ -399,16 +404,17 @@ func TestYAMLPipelineSpec(t *testing.T) {
 		  pfs:
 		    glob: /*
 		    repo: first
+		    project: P
 		transform:
 		  cmd: [ /bin/bash ]
 		  stdin:
 		    - "cp /pfs/first/* /pfs/out"
 		EOF
-		pachctl start commit input@master
-		echo foo | pachctl put file input@master:/foo
-		echo bar | pachctl put file input@master:/bar
-		echo baz | pachctl put file input@master:/baz
-		pachctl finish commit input@master
+		pachctl start commit input@master --project P
+		echo foo | pachctl put file input@master:/foo --project P
+		echo bar | pachctl put file input@master:/bar --project P
+		echo baz | pachctl put file input@master:/baz --project P
+		pachctl finish commit input@master --project P
 		pachctl wait commit second@master
 		pachctl get file second@master:/foo | match foo
 		pachctl get file second@master:/bar | match bar

--- a/src/server/pps/cmds/cmds_test.go
+++ b/src/server/pps/cmds/cmds_test.go
@@ -1239,8 +1239,9 @@ func TestPipelineWithSecret(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
-		pachctl create repo data
-		pachctl create pipeline 2>&1 <<EOF
+		pachctl create project myProject
+		pachctl create repo data --project myProject
+		pachctl create pipeline --project myProject 2>&1 <<EOF
 		{
 		    "pipeline": {"name": "{{.pipeline}}"},
 		    "input": {

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -280,7 +280,7 @@ func TestTransactions(suite *testing.T) {
 		_, err = txnClient.StartProjectCommit(project, "foo", "master")
 		require.YesError(t, err)
 		require.Matches(t, "already has a commit in this transaction", err.Error())
-		//Delete and verify deletion occurs as well
+		// Delete and verify deletion occurs as well
 		txns, err := env.PachClient.ListTransaction()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(txns))

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
@@ -119,25 +120,29 @@ func TestTransactions(suite *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
 		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
-
+		project := testutil.UniqueString("p-")
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
 
 		txnClient := env.PachClient.WithTransaction(txn)
 
+		_, err = txnClient.PfsAPIClient.CreateProject(txnClient.Ctx(), &pfs.CreateProjectRequest{
+			Project: client.NewProject(project), // projects is not transactional, so it shouldn't be added to inspect transaction request count
+		})
+		require.NoError(t, err)
 		// Create repo, start commit, finish commit
 		_, err = txnClient.PfsAPIClient.CreateRepo(txnClient.Ctx(), &pfs.CreateRepoRequest{
-			Repo: client.NewProjectRepo(pfs.DefaultProjectName, "foo"),
+			Repo: client.NewProjectRepo(project, "foo"),
 		})
 		require.NoError(t, err)
 
 		commit, err := txnClient.PfsAPIClient.StartCommit(txnClient.Ctx(), &pfs.StartCommitRequest{
-			Branch: client.NewProjectBranch(pfs.DefaultProjectName, "foo", "master"),
+			Branch: client.NewProjectBranch(project, "foo", "master"),
 		})
 		require.NoError(t, err)
 
 		_, err = txnClient.PfsAPIClient.FinishCommit(txnClient.Ctx(), &pfs.FinishCommitRequest{
-			Commit: client.NewProjectCommit(pfs.DefaultProjectName, "foo", "master", ""),
+			Commit: client.NewProjectCommit(project, "foo", "master", ""),
 		})
 		require.NoError(t, err)
 
@@ -181,17 +186,19 @@ func TestTransactions(suite *testing.T) {
 		repo := "foo"
 		branchA := "master"
 		branchB := "bar"
+		project := testutil.UniqueString("prj-")
 
-		require.NoError(t, env.PachClient.CreateProjectRepo(pfs.DefaultProjectName, repo))
-		require.NoError(t, env.PachClient.CreateProjectBranch(pfs.DefaultProjectName, repo, branchA, "", "", nil))
-		require.NoError(t, env.PachClient.CreateProjectBranch(pfs.DefaultProjectName, repo, branchB, "", "", nil))
+		require.NoError(t, env.PachClient.CreateProject(project))
+		require.NoError(t, env.PachClient.CreateProjectRepo(project, repo))
+		require.NoError(t, env.PachClient.CreateProjectBranch(project, repo, branchA, "", "", nil))
+		require.NoError(t, env.PachClient.CreateProjectBranch(project, repo, branchB, "", "", nil))
 
 		txnClient := env.PachClient.WithTransaction(txn)
-		commit, err := txnClient.StartProjectCommit(pfs.DefaultProjectName, repo, branchB)
+		commit, err := txnClient.StartProjectCommit(project, repo, branchB)
 		require.NoError(t, err)
-		err = txnClient.FinishProjectCommit(pfs.DefaultProjectName, repo, branchB, "")
+		err = txnClient.FinishProjectCommit(project, repo, branchB, "")
 		require.NoError(t, err)
-		require.NoError(t, txnClient.CreateProjectBranch(pfs.DefaultProjectName, repo, branchA, branchB, "", nil))
+		require.NoError(t, txnClient.CreateProjectBranch(project, repo, branchA, branchB, "", nil))
 
 		info, err := txnClient.FinishTransaction(txn)
 		require.NoError(t, err)
@@ -199,12 +206,28 @@ func TestTransactions(suite *testing.T) {
 		// Double-check each response value
 		requireCommitResponse(t, info.Responses[0], commit)
 		requireEmptyResponse(t, info.Responses[1])
+		// Exercise branch reading after transaction
+		_, err = env.PachClient.InspectProjectBranch(project, repo, branchA)
+		require.NoError(t, err)
 
-		commitInfo, err := env.PachClient.InspectProjectCommit(pfs.DefaultProjectName, repo, branchA, "")
+		branches, err := env.PachClient.ListProjectBranch(project, repo)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(branches))
+
+		_, err = env.PachClient.InspectProjectBranch(pfs.DefaultProjectName, repo, branchA)
+		require.YesError(t, err, "Inspecting a branch in the wrong project should fail.")
+
+		_, err = env.PachClient.ListProjectBranch(pfs.DefaultProjectName, repo)
+		require.YesError(t, err)
+		// Exercise commit reading after transaction
+		_, err = env.PachClient.InspectProjectCommit(pfs.DefaultProjectName, repo, branchA, "")
+		require.YesError(t, err, "Inspecting a commit in the wrong project should fail.")
+
+		commitInfo, err := env.PachClient.InspectProjectCommit(project, repo, branchA, "")
 		require.NoError(t, err)
 		require.Equal(t, commitInfo.Commit.ID, commit.ID)
 
-		commitInfo, err = env.PachClient.InspectProjectCommit(pfs.DefaultProjectName, repo, branchB, "")
+		commitInfo, err = env.PachClient.InspectProjectCommit(project, repo, branchB, "")
 		require.NoError(t, err)
 		require.Equal(t, commitInfo.Commit.ID, commit.ID)
 	})
@@ -237,22 +260,38 @@ func TestTransactions(suite *testing.T) {
 		ctx := pctx.TestContext(t)
 		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
 
+		project := testutil.UniqueString("prj_")
+		err := env.PachClient.CreateProject(project)
+		require.NoError(t, err)
+
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
 
 		txnClient := env.PachClient.WithTransaction(txn)
 
-		err = txnClient.CreateProjectRepo(pfs.DefaultProjectName, "foo")
+		err = txnClient.CreateProjectRepo(project, "foo")
 		require.NoError(t, err)
 
-		_, err = txnClient.StartProjectCommit(pfs.DefaultProjectName, "foo", "master")
+		_, err = txnClient.StartProjectCommit(project, "foo", "master")
 		require.NoError(t, err)
-		err = txnClient.FinishProjectCommit(pfs.DefaultProjectName, "foo", "master", "")
+		err = txnClient.FinishProjectCommit(project, "foo", "master", "")
 		require.NoError(t, err)
 
-		_, err = txnClient.StartProjectCommit(pfs.DefaultProjectName, "foo", "master")
+		_, err = txnClient.StartProjectCommit(project, "foo", "master")
 		require.YesError(t, err)
 		require.Matches(t, "already has a commit in this transaction", err.Error())
+		//Delete and verify deletion occurs as well
+		txns, err := env.PachClient.ListTransaction()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(txns))
+
+		err = txnClient.DeleteTransaction(txn)
+		require.NoError(t, err)
+
+		txns, err = env.PachClient.ListTransaction()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(txns))
+
 	})
 
 	// Test that a transactional change to multiple repos will only propagate a


### PR DESCRIPTION
For the most part, this PR has test changes to finish exercising pachctl commands with projects.

So, most of the changes are changing pfs.DefaultProjectName to a dynamic project name. This PR should make it so all of the non-auth commands are covered at the cli or api level.

There were a few changes for test stability that I made while I was running the tests and touching the code. Those changes were a bit different, so here's the explanation of what was changed with those tests and why:

- internal/testutil/kubeclient.go was not checking for pod readiness correctly, only for _running_ status which occurs much sooner than _readiness_. In particular, pod delete wasn't properly waiting for the pod to go down before checking that it was up, so it immediately found a running pod and assumed it was back online, when it had never gone down in the first place. Additionally, a new function was added to wait for any pod to be in a running and ready state, not just pachd.
- TestDatumSetCache in pachyderm_test.go uses the new pod delete waits to ensure etcd has a few seconds of uptime before it's deleted. Before, if etcd took too long to come up(~45 seconds) then very few datums would be processed. Since there are 90 datums, this could cause the test to take much longer than the 10 minute timeout. Now that it waits, we should guarantee a more consistent amount of up before being re-deleted.
- TestRapidUpdatePipelines in pachyderm_test.go was changed to use the new utility to wait for the pipeline to start before updating, rather than using sleep(). The pipeline name was changed to not be so long(it wasn't coming up the first time before  since the name was too long). Finally, I changed to use the constant retry rather than exponential so the tests finishes within 10 seconds of success, rather than 1 minute. I'm less sure these changes fully resolve issues on this test but they seem to help.

