### PR TITLE
Improve TestUpgradeSimple by leveraging OpenCV example

### DIFF
--- a/etc/testing/circle/deploy_test.sh
+++ b/etc/testing/circle/deploy_test.sh
@@ -7,7 +7,7 @@ pachctl config update context "$(pachctl config get active-context)" --pachd-add
 # deploy object storage
 kubectl apply -f etc/testing/minio.yaml
 
-helm repo add pach https://helm.pachyderm.com
+helm repo add pachyderm https://helm.pachyderm.com
 
 helm repo update
 

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	helmChartPublishedPath = "pach/pachyderm"
+	helmChartPublishedPath = "pachyderm/pachyderm"
 	localImage             = "local"
 	licenseKeySecretName   = "enterprise-license-key-secret"
 )


### PR DESCRIPTION
Previously, we found a bug (https://github.com/pachyderm/pachyderm/pull/8513) in the migration code that wasn't caught by our upgrade tests. It was found manually by running OpenCV example locally. 

This PR updates the test to leverage OpenCV so that we can have better coverage.