### PR TITLE
[CORE-1666] Implement the anonymous interface expected by status.FromError

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -236,6 +236,12 @@ func (e *ErrNotAuthorized) Error() string {
 	return fmt.Sprintf("%v is %v - needs permissions %v on %v %v. Run `pachctl auth roles-for-permission` to find roles that grant a given permission.", e.Subject, errNotAuthorizedMsg, e.Required, e.Resource.Type, e.Resource.Name)
 }
 
+// Implement the interface expected by status.FromError.  An ErrNotAuthorized is
+// a permission-denied status.
+func (e *ErrNotAuthorized) GRPCStatus() *status.Status {
+	return status.New(codes.PermissionDenied, e.Error())
+}
+
 // IsErrNotAuthorized checks if an error is a ErrNotAuthorized
 func IsErrNotAuthorized(err error) bool {
 	if err == nil {

--- a/src/auth/auth_err_test.go
+++ b/src/auth/auth_err_test.go
@@ -3,14 +3,16 @@ package auth
 import (
 	"testing"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // grpcify returns an error e such that e.Error() is similar to what grpc
 // errors emit (though this doesn't convert 'error' to an actual GRPC error)
 func grpcify(err error) error {
-	return errors.Errorf("rpc error: code = Unknown desc = %s", err.Error())
+	return status.Convert(err).Err()
+	//return errors.Errorf("rpc error: code = Unknown desc = %s", err.Error())
 }
 
 func TestIsErrNotActivated(t *testing.T) {
@@ -65,6 +67,13 @@ func TestIsErrNotAuthorized(t *testing.T) {
 		Resource: Resource{Type: ResourceType_CLUSTER},
 		Required: []Permission{},
 	})))
+	s, ok := status.FromError(grpcify(&ErrNotAuthorized{
+		Subject:  "alice",
+		Resource: Resource{Type: ResourceType_CLUSTER},
+		Required: []Permission{},
+	}))
+	require.True(t, ok, "ErrNotAuthorized should be a gRPC status")
+	require.Equal(t, s.Code(), codes.PermissionDenied, "ErrNotAuthorized should be a gRPC PermissionDenied")
 }
 
 func TestErrNoRoleBinding(t *testing.T) {

--- a/src/auth/auth_err_test.go
+++ b/src/auth/auth_err_test.go
@@ -11,8 +11,7 @@ import (
 // grpcify returns an error e such that e.Error() is similar to what grpc
 // errors emit (though this doesn't convert 'error' to an actual GRPC error)
 func grpcify(err error) error {
-	return status.Convert(err).Err()
-	//return errors.Errorf("rpc error: code = Unknown desc = %s", err.Error())
+	return status.Convert(err).Err() //nolint:wrapcheck
 }
 
 func TestIsErrNotActivated(t *testing.T) {

--- a/src/server/identity/server/api_server_test.go
+++ b/src/server/identity/server/api_server_test.go
@@ -90,55 +90,55 @@ func TestUserNotAdmin(t *testing.T) {
 	aliceClient := tu.AuthenticatedPachClient(t, c, alice, peerPort)
 	_, err := aliceClient.SetIdentityServerConfig(aliceClient.Ctx(), &identity.SetIdentityServerConfigRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.GetIdentityServerConfig(aliceClient.Ctx(), &identity.GetIdentityServerConfigRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.CreateIDPConnector(aliceClient.Ctx(), &identity.CreateIDPConnectorRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.GetIDPConnector(aliceClient.Ctx(), &identity.GetIDPConnectorRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.UpdateIDPConnector(aliceClient.Ctx(), &identity.UpdateIDPConnectorRequest{})
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 	require.YesError(t, err)
 
 	_, err = aliceClient.ListIDPConnectors(aliceClient.Ctx(), &identity.ListIDPConnectorsRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.DeleteIDPConnector(aliceClient.Ctx(), &identity.DeleteIDPConnectorRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.CreateOIDCClient(aliceClient.Ctx(), &identity.CreateOIDCClientRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.GetOIDCClient(aliceClient.Ctx(), &identity.GetOIDCClientRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.UpdateOIDCClient(aliceClient.Ctx(), &identity.UpdateOIDCClientRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.ListOIDCClients(aliceClient.Ctx(), &identity.ListOIDCClientsRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.DeleteOIDCClient(aliceClient.Ctx(), &identity.DeleteOIDCClientRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 
 	_, err = aliceClient.IdentityAPIClient.DeleteAll(aliceClient.Ctx(), &identity.DeleteAllRequest{})
 	require.YesError(t, err)
-	require.Matches(t, fmt.Sprintf("rpc error: code = Unknown desc = %v is not authorized to perform this operation", alice), err.Error())
+	require.Matches(t, fmt.Sprintf("rpc error: code = PermissionDenied desc = %v is not authorized to perform this operation", alice), err.Error())
 }
 
 // TestSetConfiguration tests that the web server configuration reloads when the etcd config value is updated


### PR DESCRIPTION
This makes an `auth.ErrNotAuthorized` a gRPC PermissionDenied status rather than an Unknown error.