### PR TITLE
back port new nightly load iac envs

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -24,6 +24,11 @@ orbs:
   gcp-cli: circleci/gcp-cli@2.4.1
   gh: circleci/github-cli@2.1
   codecov: codecov/codecov@1.1.0
+  pulumi: pulumi/pulumi@2.1.0
+  aws-cli: circleci/aws-cli@3.1.1
+  node: circleci/node@5.0.2
+  kubernetes: circleci/kubernetes@1.3.0
+  aws-eks: circleci/aws-eks@2.2.0
 
 parameters:
   machine_image:
@@ -404,6 +409,8 @@ jobs:
     parameters:
       bucket:
         type: string
+      env:
+        type: string
     resource_class: large
     machine:
       image: << pipeline.parameters.machine_image >>
@@ -413,15 +420,26 @@ jobs:
       GOOGLE_COMPUTE_ZONE: us-east1-b
       GOOGLE_COMPUTE_REGION: us-east1
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: |
+          cat /tmp/workspace/bash.env > $BASH_ENV
       - checkout
       - gcp-cli/initialize
       - go/install:
           version: << pipeline.parameters.go-version >>
+      - install-pulumi-deps
       - run: |
           echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
       - run:
           command: etc/testing/circle/run_all_load_tests.sh
           no_output_timeout: 1h
+      - run:
+          name: Destroy test env on fail
+          command: |
+            sleep 300 #wait for CNI warm pool population to acquiesce before destroy
+            pulumi destroy --yes --stack << parameters.env >> --cwd etc/testing/circle/workloads/pulumi/aws
+          when: on_fail
       - store_artifacts:
           path: /tmp/debug-dump
           destination: debug-dump
@@ -1023,23 +1041,102 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ./
+          at: /tmp/workspace
+      - run: |
+          cat /tmp/workspace/bash.env > $BASH_ENV
       - run:
           name: echo bins
           command: |
-            ls -la dist-pach/*
-            ls -la cr-release-packages/*
+            ls -la /tmp/workspace/dist-pach/*
+            ls -la /tmp/workspace/cr-release-packages/*
       - run:
           name: "test aws examples"
           command: |
-            etc/testing/circle/run_release_tests.sh "aws"
+            etc/testing/circle/run_release_tests.sh
           no_output_timeout: 1h
+      - install-pulumi-deps
+      - run:
+          name: Destroy test env on fail
+          command: |
+            sleep 300 #wait for CNI warm pool population to acquiesce before destroy
+            pulumi destroy --yes --stack qa1 --cwd etc/testing/circle/workloads/pulumi/aws
+          when: on_fail
       - store_artifacts:
           path: /tmp/debug-dump
           destination: debug-dump
+  pulumi-aws-test-env:
+    parameters:
+      env:
+        type: string
+      action:
+        type: string
+      pachdVersion:
+        type: string
+        default: ""
+      helmChartVersion:
+        type: string
+        default: ""
+    resource_class: large
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    steps:
+      - checkout
+      - node/install
+      - kubernetes/install
+      - aws-eks/install-aws-iam-authenticator
+      - aws-cli/setup
+      - pulumi/login
+      - run: |
+          pulumi plugin install resource eks v0.40.0
+      - when:
+          condition:
+            and:
+              - equal: ["update", << parameters.action >>]
+          steps:
+            - run:
+                name: set few config values
+                command: |
+                  cd etc/testing/circle/workloads/pulumi/aws
+                  pulumi stack select pachyderm/core/<< parameters.env >> --create
+                  pulumi config set pachdVersion << parameters.pachdVersion >>
+                  [[ ! -z "<< parameters.helmChartVersion >>" ]] && pulumi config set helmChartVersion << parameters.helmChartVersion >>
+                  pulumi config set --secret rdsPGDBPassword ${PULUMI_TEST_DB_PW}
+            - pulumi/update:
+                stack: pachyderm/core/<< parameters.env >>
+                working_directory: ./etc/testing/circle/workloads/pulumi/aws/
+            - run:
+                name: gather stack output
+                command: |
+                  cd etc/testing/circle/workloads/pulumi/aws
+                  pulumi stack select pachyderm/core/<< parameters.env >>
+                  pulumi stack output kubeconfig > kubeconfig.yml
+                  KUBECONFIG=./kubeconfig.yml kubectl get nodes
+                  PACHD_IP=$(KUBECONFIG=./kubeconfig.yml kubectl get services --all-namespaces | grep pachyderm-proxy | awk '{print $5}')
+                  echo $PACHD_IP
+                  echo "export PACHD_IP=$PACHD_IP" >> $BASH_ENV
+                  mkdir -p workspace
+                  cp $BASH_ENV workspace/bash.env
+            - persist_to_workspace:
+                root: etc/testing/circle/workloads/pulumi/aws/workspace
+                paths:
+                  - bash.env
+      - when:
+          condition:
+            and:
+              - equal: ["destroy", << parameters.action >>]
+          steps:
+            - run:
+                name: wait for CNI warm pool population to acquiesce before destroy
+                command: |
+                  sleep 300
+            - pulumi/destroy:
+                stack: pachyderm/core/<< parameters.env >>
+                working_directory: ./etc/testing/circle/workloads/pulumi/aws/
   cust-prerelease-testing:
     parameters:
       customer:
+        type: string
+      env:
         type: string
     resource_class: large
     machine:
@@ -1047,17 +1144,26 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ./
+          at: /tmp/workspace
+      - run: |
+          cat /tmp/workspace/bash.env > $BASH_ENV
       - run:
           name: echo bins
           command: |
-            ls -la dist-pach/*
-            ls -la cr-release-packages/*
+            ls -la /tmp/workspace/dist-pach/*
+            ls -la /tmp/workspace/cr-release-packages/*
       - run:
           name: "test customer workload"
           command: |
             etc/testing/circle/run_cust_release_tests.sh << parameters.customer >>
           no_output_timeout: 1h
+      - install-pulumi-deps
+      - run:
+          name: Destroy test env on fail
+          command: |
+            sleep 300 #wait for CNI warm pool population to acquiesce before destroy
+            pulumi destroy --yes --stack << parameters.env >> --cwd etc/testing/circle/workloads/pulumi/aws
+          when: on_fail
       - store_artifacts:
           path: /tmp/debug-dump
           destination: debug-dump
@@ -1229,28 +1335,130 @@ workflows:
     when: << pipeline.parameters.run_load_tests >>
     jobs:
       - build-docker-images
-      - nightly-load:
+      - pulumi-aws-test-env:
+          name: create-aws-test-env-LOAD1
+          pachdVersion: $CIRCLE_SHA1
+          action: update
+          env: LOAD1
           requires:
             - build-docker-images
-          matrix:
-            parameters:
-              bucket:
-                - LOAD1
-                - LOAD2
-                - LOAD3
-                - LOAD4
-                - LOAD5
-                - LOAD6
-                - LOAD7
-                - LOAD8
-                - LOAD9
-                - LOAD10
-                - LOAD11
-                - LOAD12
-                  # Disabled for now since they take too long, may consider reenabling later.
-                  #- LOAD13
-                  #- LOAD14
-                  #- LOAD15
+      - pulumi-aws-test-env:
+          name: create-aws-test-env-LOAD2
+          pachdVersion: $CIRCLE_SHA1
+          action: update
+          env: LOAD2
+          requires:
+            - build-docker-images
+      - pulumi-aws-test-env:
+          name: create-aws-test-env-LOAD3
+          pachdVersion: $CIRCLE_SHA1
+          action: update
+          env: LOAD3
+          requires:
+            - build-docker-images
+      - pulumi-aws-test-env:
+          name: create-aws-test-env-LOAD4
+          pachdVersion: $CIRCLE_SHA1
+          action: update
+          env: LOAD4
+          requires:
+            - build-docker-images
+      - nightly-load:
+          name: nightly-load-LOAD1
+          requires:
+            - create-aws-test-env-LOAD1
+          bucket: LOAD1
+          env: LOAD1
+      - nightly-load:
+          name: nightly-load-LOAD2
+          requires:
+            - create-aws-test-env-LOAD2
+          bucket: LOAD2
+          env: LOAD2
+      - nightly-load:
+          name: nightly-load-LOAD3
+          requires:
+            - create-aws-test-env-LOAD3
+          bucket: LOAD3
+          env: LOAD3
+      - nightly-load:
+          name: nightly-load-LOAD4
+          requires:
+            - create-aws-test-env-LOAD4
+          bucket: LOAD4
+          env: LOAD4
+      - nightly-load:
+          name: nightly-load-LOAD5
+          requires:
+            - nightly-load-LOAD1
+          bucket: LOAD5
+          env: LOAD1
+      - nightly-load:
+          name: nightly-load-LOAD6
+          requires:
+            - nightly-load-LOAD2
+          bucket: LOAD6
+          env: LOAD2
+      - nightly-load:
+          name: nightly-load-LOAD7
+          requires:
+            - nightly-load-LOAD3
+          bucket: LOAD7
+          env: LOAD3
+      - nightly-load:
+          name: nightly-load-LOAD8
+          requires:
+            - nightly-load-LOAD4
+          bucket: LOAD8
+          env: LOAD4
+      - nightly-load:
+          name: nightly-load-LOAD9
+          requires:
+            - nightly-load-LOAD5
+          bucket: LOAD9
+          env: LOAD1
+      - nightly-load:
+          name: nightly-load-LOAD10
+          requires:
+            - nightly-load-LOAD6
+          bucket: LOAD10
+          env: LOAD2
+      - nightly-load:
+          name: nightly-load-LOAD11
+          requires:
+            - nightly-load-LOAD7
+          bucket: LOAD11
+          env: LOAD3
+      - nightly-load:
+          name: nightly-load-LOAD12
+          requires:
+            - nightly-load-LOAD8
+          bucket: LOAD12
+          env: LOAD4
+      - pulumi-aws-test-env:
+          name: destroy-aws-testing-env-LOAD1
+          action: destroy
+          requires:
+            - nightly-load-LOAD9
+          env: LOAD1
+      - pulumi-aws-test-env:
+          name: destroy-aws-testing-env-LOAD2
+          action: destroy
+          requires:
+            - nightly-load-LOAD10
+          env: LOAD2
+      - pulumi-aws-test-env:
+          name: destroy-aws-testing-env-LOAD3
+          action: destroy
+          requires:
+            - nightly-load-LOAD11
+          env: LOAD3
+      - pulumi-aws-test-env:
+          name: destroy-aws-testing-env-LOAD4
+          action: destroy
+          requires:
+            - nightly-load-LOAD12
+          env: LOAD4
   rootless-tests:
     when:
       or:
@@ -1359,38 +1567,82 @@ workflows:
           requires:
             - jupyter-extension-build
             - build-pachctl-bin
-      - gcp-prerelease-testing:
+      - pulumi-aws-test-env:
+          name: aws-prerelease-testing-env-1
+          env: qa1
+          action: update
+          pachdVersion: $CIRCLE_SHA1
+          helmChartVersion: ${CIRCLE_TAG:1}-${CIRCLE_SHA1}
           filters: *only-release-tags
+          requires:
+            - build-docker-images
+            - build-pachctl-bin
+            - publish-chart-preview
+            - release-github-draft
+      - pulumi-aws-test-env:
+          name: aws-prerelease-testing-env-2
+          env: qa2
+          action: update
+          pachdVersion: $CIRCLE_SHA1
+          helmChartVersion: ${CIRCLE_TAG:1}-${CIRCLE_SHA1}
+          filters: *only-alpha-tags
+          requires:
+            - build-docker-images
+            - build-pachctl-bin
+            - publish-chart-preview
+            - release-github-draft
+      - pulumi-aws-test-env:
+          name: aws-prerelease-testing-env-3
+          env: qa3
+          action: update
+          pachdVersion: $CIRCLE_SHA1
+          helmChartVersion: ${CIRCLE_TAG:1}-${CIRCLE_SHA1}
+          filters: *only-alpha-tags
           requires:
             - build-docker-images
             - build-pachctl-bin
             - publish-chart-preview
             - release-github-draft
       - aws-prerelease-testing:
+          name: aws-testing
           filters: *only-release-tags
           requires:
-            - build-docker-images
-            - build-pachctl-bin
-            - publish-chart-preview
-            - release-github-draft
+            - aws-prerelease-testing-env-1
       - cust-prerelease-testing:
           name: wp-testing
           customer: wp
+          env: qa2
           filters: *only-alpha-tags
           requires:
-            - build-docker-images
-            - build-pachctl-bin
-            - publish-chart-preview
-            - release-github-draft
+            - aws-prerelease-testing-env-2
       - cust-prerelease-testing:
           name: btl-testing
           customer: btl
+          env: qa3
           filters: *only-alpha-tags
           requires:
-            - build-docker-images
-            - build-pachctl-bin
-            - publish-chart-preview
-            - release-github-draft
+            - aws-prerelease-testing-env-3
+      - pulumi-aws-test-env:
+          name: destroy-aws-prerelease-testing-env-1
+          env: qa1
+          action: destroy
+          filters: *only-release-tags
+          requires:
+            - aws-testing
+      - pulumi-aws-test-env:
+          name: destroy-aws-prerelease-testing-env-2
+          env: qa2
+          action: destroy
+          filters: *only-alpha-tags
+          requires:
+            - wp-testing
+      - pulumi-aws-test-env:
+          name: destroy-aws-prerelease-testing-env-3
+          env: qa3
+          action: destroy
+          filters: *only-alpha-tags
+          requires:
+            - btl-testing
       - console-release-draft:
           filters: *only-release-tags
           requires:
@@ -1493,21 +1745,37 @@ workflows:
           filters: *only-nightly-tags
           requires:
             - build-pachctl-bin
-      - gcp-prerelease-testing:
+      - pulumi-aws-test-env:
+          name: create-aws-test-env
+          env: qa1
+          action: update
+          pachdVersion: $CIRCLE_SHA1
+          helmChartVersion: ${CIRCLE_TAG:1}-${CIRCLE_SHA1}
           filters: *only-nightly-tags
           requires:
             - build-docker-images
             - build-pachctl-bin
             - publish-chart-preview
             - release-github-draft
+      - aws-prerelease-testing:
+          filters: *only-nightly-tags
+          requires:
+            - create-aws-test-env
+      - pulumi-aws-test-env:
+          name: destroy-aws-test-env
+          env: qa1
+          action: destroy
+          filters: *only-nightly-tags
+          requires:
+            - aws-prerelease-testing
       - release-docker-hub:
           filters: *only-nightly-tags
           requires:
-            - gcp-prerelease-testing
+            - aws-prerelease-testing
       - release-github:
           filters: *only-nightly-tags
           requires:
-            - gcp-prerelease-testing
+            - aws-prerelease-testing
       - release-hombrew-tap:
           filters: *only-nightly-tags
           requires:
@@ -1516,7 +1784,7 @@ workflows:
           name: publish-helm-chart
           filters: *only-nightly-tags
           requires:
-            - gcp-prerelease-testing
+            - aws-prerelease-testing
 
 commands:
   install-jupyter-test-deps:
@@ -1568,3 +1836,12 @@ commands:
           command: |-
             echo '{"pachd_address": "grpc://'"$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)":30650'"}' | pachctl config set context local --overwrite
             pachctl config set active-context local
+  install-pulumi-deps:
+    steps:
+      - node/install
+      - kubernetes/install
+      - aws-eks/install-aws-iam-authenticator
+      - aws-cli/setup
+      - pulumi/login
+      - run: |
+          pulumi plugin install resource eks v0.40.0

--- a/etc/testing/circle/run_cust_release_tests.sh
+++ b/etc/testing/circle/run_cust_release_tests.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-tar -xvzf ./dist-pach/pachctl/pachctl_*_linux_amd64.tar.gz -C /tmp
+tar -xvzf /tmp/workspace/dist-pach/pachctl/pachctl_*_linux_amd64.tar.gz -C /tmp
 
 sudo mv /tmp/pachctl_*/pachctl /usr/local/bin && chmod +x /usr/local/bin/pachctl
 
@@ -12,75 +12,19 @@ pachctl version --client-only
 VERSION="$(pachctl version --client-only)"
 export VERSION
 
-# wait for 5mins artifact hub to sync helm chart.
-# should be replaced with a ping 
-sleep 300
-
-# provision a aws pulumi test env
-TIMESTAMP=$(date +%T | sed 's/://g')
-WORKSPACE="${1}-${CIRCLE_SHA1:0:7}-${TIMESTAMP}"
-
-
-if [ "${1}" = "wp" ]; then
-  curl --fail -X POST -H "Authorization: Bearer ${HELIUM_API_TOKEN}" \
-    -F name="${WORKSPACE}" -F pachdVersion="${CIRCLE_SHA1}" -F helmVersion="${CIRCLE_TAG:1}-${CIRCLE_SHA1}" -F backend="aws_cluster" \
-    -F disableNotebooks="True" -F infraJson=@etc/testing/circle/workloads/aws-wp/infra.json -F valuesYaml=@etc/testing/circle/workloads/aws-wp/values.yaml \
-https://helium.pachyderm.io/v1/api/workspace
-elif [ "${1}" = "btl" ]; then
-  curl --fail -X POST -H "Authorization: Bearer ${HELIUM_API_TOKEN}" \
-    -F name="${WORKSPACE}" -F pachdVersion="${CIRCLE_SHA1}" -F helmVersion="${CIRCLE_TAG:1}-${CIRCLE_SHA1}" -F backend="aws_cluster" \
-    -F disableNotebooks="True" -F infraJson=@etc/testing/circle/workloads/aws-btl/infra.json -F valuesYaml=@etc/testing/circle/workloads/aws-btl/values.yaml \
-https://helium.pachyderm.io/v1/api/workspace
-else
-  echo "no valid customer name provided"
-  exit 1
-fi
-
-# wait for helium to kick off to pulumi before pinging it.
-sleep 5
-
-for _ in $(seq 180); do
-  STATUS=$(curl -s -H "Authorization: Bearer ${HELIUM_API_TOKEN}" "https://helium.pachyderm.io/v1/api/workspace/${WORKSPACE}" | jq .Workspace.Status | tr -d '"')
-  if [[ ${STATUS} == "ready" ]]
-  then
-    echo "success"
-    break
-  fi
-  echo 'sleeping'
-  sleep 10
-done
-
-if [[ ${STATUS} != "ready" ]]
-then
-  echo "failed to provision pulumi workspace"
-  exit 1
-fi
-
-pachdIp=$(curl -s -H "Authorization: Bearer ${HELIUM_API_TOKEN}" "https://helium.pachyderm.io/v1/api/workspace/${WORKSPACE}"  | jq .Workspace.PachdIp)
-withEnvoy=$(echo "$pachdIp" | sed 's/grpc:\/\//grpc:\/\/pachd-/g' | sed 's/30651/30650/g')
-echo "${withEnvoy}"
-pachctlCtx=$(echo "{\"pachd_address\": ${withEnvoy}, \"source\": 2}" | tr -d \\)
-echo "${pachctlCtx}"
-echo "${pachctlCtx}" | pachctl config set context "${WORKSPACE}" --overwrite && pachctl config set active-context "${WORKSPACE}"
-echo "${HELIUM_PACHCTL_AUTH_TOKEN}" | pachctl auth use-auth-token
+echo "{\"pachd_address\": \"grpc://${PACHD_IP}:80\", \"session_token\": \"test\"}" | tr -d \\ | pachctl config set context "test" --overwrite
+pachctl config set active-context "test"
 
 # Print client and server versions, for debugging.  (Also waits for proxy to discover pachd, etc.)
-READY=false
 for i in $(seq 1 20); do
     if pachctl version; then
         echo "pachd ready after $i attempts"
-        READY=true
         break
     else
         sleep 5
         continue
     fi
 done
-
-if [ "$READY" = false ] ; then
-    echo 'pachd failed to start'
-    exit 1
-fi
 
 if [ "${1}" = "wp" ]; then
   # cloning wp-workload test repo

--- a/etc/testing/circle/run_load_tests.sh
+++ b/etc/testing/circle/run_load_tests.sh
@@ -21,34 +21,8 @@ pachctl version --client-only
 VERSION="$(pachctl version --client-only)"
 export VERSION
 
-
-JOB=$(echo "$CIRCLE_JOB" | tr '[:upper:]' '[:lower:]')
-
-# # provision a pulumi load test env
-curl --fail -X POST -H "Authorization: Bearer ${HELIUM_API_TOKEN}" \
- -F name=commit-"${CIRCLE_SHA1:0:7}-${JOB}" -F pachdVersion="${CIRCLE_SHA1}" -F backend=gcp_namespace_only -F clusterStack="pachyderm/helium/nightly-cluster" \
-  -F disableNotebooks="True" -F valuesYaml=@etc/testing/circle/helm-load-env-values.yaml \
-  https://helium.pachyderm.io/v1/api/workspace
-
-# wait for helium to kick off to pulumi before pinging it.
-sleep 5
-
-for _ in $(seq 108); do
-  STATUS=$(curl -s -H "Authorization: Bearer ${HELIUM_API_TOKEN}" "https://helium.pachyderm.io/v1/api/workspace/commit-${CIRCLE_SHA1:0:7}-${JOB}" | jq .Workspace.Status | tr -d '"')
-  if [[ ${STATUS} == "ready" ]]
-  then
-    echo "success"
-    break
-  fi
-  echo 'sleeping'
-  sleep 10
-done
-
-pachdIp=$(curl -s -H "Authorization: Bearer ${HELIUM_API_TOKEN}" "https://helium.pachyderm.io/v1/api/workspace/commit-${CIRCLE_SHA1:0:7}-${JOB}"  | jq .Workspace.PachdIp)
-
-echo "{\"pachd_address\": ${pachdIp}, \"source\": 2}" | tr -d \\ | pachctl config set context "commit-${CIRCLE_SHA1:0:7}-${JOB}" --overwrite && pachctl config set active-context "commit-${CIRCLE_SHA1:0:7}-${JOB}"
-
-echo "${HELIUM_PACHCTL_AUTH_TOKEN}" | pachctl auth use-auth-token
+echo "{\"pachd_address\": \"grpc://${PACHD_IP}:80\", \"session_token\": \"test\"}" | tr -d \\ | pachctl config set context "test" --overwrite
+pachctl config set active-context "test"
 
 # Print client and server versions, for debugging.  (Also waits for proxy to discover pachd, etc.)
 for i in $(seq 1 20); do
@@ -66,7 +40,9 @@ set +e
 
 PFS_RESPONSE_SPEC=$(pachctl run pfs-load-test "${@}")
 
-if [ "${?}" -ne 0 ]; then
+# shellcheck disable=SC2086
+# shellcheck disable=SC2046
+if [ "${?}" -ne 0 ] || [ $(jq 'has("error")' <<< $PFS_RESPONSE_SPEC) == true ]; then
 	pachctl debug dump /tmp/debug-dump
 	exit 1
 fi
@@ -80,6 +56,12 @@ bq insert --ignore_unknown_values insights.load-tests << EOF
 EOF
 
 fi
+
+pachctl delete pipeline --all
+pachctl delete repo --all
+
+# give 5 mins for gc to get ahead before next load test is run.
+sleep 300
 
 set -e
 pachctl debug dump /tmp/debug-dump

--- a/etc/testing/circle/run_release_tests.sh
+++ b/etc/testing/circle/run_release_tests.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-tar -xvzf ./dist-pach/pachctl/pachctl_*_linux_amd64.tar.gz -C /tmp
+tar -xvzf /tmp/workspace/dist-pach/pachctl/pachctl_*_linux_amd64.tar.gz -C /tmp
 
 sudo mv /tmp/pachctl_*/pachctl /usr/local/bin && chmod +x /usr/local/bin/pachctl
 
@@ -12,69 +12,8 @@ pachctl version --client-only
 VERSION="$(pachctl version --client-only)"
 export VERSION
 
-# wait for 5mins artifact hub to sync helm chart.
-# should be replaced with a ping 
-sleep 300
-
-
-# provision a pulumi test env
-WORKSPACE=${CIRCLE_TAG//./-}
-if [ "${1-default}" = "aws" ]; then
-  WORKSPACE=aws-${CIRCLE_TAG//./-}
-else
-  # assume default gcp
-  WORKSPACE=gcp-${CIRCLE_TAG//./-}
-fi
-
-if [ "${1-default}" = "aws" ]; then
-  curl --fail -X POST -H "Authorization: Bearer ${HELIUM_API_TOKEN}" \
-  -F name="${WORKSPACE}-${CIRCLE_SHA1:0:7}" -F pachdVersion="${CIRCLE_SHA1}" -F helmVersion="${CIRCLE_TAG:1}-${CIRCLE_SHA1}" \
-  -F disableNotebooks="True" \
-  -F backend="aws_cluster" -F infraJson=@etc/testing/circle/workloads/aws-examples/infra.json -F valuesYaml=@etc/testing/circle/workloads/aws-examples/values.yaml \
-    https://helium.pachyderm.io/v1/api/workspace
-else
-  # assume default gcp
-  curl --fail -X POST -H "Authorization: Bearer ${HELIUM_API_TOKEN}" \
-  -F disableNotebooks="True" \
-  -F name="${WORKSPACE}-${CIRCLE_SHA1:0:7}" -F pachdVersion="${CIRCLE_SHA1}" -F helmVersion="${CIRCLE_TAG:1}-${CIRCLE_SHA1}" \
-    https://helium.pachyderm.io/v1/api/workspace
-fi
-
-
-# wait for helium to kick off to pulumi before pinging it.
-sleep 5
-
-for _ in $(seq 180); do
-  STATUS=$(curl -s -H "Authorization: Bearer ${HELIUM_API_TOKEN}" "https://helium.pachyderm.io/v1/api/workspace/${WORKSPACE}-${CIRCLE_SHA1:0:7}" | jq .Workspace.Status | tr -d '"')
-  if [[ ${STATUS} == "ready" ]]
-  then
-    echo "success"
-    break
-  fi
-  echo 'sleeping'
-  sleep 10
-done
-
-if [[ ${STATUS} != "ready" ]]
-then
-  echo "failed to provision pulumi workspace"
-  exit 1
-fi
-
-pachdIp=$(curl -s -H "Authorization: Bearer ${HELIUM_API_TOKEN}" "https://helium.pachyderm.io/v1/api/workspace/${WORKSPACE}-${CIRCLE_SHA1:0:7}"  | jq .Workspace.PachdIp)
-
-if [ "${1-default}" = "aws" ]; then
-  withEnvoy=$(echo "$pachdIp" | sed 's/grpc:\/\//grpc:\/\/pachd-/g' | sed 's/30651/30650/g')
-  echo "${withEnvoy}"
-  pachctlCtx=$(echo "{\"pachd_address\": ${withEnvoy}, \"source\": 2}" | tr -d \\)
-  echo "${pachctlCtx}"
-  echo "${pachctlCtx}" | pachctl config set context "${WORKSPACE}-${CIRCLE_SHA1:0:7}" --overwrite && pachctl config set active-context "${WORKSPACE}-${CIRCLE_SHA1:0:7}"
-else
-  # assume default gcp
-  echo "{\"pachd_address\": ${pachdIp}, \"source\": 2}" | tr -d \\ | pachctl config set context "${WORKSPACE}-${CIRCLE_SHA1:0:7}" --overwrite && pachctl config set active-context "${WORKSPACE}-${CIRCLE_SHA1:0:7}"
-fi
-
-echo "${HELIUM_PACHCTL_AUTH_TOKEN}" | pachctl auth use-auth-token
+echo "{\"pachd_address\": \"grpc://${PACHD_IP}:80\", \"session_token\": \"test\"}" | tr -d \\ | pachctl config set context "test" --overwrite
+pachctl config set active-context "test"
 
 # Print client and server versions, for debugging.  (Also waits for proxy to discover pachd, etc.)
 READY=false

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD1.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD1.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-west-2
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD2.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD2.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-west-2
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD3.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD3.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-west-2
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD4.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.LOAD4.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-west-2
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.dev1.README.md
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.dev1.README.md
@@ -1,0 +1,36 @@
+# Dev 1 Stack
+
+> Used for testing pulumi infra changes for the pulumi core project.
+
+# Overview
+
+This stack is reserved for testing pulumi IAC itself. The `pulumi up` is usually executed locally not from CI. This provides an environment to test IAC changes before they are commited and used by the other stacks. 
+
+> ITS A GOOD IDEA TO ASK IF ANYONE ELSE IS USING THIS STACK. You can always create a DEV2 etc if needed.
+
+# Environment Variables
+
+The test DB test password is reqiored and needs to be set like so. Never check these values in. CI Uses its own stored in CircleCI.
+
+> pulumi config set --secret rdsPGDBPassword $IAC_CI_DB_PASSWORD
+
+`$ENT_ACT_CODE` - Test enterprise env variable key needs to be set locally from where ever the `pulumi up` is called from. 
+
+The following can be overwritten 
+
+`pulumi config set pachdVersion << pachdVersion >>`
+
+`pulumi config set helmChartVersion << helmChartVersion >>`
+
+# Tags
+
+Tag all resources so we can track billing and usage.
+
+```
+		Tags: pulumi.StringMap{
+			"Project": pulumi.String("Feature Testing"),
+			"Service": pulumi.String("CI"),
+			"Owner":   pulumi.String("pachyderm-ci"),
+			"Team":    pulumi.String("Core"),
+		},
+```

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.dev1.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.dev1.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-west-2
+  core:pachdVersion: 2.4.4

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa1.README.md
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa1.README.md
@@ -1,0 +1,9 @@
+# QA 1 Stack
+
+> Used sanity aws example release tests.
+
+# Overview
+
+| cloud | instance count |
+|-- | --|
+| `aws` | 3 |

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa1.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa1.yaml
@@ -1,0 +1,4 @@
+config:
+  aws:region: us-west-2
+  postgresql:host: wp-postgresql
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa2.README.md
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa2.README.md
@@ -1,0 +1,9 @@
+# QA 2 Stack
+
+> Used as customer mock alpha test envs.
+
+# Overview
+
+| cloud | instance count |
+|-- | --|
+| `aws` | 3 |

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa2.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa2.yaml
@@ -1,0 +1,4 @@
+config:
+  aws:region: us-west-2
+  postgresql:host: wp-postgresql
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa3.README.md
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa3.README.md
@@ -1,0 +1,9 @@
+# QA 3 Stack
+
+> Used as customer mock alpha test envs.
+
+# Overview
+
+| cloud | instance count |
+|-- | --|
+| `aws` | 3 |

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa3.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.qa3.yaml
@@ -1,0 +1,4 @@
+config:
+  aws:region: us-west-2
+  postgresql:host: wp-postgresql
+  eksNodeInstanceType: m5.2xlarge

--- a/etc/testing/circle/workloads/pulumi/aws/Pulumi.yaml
+++ b/etc/testing/circle/workloads/pulumi/aws/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: core
+runtime: go
+description: Houses pachyderm core stacks.

--- a/etc/testing/circle/workloads/pulumi/aws/app.go
+++ b/etc/testing/circle/workloads/pulumi/aws/app.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/rds"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/helm/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *iam.Role, rdsInstance *rds.Instance, bucket *s3.Bucket) error {
+	cfg := config.New(ctx, "")
+	enterpriseKey := os.Getenv("ENT_ACT_CODE")
+	if enterpriseKey == "" {
+		return errors.WithStack(fmt.Errorf("need to supply env var ENT_ACT_CODE"))
+	}
+	awsSAkey := os.Getenv("AWS_ACCESS_KEY_ID")
+	awsSAsecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+	pachdImageTag, err := cfg.Try("pachdVersion")
+	if err != nil {
+		pachdImageTag = "2.4.4"
+	}
+	helmChartVersion, err := cfg.Try("helmChartVersion")
+	if err != nil {
+		helmChartVersion = ""
+	}
+
+	namespace, err := corev1.NewNamespace(ctx, "test-ns", &corev1.NamespaceArgs{},
+		pulumi.Provider(k8sProvider))
+
+	if err != nil {
+		return errors.WithStack(fmt.Errorf("error occurred while attempting to create test-ns: %w", err))
+	}
+
+	values := pulumi.Map{
+		"proxy": pulumi.Map{
+			"enabled": pulumi.Bool(true),
+			"service": pulumi.Map{
+				"type": pulumi.String("LoadBalancer"),
+			},
+		},
+		"console": pulumi.Map{
+			"enabled": pulumi.Bool(false),
+		},
+		"pachd": pulumi.Map{
+			"logLevel": pulumi.String("debug"),
+			"image": pulumi.Map{
+				"tag": pulumi.String(pachdImageTag),
+			},
+			"storage": pulumi.Map{
+				"amazon": pulumi.Map{
+					"bucket": bucket.Bucket,
+					"region": pulumi.String("us-west-2"),
+					"id":     pulumi.String(awsSAkey),
+					"secret": pulumi.String(awsSAsecret),
+				},
+			},
+			"externalService": pulumi.Map{
+				"enabled": pulumi.Bool(true),
+			},
+			"enterpriseLicenseKey": pulumi.String(enterpriseKey),
+			"oauthClientSecret":    pulumi.String("test"),
+			"rootToken":            pulumi.String("test"),
+			"enterpriseSecret":     pulumi.String("test"),
+		},
+		"deployTarget": pulumi.String("AMAZON"),
+		"global": pulumi.Map{
+			"postgresql": pulumi.Map{
+				"postgresqlHost":                   rdsInstance.Address,
+				"postgresqlUsername":               pulumi.String("postgres"),
+				"postgresqlPassword":               cfg.RequireSecret("rdsPGDBPassword"),
+				"postgresqlPostgresPassword":       cfg.RequireSecret("rdsPGDBPassword"),
+				"identityDatabaseFullNameOverride": pulumi.String("dex"),
+			},
+		},
+		"postgresql": pulumi.Map{
+			"enabled": pulumi.Bool(false),
+		},
+	}
+
+	if helmChartVersion == "" {
+		_, err = helm.NewRelease(ctx, "pach-release", &helm.ReleaseArgs{
+			Namespace: namespace.Metadata.Elem().Name(),
+			RepositoryOpts: helm.RepositoryOptsArgs{
+				Repo: pulumi.String("https://helm.pachyderm.com"),
+			},
+			Chart:   pulumi.String("pachyderm"),
+			Timeout: pulumi.Int(1200),
+			Values:  values,
+		}, pulumi.Provider(k8sProvider))
+	} else {
+		_, err = helm.NewRelease(ctx, "pach-release", &helm.ReleaseArgs{
+			Namespace: namespace.Metadata.Elem().Name(),
+			RepositoryOpts: helm.RepositoryOptsArgs{
+				Repo: pulumi.String("https://helm.pachyderm.com"),
+			},
+			Chart:   pulumi.String("pachyderm"),
+			Timeout: pulumi.Int(1200),
+			Version: pulumi.String(helmChartVersion),
+			Values:  values,
+		}, pulumi.Provider(k8sProvider))
+	}
+
+	if err != nil {
+		return errors.WithStack(fmt.Errorf("failed to successfully helm install: %w", err))
+	}
+
+	return nil
+}

--- a/etc/testing/circle/workloads/pulumi/aws/cluster.go
+++ b/etc/testing/circle/workloads/pulumi/aws/cluster.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	awseks "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/eks"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ec2"
+	"github.com/pulumi/pulumi-eks/sdk/go/eks"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	storagev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/storage/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+// Create a new EKS cluster; this leverages the pulumi aws crosswalk library.
+// aws crosswalk (awsx) is a higher level library that makes it easier to
+// create AWS resources since it created all the associated networking.
+func DeployCluster(ctx *pulumi.Context) (*kubernetes.Provider, *iam.Role, error) {
+	cfg := config.New(ctx, "")
+	minClusterSize, err := cfg.TryInt("minClusterSize")
+	if err != nil {
+		minClusterSize = 1
+	}
+	maxClusterSize, err := cfg.TryInt("maxClusterSize")
+	if err != nil {
+		maxClusterSize = 3
+	}
+	desiredClusterSize, err := cfg.TryInt("desiredClusterSize")
+	if err != nil {
+		desiredClusterSize = 1
+	}
+	eksNodeInstanceType, err := cfg.Try("eksNodeInstanceType")
+	if err != nil {
+		eksNodeInstanceType = "t2.medium"
+	}
+	vpcNetworkCidr, err := cfg.Try("vpcNetworkCidr")
+	if err != nil {
+		vpcNetworkCidr = "10.0.0.0/16"
+	}
+
+	// Create a new VPC, subnets, and associated infrastructure
+	vpcName := fmt.Sprintf("eks-%s-vpc", ctx.Stack())
+	eksVpc, err := ec2.NewVpc(ctx, vpcName, &ec2.VpcArgs{
+		EnableDnsHostnames: pulumi.Bool(true),
+		CidrBlock:          &vpcNetworkCidr,
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("Feature Testing"),
+			"Service":     pulumi.String("CI"),
+			"Owner":       pulumi.String("pachyderm-ci"),
+			"Team":        pulumi.String("Core"),
+			"Environment": pulumi.String(ctx.Stack()),
+		},
+	})
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error creating VPC: %w", err))
+	}
+
+	// Create a new EKS cluster
+	eksClusterName := fmt.Sprintf("eks-%s-cluster", ctx.Stack())
+	eksCluster, err := eks.NewCluster(ctx, eksClusterName, &eks.ClusterArgs{
+		// Put the cluster in the new VPC created earlier
+		VpcId:              eksVpc.VpcId,
+		CreateOidcProvider: pulumi.Bool(true),
+		// Public subnets will be used for load balancers
+		PublicSubnetIds: eksVpc.PublicSubnetIds,
+		// Private subnets will be used for cluster nodes
+		PrivateSubnetIds: eksVpc.PrivateSubnetIds,
+		// Change configuration values above to change any of the following settings
+		InstanceType:    pulumi.String(eksNodeInstanceType),
+		DesiredCapacity: pulumi.Int(desiredClusterSize),
+		MinSize:         pulumi.Int(minClusterSize),
+		MaxSize:         pulumi.Int(maxClusterSize),
+		// Do not give the worker nodes a public IP address
+		NodeAssociatePublicIpAddress: pulumi.BoolRef(false),
+		// Uncomment the next two lines for a private cluster (VPN access required)
+		// EndpointPrivateAccess: 	      pulumi.Bool(true),
+		// EndpointPublicAccess:         pulumi.Bool(false),
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("Feature Testing"),
+			"Service":     pulumi.String("CI"),
+			"Owner":       pulumi.String("pachyderm-ci"),
+			"Team":        pulumi.String("Core"),
+			"Environment": pulumi.String(ctx.Stack()),
+		},
+	})
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error creating EKS cluster: %w", err))
+	}
+
+	k8sProvider, err := kubernetes.NewProvider(ctx, "k8sprovider", &kubernetes.ProviderArgs{
+		Kubeconfig: eksCluster.KubeconfigJson,
+	})
+
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error creating k8s provider: %w", err))
+	}
+
+	clusterOidcProviderUrl := eksCluster.Core.OidcProvider().Url()
+
+	assumeRolePolicyDocument := pulumi.All(clusterOidcProviderUrl, eksCluster.Core.OidcProvider().Arn()).ApplyT(func(args []interface{}) (string, error) {
+		url := args[0].(string)
+		arn := args[1].(string)
+
+		urlTrimmed := strings.TrimPrefix(url, "https://")
+		urlAud := fmt.Sprintf("%s:aud", urlTrimmed)
+		urlSub := fmt.Sprintf("%s:sub", urlTrimmed)
+
+		assumeRolePolicy, _ := iam.GetPolicyDocument(ctx, &iam.GetPolicyDocumentArgs{
+			Statements: []iam.GetPolicyDocumentStatement{
+				{
+					Sid: &[]string{"allowK8sServiceAccount"}[0],
+					Actions: []string{
+						"sts:AssumeRoleWithWebIdentity",
+					},
+					Principals: []iam.GetPolicyDocumentStatementPrincipal{
+						{
+							Identifiers: []string{
+								arn,
+							},
+							Type: "Federated",
+						},
+					},
+					Conditions: []iam.GetPolicyDocumentStatementCondition{
+						{
+							Test:     "StringEquals",
+							Variable: urlAud,
+							Values: []string{
+								"sts.amazonaws.com",
+							},
+						},
+						{
+							Test:     "StringEquals",
+							Variable: urlSub,
+							Values: []string{
+								"system:serviceaccount:kube-system:ebs-csi-controller-sa",
+							},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return "", errors.WithStack(fmt.Errorf("error creating assume role policy: %w", err))
+		}
+		return assumeRolePolicy.Json, nil
+	})
+
+	saRoleName := fmt.Sprintf("ebscsi-%s-sa-role", ctx.Stack())
+	saRole, err := iam.NewRole(ctx, saRoleName, &iam.RoleArgs{
+		AssumeRolePolicy: assumeRolePolicyDocument,
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("Feature Testing"),
+			"Service":     pulumi.String("CI"),
+			"Owner":       pulumi.String("pachyderm-ci"),
+			"Team":        pulumi.String("Core"),
+			"Environment": pulumi.String(ctx.Stack()),
+		},
+	})
+
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error creating service account role: %w", err))
+	}
+
+	_, err = iam.NewRolePolicyAttachment(ctx, "attach-ebs-csi-policy", &iam.RolePolicyAttachmentArgs{
+		Role:      saRole,
+		PolicyArn: pulumi.String("arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"),
+	})
+
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error attaching policy to service account role: %w", err))
+	}
+
+	_, err = awseks.NewAddon(ctx, "aws-ebs-csi-driver", &awseks.AddonArgs{
+		ClusterName:           eksCluster.EksCluster.Name(),
+		AddonName:             pulumi.String("aws-ebs-csi-driver"),
+		ServiceAccountRoleArn: saRole.Arn,
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("Feature Testing"),
+			"Service":     pulumi.String("CI"),
+			"Owner":       pulumi.String("pachyderm-ci"),
+			"Team":        pulumi.String("Core"),
+			"Environment": pulumi.String(ctx.Stack()),
+		},
+	})
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error creating EBS CSI driver addon: %w", err))
+	}
+
+	_, err = storagev1.NewStorageClass(ctx, "gp3", &storagev1.StorageClassArgs{
+		Provisioner: pulumi.String("ebs.csi.aws.com"),
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String("gp3"),
+		},
+		Parameters: pulumi.StringMap{
+			"type":   pulumi.String("gp3"),
+			"fsType": pulumi.String("ext4"),
+		},
+	}, pulumi.Provider(k8sProvider))
+
+	if err != nil {
+		return nil, nil, errors.WithStack(fmt.Errorf("error creating storage class: %w", err))
+	}
+
+	// Export some values in case they are needed elsewhere
+	ctx.Export("kubeconfig", eksCluster.Kubeconfig)
+	ctx.Export("vpcId", eksVpc.VpcId)
+
+	return k8sProvider, saRole, nil
+}

--- a/etc/testing/circle/workloads/pulumi/aws/database.go
+++ b/etc/testing/circle/workloads/pulumi/aws/database.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/rds"
+	postgresql "github.com/pulumi/pulumi-postgresql/sdk/v3/go/postgresql"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func DeployRDS(ctx *pulumi.Context) (*rds.Instance, error) {
+	cfg := config.New(ctx, "")
+	rdsAllocatedStorage, err := cfg.TryInt("rdsAllocatedStorage")
+	if err != nil {
+		rdsAllocatedStorage = 20
+	}
+	rdsInstanceClass, err := cfg.Try("rdsInstanceClass")
+	if err != nil {
+		rdsInstanceClass = "db.m6g.large"
+	}
+	rdsDiskType, err := cfg.Try("rdsDiskType")
+	if err != nil {
+		rdsDiskType = "gp2"
+	}
+	rdsDiskIOPs, err := cfg.TryInt("rdsDiskIOPs")
+	if err != nil {
+		rdsDiskIOPs = 1000
+	}
+
+	rdsInstanceArgs := &rds.InstanceArgs{
+		AllocatedStorage:   pulumi.Int(rdsAllocatedStorage),
+		Engine:             pulumi.String("postgres"),
+		EngineVersion:      pulumi.String("13.9"),
+		InstanceClass:      pulumi.String(rdsInstanceClass),
+		DbName:             pulumi.String("pachyderm"),
+		Password:           cfg.RequireSecret("rdsPGDBPassword"),
+		SkipFinalSnapshot:  pulumi.Bool(true),
+		StorageType:        pulumi.String(rdsDiskType),
+		Username:           pulumi.String("postgres"),
+		PubliclyAccessible: pulumi.Bool(true),
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("Feature Testing"),
+			"Service":     pulumi.String("CI"),
+			"Owner":       pulumi.String("pachyderm-ci"),
+			"Team":        pulumi.String("Core"),
+			"Environment": pulumi.String(ctx.Stack()),
+		},
+	}
+
+	if rdsDiskType == "io1" {
+		rdsInstanceArgs.Iops = pulumi.Int(rdsDiskIOPs)
+	}
+
+	rdsInstanceName := strings.ToLower(fmt.Sprintf("rds-%s-instance", ctx.Stack()))
+	r, err := rds.NewInstance(ctx, rdsInstanceName, rdsInstanceArgs)
+
+	if err != nil {
+		return nil, errors.WithStack(fmt.Errorf("error creating RDS instance: %w", err))
+	}
+
+	rdsProviderName := fmt.Sprintf("%s-postgresql", ctx.Stack())
+	postgresProvider, err := postgresql.NewProvider(ctx, rdsProviderName, &postgresql.ProviderArgs{
+		Host:     r.Address,
+		Port:     r.Port,
+		Username: r.Username,
+		Password: r.Password,
+	})
+
+	if err != nil {
+		return nil, errors.WithStack(fmt.Errorf("error creating postgres provider: %w", err))
+	}
+	dexDbName := "dex"
+	_, err = postgresql.NewDatabase(ctx, dexDbName, &postgresql.DatabaseArgs{Name: pulumi.StringPtr(dexDbName)}, pulumi.Provider(postgresProvider))
+
+	if err != nil {
+		return nil, errors.WithStack(fmt.Errorf("error creating dex database: %w", err))
+	}
+
+	return r, nil
+}

--- a/etc/testing/circle/workloads/pulumi/aws/main.go
+++ b/etc/testing/circle/workloads/pulumi/aws/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(DeployResources())
+}
+
+func DeployResources() pulumi.RunFunc {
+	return func(ctx *pulumi.Context) error {
+		k8sProvider, saRole, err := DeployCluster(ctx)
+		if err != nil {
+			return err
+		}
+		rdsInstance, err := DeployRDS(ctx)
+		if err != nil {
+			return err
+		}
+		bucket, err := DeployBucket(ctx)
+		if err != nil {
+			return err
+		}
+		err = DeployApp(ctx, k8sProvider, saRole, rdsInstance, bucket)
+		if err != nil {
+			return err
+		}
+
+		readmePath := fmt.Sprintf("./Pulumi.%s.README.md", ctx.Stack())
+		if _, err := os.Stat(readmePath); err == nil {
+			readmeBytes, err := os.ReadFile(readmePath)
+			if err != nil {
+				return errors.WithStack(fmt.Errorf("failed to read readme: %v", err))
+			}
+			ctx.Export("readme", pulumi.String(string(readmeBytes)))
+		} else {
+			fmt.Printf("README file does not exist.\n")
+		}
+
+		return nil
+	}
+}

--- a/etc/testing/circle/workloads/pulumi/aws/storage.go
+++ b/etc/testing/circle/workloads/pulumi/aws/storage.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func DeployBucket(ctx *pulumi.Context) (*s3.Bucket, error) {
+	bucketName := strings.ToLower(fmt.Sprintf("s3-%s-bucket", ctx.Stack()))
+	bucket, err := s3.NewBucket(ctx, bucketName, &s3.BucketArgs{
+		Bucket:       pulumi.String(bucketName),
+		Acl:          pulumi.String("public-read-write"),
+		ForceDestroy: pulumi.Bool(true),
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("Feature Testing"),
+			"Service":     pulumi.String("CI"),
+			"Owner":       pulumi.String("pachyderm-ci"),
+			"Team":        pulumi.String("Core"),
+			"Environment": pulumi.String(ctx.Stack()),
+		},
+	})
+
+	if err != nil {
+		return nil, errors.WithStack(fmt.Errorf("error creating S3 bucket: %w", err))
+	}
+
+	ctx.Export("bucketName", bucket.Bucket)
+
+	return bucket, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-lambda-go v1.17.0
 	github.com/aws/aws-sdk-go v1.44.68
 	github.com/breml/rootcerts v0.2.4
-	github.com/c-bata/go-prompt v0.2.3
+	github.com/c-bata/go-prompt v0.2.5
 	github.com/cevaris/ordered_map v0.0.0-20190319150403-3adeae072e73
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible
 	github.com/coreos/go-oidc v2.2.1+incompatible
@@ -60,6 +60,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.37.0
+	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.17.0
+	github.com/pulumi/pulumi/sdk/v3 v3.50.1
 	github.com/robfig/cron v1.2.0
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/segmentio/analytics-go v0.0.0-20160426181448-2d840d861c32
@@ -79,7 +81,7 @@ require (
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.24.0
 	gocloud.dev v0.27.0
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503
 	golang.org/x/exp v0.0.0-20221019170559-20944726eadf
 	golang.org/x/mod v0.7.0
 	golang.org/x/net v0.7.0
@@ -98,6 +100,37 @@ require (
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/kubectl v0.26.0
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
+)
+
+require (
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cheggaaa/pb v1.0.27 // indirect
+	github.com/djherbis/times v1.2.0 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-git/go-git/v5 v5.4.2 // indirect
+	github.com/golang/glog v1.0.0 // indirect
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/opentracing/basictracer-go v1.0.0 // indirect
+	github.com/pulumi/pulumi-docker/sdk/v3 v3.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
+	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
+	github.com/xanzy/ssh-agent v0.3.2 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	lukechampine.com/frand v1.4.2 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect
 )
 
 require (
@@ -245,12 +278,16 @@ require (
 	github.com/opencontainers/runc v1.1.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.11 // indirect
-	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
+	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/pquerna/otp v1.2.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/pulumi/pulumi-aws/sdk/v5 v5.28.0
+	github.com/pulumi/pulumi-awsx/sdk v1.0.1
+	github.com/pulumi/pulumi-eks/sdk v1.0.1
+	github.com/pulumi/pulumi-postgresql/sdk/v3 v3.6.0
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/xid v1.4.0 // indirect
 	github.com/russellhaering/goxmldsig v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnl
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
@@ -208,6 +210,8 @@ github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:m
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
+github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -220,10 +224,15 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
+github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
+github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -232,6 +241,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
+github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
+github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 h1:q4dksr6ICHXqG5hm0ZW5IHyeEJXoIJSOZeBLmWPNeIQ=
 github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40/go.mod h1:Q7yQnSMnLvcXlZ8RV+jwz/6y1rQTqbX6C82SndT52Zs=
@@ -327,6 +338,7 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blend/go-sdk v1.20210908.5 h1:snyngpyEgUM/aWkEtL2i7xigcW0yyac5erHXcjuafug=
 github.com/blend/go-sdk v1.20210908.5/go.mod h1:S74F5c2Ps2heAEJS865XN4behrdblHlu68hZ10sK4FA=
@@ -344,8 +356,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/c-bata/go-prompt v0.2.3 h1:jjCS+QhG/sULBhAaBdjb2PlMRVaKXQgn+4yzaauvs2s=
-github.com/c-bata/go-prompt v0.2.3/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
+github.com/c-bata/go-prompt v0.2.5 h1:3zg6PecEywxNn0xiqcXHD96fkbxghD+gdB2tbsYfl+Y=
+github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -366,6 +378,8 @@ github.com/cevaris/ordered_map v0.0.0-20190319150403-3adeae072e73/go.mod h1:507v
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
+github.com/cheggaaa/pb v1.0.18/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
+github.com/cheggaaa/pb v1.0.27 h1:wIkZHkNfC7R6GI5w7l/PdAdzXzlrbcI3p8OAlnkTsnc=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chmduquesne/rollinghash v4.0.0+incompatible h1:hnREQO+DXjqIw3rUTzWN7/+Dpw+N5Um8zpKV0JOEgbo=
 github.com/chmduquesne/rollinghash v4.0.0+incompatible/go.mod h1:Uc2I36RRfTAf7Dge82bi3RU0OQUmXT9iweIcPqvr8A0=
@@ -535,6 +549,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
@@ -565,6 +580,8 @@ github.com/digitalocean/godo v1.78.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm
 github.com/digitalocean/godo v1.81.0/go.mod h1:BPCqvwbjbGqxuUnIKB4EvS/AX7IDnNmt5fwvIkWo+ew=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/djherbis/times v1.2.0 h1:xANXjsC/iBqbO00vkWlYwPWgBgEVU6m6AFYg0Pic+Mc=
+github.com/djherbis/times v1.2.0/go.mod h1:CGMZlo255K5r4Yw0b9RRfFQpM2y7uOmxg4jm9HsaVf8=
 github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlmiddlecote/sqlstats v1.0.2 h1:gSU11YN23D/iY50A2zVYwgXgy072khatTsIW6UPjUtI=
@@ -617,6 +634,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -647,6 +666,7 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -677,6 +697,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
+github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
+github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -687,6 +709,15 @@ github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
 github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
+github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
+github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
+github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
+github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
+github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -801,6 +832,7 @@ github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -998,6 +1030,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.2 h1:ERKrevVTnCw3Wu4I3mtR15QU3gtWy86cBo6De0jEohg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.2/go.mod h1:chrfS3YoLAlKTRE5cFWvCbt8uGAjshktT4PveTUpsFQ=
+github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
@@ -1046,6 +1079,7 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -1162,8 +1196,11 @@ github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 h1:IPJ3dvxmJ4uczJe5YQdrYB16oTJlGSC/OyZDqUk9xX4=
 github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869/go.mod h1:cJ6Cj7dQo+O6GJNiMx+Pa94qKj+TG8ONdKHgMNIyyag=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
 github.com/jinzhu/gorm v1.9.10/go.mod h1:Kh6hTsSGffh4ui079FHrR5Gg+5D0hgihqDcsDN2BBJY=
@@ -1207,6 +1244,9 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
+github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -1280,6 +1320,8 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
+github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
 github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -1308,6 +1350,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -1358,6 +1401,8 @@ github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HK
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
@@ -1490,6 +1535,7 @@ github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuh
 github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e h1:4cPxUYdgaGzZIT5/j0IfqOrrXmq6bG8AwvwisMXpdrg=
 github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
+github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7lZWlQw5UXuoo=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -1512,6 +1558,7 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
@@ -1540,8 +1587,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 h1:A7GG7zcGjl3jqAqGPmcNjd/D9hzL95SuoOQAaFNdLU0=
-github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
+github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -1616,6 +1663,26 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/pulumi-aws/sdk/v5 v5.1.2/go.mod h1:5Bl3enkEyJD5oDkNZYfduZP7aP3xFjCf7yaBdNuifEo=
+github.com/pulumi/pulumi-aws/sdk/v5 v5.28.0 h1:z9vYkJ+w8JJy5TRV6KCw5Rw3miFhbh4lAB79O6TQJjA=
+github.com/pulumi/pulumi-aws/sdk/v5 v5.28.0/go.mod h1:axXtUAYEclH+SVqr/QmWFzMfJchxrrPiyMrywCcMF9A=
+github.com/pulumi/pulumi-awsx/sdk v1.0.1 h1:Hz5TQ3XAnHQge2F+ydNL1DKxMRXTZY1gk/MSou/2nls=
+github.com/pulumi/pulumi-awsx/sdk v1.0.1/go.mod h1:jwPmIPvPTVYkq+n6Nz/QfMhNZ1cHvBSORdRYvljV9Xo=
+github.com/pulumi/pulumi-docker/sdk/v3 v3.2.0 h1:7liqzpMLCmk7BIO7w6f6JCh9IdtwCp0a//jA12i6eyo=
+github.com/pulumi/pulumi-docker/sdk/v3 v3.2.0/go.mod h1:TACDfD6SWGyaHmWLrtHAuGiZ+pTBD4OYYFb5kTyxdtQ=
+github.com/pulumi/pulumi-eks/sdk v1.0.1 h1:/QstsE+ETWhx3hYVDWHhn4GT7V9aVWrPtyCjKckxB8o=
+github.com/pulumi/pulumi-eks/sdk v1.0.1/go.mod h1:H1+qy3r+WqP4Bw/zSd6vb+ZoY3zjDkCq0B1IScAcxhk=
+github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.17.0 h1:lI8b6zQg4+MgeV2chGi6FC3YRVk7RVMG3Mc8jAy7QZc=
+github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.17.0/go.mod h1:w+Y1d8uqc+gv7JYWLF4rfzvTsIIHR1SCL+GG6sX1xMM=
+github.com/pulumi/pulumi-postgresql/sdk/v3 v3.6.0 h1:WDdcsz0vSOP62hNCi1QBOXVJa/dUTVOmkboQNKmSqS0=
+github.com/pulumi/pulumi-postgresql/sdk/v3 v3.6.0/go.mod h1:twILPrRHxjk0H/1EThW6UMJlc+b9COJd8hOC/i1rp8Q=
+github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
+github.com/pulumi/pulumi/sdk/v3 v3.25.0/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
+github.com/pulumi/pulumi/sdk/v3 v3.27.0/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
+github.com/pulumi/pulumi/sdk/v3 v3.32.1/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
+github.com/pulumi/pulumi/sdk/v3 v3.36.0/go.mod h1:e1xuPnh9aKzCesrFf96DEzcybLdRWRMhKeKVBmb2lm0=
+github.com/pulumi/pulumi/sdk/v3 v3.50.1 h1:te0QzDEaovgya2Vtunhw4W3bABxvu2/a6dgzM5I32oI=
+github.com/pulumi/pulumi/sdk/v3 v3.50.1/go.mod h1:tqQ4z9ocyM/UI2VQ7ZReWR3w6dF5ffEozoHipOMcDh4=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -1630,8 +1697,9 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
@@ -1646,9 +1714,13 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -1711,6 +1783,7 @@ github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -1725,6 +1798,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
+github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -1754,6 +1828,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
+github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 h1:9VTskZOIRf2vKF3UL8TuWElry5pgUpV1tFSe/e/0m/E=
+github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tilinna/clock v1.0.2/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
@@ -1764,8 +1840,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
+github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 h1:X9dsIWPuuEJlPX//UmRKophhOKCGXc46RVIGuttks68=
+github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7/go.mod h1:UxoP3EypF8JfGEjAII8jx1q8rQyDnX8qdTCs/UQBVIE=
+github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-client-go v2.28.0+incompatible h1:G4QSBfvPKvg5ZM2j9MrJFdfI5iSljY/WnJqOGFao6HI=
 github.com/uber/jaeger-client-go v2.28.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -1796,6 +1876,10 @@ github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLV
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
+github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
+github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
+github.com/xanzy/ssh-agent v0.3.2 h1:eKj4SX2Fe7mui28ZgnFW5fmTz1EIr7ugo5s6wDxdHBM=
+github.com/xanzy/ssh-agent v0.3.2/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
@@ -1963,6 +2047,7 @@ golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
@@ -1979,6 +2064,7 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -1989,6 +2075,7 @@ golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -2000,8 +2087,9 @@ golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 h1:vJ2V3lFLg+bBhgroYuRfyN583UzVveQmIXjc8T/y3to=
+golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -2099,6 +2187,7 @@ golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -2113,6 +2202,7 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
@@ -2193,6 +2283,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2263,6 +2354,7 @@ golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200922070232-aee5d888a860/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2289,6 +2381,7 @@ golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2301,6 +2394,7 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210903071746-97244b99971b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2394,6 +2488,7 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -2428,6 +2523,7 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200608174601-1b747fd94509/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -2563,6 +2659,7 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
+google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2705,6 +2802,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
+gopkg.in/cheggaaa/pb.v1 v1.0.28 h1:n1tBJnnK2r7g9OW2btFH91V92STTUevLXYFb8gy9EMk=
+gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
@@ -2726,8 +2825,12 @@ gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
+gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
+gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
 gopkg.in/telebot.v3 v3.0.0/go.mod h1:7rExV8/0mDDNu9epSrDm/8j22KLaActH1Tbee6YjzWg=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -2833,7 +2936,11 @@ k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20221107191617-1a15be271d1d h1:0Smp/HP1OH4Rvhe+4B8nWGERtlqAGSftbSbbmm45oFs=
 k8s.io/utils v0.0.0-20221107191617-1a15be271d1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+lukechampine.com/frand v1.4.2 h1:RzFIpOvkMXuPMBb9maa4ND4wjBn71E1Jpf8BzJHMaVw=
+lukechampine.com/frand v1.4.2/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dtj3s=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
+pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=
+pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
@@ -2860,4 +2967,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
+sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 h1:ucqkfpjg9WzSUubAO62csmucvxl4/JeW3F4I4909XkM=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/src/internal/pfsload/worker.go
+++ b/src/internal/pfsload/worker.go
@@ -43,10 +43,11 @@ func Worker(pachClient *client.APIClient, taskService task.Service) error {
 func processPutFileTask(pachClient *client.APIClient, task *PutFileTask) (*types.Any, error) {
 	result := &PutFileTaskResult{}
 	if err := log.LogStep(pachClient.Ctx(), "putFileTask", func(ctx context.Context) error {
+		pachClient = pachClient.WithCtx(ctx)
 		pachClient.SetAuthToken(task.AuthToken)
 		client := NewValidatorClient(NewPachClient(pachClient))
 		fileSource := NewFileSource(task.FileSource, rand.New(rand.NewSource(task.Seed)))
-		fileSetId, err := PutFile(ctx, client, fileSource, int(task.Count))
+		fileSetId, err := PutFile(pachClient.Ctx(), client, fileSource, int(task.Count))
 		if err != nil {
 			return err
 		}

--- a/src/testing/match/match.go
+++ b/src/testing/match/match.go
@@ -20,15 +20,15 @@ import (
 	"strings"
 )
 
-var invert = flag.Bool("v", false, "If set, match returns an error if the "+
-	"given regex does not match any text on stdin")
-
 func die(f string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, f, args...)
 	os.Exit(1)
 }
 
 func main() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	var invert = flag.Bool("v", false, "If set, match returns an error if the "+
+		"given regex does not match any text on stdin")
 	flag.Parse()
 	if flag.NArg() == 0 {
 		die("Must provide a regex to match")


### PR DESCRIPTION
back porting new iac envs so we can run load tests for `2.5.x` branch