### PR TITLE
[CORE-1462] re-introduce explicit audit log

### DIFF
--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"reflect"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -168,6 +169,12 @@ func (li *LoggingInterceptor) UnaryServerInterceptor(ctx context.Context, req in
 
 	service, method := parseMethod(info.FullMethod)
 	ctx = getCommonLogger(ctx, service, method)
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok && len(md.Get("command")) > 0 {
+		command := md.Get("command")
+		dolog(ctx, log.InfoLevel, "audit log: %s"+strings.Join(command, ""))
+	}
 
 	// NOTE(jonathan): We use service/method in the log messages so that rate limiting applies
 	// per-RPC instead of for all RPCs.  (Rate limiting algorithm looks at the message and the

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -98,7 +98,11 @@ func getCommonLogger(ctx context.Context, service, method string) context.Contex
 		}
 		if command := md.Get("command"); command != nil {
 			f = append(f, zap.Strings("command", command))
-			log.Info(ctx, "audit log: ", f...)
+			if method != "InspectCluster" {
+				// InspectCluster is called by the client to get the deployment ID, so
+				// we don't want to log that.
+				log.Info(ctx, "audit log", f...)
+			}
 		}
 	}
 	if peer, ok := peer.FromContext(ctx); ok {

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -173,7 +173,7 @@ func (li *LoggingInterceptor) UnaryServerInterceptor(ctx context.Context, req in
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok && len(md.Get("command")) > 0 {
 		command := md.Get("command")
-		dolog(ctx, log.InfoLevel, "audit log: %s"+strings.Join(command, ""))
+		dolog(ctx, log.InfoLevel, "audit log: "+strings.Join(command, ""))
 	}
 
 	// NOTE(jonathan): We use service/method in the log messages so that rate limiting applies

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"reflect"
-	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -99,6 +98,7 @@ func getCommonLogger(ctx context.Context, service, method string) context.Contex
 		}
 		if command := md.Get("command"); command != nil {
 			f = append(f, zap.Strings("command", command))
+			log.Info(ctx, "audit log: ", f...)
 		}
 	}
 	if peer, ok := peer.FromContext(ctx); ok {
@@ -169,12 +169,6 @@ func (li *LoggingInterceptor) UnaryServerInterceptor(ctx context.Context, req in
 
 	service, method := parseMethod(info.FullMethod)
 	ctx = getCommonLogger(ctx, service, method)
-
-	md, ok := metadata.FromIncomingContext(ctx)
-	if ok && len(md.Get("command")) > 0 {
-		command := md.Get("command")
-		dolog(ctx, log.InfoLevel, "audit log: "+strings.Join(command, ""))
-	}
 
 	// NOTE(jonathan): We use service/method in the log messages so that rate limiting applies
 	// per-RPC instead of for all RPCs.  (Rate limiting algorithm looks at the message and the


### PR DESCRIPTION
This PR adds an explicit log line for pachctl commands for audit purposes. This was previously logged as 'user command' before the logging refactor