### PR TITLE
Pipeline Jupyter Extension - push/pull SAME metadata from Jupyter notebook

### DIFF
--- a/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
+++ b/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
@@ -19,6 +19,7 @@ import {mockedRequestAPI} from 'utils/testUtils';
 import {MountPlugin} from '../mount';
 import * as requestAPI from '../../../handler';
 import {waitFor} from '@testing-library/react';
+import {INotebookTracker} from '@jupyterlab/notebook';
 
 jest.mock('../../../handler');
 
@@ -43,6 +44,7 @@ describe('mount plugin', () => {
   let factory: IFileBrowserFactory;
   let fileBrowser: FileBrowser;
   let restorer: ILayoutRestorer;
+  let tracker: INotebookTracker;
   const mockRequestAPI = requestAPI as jest.Mocked<typeof requestAPI>;
   beforeEach(() => {
     mockRequestAPI.requestAPI.mockImplementation(mockedRequestAPI(items));
@@ -102,7 +104,7 @@ describe('mount plugin', () => {
           ],
         }),
       );
-    const plugin = new MountPlugin(app, docManager, factory, restorer);
+    const plugin = new MountPlugin(app, docManager, factory, restorer, tracker);
 
     await plugin.ready;
 
@@ -124,7 +126,7 @@ describe('mount plugin', () => {
   });
 
   it('should generate the correct layout', async () => {
-    const plugin = new MountPlugin(app, docManager, factory, restorer);
+    const plugin = new MountPlugin(app, docManager, factory, restorer, tracker);
     expect(plugin.layout.title.caption).toBe('Pachyderm Mount');
     expect(plugin.layout.id).toBe('pachyderm-mount');
     expect(plugin.layout.orientation).toBe('vertical');

--- a/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
+++ b/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
@@ -19,7 +19,7 @@ import {mockedRequestAPI} from 'utils/testUtils';
 import {MountPlugin} from '../mount';
 import * as requestAPI from '../../../handler';
 import {waitFor} from '@testing-library/react';
-import {INotebookTracker} from '@jupyterlab/notebook';
+import {INotebookTracker, NotebookTracker} from '@jupyterlab/notebook';
 
 jest.mock('../../../handler');
 
@@ -70,7 +70,7 @@ describe('mount plugin', () => {
       defaultBrowser: fileBrowser,
       tracker: new WidgetTracker<FileBrowser>({namespace: 'test'}),
     };
-
+    tracker = new NotebookTracker({namespace: 'test'});
     restorer = new LayoutRestorer({
       connector: new StateDB(),
       first: Promise.resolve<void>(void 0),

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import {closeIcon} from '@jupyterlab/ui-components';
 import {usePipeline} from './hooks/usePipeline';
+import {SameMetadata} from '../../types';
 
 type PipelineProps = {
   setShowPipeline: (shouldShow: boolean) => void;
+  saveNotebookMetadata: (metadata: any) => void;
+  metadata: SameMetadata | undefined;
 };
 
 const placeholderInputSpec = `pfs:
@@ -13,7 +16,11 @@ const placeholderInputSpec = `pfs:
 `;
 const placeholderRequirements = './requirements.txt';
 
-const Pipeline: React.FC<PipelineProps> = ({setShowPipeline}) => {
+const Pipeline: React.FC<PipelineProps> = ({
+  setShowPipeline,
+  saveNotebookMetadata,
+  metadata,
+}) => {
   const {
     loading,
     pipelineName,
@@ -25,8 +32,9 @@ const Pipeline: React.FC<PipelineProps> = ({setShowPipeline}) => {
     requirements,
     setRequirements,
     callCreatePipeline,
+    callSavePipeline,
     errorMessage,
-  } = usePipeline();
+  } = usePipeline(metadata, saveNotebookMetadata);
 
   return (
     <div className="pachyderm-mount-pipeline-base">
@@ -53,9 +61,7 @@ const Pipeline: React.FC<PipelineProps> = ({setShowPipeline}) => {
         <button
           data-testid="Pipeline__save"
           className="pachyderm-button-link"
-          onClick={async () => {
-            return;
-          }}
+          onClick={callSavePipeline}
         >
           Save
         </button>

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
@@ -6,9 +6,29 @@ import * as requestAPI from '../../../../../handler';
 import {mockedRequestAPI} from 'utils/testUtils';
 import Pipeline from '../Pipeline';
 jest.mock('../../../../../handler');
+import {SameMetadata} from '../../../types';
 
 describe('PPS screen', () => {
   let setShowPipeline = jest.fn();
+  const saveNotebookMetaData = jest.fn();
+  const md: SameMetadata = {
+    apiVersion: '',
+    environments: {
+      default: {
+        image_tag: '',
+      },
+    },
+    metadata: {
+      name: '',
+    },
+    notebook: {
+      requirements: '',
+    },
+    run: {
+      name: '',
+    },
+  };
+
   const mockRequestAPI = requestAPI as jest.Mocked<typeof requestAPI>;
 
   beforeEach(() => {
@@ -19,7 +39,11 @@ describe('PPS screen', () => {
   describe('spec preview', () => {
     it('proper preview', async () => {
       const {getByTestId, findByTestId} = render(
-        <Pipeline setShowPipeline={setShowPipeline} />,
+        <Pipeline
+          metadata={md}
+          setShowPipeline={setShowPipeline}
+          saveNotebookMetadata={saveNotebookMetaData}
+        />,
       );
 
       const inputPipelineName = await findByTestId(

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -30,18 +30,11 @@ export const usePipeline = (
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
-    console.log('use effect: metadata: ', metadata);
-    setImageName(
-      metadata?.environments.default.image_tag
-        ? metadata?.environments.default.image_tag
-        : '',
-    );
-    setPipelineName(metadata?.metadata.name ? metadata?.metadata.name : '');
-    setRequirements(
-      metadata?.notebook.requirements ? metadata?.notebook.requirements : '',
-    );
+    setImageName(metadata?.environments.default.image_tag ?? '');
+    setPipelineName(metadata?.metadata.name ?? '');
+    setRequirements(metadata?.notebook.requirements ?? '');
     if (metadata?.run.input) {
-      const input = JSON.parse(metadata?.run.input);
+      const input = JSON.parse(metadata?.run.input); //TODO: Catch errors
       setInputSpec(YAML.stringify(input));
     } else {
       setInputSpec('');

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -40,7 +40,12 @@ export const usePipeline = (
     setRequirements(
       metadata?.notebook.requirements ? metadata?.notebook.requirements : '',
     );
-    //TODO Pipeline spec
+    if (metadata?.run.input) {
+      const input = JSON.parse(metadata?.run.input);
+      setInputSpec(YAML.stringify(input));
+    } else {
+      setInputSpec('');
+    }
   }, [metadata]);
 
   const callCreatePipeline = async () => {
@@ -74,6 +79,17 @@ export const usePipeline = (
   };
 
   const callSavePipeline = async () => {
+    let input;
+    try {
+      input = YAML.parse(inputSpec);
+    } catch (e) {
+      if (e instanceof YAML.YAMLParseError) {
+        input = JSON.parse(inputSpec);
+      } else {
+        throw e;
+      }
+    }
+
     const samemeta: SameMetadata = {
       apiVersion: 'sameproject.ml/v1alpha1',
       environments: {
@@ -90,6 +106,7 @@ export const usePipeline = (
       },
       run: {
         name: pipelineName + ' run',
+        input: JSON.stringify(input),
       },
     };
 

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -1,6 +1,7 @@
 import YAML from 'yaml';
 
 import {useEffect, useState} from 'react';
+import {SameMetadata} from '../../../types';
 
 export type usePipelineResponse = {
   loading: boolean;
@@ -13,16 +14,34 @@ export type usePipelineResponse = {
   requirements: string;
   setRequirements: (input: string) => void;
   callCreatePipeline: () => Promise<void>;
+  callSavePipeline: () => void;
   errorMessage: string;
 };
 
-export const usePipeline = (): usePipelineResponse => {
+export const usePipeline = (
+  metadata: SameMetadata | undefined,
+  saveNotebookMetaData: (metadata: any) => void,
+): usePipelineResponse => {
   const [loading, setLoading] = useState(false);
   const [pipelineName, setPipelineName] = useState('');
   const [imageName, setImageName] = useState('');
   const [inputSpec, setInputSpec] = useState('');
   const [requirements, setRequirements] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    console.log('use effect: metadata: ', metadata);
+    setImageName(
+      metadata?.environments.default.image_tag
+        ? metadata?.environments.default.image_tag
+        : '',
+    );
+    setPipelineName(metadata?.metadata.name ? metadata?.metadata.name : '');
+    setRequirements(
+      metadata?.notebook.requirements ? metadata?.notebook.requirements : '',
+    );
+    //TODO Pipeline spec
+  }, [metadata]);
 
   const callCreatePipeline = async () => {
     setLoading(true);
@@ -54,6 +73,30 @@ export const usePipeline = (): usePipelineResponse => {
     setLoading(false);
   };
 
+  const callSavePipeline = async () => {
+    const kalemeta: SameMetadata = {
+      apiVersion: 'sameproject.ml/v1alpha1',
+      environments: {
+        default: {
+          image_tag: imageName,
+        },
+      },
+      metadata: {
+        name: pipelineName,
+        version: '0.0.0',
+      },
+      notebook: {
+        requirements: requirements,
+      },
+      run: {
+        name: pipelineName + ' run',
+      },
+    };
+
+    saveNotebookMetaData(kalemeta);
+    console.log('save pipeline called');
+  };
+
   return {
     loading,
     pipelineName,
@@ -65,6 +108,7 @@ export const usePipeline = (): usePipelineResponse => {
     requirements,
     setRequirements,
     callCreatePipeline,
+    callSavePipeline,
     errorMessage,
   };
 };

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -98,7 +98,7 @@ export const usePipeline = (
         requirements: requirements,
       },
       run: {
-        name: pipelineName + ' run',
+        name: pipelineName,
         input: JSON.stringify(input),
       },
     };

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -74,7 +74,7 @@ export const usePipeline = (
   };
 
   const callSavePipeline = async () => {
-    const kalemeta: SameMetadata = {
+    const samemeta: SameMetadata = {
       apiVersion: 'sameproject.ml/v1alpha1',
       environments: {
         default: {
@@ -93,7 +93,7 @@ export const usePipeline = (
       },
     };
 
-    saveNotebookMetaData(kalemeta);
+    saveNotebookMetaData(samemeta);
     console.log('save pipeline called');
   };
 

--- a/jupyter-extension/src/plugins/mount/index.ts
+++ b/jupyter-extension/src/plugins/mount/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@jupyterlab/application';
 import {IDocumentManager} from '@jupyterlab/docmanager';
 import {IFileBrowserFactory} from '@jupyterlab/filebrowser';
+import {INotebookTracker} from '@jupyterlab/notebook';
 
 import {MountPlugin} from './mount';
 import {IMountPlugin} from './types';
@@ -12,14 +13,20 @@ import {IMountPlugin} from './types';
 const mount: JupyterFrontEndPlugin<IMountPlugin> = {
   id: 'jupyterlab-pachyderm:mount',
   autoStart: true,
-  requires: [IDocumentManager, IFileBrowserFactory, ILayoutRestorer],
+  requires: [
+    IDocumentManager,
+    IFileBrowserFactory,
+    ILayoutRestorer,
+    INotebookTracker,
+  ],
   activate: (
     app: JupyterFrontEnd,
     manager: IDocumentManager,
     factory: IFileBrowserFactory,
     restorer: ILayoutRestorer,
+    tracker: INotebookTracker,
   ): IMountPlugin => {
-    return new MountPlugin(app, manager, factory, restorer);
+    return new MountPlugin(app, manager, factory, restorer, tracker);
   },
 };
 

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ILayoutRestorer, JupyterFrontEnd} from '@jupyterlab/application';
+import {INotebookTracker, NotebookPanel} from '@jupyterlab/notebook';
 import {IDocumentManager} from '@jupyterlab/docmanager';
 import {SplitPanel} from '@lumino/widgets';
 import {ReactWidget, UseSignal} from '@jupyterlab/apputils';
@@ -20,6 +21,7 @@ import {
   PfsInput,
   ListMountsResponse,
   CrossInputSpec,
+  SameMetadata,
 } from './types';
 import Config from './components/Config/Config';
 import Datum from './components/Datum/Datum';
@@ -30,6 +32,8 @@ import FullPageError from './components/FullPageError/FullPageError';
 import {requestAPI} from '../../handler';
 
 export const MOUNT_BROWSER_NAME = 'mount-browser:';
+
+export const METADATA_KEY = 'same_config';
 
 export class MountPlugin implements IMountPlugin {
   private _app: JupyterFrontEnd<JupyterFrontEnd.IShell, 'desktop' | 'mobile'>;
@@ -43,6 +47,7 @@ export class MountPlugin implements IMountPlugin {
   private _mountBrowser: FileBrowser;
   private _poller: PollMounts;
   private _panel: SplitPanel;
+  private _tracker: INotebookTracker;
 
   private _showConfig = false;
   private _showConfigSignal = new Signal<this, boolean>(this);
@@ -58,16 +63,19 @@ export class MountPlugin implements IMountPlugin {
     this,
   );
   private _showPipelineSignal = new Signal<this, boolean>(this);
+  private _showMetadataSignal = new Signal<this, SameMetadata>(this);
 
   constructor(
     app: JupyterFrontEnd,
     manager: IDocumentManager,
     factory: IFileBrowserFactory,
     restorer: ILayoutRestorer,
+    tracker: INotebookTracker,
   ) {
     this._app = app;
     this._poller = new PollMounts('PollMounts');
     this._repoViewInputSpec = {};
+    this._tracker = tracker;
 
     // This is used to detect if the config goes bad (pachd address changes)
     this._poller.configSignal.connect((_, config) => {
@@ -218,7 +226,19 @@ export class MountPlugin implements IMountPlugin {
     this._datum.addClass('pachyderm-mount-datum-wrapper');
 
     this._pipeline = ReactWidget.create(
-      <Pipeline setShowPipeline={this.setShowPipeline} />,
+      <UseSignal signal={this._showMetadataSignal}>
+        {(_, metadata) => {
+          return (
+            <>
+              <Pipeline
+                setShowPipeline={this.setShowPipeline}
+                saveNotebookMetadata={this.saveNotebookMetaData}
+                metadata={metadata}
+              />
+            </>
+          );
+        }}
+      </UseSignal>,
     );
     this._pipeline.addClass('pachyderm-mount-pipeline-wrapper');
 
@@ -239,6 +259,8 @@ export class MountPlugin implements IMountPlugin {
     this._poller.mountedSignal.connect(this.verifyBrowserPath);
     this._poller.mountedSignal.connect(this.refresh);
     this._poller.unmountedSignal.connect(this.refresh);
+
+    this._tracker.currentChanged.connect(this.handleNotebookChanged, this);
 
     this._panel = new SplitPanel();
     this._panel.orientation = 'vertical';
@@ -273,6 +295,49 @@ export class MountPlugin implements IMountPlugin {
     restorer.add(this._panel, 'jupyterlab-pachyderm');
     app.shell.add(this._panel, 'left', {rank: 100});
   }
+
+  getActiveNotebook = (): NotebookPanel | null => {
+    return this._tracker.currentWidget;
+  };
+
+  /**
+   * This handles when a notebook is switched to another notebook.
+   * The parameters are automatically passed from the signal when a switch occurs.
+   */
+  handleNotebookChanged = async (
+    tracker: INotebookTracker,
+    notebook: NotebookPanel | null,
+  ): Promise<void> => {
+    // Set the current notebook and wait for the session to be ready
+    if (notebook) {
+      await notebook.sessionContext.ready;
+      console.log('notebook changed! notebook', notebook);
+      const md = notebook?.model?.metadata.get(METADATA_KEY);
+      console.log('metadata:', md);
+
+      this._showMetadataSignal.emit(md as SameMetadata);
+      await Promise.resolve();
+    } else {
+      //await this.setNotebookPanel(null);
+      console.log('notebook changed, no notebook');
+      await Promise.resolve();
+    }
+  };
+
+  getNotebookMetadata = (notebook: NotebookPanel | null): any | null => {
+    return notebook?.model?.metadata.get(METADATA_KEY);
+  };
+
+  saveNotebookMetaData = (value: any): void => {
+    const currentNotebook = this.getActiveNotebook();
+
+    if (currentNotebook !== null) {
+      currentNotebook?.model?.metadata.set(METADATA_KEY, value);
+      console.log('notebook metadata saved');
+    } else {
+      console.log('No active notebook');
+    }
+  };
 
   open = (path: string): void => {
     this._app.commands.execute('filebrowser:open-path', {

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -227,17 +227,15 @@ export class MountPlugin implements IMountPlugin {
 
     this._pipeline = ReactWidget.create(
       <UseSignal signal={this._showMetadataSignal}>
-        {(_, metadata) => {
-          return (
-            <>
-              <Pipeline
-                setShowPipeline={this.setShowPipeline}
-                saveNotebookMetadata={this.saveNotebookMetaData}
-                metadata={metadata}
-              />
-            </>
-          );
-        }}
+        {(_, metadata) => (
+          <>
+            <Pipeline
+              setShowPipeline={this.setShowPipeline}
+              saveNotebookMetadata={this.saveNotebookMetaData}
+              metadata={metadata}
+            />
+          </>
+        )}
       </UseSignal>,
     );
     this._pipeline.addClass('pachyderm-mount-pipeline-wrapper');
@@ -311,15 +309,11 @@ export class MountPlugin implements IMountPlugin {
     // Set the current notebook and wait for the session to be ready
     if (notebook) {
       await notebook.sessionContext.ready;
-      console.log('notebook changed! notebook', notebook);
       const md = notebook?.model?.metadata.get(METADATA_KEY);
-      console.log('metadata:', md);
 
       this._showMetadataSignal.emit(md as SameMetadata);
       await Promise.resolve();
     } else {
-      //await this.setNotebookPanel(null);
-      console.log('notebook changed, no notebook');
       await Promise.resolve();
     }
   };
@@ -328,11 +322,11 @@ export class MountPlugin implements IMountPlugin {
     return notebook?.model?.metadata.get(METADATA_KEY);
   };
 
-  saveNotebookMetaData = (value: any): void => {
+  saveNotebookMetaData = (metadata: any): void => {
     const currentNotebook = this.getActiveNotebook();
 
     if (currentNotebook !== null) {
-      currentNotebook?.model?.metadata.set(METADATA_KEY, value);
+      currentNotebook?.model?.metadata.set(METADATA_KEY, metadata);
       console.log('notebook metadata saved');
     } else {
       console.log('No active notebook');

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -114,5 +114,5 @@ export type SameNotebookMetadata = {
 
 export type SameRunMetadata = {
   name: string;
-  // Input spec?
+  input?: string;
 };

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -114,5 +114,5 @@ export type SameNotebookMetadata = {
 
 export type SameRunMetadata = {
   name: string;
-  input?: string;
+  input?: string; //Note: SAME doesn't actually read this field when reading from the notebook and instead inspects you to pass it on the command line
 };

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -114,5 +114,5 @@ export type SameNotebookMetadata = {
 
 export type SameRunMetadata = {
   name: string;
-  input?: string; //Note: SAME doesn't actually read this field when reading from the notebook and instead inspects you to pass it on the command line
+  input?: string; //Note: SAME doesn't actually read this field when reading from the notebook and instead expects you to pass it on the command line
 };

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -85,3 +85,34 @@ export interface IMountPlugin {
   layout: SplitPanel;
   ready: Promise<void>;
 }
+
+export type SameMetadata = {
+  apiVersion: string;
+  environments: SameEnv;
+  metadata: SameMetaMetadata;
+  notebook: SameNotebookMetadata;
+  run: SameRunMetadata;
+};
+
+export type SameEnv = {
+  default: DefaultSameEnv;
+};
+
+export type DefaultSameEnv = {
+  image_tag: string;
+};
+export type SameMetaMetadata = {
+  labels?: string[];
+  name: string;
+  version?: string;
+};
+
+export type SameNotebookMetadata = {
+  // Note: name and path are filled in when you pass the notebook to SAME
+  requirements: string;
+};
+
+export type SameRunMetadata = {
+  name: string;
+  // Input spec?
+};


### PR DESCRIPTION
TODO
- [x] Solve no metadata found on initial load problem
- [x] Pull notebook metadata code out of pipeline component (should be responsibility of container to read metadata)
- [x] Distinguish between no notebook in focus and no notebook metadata. 
- [x] Fix Tests - initialize tracker?
- [x] Wire up input spec
- [x] PR Cleanup
  - [x] Remove async from `handleNotebookChanged`? - Need sync to wait for NB metadata
  - [x] Remove extraneous logging

future work
- [ ] Warn on dirty/changed metadata before switching notebooks tabs (or just autosave?)
- [ ] Make save in sidebar save notebook?
- [ ] set configuration to blank when switching to a non notebook tab (ie a console tab)
- [ ] [Run pipeline] Notebook dirty tracking - warn when you attempt to run a pipeline from non saved notebook
- [ ] handle JSON/YAML parsing more gracefully
- [ ] Unit Testing 

future experiment
- [ ] Change pipeline component UseSignal to set props directly - What about bidirectional info flow?