### PR TITLE
paused: scaleDownWorkers: supply objectmeta; capture all errors

### DIFF
--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	lc "github.com/pachyderm/pachyderm/v2/src/license"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -526,18 +527,20 @@ func scaleDownWorkers(ctx context.Context, kc kubernetes.Interface, namespace st
 	if err != nil {
 		return errors.Errorf("could not list workers: %v", err)
 	}
+	var errs error
 	for _, w := range ww.Items {
 		if _, err := rc.UpdateScale(ctx, w.GetName(), &autoscalingv1.Scale{
+			ObjectMeta: w.ObjectMeta,
 			Spec: autoscalingv1.ScaleSpec{
 				Replicas: 0,
 			},
 		}, metav1.UpdateOptions{
 			FieldManager: "enterprise-server",
 		}); err != nil {
-			return errors.Errorf("could not scale down %s: %v", w.GetName(), err)
+			multierr.AppendInto(&errs, errors.Errorf("could not scale down %s: %v", w.GetName(), err))
 		}
 	}
-	return nil
+	return errs
 }
 
 func (a *apiServer) Unpause(ctx context.Context, req *ec.UnpauseRequest) (resp *ec.UnpauseResponse, retErr error) {


### PR DESCRIPTION
Kubernetes seems to want the ObjectMeta field these days.  pachw supplies one, so now so does paused mode pachd.  Not sure if this is an api server version issue or not; I tried upgrading client-go to v0.25 before this change and it didn't help.

I also find these loops that bail out after the first error are annoying; this adds multierr.