### PR TITLE
[Jupyter] Add default pipeline image

### DIFF
--- a/jupyter-extension/package.json
+++ b/jupyter-extension/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "schema/**/*.json",
     "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",

--- a/jupyter-extension/schema/mount.json
+++ b/jupyter-extension/schema/mount.json
@@ -1,7 +1,14 @@
 {
   "title": "Mount for Pachyderm",
   "description": "Mount for Pachyderm.",
-  "properties": {},
+  "properties": {
+    "defaultPipelineImage": {
+      "type": "string",
+      "title": "Default Pipeline Image",
+      "description": "The default value of the Container Image field of the Pipeline Extension.",
+      "default": "python:3.10"
+    }
+  },
   "additionalProperties": false,
   "type": "object"
 }

--- a/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
+++ b/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
@@ -21,6 +21,7 @@ import * as requestAPI from '../../../handler';
 import {waitFor} from '@testing-library/react';
 import {INotebookTracker, NotebookTracker} from '@jupyterlab/notebook';
 import Pipeline from '../components/Pipeline/Pipeline';
+import {MountSettings} from '../types';
 
 jest.mock('../../../handler');
 
@@ -39,6 +40,7 @@ const items = {
 
 describe('mount plugin', () => {
   let app: JupyterLab;
+  let settings: MountSettings;
   let docManager: IDocumentManager;
   let docRegistry: DocumentRegistry;
   let manager: ServiceManager;
@@ -55,6 +57,7 @@ describe('mount plugin', () => {
     };
 
     app = new JupyterLab();
+    settings = {defaultPipelineImage: ''};
     docRegistry = new DocumentRegistry();
     manager = new ServiceManager();
     docManager = new DocumentManager({
@@ -105,7 +108,14 @@ describe('mount plugin', () => {
           ],
         }),
       );
-    const plugin = new MountPlugin(app, docManager, factory, restorer, tracker);
+    const plugin = new MountPlugin(
+      app,
+      settings,
+      docManager,
+      factory,
+      restorer,
+      tracker,
+    );
 
     await plugin.ready;
 
@@ -127,7 +137,14 @@ describe('mount plugin', () => {
   });
 
   it('should generate the correct layout', async () => {
-    const plugin = new MountPlugin(app, docManager, factory, restorer, tracker);
+    const plugin = new MountPlugin(
+      app,
+      settings,
+      docManager,
+      factory,
+      restorer,
+      tracker,
+    );
     expect(plugin.layout.title.caption).toBe('Pachyderm Mount');
     expect(plugin.layout.id).toBe('pachyderm-mount');
     expect(plugin.layout.orientation).toBe('vertical');
@@ -143,7 +160,14 @@ describe('mount plugin', () => {
   });
 
   it('return from pipeline view to the correct layout', async () => {
-    const plugin = new MountPlugin(app, docManager, factory, restorer, tracker);
+    const plugin = new MountPlugin(
+      app,
+      settings,
+      docManager,
+      factory,
+      restorer,
+      tracker,
+    );
     const pipeline = plugin.layout.widgets[3];
     const fileBrowser = plugin.layout.widgets[4];
     expect(fileBrowser).toBeInstanceOf(FileBrowser);

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {closeIcon} from '@jupyterlab/ui-components';
 import {usePipeline} from './hooks/usePipeline';
-import {PpsContext, SameMetadata} from '../../types';
+import {PpsContext, SameMetadata, MountSettings} from '../../types';
 
 type PipelineProps = {
   ppsContext: PpsContext | undefined;
+  settings: MountSettings;
   setShowPipeline: (shouldShow: boolean) => void;
   saveNotebookMetadata: (metadata: SameMetadata) => void;
 };
@@ -18,6 +19,7 @@ const placeholderRequirements = './requirements.txt';
 
 const Pipeline: React.FC<PipelineProps> = ({
   ppsContext,
+  settings,
   setShowPipeline,
   saveNotebookMetadata,
 }) => {
@@ -35,7 +37,7 @@ const Pipeline: React.FC<PipelineProps> = ({
     callSavePipeline,
     errorMessage,
     responseMessage,
-  } = usePipeline(ppsContext, saveNotebookMetadata);
+  } = usePipeline(ppsContext, settings, saveNotebookMetadata);
 
   return (
     <div className="pachyderm-mount-pipeline-base">

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/__tests__/Pipeline.test.tsx
@@ -6,29 +6,13 @@ import * as requestAPI from '../../../../../handler';
 import {mockedRequestAPI} from 'utils/testUtils';
 import Pipeline from '../Pipeline';
 jest.mock('../../../../../handler');
-import {PpsContext, SameMetadata} from '../../../types';
+import {MountSettings, PpsContext} from '../../../types';
 
 describe('PPS screen', () => {
   let setShowPipeline = jest.fn();
   const saveNotebookMetaData = jest.fn();
-  const md: SameMetadata = {
-    apiVersion: '',
-    environments: {
-      default: {
-        image_tag: '',
-      },
-    },
-    metadata: {
-      name: '',
-    },
-    notebook: {
-      requirements: '',
-    },
-    run: {
-      name: '',
-    },
-  };
-  const context: PpsContext = {config: md, notebookModel: null};
+  const settings: MountSettings = {defaultPipelineImage: 'DefaultImage:Tag'};
+  const context: PpsContext = {config: null, notebookModel: null};
 
   const mockRequestAPI = requestAPI as jest.Mocked<typeof requestAPI>;
 
@@ -42,6 +26,7 @@ describe('PPS screen', () => {
       const {getByTestId, findByTestId} = render(
         <Pipeline
           ppsContext={context}
+          settings={settings}
           setShowPipeline={setShowPipeline}
           saveNotebookMetadata={saveNotebookMetaData}
         />,
@@ -53,6 +38,8 @@ describe('PPS screen', () => {
       userEvent.type(inputPipelineName, 'ThisPipelineIsNamedFred');
 
       const inputImageName = await findByTestId('Pipeline__inputImageName');
+      expect(inputImageName).toHaveValue(settings.defaultPipelineImage);
+      userEvent.clear(inputImageName);
       userEvent.type(inputImageName, 'ThisImageIsNamedLucy');
 
       const inputRequirements = await findByTestId(

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -2,7 +2,12 @@ import YAML from 'yaml';
 import {useEffect, useState} from 'react';
 import {ServerConnection} from '@jupyterlab/services';
 
-import {CreatePipelineResponse, PpsContext, SameMetadata} from '../../../types';
+import {
+  CreatePipelineResponse,
+  MountSettings,
+  PpsContext,
+  SameMetadata,
+} from '../../../types';
 import {requestAPI} from '../../../../../handler';
 
 export type usePipelineResponse = {
@@ -23,6 +28,7 @@ export type usePipelineResponse = {
 
 export const usePipeline = (
   ppsContext: PpsContext | undefined,
+  settings: MountSettings,
   saveNotebookMetaData: (metadata: SameMetadata) => void,
 ): usePipelineResponse => {
   const [loading, setLoading] = useState(false);
@@ -34,7 +40,10 @@ export const usePipeline = (
   const [responseMessage, setResponseMessage] = useState('');
 
   useEffect(() => {
-    setImageName(ppsContext?.config?.environments.default.image_tag ?? '');
+    setImageName(
+      ppsContext?.config?.environments.default.image_tag ??
+        settings.defaultPipelineImage,
+    );
     setPipelineName(ppsContext?.config?.metadata.name ?? '');
     setRequirements(ppsContext?.config?.notebook.requirements ?? '');
     setResponseMessage('');

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -29,6 +29,7 @@ import {
   CrossInputSpec,
   SameMetadata,
   PpsContext,
+  MountSettings,
 } from './types';
 import Config from './components/Config/Config';
 import Datum from './components/Datum/Datum';
@@ -74,6 +75,7 @@ export class MountPlugin implements IMountPlugin {
 
   constructor(
     app: JupyterFrontEnd,
+    settings: MountSettings,
     manager: IDocumentManager,
     factory: IFileBrowserFactory,
     restorer: ILayoutRestorer,
@@ -237,6 +239,7 @@ export class MountPlugin implements IMountPlugin {
         {(_, context) => (
           <Pipeline
             ppsContext={context}
+            settings={settings}
             setShowPipeline={this.setShowPipeline}
             saveNotebookMetadata={this.saveNotebookMetadata}
           />

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -16,6 +16,10 @@ export type clusterStatus = 'INVALID' | 'AUTH_DISABLED' | 'AUTH_ENABLED';
 
 export type authorization = 'off' | 'none' | 'read' | 'write';
 
+export type MountSettings = {
+  defaultPipelineImage: string;
+};
+
 export type Mount = {
   name: string;
   repo: string;


### PR DESCRIPTION
The mount extension now hooks into the builtin `ISettingRegistry`. I used [this repo](https://github.com/jupyterlab/extension-examples/tree/master/settings) as a guide for implementation.

Users can set the value of `defaultPipelineImage` in two ways:
- setting the value in `<sys-prefix>/share/jupyter/lab/settings/overrides.json` where `sys-prefix` is the directory of there virtual environment where the extension is installed (venv).
```json
{
  "jupyterlab-pachyderm:mount":  {
    "defaultPipelineImage": "org/image:tag"
  }
}
```

- updating the value within the jupyter UI under `Settings > Advanced Settings Editor`
<img width="863" alt="image" src="https://user-images.githubusercontent.com/28938409/231913350-e3c98605-6b05-46d5-818d-2dcfdce4912f.png">


## Notes
- We can set this value to whatever we want, I just chose `python:3.10` as a non-controversial option.
- I don't think we'd be able to "detect what image the notebook server is running" very easily, and even if we could I don't know if its useful for that to be the default value. 