### PR TITLE
Add more context to the worker's logging when user code context is ca…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ parameters:
     default: ""
   go-version:
     type: string
-    default: "1.19"
+    default: "1.20"
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ parameters:
     default: ""
   go-version:
     type: string
-    default: "1.20"
+    default: "1.20.2"
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -478,13 +478,22 @@ jobs:
       resource_class:
         type: string
         default: xlarge
+      arch:
+        type: string
+        default: amd64
     resource_class: << parameters.resource_class >>
     machine:
       image: << pipeline.parameters.machine_image >>
     steps:
       - checkout
-      - go/install:
-          version: << pipeline.parameters.go-version >>
+      # go/install doesn't support arm64 yet
+      - run:
+          name: install go
+          command: |
+            sudo rm -rf /usr/local/go && curl --fail --location -sS "https://dl.google.com/go/go<< pipeline.parameters.go-version >>.linux-<< parameters.arch >>.tar.gz" | sudo tar --no-same-owner -xz -C /usr/local
+            echo "export PATH=$PATH:/usr/local/go/bin" >> "$BASH_ENV"
+            sudo chown -R "$(whoami)": /usr/local/go
+            echo "Installed " && go version
       - run:
           name: setup env vars
           command: |
@@ -1490,9 +1499,11 @@ workflows:
       - deploy-tests:
           name: amd64 deploy tests
           resource_class: xlarge # amd64
+          arch: amd64
       - deploy-tests:
           name: arm64 deploy tests
           resource_class: arm.xlarge # arm64
+          arch: arm64
   jupyter-extension:
     when: << pipeline.parameters.run-jupyter-jobs >>
     jobs:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -449,6 +449,8 @@ jobs:
       image: << pipeline.parameters.machine_image >>
     steps:
       - checkout
+      - go/install:
+          version: << pipeline.parameters.go-version >>
       - run:
           name: setup env vars
           command: |

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -483,6 +483,8 @@ jobs:
       image: << pipeline.parameters.machine_image >>
     steps:
       - checkout
+      - go/install:
+          version: << pipeline.parameters.go-version >>
       - run:
           name: setup env vars
           command: |

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -333,7 +333,11 @@ func (d *driver) RunUserCode(
 	logger.Logf("beginning to run user code")
 	defer func(start time.Time) {
 		if retErr != nil {
-			logger.Logf("errored running user code after %v: %v", time.Since(start), retErr)
+			if ctxErr := context.Cause(ctx); ctxErr != nil {
+				logger.Errf("errored running user code after %v: %v because %v", time.Since(start), retErr, ctxErr)
+			} else {
+				logger.Errf("errored running user code after %v: %v", time.Since(start), retErr)
+			}
 		} else {
 			logger.Logf("finished running user code after %v", time.Since(start))
 		}

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -412,7 +412,11 @@ func (d *driver) RunUserErrorHandlingCode(
 	logger.Logf("beginning to run user error handling code")
 	defer func(start time.Time) {
 		if retErr != nil {
-			logger.Logf("errored running user error handling code after %v: %v", time.Since(start), retErr)
+			if ctxErr := context.Cause(ctx); ctxErr != nil {
+				logger.Errf("errored running user error handling code after %v: %v because %v", time.Since(start), retErr, ctxErr)
+			} else {
+				logger.Errf("errored running user error handling code after %v: %v", time.Since(start), retErr)
+			}
 		} else {
 			logger.Logf("finished running user error handling code after %v", time.Since(start))
 		}


### PR DESCRIPTION
…nceled

For example, when the user code's context gets cancelled due to timeout, we now log with:
```
errored running user code after <duration>: signal: killed because context deadline exceeded
```

If the context wasn't cancelled, then the log message will remain the same as before.