### PR TITLE
Backport CORE-1507 list datum fix to 2.5.x

### DIFF
--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -522,6 +522,14 @@ each datum.`,
 				if err != nil {
 					return err
 				}
+				if err := pps.VisitInput(request.Input, func(i *pps.Input) error {
+					if i.Pfs != nil && i.Pfs.Project == "" {
+						i.Pfs.Project = project
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
 				return client.ListDatumInput(request.Input, printF)
 			} else if len(args) == 1 {
 				job, err := cmdutil.ParseJob(project, args[0])


### PR DESCRIPTION
This fixes the broken behaviour of list datum from file, where a user does not provid the project in the PPS Input section, and we wrongly infer the default project. Now, we use the current project in the local context to infer the project.

Solves CORE-1507, which unblocks the 2.5 release GA release.