### PR TITLE
pachctl: add "misc" section to pachctl for random tools; add some network tools

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -33,6 +33,7 @@ import (
 	enterprisecmds "github.com/pachyderm/pachyderm/v2/src/server/enterprise/cmds"
 	identitycmds "github.com/pachyderm/pachyderm/v2/src/server/identity/cmds"
 	licensecmds "github.com/pachyderm/pachyderm/v2/src/server/license/cmds"
+	misccmds "github.com/pachyderm/pachyderm/v2/src/server/misc/cmds"
 	pfscmds "github.com/pachyderm/pachyderm/v2/src/server/pfs/cmds"
 	ppscmds "github.com/pachyderm/pachyderm/v2/src/server/pps/cmds"
 	txncmds "github.com/pachyderm/pachyderm/v2/src/server/transaction/cmds"
@@ -856,6 +857,7 @@ This resets the cluster to its initial state.`,
 	subcommands = append(subcommands, configcmds.Cmds()...)
 	subcommands = append(subcommands, configcmds.ConnectCmds()...)
 	subcommands = append(subcommands, taskcmds.Cmds()...)
+	subcommands = append(subcommands, misccmds.Cmds()...)
 
 	cmdutil.MergeCommands(rootCmd, subcommands)
 

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -35,6 +35,9 @@ func Cmds() []*cobra.Command {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.DialContext = d.DialContext
 	t.TLSClientConfig.VerifyConnection = func(cs tls.ConnectionState) error {
+		for _, cert := range cs.PeerCertificates {
+			fmt.Printf("tls: cert: %v\n", cert.Subject.String())
+		}
 		fmt.Printf("tls: server name: %v\n", cs.ServerName)
 		fmt.Printf("tls: negotiated protocol: %v\n", cs.NegotiatedProtocol)
 		fmt.Println()

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -1,0 +1,107 @@
+package cmds
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"syscall"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
+	"github.com/spf13/cobra"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+func Cmds() []*cobra.Command {
+	var commands []*cobra.Command
+
+	var d net.Dialer
+	d.ControlContext = func(ctx context.Context, network, address string, c syscall.RawConn) error {
+		log.Debug(ctx, "ControlContext", zap.String("network", network), zap.String("address", address))
+		return nil
+	}
+	r := new(net.Resolver)
+	d.Resolver = r
+	r.Dial = func(ctx context.Context, network, address string) (_ net.Conn, retErr error) {
+		defer log.Span(ctx, "DialDNS", zap.String("network", network), zap.String("address", address))(log.Errorp(&retErr))
+		return d.DialContext(ctx, network, address) //nolint:wrapcheck
+	}
+
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = d.DialContext
+	hc := &http.Client{
+		Transport: promutil.InstrumentRoundTripper("pachctl", t),
+	}
+
+	dnsLookup := &cobra.Command{
+		Use:   "{{alias}} <hostname>",
+		Short: "Do a DNS lookup on a hostname.",
+		Long:  "Do a DNS lookup on a hostname.",
+		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
+			ctx := pctx.Background("")
+			var errs error
+			if result, err := r.LookupHost(ctx, args[0]); err != nil {
+				multierr.AppendInto(&errs, errors.Wrap(err, "lookup host"))
+			} else {
+				fmt.Printf("A: %v\n", result)
+			}
+			if result, err := r.LookupCNAME(ctx, args[0]); err != nil {
+				multierr.AppendInto(&errs, errors.Wrap(err, "lookup cname"))
+			} else {
+				fmt.Printf("CNAME: %v\n", result)
+			}
+			if result, err := r.LookupAddr(ctx, args[0]); err != nil {
+				multierr.AppendInto(&errs, errors.Wrap(err, "lookup reverse address"))
+			} else {
+				fmt.Printf("IP: %v\n", result)
+			}
+			if errs != nil {
+				fmt.Printf("\nDo not be alarmed by the below errors; some lookups are expected to fail.\n")
+			}
+			return errs
+		}),
+	}
+	commands = append(commands, cmdutil.CreateAlias(dnsLookup, "misc dns-lookup"))
+
+	httpHead := &cobra.Command{
+		Use:   "{{alias}} <url>",
+		Short: "Make an HTTP HEAD request.",
+		Long:  "Make an HTTP HEAD request.",
+		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
+			ctx := pctx.Background("")
+			req, err := http.NewRequestWithContext(ctx, "HEAD", args[0], nil)
+			if err != nil {
+				return errors.Wrap(err, "NewRequest")
+			}
+			if content, err := httputil.DumpRequestOut(req, false); err == nil {
+				fmt.Printf("%s", content)
+			}
+			res, err := hc.Do(req)
+			if res != nil {
+				defer res.Body.Close()
+				if content, err := httputil.DumpResponse(res, true); err == nil {
+					fmt.Printf("%s", content)
+				}
+			}
+			if err != nil {
+				return errors.Wrap(err, "Do")
+			}
+			return nil
+		}),
+	}
+	commands = append(commands, cmdutil.CreateAlias(httpHead, "misc http-head"))
+
+	misc := &cobra.Command{
+		Short:  "Miscellaneous utilities unrelated to Pachyderm itself.",
+		Long:   "Miscellaneous utilities unrelated to Pachyderm itself.",
+		Hidden: true,
+	}
+	commands = append(commands, cmdutil.CreateAlias(misc, "misc"))
+	return commands
+}

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"os"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -67,9 +68,12 @@ func Cmds() []*cobra.Command {
 				fmt.Printf("IP: %v\n", result)
 			}
 			if errs != nil {
-				fmt.Printf("\nDo not be alarmed by the below errors; some lookups are expected to fail.\n")
+				fmt.Fprintf(os.Stderr, "some lookups not successful, this is normally fine:\n")
+				for _, err := range multierr.Errors(errs) {
+					fmt.Fprintf(os.Stderr, "    %v\n", err)
+				}
 			}
-			return errs
+			return nil
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(dnsLookup, "misc dns-lookup"))

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
-	"syscall"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -23,14 +22,7 @@ func Cmds() []*cobra.Command {
 	var commands []*cobra.Command
 
 	var d net.Dialer
-	d.ControlContext = func(ctx context.Context, network, address string, c syscall.RawConn) error {
-		var fd uintptr
-		c.Control(func(f uintptr) {
-			fd = f
-		})
-		log.Debug(ctx, "created socket for connection", zap.String("network", network), zap.String("address", address), zap.Any("rawConn", c), zap.String("rawConn.type", fmt.Sprintf("%T", c)), zap.Uintptr("fd", fd))
-		return nil
-	}
+	setupControl(&d)
 
 	r := new(net.Resolver)
 	d.Resolver = r

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -117,7 +117,7 @@ func Cmds() []*cobra.Command {
 				return errors.Wrap(err, "Dial")
 			}
 			fmt.Printf("OK: %s -> %s\n", conn.LocalAddr(), conn.RemoteAddr())
-			return conn.Close()
+			return errors.Wrap(conn.Close(), "Close")
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(dial, "misc dial"))

--- a/src/server/misc/cmds/cmds_1.20.go
+++ b/src/server/misc/cmds/cmds_1.20.go
@@ -15,9 +15,7 @@ import (
 func setupControl(d *net.Dialer) {
 	d.ControlContext = func(ctx context.Context, network, address string, c syscall.RawConn) error {
 		var fd uintptr
-		c.Control(func(f uintptr) {
-			fd = f
-		})
+		c.Control(func(f uintptr) { fd = f }) //nolint:errcheck
 		log.Debug(ctx, "created socket for connection", zap.String("network", network), zap.String("address", address), zap.Any("rawConn", c), zap.String("rawConn.type", fmt.Sprintf("%T", c)), zap.Uintptr("fd", fd))
 		return nil
 	}

--- a/src/server/misc/cmds/cmds_1.20.go
+++ b/src/server/misc/cmds/cmds_1.20.go
@@ -1,0 +1,24 @@
+//go:build go1.20
+
+package cmds
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"go.uber.org/zap"
+)
+
+func setupControl(d *net.Dialer) {
+	d.ControlContext = func(ctx context.Context, network, address string, c syscall.RawConn) error {
+		var fd uintptr
+		c.Control(func(f uintptr) {
+			fd = f
+		})
+		log.Debug(ctx, "created socket for connection", zap.String("network", network), zap.String("address", address), zap.Any("rawConn", c), zap.String("rawConn.type", fmt.Sprintf("%T", c)), zap.Uintptr("fd", fd))
+		return nil
+	}
+}

--- a/src/server/misc/cmds/cmds_non1.20.go
+++ b/src/server/misc/cmds/cmds_non1.20.go
@@ -1,0 +1,9 @@
+//go:build !go1.20
+
+package cmds
+
+import (
+	"net"
+)
+
+func setupControl(d *net.Dialer) {}


### PR DESCRIPTION
This adds `pachctl misc`, and is hidden by default.

```
$ pachctl misc help
Miscellaneous utilities unrelated to Pachyderm itself.  These utilities can be removed or changed in minor releases; do not rely on them.

Usage:
  pachctl misc [command]

Available Commands:
  dial        Dials a network server and then disconnects.
  dns-lookup  Do a DNS lookup on a hostname.
  http-head   Make an HTTP HEAD request.

Flags:
  -h, --help   help for misc

Global Flags:
      --no-color   Turn off colors.
  -v, --verbose    Output verbose logs
```


`pachctl misc dial`: to dial a network address and print debugging info:

```
$ pachctl misc dial tcp 192.168.1.1:53 -v
2023-02-20T18:19:48.523-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "tcp4", "address": "192.168.1.1:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 9}
OK: 192.168.1.70:54588 -> 192.168.1.1:53
```

`pachctl misc dns-lookup`: to lookup a host using go's DNS stack:
```
$ pachctl misc dns-lookup dns.google. -v
2023-02-20T18:21:00.048-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.999976399s"}
2023-02-20T18:21:00.048-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 9}
2023-02-20T18:21:00.048-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.999996599s"}
2023-02-20T18:21:00.048-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "93.402µs"}
2023-02-20T18:21:00.048-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 10}
2023-02-20T18:21:00.048-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "45.201µs"}
A: [2001:4860:4860::8888 2001:4860:4860::8844 8.8.4.4 8.8.8.8]
2023-02-20T18:21:00.078-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.9999803s"}
2023-02-20T18:21:00.078-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 9}
2023-02-20T18:21:00.078-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "85.902µs"}
2023-02-20T18:21:00.078-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.9999976s"}
2023-02-20T18:21:00.078-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.9999942s"}
2023-02-20T18:21:00.078-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 10}
2023-02-20T18:21:00.078-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 11}
2023-02-20T18:21:00.078-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "69.902µs"}
2023-02-20T18:21:00.078-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "103.503µs"}
CNAME: dns.google.

Do not be alarmed by the below errors; some lookups are expected to fail.
lookup reverse address: lookup dns.google.: unrecognized address
```
`pachctl misc http-head` to perform an HTTP HEAD request:
```
$ pachctl misc http-head http://jrock.us -v
HEAD / HTTP/1.1
Host: jrock.us
User-Agent: Go-http-client/1.1

2023-02-20T18:21:51.003-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.9999925s"}
2023-02-20T18:21:51.004-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 9}
2023-02-20T18:21:51.004-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "105.203µs"}
2023-02-20T18:21:51.003-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.999970699s"}
2023-02-20T18:21:51.004-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 10}
2023-02-20T18:21:51.004-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "127.903µs"}
2023-02-20T18:21:51.083-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "tcp4", "address": "206.189.254.193:80", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 9}
2023-02-20T18:21:51.123-0500    DEBUG   outgoingHttp    promutil/promutil.go:66 outgoing http request complete  {"name": "pachctl", "method": "HEAD", "uri": "http://jrock.us", "duration": "120.109737ms", "status": "301 Moved Permanently"}
2023-02-20T18:21:51.123-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.9999956s"}
2023-02-20T18:21:51.123-0500    DEBUG   DialDNS cmds/cmds.go:38 DialDNS: span start     {"network": "udp", "address": "8.8.8.8:53", "timeout": "4.9999943s"}
2023-02-20T18:21:51.123-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 10}
2023-02-20T18:21:51.123-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "udp4", "address": "8.8.8.8:53", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 11}
2023-02-20T18:21:51.123-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "118.603µs"}
2023-02-20T18:21:51.123-0500    DEBUG   DialDNS cmds/cmds.go:39 DialDNS: span finished ok       {"network": "udp", "address": "8.8.8.8:53", "spanDuration": "81.902µs"}
2023-02-20T18:21:51.169-0500    DEBUG   cmds/cmds.go:31 created socket for connection   {"network": "tcp4", "address": "206.189.254.193:443", "rawConn": {}, "rawConn.type": "*net.rawConn", "fd": 10}
tls: server name: jrock.us
tls: negotiated protocol: h2

2023-02-20T18:21:51.246-0500    DEBUG   outgoingHttp    promutil/promutil.go:66 outgoing http request complete  {"name": "pachctl", "method": "HEAD", "uri": "https://jrock.us/", "duration": "122.753903ms", "status": "200 OK"}
HTTP/2.0 200 OK
Content-Length: 2403
Accept-Ranges: bytes
Content-Type: text/html
Date: Mon, 20 Feb 2023 23:21:51 GMT
Etag: "619c7d76-963"
Last-Modified: Tue, 23 Nov 2021 05:34:46 GMT
Server: envoy
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
X-Envoy-Upstream-Service-Time: 0
X-Pod: envoy-86f799c4c8-m6jnz
X-Ratelimit-Limit: 120, 120;w=60
X-Ratelimit-Remaining: 119
X-Ratelimit-Reset: 9
```
```