### PR TITLE
helm: allow loki internal comms to use large message sizes

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -233,6 +233,11 @@ loki-stack:
       nodeSelector: {}
       tolerations: []
     config:
+      server:
+        grpc_server_max_recv_msg_size: 67108864 # 64MiB
+      query_scheduler:
+        grpc_client_config:
+          max_send_msg_size: 67108864 # 64MiB
       limits_config:
         retention_period: 24h
         retention_stream:


### PR DESCRIPTION
This is necessary when 1000 lines don't fit in its internal grpc max message size; a common occurrence. 

Here is a pipeline that will produce logs that break loki:

```json
{
    "pipeline": {
        "name": "longlogs"
    },
    "input": {
        "pfs": {
            "glob": "/*",
            "repo": "logs"
        }
    },
    "transform": {
        "cmd": ["sh"],
        "stdin": [
            "echo LOTS OF LOGS",
            "for i in `seq 1 10`; do dd if=/dev/urandom bs=1M count=1 of=/dev/stdout  2>/dev/null | base64 -w 0; echo; done",
            "cp -av /pfs/logs/* /pfs/out"
        ]
    }
}
```
Without this change, a debug dump will not have loki logs for this pipeline.  With this change, it will.

This is part of CORE-1499.