### PR TITLE
[CORE-1441] [2.4.x] leave pipelines in STANDBY until they're FINISHED

### DIFF
--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -164,7 +164,7 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 						if !ok {
 							return nil // subscribeCommit exited, nothing left to do
 						}
-						if ci.Finishing != nil {
+						if ci.Finished != nil {
 							continue
 						}
 						childSpan, ctx = extended.AddSpanToAnyPipelineTrace(oldCtx,


### PR DESCRIPTION
This is the 2.4.x version of #8499

When monitorPipeline starts, the first thing it does is [put its pipeline
in STANDBY](https://github.com/pachyderm/pachyderm/blob/8fca5b912358c15f67d8b19a32f84d2ba507571c/src/server/pps/server/monitor.go#L137). Then, it [listens on ciChan for commits in READY and takes
the pipeline out of STANDBY if it gets any](https://github.com/pachyderm/pachyderm/blob/8fca5b912358c15f67d8b19a32f84d2ba507571c/src/server/pps/server/monitor.go#L163). Meanwhile, another goro
[calls SubscribeCommit and puts any events into ciChan](https://github.com/pachyderm/pachyderm/blob/8fca5b912358c15f67d8b19a32f84d2ba507571c/src/server/pps/server/monitor.go#L110).

The issue is that the first goro discards PFS events where the commit is
FINISHING, so if the PPS master restarts while a commit is in FINISHING,
it'll come back up, put the pipeline in STANDBY, and then won't take it
out. This leaves the commit stuck in FINISHING until compaction finishes
much later.

This PR changes the logic in `monitorPipeline` so that if a `monitorPipeline`
goro's pipeline has a commit in FINISHING, the pipeline goes into RUNNING
and stays there until the commit is FINISHED.