### PR TITLE
[2.6.x] [CORE-1202] Adjust pachctl logs --job to take into account job finish…

### DIFF
--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -827,7 +827,9 @@ func (c APIClient) getLogs(projectName, pipelineName, jobID string, data []strin
 		Master:         master,
 		Follow:         follow,
 		UseLokiBackend: useLoki,
-		Since:          types.DurationProto(since),
+	}
+	if since != 0 {
+		request.Since = types.DurationProto(since)
 	}
 	if pipelineName != "" {
 		request.Pipeline = NewProjectPipeline(projectName, pipelineName)

--- a/src/internal/cmdutil/cobra.go
+++ b/src/internal/cmdutil/cobra.go
@@ -23,17 +23,25 @@ import (
 // errors that are returned by the run commands.
 var PrintErrorStacks bool
 
-// RunFixedArgs wraps a function in a function
-// that checks its exact argument count.
+// RunFixedArgs wraps a function in a function that checks its exact argument
+// count.
 func RunFixedArgs(numArgs int, run func([]string) error) func(*cobra.Command, []string) {
+	return RunFixedArgsCmd(numArgs, func(_ *cobra.Command, args []string) error {
+		return run(args)
+	})
+}
+
+// RunFixedArgsCmd wraps a function in a function that checks its exact argument
+// count.
+func RunFixedArgsCmd(numArgs int, run func(*cobra.Command, []string) error) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
-		if len(args) != numArgs {
-			fmt.Printf("expected %d arguments, got %d\n\n", numArgs, len(args))
+		if expected, got := numArgs, len(args); expected != got {
+			fmt.Fprintf(cmd.OutOrStderr(), "expected %d arguments, got %d\n\n", expected, got)
 			cmd.Usage()
-		} else {
-			if err := run(args); err != nil {
-				ErrorAndExitf("%v", err)
-			}
+			os.Exit(1)
+		}
+		if err := run(cmd, args); err != nil {
+			ErrorAndExitf("%v", err)
 		}
 	}
 }
@@ -43,12 +51,12 @@ func RunFixedArgs(numArgs int, run func([]string) error) func(*cobra.Command, []
 func RunBoundedArgs(min int, max int, run func([]string) error) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min || len(args) > max {
-			fmt.Printf("expected %d to %d arguments, got %d\n\n", min, max, len(args))
+			fmt.Fprintf(cmd.OutOrStderr(), "expected %d to %d arguments, got %d\n\n", min, max, len(args))
 			cmd.Usage()
-		} else {
-			if err := run(args); err != nil {
-				ErrorAndExitf("%v", err)
-			}
+			os.Exit(1)
+		}
+		if err := run(args); err != nil {
+			ErrorAndExitf("%v", err)
 		}
 	}
 }
@@ -58,12 +66,12 @@ func RunBoundedArgs(min int, max int, run func([]string) error) func(*cobra.Comm
 func RunMinimumArgs(min int, run func([]string) error) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if len(args) < min {
-			fmt.Printf("expected at least %d arguments, got %d\n\n", min, len(args))
+			fmt.Fprintf(cmd.OutOrStderr(), "expected at least %d arguments, got %d\n\n", min, len(args))
 			cmd.Usage()
-		} else {
-			if err := run(args); err != nil {
-				ErrorAndExitf("%v", err)
-			}
+			os.Exit(1)
+		}
+		if err := run(args); err != nil {
+			ErrorAndExitf("%v", err)
 		}
 	}
 }

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -700,7 +700,7 @@ each datum.`,
 
 	# Return logs emitted by the pipeline \"filter\" while processing /apple.txt and a file with the hash 123aef
 	$ {{alias}} --pipeline=filter --inputs=/apple.txt,123aef`,
-		Run: cmdutil.RunFixedArgs(0, func(args []string) error {
+		Run: cmdutil.RunFixedArgsCmd(0, func(cmd *cobra.Command, args []string) error {
 			client, err := pachctlCfg.NewOnUserMachine(mainCtx, false)
 			if err != nil {
 				return errors.Wrapf(err, "error connecting to pachd")
@@ -721,7 +721,7 @@ each datum.`,
 			}
 			since, err := time.ParseDuration(since)
 			if err != nil {
-				return errors.Wrapf(err, "error parsing since(%q)", since)
+				return errors.Wrapf(err, "error parsing since (%q)", since)
 			}
 			if tail != 0 {
 				return errors.Errorf("tail has been deprecated and removed from Pachyderm, use --since instead")
@@ -742,6 +742,9 @@ each datum.`,
 			}
 
 			// Issue RPC
+			if !cmd.Flags().Changed("since") {
+				since = 0
+			}
 			iter := client.GetProjectLogs(project, pipelineName, jobID, data, datumID, master, follow, since)
 			var buf bytes.Buffer
 			m := &jsonpb.Marshaler{}


### PR DESCRIPTION
This is a backport of [049d0dd](https://github.com/pachyderm/pachyderm/commit/049d0dd739cbe03c434db68a4ce455bdb9fb32b4).

- If --since is explicitly set, respect it.
- If --since is not set, this is a job log request and there is a job creation timestamp, then return logs from an hour prior to job creation (to account for clock skew) to the present.
- Otherwise return logs from the last 24 hours.