### PR TITLE
Grab helm release info out of debug dumps

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -2,11 +2,16 @@ package server
 
 import (
 	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"os"
+	"path"
 	"reflect"
 	"runtime"
 	runtimedebug "runtime/debug"
@@ -19,6 +24,7 @@ import (
 	"github.com/wcharczuk/go-chart"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -174,6 +180,9 @@ func (s *debugServer) handleRedirect(
 				if err := s.collectDatabaseDump(ctx, tw, databasePrefix); err != nil {
 					multierr.AppendInto(&errs, errors.Wrap(err, "collectDatabaseDump"))
 				}
+			}
+			if err := s.helmReleases(ctx, tw); err != nil {
+				multierr.AppendInto(&errs, errors.Wrap(err, "helmReleases"))
 			}
 			return errs
 		})
@@ -1161,4 +1170,147 @@ func redirectDump(ctx context.Context, c debug.DebugClient, filter *debug.Filter
 		return nil, errors.EnsureStack(err)
 	}
 	return grpcutil.NewStreamingBytesReader(dumpC, nil), nil
+}
+
+// handleHelmSecret decodes a helm release secret into its various components.  A returned error
+// should be written into error.txt.
+func handleHelmSecret(ctx context.Context, tw *tar.Writer, secret v1.Secret) error {
+	var errs error
+	name := secret.Name
+	if got, want := string(secret.Type), "helm.sh/release.v1"; got != want {
+		return errors.Errorf("helm-owned secret of unknown version; got %v want %v", got, want)
+	}
+	if secret.Data == nil {
+		log.Debug(ctx, "skipping helm secret with no data", zap.String("secretName", name))
+		return nil
+	}
+	releaseData, ok := secret.Data["release"]
+	if !ok {
+		log.Debug(ctx, "secret data doesn't have a release key", zap.String("secretName", name))
+		return nil
+	}
+
+	// There are a few labels that helm adds that are interesting (the "release
+	// status").  Grab those and write to metadata.json.
+	if err := collectDebugFile(tw, path.Join("helm", name, "metadata"), "json", func(w io.Writer) error {
+		text, err := json.Marshal(secret.ObjectMeta)
+		if err != nil {
+			return errors.Wrap(err, "marshal ObjectMeta")
+		}
+		if _, err := w.Write(text); err != nil {
+			return errors.Wrap(err, "write ObjectMeta json")
+		}
+		return nil
+	}); err != nil {
+		// We can still try to get the release JSON if the metadata doesn't marshal
+		// or write cleanly.
+		multierr.AppendInto(&errs, errors.Wrapf(err, "%v: collect metadata", name))
+	}
+
+	// Get the text of the release and write it to release.json.
+	var releaseJSON []byte
+	if err := collectDebugFile(tw, path.Join("helm", name, "release"), "json", func(w io.Writer) error {
+		// The helm release data is base64-encoded gzipped JSON-marshalled protobuf.
+		// The base64 encoding is IN ADDITION to the base64 encoding that k8s does
+		// when serving secrets through the API; client-go removes that for us.
+		var err error
+		releaseJSON, err = base64.StdEncoding.DecodeString(string(releaseData))
+		if err != nil {
+			releaseJSON = nil
+			return errors.Wrap(err, "decode base64")
+		}
+
+		// Older versions of helm do not compress the data; this check is for the
+		// gzip header; if deteced, decompress.
+		if len(releaseJSON) > 3 && bytes.Equal(releaseJSON[0:3], []byte{0x1f, 0x8b, 0x08}) {
+			gz, err := gzip.NewReader(bytes.NewReader(releaseJSON))
+			if err != nil {
+				return errors.Wrap(err, "create gzip reader")
+			}
+			releaseJSON, err = io.ReadAll(gz)
+			if err != nil {
+				return errors.Wrap(err, "decompress")
+			}
+			if err := gz.Close(); err != nil {
+				return errors.Wrap(err, "close gzip reader")
+			}
+		}
+
+		// Write out the raw release JSON, so fields we don't pick out in the next
+		// phase can be parsed out by the person analyzing the dump if necessary.
+		if _, err := w.Write(releaseJSON); err != nil {
+			return errors.Wrap(err, "write release")
+		}
+		return nil
+	}); err != nil {
+		multierr.AppendInto(&errs, errors.Wrapf(err, "%v: collect release", name))
+		// The next steps need the release JSON, so we have to give up if any of
+		// this failed.  Technically if the write fails, we could continue, but it
+		// doesn't seem worth the effort because the next writes are also likely to
+		// fail.
+		return errs
+	}
+
+	// Unmarshal the release JSON, and start writing files for each interesting part.
+	var release struct {
+		// Config is the merged values.yaml that aren't in the chart.
+		Config map[string]any `json:"config"`
+		// Manifest is the rendered manifest that was applied to the cluster.
+		Manifest string `json:"manifest"`
+	}
+	if err := json.Unmarshal(releaseJSON, &release); err != nil {
+		multierr.AppendInto(&errs, errors.Wrapf(err, "%v: unmarshal release json", name))
+		return errs
+	}
+
+	// Write the manifest YAML.
+	if err := collectDebugFile(tw, path.Join("helm", name, "manifest"), "yaml", func(w io.Writer) error {
+		// Helm adds a newline at the end of the manifest.
+		if _, err := fmt.Fprintf(w, "%s", release.Manifest); err != nil {
+			return errors.Wrap(err, "print manifest")
+		}
+		return nil
+	}); err != nil {
+		multierr.AppendInto(&errs, errors.Wrapf(err, "%v: write manifest.yaml", name))
+		// We can try the next step if this fails.
+	}
+
+	// Write values.yaml.
+	if err := collectDebugFile(tw, path.Join("helm", name, "values"), "yaml", func(w io.Writer) error {
+		b, err := yaml.Marshal(release.Config)
+		if err != nil {
+			return errors.Wrap(err, "marshal values to yaml")
+		}
+		if _, err := w.Write(b); err != nil {
+			return errors.Wrap(err, "print values")
+		}
+		return nil
+	}); err != nil {
+		multierr.AppendInto(&errs, errors.Wrapf(err, "%v: write values.yaml", name))
+	}
+	return errs
+}
+
+func (s *debugServer) helmReleases(ctx context.Context, tw *tar.Writer) (retErr error) {
+	ctx, end := log.SpanContext(ctx, "collectHelmReleases")
+	defer end(log.Errorp(&retErr))
+	// Helm stores release data in secrets by default.  Users can override this by exporting
+	// HELM_DRIVER and using something else, in which case, we won't get anything here.
+	// https://helm.sh/docs/topics/advanced/#storage-backends
+	secrets, err := s.env.GetKubeClient().CoreV1().Secrets(s.env.Config().Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "owner=helm",
+	})
+	if err != nil {
+		return errors.EnsureStack(err)
+	}
+	var writeErrs error
+	for _, secret := range secrets.Items {
+		if err := handleHelmSecret(ctx, tw, secret); err != nil {
+			if err := writeErrorFile(tw, err, path.Join("helm", secret.Name)); err != nil {
+				multierr.AppendInto(&writeErrs, errors.Wrapf(err, "%v: write error.txt", secret.Name))
+				continue
+			}
+		}
+	}
+	return writeErrs
 }

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wcharczuk/go-chart"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1181,12 +1182,12 @@ func handleHelmSecret(ctx context.Context, tw *tar.Writer, secret v1.Secret) err
 		return errors.Errorf("helm-owned secret of unknown version; got %v want %v", got, want)
 	}
 	if secret.Data == nil {
-		log.Debug(ctx, "skipping helm secret with no data", zap.String("secretName", name))
+		log.Info(ctx, "skipping helm secret with no data", zap.String("secretName", name))
 		return nil
 	}
 	releaseData, ok := secret.Data["release"]
 	if !ok {
-		log.Debug(ctx, "secret data doesn't have a release key", zap.String("secretName", name))
+		log.Info(ctx, "secret data doesn't have a release key", zap.String("secretName", name), zap.Strings("keys", maps.Keys(secret.Data)))
 		return nil
 	}
 


### PR DESCRIPTION
This looks for secrets with owner=helm in k8s, which are helm's dump of all "release" metadata.  The debug dumper finds these and extracts some of the data; producing release.json (the full helm release data structure, including the chart YAML, values, version info, etc.), manifest.yaml (the manifest that was applied to the cluster to do the release), and values.yaml (the merged set of values overridden by the user).  I think it's a good start; if we need more stuff we could explicitly extract it.

Each "release" ends up being a directory under helm/<release secret name>.