### PR TITLE
error check for commit id row iterator

### DIFF
--- a/src/internal/clusterstate/v2.6.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.6.0/pfsdb.go
@@ -264,6 +264,9 @@ func getCommitIntId(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) (in
 			return 0, errors.Wrapf(err, "scan int_id for commit_id %q", oldCommitKey(commit))
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return 0, errors.EnsureStack(err)
+	}
 	return id, nil
 }
 
@@ -348,6 +351,9 @@ func commitProvenance(tx *pachsql.Tx, repo *pfs.Repo, branch *pfs.Branch, commit
 			ID: strings.Split(commitId, "=")[1],
 		}
 		commitProvenance = append(commitProvenance, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.EnsureStack(err)
 	}
 	return commitProvenance, nil
 }
@@ -570,6 +576,9 @@ func commitSubvenance(ctx context.Context, tx *pachsql.Tx, c *pfs.Commit) ([]*pf
 			ID:     id,
 		}
 		commitSubvenance = append(commitSubvenance, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.EnsureStack(err)
 	}
 	return commitSubvenance, nil
 }

--- a/src/internal/pachsql/table_info.go
+++ b/src/internal/pachsql/table_info.go
@@ -62,6 +62,9 @@ func GetTableInfoTx(tx *Tx, tablePath string) (*TableInfo, error) {
 					return nil, errors.EnsureStack(err)
 				}
 			}
+			if err = rows.Err(); err != nil {
+				return nil, errors.EnsureStack(err)
+			}
 		}
 	}
 	q := fmt.Sprintf(`

--- a/src/internal/pfsdb/commit_provenance.go
+++ b/src/internal/pfsdb/commit_provenance.go
@@ -59,6 +59,9 @@ func CommitSetProvenance(tx *pachsql.Tx, id string) (_ []*pfs.Commit, retErr err
 		}
 		cs = append(cs, ParseCommit(commit))
 	}
+	if err = rows.Err(); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
 	return cs, nil
 }
 
@@ -94,6 +97,9 @@ func CommitSetSubvenance(tx *pachsql.Tx, id string) (_ []*pfs.Commit, retErr err
 			return nil, errors.EnsureStack(err)
 		}
 		cs = append(cs, ParseCommit(commit))
+	}
+	if err = rows.Err(); err != nil {
+		return nil, errors.EnsureStack(err)
 	}
 	return cs, nil
 }

--- a/src/internal/pfsdb/commit_provenance.go
+++ b/src/internal/pfsdb/commit_provenance.go
@@ -122,6 +122,9 @@ func getCommitTableID(tx *pachsql.Tx, commit *pfs.Commit) (_ int, retErr error) 
 			return 0, errors.EnsureStack(err)
 		}
 	}
+	if err = rows.Err(); err != nil {
+		return 0, errors.EnsureStack(err)
+	}
 	return id, nil
 }
 


### PR DESCRIPTION
When getCommitTableId has lock contention on the `from` commit when iterating over table rows, we swallow the error. This causes the `to` commit to fail unexpectedly.

Some logs I had locally that show the interaction:
```
{"severity":"info","time":"2023-04-20T18:19:56.950791756Z","caller":"pfsdb/commit_provenance.go:112","message":"DNJ select int_id about to query","commitKey":"default/perf_test_pipeline392433773.user@a3da231a54d24fd5a0f4e5fabbd1d85b"}
{"severity":"info","time":"2023-04-20T18:19:56.951042217Z","caller":"pfsdb/commit_provenance.go:125","message":"DNJ entering row loop","commitKey":"default/perf_test_pipeline392433773.user@a3da231a54d24fd5a0f4e5fabbd1d85b"}
// Below error is ignored, this PR un-ignores it.
{"severity":"info","time":"2023-04-20T18:19:56.951147654Z","caller":"pfsdb/commit_provenance.go:136","message":"DNJ in row loop EXITED with err!","error":"ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)","commitKey":"default/perf_test_pipeline392433773.user@a3da231a54d24fd5a0f4e5fabbd1d85b"}
{"severity":"info","time":"2023-04-20T18:19:56.951305956Z","caller":"pfsdb/commit_provenance.go:112","message":"DNJ select int_id about to query","commitKey":"default/perf_test392433773.user@3ec0774af57f4b6aae93df0b6fd5177f"}
//Below error is how the ignored error manifests.
{"severity":"info","time":"2023-04-20T18:19:56.951464811Z","caller":"pfsdb/commit_provenance.go:115","message":"DNJ select int_id err","error":"ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)","commitKey":"default/perf_test392433773.user@3ec0774af57f4b6aae93df0b6fd5177f"}
```

According to row.Next() docs `Next prepares the next result row for reading with the Scan method. It returns true on success, or false if there is no next result row or an error happened while preparing it. Err should be consulted to distinguish between the two cases. `

So we shall consult rows.Err(). 

I've run several thousand tests with this and I no longer see the create pipeline and put file errors.

The first commit has the minimal fix that fixes the issue. The second commit, I searched for rows.Next() and added an error check anywhere it was missing. I think this should be safe - we shouldn't ever want to silently ignore the error I don't think, but let me know if we should.

https://pachyderm.atlassian.net/browse/CORE-1632