### PR TITLE
migrate auth_tokens table if auth not active

### DIFF
--- a/src/internal/clusterstate/current.go
+++ b/src/internal/clusterstate/current.go
@@ -2,4 +2,4 @@ package clusterstate
 
 // DesiredClusterState is the set of migrations to apply to run pachd at the current version.
 // New migrations should be appended to the end.
-var DesiredClusterState = state_2_5_0
+var DesiredClusterState = state_2_5_4

--- a/src/internal/clusterstate/v2.5.4.go
+++ b/src/internal/clusterstate/v2.5.4.go
@@ -1,0 +1,18 @@
+// DO NOT MODIFY THIS STATE
+// IT HAS ALREADY SHIPPED IN A RELEASE
+package clusterstate
+
+import (
+	"context"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+)
+
+var state_2_5_4 migrations.State = state_2_5_0.
+	Apply("Lengthen auth token column length for projects", func(ctx context.Context, env migrations.Env) error {
+		if _, err := env.Tx.ExecContext(ctx, `ALTER TABLE auth.auth_tokens ALTER COLUMN subject TYPE varchar(128)`); err != nil {
+			return errors.Wrap(err, "could not alter column subject in table auth.auth_tokens from varchar(64) to varchar(128)")
+		}
+		return nil
+	})


### PR DESCRIPTION
Design: https://www.notion.so/2023-04-05-Projects-Auth-migrate-hot-fix-patch-fix-migrate-5a3dc29e9b384889995a053e9e30031d

2.6 version: https://github.com/pachyderm/pachyderm/pull/8722

Adding design/slack commenters as reviewers for visibility, although this should just match the design.