### PR TITLE
Update vscode workspace settings to include Go build tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "go.inferGopath": false
+    "go.inferGopath": false,
+    "go.buildTags": "unit_test,k8s"
 }


### PR DESCRIPTION
Support vscode language server to compile our test code which requires explicit build tags.