### PR TITLE
[Jupyter] Hookup "Create Pipeline" button

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -38,6 +38,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path} | body: {config}")
 
+        # TODO: There's a lot of data-munging here that can error.
         input_spec = config['run'].pop("input")  # Input not allowed in SAME metadata.
         # Paths are relative to the config file. Since the config is being written into
         #  a temporary file, we need to specify an absolute path.

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -57,21 +57,21 @@ def dev_server():
     # Give time for python test server to start
     time.sleep(3)
 
-    # r = requests.put(
-    #     f"{BASE_URL}/config", data=json.dumps({"pachd_address": "localhost:30650"})
-    # )
+    r = requests.put(
+        f"{BASE_URL}/config", data=json.dumps({"pachd_address": "localhost:30650"})
+    )
 
     # Give time for mount server to start
-    running = True
-    # for _ in range(15):
-    #     try:
-    #         r = requests.get(f"{BASE_URL}/config", timeout=1)
-    #         if r.status_code == 200 and r.json()["cluster_status"] != "INVALID":
-    #             running = True
-    #             break
-    #     except Exception:
-    #         pass
-    #     time.sleep(1)
+    running = False
+    for _ in range(15):
+        try:
+            r = requests.get(f"{BASE_URL}/config", timeout=1)
+            if r.status_code == 200 and r.json()["cluster_status"] != "INVALID":
+                running = True
+                break
+        except Exception:
+            pass
+        time.sleep(1)
 
     if running:
         yield

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import time
 import json
+from pathlib import Path
 
 import pytest
 import requests
@@ -16,6 +17,8 @@ BASE_URL = f"{ADDRESS}/{NAMESPACE}/{VERSION}"
 CONFIG_PATH = "~/.pachyderm/config.json"
 ROOT_TOKEN = "iamroot"
 DEFAULT_PROJECT = "default"
+
+TEST_NOTEBOOK = Path(__file__).parent.joinpath('data/TestNotebook.ipynb')
 
 
 @pytest.fixture()
@@ -395,9 +398,16 @@ def simple_pachyderm_env():
 
 def test_pps(dev_server, simple_pachyderm_env):
     client, repo_name, pipeline_name = simple_pachyderm_env
-
+    path = TEST_NOTEBOOK.relative_to(Path.cwd())
+    image = "combinatorml/jupyterlab-tensorflow-opencv:0.9"
     input_spec = dict(pfs=dict(repo=repo_name, glob="/*"))
-    data = dict(pipeline_name=pipeline_name, input=input_spec)
-    r = requests.put(f"{BASE_URL}/pps/_create", data=json.dumps(data))
+    data = dict(
+        apiVersion='sameproject.ml/v1alpha1',
+        environments=dict(default=dict(image_tag=image)),
+        metadata=dict(name=pipeline_name, version='0.0.0'),
+        notebook=dict(requirements=''),
+        run=dict(name=pipeline_name, input=json.dumps(input_spec)),
+    )
+    r = requests.put(f"{BASE_URL}/pps/_create/{path}", data=json.dumps(data))
     assert r.status_code == 200
     assert next(client.inspect_pipeline(pipeline_name))

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -5,6 +5,7 @@ import {SameMetadata} from '../../types';
 
 type PipelineProps = {
   setShowPipeline: (shouldShow: boolean) => void;
+  notebookPath: string | undefined;
   saveNotebookMetadata: (metadata: any) => void;
   metadata: SameMetadata | undefined;
 };
@@ -18,6 +19,7 @@ const placeholderRequirements = './requirements.txt';
 
 const Pipeline: React.FC<PipelineProps> = ({
   setShowPipeline,
+  notebookPath,
   saveNotebookMetadata,
   metadata,
 }) => {
@@ -34,7 +36,7 @@ const Pipeline: React.FC<PipelineProps> = ({
     callCreatePipeline,
     callSavePipeline,
     errorMessage,
-  } = usePipeline(metadata, saveNotebookMetadata);
+  } = usePipeline(metadata, notebookPath, saveNotebookMetadata);
 
   return (
     <div className="pachyderm-mount-pipeline-base">

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
@@ -42,6 +42,7 @@ describe('PPS screen', () => {
         <Pipeline
           metadata={md}
           setShowPipeline={setShowPipeline}
+          notebookPath={'FakeNotebook.ipynb'}
           saveNotebookMetadata={saveNotebookMetaData}
         />,
       );

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -44,45 +44,48 @@ export const usePipeline = (
     }
   }, [metadata]);
 
-  let input;
-  try {
-    input = YAML.parse(inputSpec);
-  } catch (e) {
-    if (e instanceof YAML.YAMLParseError) {
-      input = JSON.parse(inputSpec);
-    } else {
-      throw e;
+  const createSameMetadata = (): SameMetadata => {
+    let input: string;
+    try {
+      input = YAML.parse(inputSpec);
+    } catch (e) {
+      if (e instanceof YAML.YAMLParseError) {
+        input = JSON.parse(inputSpec);
+      } else {
+        throw e;
+      }
     }
-  }
 
-  const samemeta: SameMetadata = {
-    apiVersion: 'sameproject.ml/v1alpha1',
-    environments: {
-      default: {
-        image_tag: imageName,
+    return {
+      apiVersion: 'sameproject.ml/v1alpha1',
+      environments: {
+        default: {
+          image_tag: imageName,
+        },
       },
-    },
-    metadata: {
-      name: pipelineName,
-      version: '0.0.0',
-    },
-    notebook: {
-      requirements: requirements,
-    },
-    run: {
-      name: pipelineName,
-      input: JSON.stringify(input),
-    },
+      metadata: {
+        name: pipelineName,
+        version: '0.0.0',
+      },
+      notebook: {
+        requirements: requirements,
+      },
+      run: {
+        name: pipelineName,
+        input: JSON.stringify(input),
+      },
+    };
   };
 
   const callCreatePipeline = async () => {
     setLoading(true);
     setErrorMessage('');
 
+    const sameMetadata = createSameMetadata();
     const response = await requestAPI<CreatePipelineResponse>(
       `pps/_create/${notebookPath}`,
       'PUT',
-      samemeta as ReadonlyJSONObject,
+      sameMetadata as ReadonlyJSONObject,
     );
     if (response.error) {
       setErrorMessage(response.error);
@@ -92,7 +95,8 @@ export const usePipeline = (
   };
 
   const callSavePipeline = async () => {
-    saveNotebookMetaData(samemeta);
+    const sameMetadata = createSameMetadata();
+    saveNotebookMetaData(sameMetadata);
     console.log('save pipeline called');
   };
 

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -4,6 +4,7 @@ import {useEffect, useState} from 'react';
 import {CreatePipelineResponse, SameMetadata} from '../../../types';
 import {requestAPI} from '../../../../../handler';
 import {ReadonlyJSONObject} from '@lumino/coreutils';
+import {ServerConnection} from '@jupyterlab/services';
 
 export type usePipelineResponse = {
   loading: boolean;
@@ -82,13 +83,18 @@ export const usePipeline = (
     setErrorMessage('');
 
     const sameMetadata = createSameMetadata();
-    const response = await requestAPI<CreatePipelineResponse>(
-      `pps/_create/${notebookPath}`,
-      'PUT',
-      sameMetadata as ReadonlyJSONObject,
-    );
-    if (response.error) {
-      setErrorMessage(response.error);
+    try {
+      const response = await requestAPI<CreatePipelineResponse>(
+        `pps/_create/${notebookPath}`,
+        'PUT',
+        sameMetadata as ReadonlyJSONObject,
+      );
+    } catch (e) {
+      if (e instanceof ServerConnection.ResponseError) {
+        setErrorMessage(e.message);
+      } else {
+        throw e;
+      }
     }
     console.log('create pipeline called');
     setLoading(false);

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -231,6 +231,9 @@ export class MountPlugin implements IMountPlugin {
           <>
             <Pipeline
               setShowPipeline={this.setShowPipeline}
+              notebookPath={
+                this.getActiveNotebook()?.sessionContext?.session?.path
+              }
               saveNotebookMetadata={this.saveNotebookMetaData}
               metadata={metadata}
             />

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -116,3 +116,7 @@ export type SameRunMetadata = {
   name: string;
   input?: string; //Note: SAME doesn't actually read this field when reading from the notebook and instead expects you to pass it on the command line
 };
+
+export type CreatePipelineResponse = {
+  error: string | null;
+};

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -118,5 +118,5 @@ export type SameRunMetadata = {
 };
 
 export type CreatePipelineResponse = {
-  error: string | null;
+  message: string | null;
 };


### PR DESCRIPTION
* Implement callCreatePipeline function in the frontend
* Update python backend to handle real same config body sent from the frontend

Future work
- [ ] Add visual feedback pipeline has started to run (modal?)
- [ ] Display nicer error if pipeline fails (currently a stack trace)
- [ ] Check if notebook saved (dirty) before running pipeline
- [ ] SAME is extremely slow, perhaps this will be fixed when we interact with pachyderm directly, may need to add loading spinner
- [ ] Input spec - handle JSON in call cases (ie, saving notebook)
- [ ] e2e tests