### PR TITLE
[Jupyter] Qualify unmounted repos keys by project

### DIFF
--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
@@ -33,7 +33,10 @@ const ListUnmount: React.FC<ListUnmountProps> = ({
 
   useEffect(() => {
     const branchMounted = mountedItems.find(
-      (mount) => mount.repo === item.repo && mount.branch === selectedBranch,
+      (mount) =>
+        mount.repo === item.repo &&
+        mount.project === item.project &&
+        mount.branch === selectedBranch,
     );
     setSelectedBranchMounted(branchMounted ? true : false);
   }, [mountedItems, selectedBranch]);

--- a/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
@@ -60,7 +60,7 @@ const SortableList: React.FC<SortableListProps> = ({
             ) : (
               <ListUnmount
                 item={item}
-                key={item.repo}
+                key={`${item.project}_${item.repo}`}
                 updateData={updateData}
                 mountedItems={mountedItems}
               />


### PR DESCRIPTION
There were a couple spots where project wasn't added as a qualifier to repos in the unmounted repositories list. This led to funky behavior with repos of the same name in different projects. When one of those repos was mounted, the "Mount" button for all other repos sharing the same name was disabled if the selected branch in the dropdown matched the branch name of the mounted repo's branch.