### PR TITLE
[2.5.x] Fix auth activation from the environment

### DIFF
--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -127,44 +128,88 @@ func NewAuthServer(env Env, public, requireNoncriticalServers, watchesEnabled bo
 	return s, nil
 }
 
+// ActivationScope is an additional service to activate auth for.
+type ActivationScope int
+
+const (
+	ActivationScopePFS ActivationScope = iota // Activate auth for PFS.
+	ActivationScopePPS                        // Activate auth for PPS.
+)
+
+// String implements fmt.Stringer.
+func (s ActivationScope) String() string {
+	switch s { //exhaustive:enforce
+	case ActivationScopePFS:
+		return "PFS"
+	case ActivationScopePPS:
+		return "PPS"
+	}
+	panic(fmt.Sprintf("invalid auth scope %d", int(s)))
+}
+
+// ActivateAuthEverywhere activates auth, and PPS and PFS auth, in a single transaction.  It is only
+// exposed publicly for testing; do not call it from outside this package.
+func (a *apiServer) ActivateAuthEverywhere(ctx context.Context, scopes []ActivationScope, rootToken string) error {
+	if err := a.env.TxnEnv.WithWriteContext(ctx, func(txCtx *txncontext.TransactionContext) error {
+		log.Debug(ctx, "attempting to activate auth")
+		if _, err := a.activateInTransaction(ctx, txCtx, &auth.ActivateRequest{
+			RootToken: rootToken,
+		}); err != nil {
+			if !errors.Is(err, auth.ErrAlreadyActivated) {
+				return errors.Wrap(err, "activate auth")
+			}
+			log.Debug(ctx, "auth already active; rotating root token")
+			_, err := a.rotateRootTokenInTransaction(txCtx,
+				&auth.RotateRootTokenRequest{
+					RootToken: rootToken,
+				})
+			return errors.Wrap(err, "rotate root token")
+		}
+		for _, s := range scopes {
+			switch s { //exhaustive:enforce
+			case ActivationScopePFS:
+				log.Debug(ctx, "attempting to activate PFS auth")
+				if _, err := a.env.GetPfsServer().ActivateAuthInTransaction(txCtx, &pfs.ActivateAuthRequest{}); err != nil {
+					return errors.Wrap(err, "activate auth for pfs")
+				}
+			case ActivationScopePPS:
+				log.Debug(ctx, "attempting to activate PPS auth")
+				if _, err := a.env.GetPpsServer().ActivateAuthInTransaction(txCtx, &pps.ActivateAuthRequest{}); err != nil {
+					return errors.Wrap(err, "activate auth for pps")
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "activate auth everywhere (%v)", scopes)
+	}
+	log.Info(ctx, "activated auth ok", zap.Stringers("scopes", scopes))
+	return nil
+}
+
 func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 	if !a.env.Config.ActivateAuth {
 		return nil
 	}
 	log.Info(ctx, "Started to configure auth server via environment")
 	ctx = internalauth.AsInternalUser(ctx, authdb.InternalUser)
-	if err := func() error {
-		// handle auth activation
-		if a.env.Config.AuthRootToken != "" {
-			if err := a.env.TxnEnv.WithWriteContext(ctx, func(txCtx *txncontext.TransactionContext) error {
-				if _, err := a.activateInTransaction(ctx, txCtx, &auth.ActivateRequest{
-					RootToken: a.env.Config.AuthRootToken,
-				}); err != nil {
-					if !errors.Is(err, auth.ErrAlreadyActivated) {
-						return errors.Wrapf(err, "activate auth")
-					}
-					_, err := a.rotateRootTokenInTransaction(txCtx,
-						&auth.RotateRootTokenRequest{
-							RootToken: a.env.Config.AuthRootToken,
-						})
-					return errors.Wrapf(err, "rotate root token")
-				} else {
-					if a.env.Config.PachdSpecificConfiguration != nil {
-						if _, err := a.env.GetPfsServer().ActivateAuthInTransaction(txCtx, &pfs.ActivateAuthRequest{}); err != nil {
-							return errors.Wrap(err, "activate auth for pfs")
-						}
-						if _, err := a.env.GetPpsServer().ActivateAuthInTransaction(txCtx, &pps.ActivateAuthRequest{}); err != nil {
-							return errors.Wrap(err, "activate auth for pps")
-						}
-					}
-				}
-				return nil
-			}); err != nil {
-				return errors.Wrapf(err, "activate auth via environment")
-			}
+	// handle auth activation
+	if rootToken := a.env.Config.AuthRootToken; rootToken != "" {
+		var scopes []ActivationScope
+		if a.env.Config.PachdSpecificConfiguration != nil {
+			// If this is pachd and not the enterprise server, activate auth for PFS and
+			// PPS.
+			scopes = []ActivationScope{ActivationScopePFS, ActivationScopePPS}
 		}
+		if err := a.ActivateAuthEverywhere(ctx, scopes, rootToken); err != nil {
+			return errors.Wrapf(err, "activate auth via environment")
+		}
+	}
+
+	if err := func() error {
 		// handle oidc clients & this cluster's auth config
 		if a.env.Config.AuthConfig != "" && a.env.Config.IdentityClients != "" {
+			log.Info(ctx, "attempting to add or update oidc clients")
 			var config auth.OIDCConfig
 			var clients []identity.OIDCClient
 			if err := yaml.Unmarshal([]byte(a.env.Config.AuthConfig), &config); err != nil {
@@ -175,7 +220,6 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 				return errors.Wrapf(err, "unmarshal identity clients: %q", a.env.Config.IdentityClients)
 			}
 			if a.env.Config.IdentityAdditionalClients != "" {
-				log.Info(ctx, "Adding extra oidc clients configured via environment")
 				var extras []identity.OIDCClient
 				if err := yaml.Unmarshal([]byte(a.env.Config.IdentityAdditionalClients), &extras); err != nil {
 					return errors.Wrapf(err, "unmarshal extra identity clients: %q", a.env.Config.IdentityAdditionalClients)
@@ -183,15 +227,17 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 				clients = append(clients, extras...)
 			}
 			for _, c := range clients {
+				log.Info(ctx, "adding oidc client", zap.String("id", c.Id), zap.Bool("via_enterprise_server", a.env.Config.EnterpriseMember))
 				if c.Id == config.ClientID { // c represents pachd
 					c.Secret = config.ClientSecret
 					if a.env.Config.TrustedPeers != "" {
-						log.Info(ctx, "Adding additional pachd trusted peers configured via environment")
 						var tps []string
 						if err := yaml.Unmarshal([]byte(a.env.Config.TrustedPeers), &tps); err != nil {
 							return errors.Wrapf(err, "unmarshal trusted peers: %q", a.env.Config.TrustedPeers)
 						}
 						c.TrustedPeers = append(c.TrustedPeers, tps...)
+						log.Info(ctx, "adding additional pachd trusted peers configured via environment", zap.Strings("trusted_peers", c.TrustedPeers), zap.String("id", c.Id))
+
 					}
 				}
 				if c.Id == a.env.Config.ConsoleOAuthID {
@@ -230,12 +276,14 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 					}
 				}
 			}
+			log.Info(ctx, "setting auth configuration", log.Proto("config", &config))
 			if _, err := a.SetConfiguration(ctx, &auth.SetConfigurationRequest{Configuration: &config}); err != nil {
 				return err
 			}
 		}
 		// cluster role bindings
 		if a.env.Config.AuthClusterRoleBindings != "" {
+			log.Info(ctx, "setting up cluster role bindings")
 			var roleBinding map[string][]string
 			if err := yaml.Unmarshal([]byte(a.env.Config.AuthClusterRoleBindings), &roleBinding); err != nil {
 				return errors.Wrapf(err, "unmarshal auth cluster role bindings: %q", a.env.Config.AuthClusterRoleBindings)
@@ -249,11 +297,14 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 			for p := range existing.Binding.Entries {
 				// `pach:` user role bindings cannot be modified
 				if strings.HasPrefix(p, auth.PachPrefix) || strings.HasPrefix(p, auth.InternalPrefix) {
+					log.Info(ctx, "skipping role binding because pach: role bindings cannot be modified", zap.String("principal", p))
 					continue
 				}
 				if _, ok := roleBinding[p]; !ok {
+					rsc := &auth.Resource{Type: auth.ResourceType_CLUSTER}
+					log.Debug(ctx, "unsetting existing role binding", log.Proto("resource", rsc), zap.String("principal", p))
 					if _, err := a.ModifyRoleBinding(ctx, &auth.ModifyRoleBindingRequest{
-						Resource:  &auth.Resource{Type: auth.ResourceType_CLUSTER},
+						Resource:  rsc,
 						Principal: p,
 					}); err != nil {
 						return errors.Wrapf(err, "unset principal cluster role bindings for principal %q", p)
@@ -261,8 +312,10 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 				}
 			}
 			for p, r := range roleBinding {
+				rsc := &auth.Resource{Type: auth.ResourceType_CLUSTER}
+				log.Info(ctx, "modifying existing role binding", log.Proto("resource", rsc), zap.String("principal", p), zap.Strings("roles", r))
 				if _, err := a.ModifyRoleBinding(ctx, &auth.ModifyRoleBindingRequest{
-					Resource:  &auth.Resource{Type: auth.ResourceType_CLUSTER},
+					Resource:  rsc,
 					Principal: p,
 					Roles:     r,
 				}); err != nil {
@@ -328,7 +381,7 @@ func (a *apiServer) isActiveInTransaction(txnCtx *txncontext.TransactionContext)
 // and returns an error if auth is not activated. This can require hitting
 // postgres if watches are not enabled (in the worker sidecar).
 func (a *apiServer) getClusterRoleBindingInTransaction(txnCtx *txncontext.TransactionContext) (*auth.RoleBinding, error) {
-	if a.watchesEnabled {
+	if a.watchesEnabled && !txnCtx.AuthBeingActivated.Load() {
 		bindings, ok := a.clusterRoleBindingCache.Load().(*auth.RoleBinding)
 		if !ok {
 			return nil, errors.New("cached cluster binding had unexpected type")
@@ -466,25 +519,20 @@ func (a *apiServer) activateInTransaction(ctx context.Context, txCtx *txncontext
 
 	// Store a new Pachyderm token (as the caller is authenticating) and
 	// initialize the root user as a cluster admin
-	if err := a.env.TxnEnv.WithWriteContext(ctx, func(txCtx *txncontext.TransactionContext) error {
-		roleBindings := a.roleBindings.ReadWrite(txCtx.SqlTx)
-		if err := roleBindings.Put(auth.ClusterRoleBindingKey, &auth.RoleBinding{
-			Entries: map[string]*auth.Roles{
-				auth.RootUser:               {Roles: map[string]bool{auth.ClusterAdminRole: true}},
-				authdb.InternalUser:         {Roles: map[string]bool{auth.ClusterAdminRole: true}},
-				auth.AllClusterUsersSubject: {Roles: map[string]bool{auth.ProjectCreator: true}},
-			},
-		}); err != nil {
-			return errors.EnsureStack(err)
-		}
-		// TODO CORE-1048 make all users ProjectWriter for default project
-		if err := a.CreateRoleBindingInTransaction(txCtx, "", nil, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: pfs.DefaultProjectName}); err != nil {
-			return errors.Wrapf(err, "could not create role binding for project %q", pfs.DefaultProjectName)
-		}
-		return a.insertAuthTokenNoTTLInTransaction(txCtx, auth.HashToken(pachToken), auth.RootUser)
+	roleBindings := a.roleBindings.ReadWrite(txCtx.SqlTx)
+	if err := roleBindings.Put(auth.ClusterRoleBindingKey, &auth.RoleBinding{
+		Entries: map[string]*auth.Roles{
+			auth.RootUser:               {Roles: map[string]bool{auth.ClusterAdminRole: true}},
+			authdb.InternalUser:         {Roles: map[string]bool{auth.ClusterAdminRole: true}},
+			auth.AllClusterUsersSubject: {Roles: map[string]bool{auth.ProjectCreator: true}},
+		},
 	}); err != nil {
-		return nil, errors.Wrapf(err, "insert root token")
+		return nil, errors.Wrap(err, "add cluster role binding")
 	}
+	if err := a.insertAuthTokenNoTTLInTransaction(txCtx, auth.HashToken(pachToken), auth.RootUser); err != nil {
+		return nil, errors.Wrap(err, "insert root token")
+	}
+	txCtx.AuthBeingActivated.Store(true)
 	return &auth.ActivateResponse{PachToken: pachToken}, nil
 }
 

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -276,7 +276,7 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 					}
 				}
 			}
-			log.Info(ctx, "setting auth configuration", log.Proto("config", &config))
+			log.Info(ctx, "setting auth configuration")
 			if _, err := a.SetConfiguration(ctx, &auth.SetConfigurationRequest{Configuration: &config}); err != nil {
 				return err
 			}

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -18,12 +18,14 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/authdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/clientsdk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	internalauth "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
@@ -31,6 +33,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/license"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
 )
 
 func envWithAuth(t *testing.T) *realenv.RealEnv {
@@ -2420,6 +2423,62 @@ func TestModifyRoleBindingAccess(t *testing.T) {
 	}
 }
 
+func TestListRepoAfterAuthActivation(t *testing.T) {
+	// This test ensures that CORE-1548 doesn't come back.
+	t.Parallel()
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	c := env.PachClient.WithCtx(ctx)
+	ctx = c.Ctx()
+
+	// Create a repo in the default project.
+	err := c.CreateProjectRepo("default", "test")
+	require.NoError(t, err, "should create the default/test repo")
+
+	// Create a pipeline, to ensure that PPS auth activation works.
+	err = c.CreateProjectPipeline("default", "pipeline", "", nil, nil, &pps.ParallelismSpec{}, client.NewProjectPFSInput("default", "test", "*"), "", false)
+	require.NoError(t, err, "should create the default/pipeline pipeline")
+
+	// Ensure we can list repos, and that this one shows up.
+	ensureTestRepoExists := func(c *client.APIClient) {
+		t.Helper()
+		repos, err := c.ListRepo()
+		require.NoError(t, err, "should be able to list repos")
+
+		got := make(map[string]struct{})
+		for _, r := range repos {
+			got[r.GetRepo().String()] = struct{}{}
+		}
+		require.Equal(t, map[string]struct{}{"default/test": {}, "default/pipeline": {}}, got, "should have one repo: default/test")
+	}
+	ensureTestRepoExists(c)
+
+	// Prepare to activate auth.
+	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
+
+	// Enterprise needs a license.
+	tu.ActivateLicense(t, c, peerPort)
+
+	// Activate enterprise.
+	_, err = env.PachClient.Enterprise.Activate(env.PachClient.Ctx(),
+		&enterprise.ActivateRequest{
+			LicenseServer: "grpc://localhost:" + peerPort,
+			Id:            "localhost",
+			Secret:        "localhost",
+		})
+	require.NoError(t, err, "should activate enterprise")
+
+	// Then setup auth in a single transaction.
+	err = env.AuthServer.(interface {
+		ActivateAuthEverywhere(context.Context, []authserver.ActivationScope, string) error
+	}).ActivateAuthEverywhere(internalauth.AsInternalUser(ctx, authdb.InternalUser), []authserver.ActivationScope{authserver.ActivationScopePFS, authserver.ActivationScopePPS}, tu.RootToken)
+	require.NoError(t, err, "should activate auth everywhere")
+
+	// Ensure we can still list repos.
+	c.SetAuthToken(tu.RootToken)
+	ensureTestRepoExists(c)
+}
+
 func TestPreAuthProjects(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
@@ -2428,7 +2487,7 @@ func TestPreAuthProjects(t *testing.T) {
 	project := tu.UniqueString("project")
 	require.NoError(t, c.CreateProject(project))
 
-	// activate auth auth
+	// activate enterprise + auth
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateLicense(t, c, peerPort)
 	_, err := env.PachClient.Enterprise.Activate(env.PachClient.Ctx(),
@@ -2442,7 +2501,11 @@ func TestPreAuthProjects(t *testing.T) {
 	require.NoError(t, err)
 	c.SetAuthToken(tu.RootToken)
 
-	// default project's role binding should be created automatically via auth activation
+	// activate pfs auth
+	_, err = c.PfsAPIClient.ActivateAuth(c.Ctx(), &pfs.ActivateAuthRequest{})
+	require.NoError(t, err)
+
+	// default project's role binding should be created automatically via PFS auth activation
 	_, err = c.ModifyRoleBinding(c.Ctx(), &auth.ModifyRoleBindingRequest{
 		Principal: tu.Robot("marvin"),
 		Roles:     []string{},
@@ -2450,19 +2513,7 @@ func TestPreAuthProjects(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// however non-defualt projects get their role bindings through pfs auth activation
-	_, err = c.ModifyRoleBinding(c.Ctx(), &auth.ModifyRoleBindingRequest{
-		Principal: tu.Robot("marvin"),
-		Roles:     []string{},
-		Resource:  &auth.Resource{Type: auth.ResourceType_PROJECT, Name: project},
-	})
-	require.YesError(t, err)
-
-	// activate pfs auth
-	_, err = c.PfsAPIClient.ActivateAuth(c.Ctx(), &pfs.ActivateAuthRequest{})
-	require.NoError(t, err)
-
-	// We are just using ModifyRoleBinding to trigger some code that checks for the project's role binding.
+	// non-default projects also get their role bindings through pfs auth activation
 	_, err = c.ModifyRoleBinding(c.Ctx(), &auth.ModifyRoleBindingRequest{
 		Principal: tu.Robot("marvin"),
 		Roles:     []string{},


### PR DESCRIPTION
Backport of #8678.

Relative to the version in master, I removed a log line that would log sensitive information in 2.5 (no log redaction yet).  I also didn't fix any TODOs in the nearby code; 2.6 adds some new roles around projects, we don't add that one here.

* auth: setup default project role binding where we set up all the other role bindings; to avoid a txn conflict

* auth: add test for the transaction problems; adjust old tests that rely on half-activated auth; add log messages to auth activation flow

* fix logging typos and incorrect fields; make sure the test fails when the bug is re-introduced (it does)

* auth: activateInTransaction: avoid nested transaction

* auth: we rely on transactions being committed too early; fixing that opened a new issue; so now the transaction context also caches whether or not auth is enabled

* lint

* improve comment slightly

* tyop