### PR TITLE
distribute deploy tests round-robin to executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,8 +242,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - v2.0.0
-                - v2.3.9
-                - v2.4.0
-                - v2.5.0-alpha.4
+                - v2.4.6
+                - v2.5.1
                 - latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -482,6 +482,7 @@ jobs:
         type: string
         default: amd64
     resource_class: << parameters.resource_class >>
+    parallelism: 4
     machine:
       image: << pipeline.parameters.machine_image >>
     steps:


### PR DESCRIPTION
This adds 4 executors for the deploy tests. This should lead to 5+ minute speed up for the pipelines. from ~18-20 minutes to ~12-15 minutes. This should mean the bottleneck for ci pipeline performance is now another job.
![image](https://user-images.githubusercontent.com/116583733/226689153-2a280b3b-a809-4b92-b0c0-5b8c79524c73.png)

this unfortunately does not split sub-tests since `go test -list` can't calculate them without starting the execution.

I also updated the api performance test versions while I was there since they hadn't been updated since before the 2.5 release.