### PR TITLE
[PFS-70] Only define GOOGLE_APPLICATION_CREDENTIALS if GOOGLE_CREDS is also defined

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/storage-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/storage-secret.yaml
@@ -15,7 +15,7 @@ data:
   {{- if eq (include "pachyderm.storageBackend" . )  "GOOGLE" }}
   GOOGLE_BUCKET: {{ required "Google bucket required" .Values.pachd.storage.google.bucket | b64enc | quote }}
   GOOGLE_CRED: {{ .Values.pachd.storage.google.cred | b64enc | quote }}
-  {{- if not (empty .Values.pachd.storage.google.cred) -}}
+  {{ if .Values.pachd.storage.google.cred }}
   # This path is used by go-cdk for gcp authentication when GOOGLE_CRED is defined.
   GOOGLE_APPLICATION_CREDENTIALS: {{ "/pachyderm-storage-secret/GOOGLE_CRED" | b64enc | quote }}
   {{ end }}

--- a/etc/helm/pachyderm/templates/pachd/storage-secret.yaml
+++ b/etc/helm/pachyderm/templates/pachd/storage-secret.yaml
@@ -15,8 +15,10 @@ data:
   {{- if eq (include "pachyderm.storageBackend" . )  "GOOGLE" }}
   GOOGLE_BUCKET: {{ required "Google bucket required" .Values.pachd.storage.google.bucket | b64enc | quote }}
   GOOGLE_CRED: {{ .Values.pachd.storage.google.cred | b64enc | quote }}
-  # This path is used by go-cdk for gcp authentication
+  {{- if not (empty .Values.pachd.storage.google.cred) -}}
+  # This path is used by go-cdk for gcp authentication when GOOGLE_CRED is defined.
   GOOGLE_APPLICATION_CREDENTIALS: {{ "/pachyderm-storage-secret/GOOGLE_CRED" | b64enc | quote }}
+  {{ end }}
   {{- else if eq (include "pachyderm.storageBackend" . ) "MINIO" }}
   MINIO_BUCKET: {{ .Values.pachd.storage.minio.bucket | toString | b64enc | quote }}
   MINIO_ENDPOINT: {{ .Values.pachd.storage.minio.endpoint | toString| b64enc | quote }}


### PR DESCRIPTION
A bug was introduced as part of the `go-cdk` object storage client migration where GCP users were forced to use environment variables for authentication. This is because `GOOGLE_APPLICATION_CREDENTIALS` was always being defined, even in cases where no credentials were being supplied (like when using workload identity). The solution is to only set `GOOGLE_APPLICATION_CREDENTIALS` when `GOOGLE_CREDS` is also defined by the user.