### PR TITLE
Compact Diff File Sets in Old Commits When Calling Find Commits

### DIFF
--- a/src/internal/storage/fileset/compaction.go
+++ b/src/internal/storage/fileset/compaction.go
@@ -21,7 +21,7 @@ import (
 func (s *Storage) IsCompacted(ctx context.Context, id ID) (bool, error) {
 	var prev *Primitive
 	compacted := true
-	if err := s.flatten(ctx, []ID{id}, func(fsId ID) error {
+	if err := s.Flatten(ctx, []ID{id}, func(fsId ID) error {
 		curr, err := s.getPrimitive(ctx, fsId)
 		if err != nil {
 			return err

--- a/src/internal/storage/fileset/compaction.go
+++ b/src/internal/storage/fileset/compaction.go
@@ -6,42 +6,68 @@ import (
 	"time"
 
 	units "github.com/docker/go-units"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
-// IsCompacted returns true if the file sets are already in compacted form.
-func (s *Storage) IsCompacted(ctx context.Context, ids []ID) (bool, error) {
-	prims, err := s.flattenPrimitives(ctx, ids)
-	if err != nil {
+// IsCompacted returns true if the file sets are already in a compacted form.
+func (s *Storage) IsCompacted(ctx context.Context, id ID) (bool, error) {
+	var prev *Primitive
+	compacted := true
+	if err := s.flatten(ctx, []ID{id}, func(fsId ID) error {
+		curr, err := s.getPrimitive(ctx, fsId)
+		if err != nil {
+			return err
+		}
+		if prev != nil && !s.isCompactedPair(prev, curr) {
+			compacted = false
+			return errutil.ErrBreak
+		}
+		prev = curr
+		return nil
+	}); err != nil {
 		return false, err
 	}
-	return isCompacted(s.compactionConfig, prims), nil
+	return compacted, nil
 }
 
-func isCompacted(config *CompactionConfig, prims []*Primitive) bool {
-	return config.FixedDelay > int64(len(prims)) || indexOfCompacted(config.LevelFactor, prims) == len(prims)
+func (s *Storage) isCompactedPair(left, right *Primitive) bool {
+	return compactionScore(left) >= compactionScore(right)*s.compactionConfig.LevelFactor
+}
+
+func (s *Storage) isCompacted(prims []*Primitive) bool {
+	return s.indexOfCompacted(prims) == len(prims)
 }
 
 // indexOfCompacted returns the last value of i for which the "compacted relationship" is maintained for all layers[:i+1].
 // The "compacted relationship" is defined as leftScore >= (rightScore * factor).
 // If there is an element at i+1, it will be the first element which does not satisfy the compacted relationship with i.
-func indexOfCompacted(factor int64, prims []*Primitive) int {
+func (s *Storage) indexOfCompacted(prims []*Primitive) int {
 	for i := 0; i < len(prims)-1; i++ {
-		leftScore := compactionScore(prims[i])
-		rightScore := compactionScore(prims[i+1])
-		if leftScore < rightScore*factor {
+		if !s.isCompactedPair(prims[i], prims[i+1]) {
+			return i
+		}
+	}
+	return len(prims)
+}
+
+// indexOfCompactedOptimized is like indexOfCompacted but runs an optimization to reduce extra compaction operations.
+func (s *Storage) indexOfCompactedOptimized(prims []*Primitive) int {
+	for i := 0; i < len(prims)-1; i++ {
+		if !s.isCompactedPair(prims[i], prims[i+1]) {
 			var score int64
 			for j := i; j < len(prims); j++ {
 				score += compactionScore(prims[j])
 			}
 			for ; i > 0; i-- {
-				if compactionScore(prims[i-1]) >= score*factor {
+				if compactionScore(prims[i-1]) >= score*s.compactionConfig.LevelFactor {
 					return i
 				}
 				score += compactionScore(prims[i-1])
@@ -95,7 +121,7 @@ type CompactCallback func(context.Context, []ID, time.Duration) (*ID, error)
 
 // CompactLevelBased performs a level-based compaction on the passed in file sets.
 func (s *Storage) CompactLevelBased(ctx context.Context, ids []ID, maxFanIn int, ttl time.Duration, compact CompactCallback) (*ID, error) {
-	ids, err := s.Flatten(ctx, ids)
+	ids, err := s.FlattenAll(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -103,19 +129,19 @@ func (s *Storage) CompactLevelBased(ctx context.Context, ids []ID, maxFanIn int,
 	if err != nil {
 		return nil, err
 	}
-	if isCompacted(s.compactionConfig, prims) {
+	if s.isCompacted(prims) {
 		return s.Compose(ctx, ids, ttl)
 	}
 	var id *ID
 	if err := s.WithRenewer(ctx, ttl, func(ctx context.Context, renewer *Renewer) error {
-		i := indexOfCompacted(s.compactionConfig.LevelFactor, prims)
+		i := s.indexOfCompactedOptimized(prims)
 		if err := log.LogStep(ctx, "compactLevels", func(ctx context.Context) error {
 			id, err = s.compactLevels(ctx, ids[i:], maxFanIn, ttl, compact)
 			if err != nil {
 				return err
 			}
 			return renewer.Add(ctx, *id)
-		}, zap.Int("indexOfCompacted", i), zap.Int("ids", len(ids))); err != nil {
+		}, zap.Int("indexOfCompactedOptimized", i), zap.Int("ids", len(ids))); err != nil {
 			return err
 		}
 		id, err = s.CompactLevelBased(ctx, append(ids[:i], *id), maxFanIn, ttl, compact)

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -7,25 +7,22 @@ import (
 	"time"
 
 	units "github.com/docker/go-units"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
 	// DefaultMemoryThreshold is the default for the memory threshold that must
 	// be met before a file set part is serialized (excluding close).
 	DefaultMemoryThreshold = units.GB
-	// DefaultCompactionFixedDelay is the default fixed delay for compaction.
-	// This is expressed as the number of primitive filesets.
-	// TODO: Potentially remove this configuration.
-	// It is easy to footgun with this configuration.
-	DefaultCompactionFixedDelay = 1
 	// DefaultCompactionLevelFactor is the default factor that level sizes increase by in a compacted fileset.
 	DefaultCompactionLevelFactor = 10
 	DefaultPrefetchLimit         = 10
@@ -65,7 +62,7 @@ type Storage struct {
 }
 
 type CompactionConfig struct {
-	FixedDelay, LevelFactor int64
+	LevelFactor int64
 }
 
 // NewStorage creates a new Storage.
@@ -81,7 +78,6 @@ func NewStorage(mds MetadataStore, tr track.Tracker, chunks *chunk.Storage, opts
 			SizeBytes: index.DefaultShardSizeThreshold,
 		},
 		compactionConfig: &CompactionConfig{
-			FixedDelay:  DefaultCompactionFixedDelay,
 			LevelFactor: DefaultCompactionLevelFactor,
 		},
 		filesetSem:    semaphore.NewWeighted(math.MaxInt64),
@@ -126,7 +122,7 @@ func (s *Storage) newReader(id ID) *Reader {
 // Open opens a file set for reading.
 func (s *Storage) Open(ctx context.Context, ids []ID) (FileSet, error) {
 	var err error
-	ids, err = s.Flatten(ctx, ids)
+	ids, err = s.FlattenAll(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -185,39 +181,55 @@ func (s *Storage) CloneTx(tx *pachsql.Tx, id ID, ttl time.Duration) (*ID, error)
 	}
 }
 
-// Flatten takes a list of IDs and replaces references to composite FileSets
+// FlattenAll takes a list of IDs and replaces references to composite FileSets
 // with references to all their layers inplace.
 // The returned IDs will only contain ids of Primitive FileSets
-func (s *Storage) Flatten(ctx context.Context, ids []ID) ([]ID, error) {
+func (s *Storage) FlattenAll(ctx context.Context, ids []ID) ([]ID, error) {
 	flattened := make([]ID, 0, len(ids))
-	for _, id := range ids {
-		md, err := s.store.Get(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		switch x := md.Value.(type) {
-		case *Metadata_Primitive:
-			flattened = append(flattened, id)
-		case *Metadata_Composite:
-			ids, err := x.Composite.PointsTo()
-			if err != nil {
-				return nil, err
-			}
-			ids2, err := s.Flatten(ctx, ids)
-			if err != nil {
-				return nil, err
-			}
-			flattened = append(flattened, ids2...)
-		default:
-			// TODO: should it be?
-			return nil, errors.Errorf("Flatten is not defined for empty filesets")
-		}
+	if err := s.flatten(ctx, ids, func(id ID) error {
+		flattened = append(flattened, id)
+		return nil
+	}); err != nil {
+		return nil, errors.EnsureStack(err)
 	}
 	return flattened, nil
 }
 
+func (s *Storage) flatten(ctx context.Context, ids []ID, cb func(id ID) error) error {
+	for _, id := range ids {
+		md, err := s.store.Get(ctx, id)
+		if err != nil {
+			return err
+		}
+		switch x := md.Value.(type) {
+		case *Metadata_Primitive:
+			if err := cb(id); err != nil {
+				if err != errutil.ErrBreak {
+					return err
+				}
+				return nil
+			}
+		case *Metadata_Composite:
+			ids, err := x.Composite.PointsTo()
+			if err != nil {
+				return err
+			}
+			if err := s.flatten(ctx, ids, cb); err != nil {
+				if err != errutil.ErrBreak {
+					return err
+				}
+				return nil
+			}
+		default:
+			// TODO: should it be?
+			return errors.Errorf("flatten is not defined for empty filesets")
+		}
+	}
+	return nil
+}
+
 func (s *Storage) flattenPrimitives(ctx context.Context, ids []ID) ([]*Primitive, error) {
-	ids, err := s.Flatten(ctx, ids)
+	ids, err := s.FlattenAll(ctx, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -181,18 +181,6 @@ func (s *Storage) CloneTx(tx *pachsql.Tx, id ID, ttl time.Duration) (*ID, error)
 	}
 }
 
-// FlattenAll is like Flatten, but collects the primitives to return to the user.
-func (s *Storage) FlattenAll(ctx context.Context, ids []ID) ([]ID, error) {
-	flattened := make([]ID, 0, len(ids))
-	if err := s.Flatten(ctx, ids, func(id ID) error {
-		flattened = append(flattened, id)
-		return nil
-	}); err != nil {
-		return nil, errors.EnsureStack(err)
-	}
-	return flattened, nil
-}
-
 // Flatten iterates through IDs and replaces references to composite file sets
 // with all their layers in place and executes the user provided callback
 // against each primitive file set.
@@ -227,6 +215,18 @@ func (s *Storage) Flatten(ctx context.Context, ids []ID, cb func(id ID) error) e
 		}
 	}
 	return nil
+}
+
+// FlattenAll is like Flatten, but collects the primitives to return to the user.
+func (s *Storage) FlattenAll(ctx context.Context, ids []ID) ([]ID, error) {
+	flattened := make([]ID, 0, len(ids))
+	if err := s.Flatten(ctx, ids, func(id ID) error {
+		flattened = append(flattened, id)
+		return nil
+	}); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return flattened, nil
 }
 
 func (s *Storage) flattenPrimitives(ctx context.Context, ids []ID) ([]*Primitive, error) {

--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -30,7 +30,7 @@ type commitStore interface {
 	SetDiffFileSet(ctx context.Context, commit *pfs.Commit, id fileset.ID) error
 	// SetDiffFileSetTx is like SetDiffFileSet, but in a transaction
 	SetDiffFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, id fileset.ID) error
-	// GetTotalFileSet returns the total fil eset for a commit.
+	// GetTotalFileSet returns the total file set for a commit.
 	GetTotalFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error)
 	// GetTotalFileSetTx is like GetTotalFileSet, but in a transaction
 	GetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit) (*fileset.ID, error)

--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -22,21 +22,21 @@ type commitStore interface {
 	AddFileSet(ctx context.Context, commit *pfs.Commit, filesetID fileset.ID) error
 	// AddFileSetTx is identical to AddFileSet except it runs in the provided transaction.
 	AddFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, filesetID fileset.ID) error
-	// SetTotalFileSet sets the total fileset for the commit, overwriting whatever is there.
+	// SetTotalFileSet sets the total file set for the commit, overwriting whatever is there.
 	SetTotalFileSet(ctx context.Context, commit *pfs.Commit, id fileset.ID) error
 	// SetTotalFileSetTx is like SetTotalFileSet, but in a transaction
 	SetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, id fileset.ID) error
-	// SetDiffFileSet sets the diff fileset for the commit, overwriting whatever is there.
+	// SetDiffFileSet sets the diff file set for the commit, overwriting whatever is there.
 	SetDiffFileSet(ctx context.Context, commit *pfs.Commit, id fileset.ID) error
 	// SetDiffFileSetTx is like SetDiffFileSet, but in a transaction
 	SetDiffFileSetTx(tx *pachsql.Tx, commit *pfs.Commit, id fileset.ID) error
-	// GetTotalFileSet returns the total fileset for a commit.
+	// GetTotalFileSet returns the total fil eset for a commit.
 	GetTotalFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error)
 	// GetTotalFileSetTx is like GetTotalFileSet, but in a transaction
 	GetTotalFileSetTx(tx *pachsql.Tx, commit *pfs.Commit) (*fileset.ID, error)
-	// GetDiffFileSet returns the diff fileset for a commit
+	// GetDiffFileSet returns the diff file set for a commit
 	GetDiffFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error)
-	// DropFileSets clears the diff and total filesets for the commit.
+	// DropFileSets clears the diff and total file sets for the commit.
 	DropFileSets(ctx context.Context, commit *pfs.Commit) error
 	// DropFileSetsTx is identical to DropFileSets except it runs in the provided transaction.
 	DropFileSetsTx(tx *pachsql.Tx, commit *pfs.Commit) error

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -735,7 +735,7 @@ func (d *driver) findCommits(ctx context.Context, request *pfs.FindCommitsReques
 }
 
 func (d *driver) isPathModifiedInCommit(ctx context.Context, commit *pfs.Commit, filePath string) (bool, error) {
-	diffID, err := d.getCompactedDiffFileset(ctx, commit)
+	diffID, err := d.getCompactedDiffFileSet(ctx, commit)
 	if err != nil {
 		return false, err
 	}
@@ -774,7 +774,7 @@ func (d *driver) isPathModifiedInCommit(ctx context.Context, commit *pfs.Commit,
 	return found, nil
 }
 
-func (d *driver) getCompactedDiffFileset(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
+func (d *driver) getCompactedDiffFileSet(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
 	var compactedDiff *fileset.ID
 	return compactedDiff, backoff.RetryUntilCancel(ctx, func() error {
 		diff, err := d.getDiffFileSetIfCompacted(ctx, commit)
@@ -785,8 +785,8 @@ func (d *driver) getCompactedDiffFileset(ctx context.Context, commit *pfs.Commit
 			compactedDiff = diff
 			return nil
 		}
-		return errors.Errorf("diff fileset for commit %s is not compacted yet", commit.ID)
-	}, backoff.NewConstantBackOff(time.Second), backoff.NotifyCtx(ctx, "getCompactedDiffFileset for "+commit.ID))
+		return errors.Errorf("diff file set for commit %s is not compacted yet", commit.ID)
+	}, backoff.NewConstantBackOff(time.Second), backoff.NotifyCtx(ctx, "getCompactedDiffFileSet for "+commit.ID))
 }
 
 func (d *driver) getDiffFileSetIfCompacted(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
@@ -794,7 +794,7 @@ func (d *driver) getDiffFileSetIfCompacted(ctx context.Context, commit *pfs.Comm
 	if err != nil {
 		return nil, err
 	}
-	isCompacted, err := d.storage.IsCompacted(ctx, []fileset.ID{*diff})
+	isCompacted, err := d.storage.IsCompacted(ctx, *diff)
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +806,7 @@ func (d *driver) getDiffFileSetIfCompacted(ctx context.Context, commit *pfs.Comm
 		return nil, err
 	}
 	if commitInfo.Finished != nil {
-		return nil, errors.Errorf("cannot get compacted diff fileset for commit %s that is not finished", commit.ID)
+		return nil, errors.Errorf("cannot get compacted diff file set for commit %s that is not finished", commit.ID)
 	}
 	return nil, d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		return d.finishCommit(txnCtx, commit, "", "", false)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
@@ -734,7 +735,7 @@ func (d *driver) findCommits(ctx context.Context, request *pfs.FindCommitsReques
 }
 
 func (d *driver) isPathModifiedInCommit(ctx context.Context, commit *pfs.Commit, filePath string) (bool, error) {
-	diffID, err := d.commitStore.GetDiffFileSet(ctx, commit)
+	diffID, err := d.getCompactedDiffFileset(ctx, commit)
 	if err != nil {
 		return false, err
 	}
@@ -771,6 +772,45 @@ func (d *driver) isPathModifiedInCommit(ctx context.Context, commit *pfs.Commit,
 		return false, err
 	}
 	return found, nil
+}
+
+func (d *driver) getCompactedDiffFileset(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
+	var compactedDiff *fileset.ID
+	return compactedDiff, backoff.RetryUntilCancel(ctx, func() error {
+		diff, err := d.getDiffFileSetIfCompacted(ctx, commit)
+		if err != nil {
+			return err
+		}
+		if diff != nil {
+			compactedDiff = diff
+			return nil
+		}
+		return errors.Errorf("diff fileset for commit %s is not compacted yet", commit.ID)
+	}, backoff.NewConstantBackOff(time.Second), backoff.NotifyCtx(ctx, "getCompactedDiffFileset for "+commit.ID))
+}
+
+func (d *driver) getDiffFileSetIfCompacted(ctx context.Context, commit *pfs.Commit) (*fileset.ID, error) {
+	diff, err := d.commitStore.GetDiffFileSet(ctx, commit)
+	if err != nil {
+		return nil, err
+	}
+	isCompacted, err := d.storage.IsCompacted(ctx, []fileset.ID{*diff})
+	if err != nil {
+		return nil, err
+	}
+	if isCompacted {
+		return diff, nil
+	}
+	commitInfo, err := d.inspectCommit(ctx, commit, pfs.CommitState_STARTED)
+	if err != nil {
+		return nil, err
+	}
+	if commitInfo.Finished != nil {
+		return nil, errors.Errorf("cannot get compacted diff fileset for commit %s that is not finished", commit.ID)
+	}
+	return nil, d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
+		return d.finishCommit(txnCtx, commit, "", "", false)
+	})
 }
 
 // The ProjectInfo provided to the closure is repurposed on each invocation, so it's the client's responsibility to clone the ProjectInfo if desired

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -180,67 +180,58 @@ func (d *driver) finishRepoCommits(ctx context.Context, repoKey string) error {
 				compactor := newCompactor(d.storage, d.env.StorageConfig.StorageCompactionMaxFanIn)
 				taskDoer := d.env.TaskService.NewDoer(StorageTaskNamespace, commit.ID, cache)
 				var totalId *fileset.ID
-				start := time.Now()
-				totalId, err := d.compactCommit(ctx, compactor, taskDoer, commit)
-				if err != nil {
-					return err
-				}
-				details := &pfs.CommitInfo_Details{
-					CompactingTime: types.DurationProto(time.Since(start)),
-				}
-				// Validate the commit.
-				start = time.Now()
-				var validationError string
-				if err := log.LogStep(ctx, "validateCommit", func(ctx context.Context) error {
+				return errors.EnsureStack(d.storage.WithRenewer(ctx, defaultTTL, func(ctx context.Context, renewer *fileset.Renewer) error {
+					start := time.Now()
+					// Compacting the diff before getting the total allows us to compose the
+					// total file set so that it includes the compacted diff.
+					if err := log.LogStep(ctx, "compactDiffFileSet", func(ctx context.Context) error {
+						return d.compactDiffFileSet(ctx, compactor, taskDoer, renewer, commit)
+					}); err != nil {
+						return err
+					}
 					var err error
-					validationError, details.SizeBytes, err = compactor.Validate(ctx, taskDoer, *totalId)
-					return err
-				}); err != nil {
-					return err
-				}
-				details.ValidatingTime = types.DurationProto(time.Since(start))
-				// Finish the commit.
-				return d.finalizeCommit(ctx, commit, validationError, details, totalId)
+					// A commit may have a compacted total file set, but an uncompacted diff file set.
+					// If a total exists, this commit has been through total file set compaction before
+					// and the rest of the compaction steps can be skipped.
+					totalId, err = d.commitStore.GetTotalFileSet(ctx, commit)
+					if err == nil {
+						return d.finalizeCommit(ctx, commit, commitInfo.Error, commitInfo.Details, totalId)
+					}
+					if err != nil && !errors.Is(err, errNoTotalFileSet) {
+						return errors.EnsureStack(err)
+					}
+					if err := log.LogStep(ctx, "compactTotalFileSet", func(ctx context.Context) error {
+						totalId, err = d.compactTotalFileSet(ctx, compactor, taskDoer, renewer, commit)
+						if err != nil {
+							return err
+						}
+						return nil
+					}); err != nil {
+						return err
+					}
+					details := &pfs.CommitInfo_Details{
+						CompactingTime: types.DurationProto(time.Since(start)),
+					}
+					// Validate the commit.
+					start = time.Now()
+					var validationError string
+					if err := log.LogStep(ctx, "validateCommit", func(ctx context.Context) error {
+						var err error
+						validationError, details.SizeBytes, err = compactor.Validate(ctx, taskDoer, *totalId)
+						return err
+					}); err != nil {
+						return err
+					}
+					details.ValidatingTime = types.DurationProto(time.Since(start))
+					// Finish the commit.
+					return d.finalizeCommit(ctx, commit, validationError, details, totalId)
+				}))
 			}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 				log.Error(ctx, "error finishing commit", zap.Error(err), zap.Duration("retryAfter", d))
 				return nil
 			})
 		}, zap.Bool("finishing", true), log.Proto("commit", commitInfo.Commit), zap.String("repo", key))
 	}, watch.WithSort(col.SortByCreateRevision, col.SortAscend), watch.IgnoreDelete))
-}
-
-func (d *driver) compactCommit(ctx context.Context, compactor *compactor, doer task.Doer, commit *pfs.Commit) (*fileset.ID, error) {
-	var totalId *fileset.ID
-	if err := d.storage.WithRenewer(ctx, defaultTTL, func(ctx context.Context, renewer *fileset.Renewer) error {
-		var err error
-		// Compacting the diff before getting the total allows us to compose the
-		// total file set so that it includes the compacted diff.
-		if err := log.LogStep(ctx, "compactDiffFileSet", func(ctx context.Context) error {
-			return d.compactDiffFileSet(ctx, compactor, doer, renewer, commit)
-		}); err != nil {
-			return err
-		}
-		// A commit may have a compacted total file set, but an uncompacted diff file set.
-		// If a total exists, this commit has been through total file set compaction before
-		// and the rest of the compaction steps can be skipped.
-		totalId, err = d.commitStore.GetTotalFileSet(ctx, commit)
-		if err == nil {
-			return nil
-		}
-		if err != nil && !errors.Is(err, errNoTotalFileSet) {
-			return errors.EnsureStack(err)
-		}
-		return log.LogStep(ctx, "compactTotalFileSet", func(ctx context.Context) error {
-			totalId, err = d.compactTotalFileSet(ctx, compactor, doer, renewer, commit)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}); err != nil {
-		return nil, err
-	}
-	return totalId, nil
 }
 
 func (d *driver) compactDiffFileSet(ctx context.Context, compactor *compactor, doer task.Doer, renewer *fileset.Renewer, commit *pfs.Commit) error {


### PR DESCRIPTION
## Description
This PR implements a simple backfill strategy for handling reads on uncompacted diff file sets. These file sets will be compacted at read time by the PFS master's driver. It is possible that multiple concurrent client calls could lead to the driver attempting to recompact the diff file set for the same commit at the same time and waste work, but we think its a worthy trade off for keeping the master code simpler.

To make this more efficient, the PFS team revisited the IsCompacted() logic which involved making optimizations to Flatten() so that it would stream over a set of primitives rather than holding all the primitives in memory. Some helper functions were also modified to reduce duplicate code.