### PR TITLE
driver: repair "unexpectedly-remaining subprocess" message

### DIFF
--- a/src/internal/cmputil/cmputil.go
+++ b/src/internal/cmputil/cmputil.go
@@ -1,0 +1,24 @@
+// Package cmputil provides utilities for cmp.Diff.
+package cmputil
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// RegexpStrings treats strings that start and end with / as regular expressions, i.e. "/foo/" would
+// match "foobar".
+func RegexpStrings() cmp.Option {
+	return cmp.Comparer(func(a, b string) bool {
+		if strings.HasPrefix(a, "/") && strings.HasSuffix(a, "/") && len(a) > 2 {
+			rx := regexp.MustCompile(a[1 : len(a)-1])
+			return rx.MatchString(b)
+		} else if strings.HasPrefix(b, "/") && strings.HasSuffix(b, "/") && len(b) > 2 {
+			rx := regexp.MustCompile(b[1 : len(b)-1])
+			return rx.MatchString(a)
+		}
+		return a == b
+	})
+}

--- a/src/internal/cmputil/cmputil_test.go
+++ b/src/internal/cmputil/cmputil_test.go
@@ -1,0 +1,54 @@
+package cmputil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRegexpStrings(t *testing.T) {
+	testData := []struct {
+		name     string
+		a, b     []string
+		wantDiff bool
+	}{
+		{
+			name: "regexp_b",
+			a:    []string{"foo", "bar", "baz"},
+			b:    []string{"/^foo$/", "/^ba/", "/^ba/"},
+		},
+		{
+			name:     "regexp_b_mismatch",
+			a:        []string{"foo", "bar", "baz"},
+			b:        []string{"/^food$/", "/^ba/", "/^ba/"},
+			wantDiff: true,
+		},
+		{
+			name: "regexp_a",
+			a:    []string{"/^foo$/", "/^ba/", "/^ba/"},
+			b:    []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "literal_match",
+			a:    []string{"a"},
+			b:    []string{"a"},
+		},
+		{
+			name:     "literal_mismatch",
+			a:        []string{"a"},
+			b:        []string{"b"},
+			wantDiff: true,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			diff := cmp.Diff(test.a, test.b, RegexpStrings())
+			if !test.wantDiff && diff != "" {
+				t.Errorf("unexpected diff:\n%s", diff)
+			} else if test.wantDiff && diff == "" {
+				t.Error("diff empty, but wanted one")
+			}
+		})
+	}
+}

--- a/src/server/worker/driver/driver_linux_test.go
+++ b/src/server/worker/driver/driver_linux_test.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pachyderm/pachyderm/v2/src/internal/cmputil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
+)
+
+func TestLogUnexpectedSubprocesses(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	d := &driver{
+		pipelineInfo: &pps.PipelineInfo{
+			Details: &pps.PipelineInfo_Details{
+				Transform: &pps.Transform{
+					Cmd: []string{
+						"sh",
+						"-c",
+						"sleep infinity & echo hello",
+					},
+				},
+			},
+		},
+	}
+	logger := logs.NewTest(ctx)
+	if err := d.RunUserCode(ctx, logger, nil); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(logger.Errors, ([]string)(nil), cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("unexpected errors:\n%s", diff)
+	}
+	var got []string
+	for _, x := range logger.Logs {
+		if !strings.HasPrefix(x, "warning:") { // Sometimes this races; as long as we see the expected messages, we're happy.
+			got = append(got, x)
+		}
+	}
+	want := []string{
+		"/^beginning to run user code/",
+		"/^note: about to kill unexpectedly-remaining subprocess.*sleep infinity/",
+		"/^finished running user code/",
+	}
+	if diff := cmp.Diff(got, want, cmputil.RegexpStrings()); diff != "" {
+		t.Errorf("logs (-got +want):\n%s", diff)
+	}
+}

--- a/src/server/worker/driver/ps_linux.go
+++ b/src/server/worker/driver/ps_linux.go
@@ -3,6 +3,8 @@
 package driver
 
 import (
+	"fmt"
+
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
 	"github.com/prometheus/procfs"
 )
@@ -14,12 +16,31 @@ func logRunningProcesses(l logs.TaggedLogger, pgid int) {
 	fs, err := procfs.NewFS("/proc")
 	if err != nil {
 		l.Logf("warning: unable to process /proc (to provide debug information about orphaned child processes): %v", err)
+		return
 	}
 	pp, err := fs.AllProcs()
 	if err != nil {
 		l.Logf("warning: unable to get stats from /proc (to provide debug information about orphaned child processes): %v", err)
+		return
 	}
 	for _, p := range pp {
-		l.Logf("note: about to kill unexpectedly-remaining subprocess of the user code: pid=%v comm=%v cmdline=%s", p.PID, p.Comm, p.CmdLine)
+		stat, err := p.Stat()
+		if err != nil {
+			l.Logf("warning: unable to get stats about pid %v (to provide debug information about orphaned child processes): %v", p.PID, err)
+			continue
+		}
+		if stat.PGRP != pgid {
+			// This process isn't in the child's process group; we won't be killing it.
+			continue
+		}
+		comm, err := p.Comm()
+		if err != nil {
+			comm = fmt.Sprintf("<unknown: %v>", err)
+		}
+		cmdline, err := p.CmdLine()
+		if err != nil {
+			cmdline = []string{fmt.Sprintf("<unknown: %v>", err)}
+		}
+		l.Logf("note: about to kill unexpectedly-remaining subprocess of the user code: pid=%v comm=%v cmdline=%s", p.PID, comm, cmdline)
 	}
 }

--- a/src/server/worker/driver/ps_linux_test.go
+++ b/src/server/worker/driver/ps_linux_test.go
@@ -3,31 +3,22 @@
 package driver
 
 import (
-	"fmt"
 	"strings"
 	"syscall"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
 )
 
-type testLogger struct {
-	logs.TaggedLogger
-	entries []string
-}
-
-func (l *testLogger) Logf(format string, args ...any) {
-	l.entries = append(l.entries, fmt.Sprintf(format, args...))
-}
-
 func TestLogRunningProcesses(t *testing.T) {
-	l := new(testLogger)
+	ctx := pctx.TestContext(t)
+	l := logs.NewTest(ctx)
 	logRunningProcesses(l, syscall.Getpgrp())
-	t.Logf("entries:\n\t%v", strings.Join(l.entries, "\n\t"))
-	if len(l.entries) < 1 {
+	if len(l.Logs) < 1 {
 		t.Errorf("expected logs")
 	}
-	for _, ent := range l.entries {
+	for _, ent := range l.Logs {
 		if strings.HasPrefix(ent, "warning: ") {
 			t.Errorf("unexpected warning: %q", ent)
 		}


### PR DESCRIPTION
This got refactored and stopped working; the new version didn't check the PGRP against the process group, and didn't format Comm or Cmdline since those are functions now.  I added some tests, and test infrastructure.