### PR TITLE
Djanicek/core 1481/debug fix

### DIFF
--- a/src/internal/pachd/pachw.go
+++ b/src/internal/pachd/pachw.go
@@ -50,6 +50,7 @@ func (pachwb *pachwBuilder) registerAuthServer(ctx context.Context) error {
 		auth.RegisterAPIServer(s, apiServer)
 	})
 	pachwb.env.SetAuthServer(apiServer)
+	pachwb.enterpriseEnv.AuthServer = apiServer
 	return nil
 }
 
@@ -83,9 +84,9 @@ func (pachwb *pachwBuilder) buildAndRun(ctx context.Context) error {
 		pachwb.initKube,
 		pachwb.setupDB,
 		pachwb.initInternalServer,
+		pachwb.registerEnterpriseServer,
 		pachwb.registerAuthServer,
 		pachwb.registerPFSServer, //PFS seems to need a non-nil auth server.
-		pachwb.registerEnterpriseServer,
 		pachwb.registerTransactionServer,
 		pachwb.registerHealthServer,
 		pachwb.resumeHealth,

--- a/src/internal/pachd/pachw.go
+++ b/src/internal/pachd/pachw.go
@@ -44,7 +44,7 @@ func (pachwb *pachwBuilder) registerPFSServer(ctx context.Context) error {
 func (pachwb *pachwBuilder) registerAuthServer(ctx context.Context) error {
 	apiServer, err := authserver.NewAuthServer(
 		authserver.EnvFromServiceEnv(pachwb.env, pachwb.txnEnv),
-		true, !pachwb.daemon.criticalServersOnly, false,
+		false, !pachwb.daemon.criticalServersOnly, false,
 	)
 	if err != nil {
 		return err
@@ -72,9 +72,7 @@ func (pachwb *pachwBuilder) registerEnterpriseServer(ctx context.Context) error 
 	pachwb.forGRPCServer(func(s *grpc.Server) {
 		enterprise.RegisterAPIServer(s, apiServer)
 	})
-	// pachwb.bootstrappers = append(pachwb.bootstrappers, apiServer)
 	pachwb.env.SetEnterpriseServer(apiServer)
-	// pachwb.licenseEnv.EnterpriseServer = apiServer
 	return nil
 }
 
@@ -105,7 +103,6 @@ func (pachwb *pachwBuilder) buildAndRun(ctx context.Context) error {
 		pachwb.initInternalServer,
 		pachwb.registerAuthServer,
 		pachwb.registerPFSServer, //PFS seems to need a non-nil auth server.
-		pachwb.registerPPSServer,
 		pachwb.registerEnterpriseServer,
 		pachwb.registerTransactionServer,
 		pachwb.registerHealthServer,

--- a/src/internal/pachd/pachw.go
+++ b/src/internal/pachd/pachw.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
-	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
-	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
-	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
 	eprsserver "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
@@ -73,21 +70,6 @@ func (pachwb *pachwBuilder) registerEnterpriseServer(ctx context.Context) error 
 		enterprise.RegisterAPIServer(s, apiServer)
 	})
 	pachwb.env.SetEnterpriseServer(apiServer)
-	return nil
-}
-
-func (pachwb *pachwBuilder) setupDB(ctx context.Context) error {
-	// TODO: currently all pachds attempt to apply migrations, we should coordinate this
-	if err := dbutil.WaitUntilReady(ctx, pachwb.env.GetDBClient()); err != nil {
-		return err
-	}
-	// if err := migrations.ApplyMigrations(ctx, b.env.GetDBClient(), migrations.MakeEnv(nil, b.env.GetEtcdClient()), clusterstate.DesiredClusterState); err != nil {
-	// 	return err
-	// }
-	if err := migrations.BlockUntil(ctx, pachwb.env.GetDBClient(), clusterstate.DesiredClusterState); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -351,7 +351,7 @@ func (env *NonblockingServiceEnv) initDirectDBClient(ctx context.Context) error 
 func (env *NonblockingServiceEnv) initDBClient(ctx context.Context) error {
 	ctx, end := log.SpanContext(ctx, "initDBClient")
 	defer end()
-
+	time.Sleep(2 * time.Second)
 	db, err := dbutil.NewDB(
 		dbutil.WithHostPort(env.config.PGBouncerHost, env.config.PGBouncerPort),
 		dbutil.WithDBName(env.config.PostgresDBName),

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -351,7 +351,7 @@ func (env *NonblockingServiceEnv) initDirectDBClient(ctx context.Context) error 
 func (env *NonblockingServiceEnv) initDBClient(ctx context.Context) error {
 	ctx, end := log.SpanContext(ctx, "initDBClient")
 	defer end()
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 	db, err := dbutil.NewDB(
 		dbutil.WithHostPort(env.config.PGBouncerHost, env.config.PGBouncerPort),
 		dbutil.WithDBName(env.config.PostgresDBName),

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -351,7 +351,7 @@ func (env *NonblockingServiceEnv) initDirectDBClient(ctx context.Context) error 
 func (env *NonblockingServiceEnv) initDBClient(ctx context.Context) error {
 	ctx, end := log.SpanContext(ctx, "initDBClient")
 	defer end()
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 	db, err := dbutil.NewDB(
 		dbutil.WithHostPort(env.config.PGBouncerHost, env.config.PGBouncerPort),
 		dbutil.WithDBName(env.config.PostgresDBName),

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -351,7 +351,6 @@ func (env *NonblockingServiceEnv) initDirectDBClient(ctx context.Context) error 
 func (env *NonblockingServiceEnv) initDBClient(ctx context.Context) error {
 	ctx, end := log.SpanContext(ctx, "initDBClient")
 	defer end()
-	time.Sleep(5 * time.Second)
 	db, err := dbutil.NewDB(
 		dbutil.WithHostPort(env.config.PGBouncerHost, env.config.PGBouncerPort),
 		dbutil.WithDBName(env.config.PostgresDBName),

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -351,7 +351,7 @@ func (env *NonblockingServiceEnv) initDirectDBClient(ctx context.Context) error 
 func (env *NonblockingServiceEnv) initDBClient(ctx context.Context) error {
 	ctx, end := log.SpanContext(ctx, "initDBClient")
 	defer end()
-	time.Sleep(10 * time.Second)
+	time.Sleep(3 * time.Second)
 	db, err := dbutil.NewDB(
 		dbutil.WithHostPort(env.config.PGBouncerHost, env.config.PGBouncerPort),
 		dbutil.WithDBName(env.config.PostgresDBName),

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -83,7 +83,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 	// We use a long pipeline name (gt 64 chars) to test whether our auth tokens,
 	// which originally had a 64 limit, can handle the upgrade which adds the project names to the subject key.
 	montage := montageRepo + "01234567890123456789012345678901234567890"
-	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) { /* preUpgrade */
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			require.NoError(t, c.CreateProjectRepo(pfs.DefaultProjectName, imagesRepo))
@@ -194,7 +194,7 @@ validator:
     count: 1
 `
 	var stateID string
-	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) {
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			t.Log("before upgrade: starting load test")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -58,7 +58,7 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 				k,
 				&minikubetestenv.DeployOpts{
 					WaitSeconds:  0,
-					CleanupAfter: true,
+					CleanupAfter: false,
 					PortOffset:   portOffset,
 				}))
 			t.Logf("postUpgrade done")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -83,7 +83,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 	// We use a long pipeline name (gt 64 chars) to test whether our auth tokens,
 	// which originally had a 64 limit, can handle the upgrade which adds the project names to the subject key.
 	montage := montageRepo + "01234567890123456789012345678901234567890"
-	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) { /* preUpgrade */
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			require.NoError(t, c.CreateProjectRepo(pfs.DefaultProjectName, imagesRepo))

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -57,9 +57,7 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 				ns,
 				k,
 				&minikubetestenv.DeployOpts{
-					WaitSeconds:  0,
-					CleanupAfter: false,
-					PortOffset:   portOffset,
+					PortOffset: portOffset,
 				}))
 			t.Logf("postUpgrade done")
 		})

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -194,7 +194,7 @@ validator:
     count: 1
 `
 	var stateID string
-	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) {
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			t.Log("before upgrade: starting load test")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -204,7 +204,7 @@ validator:
     count: 1
 `
 	var stateID string
-	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) {
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			t.Log("before upgrade: starting load test")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -67,6 +67,9 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 					WaitSeconds:  10,
 					CleanupAfter: true,
 					PortOffset:   portOffset,
+					ValueOverrides: map[string]string{
+						"pachw.minReplicas": "1",
+					},
 				}))
 			t.Logf("postUpgrade done")
 		})

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -64,7 +64,7 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 				ns,
 				k,
 				&minikubetestenv.DeployOpts{
-					WaitSeconds:  10,
+					WaitSeconds:  20,
 					CleanupAfter: true,
 					PortOffset:   portOffset,
 					ValueOverrides: map[string]string{
@@ -204,7 +204,7 @@ validator:
     count: 1
 `
 	var stateID string
-	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) {
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			t.Log("before upgrade: starting load test")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -64,11 +64,12 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 				ns,
 				k,
 				&minikubetestenv.DeployOpts{
-					WaitSeconds:  20,
-					CleanupAfter: true,
+					WaitSeconds:  10,
+					CleanupAfter: false,
 					PortOffset:   portOffset,
 					ValueOverrides: map[string]string{
 						"pachw.minReplicas": "1",
+						"pachd.logLevel":    "debug",
 					},
 				}))
 			t.Logf("postUpgrade done")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -50,13 +50,6 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 					Version:     from,
 					DisableLoki: true,
 					PortOffset:  portOffset,
-					// For 2.3 -> future upgrades, we'll want to delete these
-					// overrides.  They became the default (instead of random)
-					// in the 2.3 alpha cycle.
-					ValueOverrides: map[string]string{
-						"global.postgresql.postgresqlPassword":         "insecure-user-password",
-						"global.postgresql.postgresqlPostgresPassword": "insecure-root-password",
-					},
 				}))
 			t.Logf("preUpgrade done; starting postUpgrade")
 			postUpgrade(t, minikubetestenv.UpgradeRelease(t,
@@ -64,13 +57,9 @@ func upgradeTest(suite *testing.T, ctx context.Context, parallelOK bool, fromVer
 				ns,
 				k,
 				&minikubetestenv.DeployOpts{
-					WaitSeconds:  10,
-					CleanupAfter: false,
+					WaitSeconds:  0,
+					CleanupAfter: true,
 					PortOffset:   portOffset,
-					ValueOverrides: map[string]string{
-						"pachw.minReplicas": "1",
-						"pachd.logLevel":    "debug",
-					},
 				}))
 			t.Logf("postUpgrade done")
 		})


### PR DESCRIPTION
**There are 2 issues** with the upgrade load tests(there are more, but keeping the scope to these two EOF errors) 

1. The auth interceptor fails without a registered Enterprise server
2. Pachw can connect to the old postgres if the tests start running before the helm upgrade is complete. Any DB connections from pachw then fail if this happens.

**To solve this we**

1.  register the enterprise server when we buildAndRun pachw
2. We wait for postgres to be ready before running the load test. This follows what we do with other pods on start up and potentially also helps stabilize other upgrade tests.

**Considered but not done:**

I looked into adding retries into the load tests or upgrade tests somewhere to address issue 2

- It is difficult to restart in the upgrade_test itself because the load tests don't fail atomically(they start a commit and potentially make repos), so a retry from the same state never works.
- Retrying in the load test means we have to restart the worker process to get a new DB client, which is slower and I'm worried about the effects of adding retries to a test that is designed to measure test duration, and that is not primarily designed for the upgrade test. I did get this working by using panic() in the pfsload worker on error, but simply waiting for postgres seems like the cleanest fix to me at the moment.

**Idiosyncrasies in the PR**

- Wait seconds is now 0. It was 10, probably because someone notice the DB errors, but didn't know what was up. Now that we wait correctly we can toss the artificial wait.
- Cleanup after is false. This lets the CI pipeline actually dump the k8s logs and pods on failure which makes debugging easier, and it does not appear to have any functional impact(and it shouldn't based on code flow). Better debugging is nice.
- I synced registerAuthServer a little bit with pachd, but stopped short of setting public=true since it wasn't necessary to fix issue 1