### PR TITLE
[PFS-86] Fix get file url output paths

### DIFF
--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2091,21 +2091,21 @@ func TestPutFileURL(t *testing.T) {
 	c := env.PachClient
 	alice := tu.UniqueString("robot:alice")
 	aliceClient := tu.AuthenticateClient(t, c, alice)
+	ctx := aliceClient.Ctx()
 	repo := "repo"
 	require.NoError(t, aliceClient.CreateProjectRepo(pfs.DefaultProjectName, repo))
 	commit, err := aliceClient.StartProjectCommit(pfs.DefaultProjectName, repo, "master")
 	require.NoError(t, err)
-	objC := dockertestenv.NewTestObjClient(env.Context, t)
+	bucket, url := dockertestenv.NewTestBucket(ctx, t)
 	paths := []string{"files/foo", "files/bar", "files/fizz"}
 	for _, path := range paths {
-		require.NoError(t, objC.Put(aliceClient.Ctx(), path, strings.NewReader(path)))
+		require.NoError(t, bucket.WriteAll(ctx, path, []byte(path), nil))
 	}
-	bucketURL := objC.BucketURL().String()
 	for _, p := range paths {
-		objURL := bucketURL + "/" + p
+		objURL := url + "/" + p
 		require.NoError(t, aliceClient.PutFileURL(commit, p, objURL, false))
 	}
-	srcURL := bucketURL + "/files"
+	srcURL := url + "/files"
 	require.NoError(t, aliceClient.PutFileURL(commit, "recursive", srcURL, true))
 	check := func() {
 		cis, err := aliceClient.ListCommit(client.NewProjectRepo(pfs.DefaultProjectName, repo), nil, nil, 0)
@@ -2146,6 +2146,7 @@ func TestGetFileURL(t *testing.T) {
 	c := env.PachClient
 	alice := tu.UniqueString("robot:alice")
 	aliceClient := tu.AuthenticateClient(t, c, alice)
+	ctx := aliceClient.Ctx()
 	repo := "repo"
 	require.NoError(t, aliceClient.CreateProjectRepo(pfs.DefaultProjectName, repo))
 	commit, err := aliceClient.StartProjectCommit(pfs.DefaultProjectName, repo, "master")
@@ -2155,24 +2156,29 @@ func TestGetFileURL(t *testing.T) {
 		require.NoError(t, aliceClient.PutFile(commit, path, strings.NewReader(path)))
 	}
 	check := func() {
-		objC := dockertestenv.NewTestObjClient(aliceClient.Ctx(), t)
-		bucketURL := objC.BucketURL().String()
+		bucket, url := dockertestenv.NewTestBucket(ctx, t)
 		for _, path := range paths {
-			require.NoError(t, aliceClient.GetFileURL(commit, path, bucketURL))
+			require.NoError(t, env.PachClient.GetFileURL(commit, path, url))
 		}
 		for _, path := range paths {
-			buf := &bytes.Buffer{}
-			err := objC.Get(context.Background(), path, buf)
+			data, err := bucket.ReadAll(ctx, path)
 			require.NoError(t, err)
-			require.True(t, bytes.Equal([]byte(path), buf.Bytes()))
+			require.True(t, bytes.Equal([]byte(path), data))
+			require.NoError(t, bucket.Delete(ctx, path))
 		}
-		require.NoError(t, objC.Delete(aliceClient.Ctx(), "files/*"))
-		require.NoError(t, aliceClient.GetFileURL(commit, "files/*", bucketURL))
+		require.NoError(t, env.PachClient.GetFileURL(commit, "files/*", url))
 		for _, path := range paths {
-			buf := &bytes.Buffer{}
-			err := objC.Get(context.Background(), path, buf)
+			data, err := bucket.ReadAll(ctx, path)
 			require.NoError(t, err)
-			require.True(t, bytes.Equal([]byte(path), buf.Bytes()))
+			require.True(t, bytes.Equal([]byte(path), data))
+			require.NoError(t, bucket.Delete(ctx, path))
+		}
+		prefix := "/prefix"
+		require.NoError(t, env.PachClient.GetFileURL(commit, "files/*", url+prefix))
+		for _, path := range paths {
+			data, err := bucket.ReadAll(ctx, prefix+"/"+path)
+			require.NoError(t, err)
+			require.True(t, bytes.Equal([]byte(path), data))
 		}
 	}
 	check()

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5784,17 +5784,16 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.CreateProjectRepo(pfs.DefaultProjectName, repo))
 		commit, err := env.PachClient.StartProjectCommit(pfs.DefaultProjectName, repo, "master")
 		require.NoError(t, err)
-		objC := dockertestenv.NewTestObjClient(env.Context, t)
+		bucket, url := dockertestenv.NewTestBucket(env.Context, t)
 		paths := []string{"files/foo", "files/bar", "files/fizz"}
 		for _, path := range paths {
-			require.NoError(t, objC.Put(ctx, path, strings.NewReader(path)))
+			require.NoError(t, bucket.WriteAll(ctx, path, []byte(path), nil))
 		}
-		bucketURL := objC.BucketURL().String()
 		for _, p := range paths {
-			objURL := bucketURL + "/" + p
+			objURL := url + "/" + p
 			require.NoError(t, env.PachClient.PutFileURL(commit, p, objURL, false))
 		}
-		srcURL := bucketURL + "/files"
+		srcURL := url + "/files"
 		require.NoError(t, env.PachClient.PutFileURL(commit, "recursive", srcURL, true))
 		check := func() {
 			cis, err := env.PachClient.ListCommit(client.NewProjectRepo(pfs.DefaultProjectName, repo), nil, nil, 0)
@@ -5829,24 +5828,29 @@ func TestPFS(suite *testing.T) {
 			require.NoError(t, env.PachClient.PutFile(commit, path, strings.NewReader(path)))
 		}
 		check := func() {
-			objC := dockertestenv.NewTestObjClient(ctx, t)
-			bucketURL := objC.BucketURL().String()
+			bucket, url := dockertestenv.NewTestBucket(ctx, t)
 			for _, path := range paths {
-				require.NoError(t, env.PachClient.GetFileURL(commit, path, bucketURL))
+				require.NoError(t, env.PachClient.GetFileURL(commit, path, url))
 			}
 			for _, path := range paths {
-				buf := &bytes.Buffer{}
-				err := objC.Get(context.Background(), path, buf)
+				data, err := bucket.ReadAll(ctx, path)
 				require.NoError(t, err)
-				require.True(t, bytes.Equal([]byte(path), buf.Bytes()))
+				require.True(t, bytes.Equal([]byte(path), data))
+				require.NoError(t, bucket.Delete(ctx, path))
 			}
-			require.NoError(t, objC.Delete(ctx, "files/*"))
-			require.NoError(t, env.PachClient.GetFileURL(commit, "files/*", bucketURL))
+			require.NoError(t, env.PachClient.GetFileURL(commit, "files/*", url))
 			for _, path := range paths {
-				buf := &bytes.Buffer{}
-				err := objC.Get(context.Background(), path, buf)
+				data, err := bucket.ReadAll(ctx, path)
 				require.NoError(t, err)
-				require.True(t, bytes.Equal([]byte(path), buf.Bytes()))
+				require.True(t, bytes.Equal([]byte(path), data))
+				require.NoError(t, bucket.Delete(ctx, path))
+			}
+			prefix := "/prefix"
+			require.NoError(t, env.PachClient.GetFileURL(commit, "files/*", url+prefix))
+			for _, path := range paths {
+				data, err := bucket.ReadAll(ctx, prefix+"/"+path)
+				require.NoError(t, err)
+				require.True(t, bytes.Equal([]byte(path), data))
 			}
 		}
 		check()


### PR DESCRIPTION
This PR makes a few changes to the get file url functionality:
- Removes the leading slash from the output paths. Directories as a concept don't exist in object storage and are typically simulated by a non-empty path with a trailing slash, so a root directory and paths with leading slashes aren't expected. This expectation seems to be baked into certain object storage providers (i.e. gcs), which is resulting with paths with double slashes due to bucket + object path concatenations. These seem to be removed automatically by the gcs client that was used prior to our migration to go cdk, so we now just remove the leading slash in our code.
- Fixes support for output path prefixes. Prior to the 2.5.0 get file url changes, an object path in the url would be used as a prefix for the exported files. This was unintentionally removed in the 2.5.0 changes, so it was re-implemented in terms of the new code and a test was added.
- The put / get file url tests were updated to use go cdk rather than the old object storage clients.