### PR TITLE
[INT-802] Implement the S3 Gateway bucket name proposal

### DIFF
--- a/src/server/pfs/s3/auth.go
+++ b/src/server/pfs/s3/auth.go
@@ -4,7 +4,6 @@ package s3
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/pachyderm/pachyderm/v2/src/auth"
@@ -15,13 +14,7 @@ import (
 
 func (c *controller) SecretKey(r *http.Request, accessKey string, region *string) (*string, error) {
 	log.Debug(r.Context(), "SecretKey", zap.Stringp("region", region))
-
 	pc := c.clientFactory(r.Context())
-
-	if strings.HasPrefix(accessKey, "PAC1") {
-		mux.Vars(r)[isProjectAwareVar] = isProjectAwareValue
-		accessKey = accessKey[4:]
-	}
 	pc.SetAuthToken(accessKey)
 
 	// WhoAmI will simultaneously check that auth is enabled, and that the

--- a/src/server/pfs/s3/driver.go
+++ b/src/server/pfs/s3/driver.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
@@ -54,47 +53,20 @@ func NewMasterDriver() *MasterDriver {
 	return &MasterDriver{}
 }
 
-func branchBucketName(b *pfs.Branch) string {
-	if b.Repo.Type == pfs.UserRepoType {
-		return fmt.Sprintf("%s.%s", b.Name, b.Repo.Name)
-	}
-	return fmt.Sprintf("%s.%s.%s", b.Name, b.Repo.Type, b.Repo.Name)
-}
-
-func projectBranchBucketName(b *pfs.Branch) string {
-	if b.Repo.Type == pfs.UserRepoType {
-		return fmt.Sprintf("%s.%s.%s", b.Name, b.Repo.Name, b.Repo.Project.Name)
-	}
-	return fmt.Sprintf("%s.%s.%s.%s", b.Name, b.Repo.Type, b.Repo.Name, b.Repo.Project.Name)
-}
-
 func (d *MasterDriver) listBuckets(pc *client.APIClient, r *http.Request, buckets *[]*s2.Bucket) error {
-	var isProjectAware = mux.Vars(r)[isProjectAwareVar] == isProjectAwareValue
-	repos, err := pc.ListRepoByType("") // get repos of all types
+	repos, err := pc.ListRepo() // get repos of all types
 	if err != nil {
 		return err
 	}
 
 	for _, repo := range repos {
-		if !isProjectAware && repo.Repo.Project.Name != pfs.DefaultProjectName {
-			continue // skip repos not in the default project
-		}
-		if repo.Repo.Type == pfs.SpecRepoType {
-			continue // hide spec repos, but allow meta/stats repos
-		}
 		t, err := types.TimestampFromProto(repo.Created)
 		if err != nil {
 			return err
 		}
-		for _, branch := range repo.Branches {
-			var name string
-			if isProjectAware {
-				name = projectBranchBucketName(branch)
-			} else {
-				name = branchBucketName(branch)
-			}
+		for _, b := range repo.Branches {
 			*buckets = append(*buckets, &s2.Bucket{
-				Name:         name,
+				Name:         fmt.Sprintf("%s.%s.%s", b.Name, b.Repo.Name, b.Repo.Project.Name),
 				CreationDate: t,
 			})
 		}
@@ -103,10 +75,12 @@ func (d *MasterDriver) listBuckets(pc *client.APIClient, r *http.Request, bucket
 	return nil
 }
 
-func bucketNameToCommit(bucketName string) *pfs.Commit {
-	var id string
-	branch := "master"
-	var repo *pfs.Repo
+func bucketNameToCommit(bucketName string) (*pfs.Commit, error) {
+	var (
+		id     string
+		branch string
+		repo   *pfs.Repo
+	)
 
 	// the name is [commitID.][branch. | branch.type.]repoName
 	// in particular, to access a non-user system repo, the branch name must be given
@@ -115,64 +89,31 @@ func bucketNameToCommit(bucketName string) *pfs.Commit {
 		id = parts[0]
 		parts = parts[1:]
 	}
-	if len(parts) > 1 {
-		branch = parts[0]
-		parts = parts[1:]
-	}
-	if len(parts) == 1 {
-		repo = client.NewProjectRepo(pfs.DefaultProjectName, parts[0])
-	} else {
-		repo = client.NewSystemProjectRepo(pfs.DefaultProjectName, parts[1], parts[0])
-	}
 
-	return repo.NewCommit(branch, id)
-}
-
-func bucketNameToProjectCommit(bucketName string) (*pfs.Commit, error) {
-	var id string
-	branch := "master"
-	var repo *pfs.Repo
-
-	// the name is [commitID.][branch. | branch.type.]repoName.projectName
-	// in particular, to access a non-user system repo, the branch name must be given
-	parts := strings.SplitN(bucketName, ".", 5)
-	if uuid.IsUUIDWithoutDashes(parts[0]) {
-		id = parts[0]
-		parts = parts[1:]
-	}
-	if len(parts) > 2 {
-		branch = parts[0]
-		parts = parts[1:]
-	}
 	switch len(parts) {
 	case 0:
-		return nil, errors.Errorf("bad bucket name %s", bucketName)
+		return nil, errors.Errorf("invalid bucket name %q; must include a repo", bucketName)
 	case 1:
-		return nil, errors.Errorf("bad bucket name %s", bucketName)
+		// e.g. s3://myrepo
+		repo, branch = client.NewProjectRepo(pfs.DefaultProjectName, parts[0]), "master"
 	case 2:
-		repo = client.NewProjectRepo(parts[1], parts[0])
+		// e.g. s3://mybranch.myrepo
+		repo, branch = client.NewProjectRepo(pfs.DefaultProjectName, parts[1]), parts[0]
 	case 3:
-		repo = client.NewSystemProjectRepo(parts[2], parts[1], parts[0])
-	default:
-		return nil, errors.Errorf("bad bucket name %s", bucketName)
+		// e.g. s3://mybranch.myrepo.myproject
+		repo, branch = client.NewProjectRepo(parts[2], parts[1]), parts[0]
 	}
 
 	return repo.NewCommit(branch, id), nil
 }
 
 func (d *MasterDriver) bucket(pc *client.APIClient, r *http.Request, name string) (*Bucket, error) {
-	if mux.Vars(r)[isProjectAwareVar] == isProjectAwareValue {
-		commit, err := bucketNameToProjectCommit(name)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not map bucket name to commit")
-		}
-		return &Bucket{
-			Commit: commit,
-			Name:   name,
-		}, nil
+	commit, err := bucketNameToCommit(name)
+	if err != nil {
+		return nil, err
 	}
 	return &Bucket{
-		Commit: bucketNameToCommit(name),
+		Commit: commit,
 		Name:   name,
 	}, nil
 }

--- a/src/server/pfs/s3/driver.go
+++ b/src/server/pfs/s3/driver.go
@@ -54,7 +54,7 @@ func NewMasterDriver() *MasterDriver {
 }
 
 func (d *MasterDriver) listBuckets(pc *client.APIClient, r *http.Request, buckets *[]*s2.Bucket) error {
-	repos, err := pc.ListRepo() // get repos of all types
+	repos, err := pc.ListRepo() // get all user-type repos
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (d *MasterDriver) listBuckets(pc *client.APIClient, r *http.Request, bucket
 		}
 		for _, b := range repo.Branches {
 			*buckets = append(*buckets, &s2.Bucket{
-				Name:         fmt.Sprintf("%s.%s.%s", b.Name, b.Repo.Name, b.Repo.Project.Name),
+				Name:         fmt.Sprintf("%s.%s.%s", b.GetName(), b.GetRepo().GetName(), b.GetRepo().GetProject().GetName()),
 				CreationDate: t,
 			})
 		}

--- a/src/server/pfs/s3/driver_test.go
+++ b/src/server/pfs/s3/driver_test.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -212,5 +213,15 @@ func TestBucketNameToCommit(t *testing.T) {
 		if c.Branch.Repo.Project.Name != cc.Branch.Repo.Project.Name {
 			t.Errorf("%s: mismatched project names: %s ≠ %s", b, c.Branch.Repo.Project.Name, cc.Branch.Repo.Project.Name)
 		}
+	}
+}
+
+func TestBucketNameError(t *testing.T) {
+	c, err := bucketNameToCommit("7b234298216044d4accaf3f472175a54.too.many.components.bucket")
+	if err == nil {
+		t.Fatalf("expected error but valid result: %+v", c)
+	}
+	if !strings.Contains(err.Error(), "invalid bucket name") {
+		t.Fatalf("expected 'invalid bucket name' error, but got: %v", err)
 	}
 }

--- a/src/server/pfs/s3/driver_test.go
+++ b/src/server/pfs/s3/driver_test.go
@@ -6,10 +6,140 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
-func TestBucketNameToProjectCommit(t *testing.T) {
-	// pattern: [commitID.][branch. | branch.type.]repoName.projectName
+func TestBucketNameToCommit(t *testing.T) {
+	// pattern: [commitID.][branch.]repoName[.projectName]
 	var cases = map[string]*pfs.Commit{
-		"8b234298216044d4accaf3f472175a54.testLOPed701519c9c4.default": {
+		"testLOPed701519c9c4": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "master",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"master.testLOPed701519c9c4": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "master",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"notmaster.testLOPed701519c9c4": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "notmaster",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"master.testLOPed701519c9c4.default": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "master",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"notmaster.testLOPed701519c9c4.default": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "notmaster",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"master.testLOPed701519c9c4.proj": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "master",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "proj",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"notmaster.testLOPed701519c9c4.proj": {
+			ID: "",
+			Branch: &pfs.Branch{
+				Name: "notmaster",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "proj",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"8b234298216044d4accaf3f472175a54.testLOPed701519c9c4": {
+			ID: "8b234298216044d4accaf3f472175a54",
+			Branch: &pfs.Branch{
+				Name: "master",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"8b234298216044d4accaf3f472175a54.master.testLOPed701519c9c4": {
+			ID: "8b234298216044d4accaf3f472175a54",
+			Branch: &pfs.Branch{
+				Name: "master",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"8b234298216044d4accaf3f472175a54.notmaster.testLOPed701519c9c4": {
+			ID: "8b234298216044d4accaf3f472175a54",
+			Branch: &pfs.Branch{
+				Name: "notmaster",
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "testLOPed701519c9c4",
+					Type: pfs.UserRepoType,
+				},
+			},
+		},
+		"8b234298216044d4accaf3f472175a54.master.testLOPed701519c9c4.default": {
 			ID: "8b234298216044d4accaf3f472175a54",
 			Branch: &pfs.Branch{
 				Name: "master",
@@ -35,52 +165,26 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 				},
 			},
 		},
-		"8b234298216044d4accaf3f472175a54.notmaster.spec.testLOPed701519c9c4.default": {
+		"8b234298216044d4accaf3f472175a54.master.testLOPed701519c9c4.proj": {
 			ID: "8b234298216044d4accaf3f472175a54",
 			Branch: &pfs.Branch{
-				Name: "notmaster",
+				Name: "master",
 				Repo: &pfs.Repo{
 					Project: &pfs.Project{
-						Name: "default",
-					},
-					Name: "testLOPed701519c9c4",
-					Type: pfs.SpecRepoType,
-				},
-			},
-		},
-		"notmaster.testLOPed701519c9c4.default": {
-			ID: "",
-			Branch: &pfs.Branch{
-				Name: "notmaster",
-				Repo: &pfs.Repo{
-					Project: &pfs.Project{
-						Name: "default",
+						Name: "proj",
 					},
 					Name: "testLOPed701519c9c4",
 					Type: pfs.UserRepoType,
 				},
 			},
 		},
-		"notmaster.spec.testLOPed701519c9c4.default": {
-			ID: "",
+		"8b234298216044d4accaf3f472175a54.notmaster.testLOPed701519c9c4.proj": {
+			ID: "8b234298216044d4accaf3f472175a54",
 			Branch: &pfs.Branch{
 				Name: "notmaster",
 				Repo: &pfs.Repo{
 					Project: &pfs.Project{
-						Name: "default",
-					},
-					Name: "testLOPed701519c9c4",
-					Type: pfs.SpecRepoType,
-				},
-			},
-		},
-		"testLOPed701519c9c4.default": {
-			ID: "",
-			Branch: &pfs.Branch{
-				Name: "master",
-				Repo: &pfs.Repo{
-					Project: &pfs.Project{
-						Name: "default",
+						Name: "proj",
 					},
 					Name: "testLOPed701519c9c4",
 					Type: pfs.UserRepoType,
@@ -89,7 +193,7 @@ func TestBucketNameToProjectCommit(t *testing.T) {
 		},
 	}
 	for b, c := range cases {
-		cc, err := bucketNameToProjectCommit(b)
+		cc, err := bucketNameToCommit(b)
 		if err != nil {
 			t.Error(err)
 		}

--- a/src/server/pfs/s3/s3.go
+++ b/src/server/pfs/s3/s3.go
@@ -34,9 +34,6 @@ const (
 
 	// The S3 location served back
 	globalLocation = "PACHYDERM"
-
-	isProjectAwareVar   = "isProjectAware"
-	isProjectAwareValue = "yes"
 )
 
 // The S3 user associated with all PFS content
@@ -65,11 +62,10 @@ func (c *controller) requestClient(r *http.Request) *client.APIClient {
 	vars := mux.Vars(r)
 	if vars["s3gAuth"] != "disabled" {
 		accessKey := vars["authAccessKey"]
-		if strings.HasPrefix(accessKey, "PAC1") {
-			vars[isProjectAwareVar] = isProjectAwareValue
-			accessKey = accessKey[4:]
-		}
-		if accessKey != "" {
+		if accessKey == "" {
+			log.Error(pc.Ctx(), "S3 gateway requests did not include authAccessKey")
+		} else {
+			// this should always run
 			pc.SetAuthToken(accessKey)
 		}
 	}

--- a/src/server/pfs/s3/util_test.go
+++ b/src/server/pfs/s3/util_test.go
@@ -167,7 +167,7 @@ func projectTestRunner(ctx context.Context, t *testing.T, pachClient *client.API
 
 	port := listener.Addr().(*net.TCPAddr).Port
 
-	minioClient, err := minio.NewV4(fmt.Sprintf("127.0.0.1:%d", port), "PAC11234", "1234", false)
+	minioClient, err := minio.NewV4(fmt.Sprintf("127.0.0.1:%d", port), "1234", "1234", false)
 	require.NoError(t, err)
 
 	t.Run(group, func(t *testing.T) {

--- a/src/server/pps/server/s3g_sidecar_test.go
+++ b/src/server/pps/server/s3g_sidecar_test.go
@@ -119,7 +119,7 @@ func TestS3PipelineErrors(t *testing.T) {
 	require.Matches(t, "join", err.Error())
 }
 
-func testS3Input(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey, ns, projectName string) {
+func testS3Input(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, repo))
 	masterCommit := client.NewProjectCommit(projectName, repo, "master", "")
@@ -139,8 +139,8 @@ func testS3Input(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey
 				"aws --endpoint=${S3_ENDPOINT} s3 ls s3://input_repo >/pfs/out/s3_files",
 			},
 			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     accessKeyID,
-				"AWS_SECRET_ACCESS_KEY": secretAccessKey,
+				"AWS_ACCESS_KEY_ID":     userToken,
+				"AWS_SECRET_ACCESS_KEY": userToken,
 			},
 		},
 		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -213,18 +213,17 @@ func TestS3Input(t *testing.T) {
 	if userToken == "" {
 		userToken = "abc123"
 	}
-	t.Run("ProjectUnaware", func(t *testing.T) {
-		testS3Input(t, c, userToken, userToken, ns, pfs.DefaultProjectName)
+	t.Run("DefaultProject", func(t *testing.T) {
+		testS3Input(t, c, userToken, ns, pfs.DefaultProjectName)
 	})
-	t.Run("ProjectAware", func(t *testing.T) {
-		accessKeyID := "PAC1" + userToken
+	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3Input(t, c, accessKeyID, userToken, ns, projectName)
+		testS3Input(t, c, userToken, ns, projectName)
 	})
 }
 
-func testS3Chain(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey, ns, projectName string) {
+func testS3Chain(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
 	dataRepo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, dataRepo))
 	dataCommit := client.NewProjectCommit(projectName, dataRepo, "master", "")
@@ -249,8 +248,8 @@ func testS3Chain(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey
 						"aws --endpoint=${S3_ENDPOINT} s3 cp /tmp/s3in s3://out/file",
 					},
 					Env: map[string]string{
-						"AWS_ACCESS_KEY_ID":     accessKeyID,
-						"AWS_SECRET_ACCESS_KEY": secretAccessKey,
+						"AWS_ACCESS_KEY_ID":     userToken,
+						"AWS_SECRET_ACCESS_KEY": userToken,
 					},
 				},
 				ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -291,14 +290,13 @@ func TestS3Chain(t *testing.T) {
 	if userToken == "" {
 		userToken = "abc123"
 	}
-	t.Run("ProjectUnaware", func(t *testing.T) {
-		testS3Chain(t, c, userToken, userToken, ns, pfs.DefaultProjectName)
+	t.Run("DefaultProject", func(t *testing.T) {
+		testS3Chain(t, c, userToken, ns, pfs.DefaultProjectName)
 	})
-	t.Run("ProjectAware", func(t *testing.T) {
-		accessKeyID := "PAC1" + userToken
+	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3Chain(t, c, accessKeyID, userToken, ns, projectName)
+		testS3Chain(t, c, userToken, ns, projectName)
 	})
 }
 
@@ -351,7 +349,7 @@ func TestNamespaceInEndpoint(t *testing.T) {
 	require.True(t, strings.Contains(buf.String(), "."+ns))
 }
 
-func testS3Output(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey, ns, projectName string) {
+func testS3Output(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, repo))
 	masterCommit := client.NewProjectCommit(projectName, repo, "master", "")
@@ -370,8 +368,8 @@ func testS3Output(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKe
 				"aws --endpoint=${S3_ENDPOINT} s3 ls | aws --endpoint=${S3_ENDPOINT} s3 cp - s3://out/s3_buckets",
 			},
 			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     accessKeyID,
-				"AWS_SECRET_ACCESS_KEY": secretAccessKey,
+				"AWS_ACCESS_KEY_ID":     userToken,
+				"AWS_SECRET_ACCESS_KEY": userToken,
 			},
 		},
 		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -439,18 +437,17 @@ func TestS3Output(t *testing.T) {
 	if userToken == "" {
 		userToken = "abc123"
 	}
-	t.Run("ProjectUnaware", func(t *testing.T) {
-		testS3Output(t, c, userToken, userToken, ns, pfs.DefaultProjectName)
+	t.Run("DefaultProject", func(t *testing.T) {
+		testS3Output(t, c, userToken, ns, pfs.DefaultProjectName)
 	})
-	t.Run("ProjectAware", func(t *testing.T) {
-		accessKeyID := "PAC1" + userToken
+	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3Output(t, c, accessKeyID, userToken, ns, projectName)
+		testS3Output(t, c, userToken, ns, projectName)
 	})
 }
 
-func testFullS3(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey, ns, projectName string) {
+func testFullS3(t *testing.T, c *client.APIClient, userToken, ns, projectName string) {
 	repo := tu.UniqueString("data")
 	require.NoError(t, c.CreateProjectRepo(projectName, repo))
 	masterCommit := client.NewProjectCommit(projectName, repo, "master", "")
@@ -469,8 +466,8 @@ func testFullS3(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey,
 				"aws --endpoint=${S3_ENDPOINT} s3 ls | aws --endpoint=${S3_ENDPOINT} s3 cp - s3://out/s3_buckets",
 			},
 			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     accessKeyID,
-				"AWS_SECRET_ACCESS_KEY": secretAccessKey,
+				"AWS_ACCESS_KEY_ID":     userToken,
+				"AWS_SECRET_ACCESS_KEY": userToken,
 			},
 		},
 		ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -539,19 +536,18 @@ func TestFullS3(t *testing.T) {
 	if userToken == "" {
 		userToken = "abc123"
 	}
-	t.Run("ProjectUnaware", func(t *testing.T) {
-		testFullS3(t, c, userToken, userToken, ns, pfs.DefaultProjectName)
+	t.Run("DefaultProject", func(t *testing.T) {
+		testFullS3(t, c, userToken, ns, pfs.DefaultProjectName)
 	})
-	t.Run("ProjectAware", func(t *testing.T) {
-		accessKeyID := "PAC1" + userToken
+	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testFullS3(t, c, accessKeyID, userToken, ns, projectName)
+		testFullS3(t, c, userToken, ns, projectName)
 	})
 }
 
 // repoBucket returns the bucket name for a repo.
-func testS3SkippedDatums(t *testing.T, c *client.APIClient, accessKeyID, secretAccessKey, ns, projectName string, repoBucket func(project, repo string) string) {
+func testS3SkippedDatums(t *testing.T, c *client.APIClient, userToken, ns, projectName string, repoBucket func(project, repo string) string) {
 	t.Run("S3Inputs", func(t *testing.T) {
 		// TODO(2.0 optional): Duplicate file paths from different datums no longer allowed.
 		t.Skip("Duplicate file paths from different datums no longer allowed.")
@@ -588,8 +584,8 @@ func testS3SkippedDatums(t *testing.T, c *client.APIClient, accessKeyID, secretA
 					"echo \"$(cat /tmp/bg) $(cat /tmp/pfsin) $(cat /tmp/s3in)\" >/pfs/out/out",
 				},
 				Env: map[string]string{
-					"AWS_ACCESS_KEY_ID":     accessKeyID,
-					"AWS_SECRET_ACCESS_KEY": secretAccessKey,
+					"AWS_ACCESS_KEY_ID":     userToken,
+					"AWS_SECRET_ACCESS_KEY": userToken,
 				},
 			},
 			ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -756,8 +752,8 @@ func testS3SkippedDatums(t *testing.T, c *client.APIClient, accessKeyID, secretA
 					"aws --endpoint=${S3_ENDPOINT} s3 cp /tmp/bg s3://out/bg/\"$(cat /tmp/bg)\"",
 				},
 				Env: map[string]string{
-					"AWS_ACCESS_KEY_ID":     accessKeyID,
-					"AWS_SECRET_ACCESS_KEY": secretAccessKey,
+					"AWS_ACCESS_KEY_ID":     userToken,
+					"AWS_SECRET_ACCESS_KEY": userToken,
 				},
 			},
 			ParallelismSpec: &pps.ParallelismSpec{Constant: 1},
@@ -832,13 +828,12 @@ func TestS3SkippedDatums(t *testing.T) {
 	if userToken == "" {
 		userToken = "abc123"
 	}
-	t.Run("ProjectUnaware", func(t *testing.T) {
-		testS3SkippedDatums(t, c, userToken, userToken, ns, pfs.DefaultProjectName, func(p, r string) string { return r })
+	t.Run("DefaultProject", func(t *testing.T) {
+		testS3SkippedDatums(t, c, userToken, ns, pfs.DefaultProjectName, func(p, r string) string { return r })
 	})
-	t.Run("ProjectAware", func(t *testing.T) {
-		accessKeyID := "PAC1" + userToken
+	t.Run("NonDefaultProject", func(t *testing.T) {
 		projectName := tu.UniqueString("project")
 		require.NoError(t, c.CreateProject(projectName))
-		testS3SkippedDatums(t, c, accessKeyID, userToken, ns, projectName, func(p, r string) string { return r + "." + p })
+		testS3SkippedDatums(t, c, userToken, ns, projectName, func(p, r string) string { return r + "." + p })
 	})
 }


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1fZOMtcS0onT2AKjd3qqP9FsssjIa_uvNpJc9oJ1ADI0/edit#heading=h.od8ud5qhgnpc

* Remove meta repos from the S3 gateway
* ListBucket returns exclusively bucket names of the form branch.repo.project (even when branch="master" and project="default")
* Otherwise, preserve backwards compatibility when resolving bucket names (so "s3://repo" and "s3://branch.repo" still resolve correctly as well)