### PR TITLE
[CORE-1578] Use a procfs library to parse /proc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.2 // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
@@ -284,7 +284,7 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/pquerna/otp v1.2.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/prometheus/procfs v0.7.3
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.28.0
 	github.com/pulumi/pulumi-awsx/sdk v1.0.1
 	github.com/pulumi/pulumi-eks/sdk v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1018,7 +1018,6 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWet
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
-github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=

--- a/src/server/worker/driver/ps_linux.go
+++ b/src/server/worker/driver/ps_linux.go
@@ -3,79 +3,23 @@
 package driver
 
 import (
-	"bytes"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strconv"
-
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
+	"github.com/prometheus/procfs"
 )
 
 // logRunningProcesses will print the cmdline of processes that we'd kill if we killed the provided
 // process group.  Looking at these logs will let users know that they might be doing something
 // interesting accidentally.
 func logRunningProcesses(l logs.TaggedLogger, pgid int) {
-	err := filepath.WalkDir("/proc", func(path string, d fs.DirEntry, err error) error {
-		if path == "/proc" {
-			return nil
-		}
-		if !d.IsDir() {
-			return filepath.SkipDir
-		}
-		if err != nil {
-			return err
-		}
-
-		pid, err := strconv.Atoi(d.Name())
-		if err != nil {
-			// Not a PID directory.
-			return filepath.SkipDir
-		}
-		stat, err := os.ReadFile(filepath.Join(path, "stat"))
-		if err != nil {
-			l.Logf("warning: unable to read stat: %v", err)
-			return filepath.SkipDir
-		}
-		// From proc(5):
-		// /proc/[pid]/stat
-		//
-		//     Status information about the process.  This is used by ps(1).  It is defined
-		//     in the kernel source file fs/proc/array.c.
-		//         (1) pid  %d
-		//         The process ID.
-		//         (2) comm  %s
-		//         The  filename of the executable, in parentheses.
-		//         ...
-		//         (5) pgrp  %d
-		//         The process group ID of the process.
-		//
-		// That man page is 1-indexed.
-		var comm string
-		statParts := bytes.SplitN(stat, []byte{' '}, 6)
-		if len(statParts) > 4 {
-			pgrp, err := strconv.Atoi(string(statParts[4]))
-			if err != nil {
-				l.Logf("warning: unable to parse %v/stat[4]: %v", path, err)
-				return filepath.SkipDir
-			}
-			if pgrp != pgid {
-				// Not something we're going to try and kill; ignore.
-				return filepath.SkipDir
-			}
-			comm = string(statParts[1])
-		}
-
-		cmdline, err := os.ReadFile(filepath.Join(path, "cmdline"))
-		if err != nil {
-			l.Logf("warning: unable to read cmdline: %v", err)
-		}
-		cmdlineParts := bytes.Split(cmdline, []byte{0})
-
-		l.Logf("note: about to kill unexpectedly-remaining subprocess of the user code: pid=%v comm=%v cmdline=%s", pid, comm, bytes.Join(cmdlineParts, []byte{' '}))
-		return filepath.SkipDir
-	})
+	fs, err := procfs.NewFS("/proc")
 	if err != nil {
-		l.Logf("warning: unable to walk /proc (to provide debug information about orphaned child processes): %v", err)
+		l.Logf("warning: unable to process /proc (to provide debug information about orphaned child processes): %v", err)
+	}
+	pp, err := fs.AllProcs()
+	if err != nil {
+		l.Logf("warning: unable to get stats from /proc (to provide debug information about orphaned child processes): %v", err)
+	}
+	for _, p := range pp {
+		l.Logf("note: about to kill unexpectedly-remaining subprocess of the user code: pid=%v comm=%v cmdline=%s", p.PID, p.Comm, p.CmdLine)
 	}
 }


### PR DESCRIPTION
It is possible for the comm field of a process’s stat file to contain a space; this threw off our parsing, resulting in parse errors. Switched to a library recommended by @jrockway.

Ran `go mod tidy` since we now use it directly.