### PR TITLE
Rename /download route to /archive

### DIFF
--- a/etc/generate-envoy-config/envoy-tls.jsonnet
+++ b/etc/generate-envoy-config/envoy-tls.jsonnet
@@ -16,7 +16,7 @@ Envoy.bootstrap(
     Envoy.httpsListener(
       port=8443,
       name='proxy-https',
-      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-download', 'console'])
+      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-archive', 'console'])
     ),
 
     // Unlike the cleartext configuration, we don't serve direct routes to individual pachd/console

--- a/etc/generate-envoy-config/envoy.jsonnet
+++ b/etc/generate-envoy-config/envoy.jsonnet
@@ -9,7 +9,7 @@ Envoy.bootstrap(
       name='proxy-http',
       // Everything except the metrics service is served on the multiplexed route.  The order of
       // services' routes is important!
-      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-download', 'console'])
+      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-archive', 'console'])
     ),
 
     // In case someone port-forwards port 8443 because they were expecting TLS to be working, this

--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -123,13 +123,13 @@
       no_traffic_healthy_interval: '10s',
     },
   },
-  'pachd-download': {
+  'pachd-archive': {
     internal_port: 1659,
     service: 'pachd-proxy-backend',
     routes: [
       {
         match: {
-          prefix: '/download',
+          prefix: '/archive',
         },
         route: {
           cluster: 'pachd-download',

--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -132,7 +132,7 @@
           prefix: '/archive',
         },
         route: {
-          cluster: 'pachd-download',
+          cluster: 'pachd-archive',
           idle_timeout: '600s',
           timeout: '604800s',
         },

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -812,7 +812,7 @@
                                              "prefix": "/archive"
                                           },
                                           "route": {
-                                             "cluster": "pachd-download",
+                                             "cluster": "pachd-archive",
                                              "idle_timeout": "600s",
                                              "timeout": "604800s"
                                           }

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -219,7 +219,7 @@
             ],
             "lb_policy": "random",
             "load_assignment": {
-               "cluster_name": "pachd-download",
+               "cluster_name": "pachd-archive",
                "endpoints": [
                   {
                      "lb_endpoints": [
@@ -237,7 +237,7 @@
                   }
                ]
             },
-            "name": "pachd-download",
+            "name": "pachd-archive",
             "type": "strict_dns",
             "upstream_connection_options": {
                "tcp_keepalive": { }
@@ -809,7 +809,7 @@
                                        },
                                        {
                                           "match": {
-                                             "prefix": "/download"
+                                             "prefix": "/archive"
                                           },
                                           "route": {
                                              "cluster": "pachd-download",

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -683,7 +683,7 @@
                                              "prefix": "/archive"
                                           },
                                           "route": {
-                                             "cluster": "pachd-download",
+                                             "cluster": "pachd-archive",
                                              "idle_timeout": "600s",
                                              "timeout": "604800s"
                                           }
@@ -1896,7 +1896,7 @@
                                              "prefix": "/archive"
                                           },
                                           "route": {
-                                             "cluster": "pachd-download",
+                                             "cluster": "pachd-archive",
                                              "idle_timeout": "600s",
                                              "timeout": "604800s"
                                           }

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -219,7 +219,7 @@
             ],
             "lb_policy": "random",
             "load_assignment": {
-               "cluster_name": "pachd-download",
+               "cluster_name": "pachd-archive",
                "endpoints": [
                   {
                      "lb_endpoints": [
@@ -237,7 +237,7 @@
                   }
                ]
             },
-            "name": "pachd-download",
+            "name": "pachd-archive",
             "type": "strict_dns",
             "upstream_connection_options": {
                "tcp_keepalive": { }
@@ -680,7 +680,7 @@
                                        },
                                        {
                                           "match": {
-                                             "prefix": "/download"
+                                             "prefix": "/archive"
                                           },
                                           "route": {
                                              "cluster": "pachd-download",
@@ -1766,7 +1766,7 @@
                            "duration_ms": "%DURATION%",
                            "grpc_message": "%RESP(GRPC-MESSAGE):64%",
                            "grpc_status_code": "%GRPC_STATUS(SNAKE_STRING)%",
-                           "listener": "direct-pachd-download",
+                           "listener": "direct-pachd-archive",
                            "message": "listener log",
                            "method": "%REQ(:method)%",
                            "pachctl_command": "%REQ(COMMAND):64%",
@@ -1893,7 +1893,7 @@
                                     "routes": [
                                        {
                                           "match": {
-                                             "prefix": "/download"
+                                             "prefix": "/archive"
                                           },
                                           "route": {
                                              "cluster": "pachd-download",
@@ -1905,7 +1905,7 @@
                                  }
                               ]
                            },
-                           "stat_prefix": "direct-pachd-download",
+                           "stat_prefix": "direct-pachd-archive",
                            "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
@@ -1913,7 +1913,7 @@
                   ]
                }
             ],
-            "name": "direct-pachd-download",
+            "name": "direct-pachd-archive",
             "per_connection_buffer_limit_bytes": 32768,
             "traffic_direction": "INBOUND"
          },

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -444,7 +444,7 @@ spec:
           name: prom-metrics
           protocol: TCP
         - containerPort: 1659
-          name: download-port
+          name: archive-port
           protocol: TCP
         readinessProbe:
           exec:

--- a/etc/helm/pachyderm/templates/proxy/deployment.yaml
+++ b/etc/helm/pachyderm/templates/proxy/deployment.yaml
@@ -100,7 +100,7 @@ spec:
               containerPort: 1658
             - name: metrics-direct
               containerPort: 1656
-            - name: download-direct
+            - name: archive-direct
               containerPort: 1659
           readinessProbe:
             httpGet:

--- a/etc/helm/pachyderm/templates/proxy/pachd-proxy-backend-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/pachd-proxy-backend-service.yaml
@@ -29,9 +29,9 @@ spec:
     port: 1656
     protocol: TCP
     targetPort: prom-metrics
-  - name: download-port
+  - name: archive-port
     port: 1659
-    targetPort: download-port
+    targetPort: archive-port
   selector:
     {{- if .Values.enterpriseServer.enabled }}
     app: pach-enterprise

--- a/src/internal/archiveserver/archiveserver.go
+++ b/src/internal/archiveserver/archiveserver.go
@@ -30,7 +30,7 @@ type Server struct {
 	pachClientFactory func(context.Context) *client.APIClient
 }
 
-// ServeHTTP implements http.Handler for the /download/ route.
+// ServeHTTP implements http.Handler for the /archive/ route.
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	if got, want := req.Method, http.MethodGet; got != want {

--- a/src/internal/archiveserver/archiveserver_test.go
+++ b/src/internal/archiveserver/archiveserver_test.go
@@ -141,33 +141,33 @@ var testData = []struct {
 	{
 		name:      "empty download",
 		method:    "GET",
-		url:       "http://pachyderm.example.com/download/AQ.zip",
+		url:       "http://pachyderm.example.com/archive/AQ.zip",
 		wantCode:  http.StatusOK,
 		wantFiles: map[string]string{},
 	},
 	{
 		name:      "empty download with auth token",
 		method:    "GET",
-		url:       "http://pachyderm.example.com/download/AQ.zip?authn-token=foobar",
+		url:       "http://pachyderm.example.com/archive/AQ.zip?authn-token=foobar",
 		wantCode:  http.StatusOK,
 		wantFiles: map[string]string{},
 	},
 	{
 		name:     "invalid output format",
 		method:   "GET",
-		url:      "http://pachyderm.example.com/download/AQ.tar.bz2",
+		url:      "http://pachyderm.example.com/archive/AQ.tar.bz2",
 		wantCode: http.StatusBadRequest,
 	},
 	{
 		name:     "unknown method",
 		method:   "HEAD",
-		url:      "http://pachyderm.example.com/download/AQ.zip",
+		url:      "http://pachyderm.example.com/archive/AQ.zip",
 		wantCode: http.StatusMethodNotAllowed,
 	},
 	{
 		name:     "download with some content",
 		method:   "GET",
-		url:      "https://pachyderm.example.com/download/ASi1L_0EaHUBAEQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZS5wbmcAAxQEBQPYsGPLbFDb.zip",
+		url:      "https://pachyderm.example.com/archive/ASi1L_0EaHUBAEQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZS5wbmcAAxQEBQPYsGPLbFDb.zip",
 		wantCode: http.StatusOK,
 		wantFiles: map[string]string{
 			"default/images/44444444444444444444444444444444/hello.txt":         "hello",
@@ -178,7 +178,7 @@ var testData = []struct {
 	{
 		name:     "download with some content, commit references in URL",
 		method:   "GET",
-		url:      "https://pachyderm.example.com/download/ASi1L_0EaL0BAIQCZGVmYXVsdC9pbWFnZXNANDovaGVsbG8udHh0AG1vbnRhZ2UucG5nAAQATRHgK2e8IpIGLAGgJI8S.zip",
+		url:      "https://pachyderm.example.com/archive/ASi1L_0EaL0BAIQCZGVmYXVsdC9pbWFnZXNANDovaGVsbG8udHh0AG1vbnRhZ2UucG5nAAQATRHgK2e8IpIGLAGgJI8S.zip",
 		wantCode: http.StatusOK,
 		wantFiles: map[string]string{
 			"default/images/44444444444444444444444444444444/hello.txt":    "hello",
@@ -188,7 +188,7 @@ var testData = []struct {
 	{
 		name:     "download with an error reading files",
 		method:   "GET",
-		url:      "https://pachyderm.example.com/download/ASi1L_0EaPkAAGRlZmF1bHQvdGVzdEBtYXN0ZXI6L2Vycm9yLnR4dABwDhIY.zip",
+		url:      "https://pachyderm.example.com/archive/ASi1L_0EaPkAAGRlZmF1bHQvdGVzdEBtYXN0ZXI6L2Vycm9yLnR4dABwDhIY.zip",
 		wantCode: http.StatusOK,
 		wantFiles: map[string]string{
 			"@error.txt": "path default/test@=44444444444444444444444444444444:/error.txt: read TAR header: error reading from the server\n",
@@ -242,12 +242,12 @@ func FuzzHTTP(f *testing.F) {
 		}
 
 		up, err := url.Parse(u)
-		isDownload := err == nil && strings.HasPrefix(up.Path, "/download/")
+		isArchive := err == nil && strings.HasPrefix(up.Path, "/archive/")
 
 		// Then use the normal testing machinery.
 		code, body := doTest(t, "GET", u)
-		if code == http.StatusOK && isDownload && body.Len() > 0 {
-			// If the code is OK and the URL starts with /download/, then there should
+		if code == http.StatusOK && isArchive && body.Len() > 0 {
+			// If the code is OK and the URL starts with /archive/, then there should
 			// be either nothing, or a zip.  Assert that the ZIP is readable.
 			bs := body.Bytes()
 			t.Logf("potential zip bytes: %x %s", bs, bs)

--- a/src/internal/archiveserver/http.go
+++ b/src/internal/archiveserver/http.go
@@ -24,7 +24,7 @@ func NewHTTP(port uint16, pachClientFactory func(ctx context.Context) *client.AP
 	handler := &Server{
 		pachClientFactory: pachClientFactory,
 	}
-	mux.Handle("/download/", CSRFWrapper(handler))
+	mux.Handle("/archive/", CSRFWrapper(handler))
 	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("healthy\n")) //nolint:errcheck

--- a/src/internal/archiveserver/request.go
+++ b/src/internal/archiveserver/request.go
@@ -36,13 +36,13 @@ func ArchiveFromURL(u *url.URL) (*ArchiveRequest, error) {
 	}
 	parts := strings.Split(u.Path, "/")
 	if len(parts) != 3 {
-		return nil, errors.Errorf("invalid download path; expected /download/<spec>, but got %v path parts", len(parts))
+		return nil, errors.Errorf("invalid download path; expected /archive/<spec>, but got %v path parts", len(parts))
 	}
 	if got, want := parts[0], ""; got != want {
 		return nil, errors.New("expected leading /")
 	}
-	if got, want := parts[1], "download"; got != want {
-		return nil, errors.New("expected download/ as the first part of the path")
+	if got, want := parts[1], "archive"; got != want {
+		return nil, errors.New("expected archive/ as the first part of the path")
 	}
 	rawFilename := parts[2]
 	fileParts := strings.SplitN(rawFilename, ".", 2)

--- a/src/internal/archiveserver/request_test.go
+++ b/src/internal/archiveserver/request_test.go
@@ -16,7 +16,7 @@ func TestArchiveRequest(t *testing.T) {
 	}{
 		{
 			name: "empty URL",
-			url:  "https://pachyderm.example.com/download/AQ.zip", // 0x01 | base64url == AQ
+			url:  "https://pachyderm.example.com/archive/AQ.zip", // 0x01 | base64url == AQ
 		},
 		{
 			name:    "wrong path",
@@ -25,7 +25,7 @@ func TestArchiveRequest(t *testing.T) {
 		},
 		{
 			name:    "wrong version",
-			url:     "https://pachdyerm.example.com/download/Ag.zip", // 0x02 | base64url == Ag
+			url:     "https://pachdyerm.example.com/archive/Ag.zip", // 0x02 | base64url == Ag
 			wantErr: true,
 		},
 		{
@@ -40,22 +40,22 @@ func TestArchiveRequest(t *testing.T) {
 		},
 		{
 			name:    "long url",
-			url:     "https://pachyderm.example.com/lots/of/stuff/download/AQ.zip",
+			url:     "https://pachyderm.example.com/lots/of/stuff/archive/AQ.zip",
 			wantErr: true,
 		},
 		{
 			name:    "missing extension",
-			url:     "https://pachyderm.example.com/download/AQ",
+			url:     "https://pachyderm.example.com/archive/AQ",
 			wantErr: true,
 		},
 		{
 			name:    "unsupported extension",
-			url:     "https://pachyderm.example.com/download/AQ.tar",
+			url:     "https://pachyderm.example.com/archive/AQ.tar",
 			wantErr: true,
 		},
 		{
 			name: "doc example",
-			url:  "https://pachyderm.example.com/download/ASi1L_0EaHUBAEQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZS5wbmcAAxQEBQPYsGPLbFDb.zip",
+			url:  "https://pachyderm.example.com/archive/ASi1L_0EaHUBAEQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZS5wbmcAAxQEBQPYsGPLbFDb.zip",
 			wantPaths: []string{
 				"default/images@master:/",
 				"default/montage@master:/montage.png",
@@ -63,7 +63,7 @@ func TestArchiveRequest(t *testing.T) {
 		},
 		{
 			name: "doc example, different compression settings",
-			url:  "https://pachyderm.example.com/download/ASi1L_0EAK0BALQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZW1vbnRhZ2UucG5nAAIQBFwMS4wBy2xQ2w.zip",
+			url:  "https://pachyderm.example.com/archive/ASi1L_0EAK0BALQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZW1vbnRhZ2UucG5nAAIQBFwMS4wBy2xQ2w.zip",
 			wantPaths: []string{
 				"default/images@master:/",
 				"default/montage@master:/montage.png",
@@ -111,8 +111,8 @@ func TestArchiveRequest(t *testing.T) {
 }
 
 func FuzzArchiveRequest(f *testing.F) {
-	f.Add("https://pachyderm.example.com/download/ASi1L_0EaHUBAEQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZS5wbmcAAxQEBQPYsGPLbFDb.zip")
-	f.Add("https://pachyderm.example.com/download/ASi1L_0EAK0BALQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZW1vbnRhZ2UucG5nAAIQBFwMS4wBy2xQ2w.zip")
+	f.Add("https://pachyderm.example.com/archive/ASi1L_0EaHUBAEQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZS5wbmcAAxQEBQPYsGPLbFDb.zip")
+	f.Add("https://pachyderm.example.com/archive/ASi1L_0EAK0BALQCZGVmYXVsdC9pbWFnZXNAbWFzdGVyOi8AbW9udGFnZW1vbnRhZ2UucG5nAAIQBFwMS4wBy2xQ2w.zip")
 	f.Fuzz(func(t *testing.T, in string) {
 		u, err := url.Parse(in)
 		if err != nil {

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -132,8 +132,8 @@ func Cmds(ctx context.Context) []*cobra.Command {
 	// you click it).
 	generateURL := &cobra.Command{
 		Use:   "{{alias}} project/repo@branch_or_commit:/file_or_directory ...",
-		Short: "Generates the encoded part of a download URL.",
-		Long:  "Generates the encoded part of a download URL.",
+		Short: "Generates the encoded part of an archive download URL.",
+		Long:  "Generates the encoded part of an archive download URL.",
 		Run: cmdutil.Run(func(args []string) error {
 			u, err := archiveserver.EncodeV1(args)
 			if err != nil {
@@ -147,15 +147,15 @@ func Cmds(ctx context.Context) []*cobra.Command {
 
 	decodeURL := &cobra.Command{
 		Use:   "{{alias}} <url>",
-		Short: "Decodes the encoded part of a download URL.",
-		Long:  "Decodes the encoded part of a download URL.",
+		Short: "Decodes the encoded part of an archive download URL.",
+		Long:  "Decodes the encoded part of an archive download URL.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) error {
 			u, err := url.Parse(args[0])
 			if err != nil {
 				return errors.Wrap(err, "url.Parse")
 			}
-			if !strings.HasPrefix(u.Path, "/download/") {
-				u.Path = "/download/" + u.Path
+			if !strings.HasPrefix(u.Path, "/archive/") {
+				u.Path = "/archive/" + u.Path
 			}
 			if !strings.HasSuffix(u.Path, ".zip") {
 				u.Path = u.Path + ".zip"

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -154,7 +154,7 @@ func proxyTest(t *testing.T, httpClient *http.Client, c *client.APIClient, secur
 		require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
 			// This test unfortunately depends on TestGRPC having run successfully.
 			// Refactor.
-			url := httpPrefix + addr + "/download/" + file + ".zip"
+			url := httpPrefix + addr + "/archive/" + file + ".zip"
 			return get(t, httpClient, url)
 		})
 	})


### PR DESCRIPTION
We uh forgot that /download is a console-internal route for single-file downloads.  This renames the archiveserver route to /archive, which makes more sense anyway.

Some may argue that the `pachctl misc` commands should also be renamed, but whatever, nobody is going to run them except us.