### PR TITLE
Add the ability to collect code coverage at runtime

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -384,6 +384,8 @@ spec:
         - name: PIPELINE_DEFAULT_STORAGE_REQUEST
           value: {{ .Values.pachd.defaultPipelineStorageRequest | quote }}
         {{- end }}
+        - name: GOCOVERDIR
+          value: /tmp
         envFrom:
           - secretRef:
               name: pachyderm-storage-secret

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -188,9 +188,6 @@ func (s *debugServer) handleRedirect(
 					multierr.AppendInto(&errs, errors.Wrap(err, "collectDatabaseDump"))
 				}
 			}
-			if err := s.helmReleases(ctx, tw); err != nil {
-				multierr.AppendInto(&errs, errors.Wrap(err, "helmReleases"))
-			}
 			return errs
 		})
 	})
@@ -571,6 +568,10 @@ func (s *debugServer) collectPachdDumpFunc(limit int64) collectFunc {
 		defer end(log.Errorp(&retErr))
 
 		var errs error
+		// Collect helm info.
+		if err := s.helmReleases(ctx, tw); err != nil {
+			multierr.AppendInto(&errs, errors.Wrap(err, "helmReleases"))
+		}
 		// Collect input repos.
 		if err := s.collectInputRepos(ctx, tw, pachClient, limit); err != nil {
 			multierr.AppendInto(&errs, errors.Wrap(err, "collectInputRepos"))

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -177,6 +177,9 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 	}, {
 		Name:  log.EnvLogLevel,
 		Value: kd.config.LogLevel,
+	}, {
+		Name:  "GOCOVERDIR",
+		Value: "/tmp",
 	},
 		// These are set explicitly below to prevent kubernetes from setting them to the service host and port.
 		{


### PR DESCRIPTION
Build pachd and the worker like:

```
CGO_ENABLED=0 go1.20rc3 build -cover -covermode=atomic -coverpkg=github.com/pachyderm/pachyderm/v2/... -ldflags '-X github.com/pachyderm/pachyderm/v2/src/version.AdditionalVersion=whatever' ./src/server/cmd/pachd
CGO_ENABLED=0 go1.20rc3 build -cover -covermode=atomic -coverpkg=github.com/pachyderm/pachyderm/v2/... -ldflags '-X github.com/pachyderm/pachyderm/v2/src/version.AdditionalVersion=whatever' ./src/server/cmd/worker
```

and put those into docker images that you deploy.

Then you can run `pachctl debug profile cover /tmp/c.tgz` and extract that into `/tmp/c`.  This will yield a directory tree like:

```
pachd/pachd-65859b958c-p9vn5/pachd/cover/covcounters.5b2b08247cc726a6a6fd90c57f5ac890.1.1675039122302098081
pachd/pachd-65859b958c-p9vn5/pachd/cover/covmeta.5b2b08247cc726a6a6fd90c57f5ac890
pipelines/default/edges/pods/pipeline-default-edges-v4-2f72x/user/cover/covcounters.2a0626c3eb9ca4b5c8dfa1ed6401956c.13.1675039122346637629
pipelines/default/edges/pods/pipeline-default-edges-v4-2f72x/user/cover/covmeta.2a0626c3eb9ca4b5c8dfa1ed6401956c
pipelines/default/edges/pods/pipeline-default-edges-v4-2f72x/storage/cover/covcounters.6fc949d6de26587d9383daa884bc18e3.1.1675039122370750596
pipelines/default/edges/pods/pipeline-default-edges-v4-2f72x/storage/cover/covmeta.6fc949d6de26587d9383daa884bc18e3
pipelines/default/montage/pods/pipeline-default-montage-v1-47lmd/user/cover/covcounters.11653f3987e47e28de96e76577d07c24.13.1675039122493901794
pipelines/default/montage/pods/pipeline-default-montage-v1-47lmd/user/cover/covmeta.11653f3987e47e28de96e76577d07c24
pipelines/default/montage/pods/pipeline-default-montage-v1-47lmd/storage/cover/covcounters.34f138c800006936675d18104be808c5.1.1675039122517518950
pipelines/default/montage/pods/pipeline-default-montage-v1-47lmd/storage/cover/covmeta.34f138c800006936675d18104be808c5
```

In a `cover` directory, like `/tmp/c/pachd/pachd-65859b958c-p9vn5/pachd/cover` in the above dump, run `go1.20rc3 tool covdata textfmt -i . -o /tmp/c/profile.txt`.  In the pachyderm checkout you built from, run `go tool cover -o cover.html -html /tmp/c/profile.txt`.  Then in a browser, view cover.html:

![Capture](https://user-images.githubusercontent.com/2367/215367122-22320b57-123b-48d8-aafe-ffe550dfc6cc.JPG)

