### PR TITLE
[Jupyter] Read PPS config from notebook

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -720,9 +720,6 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      # Install and cache Python dependencies
-      - restore_cache:
-          key: pip<< parameters.python-version >>-cache-v12-<< pipeline.git.branch >>-{{ checksum "ci-requirements.txt" }}
       - run:
           name: "Install Python dependencies"
           command: |
@@ -730,10 +727,6 @@ jobs:
             . venv/bin/activate
             python -m pip install --upgrade pip
             python -m pip install -r ci-requirements.txt
-      - save_cache:
-          key: pip<< parameters.python-version >>-cache-v12-<< pipeline.git.branch >>-{{ checksum "ci-requirements.txt" }}
-          paths:
-            - "venv"
 
       # Install and cache Node dependencies
       - restore_cache:
@@ -866,9 +859,6 @@ jobs:
                 contents="$(jq --arg version ${CIRCLE_TAG:1} '.version = $version' package.json)" && echo "${contents}" > package.json
             fi
 
-      # Install and cache Python dependencies
-      - restore_cache:
-          key: core-pip3.10-cache-v1-{{ checksum "ci-requirements.txt" }}
       - run:
           name: "Install Python dependencies"
           command: |
@@ -876,10 +866,6 @@ jobs:
             . venv/bin/activate
             python -m pip install --upgrade pip
             python -m pip install -r ci-requirements.txt
-      - save_cache:
-          key: core-pip3.10-cache-v1-{{ checksum "ci-requirements.txt" }}
-          paths:
-            - "venv"
 
       # Install and cache Node dependencies
       - restore_cache:
@@ -915,9 +901,6 @@ jobs:
           path: ~/project
       - attach_workspace:
           at: .
-      # Install and cache Python dependencies
-      - restore_cache:
-          key: core-pip3.10-cache-v1-{{ checksum "ci-requirements.txt" }}
       - run:
           name: "Install Python dependencies"
           command: |
@@ -925,10 +908,6 @@ jobs:
             . venv/bin/activate
             python -m pip install --upgrade pip
             python -m pip install -r ci-requirements.txt
-      - save_cache:
-          key: core-pip3.10-cache-v1-{{ checksum "ci-requirements.txt" }}
-          paths:
-            - "venv"
       - run:
           name: Init .pypirc
           command: |
@@ -950,9 +929,6 @@ jobs:
           path: ~/project
       - attach_workspace:
           at: .
-      # Install and cache Python dependencies
-      - restore_cache:
-          key: core-pip3.10-cache-v1-{{ checksum "ci-requirements.txt" }}
       - run:
           name: "Install Python dependencies"
           command: |
@@ -960,10 +936,6 @@ jobs:
             . venv/bin/activate
             python -m pip install --upgrade pip
             python -m pip install -r ci-requirements.txt
-      - save_cache:
-          key: core-pip3.10-cache-v1-{{ checksum "ci-requirements.txt" }}
-          paths:
-            - "venv"
       - run:
           name: Init .pypirc
           command: |

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -275,16 +275,15 @@ class PPSCreateHandler(BaseHandler):
     @tornado.web.authenticated
     async def get(self, path):
         """Get the pipeline spec for the specified notebook."""
-        body = self.get_json_body()
-        response = await self.pps_client.generate(path, body)
-        self.finish(response)
+        response = await self.pps_client.generate(path)
+        await self.finish(response)
 
     @tornado.web.authenticated
     async def put(self, path):
         """Create the pipeline for the specified notebook."""
         body = self.get_json_body()
         response = await self.pps_client.create(path, body)
-        self.finish(response)
+        await self.finish(response)
 
 
 def setup_handlers(web_app):

--- a/jupyter-extension/jupyterlab_pachyderm/tests/__init__.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+TEST_NOTEBOOK = Path(__file__).parent.joinpath('data/TestNotebook.ipynb')

--- a/jupyter-extension/jupyterlab_pachyderm/tests/data/TestNotebook.ipynb
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/data/TestNotebook.ipynb
@@ -27,6 +27,25 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.6"
+  },
+  "same_config": {
+   "apiVersion": "sameproject.ml/v1alpha1",
+   "environments": {
+    "default": {
+     "image_tag": "python:3.11"
+    }
+   },
+   "metadata": {
+    "name": "sameless_test",
+    "version": "0.0.0"
+   },
+   "notebook": {
+    "requirements": ""
+   },
+   "run": {
+    "input": "{\"pfs\":{\"repo\":\"images\",\"glob\":\"/*\"}}",
+    "name": "sameless_test"
+   }
   }
  },
  "nbformat": 4,

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import {closeIcon} from '@jupyterlab/ui-components';
 import {usePipeline} from './hooks/usePipeline';
-import {SameMetadata} from '../../types';
+import {PpsContext, SameMetadata} from '../../types';
 
 type PipelineProps = {
+  ppsContext: PpsContext | undefined;
   setShowPipeline: (shouldShow: boolean) => void;
-  notebookPath: string | undefined;
-  saveNotebookMetadata: (metadata: any) => void;
-  metadata: SameMetadata | undefined;
+  saveNotebookMetadata: (metadata: SameMetadata) => void;
 };
 
 const placeholderInputSpec = `pfs:
@@ -18,10 +17,9 @@ const placeholderInputSpec = `pfs:
 const placeholderRequirements = './requirements.txt';
 
 const Pipeline: React.FC<PipelineProps> = ({
+  ppsContext,
   setShowPipeline,
-  notebookPath,
   saveNotebookMetadata,
-  metadata,
 }) => {
   const {
     loading,
@@ -37,7 +35,7 @@ const Pipeline: React.FC<PipelineProps> = ({
     callSavePipeline,
     errorMessage,
     responseMessage,
-  } = usePipeline(metadata, notebookPath, saveNotebookMetadata);
+  } = usePipeline(ppsContext, saveNotebookMetadata);
 
   return (
     <div className="pachyderm-mount-pipeline-base">

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
@@ -6,7 +6,7 @@ import * as requestAPI from '../../../../../handler';
 import {mockedRequestAPI} from 'utils/testUtils';
 import Pipeline from '../Pipeline';
 jest.mock('../../../../../handler');
-import {SameMetadata} from '../../../types';
+import {PpsContext, SameMetadata} from '../../../types';
 
 describe('PPS screen', () => {
   let setShowPipeline = jest.fn();
@@ -28,6 +28,7 @@ describe('PPS screen', () => {
       name: '',
     },
   };
+  const context: PpsContext = {config: md, notebookModel: null};
 
   const mockRequestAPI = requestAPI as jest.Mocked<typeof requestAPI>;
 
@@ -40,9 +41,8 @@ describe('PPS screen', () => {
     it('proper preview', async () => {
       const {getByTestId, findByTestId} = render(
         <Pipeline
-          metadata={md}
+          ppsContext={context}
           setShowPipeline={setShowPipeline}
-          notebookPath={'FakeNotebook.ipynb'}
           saveNotebookMetadata={saveNotebookMetaData}
         />,
       );

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -1,9 +1,9 @@
 import YAML from 'yaml';
-
 import {useEffect, useState} from 'react';
-import {CreatePipelineResponse, SameMetadata} from '../../../types';
-import {requestAPI} from '../../../../../handler';
 import {ServerConnection} from '@jupyterlab/services';
+
+import {CreatePipelineResponse, PpsContext, SameMetadata} from '../../../types';
+import {requestAPI} from '../../../../../handler';
 
 export type usePipelineResponse = {
   loading: boolean;
@@ -22,9 +22,8 @@ export type usePipelineResponse = {
 };
 
 export const usePipeline = (
-  metadata: SameMetadata | undefined,
-  notebookPath: string | undefined,
-  saveNotebookMetaData: (metadata: any) => void,
+  ppsContext: PpsContext | undefined,
+  saveNotebookMetaData: (metadata: SameMetadata) => void,
 ): usePipelineResponse => {
   const [loading, setLoading] = useState(false);
   const [pipelineName, setPipelineName] = useState('');
@@ -34,20 +33,56 @@ export const usePipeline = (
   const [errorMessage, setErrorMessage] = useState('');
   const [responseMessage, setResponseMessage] = useState('');
 
+  console.log('called usePipeline');
+
   useEffect(() => {
-    setImageName(metadata?.environments.default.image_tag ?? '');
-    setPipelineName(metadata?.metadata.name ?? '');
-    setRequirements(metadata?.notebook.requirements ?? '');
+    setImageName(ppsContext?.config?.environments.default.image_tag ?? '');
+    setPipelineName(ppsContext?.config?.metadata.name ?? '');
+    setRequirements(ppsContext?.config?.notebook.requirements ?? '');
     setResponseMessage('');
-    if (metadata?.run.input) {
-      const input = JSON.parse(metadata?.run.input); //TODO: Catch errors
+    if (ppsContext?.config?.run.input) {
+      const input = JSON.parse(ppsContext.config.run.input); //TODO: Catch errors
       setInputSpec(YAML.stringify(input));
     } else {
       setInputSpec('');
     }
-  }, [metadata]);
+  }, [ppsContext]);
 
-  const createSameMetadata = (): SameMetadata => {
+  let callCreatePipeline: () => Promise<void>;
+  if (ppsContext?.notebookModel) {
+    const notebook = ppsContext.notebookModel;
+    callCreatePipeline = async () => {
+      setLoading(true);
+      setErrorMessage('');
+      setResponseMessage('');
+      try {
+        const response = await requestAPI<CreatePipelineResponse>(
+          `pps/_create/${notebook.path}`,
+          'PUT',
+          {last_modified_time: notebook.last_modified},
+        );
+        if (response.message !== null) {
+          setResponseMessage(response.message);
+        }
+      } catch (e) {
+        if (e instanceof ServerConnection.ResponseError) {
+          setErrorMessage(e.message);
+        } else {
+          throw e;
+        }
+      }
+      console.log('create pipeline called');
+      setLoading(false);
+    };
+  } else {
+    console.log('No notebookModel');
+    // If no notebookModel is defined, we cannot create a pipeline.
+    callCreatePipeline = async () => {
+      setErrorMessage('Error: No notebook in focus');
+    };
+  }
+
+  const callSavePipeline = async () => {
     let input: string;
     try {
       input = YAML.parse(inputSpec);
@@ -59,7 +94,7 @@ export const usePipeline = (
       }
     }
 
-    return {
+    const sameMetadata = {
       apiVersion: 'sameproject.ml/v1alpha1',
       environments: {
         default: {
@@ -78,52 +113,6 @@ export const usePipeline = (
         input: JSON.stringify(input),
       },
     };
-  };
-
-  const callCreatePipeline = async () => {
-    setLoading(true);
-    setErrorMessage('');
-    setResponseMessage('');
-
-    let input: string;
-    try {
-      input = YAML.parse(inputSpec);
-    } catch (e) {
-      if (e instanceof YAML.YAMLParseError) {
-        input = JSON.parse(inputSpec);
-      } else {
-        throw e;
-      }
-    }
-
-    // const sameMetadata = createSameMetadata();
-    try {
-      const response = await requestAPI<CreatePipelineResponse>(
-        `pps/_create/${notebookPath}`,
-        'PUT',
-        {
-          pipeline_name: pipelineName,
-          image: imageName,
-          requirements: requirements,
-          input_spec: input,
-        },
-      );
-      if (response.message !== null) {
-        setResponseMessage(response.message);
-      }
-    } catch (e) {
-      if (e instanceof ServerConnection.ResponseError) {
-        setErrorMessage(e.message);
-      } else {
-        throw e;
-      }
-    }
-    console.log('create pipeline called');
-    setLoading(false);
-  };
-
-  const callSavePipeline = async () => {
-    const sameMetadata = createSameMetadata();
     saveNotebookMetaData(sameMetadata);
     console.log('save pipeline called');
   };

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -33,8 +33,6 @@ export const usePipeline = (
   const [errorMessage, setErrorMessage] = useState('');
   const [responseMessage, setResponseMessage] = useState('');
 
-  console.log('called usePipeline');
-
   useEffect(() => {
     setImageName(ppsContext?.config?.environments.default.image_tag ?? '');
     setPipelineName(ppsContext?.config?.metadata.name ?? '');
@@ -71,11 +69,9 @@ export const usePipeline = (
           throw e;
         }
       }
-      console.log('create pipeline called');
       setLoading(false);
     };
   } else {
-    console.log('No notebookModel');
     // If no notebookModel is defined, we cannot create a pipeline.
     callCreatePipeline = async () => {
       setErrorMessage('Error: No notebook in focus');
@@ -114,7 +110,6 @@ export const usePipeline = (
       },
     };
     saveNotebookMetaData(sameMetadata);
-    console.log('save pipeline called');
   };
 
   return {

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -57,7 +57,7 @@ export const usePipeline = (
       setResponseMessage('');
       try {
         const response = await requestAPI<CreatePipelineResponse>(
-          `pps/_create/${notebook.path}`,
+          `pps/_create/${encodeURI(notebook.path)}`,
           'PUT',
           {last_modified_time: notebook.last_modified},
         );

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -314,7 +314,6 @@ export class MountPlugin implements IMountPlugin {
     // Set the current notebook and wait for the session to be ready
     let context: PpsContext;
     if (notebook) {
-      console.log('handleNotebookChanged called with notebook value');
       await notebook.sessionContext.ready;
       notebook.context.fileChanged.connect(this.handleNotebookReload);
       context = {
@@ -322,7 +321,6 @@ export class MountPlugin implements IMountPlugin {
         notebookModel: notebook.context.contentsModel,
       };
     } else {
-      console.log('handleNotebookChanged called without notebook value');
       context = {config: null, notebookModel: null};
     }
     this._ppsContextSignal.emit(context);
@@ -337,7 +335,6 @@ export class MountPlugin implements IMountPlugin {
     _docContext: DocumentRegistry.IContext<INotebookModel>,
     model: Contents.IModel,
   ): Promise<void> => {
-    console.log('handleNotebookReload called');
     const context: PpsContext = {
       config: this.getNotebookMetadata(),
       notebookModel: model,

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -312,18 +312,20 @@ export class MountPlugin implements IMountPlugin {
     notebook: NotebookPanel | null,
   ): Promise<void> => {
     // Set the current notebook and wait for the session to be ready
+    let context: PpsContext;
     if (notebook) {
       console.log('handleNotebookChanged called with notebook value');
       await notebook.sessionContext.ready;
       notebook.context.fileChanged.connect(this.handleNotebookReload);
-      const context: PpsContext = {
+      context = {
         config: this.getNotebookMetadata(notebook),
         notebookModel: notebook.context.contentsModel,
       };
-      this._ppsContextSignal.emit(context);
     } else {
       console.log('handleNotebookChanged called without notebook value');
+      context = {config: null, notebookModel: null};
     }
+    this._ppsContextSignal.emit(context);
     await Promise.resolve();
   };
 

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import {ILayoutRestorer, JupyterFrontEnd} from '@jupyterlab/application';
-import {INotebookTracker, NotebookPanel} from '@jupyterlab/notebook';
-import {IDocumentManager} from '@jupyterlab/docmanager';
-import {SplitPanel} from '@lumino/widgets';
 import {ReactWidget, UseSignal} from '@jupyterlab/apputils';
+import {IDocumentManager} from '@jupyterlab/docmanager';
+import {DocumentRegistry} from '@jupyterlab/docregistry';
 import {FileBrowser, IFileBrowserFactory} from '@jupyterlab/filebrowser';
+import {
+  INotebookModel,
+  INotebookTracker,
+  NotebookPanel,
+} from '@jupyterlab/notebook';
+import {Contents} from '@jupyterlab/services';
 import {settingsIcon, spreadsheetIcon} from '@jupyterlab/ui-components';
-import {Signal} from '@lumino/signaling';
 import {JSONObject} from '@lumino/coreutils';
+import {Signal} from '@lumino/signaling';
+import {SplitPanel} from '@lumino/widgets';
 
 import {mountLogoIcon} from '../../utils/icons';
 import {PollMounts} from './pollMounts';
@@ -22,6 +28,7 @@ import {
   ListMountsResponse,
   CrossInputSpec,
   SameMetadata,
+  PpsContext,
 } from './types';
 import Config from './components/Config/Config';
 import Datum from './components/Datum/Datum';
@@ -63,7 +70,7 @@ export class MountPlugin implements IMountPlugin {
     this,
   );
   private _showPipelineSignal = new Signal<this, boolean>(this);
-  private _showMetadataSignal = new Signal<this, SameMetadata>(this);
+  private _ppsContextSignal = new Signal<this, PpsContext>(this);
 
   constructor(
     app: JupyterFrontEnd,
@@ -226,18 +233,13 @@ export class MountPlugin implements IMountPlugin {
     this._datum.addClass('pachyderm-mount-datum-wrapper');
 
     this._pipeline = ReactWidget.create(
-      <UseSignal signal={this._showMetadataSignal}>
-        {(_, metadata) => (
-          <>
-            <Pipeline
-              setShowPipeline={this.setShowPipeline}
-              notebookPath={
-                this.getActiveNotebook()?.sessionContext?.session?.path
-              }
-              saveNotebookMetadata={this.saveNotebookMetaData}
-              metadata={metadata}
-            />
-          </>
+      <UseSignal signal={this._ppsContextSignal}>
+        {(_, context) => (
+          <Pipeline
+            ppsContext={context}
+            setShowPipeline={this.setShowPipeline}
+            saveNotebookMetadata={this.saveNotebookMetadata}
+          />
         )}
       </UseSignal>,
     );
@@ -311,21 +313,43 @@ export class MountPlugin implements IMountPlugin {
   ): Promise<void> => {
     // Set the current notebook and wait for the session to be ready
     if (notebook) {
+      console.log('handleNotebookChanged called with notebook value');
       await notebook.sessionContext.ready;
-      const md = notebook?.model?.metadata.get(METADATA_KEY);
-
-      this._showMetadataSignal.emit(md as SameMetadata);
-      await Promise.resolve();
+      notebook.context.fileChanged.connect(this.handleNotebookReload);
+      const context: PpsContext = {
+        config: this.getNotebookMetadata(notebook),
+        notebookModel: notebook.context.contentsModel,
+      };
+      this._ppsContextSignal.emit(context);
     } else {
-      await Promise.resolve();
+      console.log('handleNotebookChanged called without notebook value');
     }
+    await Promise.resolve();
   };
 
-  getNotebookMetadata = (notebook: NotebookPanel | null): any | null => {
+  /**
+   * This handles when a ContentModel of NotebookPanel is changed.
+   * This occurs when a notebook file is saved and reloaded from disk.
+   */
+  handleNotebookReload = async (
+    _docContext: DocumentRegistry.IContext<INotebookModel>,
+    model: Contents.IModel,
+  ): Promise<void> => {
+    console.log('handleNotebookReload called');
+    const context: PpsContext = {
+      config: this.getNotebookMetadata(),
+      notebookModel: model,
+    };
+    this._ppsContextSignal.emit(context);
+    await Promise.resolve();
+  };
+
+  getNotebookMetadata = (notebook?: NotebookPanel | null): any | null => {
+    notebook = notebook ?? this.getActiveNotebook();
     return notebook?.model?.metadata.get(METADATA_KEY);
   };
 
-  saveNotebookMetaData = (metadata: any): void => {
+  saveNotebookMetadata = (metadata: SameMetadata): void => {
     const currentNotebook = this.getActiveNotebook();
 
     if (currentNotebook !== null) {

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -1,3 +1,4 @@
+import {Contents} from '@jupyterlab/services';
 import {SplitPanel} from '@lumino/widgets';
 import {JSONObject} from '@lumino/coreutils';
 
@@ -91,6 +92,11 @@ export type PpsConfig = {
   image: string;
   requirements: string | null;
   input_spec: any;
+};
+
+export type PpsContext = {
+  config: SameMetadata | null;
+  notebookModel: Contents.IModel | null;
 };
 
 export type SameMetadata = {


### PR DESCRIPTION
Tasks
- [x] Backend reads config from notebook metadata
- [x] Use last_modified_time to verify correct notebook version
  - [x] Access last_modified_time in frontend
  - [x] Feed last_modified_time to Pipeline react widget at render time
  - [x] Rerender Pipeline widget on save to disk.
    - [x] Bundle relevant frontend data into a PpsContext object.
- [x] Remove request body from pps/_create GET call.
- [x] Remove logging statements.

Future Tasks
- [ ] Restructure PPS config
- [ ] Don't stringify input spec on save

Test cases
- Confirmed tripping of last_modified timestamp check by: create a pipeline enabled notebook and saving it, using `touch` to bump the timestamp on the file, then clicking `Create Pipeline` in the UI.
- Tried creating a pipeline with a deeply nested notebook `./test/something/new/InFolder.ipynb` which was created correctly.