### PR TITLE
Implement datum dotenv file functionality

### DIFF
--- a/examples/opencv/montage.json
+++ b/examples/opencv/montage.json
@@ -20,7 +20,7 @@
   "transform": {
     "cmd": [ "sh" ],
     "image": "dpokidov/imagemagick:7.1.0-23",
-    "stdin": [ "montage -shadow -background SkyBlue -geometry 300x300+2+2 $(find /pfs -type f | sort) /pfs/out/montage.png" ]
+    "stdin": [ "montage -shadow -background SkyBlue -geometry 300x300+2+2 $(find -L /pfs/images /pfs/edges -type f | sort) /pfs/out/montage.png" ]
   }
 }
 

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -6584,6 +6584,7 @@ func TestMetaRepoContents(t *testing.T) {
 		}))
 		expectedFiles := map[string]struct{}{
 			fmt.Sprintf("/meta/%v/meta", datumID):                      {},
+			fmt.Sprintf("/pfs/%v/.env", datumID):                       {},
 			fmt.Sprintf("/pfs/%v/%v/%v", datumID, dataRepo, inputFile): {},
 			fmt.Sprintf("/pfs/%v/out/%v", datumID, inputFile):          {},
 		}

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -9877,7 +9877,7 @@ func TestMalformedPipeline(t *testing.T) {
 		Input:     client.NewProjectPFSInput(pfs.DefaultProjectName, "out", "/*"),
 	})
 	require.YesError(t, err)
-	require.Matches(t, "input cannot be named \"out\"", err.Error())
+	require.Matches(t, "input cannot be named out", err.Error())
 
 	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
 		Pipeline:  client.NewProjectPipeline(pfs.DefaultProjectName, pipelineName),
@@ -9885,7 +9885,7 @@ func TestMalformedPipeline(t *testing.T) {
 		Input:     &pps.Input{Pfs: &pps.PFSInput{Name: "out", Repo: dataRepo, Glob: "/*"}},
 	})
 	require.YesError(t, err)
-	require.Matches(t, "input cannot be named \"out\"", err.Error())
+	require.Matches(t, "input cannot be named out", err.Error())
 
 	_, err = c.PpsAPIClient.CreatePipeline(c.Ctx(), &pps.CreatePipelineRequest{
 		Pipeline:  client.NewProjectPipeline(pfs.DefaultProjectName, pipelineName),

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -11641,4 +11641,23 @@ func TestDatumBatching(t *testing.T) {
 		request := createPipelineRequest(pipeline, script)
 		checkState(request, pps.JobState_JOB_FAILURE)
 	})
+	t.Run("Env", func(t *testing.T) {
+		// This test will error if the datum id environment variable isn't set and distinct for each datum.
+		script := fmt.Sprintf(`
+			set -a
+			while true
+			do
+				pachctl next datum
+				source /pfs/.env
+				if [ -z $%s ]
+				then
+					exit 1
+				fi
+				touch /pfs/out/$%s
+			done
+			`, client.DatumIDEnv, client.DatumIDEnv)
+		pipeline := tu.UniqueString("DatumBatchingEnv")
+		request := createPipelineRequest(pipeline, script)
+		checkState(request, pps.JobState_JOB_SUCCESS)
+	})
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -184,9 +184,7 @@ func validateName(name string) error {
 		return errors.Errorf("input must specify a name")
 	}
 	switch name {
-	case common.OutputPrefix:
-		fallthrough
-	case common.EnvFileName:
+	case common.OutputPrefix, common.EnvFileName:
 		return errors.Errorf("input cannot be named %v", name)
 	}
 	return nil
@@ -1882,6 +1880,7 @@ func (a *apiServer) validateEgress(pipelineName string, egress *pps.Egress) erro
 	return pfsServer.ValidateSQLDatabaseEgress(egress.GetSqlDatabase())
 }
 
+// TODO: Add a test that ensures this code runs.
 func (a *apiServer) validatePipeline(pipelineInfo *pps.PipelineInfo) error {
 	if pipelineInfo.Pipeline == nil {
 		return errors.New("invalid pipeline spec: Pipeline field cannot be nil")

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -129,11 +129,17 @@ func validateNames(names map[string]bool, input *pps.Input) error {
 	case input == nil:
 		return nil // spouts can have nil input
 	case input.Pfs != nil:
+		if err := validateName(input.Pfs.Name); err != nil {
+			return err
+		}
 		if names[input.Pfs.Name] {
 			return errors.Errorf(`name "%s" was used more than once`, input.Pfs.Name)
 		}
 		names[input.Pfs.Name] = true
 	case input.Cron != nil:
+		if err := validateName(input.Cron.Name); err != nil {
+			return err
+		}
 		if names[input.Cron.Name] {
 			return errors.Errorf(`name "%s" was used more than once`, input.Cron.Name)
 		}
@@ -173,6 +179,19 @@ func validateNames(names map[string]bool, input *pps.Input) error {
 	return nil
 }
 
+func validateName(name string) error {
+	if name == "" {
+		return errors.Errorf("input must specify a name")
+	}
+	switch name {
+	case common.OutputPrefix:
+		fallthrough
+	case common.EnvFileName:
+		return errors.Errorf("input cannot be named %v", name)
+	}
+	return nil
+}
+
 func (a *apiServer) validateInput(pipeline *pps.Pipeline, input *pps.Input) error {
 	if err := validateNames(make(map[string]bool), input); err != nil {
 		return err
@@ -185,11 +204,6 @@ func (a *apiServer) validateInput(pipeline *pps.Pipeline, input *pps.Input) erro
 			}
 			set = true
 			switch {
-			case len(input.Pfs.Name) == 0:
-				return errors.Errorf("input must specify a name")
-			case input.Pfs.Name == "out":
-				return errors.Errorf("input cannot be named \"out\", as pachyderm " +
-					"already creates /pfs/out to collect job output")
 			case input.Pfs.Repo == "":
 				return errors.Errorf("input must specify a repo")
 			case input.Pfs.Repo == "out" && input.Pfs.Name == "":
@@ -264,9 +278,6 @@ func (a *apiServer) validateInput(pipeline *pps.Pipeline, input *pps.Input) erro
 				return errors.Errorf("multiple input types set")
 			}
 			set = true
-			if len(input.Cron.Name) == 0 {
-				return errors.Errorf("input must specify a name")
-			}
 			if _, err := cronutil.ParseCronExpression(input.Cron.Spec); err != nil {
 				return errors.Wrapf(err, "error parsing cron-spec")
 			}

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -1880,7 +1880,6 @@ func (a *apiServer) validateEgress(pipelineName string, egress *pps.Egress) erro
 	return pfsServer.ValidateSQLDatabaseEgress(egress.GetSqlDatabase())
 }
 
-// TODO: Add a test that ensures this code runs.
 func (a *apiServer) validatePipeline(pipelineInfo *pps.PipelineInfo) error {
 	if pipelineInfo.Pipeline == nil {
 		return errors.New("invalid pipeline spec: Pipeline field cannot be nil")

--- a/src/server/worker/common/common.go
+++ b/src/server/worker/common/common.go
@@ -23,6 +23,8 @@ const (
 	OutputPrefix = "out"
 	// TmpFileName is the name of the tmp file.
 	TmpFileName = "tmp"
+	// EnvFileName is the name of the env file.
+	EnvFileName = ".env"
 	TTL         = 15 * time.Minute
 )
 

--- a/src/server/worker/datum/datum.go
+++ b/src/server/worker/datum/datum.go
@@ -246,7 +246,8 @@ func (d *Datum) createEnvFile() error {
 	for _, e := range d.env {
 		envStr += e + "\n"
 	}
-	return os.WriteFile(path.Join(d.PFSStorageRoot(), common.EnvFileName), []byte(envStr), 0666)
+	err := os.WriteFile(path.Join(d.PFSStorageRoot(), common.EnvFileName), []byte(envStr), 0666)
+	return errors.EnsureStack(err)
 }
 
 func (d *Datum) downloadData(downloader pfssync.Downloader) error {

--- a/src/server/worker/datum/option.go
+++ b/src/server/worker/datum/option.go
@@ -62,3 +62,10 @@ func WithPrefixIndex() Option {
 		d.IDPrefix = fmt.Sprintf("%032d", d.meta.Index) + "-"
 	}
 }
+
+// WithEnv sets the environment variables.
+func WithEnv(env []string) Option {
+	return func(d *Datum) {
+		d.env = env
+	}
+}

--- a/src/server/worker/driver/driver_unix.go
+++ b/src/server/worker/driver/driver_unix.go
@@ -153,6 +153,13 @@ func (d *driver) linkData(inputs []*common.Input, dir string) error {
 		return err
 	}
 
+	// link env file
+	src := filepath.Join(dir, common.EnvFileName)
+	dst := filepath.Join(d.InputDir(), common.EnvFileName)
+	if err := os.Symlink(src, dst); err != nil {
+		return errors.EnsureStack(err)
+	}
+
 	// sometimes for group inputs, this part may get run multiple times for the same file
 	seen := make(map[string]bool)
 	for _, input := range inputs {

--- a/src/server/worker/driver/driver_windows.go
+++ b/src/server/worker/driver/driver_windows.go
@@ -4,6 +4,7 @@
 package driver
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -12,6 +13,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/common"
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
 )
 
 // Note: these are stubs only meant for tests - the worker does not run on windows
@@ -50,6 +52,13 @@ func (d *driver) moveData(inputs []*common.Input, dir string) error {
 	// Make sure that the previous outputs are removed.
 	if err := d.unlinkData(inputs); err != nil {
 		return err
+	}
+
+	// rename env file
+	src := filepath.Join(dir, common.EnvFileName)
+	dst := filepath.Join(d.InputDir(), common.EnvFileName)
+	if err := os.Rename(src, dst); err != nil {
+		return errors.EnsureStack(err)
 	}
 
 	// sometimes for group inputs, this part may get run multiple times for the same file

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -390,7 +390,7 @@ func forEachDatum(ctx context.Context, driver driver.Driver, baseLogger logs.Tag
 			inputs := meta.Inputs
 			logger := baseLogger.WithData(inputs)
 			env := driver.UserCodeEnv(logger.JobID(), task.OutputCommit, inputs)
-			var opts []datum.Option
+			opts := []datum.Option{datum.WithEnv(env)}
 			if driver.PipelineInfo().Details.DatumTimeout != nil {
 				timeout, err := types.DurationFromProto(driver.PipelineInfo().Details.DatumTimeout)
 				if err != nil {

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -183,7 +183,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 					montage,
 					"dpokidov/imagemagick:7.1.0-23",
 					[]string{"sh"}, /* cmd */
-					[]string{"montage -shadow -background SkyBlue -geometry 300x300+2+2 $(find /pfs -type f | sort) /pfs/out/montage.png"}, /* stdin */
+					[]string{fmt.Sprintf("montage -shadow -background SkyBlue -geometry 300x300+2+2 $(find -L /pfs/%s /pfs/%s -type f | sort) /pfs/out/montage.png", imagesRepo, edgesRepo)}, /* stdin */
 					nil, /* parallelismSpec */
 					&pps.Input{Cross: []*pps.Input{
 						{Pfs: &pps.PFSInput{Repo: imagesRepo, Glob: "/"}},

--- a/src/worker/worker.proto
+++ b/src/worker/worker.proto
@@ -16,10 +16,16 @@ message CancelResponse {
   bool success = 1;
 }
 
+// Error indicates that the processing of the current datum errored.
+// Datum error semantics with datum batching enabled are similar to datum error
+// semantics without datum batching enabled in that the datum may be retried,
+// recovered, or result with a job failure.
 message NextDatumRequest {
   string error = 1;
 }
 
+// Env is a list of environment variables that should be set for the processing
+// of the next datum.
 message NextDatumResponse {
   repeated string env = 1;
 }
@@ -27,5 +33,15 @@ message NextDatumResponse {
 service Worker {
   rpc Status(google.protobuf.Empty) returns (pps_v2.WorkerStatus) {}
   rpc Cancel(CancelRequest) returns (CancelResponse) {}
+  // NextDatum should only be called by user code running in a pipeline with
+  // datum batching enabled.
+  // NextDatum will signal to the worker code that the user code is ready to
+  // proceed to the next datum. This generally means setting up the next
+  // datum's filesystem state and updating internal metadata similarly to datum
+  // processing in a normal pipeline.
+  // NextDatum is a synchronous operation, so user code should expect to block
+  // on this until the next datum is set up for processing.
+  // User code should generally be migratable to datum batching by wrapping it
+  // in a loop that calls next datum.
   rpc NextDatum(NextDatumRequest) returns (NextDatumResponse) {}
 }


### PR DESCRIPTION
This PR implements functionality that will expose a dotenv file (https://pypi.org/project/python-dotenv/) through the local filesystem (at `/pfs/.env`) for user code during datum processing. This functionality was designed with the goal of providing datum environment variables when datum batching is enabled, but it is going to be available for pipelines without datum batching enabled as well. When datum batching isn't enabled, the environment variables are still going to be set appropriately, but the dotenv file will be available for use by user code and be stored in the meta commit for provenance tracking.