### PR TITLE
fix pulumi s3 bucket creation failures on load test envs

### DIFF
--- a/etc/testing/circle/workloads/pulumi/aws/storage.go
+++ b/etc/testing/circle/workloads/pulumi/aws/storage.go
@@ -13,7 +13,6 @@ func DeployBucket(ctx *pulumi.Context) (*s3.Bucket, error) {
 	bucketName := strings.ToLower(fmt.Sprintf("s3-%s-bucket", ctx.Stack()))
 	bucket, err := s3.NewBucket(ctx, bucketName, &s3.BucketArgs{
 		Bucket:       pulumi.String(bucketName),
-		Acl:          pulumi.String("public-read-write"),
 		ForceDestroy: pulumi.Bool(true),
 		Tags: pulumi.StringMap{
 			"Project":     pulumi.String("Feature Testing"),


### PR DESCRIPTION
AWS rolled out a stricter [policy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html) on s3 bucket creations, this should fix the pulumi up failures, and accept the defaults.