### PR TITLE
pipeline creation confirmation in jupyterlabs_pachyderm pipeline extension

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -63,7 +63,8 @@ class PPSClient:
         )
 
         return json.dumps(
-            dict(message=None)  # We can send back console link here.
+            dict(message="Create pipeline request sent. You may monitor its status by running"
+                 " \"pachctl list pipelines\" in a terminal.")  # We can send back console link here.
         )
 
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -408,6 +408,8 @@ def test_pps(dev_server, simple_pachyderm_env):
     r = requests.put(f"{BASE_URL}/pps/_create/{path}", data=json.dumps(data))
     assert r.status_code == 200
     assert next(client.inspect_pipeline(pipeline_name))
+    assert r.json()["message"] == ("Create pipeline request sent. You may monitor its "
+    "status by running \"pachctl list pipelines\" in a terminal.")
 
 
 @pytest.mark.parametrize('excluded_field', ('pipeline_name', 'image', 'input_spec'))

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -36,6 +36,7 @@ const Pipeline: React.FC<PipelineProps> = ({
     callCreatePipeline,
     callSavePipeline,
     errorMessage,
+    responseMessage
   } = usePipeline(metadata, notebookPath, saveNotebookMetadata);
 
   return (
@@ -82,6 +83,13 @@ const Pipeline: React.FC<PipelineProps> = ({
         data-testid="Pipeline__errorMessage"
       >
         {errorMessage}
+      </span>
+
+      <span
+        className="pachyderm-pipeline-response"
+        data-testid="Pipeline__responseMessage"
+      >
+        {responseMessage}
       </span>
 
       <div className="pachyderm-pipeline-input-wrapper">

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -36,7 +36,7 @@ const Pipeline: React.FC<PipelineProps> = ({
     callCreatePipeline,
     callSavePipeline,
     errorMessage,
-    responseMessage
+    responseMessage,
   } = usePipeline(metadata, notebookPath, saveNotebookMetadata);
 
   return (

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -107,7 +107,7 @@ export const usePipeline = (
           input_spec: input,
         },
       );
-      if (response.message != null) {
+      if (response.message !== null) {
         setResponseMessage(response.message);
       }
     } catch (e) {

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -18,6 +18,7 @@ export type usePipelineResponse = {
   callCreatePipeline: () => Promise<void>;
   callSavePipeline: () => void;
   errorMessage: string;
+  responseMessage: string;
 };
 
 export const usePipeline = (
@@ -31,6 +32,7 @@ export const usePipeline = (
   const [inputSpec, setInputSpec] = useState('');
   const [requirements, setRequirements] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [responseMessage, setResponseMessage] = useState('');
 
   useEffect(() => {
     setImageName(metadata?.environments.default.image_tag ?? '');
@@ -80,6 +82,7 @@ export const usePipeline = (
   const callCreatePipeline = async () => {
     setLoading(true);
     setErrorMessage('');
+    setResponseMessage('');
 
     let input: string;
     try {
@@ -104,6 +107,9 @@ export const usePipeline = (
           input_spec: input,
         },
       );
+      if (response.message != null) {
+        setResponseMessage(response.message);
+      }
     } catch (e) {
       if (e instanceof ServerConnection.ResponseError) {
         setErrorMessage(e.message);
@@ -134,5 +140,6 @@ export const usePipeline = (
     callCreatePipeline,
     callSavePipeline,
     errorMessage,
+    responseMessage,
   };
 };

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -38,6 +38,7 @@ export const usePipeline = (
     setImageName(metadata?.environments.default.image_tag ?? '');
     setPipelineName(metadata?.metadata.name ?? '');
     setRequirements(metadata?.notebook.requirements ?? '');
+    setResponseMessage('');
     if (metadata?.run.input) {
       const input = JSON.parse(metadata?.run.input); //TODO: Catch errors
       setInputSpec(YAML.stringify(input));


### PR DESCRIPTION
Currently, there is no confirmation that a request to create a pipeline is sent when users create one through the jupyterlabs_pachyderm pipeline extension. This change makes it so that the extension displays a message once the request has been dispatched.