### PR TITLE
Populate empty projects in project selection within Jupyter extension

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -58,6 +58,20 @@ class MountsHandler(BaseHandler):
             )
 
 
+class ProjectsHandler(BaseHandler):
+    @tornado.web.authenticated
+    async def get(self):
+        try:
+            response = await self.mount_client.list_projects()
+            get_logger().debug(f"Projects: {response}")
+            self.finish(response)
+        except Exception as e:
+            get_logger().error("Error listing projects.", exc_info=True)
+            raise tornado.web.HTTPError(
+                status_code=getattr(e, "code", 500), reason=f"Error listing projects: {e}."
+            )
+
+
 class MountHandler(BaseHandler):
     @tornado.web.authenticated
     async def put(self):
@@ -313,6 +327,7 @@ def setup_handlers(web_app):
     _handlers = [
         ("/repos", ReposHandler),
         ("/mounts", MountsHandler),
+        ("/projects", ProjectsHandler),
         ("/_mount", MountHandler),
         ("/_unmount", UnmountHandler),
         ("/_commit", CommitHandler),

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -105,6 +105,11 @@ class MountServerClient(MountInterface):
         await self._ensure_mount_server()
         response = await self.client.fetch(f"{self.address}/mounts")
         return response.body
+
+    async def list_projects(self):
+        await self._ensure_mount_server()
+        response = await self.client.fetch(f"{self.address}/projects")
+        return response.body
         
     async def mount(self, body):
         await self._ensure_mount_server()

--- a/jupyter-extension/jupyterlab_pachyderm/pachyderm.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pachyderm.py
@@ -5,6 +5,9 @@ class MountInterface:
     async def list_mounts(self):
         pass
 
+    async def list_projects(self):
+        pass
+
     async def mount(self, body):
         pass
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_handlers.py
@@ -552,6 +552,28 @@ async def test_pps_get(jp_fetch):
         assert expected_key in body
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
+@patch(
+    "jupyterlab_pachyderm.handlers.ProjectsHandler.mount_client",
+    spec=MountInterface,
+)
+async def test_get_projects(mock_client, jp_fetch):
+    test_projects = [
+        {
+            "project": {"name": "default"},
+            "auth_info":{"permissions": [1, 2, 3], "roles": ["clusterAdmin", "projectOwner"]}
+        },
+        {
+            "project": {"name": "p1"},
+            "auth_info":{"permissions": [4, 5, 6], "roles": ["test"]}
+        }
+    ]
+
+    mock_client.list_projects.return_value = json.dumps(test_projects)
+    resp = await jp_fetch(f"/{NAMESPACE}/{VERSION}/projects")
+    assert json.loads(resp.body) == test_projects
+
+
 async def test_write_token_to_config_no_context():
     timestamp = time.time_ns()
     test_config_path = f"/tmp/pach_test_config_{timestamp}.json"

--- a/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/SortableList.tsx
@@ -1,5 +1,11 @@
 import React, {useCallback, useState} from 'react';
-import {Repo, Mount, ListMountsResponse} from '../../types';
+import {
+  Repo,
+  Mount,
+  ListMountsResponse,
+  Project,
+  ProjectInfo,
+} from '../../types';
 import {caretUpIcon, caretDownIcon} from '@jupyterlab/ui-components';
 import {useSort, stringComparator} from '../../../../utils/hooks/useSort';
 import ListMount from './ListMount';
@@ -11,6 +17,7 @@ type SortableListProps = {
   updateData: (data: ListMountsResponse) => void;
   mountedItems: Mount[];
   type: string;
+  projects: ProjectInfo[];
 };
 
 const nameComparator = {
@@ -26,11 +33,12 @@ const SortableList: React.FC<SortableListProps> = ({
   updateData,
   mountedItems,
   type,
+  projects,
 }) => {
   const allProjectsLabel = 'All projects';
-  const projectsList = [
-    ...new Set(items.map((item: Mount | Repo): string => item.project)),
-  ];
+  const projectsList: string[] = projects.map(
+    (project: ProjectInfo): string => project.project.name,
+  );
   const [selectedProject, setSelectedProject] =
     useState<string>(allProjectsLabel);
 

--- a/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render, fireEvent, waitFor} from '@testing-library/react';
 
 import SortableList from '../SortableList';
-import {Repo, Mount} from 'plugins/mount/types';
+import {Repo, Mount, ProjectInfo} from 'plugins/mount/types';
 import * as requestAPI from '../../../../../handler';
 import {mockedRequestAPI} from 'utils/testUtils';
 jest.mock('../../../../../handler');
@@ -35,6 +35,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'unmounted'}
+        projects={[]}
       />,
     );
     const listItem = getByTestId('ListItem__noBranches');
@@ -60,6 +61,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'unmounted'}
+        projects={[]}
       />,
     );
     const listItem = getByTestId('ListItem__unauthorized');
@@ -94,6 +96,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'unmounted'}
+        projects={[]}
       />,
     );
     let listItems = getAllByTestId('ListItem__noBranches');
@@ -126,6 +129,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'unmounted'}
+        projects={[]}
       />,
     );
     const listItem = getByTestId('ListItem__repo');
@@ -178,6 +182,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
     const listItem = getByTestId('ListItem__repo');
@@ -227,6 +232,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
     getByText('images').click();
@@ -250,6 +256,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'unmounted'}
+        projects={[]}
       />,
     );
     const select = getByTestId('ListItem__select') as HTMLSelectElement;
@@ -297,6 +304,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
 
@@ -361,6 +369,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
     const unmountButtons = getAllByTestId('ListItem__unmount');
@@ -395,6 +404,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
 
@@ -428,6 +438,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
 
@@ -461,6 +472,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'mounted'}
+        projects={[]}
       />,
     );
 
@@ -503,6 +515,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={mountedItems}
         type={'unmounted'}
+        projects={[]}
       />,
     );
 
@@ -537,6 +550,27 @@ describe('sortable list components', () => {
       },
     ];
 
+    const projects: ProjectInfo[] = [
+      {
+        project: {
+          name: 'p1',
+        },
+        auth: {
+          permissions: [0, 1, 2],
+          roles: ['foo', 'bar'],
+        },
+      },
+      {
+        project: {
+          name: 'default',
+        },
+        auth: {
+          permissions: [3, 4, 5],
+          roles: ['foo', 'bar', 'baz'],
+        },
+      },
+    ];
+
     const {getAllByTestId, getByTestId} = render(
       <SortableList
         open={open}
@@ -544,6 +578,7 @@ describe('sortable list components', () => {
         updateData={updateData}
         mountedItems={[]}
         type={'unmounted'}
+        projects={projects}
       />,
     );
 

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -175,6 +175,7 @@ export class MountPlugin implements IMountPlugin {
               updateData={this._poller.updateData}
               mountedItems={[]}
               type={'mounted'}
+              projects={[]}
             />
           </div>
         )}
@@ -185,18 +186,23 @@ export class MountPlugin implements IMountPlugin {
     this._unmountedList = ReactWidget.create(
       <UseSignal signal={this._poller.unmountedSignal}>
         {(_, unmounted) => (
-          <div className="pachyderm-mount-base">
-            <div className="pachyderm-mount-base-title">
-              Unmounted Repositories
-            </div>
-            <SortableList
-              open={this.open}
-              items={unmounted ? unmounted : this._poller.unmounted}
-              updateData={this._poller.updateData}
-              mountedItems={this._poller.mounted}
-              type={'unmounted'}
-            />
-          </div>
+          <UseSignal signal={this._poller.projectSignal}>
+            {(_, projects) => (
+              <div className="pachyderm-mount-base">
+                <div className="pachyderm-mount-base-title">
+                  Unmounted Repositories
+                </div>
+                <SortableList
+                  open={this.open}
+                  items={unmounted ? unmounted : this._poller.unmounted}
+                  updateData={this._poller.updateData}
+                  mountedItems={this._poller.mounted}
+                  type={'unmounted'}
+                  projects={projects ? projects : this._poller.projects}
+                />
+              </div>
+            )}
+          </UseSignal>
         )}
       </UseSignal>,
     );

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -78,6 +78,20 @@ export type ListMountsResponse = {
   unmounted: {[key: string]: Repo};
 };
 
+export type Project = {
+  name: string;
+};
+
+export type ProjectAuthInfo = {
+  permissions: number[];
+  roles: string[];
+};
+
+export type ProjectInfo = {
+  project: Project;
+  auth: ProjectAuthInfo;
+};
+
 export type AuthConfig = {
   cluster_status: clusterStatus;
   pachd_address?: string;
@@ -90,10 +104,6 @@ export interface IMountPlugin {
   layout: SplitPanel;
   ready: Promise<void>;
 }
-
-export type Project = {
-  name: string;
-};
 
 export type Pipeline = {
   name: string;

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -417,6 +417,26 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 		}
 		w.Write(marshalled) //nolint:errcheck
 	})
+	router.Methods("GET").Path("/projects").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		errMsg, webCode := initialChecks(mm, true)
+		if errMsg != "" {
+			http.Error(w, errMsg, webCode)
+			return
+		}
+
+		projectsList, err := mm.Client.ListProject()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		marshalled, err := json.Marshal(projectsList)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Write(marshalled) //nolint:errcheck
+	})
 	router.Methods("GET").Path("/mounts").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		errMsg, webCode := initialChecks(mm, true)
 		if errMsg != "" {

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -1005,29 +1005,29 @@ func TestProjects(t *testing.T) {
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
 		type Project struct {
-			name string `json:"name"`
+			Name string `json:"name"`
 		}
 
 		type ProjectAuth struct {
-			permissions []int    `json:"permissions"`
-			roles       []string `json:"roles"`
+			Permissions []int    `json:"permissions"`
+			Roles       []string `json:"roles"`
 		}
 
 		type ProjectResp struct {
-			project Project     `json:"project"`
-			auth    ProjectAuth `json:"auth_info"`
+			Project Project     `json:"project"`
+			Auth    ProjectAuth `json:"auth_info"`
 		}
 
 		resp, err := get("projects")
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 		defer resp.Body.Close()
+		projectData := []ProjectResp{}
 
-		projectData := []*ProjectResp{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&projectData))
 		require.Equal(t, len(projectData), 3)
-		require.Equal(t, projectData[0].project.name, "default")
-		require.Equal(t, projectData[1].project.name, "p1")
-		require.Equal(t, projectData[2].project.name, "p2")
+		require.Equal(t, projectData[0].Project.Name, emptyProjectName)
+		require.Equal(t, projectData[1].Project.Name, projectName)
+		require.Equal(t, projectData[2].Project.Name, pfs.DefaultProjectName)
 	})
 }

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -977,3 +977,57 @@ func TestMountWithProjects(t *testing.T) {
 		require.Equal(t, 4, len((*mountsList).Mounted))
 	})
 }
+
+func TestProjects(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+
+	require.NoError(t, env.PachClient.CreateProjectRepo(pfs.DefaultProjectName, "repo"))
+	commit := client.NewProjectCommit(pfs.DefaultProjectName, "repo", "b1", "")
+	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commit = client.NewProjectCommit(pfs.DefaultProjectName, "repo", "b2", "")
+	err = env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	projectName := tu.UniqueString("p1")
+	require.NoError(t, env.PachClient.CreateProject(projectName))
+	require.NoError(t, env.PachClient.CreateProjectRepo(projectName, "repo_p1"))
+	commit = client.NewProjectCommit(projectName, "repo_p1", "b1", "")
+	err = env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commit = client.NewProjectCommit(projectName, "repo_p1", "b2", "")
+	err = env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
+	require.NoError(t, err)
+
+	emptyProjectName := tu.UniqueString("p2")
+	require.NoError(t, env.PachClient.CreateProject(emptyProjectName))
+
+	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
+		type Project struct {
+			name string `json:"name"`
+		}
+
+		type ProjectAuth struct {
+			permissions []int    `json:"permissions"`
+			roles       []string `json:"roles"`
+		}
+
+		type ProjectResp struct {
+			project Project     `json:"project"`
+			auth    ProjectAuth `json:"auth_info"`
+		}
+
+		resp, err := get("projects")
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		defer resp.Body.Close()
+
+		projectData := []*ProjectResp{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(projectData))
+		require.Equal(t, len(projectData), 3)
+		require.Equal(t, projectData[0].project.name, "default")
+		require.Equal(t, projectData[1].project.name, "p1")
+		require.Equal(t, projectData[2].project.name, "p2")
+	})
+}

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -1024,7 +1024,7 @@ func TestProjects(t *testing.T) {
 		defer resp.Body.Close()
 
 		projectData := []*ProjectResp{}
-		require.NoError(t, json.NewDecoder(resp.Body).Decode(projectData))
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&projectData))
 		require.Equal(t, len(projectData), 3)
 		require.Equal(t, projectData[0].project.name, "default")
 		require.Equal(t, projectData[1].project.name, "p1")


### PR DESCRIPTION
Currently, the way that we populate the projects list in the Jupyter extension is by taking the repos list and getting all projects from each of the repos. The issue with this is that projects with no repos can exist, and it can cause confusion if a user creates a new project without repos since it won't show up in the extension. This change adds a /projects endpoint to the mount server and makes the extension query it to retrieve all projects, including those without any repos.