### PR TITLE
[PFS-57] Propagate pachw in sidecar variable to sidecars.

### DIFF
--- a/src/internal/serviceenv/config.go
+++ b/src/internal/serviceenv/config.go
@@ -28,7 +28,7 @@ type GlobalConfiguration struct {
 	LokiPort                       string `env:"LOKI_SERVICE_PORT"`
 	OidcPort                       uint16 `env:"OIDC_PORT,default=1657"`
 	IsPachw                        bool   `env:"IS_PACHW,default=false"`
-	PachwInSidecars                bool   `env:"PACHW_IN_SIDECARS,default=false"`
+	PachwInSidecars                bool   `env:"PACHW_IN_SIDECARS,default=true"`
 	PachwMinReplicas               int    `env:"PACHW_MIN_REPLICAS"`
 	PachwMaxReplicas               int    `env:"PACHW_MAX_REPLICAS,default=1"`
 	PGBouncerHost                  string `env:"PG_BOUNCER_HOST,required"`

--- a/src/server/pfs/server/compaction.go
+++ b/src/server/pfs/server/compaction.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	"go.uber.org/zap"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
-	"go.uber.org/zap"
 )
 
 // TODO: Move fan-in configuration to fileset.Storage.
@@ -228,6 +229,7 @@ func (c *compactor) Validate(ctx context.Context, taskDoer task.Doer, id fileset
 }
 
 func compactionWorker(ctx context.Context, taskSource task.Source, storage *fileset.Storage) error {
+	log.Info(ctx, "running compaction worker")
 	return backoff.RetryUntilCancel(ctx, func() error {
 		err := taskSource.Iterate(ctx, func(ctx context.Context, input *types.Any) (*types.Any, error) {
 			switch {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -201,6 +201,9 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 			},
 		},
 	}, {
+		Name:  "PACHW_IN_SIDECARS",
+		Value: strconv.FormatBool(kd.config.PachwInSidecars),
+	}, {
 		Name:  "GC_PERCENT",
 		Value: strconv.FormatInt(int64(kd.config.GCPercent), 10),
 	}}


### PR DESCRIPTION
This PR actually propagates the `PACHW_IN_SIDECARS` environment variable down to the pipeline workers, which is needed before the `sidecarBuilders` instantiate the PFS instances.

```
$ kubectl logs default-edges-v1-9szqh -c storage | grep compaction
{"severity":"info","time":"2023-02-20T17:22:55.4582062Z","logger":"serviceenv.PFS","caller":"server/compaction.go:232","message":"running compaction worker"}

$ kubectl get pods default-edges-v1-9szqh -o yaml | grep IN_SIDE -A 3
    - name: PACHW_IN_SIDECARS
      value: "true"
```