### PR TITLE
helm: proxy: allow values.yaml to declare the proxy service external traffic policy

### DIFF
--- a/etc/helm/pachyderm/templates/proxy/service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/service.yaml
@@ -16,7 +16,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.proxy.service.type }}
+  {{- if .Values.proxy.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.proxy.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     {{- if .Values.proxy.service.httpPort }}
     - name: http-port

--- a/etc/helm/pachyderm/templates/proxy/service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/service.yaml
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.proxy.service.type }}
+  externalTrafficPolicy: {{ .Values.proxy.service.externalTrafficPolicy }}
   ports:
     {{- if .Values.proxy.service.httpPort }}
     - name: http-port

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -945,6 +945,9 @@ proxy:
       oidc: 0 # legacy 30657
       identity: 0 # legacy 30658
       metrics: 0 # legacy 30656
+    # externalTrafficPolicy determines cluster-wide routing policy; see "kubectl explain
+    # service.spec.externalTrafficPolicy".
+    externalTrafficPolicy: "Cluster"
   # Configuration for TLS (SSL, HTTPS).
   tls:
     # If true, enable TLS serving.  Enabling TLS is incompatible with support for legacy ports (you

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -947,7 +947,7 @@ proxy:
       metrics: 0 # legacy 30656
     # externalTrafficPolicy determines cluster-wide routing policy; see "kubectl explain
     # service.spec.externalTrafficPolicy".
-    externalTrafficPolicy: "Cluster"
+    externalTrafficPolicy: ""
   # Configuration for TLS (SSL, HTTPS).
   tls:
     # If true, enable TLS serving.  Enabling TLS is incompatible with support for legacy ports (you


### PR DESCRIPTION
We have to default to `""` because this field cannot exist on non-NodePort/LoadBalancer services.

This is tracked in CORE-1473.