### PR TITLE
[2.4.x] 

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -127,7 +127,7 @@ func (s *debugServer) handleRedirect(
 						// Redirect to the storage container.
 						r, err := redirect(ctx, s.sidecarClient.DebugClient, filter)
 						if err != nil {
-							multierr.AppendInto(&errs, errors.Wrap(err, "collect user container"))
+							multierr.AppendInto(&errs, errors.Wrap(err, "collect storage container"))
 						}
 						if err := collectDebugStream(tw, r); err != nil {
 							multierr.AppendInto(&errs, errors.Wrap(err, "collect debug stream"))
@@ -368,11 +368,11 @@ func (s *debugServer) Profile(request *debug.ProfileRequest, server debug.Debug_
 		pachClient,
 		server,
 		request.Filter,
-		collectProfileFunc(request.Profile),  // collectPachd
-		nil,                                  // collectPipeline
-		nil,                                  // collectWorker
-		redirectProfileFunc(request.Profile), // redirect
-		collectProfileFunc(request.Profile),  // collect
+		collectProfileFunc(request.Profile),  /* collectPachd */
+		nil,                                  /* collectPipeline */
+		nil,                                  /* collectWorker */
+		redirectProfileFunc(request.Profile), /* redirect */
+		collectProfileFunc(request.Profile),  /* collect */
 		false,
 		false,
 	)
@@ -441,11 +441,11 @@ func (s *debugServer) Binary(request *debug.BinaryRequest, server debug.Debug_Bi
 		pachClient,
 		server,
 		request.Filter,
-		collectBinary,  // collectPachd
-		nil,            // collectPipeline
-		nil,            // collectWorker
-		redirectBinary, // redirect
-		collectBinary,  // collect
+		collectBinary,  /* collectPachd */
+		nil,            /* collectPipeline */
+		nil,            /* collectWorker */
+		redirectBinary, /* redirect */
+		collectBinary,  /* collect */
 		false,
 		false,
 	)
@@ -493,11 +493,11 @@ func (s *debugServer) Dump(request *debug.DumpRequest, server debug.Debug_DumpSe
 		pachClient,
 		server,
 		request.Filter,
-		s.collectPachdDumpFunc(request.Limit),    // collectPachd
-		s.collectPipelineDumpFunc(request.Limit), // collectPipeline
-		s.collectWorkerDump,                      // collectWorker
-		redirectDump,                             // redirect
-		collectDump,                              // collect
+		s.collectPachdDumpFunc(request.Limit),    /* collectPachd */
+		s.collectPipelineDumpFunc(request.Limit), /* collectPipeline */
+		s.collectWorkerDump,                      /* collectWorker */
+		redirectDump,                             /* redirect */
+		collectDump,                              /* collect */
 		true,
 		true,
 	)

--- a/src/server/debug/server/util.go
+++ b/src/server/debug/server/util.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/fsutil"
+	"go.uber.org/multierr"
 )
 
 func join(names ...string) string {
@@ -19,15 +20,11 @@ func join(names ...string) string {
 func withDebugWriter(w io.Writer, cb func(*tar.Writer) error) (retErr error) {
 	gw := gzip.NewWriter(w)
 	defer func() {
-		if retErr == nil {
-			retErr = gw.Close()
-		}
+		multierr.AppendInto(&retErr, gw.Close())
 	}()
 	tw := tar.NewWriter(gw)
 	defer func() {
-		if retErr == nil {
-			retErr = tw.Close()
-		}
+		multierr.AppendInto(&retErr, tw.Close())
 	}()
 	return cb(tw)
 }
@@ -93,9 +90,7 @@ func collectDebugStream(tw *tar.Writer, r io.Reader, prefix ...string) (retErr e
 		return errors.EnsureStack(err)
 	}
 	defer func() {
-		if err := gr.Close(); retErr == nil {
-			retErr = err
-		}
+		multierr.AppendInto(&retErr, gr.Close())
 	}()
 	tr := tar.NewReader(gr)
 	return copyTar(tw, tr, prefix...)


### PR DESCRIPTION
Backport #8472.  This adds more timeouts to debug dumps, guarantees time within the RPC deadline to send back bytes, performs multiple erroring operations without bailing out, and lets pachctl control the timeout. 