### PR TITLE
PFS CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+
+# PFS
+/src/pfs/                @pachyderm/PFS
+/src/server/pfs/         @pachyderm/PFS
+# Exclude S3 Gateway
+/src/server/pfs/s3 


### PR DESCRIPTION
Adds back the CODEOWNERS file, this time with just the PFS directories.  We have turned off the auto-assigner for @pachyderm/pfs. Hopefully that will prevent the explosion of reviewers, and contributors can manually assign someone.