### PR TITLE
Update Go version to 1.20.4

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -36,7 +36,7 @@ parameters:
     default: ubuntu-2204:2022.10.1
   go-version:
     type: string
-    default: "1.20.3"
+    default: "1.20.4"
   go-releaser-version:
     type: string
     default: "1.17.1"

--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.3
+ARG GOVERSION=golang:1.20.4
 FROM $GOVERSION
 
 LABEL maintainer="msteffen@pachyderm.io"

--- a/etc/testing/kafka/Dockerfile
+++ b/etc/testing/kafka/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.3
+ARG GOVERSION=golang:1.20.4
 FROM $GOVERSION
 WORKDIR /app
 ADD . /app/

--- a/etc/testing/spout/Dockerfile
+++ b/etc/testing/spout/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20
+ARG GOVERSION=golang:1.20.4
 FROM $GOVERSION
 RUN mkdir /app
 ADD . /app/


### PR DESCRIPTION
This addresses three vulnerabilities.

Backports #8833 