### PR TITLE
logging middleware: log grpc metadata, including user-agent

### DIFF
--- a/src/internal/log/field.go
+++ b/src/internal/log/field.go
@@ -65,14 +65,17 @@ func RetryAttempt(i int, max int) Field {
 	return zap.Inline(&attempt{i: i, max: max})
 }
 
-// Metadata is a Field that logs the provided metadata (canonicalizing keys, and collapsing
-// single-element values to strings).
+// Metadata is a Field that logs the provided metadata (canonicalizing keys, collapsing
+// single-element values to strings, and removing the Pachyderm auth token).
 func Metadata(name string, md metadata.MD) Field {
 	return zap.Object(name, zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
 		keys := maps.Keys(md)
 		sort.Strings(keys)
 		for _, k := range keys {
 			v := md[k]
+			if k == constants.ContextTokenKey {
+				v = []string{"[MASKED]"}
+			}
 			switch len(v) {
 			case 0:
 				continue
@@ -100,9 +103,6 @@ func OutgoingMetadata(ctx context.Context) Field {
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		return zap.Skip()
-	}
-	if _, ok := md[constants.ContextTokenKey]; ok {
-		md[constants.ContextTokenKey] = []string{"..."}
 	}
 	return Metadata("metadata", md)
 }

--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -125,6 +125,9 @@ func getRequestLogger(ctx context.Context, req any) context.Context {
 	default:
 		f = append(f, zap.Any("request", x))
 	}
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		f = append(f, log.Metadata("metadata", md))
+	}
 	if deadline, ok := ctx.Deadline(); ok {
 		f = append(f, zap.Duration("deadline", time.Until(deadline)))
 	}


### PR DESCRIPTION
This helps with `pachyderm-sdk`'s desire to send some headers with each request, for client version number and whatnot.

`log.Metadata` already knows how to redact the auth token, and does.