### PR TITLE
jupyter pipeline extension - move buttons and output to the bottom and rename

### DIFF
--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -61,24 +61,6 @@ const Pipeline: React.FC<PipelineProps> = ({
         Notebook-to-Pipeline
       </span>
 
-      <div className="pachyderm-pipeline-buttons">
-        <button
-          data-testid="Pipeline__save"
-          className="pachyderm-button-link"
-          onClick={callSavePipeline}
-        >
-          Save
-        </button>
-
-        <button
-          data-testid="Pipeline__create_pipeline"
-          className="pachyderm-button-link"
-          onClick={callCreatePipeline}
-        >
-          Create Pipeline
-        </button>
-      </div>
-
       <div className="pachyderm-pipeline-current-notebook-wrapper">
         <label
           className="pachyderm-pipeline-current-notebook-label"
@@ -93,20 +75,6 @@ const Pipeline: React.FC<PipelineProps> = ({
           {currentNotebook}
         </span>
       </div>
-
-      <span
-        className="pachyderm-pipeline-error"
-        data-testid="Pipeline__errorMessage"
-      >
-        {errorMessage}
-      </span>
-
-      <span
-        className="pachyderm-pipeline-response"
-        data-testid="Pipeline__responseMessage"
-      >
-        {responseMessage}
-      </span>
 
       <div className="pachyderm-pipeline-input-wrapper">
         <label
@@ -201,6 +169,36 @@ ${inputSpec
           readOnly={true}
         ></textarea>
       </div>
+
+      <div className="pachyderm-pipeline-buttons">
+      <button
+          data-testid="Pipeline__create_pipeline"
+          className="pachyderm-button"
+          onClick={callCreatePipeline}
+        >
+          Run
+        </button>
+        &nbsp;
+      <button
+          data-testid="Pipeline__save_pipeline"
+          className="pachyderm-button"
+          onClick={callSavePipeline}
+        >
+          Save
+        </button>
+      </div>
+      <span
+        className="pachyderm-pipeline-error"
+        data-testid="Pipeline__errorMessage"
+      >
+        {errorMessage}
+      </span>
+      <span
+        className="pachyderm-pipeline-response"
+        data-testid="Pipeline__responseMessage"
+      >
+        {responseMessage}
+      </span>
     </div>
   );
 };

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -171,7 +171,7 @@ ${inputSpec
       </div>
 
       <div className="pachyderm-pipeline-buttons">
-      <button
+        <button
           data-testid="Pipeline__create_pipeline"
           className="pachyderm-button"
           onClick={callCreatePipeline}
@@ -179,7 +179,7 @@ ${inputSpec
           Run
         </button>
         &nbsp;
-      <button
+        <button
           data-testid="Pipeline__save_pipeline"
           className="pachyderm-button"
           onClick={callSavePipeline}


### PR DESCRIPTION
Some stylistic changes as per 
Jira: [INT-916]

![Screen Shot 2023-04-20 at 12 54 22 PM](https://user-images.githubusercontent.com/2468631/233435936-b88e9758-c1d7-4017-a66b-920a378018b9.png)

[INT-916]: https://pachyderm.atlassian.net/browse/INT-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ