### PR TITLE
add missing argument for automated console release

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1219,7 +1219,7 @@ jobs:
             git commit -m "bump pachyderm version"
             git push origin release-${CIRCLE_TAG:1}
             PR=$(gh pr create --base ${parentBranch} --title "bump pach version for release ${CIRCLE_TAG:1}" --body "bump pach version" --reviewer pachydermbuildbot --repo pachyderm/haberdashery)
-            gh pr review --approve --repo pachyderm/haberdashery
+            gh pr review ${PR} --approve --repo pachyderm/haberdashery
             gh pr checks ${PR} --watch --interval 10 --repo pachyderm/haberdashery
             PR_STATE=$(gh pr status --json mergeStateStatus --jq .currentBranch.mergeStateStatus --repo pachyderm/haberdashery)
             if [[ "$PR_STATE" != "CLEAN" ]]; then


### PR DESCRIPTION
fixes error on release for console `argument required when using the --repo flag`

https://app.circleci.com/pipelines/github/pachyderm/pachyderm/18279/workflows/769234d4-e826-452c-8eb7-467ace4c2573/jobs/291656