### PR TITLE
[2.4.x Backport] Gracefully handle old pipelines where output commit is ALIAS and metacommit is AUTO (#8485)

### DIFF
--- a/src/server/worker/pipeline/transform/pending_job.go
+++ b/src/server/worker/pipeline/transform/pending_job.go
@@ -108,11 +108,17 @@ func (pj *pendingJob) load() error {
 				return errors.EnsureStack(err)
 			}
 			// both commits must have succeeded - a validation error will only show up in the output
-			if metaCI.Error == "" && outputCI.Error == "" {
+			// the commit must also not be of type ALIAS, to ensure that we have a corresponding job
+			if metaCI.Error == "" && outputCI.Error == "" && outputCI.Origin.Kind != pfs.OriginKind_ALIAS {
 				break
 			}
 		}
 		pj.baseMetaCommit = metaCI.ParentCommit
+	}
+	if pj.baseMetaCommit != nil {
+		pj.logger.Logf("base meta commit for job %q is %q", pj.ji.Job.String(), pj.baseMetaCommit.ID)
+	} else {
+		pj.logger.Logf("base meta commit for job %q not selected", pj.ji.Job.String())
 	}
 	// Load the job info.
 	pj.ji, err = pachClient.InspectJob(pj.ji.Job.Pipeline.Name, pj.ji.Job.ID, true)


### PR DESCRIPTION
Gracefully handle old pipelines where output commit is ALIAS and meta commit is AUTO