### PR TITLE
[2.5.x][CORE-1495] helm: allow loki internal comms to use large message sizes; necessary…

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -233,6 +233,11 @@ loki-stack:
       nodeSelector: {}
       tolerations: []
     config:
+      server:
+        grpc_server_max_recv_msg_size: 67108864 # 64MiB
+      query_scheduler:
+        grpc_client_config:
+          max_send_msg_size: 67108864 # 64MiB
       limits_config:
         retention_period: 24h
         retention_stream:


### PR DESCRIPTION
… for debug dumps when long log lines are present (#8583)

porting https://github.com/pachyderm/pachyderm/pull/8583 to 2.5.x