### PR TITLE
Fix logger generation of pfsserver.*

### DIFF
--- a/etc/proto/protoc-gen-zap/main.go
+++ b/etc/proto/protoc-gen-zap/main.go
@@ -71,6 +71,7 @@ func generateListField(g *protogen.GeneratedFile, f *protogen.Field) {
 		if isPachydermProto(string(f.Desc.Message().FullName())) {
 			g.P("enc.AppendObject(v)")
 		} else {
+			fmt.Fprintf(os.Stderr, "** OBJECT FALLBACK ON %v\n", f.Desc.Message().FullName())
 			g.P("if obj, ok := interface{}(v).(", g.QualifiedGoIdent(zapcorePkg.Ident("ObjectMarshaler")), "); ok {")
 			g.P("enc.AppendObject(obj)")
 			g.P("} else {")
@@ -119,6 +120,7 @@ func generateMapField(g *protogen.GeneratedFile, f *protogen.Field) {
 		if isPachydermProto(string(f.Desc.Message().FullName())) {
 			g.P("enc.AddObject(", g.QualifiedGoIdent(fmtPkg.Ident("Sprintf")), "(\"%v\", k), v)")
 		} else {
+			fmt.Fprintf(os.Stderr, "** OBJECT FALLBACK ON %v\n", f.Desc.Message().FullName())
 			g.P("if obj, ok := interface{}(v).(", g.QualifiedGoIdent(zapcorePkg.Ident("ObjectMarshaler")), "); ok {")
 			g.P("enc.AddObject(", g.QualifiedGoIdent(fmtPkg.Ident("Sprintf")), "(\"%v\", k), obj)")
 			g.P("} else {")
@@ -198,7 +200,7 @@ func generatePrimitiveField(g *protogen.GeneratedFile, f *protogen.Field, opts *
 			if isPachydermProto(string(f.Desc.Message().FullName())) {
 				g.P("enc.AddObject(\"", fname, "\", x.", gname, ")")
 			} else {
-				fmt.Fprintf(os.Stderr, "** FALLBACK ON %v\n", f.Desc.Message().FullName())
+				fmt.Fprintf(os.Stderr, "** OBJECT FALLBACK ON %v\n", f.Desc.Message().FullName())
 
 				g.P("if obj, ok := interface{}(x.", gname, ").(", g.QualifiedGoIdent(zapcorePkg.Ident("ObjectMarshaler")), "); ok {")
 				g.P("enc.AddObject(\"", fname, "\", obj)")
@@ -224,6 +226,7 @@ func isPachydermProto(fullName string) bool {
 	}
 	return strings.HasPrefix(fullName, "datum.") ||
 		strings.HasPrefix(fullName, "pfsload.") ||
+		strings.HasPrefix(fullName, "pfsserver.") ||
 		strings.HasPrefix(fullName, "taskapi.")
 }
 

--- a/src/server/pfs/server/pfsserver.pb.zap.go
+++ b/src/server/pfs/server/pfsserver.pb.zap.go
@@ -19,11 +19,7 @@ func (x *ShardTask) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return nil
 	}
 	enc.AddArray("inputs", zapcore.ArrayMarshalerFunc(inputsArrMarshaller))
-	if obj, ok := interface{}(x.PathRange).(zapcore.ObjectMarshaler); ok {
-		enc.AddObject("path_range", obj)
-	} else {
-		enc.AddReflected("path_range", x.PathRange)
-	}
+	enc.AddObject("path_range", x.PathRange)
 	return nil
 }
 
@@ -33,11 +29,7 @@ func (x *ShardTaskResult) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	}
 	compact_tasksArrMarshaller := func(enc zapcore.ArrayEncoder) error {
 		for _, v := range x.CompactTasks {
-			if obj, ok := interface{}(v).(zapcore.ObjectMarshaler); ok {
-				enc.AppendObject(obj)
-			} else {
-				enc.AppendReflected(v)
-			}
+			enc.AppendObject(v)
 		}
 		return nil
 	}
@@ -65,11 +57,7 @@ func (x *CompactTask) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return nil
 	}
 	enc.AddArray("inputs", zapcore.ArrayMarshalerFunc(inputsArrMarshaller))
-	if obj, ok := interface{}(x.PathRange).(zapcore.ObjectMarshaler); ok {
-		enc.AddObject("path_range", obj)
-	} else {
-		enc.AddReflected("path_range", x.PathRange)
-	}
+	enc.AddObject("path_range", x.PathRange)
 	return nil
 }
 
@@ -108,11 +96,7 @@ func (x *ValidateTask) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return nil
 	}
 	enc.AddString("id", x.Id)
-	if obj, ok := interface{}(x.PathRange).(zapcore.ObjectMarshaler); ok {
-		enc.AddObject("path_range", obj)
-	} else {
-		enc.AddReflected("path_range", x.PathRange)
-	}
+	enc.AddObject("path_range", x.PathRange)
 	return nil
 }
 


### PR DESCRIPTION
I missed this because it only showed up for the array case, which didn't print a warning.  Now all 3 cases (array, map, primitive) print warnings, and pfsserver.* is treated as Object instead of possibly falling back to reflection.

@FahadBSyed I'll rebase and merge after your PutFileURL tasks PR.