### PR TITLE
Add a command to pachctl to test the database migrations in advance of upgrading

### DIFF
--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -35,7 +35,7 @@ func Error(ctx context.Context, msg string, fields ...Field) {
 	extractLogger(ctx).Error(msg, fields...)
 }
 
-// Exit logs a message, with fields, at level FATAL and then exits with status 0.  Level fatal is
+// Exit logs a message, with fields, at level FATAL and then exits with status 1.  Level fatal is
 // only appropriate for use in interactive scripts.
 func Exit(ctx context.Context, msg string, fields ...Field) {
 	extractLogger(ctx).Fatal(msg, fields...)

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -3,21 +3,31 @@ package cmds
 import (
 	"context"
 	"crypto/tls"
+	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"strings"
 
+	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
+	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
 	"github.com/spf13/cobra"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
@@ -174,6 +184,85 @@ func Cmds(ctx context.Context) []*cobra.Command {
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(decodeURL, "misc decode-download-url"))
+
+	testMigrations := &cobra.Command{
+		Use:   "{{alias}} <postgres dsn>",
+		Short: "Runs the database migrations against the supplied database, then rolls them back.",
+		Long:  "Runs the database migrations against the supplied database, then rolls them back.",
+		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
+			ctx, c := signal.NotifyContext(pctx.Background(""), os.Interrupt)
+			defer c()
+
+			dsn := args[0]
+			db, err := sqlx.Open("pgx", dsn)
+			if err != nil {
+				return errors.Wrap(err, "open database")
+			}
+			if err := dbutil.WaitUntilReady(ctx, db); err != nil {
+				return errors.Wrap(err, "wait for database ready")
+			}
+
+			// Create test dirs for etcd data
+			dir, err := os.MkdirTemp("", "test-migrations")
+			if err != nil {
+				return errors.Wrap(err, "create etcd server tmpdir")
+			}
+			defer os.RemoveAll(dir)
+
+			etcdConfig := embed.NewConfig()
+			etcdConfig.MaxTxnOps = 10000
+			etcdConfig.Dir = filepath.Join(dir, "dir")
+			etcdConfig.WalDir = filepath.Join(dir, "wal")
+			etcdConfig.InitialElectionTickAdvance = false
+			etcdConfig.TickMs = 10
+			etcdConfig.ElectionMs = 50
+			etcdConfig.ListenPeerUrls = []url.URL{}
+			etcdConfig.ListenClientUrls = []url.URL{{
+				Scheme: "http",
+				Host:   "localhost:7777",
+			}}
+			log.AddLoggerToEtcdServer(ctx, etcdConfig)
+			etcd, err := embed.StartEtcd(etcdConfig)
+			if err != nil {
+				return errors.Wrap(err, "start etcd")
+			}
+			defer etcd.Close()
+
+			etcdCfg := log.GetEtcdClientConfig(ctx)
+			etcdCfg.Endpoints = []string{"http://localhost:7777"}
+			etcdCfg.DialOptions = client.DefaultDialOptions()
+			etcdClient, err := clientv3.New(etcdCfg)
+			if err != nil {
+				return errors.Wrap(err, "connect to etcd")
+			}
+			defer etcdClient.Close()
+
+			txx, err := db.BeginTxx(ctx, &sql.TxOptions{
+				Isolation: sql.LevelSerializable,
+			})
+			if err != nil {
+				return errors.Wrap(err, "start tx")
+			}
+			defer func() {
+				if err := txx.Rollback(); err != nil {
+					multierr.AppendInto(&retErr, errors.Wrap(err, "rollback"))
+				}
+			}()
+			states := migrations.CollectStates(nil, clusterstate.DesiredClusterState)
+			env := migrations.MakeEnv(nil, etcdClient)
+			env.Tx = txx
+			var errs error
+			for _, s := range states {
+				if err := migrations.ApplyMigrationTx(ctx, env, s); err != nil {
+					log.Error(ctx, "migration did not apply; continuing", zap.Error(err))
+					multierr.AppendInto(&errs, err)
+				}
+			}
+			log.Info(ctx, "done applying migrations")
+			return errs
+		}),
+	}
+	commands = append(commands, cmdutil.CreateAlias(testMigrations, "misc test-migrations"))
 
 	misc := &cobra.Command{
 		Short:  "Miscellaneous utilities unrelated to Pachyderm itself.",


### PR DESCRIPTION
This creates a transaction, applies the migrations, and rolls back.  Hopefully it is helpful in testing database migrations before an actual upgrade occurs.

I opened CORE-1683 to track this feature.