### PR TITLE
auth: setup default project role binding where we set up all the others

### DIFF
--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -39,11 +39,13 @@ type TransactionContext struct {
 	// problematic when activating auth in a transaction.  The cache isn't updated because the
 	// transaction hasn't committed, but this transaction should assume that auth IS activated,
 	// because it will be when the transaction commits.  (If it rolls back, fine; inside the
-	// transaction, auth was on!)
+	// transaction, auth was on!) The reason wwe rely on caching the listener events is because
+	// pretty much every RPC in Pachyderm calls "auth.isActiveInTransaction", and the
+	// performance overhead of going to the database to determine this is too high.
 	//
-	// We rely on the listener events because pretty much every RPC in Pachyderm calls
-	// "auth.isActiveInTransaction", and the performance overhead of going to the database to
-	// determine this is too high.
+	// This variable is set to true when auth is successfully enabled in this transaction, and
+	// is checked by isActiveInTransaction.  Other transactions cannot observe this uncommitted
+	// state.
 	AuthBeingActivated atomic.Bool
 
 	ctx context.Context

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -39,7 +39,7 @@ type TransactionContext struct {
 	// problematic when activating auth in a transaction.  The cache isn't updated because the
 	// transaction hasn't committed, but this transaction should assume that auth IS activated,
 	// because it will be when the transaction commits.  (If it rolls back, fine; inside the
-	// transaction, auth was on!) The reason wwe rely on caching the listener events is because
+	// transaction, auth was on!) The reason we rely on caching the listener events is because
 	// pretty much every RPC in Pachyderm calls "auth.isActiveInTransaction", and the
 	// performance overhead of going to the database to determine this is too high.
 	//

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -477,10 +477,6 @@ func (a *apiServer) activateInTransaction(ctx context.Context, txCtx *txncontext
 		}); err != nil {
 			return errors.EnsureStack(err)
 		}
-		// Grant all users ProjectWriter role for default project
-		if err := a.CreateRoleBindingInTransaction(txCtx, auth.AllClusterUsersSubject, []string{auth.ProjectWriterRole}, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: pfs.DefaultProjectName}); err != nil {
-			return errors.Wrapf(err, "could not create role binding for project %q", pfs.DefaultProjectName)
-		}
 		return a.insertAuthTokenNoTTLInTransaction(txCtx, auth.HashToken(pachToken), auth.RootUser)
 	}); err != nil {
 		return nil, errors.Wrapf(err, "insert root token")

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/license"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
 )
 
 func envWithAuth(t *testing.T) *realenv.RealEnv {
@@ -2451,6 +2453,58 @@ func TestModifyRoleBindingAccess(t *testing.T) {
 	}
 }
 
+func TestListRepoAfterAuthActivation(t *testing.T) {
+	// This test ensures that CORE-1548 doesn't come back.
+	t.Parallel()
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	c := env.PachClient.WithCtx(ctx)
+	ctx = c.Ctx()
+
+	// Create a repo in the default project.
+	err := c.CreateProjectRepo("default", "test")
+	require.NoError(t, err, "should create the default/test repo")
+
+	// Ensure we can list repos, and that this one shows up.
+	ensureTestRepoExists := func(c *client.APIClient) {
+		t.Helper()
+		repos, err := c.ListRepo()
+		require.NoError(t, err, "should be able to list repos")
+
+		got := make(map[string]struct{})
+		for _, r := range repos {
+			got[r.GetRepo().String()] = struct{}{}
+		}
+		require.Equal(t, map[string]struct{}{"default/test": {}}, got, "should have one repo: default/test")
+	}
+	ensureTestRepoExists(c)
+
+	// Prepare to activate auth.
+	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
+
+	// Enterprise needs a license.
+	tu.ActivateLicense(t, c, peerPort)
+
+	// Activate enterprise.
+	_, err = env.PachClient.Enterprise.Activate(env.PachClient.Ctx(),
+		&enterprise.ActivateRequest{
+			LicenseServer: "grpc://localhost:" + peerPort,
+			Id:            "localhost",
+			Secret:        "localhost",
+		})
+	require.NoError(t, err, "should activate enterprise")
+
+	// Then setup auth in a single transaction.
+	err = env.AuthServer.(interface {
+		ActivateAuthEverywhere(context.Context, []authserver.ActivationScope, string) error
+	}).ActivateAuthEverywhere(ctx, []authserver.ActivationScope{authserver.ActivationScopePFS, authserver.ActivationScopePPS}, testutil.RootToken)
+	require.NoError(t, err, "should activate auth everywhere")
+
+	// Ensure we can still list repos.
+	c.SetAuthToken(testutil.RootToken)
+	ensureTestRepoExists(c)
+}
+
 func TestPreAuthProjects(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
@@ -2459,7 +2513,7 @@ func TestPreAuthProjects(t *testing.T) {
 	project := tu.UniqueString("project")
 	require.NoError(t, c.CreateProject(project))
 
-	// activate auth auth
+	// activate enterprise + auth
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateLicense(t, c, peerPort)
 	_, err := env.PachClient.Enterprise.Activate(env.PachClient.Ctx(),
@@ -2473,7 +2527,11 @@ func TestPreAuthProjects(t *testing.T) {
 	require.NoError(t, err)
 	c.SetAuthToken(tu.RootToken)
 
-	// default project's role binding should be created automatically via auth activation
+	// activate pfs auth
+	_, err = c.PfsAPIClient.ActivateAuth(c.Ctx(), &pfs.ActivateAuthRequest{})
+	require.NoError(t, err)
+
+	// default project's role binding should be created automatically via PFS auth activation
 	_, err = c.ModifyRoleBinding(c.Ctx(), &auth.ModifyRoleBindingRequest{
 		Principal: tu.Robot("marvin"),
 		Roles:     []string{},
@@ -2481,19 +2539,7 @@ func TestPreAuthProjects(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// however non-defualt projects get their role bindings through pfs auth activation
-	_, err = c.ModifyRoleBinding(c.Ctx(), &auth.ModifyRoleBindingRequest{
-		Principal: tu.Robot("marvin"),
-		Roles:     []string{},
-		Resource:  &auth.Resource{Type: auth.ResourceType_PROJECT, Name: project},
-	})
-	require.YesError(t, err)
-
-	// activate pfs auth
-	_, err = c.PfsAPIClient.ActivateAuth(c.Ctx(), &pfs.ActivateAuthRequest{})
-	require.NoError(t, err)
-
-	// We are just using ModifyRoleBinding to trigger some code that checks for the project's role binding.
+	// non-default projects also get their role bindings through pfs auth activation
 	_, err = c.ModifyRoleBinding(c.Ctx(), &auth.ModifyRoleBindingRequest{
 		Principal: tu.Robot("marvin"),
 		Roles:     []string{},

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2467,7 +2467,7 @@ func TestListRepoAfterAuthActivation(t *testing.T) {
 	require.NoError(t, err, "should create the default/test repo")
 
 	// Create a pipeline, to ensure that PPS auth activation works.
-	err = c.CreateProjectPipeline("default", "pipeline", "", nil, nil, &pps.ParallelismSpec{}, client.NewPFSInput("test", "*"), "", false)
+	err = c.CreateProjectPipeline("default", "pipeline", "", nil, nil, &pps.ParallelismSpec{}, client.NewProjectPFSInput("default", "test", "*"), "", false)
 	require.NoError(t, err, "should create the default/pipeline pipeline")
 
 	// Ensure we can list repos, and that this one shows up.

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -18,16 +18,17 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/authdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	internalauth "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
-	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/license"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -2497,11 +2498,11 @@ func TestListRepoAfterAuthActivation(t *testing.T) {
 	// Then setup auth in a single transaction.
 	err = env.AuthServer.(interface {
 		ActivateAuthEverywhere(context.Context, []authserver.ActivationScope, string) error
-	}).ActivateAuthEverywhere(ctx, []authserver.ActivationScope{authserver.ActivationScopePFS, authserver.ActivationScopePPS}, testutil.RootToken)
+	}).ActivateAuthEverywhere(internalauth.AsInternalUser(ctx, authdb.InternalUser), []authserver.ActivationScope{authserver.ActivationScopePFS, authserver.ActivationScopePPS}, tu.RootToken)
 	require.NoError(t, err, "should activate auth everywhere")
 
 	// Ensure we can still list repos.
-	c.SetAuthToken(testutil.RootToken)
+	c.SetAuthToken(tu.RootToken)
 	ensureTestRepoExists(c)
 }
 

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2466,6 +2466,10 @@ func TestListRepoAfterAuthActivation(t *testing.T) {
 	err := c.CreateProjectRepo("default", "test")
 	require.NoError(t, err, "should create the default/test repo")
 
+	// Create a pipeline, to ensure that PPS auth activation works.
+	err = c.CreateProjectPipeline("default", "pipeline", "", nil, nil, &pps.ParallelismSpec{}, client.NewPFSInput("test", "*"), "", false)
+	require.NoError(t, err, "should create the default/pipeline pipeline")
+
 	// Ensure we can list repos, and that this one shows up.
 	ensureTestRepoExists := func(c *client.APIClient) {
 		t.Helper()
@@ -2476,7 +2480,7 @@ func TestListRepoAfterAuthActivation(t *testing.T) {
 		for _, r := range repos {
 			got[r.GetRepo().String()] = struct{}{}
 		}
-		require.Equal(t, map[string]struct{}{"default/test": {}}, got, "should have one repo: default/test")
+		require.Equal(t, map[string]struct{}{"default/test": {}, "default/pipeline": {}}, got, "should have one repo: default/test")
 	}
 	ensureTestRepoExists(c)
 

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -73,7 +73,15 @@ func (a *apiServer) ActivateAuthInTransaction(txnCtx *txncontext.TransactionCont
 	// Create role bindings for projects created before auth activation
 	var projectInfo pfs.ProjectInfo
 	if err := a.driver.projects.ReadWrite(txnCtx.SqlTx).List(&projectInfo, col.DefaultOptions(), func(string) error {
-		err := a.env.AuthServer.CreateRoleBindingInTransaction(txnCtx, "", nil, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: projectInfo.Project.Name})
+		var principal string
+		var roleSlice []string
+		if projectInfo.Project.Name == pfs.DefaultProjectName {
+			// Grant all users ProjectWriter role for default project.
+			principal = auth.AllClusterUsersSubject
+			roleSlice = []string{auth.ProjectWriterRole}
+		}
+
+		err := a.env.AuthServer.CreateRoleBindingInTransaction(txnCtx, principal, roleSlice, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: projectInfo.Project.Name})
 		if err != nil && !col.IsErrExists(err) {
 			return errors.EnsureStack(err)
 		}


### PR DESCRIPTION
This avoids a transaction conflict that can't be resolved.