### PR TITLE
small utility to test loki querying without the rest of pachyderm

### DIFF
--- a/src/server/cmd/lokitool/main.go
+++ b/src/server/cmd/lokitool/main.go
@@ -1,0 +1,44 @@
+// Command lokitool uses our code to query Loki.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil"
+	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"go.uber.org/zap"
+)
+
+var (
+	addr       = flag.String("loki", "http://localhost:3100", "where loki is")
+	from       = flag.Duration("from", -30*24*time.Hour, "the start time of the query, relative to now")
+	to         = flag.Duration("to", 0, "the end time of the query, relative to now")
+	query      = flag.String("query", `{pipelineName="edges"}`, "the query string to send to loki")
+	printLines = flag.Bool("printLines", false, "whether to print the returned lines")
+)
+
+func main() {
+	flag.Parse()
+	log.InitPachctlLogger()
+	log.SetLevel(log.DebugLevel)
+	ctx := pctx.Background("")
+	l := &loki.Client{
+		Address: *addr,
+	}
+	var n int
+	if err := lokiutil.QueryRange(ctx, l, *query, time.Now().Add(*from), time.Now().Add(*to), false, func(t time.Time, line string) error {
+		n++
+		if *printLines {
+			fmt.Printf("%v: %s\n", t.Local().Format(time.RFC3339), line)
+		}
+		return nil
+	}); err != nil {
+		log.Error(ctx, "problem querying loki", zap.Error(err))
+	}
+	fmt.Fprintf(os.Stderr, "%d line(s)\n", n)
+}

--- a/src/server/cmd/parseloki/main.go
+++ b/src/server/cmd/parseloki/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bufio"
+	"log"
+	"os"
+
+	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"github.com/pachyderm/pachyderm/v2/src/server/pps/server"
+)
+
+func main() {
+	s := bufio.NewScanner(os.Stdin)
+	for s.Scan() {
+		var result pps.LogMessage
+		if err := server.ParseLokiLine(s.Text(), &result); err != nil {
+			log.Fatal(err)
+		}
+		log.Println(result)
+	}
+}


### PR DESCRIPTION
Get to Loki: `kubectl port-forward pachyderm-loki-0 3100`

Run this: `go run ./src/server/cmd/lokitool`

`-query` accepts an arbitrary query to run; be careful with quoting:

```
$ go run ./src/server/cmd/lokitool -query "{pipelineName=\"edges\"} |= \"GOMAXPROCS\""  -printLines
2023-03-15T22:58:38.241-0400    DEBUG   QueryRange      lokiutil/lokiutil.go:54 QueryRange: span start  {"from": "2023-02-13T21:58:38.241-0500", "to": "2023-03-15T22:58:38.241-0400"}
2023-03-15T22:58:40.515-0400    DEBUG   QueryRange.outgoingHttp promutil/promutil.go:66 outgoing http request complete  {"from": "2023-02-13T21:58:38.241-0500", "to": "2023-03-15T22:58:38.241-0400", "name": "loki", "method": "GET", "uri": "http://localhost:3100/loki/api/v1/query_range?direction=FORWARD&end=1678935518241584988&limit=2000&query=%7BpipelineName%3D%22edges%22%7D+%7C%3D+%22GOMAXPROCS%22&start=1676343518241584388", "duration": "2.273941135s", "status": "200 OK"}                                                         2023-02-20T14:13:18-05:00: {"message":"maxprocs: Leaving GOMAXPROCS=32: CPU quota undefined","severity":"info","time":"2023-02-20T19:13:18.640321161Z"}
2023-02-20T14:17:24-05:00: {"severity":"info","time":"2023-02-20T19:17:24.951485493Z","logger":"maxprocs","caller":"maxprocs/maxprocs.go:47","message":"maxprocs: Leaving GOMAXPROCS=32: CPU quota undefined"}
...
2023-03-15T22:58:40.516-0400    DEBUG   QueryRange      lokiutil/lokiutil.go:68 QueryRange: span finished ok    {"from": "2023-02-13T21:58:38.241-0500", "to": "2023-03-15T22:58:38.241-0400", "spanDuration": "2.274827553s", "nMsgs": 24}
24 line(s)
```