### PR TITLE
Refactor multierrors to use the standard library's errors.Join

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,75 +1,82 @@
 run:
-  timeout: 5m
-  skip-dirs:
-    - cached-deps
-  build-tags:
-    - k8s
-    - unit_test
+    timeout: 5m
+    skip-dirs:
+        - cached-deps
+    build-tags:
+        - k8s
+        - unit_test
 linters:
-  enable:
-    - wrapcheck
-    - nolintlint
-    - gofmt
-    - govet
-    - gosimple
-    - errcheck
-    - ineffassign
-    - unused
-    - asciicheck
-    - asasalint
-    - bidichk
-    - exhaustive
-    - goprintffuncname
-    - depguard
-    # - bodyclose CORE-1317
-    # - gocritic CORE-1318
-    # - gosec CORE-1319
+    enable:
+        - wrapcheck
+        - nolintlint
+        - gofmt
+        - govet
+        - gosimple
+        - errcheck
+        - ineffassign
+        - unused
+        - asciicheck
+        - asasalint
+        - bidichk
+        - exhaustive
+        - goprintffuncname
+        - depguard
+        # - bodyclose CORE-1317
+        # - gocritic CORE-1318
+        # - gosec CORE-1319
 linters-settings:
-  errcheck:
-    exclude-functions:
-      - (*database/sql.Tx).Rollback
-      - (*github.com/spf13/cobra.Command).MarkFlagCustom
-      - (*github.com/spf13/cobra.Command).Usage
-  nolintlint:
-    allow-unused: false
-    allow-leading-space: false
-    require-explanation: false
-    require-specific: true
-  wrapcheck:
-    ignoreSigs:
-      - github.com/pachyderm/pachyderm/v2/src/internal/errors.Errorf
-      - github.com/pachyderm/pachyderm/v2/src/internal/errors.New
-      - github.com/pachyderm/pachyderm/v2/src/internal/errors.Unwrap
-      - github.com/pachyderm/pachyderm/v2/src/internal/errors.EnsureStack
-      - google.golang.org/grpc/status.Error
-      - google.golang.org/grpc/status.Errorf
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-    ignorePackageGlobs:
-      # These are packages whose return values don't have to be wrapped, not packages where the
-      # linter isn't used.
-      - github.com/pachyderm/pachyderm/v2/src/*
-    ignoreInterfaceRegexps:
-      - ^fileset\.
-      - ^collection\.
-      - ^track\.
-  gofmt:
-    simplify: true
-  exhaustive:
-    default-signifies-exhaustive: true
-    # Right now, we only allow opting into the exhaustive check due to a lot of code that makes
-    # correct use of non-exhaustive switch statements.
-    # Annotate your switch statement with //exhaustive:enforce to opt in.
-    explicit-exhaustive-switch: true
-    explicit-exhaustive-map: true
-  depguard:
-    include-go-root: true
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: 'use the internal/log package'
-      - log: 'use the internal/log package'
-    ignore-file-rules:
-      - "**/src/internal/log/*.go"
-      - "**/etc/**/*.go" # /etc cannot import internal/log :(
+    errcheck:
+        exclude-functions:
+            - (*database/sql.Tx).Rollback
+            - (*github.com/spf13/cobra.Command).MarkFlagCustom
+            - (*github.com/spf13/cobra.Command).Usage
+    nolintlint:
+        allow-unused: false
+        allow-leading-space: false
+        require-explanation: false
+        require-specific: true
+    wrapcheck:
+        ignoreSigs:
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.Errorf
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.New
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.Unwrap
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.EnsureStack
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.Join
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.JoinInto
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.Close
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.Invoke
+            - github.com/pachyderm/pachyderm/v2/src/internal/errors.Invoke1
+            - google.golang.org/grpc/status.Error
+            - google.golang.org/grpc/status.Errorf
+            - .Wrap(
+            - .Wrapf(
+            - .WithMessage(
+            - .WithMessagef(
+            - .WithStack(
+        ignorePackageGlobs:
+            # These are packages whose return values don't have to be wrapped, not packages where the
+            # linter isn't used.
+            - github.com/pachyderm/pachyderm/v2/src/*
+        ignoreInterfaceRegexps:
+            - ^fileset\.
+            - ^collection\.
+            - ^track\.
+    gofmt:
+        simplify: true
+    exhaustive:
+        default-signifies-exhaustive: true
+        # Right now, we only allow opting into the exhaustive check due to a lot of code that makes
+        # correct use of non-exhaustive switch statements.
+        # Annotate your switch statement with //exhaustive:enforce to opt in.
+        explicit-exhaustive-switch: true
+        explicit-exhaustive-map: true
+    depguard:
+        include-go-root: true
+        packages-with-error-message:
+            - github.com/sirupsen/logrus: "use the internal/log package"
+            - log: "use the internal/log package"
+            - go.uber.org/multierr: "use the internal/errors package"
+            - github.com/hashicorp/go-multierror: "use the internal/errors package"
+        ignore-file-rules:
+            - "**/src/internal/log/*.go"
+            - "**/etc/**/*.go" # /etc cannot import internal/log :(

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.8
 	go.uber.org/atomic v1.9.0
 	go.uber.org/automaxprocs v1.5.1
-	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.24.0
 	gocloud.dev v0.27.0
 	golang.org/x/crypto v0.7.0
@@ -131,6 +130,7 @@ require (
 	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/xanzy/ssh-agent v0.3.2 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340
 	github.com/gruntwork-io/terratest v0.38.8
 	github.com/hanwen/go-fuse/v2 v2.1.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/itchyny/gojq v0.11.2
@@ -119,6 +118,7 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	etcd "go.etcd.io/etcd/client/v3"
-	"go.uber.org/multierr"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -418,7 +417,7 @@ func (c *postgresCollection) list(
 		}
 		defer func() {
 			if err := rs.Close(); err != nil {
-				retErr = multierr.Append(
+				retErr = errors.Join(
 					retErr,
 					errors.Wrapf(c.mapSQLError(err, ""), "closing rows for list query buffer with offset %v", offset),
 				)

--- a/src/internal/errors/multi.go
+++ b/src/internal/errors/multi.go
@@ -1,0 +1,54 @@
+package errors
+
+import (
+	stderr "errors"
+	"io"
+)
+
+// Join joins the provided errors into a single multierror.  Any nil errors are skipped, and if all
+// errors are nil, the return value is nil.
+//
+// See `go doc errors.Join` for details.
+func Join(errs ...error) error {
+	return EnsureStack(stderr.Join(errs...))
+}
+
+// JoinInto appends err into *into.  into can point to a nil error, and err can also be nil.
+func JoinInto(into *error, err error) {
+	if into == nil {
+		// into can point to a nil error, but into itself can't be nil.
+		// This is fine: var err error; JoinInto(&err, whatever)
+		panic("misuse of errors.JoinInto: into pointer must not be nil")
+	}
+	*into = Join(*into, err)
+}
+
+// Close enhances a very common pattern with multierrors; adding the error from Close() to the
+// return value of the current function:
+//
+//	 func f(what string) (retErr error) {
+//	     x := thing.Open(what)
+//	     defer errors.Close(&retErr, x, "close thing %v", what)
+//	     return x.Do()
+//	}
+//
+// A non-wrapping version is not available because an error without context is maddening.
+func Close(into *error, x io.Closer, msg string, args ...any) {
+	if err := x.Close(); err != nil {
+		JoinInto(into, Wrapf(err, msg, args...))
+	}
+}
+
+// Invoke is like Close, but for any function that returns an error.
+func Invoke(into *error, f func() error, msg string, args ...any) {
+	if err := f(); err != nil {
+		JoinInto(into, Wrapf(err, msg, args...))
+	}
+}
+
+// Invoke1 is like Invoke, but the f can take an argument.
+func Invoke1[T any](into *error, f func(T) error, x T, msg string, args ...any) {
+	if err := f(x); err != nil {
+		JoinInto(into, Wrapf(err, msg, args...))
+	}
+}

--- a/src/internal/errors/multi_test.go
+++ b/src/internal/errors/multi_test.go
@@ -1,0 +1,174 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	a     = errors.New("a")
+	b     = errors.New("b")
+	run   = errors.New("run")
+	close = errors.New("close")
+)
+
+func TestJoin(t *testing.T) {
+	testData := []struct {
+		err, target error
+	}{
+		{a, a},
+		{b, b},
+		{Join(a, b), a},
+		{Join(a, b), b},
+		{Join(a, a), a},
+		{Join(b, b), b},
+		{Join(a, Join(b)), a},
+		{Join(a, Join(b)), b},
+		{Join(nil, a, nil), a},
+		{Join(nil, a, Join(nil, b, nil, b)), a},
+		{Join(nil, a, Join(nil, b, nil, b)), b},
+	}
+
+	for _, test := range testData {
+		if !errors.Is(test.err, test.target) {
+			t.Errorf("expected Is(%v, %v) to be true", test.err, test.target)
+		}
+	}
+
+	if err := Join(nil, nil, nil); err != nil {
+		t.Errorf("Join(nil...) should be nil; got %v", err)
+	}
+}
+
+func TestJoinInto(t *testing.T) {
+	var err error
+	JoinInto(&err, a)
+	if !errors.Is(err, a) {
+		t.Errorf("err %v should be a", err)
+	}
+	JoinInto(&err, b)
+	if !errors.Is(err, a) {
+		t.Errorf("err %v should be a", err)
+	}
+	if !errors.Is(err, b) {
+		t.Errorf("err %v should be b", err)
+	}
+
+	err = b
+	JoinInto(&err, a)
+	if !errors.Is(err, a) {
+		t.Errorf("err %v should be a", err)
+	}
+	if !errors.Is(err, b) {
+		t.Errorf("err %v should be b", err)
+	}
+}
+
+type closeRecorder struct {
+	err    error
+	closed bool
+}
+
+func (c *closeRecorder) Close() error {
+	c.closed = true
+	return c.err
+}
+
+func TestClose(t *testing.T) {
+	x := new(closeRecorder)
+	err := func() (retErr error) {
+		defer Close(&retErr, x, "cleanup")
+		if x.closed {
+			t.Errorf("x closed too early")
+		}
+		return nil
+	}()
+	if !x.closed {
+		t.Errorf("x unexpectedly not closed")
+	}
+	if err != nil {
+		t.Errorf("expected nil error; got %v", err)
+	}
+
+	x = new(closeRecorder)
+	err = func() (retErr error) {
+		x.err = close
+		defer Close(&retErr, x, "cleanup")
+		return nil
+	}()
+	if !x.closed {
+		t.Errorf("x unexpectedly not closed")
+	}
+	if !errors.Is(err, close) {
+		t.Errorf("expected close error; got %v", err)
+	}
+
+	x = new(closeRecorder)
+	err = func() (retErr error) {
+		defer Close(&retErr, x, "cleanup")
+		return run //nolint:wrapcheck
+	}()
+	if !x.closed {
+		t.Errorf("x unexpectedly not closed")
+	}
+	if !errors.Is(err, run) {
+		t.Errorf("expected run error; got %v", err)
+	}
+
+	x = new(closeRecorder)
+	err = func() (retErr error) {
+		x.err = close
+		defer Close(&retErr, x, "cleanup")
+		return run //nolint:wrapcheck
+	}()
+	if !x.closed {
+		t.Errorf("x unexpectedly not closed")
+	}
+	if !errors.Is(err, run) && !errors.Is(err, close) {
+		t.Errorf("expected run and close errors; got %v", err)
+	}
+}
+
+func TestInvoke(t *testing.T) {
+	x := new(closeRecorder)
+	err := func() (retErr error) {
+		x.err = close
+		defer Invoke(&retErr, x.Close, "cleanup")
+		if x.closed {
+			t.Errorf("x closed too early")
+		}
+		return run //nolint:wrapcheck
+	}()
+	if !x.closed {
+		t.Errorf("x unexpectedly not closed")
+	}
+	if !errors.Is(err, run) && !errors.Is(err, close) {
+		t.Errorf("expected run and close errors; got %v", err)
+	}
+}
+
+func TestInvoke1(t *testing.T) {
+	x := new(closeRecorder)
+	closer := func(close bool) error {
+		if close {
+			return x.Close()
+		}
+		return nil
+	}
+	err := func() (retErr error) {
+		x.err = close
+		defer Invoke1(&retErr, closer, true, "cleanup")
+		Invoke1(&retErr, closer, false, "ignored")
+		if x.closed {
+			t.Errorf("x closed too early")
+		}
+		return run //nolint:wrapcheck
+	}()
+	if !x.closed {
+		t.Errorf("x unexpectedly not closed")
+	}
+	if !errors.Is(err, run) && !errors.Is(err, close) {
+		t.Errorf("expected run and close errors; got %v", err)
+	}
+}

--- a/src/internal/storage/chunk/gc.go
+++ b/src/internal/storage/chunk/gc.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -53,11 +52,7 @@ func (gc *GarbageCollector) RunOnce(ctx context.Context) (retErr error) {
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	defer func() {
-		if err := rows.Close(); retErr == nil {
-			retErr = multierr.Append(retErr, err)
-		}
-	}()
+	defer errors.Close(&retErr, rows, "close rows")
 	for rows.Next() {
 		var ent Entry
 		if err := rows.StructScan(&ent); err != nil {

--- a/src/internal/taskchain/task_chain.go
+++ b/src/internal/taskchain/task_chain.go
@@ -3,7 +3,6 @@ package taskchain
 import (
 	"context"
 
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -41,7 +40,7 @@ type TaskChainFunc = func(context.Context) (serCB func() error, err error)
 // CreateTask creates a new task in the task chain.
 func (c *TaskChain) CreateTask(cb TaskChainFunc) error {
 	if err := c.sem.Acquire(c.ctx, 1); err != nil {
-		err = multierror.Append(c.eg.Wait(), err)
+		err = errors.Join(c.eg.Wait(), err)
 		return errors.EnsureStack(err)
 	}
 	// get our place in line for the serial portion

--- a/src/server/debug/server/database_dump.go
+++ b/src/server/debug/server/database_dump.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"go.uber.org/multierr"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
@@ -25,10 +24,10 @@ func (s *debugServer) collectDatabaseDump(ctx context.Context, tw *tar.Writer, p
 	defer cancel()
 	var errs error
 	if err := s.collectDatabaseStats(ctxWithTimeout, tw, prefix...); err != nil {
-		multierr.AppendInto(&errs, errors.Wrap(err, "collectDatabaseStats"))
+		errors.JoinInto(&errs, errors.Wrap(err, "collectDatabaseStats"))
 	}
 	if err := s.collectDatabaseTables(ctxWithTimeout, tw, prefix...); err != nil {
-		multierr.AppendInto(&errs, errors.Wrap(err, "collectDatabaseTables"))
+		errors.JoinInto(&errs, errors.Wrap(err, "collectDatabaseTables"))
 	}
 	return errs
 }

--- a/src/server/debug/server/log.go
+++ b/src/server/debug/server/log.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -141,7 +140,7 @@ func (s *debugServer) SetLogLevel(ctx context.Context, req *debug.SetLogLevelReq
 		)
 		c()
 		if err != nil {
-			multierr.AppendInto(&enumerateErrs, errors.Wrapf(err, "ListPods(%v)", app))
+			errors.JoinInto(&enumerateErrs, errors.Wrapf(err, "ListPods(%v)", app))
 			continue
 		}
 		for _, pod := range podList.Items {

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	lc "github.com/pachyderm/pachyderm/v2/src/license"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -538,7 +537,7 @@ func scaleDownWorkers(ctx context.Context, kc kubernetes.Interface, namespace st
 		}, metav1.UpdateOptions{
 			FieldManager: "enterprise-server",
 		}); err != nil {
-			multierr.AppendInto(&errs, errors.Errorf("could not scale down %s: %v", w.GetName(), err))
+			errors.JoinInto(&errs, errors.Errorf("could not scale down %s: %v", w.GetName(), err))
 		}
 	}
 	return errs

--- a/src/server/pachw/server/pachw.go
+++ b/src/server/pachw/server/pachw.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	autoscaling_v1 "k8s.io/api/autoscaling/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,11 +44,7 @@ func (p *pachW) run(ctx context.Context) {
 		if err != nil {
 			return errors.Wrap(err, "locking pachw-controller lock")
 		}
-		defer func() {
-			if err := lock.Unlock(ctx); err != nil {
-				retErr = multierror.Append(retErr, errors.Wrap(err, "error unlocking"))
-			}
-		}()
+		defer errors.Invoke1(&retErr, lock.Unlock, ctx, "error unlocking")
 		var replicas int
 		var scaleDownCount int
 		ticker := time.NewTicker(period)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/hashicorp/go-multierror"
 	etcd "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -844,7 +843,7 @@ func (d *driver) deleteProject(txnCtx *txncontext.TransactionContext, project *p
 	}
 	var errs error
 	if err := d.listRepoInTransaction(txnCtx, false /* includeAuth */, "" /* repoType */, []*pfs.Project{project} /* projectsFilter */, func(repoInfo *pfs.RepoInfo) error {
-		errs = multierror.Append(errs, fmt.Errorf("repo %v still exists", repoInfo.GetRepo()))
+		errs = errors.Join(errs, fmt.Errorf("repo %v still exists", repoInfo.GetRepo()))
 		return nil
 	}); err != nil {
 		return err

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/itchyny/gojq"
 	opentracing "github.com/opentracing/opentracing-go"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -1838,7 +1837,7 @@ func (a *apiServer) validatePipelineRequest(request *pps.CreatePipelineRequest) 
 	var tolErrs error
 	for i, t := range request.GetTolerations() {
 		if _, err := transformToleration(t); err != nil {
-			multierr.AppendInto(&tolErrs, errors.Errorf("toleration %d/%d: %v", i+1, len(request.GetTolerations()), err))
+			errors.JoinInto(&tolErrs, errors.Errorf("toleration %d/%d: %v", i+1, len(request.GetTolerations()), err))
 		}
 	}
 	if tolErrs != nil {

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -847,7 +846,7 @@ func (kd *kubeDriver) getWorkerOptions(ctx context.Context, pipelineInfo *pps.Pi
 	for i, in := range pipelineInfo.GetDetails().GetTolerations() {
 		out, err := transformToleration(in)
 		if err != nil {
-			multierr.AppendInto(&tolErr, errors.Errorf("toleration %d/%d: %v", i+1, len(pipelineInfo.GetDetails().GetTolerations()), err))
+			errors.JoinInto(&tolErr, errors.Errorf("toleration %d/%d: %v", i+1, len(pipelineInfo.GetDetails().GetTolerations()), err))
 			continue
 		}
 		tolerations = append(tolerations, out)

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -347,9 +346,7 @@ func handleDatumSetBatching(ctx context.Context, driver driver.Driver, logger lo
 				// Restart the user code if an error occurred.
 				if retErr != nil {
 					stop()
-					if err := start(); err != nil {
-						retErr = multierror.Append(retErr, errors.Wrap(err, "error restarting user code"))
-					}
+					errors.Invoke(&retErr, start, "error restarting user code")
 				}
 			}()
 			select {


### PR DESCRIPTION
I moved over the multierror functionality from hashicorp and uber's multierr library, and refactored our code to use them.  Instead of picking one winner from the two, we are now just using Go's built-in multierrors.  I also added a lint rule to ban future uses of those two third-party libraries.

The most notable impact is that the two OSS libraries call the operation "Append", but Go calls it "Join", so our wrappers are also called Join.

Close/Invoke/InvokeN are based on go.uber.org/multierr, but without the indirection through an interface.  Closing things is 90% of our use case, so I made that nicer and didn't bring over the Invoker/Closer interfaces.  Invoke is rarely needed but logically makes sense to have.  InvokeN is useful for locks.  Any more utilities than that didn't seem necessary during the refactor, but if people have favorite wrappers we can add them here.