### PR TITLE
Expose logging options for mount server

### DIFF
--- a/jupyter-extension/Dockerfile
+++ b/jupyter-extension/Dockerfile
@@ -2,6 +2,7 @@ FROM jupyter/scipy-notebook:lab-3.3.3
 # https://github.com/pachyderm/docker-stacks/pull/1/commits/fde4beb9ff1afb404f0e34828adc1f311f4bf2d7
 
 ENV PFS_MOUNT_DIR=/pfs
+ENV MOUNT_SERVER_LOG_DIR=/tmp/mount-server.log
 
 # TODO: use ARG TARGETPLATFORM to support arm builds, downloading pachctl arm64
 # binary below (instead of ..._linux_amd64.tar.gz below). See:

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -3,6 +3,7 @@ from distutils.util import strtobool
 
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
+MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -8,7 +8,7 @@ from tornado import locks
 
 from .pachyderm import MountInterface
 from .log import get_logger
-from .env import SIDECAR_MODE
+from .env import SIDECAR_MODE, MOUNT_SERVER_LOG_DIR
 
 lock = locks.Lock()
 MOUNT_SERVER_PORT = 9002
@@ -66,13 +66,17 @@ class MountServerClient(MountInterface):
         async with lock:
             if not await self._is_mount_server_running():
                 self._unmount()
+
+                mount_server_cmd = f"mount-server --mount-dir {self.mount_dir}"
+                if MOUNT_SERVER_LOG_DIR is not None:
+                  mount_server_cmd += f" >> {MOUNT_SERVER_LOG_DIR} 2>&1"
+
                 subprocess.Popen(
                     [
                         "bash",
                         "-c",
                         "set -o pipefail; "
-                        + f"mount-server --mount-dir {self.mount_dir}"
-                        + " >> /tmp/mount-server.log 2>&1",
+                        + mount_server_cmd
                     ]
                 )
 

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -68,7 +68,7 @@ class MountServerClient(MountInterface):
                 self._unmount()
 
                 mount_server_cmd = f"mount-server --mount-dir {self.mount_dir}"
-                if MOUNT_SERVER_LOG_DIR is not None:
+                if MOUNT_SERVER_LOG_DIR is not None and MOUNT_SERVER_LOG_DIR:
                   mount_server_cmd += f" >> {MOUNT_SERVER_LOG_DIR} 2>&1"
 
                 subprocess.Popen(


### PR DESCRIPTION
Users often have trouble sending us /tmp/mount-server.log because it’s too long to copy/paste, but it’s trapped in the notebook server/sidecar container. If we could log to the container’s stdout, users could capture the logs with their existing logging solution, or at least download the logs with kubectl logs.

This change exposes the mount server log location as an ENV variable. When the ENV variable is not specified, mount-server will log to stdout/stderr, which is captured within the Jupyter extension when running as a subprocess. By default, we will still log to /tmp/mount-server.log in order to not change the behavior in an unexpected way.