### PR TITLE
Djanicek/core 1603/auth migrate

### DIFF
--- a/src/internal/clusterstate/v2.5.4.go
+++ b/src/internal/clusterstate/v2.5.4.go
@@ -1,0 +1,18 @@
+// DO NOT MODIFY THIS STATE
+// IT HAS ALREADY SHIPPED IN A RELEASE
+package clusterstate
+
+import (
+	"context"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+)
+
+var state_2_5_4 migrations.State = state_2_5_0.
+	Apply("Lengthen auth token column length for projects", func(ctx context.Context, env migrations.Env) error {
+		if _, err := env.Tx.ExecContext(ctx, `ALTER TABLE auth.auth_tokens ALTER COLUMN subject TYPE varchar(128)`); err != nil {
+			return errors.Wrap(err, "could not alter column subject in table auth.auth_tokens from varchar(64) to varchar(128)")
+		}
+		return nil
+	})

--- a/src/internal/clusterstate/v2.6.0.go
+++ b/src/internal/clusterstate/v2.6.0.go
@@ -36,4 +36,10 @@ var state_2_6_0 migrations.State = state_2_5_0.
 			return errors.Wrap(err, "could not update default project role bindings for allClusterUsers")
 		}
 		return nil
+	}).
+	Apply("Lengthen auth token column length for projects", func(ctx context.Context, env migrations.Env) error {
+		if _, err := env.Tx.ExecContext(ctx, `ALTER TABLE auth.auth_tokens ALTER COLUMN subject TYPE varchar(128)`); err != nil {
+			return errors.Wrap(err, "could not alter column subject in table auth.auth_tokens from varchar(64) to varchar(128)")
+		}
+		return nil
 	})

--- a/src/internal/clusterstate/v2.6.0.go
+++ b/src/internal/clusterstate/v2.6.0.go
@@ -16,7 +16,7 @@ func authIsActive(c collection.PostgresReadWriteCollection) bool {
 	return !errors.Is(c.Get("CLUSTER:", &auth.RoleBinding{}), collection.ErrNotFound{})
 }
 
-var state_2_6_0 migrations.State = state_2_5_0.
+var state_2_6_0 migrations.State = state_2_5_4.
 	Apply("Grant all users ProjectWriter role for the default project", func(ctx context.Context, env migrations.Env) error {
 		roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(env.Tx)
 		if !authIsActive(roleBindingsCol) {
@@ -34,12 +34,6 @@ var state_2_6_0 migrations.State = state_2_5_0.
 			return nil
 		}); err != nil {
 			return errors.Wrap(err, "could not update default project role bindings for allClusterUsers")
-		}
-		return nil
-	}).
-	Apply("Lengthen auth token column length for projects", func(ctx context.Context, env migrations.Env) error {
-		if _, err := env.Tx.ExecContext(ctx, `ALTER TABLE auth.auth_tokens ALTER COLUMN subject TYPE varchar(128)`); err != nil {
-			return errors.Wrap(err, "could not alter column subject in table auth.auth_tokens from varchar(64) to varchar(128)")
 		}
 		return nil
 	})


### PR DESCRIPTION
2.6 version of https://github.com/pachyderm/pachyderm/pull/8717

We can't cherry pick since 2.6 migrates already exist, so the boilerplate change is slightly different.

Design: https://www.notion.so/2023-04-05-Projects-Auth-migrate-hot-fix-patch-fix-migrate-5a3dc29e9b384889995a053e9e30031d

Adding design/slack commenters as reviewers for visibility, although this should just match the design.