### PR TITLE
Show the creator and caller of cancelled contexts

### DIFF
--- a/etc/benchmark-uploads/main.go
+++ b/etc/benchmark-uploads/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/blake2b"
@@ -129,7 +130,7 @@ func main() {
 	flag.Parse()
 
 	// Cancel context on first SIGINT.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := pctx.WithCancel(context.Background())
 	cancelCh := make(chan os.Signal, 1)
 	signal.Notify(cancelCh, os.Interrupt)
 	go func() {

--- a/etc/benchmark-uploads/main.go
+++ b/etc/benchmark-uploads/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pachyderm/pachyderm/v2/src/client"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/blake2b"
@@ -130,7 +129,7 @@ func main() {
 	flag.Parse()
 
 	// Cancel context on first SIGINT.
-	ctx, cancel := pctx.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	cancelCh := make(chan os.Signal, 1)
 	signal.Notify(cancelCh, os.Interrupt)
 	go func() {

--- a/src/client/debug.go
+++ b/src/client/debug.go
@@ -1,11 +1,11 @@
 package client
 
 import (
-	"context"
 	"io"
 
 	"github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 )
 
 // Profile collects a set of pprof profiles.
@@ -40,7 +40,7 @@ func (c APIClient) Dump(filter *debug.Filter, limit int64, w io.Writer) (retErr 
 	defer func() {
 		retErr = grpcutil.ScrubGRPC(retErr)
 	}()
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	dumpC, err := c.DebugClient.Dump(ctx, &debug.DumpRequest{
 		Filter: filter,

--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -1,12 +1,12 @@
 package client
 
 import (
-	"context"
 	"io"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
@@ -169,7 +169,7 @@ func (c APIClient) ListRepoByType(repoType string) (_ []*pfs.RepoInfo, retErr er
 // ListProjectRepo returns a list of RepoInfos given a ListRepoRequest, which can
 // include information about which projects to filter with.
 func (c APIClient) ListProjectRepo(r *pfs.ListRepoRequest) ([]*pfs.RepoInfo, error) {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PfsAPIClient.ListRepo(
 		ctx,
@@ -406,7 +406,7 @@ func (c APIClient) ListCommitF(repo *pfs.Repo, to, from *pfs.Commit, number int6
 		To:      to,
 		From:    from,
 	}
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	stream, err := c.PfsAPIClient.ListCommit(ctx, req)
 	if err != nil {
@@ -443,7 +443,7 @@ type FindCommitsResponse struct {
 
 // FindCommits searches for commits that reference a supplied file being modified in a branch.
 func (c APIClient) FindCommits(req *pfs.FindCommitsRequest) (*FindCommitsResponse, error) {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PfsAPIClient.FindCommits(ctx, req)
 	if err != nil {
@@ -547,7 +547,7 @@ func (c APIClient) ListBranch(repoName string) ([]*pfs.BranchInfo, error) {
 
 // ListProjectBranch lists the active branches on a Repo.
 func (c APIClient) ListProjectBranch(projectName, repoName string) ([]*pfs.BranchInfo, error) {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	var repo *pfs.Repo
 	if repoName != "" {
@@ -631,7 +631,7 @@ func (c APIClient) ListProject() (_ []*pfs.ProjectInfo, retErr error) {
 	defer func() {
 		retErr = grpcutil.ScrubGRPC(retErr)
 	}()
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PfsAPIClient.ListProject(
 		ctx,
@@ -664,7 +664,7 @@ func (c APIClient) inspectCommitSet(id string, wait bool, cb func(*pfs.CommitInf
 		CommitSet: NewCommitSet(id),
 		Wait:      wait,
 	}
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PfsAPIClient.InspectCommitSet(ctx, req)
 	if err != nil {
@@ -851,7 +851,7 @@ func (c APIClient) Fsck(fix bool, cb func(*pfs.FsckResponse) error, opts ...Fsck
 // FsckFastExit performs checks on pfs, similar to Fsck, except that it returns the
 // first fsck error it encounters and exits.
 func (c APIClient) FsckFastExit() error {
-	ctx, cancel := context.WithCancel(c.Ctx())
+	ctx, cancel := pctx.WithCancel(c.Ctx())
 	defer cancel()
 	fsckClient, err := c.PfsAPIClient.Fsck(ctx, &pfs.FsckRequest{})
 	if err != nil {

--- a/src/client/pps.go
+++ b/src/client/pps.go
@@ -1,13 +1,13 @@
 package client
 
 import (
-	"context"
 	"io"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 
@@ -294,7 +294,7 @@ func (c APIClient) WaitProjectJob(projectName, pipelineName, jobID string, detai
 }
 
 func (c APIClient) inspectJobSet(id string, wait bool, details bool, cb func(*pps.JobInfo) error) (retErr error) {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	req := &pps.InspectJobSetRequest{
 		JobSet:  NewJobSet(id),
@@ -502,7 +502,7 @@ func (c APIClient) ListProjectJobFilterF(projectName, pipelineName string, input
 	if projectName != "" && pipelineName != "" {
 		pipeline = NewProjectPipeline(projectName, pipelineName)
 	}
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PpsAPIClient.ListJob(
 		ctx,
@@ -543,7 +543,7 @@ func (c APIClient) SubscribeJob(pipelineName string, details bool, cb func(*pps.
 // SubscribeProjectJob calls the given callback with each open job in the given
 // pipeline until cancelled.
 func (c APIClient) SubscribeProjectJob(projectName, pipelineName string, details bool, cb func(*pps.JobInfo) error) error {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PpsAPIClient.SubscribeJob(
 		ctx,
@@ -700,7 +700,7 @@ func (c APIClient) ListDatumInputAll(input *pps.Input) (_ []*pps.DatumInfo, retE
 }
 
 func (c APIClient) listDatum(req *pps.ListDatumRequest, cb func(*pps.DatumInfo) error) (retErr error) {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PpsAPIClient.ListDatum(ctx, req)
 	if err != nil {
@@ -951,7 +951,7 @@ func (c APIClient) InspectProjectPipeline(projectName, pipelineName string, deta
 
 // ListPipeline returns info about all pipelines.
 func (c APIClient) ListPipeline(details bool) ([]*pps.PipelineInfo, error) {
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PpsAPIClient.ListPipeline(
 		ctx,
@@ -998,7 +998,7 @@ func (c APIClient) ListProjectPipelineHistory(projectName, pipelineName string, 
 	if pipelineName != "" {
 		pipeline = NewProjectPipeline(projectName, pipelineName)
 	}
-	ctx, cf := context.WithCancel(c.Ctx())
+	ctx, cf := pctx.WithCancel(c.Ctx())
 	defer cf()
 	client, err := c.PpsAPIClient.ListPipeline(
 		ctx,

--- a/src/client/proxy.go
+++ b/src/client/proxy.go
@@ -6,6 +6,7 @@ import (
 
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/proxy"
 )
 
@@ -66,7 +67,7 @@ func (ppl *proxyPostgresListener) Register(notifier col.Notifier) error {
 
 func (ppl *proxyPostgresListener) listen(notifier col.Notifier) {
 	channel := notifier.Channel()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := pctx.WithCancel(context.Background())
 	ppl.channelInfos[channel] = newChannelInfo(cancel, notifier)
 
 	var listenClient proxy.API_ListenClient

--- a/src/client/task.go
+++ b/src/client/task.go
@@ -1,17 +1,17 @@
 package client
 
 import (
-	"context"
 	"io"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/task"
 )
 
 // ListTask lists tasks in the given namespace and group
 func (c APIClient) ListTask(service string, namespace, group string, cb func(*task.TaskInfo) error) (retErr error) {
-	ctx, cancel := context.WithCancel(c.Ctx())
+	ctx, cancel := pctx.WithCancel(c.Ctx())
 	defer cancel()
 	defer func() {
 		retErr = grpcutil.ScrubGRPC(retErr)

--- a/src/internal/archiveserver/http.go
+++ b/src/internal/archiveserver/http.go
@@ -90,7 +90,7 @@ func (h *HTTP) ListenAndServe(ctx context.Context) error {
 	}()
 	select {
 	case <-ctx.Done():
-		log.Info(ctx, "terminating download server", zap.Error(ctx.Err()))
+		log.Info(ctx, "terminating download server", zap.Error(context.Cause(ctx)))
 		return errors.EnsureStack(h.server.Shutdown(ctx))
 	case err := <-errCh:
 		return err

--- a/src/internal/backoff/retry_test.go
+++ b/src/internal/backoff/retry_test.go
@@ -2,7 +2,6 @@ package backoff_test
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -46,7 +45,7 @@ func TestRetry(t *testing.T) {
 
 func TestRetryUntilCancel(t *testing.T) {
 	var results []int
-	ctx, cancel := context.WithCancel(pctx.TestContext(t))
+	ctx, cancel := pctx.WithCancel(pctx.TestContext(t))
 	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		results = append(results, len(results))
 		if len(results) >= 3 {
@@ -60,7 +59,7 @@ func TestRetryUntilCancel(t *testing.T) {
 }
 
 func TestRetryUntilCancelZeroBackoff(t *testing.T) {
-	ctx, cancel := context.WithCancel(pctx.TestContext(t))
+	ctx, cancel := pctx.WithCancel(pctx.TestContext(t))
 	first := true
 	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		if first {
@@ -157,7 +156,7 @@ func TestNotifyContinue(t *testing.T) {
 		t.Cleanup(zap.ReplaceGlobals(l))
 
 		var results []int
-		ctx, cancel := context.WithCancel(pctx.TestContext(t))
+		ctx, cancel := pctx.WithCancel(pctx.TestContext(t))
 		backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 			results = append(results, len(results))
 			if len(results) < 3 {
@@ -176,7 +175,7 @@ func TestNotifyContinue(t *testing.T) {
 
 func TestMustLoop(t *testing.T) {
 	var results []int
-	ctx, cancel := context.WithCancel(pctx.TestContext(t))
+	ctx, cancel := pctx.WithCancel(pctx.TestContext(t))
 	backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error { //nolint:errcheck
 		results = append(results, len(results)+1)
 		switch len(results) {

--- a/src/internal/collection/collection_test.go
+++ b/src/internal/collection/collection_test.go
@@ -60,7 +60,7 @@ func putItem(item *col.TestItem) func(rw col.ReadWriteCollection) error {
 
 // canceledContext is a helper function to provide a context that is already canceled
 func canceledContext() context.Context {
-	ctx, cancel := context.WithCancel(pctx.Child(pctx.TODO(), "canceled"))
+	ctx, cancel := pctx.WithCancel(pctx.Child(pctx.TODO(), "canceled"))
 	cancel()
 	return ctx
 }

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -161,7 +161,7 @@ func (c *etcdCollection) WithRenewer(ctx context.Context, cb func(context.Contex
 		for {
 			_, more := <-keepAliveChan
 			if !more {
-				if context.Cause(ctx) == nil {
+				if ctx.Err() == nil {
 					log.Error(ctx, "failed to renew etcd lease", zap.Stack("stacktrace"))
 					cancel()
 				}

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -151,7 +151,7 @@ func (c *etcdCollection) WithRenewer(ctx context.Context, cb func(context.Contex
 		return errors.EnsureStack(err)
 	}
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(pctx.Child(ctx, "WithRenewer"))
+	ctx, cancel = pctx.WithCancel(pctx.Child(ctx, "WithRenewer"))
 	defer cancel()
 	keepAliveChan, err := c.etcdClient.KeepAlive(ctx, resp.ID)
 	if err != nil {
@@ -161,7 +161,7 @@ func (c *etcdCollection) WithRenewer(ctx context.Context, cb func(context.Contex
 		for {
 			_, more := <-keepAliveChan
 			if !more {
-				if ctx.Err() == nil {
+				if context.Cause(ctx) == nil {
 					log.Error(ctx, "failed to renew etcd lease", zap.Stack("stacktrace"))
 					cancel()
 				}
@@ -593,7 +593,7 @@ func watchF(ctx context.Context, watcher watch.Watcher, f func(e *watch.Event) e
 				return err
 			}
 		case <-ctx.Done():
-			return errors.EnsureStack(ctx.Err())
+			return errors.EnsureStack(context.Cause(ctx))
 		}
 	}
 }

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/watch"
 	"github.com/pachyderm/pachyderm/v2/src/version"
 )
@@ -481,7 +482,7 @@ func (c *postgresReadOnlyCollection) List(val proto.Message, opts *Options, f fu
 // NOTE: Internally, List scans the collection using multiple queries,
 // making this method susceptible to inconsistent reads
 func (c *postgresReadWriteCollection) List(val proto.Message, opts *Options, f func(string) error) error {
-	ctx, cf := context.WithCancel(context.Background())
+	ctx, cf := pctx.WithCancel(context.Background())
 	defer cf()
 	return c.postgresCollection.list(ctx, nil, opts, c.tx, func(m *model) error {
 		if err := proto.Unmarshal(m.Proto, val); err != nil {

--- a/src/internal/collection/postgres_listener.go
+++ b/src/internal/collection/postgres_listener.go
@@ -122,7 +122,7 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 				// watcher (or the read collection that created it) has been canceled -
 				// unregister the watcher and stop forwarding notifications.
 				select {
-				case pw.c <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}:
+				case pw.c <- &watch.Event{Type: watch.EventError, Err: context.Cause(ctx)}:
 					pw.listener.Unregister(pw) //nolint:errcheck
 				case <-pw.done:
 				}
@@ -135,7 +135,7 @@ func (pw *postgresWatcher) forwardNotifications(ctx context.Context) {
 			// watcher (or the read collection that created it) has been canceled -
 			// unregister the watcher and stop forwarding notifications.
 			select {
-			case pw.c <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}:
+			case pw.c <- &watch.Event{Type: watch.EventError, Err: context.Cause(ctx)}:
 				pw.listener.Unregister(pw) //nolint:errcheck
 			case <-pw.done:
 			}
@@ -149,7 +149,7 @@ func (pw *postgresWatcher) sendInitial(ctx context.Context, event *watch.Event) 
 	case pw.c <- event:
 		return nil
 	case <-ctx.Done():
-		return errors.EnsureStack(ctx.Err())
+		return errors.EnsureStack(context.Cause(ctx))
 	case <-pw.done:
 		return errors.New("failed to send initial event, watcher has been closed")
 	}

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -11,6 +11,7 @@ import (
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil/random"
 	"github.com/pachyderm/pachyderm/v2/src/internal/watch"
@@ -166,7 +167,7 @@ func NewWatchShim(ctx context.Context, t *testing.T, doWatch func(context.Contex
 	watchChan := make(chan *watch.Event)
 
 	done := false
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		// There is no way to test ErrBreak behavior unless we know the set of
@@ -224,7 +225,7 @@ func watchTests(
 	watchAllTests := func(suite *testing.T, makeWatcher func(context.Context, *testing.T, ReadCallback) watch.Watcher) {
 		suite.Run("InterruptionAfterInitial", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithCancel(rctx)
+			ctx, cancel := pctx.WithCancel(rctx)
 			defer cancel()
 			reader, writer := newCollection(rctx, t)
 			row := makeProto(makeID(4))
@@ -243,7 +244,7 @@ func watchTests(
 
 		suite.Run("InterruptionDuringBackfill", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithCancel(rctx)
+			ctx, cancel := pctx.WithCancel(rctx)
 			defer cancel()
 			reader, writer := newCollection(rctx, t)
 			for i := 0; i < 10; i++ {
@@ -426,7 +427,7 @@ func watchTests(
 
 		suite.Run("InterruptionAfterInitial", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithCancel(rctx)
+			ctx, cancel := pctx.WithCancel(rctx)
 			defer cancel()
 			reader, writer := newCollection(rctx, t)
 			row := makeProto(makeID(4))
@@ -585,7 +586,7 @@ func watchTests(
 	watchByIndexTests := func(suite *testing.T, makeWatcher func(context.Context, *testing.T, ReadCallback, string) watch.Watcher) {
 		suite.Run("InterruptionAfterInitial", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithCancel(rctx)
+			ctx, cancel := pctx.WithCancel(rctx)
 			defer cancel()
 			reader, writer := newCollection(rctx, t)
 			row := makeProto(makeID(4), originalValue)

--- a/src/internal/consistenthashing/etcd_test.go
+++ b/src/internal/consistenthashing/etcd_test.go
@@ -46,7 +46,7 @@ type lockTestConfig struct {
 }
 
 func setupTest(t *testing.T) testRingConfig {
-	ctx, cancel := context.WithCancel(pctx.TestContext(t))
+	ctx, cancel := pctx.WithCancel(pctx.TestContext(t))
 	etcdEnv := testetcd.NewEnv(ctx, t)
 	return testRingConfig{
 		client: etcdEnv.EtcdClient,
@@ -115,7 +115,7 @@ func TestLockingWithDeleteWorker(t *testing.T) {
 		require.NoError(t, test.eg.Wait())
 	}()
 	nodeToDelete := strconv.Itoa(100)
-	deleteCtx, deleteCancel := context.WithCancel(test.ctx)
+	deleteCtx, deleteCancel := pctx.WithCancel(test.ctx)
 	defer deleteCancel()
 	for i := 0; i < test.workers; i++ {
 		nodeId := test.workerIds[i]
@@ -196,7 +196,7 @@ func setupLockTest(t *testing.T, numNodes, numLocks int) lockTestConfig {
 		ringConfig: setupTest(t),
 	}
 	test.eg, test.ctx = errgroup.WithContext(test.ringConfig.ctx)
-	test.ctx, test.cancel = context.WithCancel(test.ctx)
+	test.ctx, test.cancel = pctx.WithCancel(test.ctx)
 	test.workersReady = make(chan struct{}, numNodes)
 	test.beginLocking = make(chan struct{}, numNodes)
 	test.doneLocking = make(chan struct{}, numLocks)

--- a/src/internal/dbutil/tx.go
+++ b/src/internal/dbutil/tx.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
@@ -138,7 +139,7 @@ func WithTx(ctx context.Context, db *pachsql.DB, cb func(tx *pachsql.Tx) error, 
 
 	txStartedMetric.Inc()
 	err := backoff.RetryUntilCancel(ctx, func() error {
-		ctx, cf := context.WithCancel(ctx)
+		ctx, cf := pctx.WithCancel(ctx)
 		defer cf()
 		underlyingTxStartedMetric.Inc()
 		attempts++

--- a/src/internal/dlock/dlock.go
+++ b/src/internal/dlock/dlock.go
@@ -62,11 +62,11 @@ func (d *etcdImpl) Lock(ctx context.Context) (_ context.Context, retErr error) {
 	start := time.Now()
 	log.Debug(ctx, "acquired lock ok")
 
-	ctx, cancel := context.WithCancel(pctx.Child(ctx, "", pctx.WithFields(zap.Bool("locked", true))))
+	ctx, cancel := pctx.WithCancel(pctx.Child(ctx, "", pctx.WithFields(zap.Bool("locked", true))))
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Debug(ctx, "lock's context is done", zap.Error(ctx.Err()), zap.Duration("lockLifetime", time.Since(start)))
+			log.Debug(ctx, "lock's context is done", zap.Error(context.Cause(ctx)), zap.Duration("lockLifetime", time.Since(start)))
 		case <-session.Done():
 			log.Debug(ctx, "lock's session is done; cancelling associated context", zap.Duration("lockLifetime", time.Since(start)))
 			cancel()
@@ -94,11 +94,11 @@ func (d *etcdImpl) TryLock(ctx context.Context) (_ context.Context, retErr error
 	start := time.Now()
 	log.Debug(ctx, "acquired lock ok")
 
-	ctx, cancel := context.WithCancel(pctx.Child(ctx, "", pctx.WithFields(zap.Bool("locked", true))))
+	ctx, cancel := pctx.WithCancel(pctx.Child(ctx, "", pctx.WithFields(zap.Bool("locked", true))))
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Debug(ctx, "lock's context is done", zap.Error(ctx.Err()), zap.Duration("lockLifetime", time.Since(start)))
+			log.Debug(ctx, "lock's context is done", zap.Error(context.Cause(ctx)), zap.Duration("lockLifetime", time.Since(start)))
 		case <-session.Done():
 			log.Debug(ctx, "lock's session is done; cancelling associated context", zap.Duration("lockLifetime", time.Since(start)))
 			cancel()

--- a/src/internal/log/context_test.go
+++ b/src/internal/log/context_test.go
@@ -5,14 +5,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestCombineLogger(t *testing.T) {
 	lctx, h := testWithCaptureParallel(t)
-	cctx, c := pctx.WithCancel(context.Background())
+	cctx, c := context.WithCancel(context.Background())
 	c()
 	ctx := CombineLogger(cctx, lctx)
 	select {

--- a/src/internal/log/context_test.go
+++ b/src/internal/log/context_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestCombineLogger(t *testing.T) {
 	lctx, h := testWithCaptureParallel(t)
-	cctx, c := context.WithCancel(context.Background())
+	cctx, c := pctx.WithCancel(context.Background())
 	c()
 	ctx := CombineLogger(cctx, lctx)
 	select {

--- a/src/internal/log/log_test.go
+++ b/src/internal/log/log_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
 )
 
@@ -99,7 +100,7 @@ func TestWrappedContext(t *testing.T) {
 	rootCtx, h := testWithCaptureParallel(t, zap.Development())
 	timeCtx, tc := context.WithTimeout(rootCtx, time.Minute)
 	t.Cleanup(tc)
-	ctx, cc := context.WithCancel(timeCtx)
+	ctx, cc := pctx.WithCancel(timeCtx)
 	t.Cleanup(cc)
 	Debug(ctx, "this should not panic")
 

--- a/src/internal/log/log_test.go
+++ b/src/internal/log/log_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
 )
 
@@ -100,7 +99,7 @@ func TestWrappedContext(t *testing.T) {
 	rootCtx, h := testWithCaptureParallel(t, zap.Development())
 	timeCtx, tc := context.WithTimeout(rootCtx, time.Minute)
 	t.Cleanup(tc)
-	ctx, cc := pctx.WithCancel(timeCtx)
+	ctx, cc := context.WithCancel(timeCtx)
 	t.Cleanup(cc)
 	Debug(ctx, "this should not panic")
 

--- a/src/internal/log/loggers.go
+++ b/src/internal/log/loggers.go
@@ -270,7 +270,7 @@ func WatchDroppedLogs(ctx context.Context, d time.Duration) {
 		case <-t.C:
 			reportDroppedLogs(ctx)
 		case <-ctx.Done():
-			Info(ctx, "dropped log reporting ended", zap.Error(ctx.Err()))
+			Info(ctx, "dropped log reporting ended", zap.Error(context.Cause(ctx)))
 			t.Stop()
 			return
 		}

--- a/src/internal/meters/meters_test.go
+++ b/src/internal/meters/meters_test.go
@@ -1,7 +1,6 @@
 package meters
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +24,7 @@ func TestImmediate(t *testing.T) {
 
 func TestAggregatedGauge(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := context.WithCancel(ctx)
+	ctx, c := pctx.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedGauge(ctx, "test", 0, withDoneCh(doneCh)) // No log expected.
 	Set(ctx, "test", 42)                                         // No log expected.
@@ -68,7 +68,7 @@ func TestAggregatedGauge(t *testing.T) {
 
 func TestAggregatedCounter(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := context.WithCancel(ctx)
+	ctx, c := pctx.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedCounter(ctx, "test", 0, withDoneCh(doneCh))
 	for i := 0; i < 10000; i++ {
@@ -95,7 +95,7 @@ func TestAggregatedCounter(t *testing.T) {
 
 func TestAggregatedDelta(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := context.WithCancel(ctx)
+	ctx, c := pctx.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedDelta(ctx, "test", 500, withDoneCh(doneCh))
 	for i := 0; i < 1000; i++ {
@@ -125,7 +125,7 @@ func TestAggregatedDelta(t *testing.T) {
 
 func TestWithNewFields(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := context.WithCancel(ctx)
+	ctx, c := pctx.WithCancel(ctx)
 	ctx = log.ChildLogger(ctx, "a", log.WithFields(zap.Bool("a", true)))
 	t.Logf("ctx: %s", reflect.ValueOf(ctx))
 	ctxA := NewAggregatedCounter(ctx, "test", 0, Deferred())
@@ -195,7 +195,7 @@ func BenchmarkGauge(b *testing.B) {
 
 func BenchmarkAggregatedGauge(b *testing.B) {
 	ctx, w := log.NewBenchLogger(false)
-	ctx, c := context.WithCancel(ctx)
+	ctx, c := pctx.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedGauge(ctx, "bench", 0, withDoneCh(doneCh), WithFlushInterval(100*time.Millisecond))
 	writesDoneCh := make(chan struct{})

--- a/src/internal/meters/meters_test.go
+++ b/src/internal/meters/meters_test.go
@@ -1,6 +1,7 @@
 package meters
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +24,7 @@ func TestImmediate(t *testing.T) {
 
 func TestAggregatedGauge(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := pctx.WithCancel(ctx)
+	ctx, c := context.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedGauge(ctx, "test", 0, withDoneCh(doneCh)) // No log expected.
 	Set(ctx, "test", 42)                                         // No log expected.
@@ -68,7 +68,7 @@ func TestAggregatedGauge(t *testing.T) {
 
 func TestAggregatedCounter(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := pctx.WithCancel(ctx)
+	ctx, c := context.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedCounter(ctx, "test", 0, withDoneCh(doneCh))
 	for i := 0; i < 10000; i++ {
@@ -95,7 +95,7 @@ func TestAggregatedCounter(t *testing.T) {
 
 func TestAggregatedDelta(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := pctx.WithCancel(ctx)
+	ctx, c := context.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedDelta(ctx, "test", 500, withDoneCh(doneCh))
 	for i := 0; i < 1000; i++ {
@@ -125,7 +125,7 @@ func TestAggregatedDelta(t *testing.T) {
 
 func TestWithNewFields(t *testing.T) {
 	ctx, h := log.TestWithCapture(t)
-	ctx, c := pctx.WithCancel(ctx)
+	ctx, c := context.WithCancel(ctx)
 	ctx = log.ChildLogger(ctx, "a", log.WithFields(zap.Bool("a", true)))
 	t.Logf("ctx: %s", reflect.ValueOf(ctx))
 	ctxA := NewAggregatedCounter(ctx, "test", 0, Deferred())
@@ -195,7 +195,7 @@ func BenchmarkGauge(b *testing.B) {
 
 func BenchmarkAggregatedGauge(b *testing.B) {
 	ctx, w := log.NewBenchLogger(false)
-	ctx, c := pctx.WithCancel(ctx)
+	ctx, c := context.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	ctx = NewAggregatedGauge(ctx, "bench", 0, withDoneCh(doneCh), WithFlushInterval(100*time.Millisecond))
 	writesDoneCh := make(chan struct{})

--- a/src/internal/metrics/metrics.go
+++ b/src/internal/metrics/metrics.go
@@ -250,7 +250,7 @@ func inputMetrics(input *pps.Input, metrics *Metrics) {
 func (r *Reporter) internalMetrics(metrics *Metrics) {
 	// We should not return due to an error
 	// Activation code
-	ctx, cf := context.WithCancel(context.Background())
+	ctx, cf := pctx.WithCancel(context.Background())
 	defer cf()
 
 	enterpriseState, err := r.env.EnterpriseServer().GetState(ctx, &enterprise.GetStateRequest{})

--- a/src/internal/migrations/migrations.go
+++ b/src/internal/migrations/migrations.go
@@ -185,7 +185,7 @@ func BlockUntil(ctx context.Context, db *pachsql.DB, state State) error {
 		}
 		select {
 		case <-ctx.Done():
-			return errors.EnsureStack(ctx.Err())
+			return errors.EnsureStack(context.Cause(ctx))
 		case <-ticker.C:
 		}
 	}

--- a/src/internal/miscutil/work_deduper.go
+++ b/src/internal/miscutil/work_deduper.go
@@ -46,6 +46,6 @@ func (f future) await(ctx context.Context) error {
 	case <-f.done:
 		return f.err
 	case <-ctx.Done():
-		return errors.EnsureStack(ctx.Err())
+		return errors.EnsureStack(context.Cause(ctx))
 	}
 }

--- a/src/internal/obj/amazon_client.go
+++ b/src/internal/obj/amazon_client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"go.uber.org/zap"
@@ -159,7 +160,7 @@ func newAmazonClient(ctx context.Context, region, bucket string, creds *AmazonCr
 
 func (c *amazonClient) Put(ctx context.Context, name string, r io.Reader) (retErr error) {
 	defer func() { retErr = c.transformError(retErr, name) }()
-	ctx, cf := context.WithCancel(ctx)
+	ctx, cf := pctx.WithCancel(ctx)
 	defer cf()
 	_, err := c.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		ACL:             aws.String(c.advancedConfig.UploadACL),

--- a/src/internal/obj/google_client.go
+++ b/src/internal/obj/google_client.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 	"google.golang.org/api/googleapi"
@@ -59,7 +60,7 @@ func (c *googleClient) Exists(ctx context.Context, name string) (bool, error) {
 
 func (c *googleClient) Put(ctx context.Context, name string, r io.Reader) (retErr error) {
 	defer func() { retErr = c.transformError(retErr, name) }()
-	ctx, cf := context.WithCancel(ctx)
+	ctx, cf := pctx.WithCancel(ctx)
 	defer cf() // this aborts the write if the writer is not already closed
 	wc := c.bucket.Object(name).NewWriter(ctx)
 	if _, err := io.Copy(wc, r); err != nil {

--- a/src/internal/obj/testsuite.go
+++ b/src/internal/obj/testsuite.go
@@ -80,7 +80,7 @@ func TestEmptyWrite(t *testing.T, client Client) {
 //	Local client - interruptible file operations are not a thing in the stdlib
 func TestInterruption(t *testing.T, client Client) {
 	// Make a canceled context
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := pctx.WithCancel(context.Background())
 	cancel()
 
 	object := randutil.UniqueString("test-interruption-")

--- a/src/internal/pachd/prometheus.go
+++ b/src/internal/pachd/prometheus.go
@@ -36,7 +36,7 @@ func (ps prometheusServer) listenAndServe(ctx context.Context, shutdownTimeout t
 	}()
 	select {
 	case <-ctx.Done():
-		log.Info(ctx, "terminating Prometheus server due to cancelled context", zap.Error(ctx.Err()))
+		log.Info(ctx, "terminating Prometheus server due to cancelled context", zap.Error(context.Cause(ctx)))
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		return errors.EnsureStack(srv.Shutdown(ctx))

--- a/src/internal/pachd/s3.go
+++ b/src/internal/pachd/s3.go
@@ -46,7 +46,7 @@ func (ss s3Server) listenAndServe(ctx context.Context, shutdownTimeout time.Dura
 	}()
 	select {
 	case <-ctx.Done():
-		log.Info(ctx, "terminating S3 server due to cancelled context", zap.Error(ctx.Err()))
+		log.Info(ctx, "terminating S3 server due to cancelled context", zap.Error(context.Cause(ctx)))
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		return errors.EnsureStack(srv.Shutdown(ctx))

--- a/src/internal/pctx/cancel.go
+++ b/src/internal/pctx/cancel.go
@@ -1,0 +1,34 @@
+package pctx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// WithCancel is a version of context.WithCancel that returns a cancellation function that sets the
+// cancellation cause to the call frame that called the CancelFunc.
+func WithCancel(root context.Context) (context.Context, context.CancelFunc) {
+	_, createdFile, createdLine, createdOK := runtime.Caller(1)
+	ctx, c := context.WithCancelCause(root)
+	return ctx, func() {
+		_, cancelledFile, cancelledLine, cancelledOK := runtime.Caller(1)
+		b := new(strings.Builder)
+		if createdOK {
+			fmt.Fprintf(b, "context created at %v:%v", createdFile, createdLine)
+		}
+		if createdOK && cancelledOK {
+			b.WriteRune(';')
+		}
+		if cancelledOK {
+			fmt.Fprintf(b, "context cancelled at %v:%v", cancelledFile, cancelledLine)
+		}
+		err := context.Canceled
+		if createdOK || cancelledOK {
+			err = errors.New(b.String())
+		}
+		c(err)
+	}
+}

--- a/src/internal/pctx/cancel.go
+++ b/src/internal/pctx/cancel.go
@@ -20,14 +20,14 @@ func WithCancel(root context.Context) (context.Context, context.CancelFunc) {
 			fmt.Fprintf(b, "context created at %v:%v", createdFile, createdLine)
 		}
 		if createdOK && cancelledOK {
-			b.WriteRune(';')
+			b.WriteString("; ")
 		}
 		if cancelledOK {
 			fmt.Fprintf(b, "context cancelled at %v:%v", cancelledFile, cancelledLine)
 		}
 		err := context.Canceled
 		if createdOK || cancelledOK {
-			err = errors.New(b.String())
+			err = errors.Join(context.Canceled, errors.New(b.String()))
 		}
 		c(err)
 	}

--- a/src/internal/pctx/examples_test.go
+++ b/src/internal/pctx/examples_test.go
@@ -1,11 +1,11 @@
 package pctx
 
 import (
-	"context"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 )
 
 func ExampleChild() {
@@ -16,7 +16,7 @@ func ExampleChild() {
 	meters.Set(ctx, "gauge", 42)
 	meters.Sample(ctx, "sampler", "hi")
 
-	ctx, c := context.WithCancel(ctx)
+	ctx, c := pctx.WithCancel(ctx)
 	ctx = Child(ctx, "aggregated", WithCounter("counter", 0, meters.WithFlushInterval(time.Second)))
 	ctx = Child(ctx, "", WithGauge("gauge", 0, meters.WithFlushInterval(time.Second)))
 	for i := 0; i < 1<<24; i++ {

--- a/src/internal/pctx/examples_test.go
+++ b/src/internal/pctx/examples_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 )
 
 func ExampleChild() {
@@ -16,7 +15,7 @@ func ExampleChild() {
 	meters.Set(ctx, "gauge", 42)
 	meters.Sample(ctx, "sampler", "hi")
 
-	ctx, c := pctx.WithCancel(ctx)
+	ctx, c := WithCancel(ctx)
 	ctx = Child(ctx, "aggregated", WithCounter("counter", 0, meters.WithFlushInterval(time.Second)))
 	ctx = Child(ctx, "", WithGauge("gauge", 0, meters.WithFlushInterval(time.Second)))
 	for i := 0; i < 1<<24; i++ {

--- a/src/internal/pfsload/modification.go
+++ b/src/internal/pfsload/modification.go
@@ -31,7 +31,7 @@ func Modification(env *Env, commit *pfs.Commit, spec *ModificationSpec) error {
 			select {
 			case inputChan <- input:
 			case <-ctx.Done():
-				return errors.EnsureStack(ctx.Err())
+				return errors.EnsureStack(context.Cause(ctx))
 			}
 		}
 		return nil

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -157,7 +157,7 @@ func goCtx(eg *errgroup.Group, ctx context.Context, f func(context.Context) erro
 // until the client is ready.
 func InitPachOnlyEnv(rctx context.Context, config *Configuration) *NonblockingServiceEnv {
 	sctx, end := log.SpanContext(rctx, "serviceenv")
-	ctx, cancel := context.WithCancel(sctx)
+	ctx, cancel := pctx.WithCancel(sctx)
 	env := &NonblockingServiceEnv{config: config, ctx: ctx, cancel: func() { cancel(); end() }}
 	env.pachAddress = net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", env.config.PeerPort))
 	goCtx(&env.pachEg, ctx, env.initPachClient)

--- a/src/internal/storage/chunk/gc.go
+++ b/src/internal/storage/chunk/gc.go
@@ -36,7 +36,7 @@ func (gc *GarbageCollector) RunForever(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return errors.EnsureStack(ctx.Err())
+			return errors.EnsureStack(context.Cause(ctx))
 		case <-ticker.C:
 		}
 	}

--- a/src/internal/storage/chunk/reader.go
+++ b/src/internal/storage/chunk/reader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachhash"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/taskchain"
 
@@ -58,7 +59,7 @@ func (r *Reader) Get(w io.Writer) (retErr error) {
 		_, err := io.Copy(w, newDataReader(r.ctx, r.client, r.memCache, r.deduper, r.dataRefs[0], r.offsetBytes))
 		return errors.EnsureStack(err)
 	}
-	ctx, cancel := context.WithCancel(r.ctx)
+	ctx, cancel := pctx.WithCancel(r.ctx)
 	defer cancel()
 	taskChain := taskchain.New(ctx, semaphore.NewWeighted(int64(r.prefetchLimit)))
 	defer func() {

--- a/src/internal/storage/chunk/uploader.go
+++ b/src/internal/storage/chunk/uploader.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/taskchain"
 
 	"golang.org/x/sync/semaphore"
@@ -140,7 +141,7 @@ func isStableDataRef(dataRef *DataRef) bool {
 // The returned list of data references is the slice that begins at the first
 // data reference found that begins at a chunk boundary.
 func (u *Uploader) align(ctx context.Context, dataRefs []*DataRef, cb func([]byte) error) ([]*DataRef, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 	defer cancel()
 	r := u.storage.NewReader(ctx, dataRefs, WithPrefetchLimit(3))
 	if err := miscutil.WithPipe(func(w2 io.Writer) error {

--- a/src/internal/storage/fileset/compaction_test.go
+++ b/src/internal/storage/fileset/compaction_test.go
@@ -137,13 +137,13 @@ func TestCompactLevelBasedRenewal(t *testing.T) {
 	s := newTestStorage(ctx, t)
 	ttl := 100 * time.Millisecond
 	gc := s.NewGC(ttl)
-	cancelCtx, cancel := context.WithCancel(ctx)
+	cancelCtx, cancel := pctx.WithCancel(ctx)
 	defer cancel()
 	var eg *errgroup.Group
 	eg, ctx = errgroup.WithContext(cancelCtx)
 	eg.Go(func() error {
 		err := gc.RunForever(ctx)
-		if errors.Is(cancelCtx.Err(), context.Canceled) {
+		if errors.Is(context.Cause(cancelCtx), context.Canceled) {
 			err = nil
 		}
 		return err

--- a/src/internal/storage/fileset/index/writer.go
+++ b/src/internal/storage/fileset/index/writer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
 )
 
@@ -38,7 +39,7 @@ type Writer struct {
 
 // NewWriter create a new Writer.
 func NewWriter(ctx context.Context, chunks *chunk.Storage, tmpID string) *Writer {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 	return &Writer{
 		ctx:    ctx,
 		cancel: cancel,

--- a/src/internal/storage/track/gc.go
+++ b/src/internal/storage/track/gc.go
@@ -55,7 +55,7 @@ func (gc *GarbageCollector) RunForever(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return errors.EnsureStack(ctx.Err())
+			return errors.EnsureStack(context.Cause(ctx))
 		case <-ticker.C:
 		}
 	}

--- a/src/internal/task/etcd_queue.go
+++ b/src/internal/task/etcd_queue.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 
 	"github.com/cevaris/ordered_map"
 )
@@ -77,7 +78,7 @@ func (tq *taskQueue) group(ctx context.Context, groupID string, cb func(context.
 	if _, ok := tq.groups.Get(groupID); ok {
 		return errors.Errorf("errored creating group %v, which already exists", groupID)
 	}
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 	taskFuncChan := make(chan taskFunc, bufSize)
 	ge := &groupEntry{
 		cancel:       cancel,

--- a/src/internal/task/util.go
+++ b/src/internal/task/util.go
@@ -37,7 +37,7 @@ func DoOrdered(ctx context.Context, doer Doer, inputs chan *types.Any, paralleli
 				return errors.EnsureStack(err)
 			}
 		case <-ctx.Done():
-			return errors.EnsureStack(ctx.Err())
+			return errors.EnsureStack(context.Cause(ctx))
 		}
 	}
 }
@@ -71,7 +71,7 @@ func DoBatch(ctx context.Context, doer Doer, inputs []*types.Any, cb CollectFunc
 			select {
 			case inputChan <- input:
 			case <-ctx.Done():
-				return errors.EnsureStack(ctx.Err())
+				return errors.EnsureStack(context.Cause(ctx))
 			}
 		}
 		close(inputChan)

--- a/src/internal/testetcd/env.go
+++ b/src/internal/testetcd/env.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
@@ -35,7 +36,7 @@ type Env struct {
 func NewEnv(rctx context.Context, t testing.TB) *Env {
 	// Use an error group with a cancelable context to supervise every component
 	// and cancel everything if one fails
-	ctx, cancel := context.WithCancel(rctx)
+	ctx, cancel := pctx.WithCancel(rctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	t.Cleanup(func() {
 		require.NoError(t, eg.Wait())

--- a/src/internal/testpachd/mock_env.go
+++ b/src/internal/testpachd/mock_env.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testetcd"
 )
@@ -28,7 +29,7 @@ func NewMockEnv(rctx context.Context, t testing.TB, options ...InterceptorOption
 
 	// Use an error group with a cancelable context to supervise every component
 	// and cancel everything if one fails
-	ctx, cancel := context.WithCancel(rctx)
+	ctx, cancel := pctx.WithCancel(rctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	t.Cleanup(func() {
 		require.NoError(t, eg.Wait())

--- a/src/internal/testpachd/mock_pachd.go
+++ b/src/internal/testpachd/mock_pachd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	authmw "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/license"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
@@ -1969,7 +1970,7 @@ func NewMockPachd(ctx context.Context, port uint16, options ...InterceptorOption
 		errchan: make(chan error),
 	}
 
-	ctx, mock.cancel = context.WithCancel(ctx)
+	ctx, mock.cancel = pctx.WithCancel(ctx)
 
 	mock.PFS.api.mock = &mock.PFS
 	mock.PPS.api.mock = &mock.PPS

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -308,7 +308,7 @@ func (env *TransactionEnv) waitReady(ctx context.Context) error {
 	case <-env.initDone:
 		return nil
 	case <-ctx.Done():
-		return errors.EnsureStack(ctx.Err())
+		return errors.EnsureStack(context.Cause(ctx))
 	}
 }
 

--- a/src/internal/watch/watch.go
+++ b/src/internal/watch/watch.go
@@ -130,7 +130,7 @@ func NewEtcdWatcher(ctx context.Context, client *etcd.Client, trimPrefix, prefix
 			case <-done:
 				return nil
 			case <-ctx.Done():
-				return errors.EnsureStack(ctx.Err())
+				return errors.EnsureStack(context.Cause(ctx))
 			}
 		}
 		for {

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2786,7 +2786,7 @@ func TestListRepoWithProjectAccessControl(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(tc.user.Ctx())
+			ctx, cancel := pctx.WithCancel(tc.user.Ctx())
 			defer cancel()
 			lrClient, err := tc.user.PfsAPIClient.ListRepo(ctx, &pfs.ListRepoRequest{Type: pfs.UserRepoType, Projects: tc.filterBy})
 			require.NoError(t, err)
@@ -2853,7 +2853,7 @@ func TestListPipelinesWithProjectAccessControl(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(tc.c.Ctx())
+			ctx, cancel := pctx.WithCancel(tc.c.Ctx())
 			defer cancel()
 			lpClient, err := tc.c.PpsAPIClient.ListPipeline(ctx, &pps.ListPipelineRequest{Projects: tc.projects})
 			require.NoError(t, err)

--- a/src/server/identity/server/dex_web.go
+++ b/src/server/identity/server/dex_web.go
@@ -185,7 +185,7 @@ func (w *dexWeb) startWebServer(config *identity.IdentityServerConfig, connector
 		Logger:             log.NewLogrus(ctx),
 	}
 
-	ctx, w.serverCancel = context.WithCancel(ctx)
+	ctx, w.serverCancel = pctx.WithCancel(ctx)
 	w.server, err = dex_server.NewServer(ctx, serverConfig)
 	if err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/server/pachw/server/pachw.go
+++ b/src/server/pachw/server/pachw.go
@@ -78,7 +78,7 @@ func (p *pachW) run(ctx context.Context) {
 			select {
 			case <-ticker.C:
 			case <-ctx.Done():
-				return errors.EnsureStack(ctx.Err())
+				return errors.EnsureStack(context.Cause(ctx))
 			}
 		}
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3708,7 +3708,7 @@ func TestStopStandbyPipeline(t *testing.T) {
 		require.NoError(t, c.PutFile(dataCommit, "/"+file, strings.NewReader(file), client.WithAppendPutFile()))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	for ctx.Err() == nil {
+	for context.Cause(ctx) == nil {
 		pi, err := c.InspectProjectPipeline(pfs.DefaultProjectName, pipeline, false)
 		require.NoError(t, err)
 		require.NotEqual(t, pps.PipelineState_PIPELINE_RUNNING, pi.State)
@@ -10925,7 +10925,7 @@ func TestDatumSetCache(t *testing.T) {
 			DatumSetSpec: &pps.DatumSetSpec{Number: 1},
 		})
 	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := pctx.WithCancel(context.Background())
 	defer cancel()
 	go func() {
 		ticker := time.NewTimer(50 * time.Second)

--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3708,7 +3708,7 @@ func TestStopStandbyPipeline(t *testing.T) {
 		require.NoError(t, c.PutFile(dataCommit, "/"+file, strings.NewReader(file), client.WithAppendPutFile()))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	for context.Cause(ctx) == nil {
+	for ctx.Err() == nil {
 		pi, err := c.InspectProjectPipeline(pfs.DefaultProjectName, pipeline, false)
 		require.NoError(t, err)
 		require.NotEqual(t, pps.PipelineState_PIPELINE_RUNNING, pi.State)

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -87,7 +87,7 @@ func (d *driver) master(ctx context.Context) {
 }
 
 func (d *driver) finishCommits(ctx context.Context) (retErr error) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 	defer cancel()
 	repos := make(map[string]context.CancelFunc)
 	defer func() {
@@ -116,11 +116,11 @@ func (d *driver) finishCommits(ctx context.Context) (retErr error) {
 				if _, ok := repos[key]; ok {
 					return nil
 				}
-				ctx, cancel := context.WithCancel(ctx)
+				ctx, cancel := pctx.WithCancel(ctx)
 				repos[key] = cancel
 				go func() {
 					backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
-						ctx, cancel := context.WithCancel(ctx)
+						ctx, cancel := pctx.WithCancel(ctx)
 						defer cancel()
 						lockCtx, err := ring.Lock(ctx, lockPrefix)
 						if err != nil {

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -77,7 +78,7 @@ func NewSource(commitInfo *pfs.CommitInfo, fs fileset.FileSet, opts ...SourceOpt
 // Iterate calls cb for each File in the underlying fileset.FileSet, with a FileInfo computed
 // during iteration, and the File.
 func (s *source) Iterate(ctx context.Context, cb func(*pfs.FileInfo, fileset.File) error) error {
-	ctx, cf := context.WithCancel(ctx)
+	ctx, cf := pctx.WithCancel(ctx)
 	defer cf()
 	iter := fileset.NewIterator(ctx, s.fileSet.Iterate, s.dirIndexOpts...)
 	cache := make(map[string]*pfs.FileInfo)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5506,7 +5506,7 @@ func TestPFS(suite *testing.T) {
 		require.NoError(t, env.PachClient.CreateProjectBranch(pfs.DefaultProjectName, "C", "master", "", "", []*pfs.Branch{client.NewProjectBranch(pfs.DefaultProjectName, "B", "master")}))
 		require.NoError(t, finishCommit(env.PachClient, "C", "master", ""))
 
-		ctx, cancel := context.WithCancel(env.PachClient.Ctx())
+		ctx, cancel := pctx.WithCancel(env.PachClient.Ctx())
 		defer cancel()
 		pachClient := env.PachClient.WithCtx(ctx)
 
@@ -7197,7 +7197,7 @@ func TestPFS(suite *testing.T) {
 				require.False(t, strings.Contains(err.Error(), "transport is closing"), err.Error())
 			}
 		}
-		ctx, cf := context.WithCancel(c.Ctx())
+		ctx, cf := pctx.WithCancel(c.Ctx())
 		defer cf()
 		_, err := c.PfsAPIClient.CreateRepo(ctx, &pfs.CreateRepoRequest{})
 		requireNoPanic(err)

--- a/src/server/pfs/server/url.go
+++ b/src/server/pfs/server/url.go
@@ -113,7 +113,7 @@ func putFileURLRecursive(ctx context.Context, taskService task.Service, uw *file
 			select {
 			case inputChan <- input:
 			case <-ctx.Done():
-				return errors.EnsureStack(ctx.Err())
+				return errors.EnsureStack(context.Cause(ctx))
 			}
 			return nil
 		}); err != nil {
@@ -234,7 +234,7 @@ func (d *driver) getFileURL(ctx context.Context, taskService task.Service, URL s
 				select {
 				case inputChan <- input:
 				case <-ctx.Done():
-					return errors.EnsureStack(ctx.Err())
+					return errors.EnsureStack(context.Cause(ctx))
 				}
 				return nil
 			}

--- a/src/server/pps/cmds/cmds.go
+++ b/src/server/pps/cmds/cmds.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachctl"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachtmpl"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pager"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tabwriter"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing/extended"
@@ -294,7 +295,7 @@ $ {{alias}} -p foo -i bar@YYY`,
 						JqFilter:    filter,
 					}
 
-					ctx, cf := context.WithCancel(client.Ctx())
+					ctx, cf := pctx.WithCancel(client.Ctx())
 					defer cf()
 					ljClient, err := client.PpsAPIClient.ListJob(ctx, req)
 					if err != nil {

--- a/src/server/pps/server/master.go
+++ b/src/server/pps/server/master.go
@@ -140,7 +140,7 @@ func newMaster(ctx context.Context, env Env, etcdPrefix string, kd InfraDriver, 
 func (a *apiServer) master(ctx context.Context) {
 	masterLock := dlock.NewDLock(a.env.EtcdClient, path.Join(a.etcdPrefix, masterLockPath))
 	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
-		ctx, cancel := context.WithCancel(pctx.Child(ctx, "master", pctx.WithServerID()))
+		ctx, cancel := pctx.WithCancel(pctx.Child(ctx, "master", pctx.WithServerID()))
 		// set internal auth for basic operations
 		ctx = middleware_auth.AsInternalUser(ctx, "pps-master")
 		defer cancel()
@@ -154,7 +154,7 @@ func (a *apiServer) master(ctx context.Context) {
 		sd := newPipelineStateDriver(a.env.DB, a.pipelines, a.txnEnv, a.env.PFSServer)
 		m := newMaster(ctx, a.env, a.etcdPrefix, kd, sd)
 		m.run()
-		return errors.Wrapf(ctx.Err(), "ppsMaster.Run() exited unexpectedly")
+		return errors.Wrapf(context.Cause(ctx), "ppsMaster.Run() exited unexpectedly")
 	}, backoff.NewInfiniteBackOff(), func(err error, d time.Duration) error {
 		log.Error(ctx, "PPS master: error running the master process; retrying",
 			zap.Error(err), zap.Duration("retryIn", d))
@@ -211,7 +211,7 @@ eventLoop:
 					pc.Bump(e.timestamp) // raises flag in pipelineController to run again whenever it finishes
 				} else {
 					// pc's ctx is cancelled in pipelineController.tryFinish(), to avoid leaking resources
-					pcCtx, pcCancel := context.WithCancel(m.masterCtx)
+					pcCtx, pcCancel := pctx.WithCancel(m.masterCtx)
 					pc = m.newPipelineController(pcCtx, pcCancel, e.pipeline)
 					m.pcMgr.pcs[key] = pc
 					go pc.Start(e.timestamp)

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -297,7 +297,7 @@ func (pc *pipelineController) monitorCrashingPipeline(ctx context.Context, pipel
 		return nil // loop again to check for new workers
 	}), backoff.NewConstantBackOff(pc.crashingBackoff),
 		backoff.NotifyContinue(fmt.Sprintf("monitorCrashingPipeline for %s", pipelineInfo.Pipeline)),
-	); err != nil && context.Cause(ctx) == nil {
+	); err != nil && ctx.Err() == nil {
 		// retryUntilCancel should exit iff 'ctx' is cancelled, so this should be
 		// unreachable (restart master if not)
 		log.Error(ctx, "monitorCrashingPipeline is exiting prematurely which should not happen; restarting container...", zap.Error(err))

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -69,7 +69,7 @@ func (pc *pipelineController) startCrashingMonitor(ctx context.Context, pipeline
 // APIServer's fields, just wrapps the passed function in a goroutine, and
 // returns a cancel() fn to cancel it and block until it returns.
 func startMonitorThread(ctx context.Context, f func(ctx context.Context)) func() {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
 		f(ctx)
@@ -233,7 +233,7 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 							return errors.EnsureStack(err)
 						}
 					case <-ctx.Done():
-						return errors.EnsureStack(ctx.Err())
+						return errors.EnsureStack(context.Cause(ctx))
 					}
 				}
 			}, backoff.NewInfiniteBackOff(),
@@ -274,7 +274,7 @@ func (pc *pipelineController) blockStandby(pachClient *client.APIClient, commit 
 }
 
 func (pc *pipelineController) monitorCrashingPipeline(ctx context.Context, pipelineInfo *pps.PipelineInfo) {
-	ctx, cancelInner := context.WithCancel(ctx)
+	ctx, cancelInner := pctx.WithCancel(ctx)
 	if err := backoff.RetryUntilCancel(ctx, backoff.MustLoop(func() error {
 		currRC, _, err := pc.getRC(ctx, pipelineInfo)
 		if err != nil {
@@ -297,7 +297,7 @@ func (pc *pipelineController) monitorCrashingPipeline(ctx context.Context, pipel
 		return nil // loop again to check for new workers
 	}), backoff.NewConstantBackOff(pc.crashingBackoff),
 		backoff.NotifyContinue(fmt.Sprintf("monitorCrashingPipeline for %s", pipelineInfo.Pipeline)),
-	); err != nil && ctx.Err() == nil {
+	); err != nil && context.Cause(ctx) == nil {
 		// retryUntilCancel should exit iff 'ctx' is cancelled, so this should be
 		// unreachable (restart master if not)
 		log.Error(ctx, "monitorCrashingPipeline is exiting prematurely which should not happen; restarting container...", zap.Error(err))
@@ -350,7 +350,7 @@ func makeCronCommits(ctx context.Context, env Env, in *pps.Input) error {
 		select {
 		case <-time.After(time.Until(next)):
 		case <-ctx.Done():
-			return errors.EnsureStack(ctx.Err())
+			return errors.EnsureStack(context.Cause(ctx))
 		}
 		if err := cronTick(pachClient, next, in.Cron); err != nil {
 			return errors.Wrap(err, "cronTick")

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -45,7 +45,7 @@ func ppsMasterHandles(t *testing.T) (*mockStateDriver, *mockInfraDriver, *testpa
 		PFSServer:   nil,
 		TxnEnv:      nil,
 	}
-	ctx, cf := context.WithCancel(context.Background())
+	ctx, cf := pctx.WithCancel(context.Background())
 	t.Cleanup(func() { cf() })
 	master := newMaster(ctx, env, env.EtcdPrefix, iDriver, sDriver)
 	master.scaleUpInterval = 2 * time.Second

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -232,7 +232,7 @@ func (d *mockStateDriver) Watch(ctx context.Context) (<-chan *watch.Event, func(
 		defer close(d.eChan)
 		select {
 		case <-ctx.Done():
-			d.eChan <- &watch.Event{Type: watch.EventError, Err: ctx.Err()}
+			d.eChan <- &watch.Event{Type: watch.EventError, Err: context.Cause(ctx)}
 			return
 		case <-d.closeEChan:
 			return

--- a/src/server/pps/server/poller.go
+++ b/src/server/pps/server/poller.go
@@ -170,7 +170,7 @@ func (m *ppsMaster) pollPipelines(ctx context.Context) {
 		return nil
 	}), backoff.NewConstantBackOff(pollBackoffTime),
 		backoff.NotifyContinue("pollPipelines"),
-	); err != nil && context.Cause(ctx) == nil {
+	); err != nil && ctx.Err() == nil {
 		log.Error(ctx, "pollPipelines is exiting prematurely which should not happen; restarting container...", zap.Error(err))
 		os.Exit(10)
 	}
@@ -254,7 +254,7 @@ func (m *ppsMaster) pollPipelinePods(ctx context.Context) {
 			}
 		}
 	}), backoff.NewInfiniteBackOff(), backoff.NotifyContinue("pollPipelinePods"),
-	); err != nil && context.Cause(ctx) == nil {
+	); err != nil && ctx.Err() == nil {
 		log.Error(ctx, "pollPipelinePods is exiting prematurely which should not happen; restarting container...", zap.Error(err))
 		os.Exit(11)
 	}
@@ -309,7 +309,7 @@ func (m *ppsMaster) watchPipelines(ctx context.Context) {
 		}
 		return nil // reset until ctx is cancelled (RetryUntilCancel)
 	}), &backoff.ZeroBackOff{}, backoff.NotifyContinue("watchPipelines"),
-	); err != nil && context.Cause(ctx) == nil {
+	); err != nil && ctx.Err() == nil {
 		log.Error(ctx, "watchPipelines is exiting prematurely which should not happen; restarting container...", zap.Error(err))
 		os.Exit(11)
 	}

--- a/src/server/pps/server/poller.go
+++ b/src/server/pps/server/poller.go
@@ -170,7 +170,7 @@ func (m *ppsMaster) pollPipelines(ctx context.Context) {
 		return nil
 	}), backoff.NewConstantBackOff(pollBackoffTime),
 		backoff.NotifyContinue("pollPipelines"),
-	); err != nil && ctx.Err() == nil {
+	); err != nil && context.Cause(ctx) == nil {
 		log.Error(ctx, "pollPipelines is exiting prematurely which should not happen; restarting container...", zap.Error(err))
 		os.Exit(10)
 	}
@@ -254,7 +254,7 @@ func (m *ppsMaster) pollPipelinePods(ctx context.Context) {
 			}
 		}
 	}), backoff.NewInfiniteBackOff(), backoff.NotifyContinue("pollPipelinePods"),
-	); err != nil && ctx.Err() == nil {
+	); err != nil && context.Cause(ctx) == nil {
 		log.Error(ctx, "pollPipelinePods is exiting prematurely which should not happen; restarting container...", zap.Error(err))
 		os.Exit(11)
 	}
@@ -309,7 +309,7 @@ func (m *ppsMaster) watchPipelines(ctx context.Context) {
 		}
 		return nil // reset until ctx is cancelled (RetryUntilCancel)
 	}), &backoff.ZeroBackOff{}, backoff.NotifyContinue("watchPipelines"),
-	); err != nil && ctx.Err() == nil {
+	); err != nil && context.Cause(ctx) == nil {
 		log.Error(ctx, "watchPipelines is exiting prematurely which should not happen; restarting container...", zap.Error(err))
 		os.Exit(11)
 	}

--- a/src/server/worker/datum/iterator.go
+++ b/src/server/worker/datum/iterator.go
@@ -2,7 +2,6 @@ package datum
 
 import (
 	"archive/tar"
-	"context"
 	"encoding/json"
 	"io"
 	"path"
@@ -13,6 +12,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -104,7 +104,7 @@ func iterateMeta(pachClient *client.APIClient, commit *pfs.Commit, pathRange *pf
 		File:      commit.NewFile(path.Join("/", common.MetaFilePath("*"))),
 		PathRange: pathRange,
 	}
-	ctx, cancel := context.WithCancel(pachClient.Ctx())
+	ctx, cancel := pctx.WithCancel(pachClient.Ctx())
 	defer cancel()
 	client, err := pachClient.PfsAPIClient.GetFileTAR(ctx, req)
 	if err != nil {
@@ -162,7 +162,7 @@ func (mi *fileSetMultiIterator) Iterate(cb func(*Meta) error) error {
 		File:      mi.commit.NewFile("/*"),
 		PathRange: mi.pathRange,
 	}
-	ctx, cancel := context.WithCancel(mi.pachClient.Ctx())
+	ctx, cancel := pctx.WithCancel(mi.pachClient.Ctx())
 	defer cancel()
 	client, err := mi.pachClient.PfsAPIClient.GetFileTAR(ctx, req)
 	if err != nil {

--- a/src/server/worker/driver/driver_unix.go
+++ b/src/server/worker/driver/driver_unix.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/common"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
 )
@@ -44,7 +45,7 @@ func makeSysProcAttr(uid *uint32, gid *uint32) *syscall.SysProcAttr {
 // but the job will succeed.  If user code wants to fail when its children hang, it will have to
 // implement that logic itself (by calling waitpid on the children; "wait" in bash).
 func makeProcessGroupKiller(rctx context.Context, l logs.TaggedLogger, pgid int) func() {
-	ctx, c := context.WithCancel(rctx)
+	ctx, c := pctx.WithCancel(rctx)
 	go func() {
 		<-ctx.Done()
 		logRunningProcesses(l, pgid)

--- a/src/server/worker/pipeline/service/service.go
+++ b/src/server/worker/pipeline/service/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfssync"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/renew"
@@ -101,7 +102,7 @@ func forEachJob(pachClient *client.APIClient, pipelineInfo *pps.PipelineInfo, lo
 		}
 		logger.Logf("starting new service, job: %s", ji.Job.ID)
 		var ctx context.Context
-		ctx, cancel = context.WithCancel(pachClient.Ctx())
+		ctx, cancel = pctx.WithCancel(pachClient.Ctx())
 		eg, ctx = errgroup.WithContext(ctx)
 		eg.Go(func() error { return cb(ctx, ji) })
 		return nil

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -133,7 +133,7 @@ func newTestEnv(ctx context.Context, t *testing.T, pipelineInfo *pps.PipelineInf
 	)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(realEnv.PachClient.Ctx())
+	ctx, cancel := pctx.WithCancel(realEnv.PachClient.Ctx())
 	t.Cleanup(cancel)
 	driver = driver.WithContext(ctx)
 

--- a/src/server/worker/pipeline/transform/status.go
+++ b/src/server/worker/pipeline/transform/status.go
@@ -131,12 +131,12 @@ func (s *Status) NextDatum(ctx context.Context, err error) ([]string, error) {
 	select {
 	case s.nextChan <- err:
 	case <-ctx.Done():
-		return nil, errors.EnsureStack(ctx.Err())
+		return nil, errors.EnsureStack(context.Cause(ctx))
 	}
 	select {
 	case env := <-s.setupChan:
 		return env, nil
 	case <-ctx.Done():
-		return nil, errors.EnsureStack(ctx.Err())
+		return nil, errors.EnsureStack(context.Cause(ctx))
 	}
 }

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -139,7 +139,7 @@ func closeHeadCommit(ctx context.Context, env *realenv.RealEnv, branch *pfs.Bran
 
 func withTimeout(ctx context.Context, duration time.Duration) context.Context {
 	// Create a context that the caller can wait on
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := pctx.WithCancel(ctx)
 
 	go func() {
 		select {
@@ -155,7 +155,7 @@ func withTimeout(ctx context.Context, duration time.Duration) context.Context {
 
 func mockJobFromCommit(t *testing.T, env *testEnv, pi *pps.PipelineInfo, commit *pfs.Commit) (context.Context, *pps.JobInfo) {
 	// Create a context that the caller can wait on
-	ctx, cancel := context.WithCancel(env.PachClient.Ctx())
+	ctx, cancel := pctx.WithCancel(env.PachClient.Ctx())
 	// Mock out the initial ListJob, and InspectJob calls
 	jobInfo := &pps.JobInfo{Job: client.NewProjectJob(pi.Pipeline.Project.GetName(), pi.Pipeline.Name, commit.ID)}
 	jobInfo.OutputCommit = client.NewProjectCommit(pi.Pipeline.Project.GetName(), pi.Pipeline.Name, pi.Details.OutputBranch, commit.ID)

--- a/src/server/worker/worker.go
+++ b/src/server/worker/worker.go
@@ -134,7 +134,7 @@ func (w *Worker) master(logger logs.TaggedLogger, env serviceenv.ServiceEnv) {
 	b.InitialInterval = 10 * time.Second
 	backoff.RetryNotify(func() error { //nolint:errcheck
 		// We use pachClient.Ctx here because it contains auth information.
-		ctx, cancel := context.WithCancel(w.driver.PachClient().Ctx())
+		ctx, cancel := pctx.WithCancel(w.driver.PachClient().Ctx())
 		defer cancel() // make sure that everything this loop might spawn gets cleaned up
 		ctx, err := masterLock.Lock(ctx)
 		if err != nil {


### PR DESCRIPTION
This adds pctx.WithCancel, a drop-in replacement for context.WithCancel, which includes the context creator and context canceller's file:line information in the Cause.  This also refactors most uses of ctx.Err() with context.Cause(ctx), so that most functions will report our improved error instead of "context cancelled".

I used the following gopatch to perform the refactoring:
```patch
 @@
@@
- import "context"
- context.WithCancel
+ import "github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+ pctx.WithCancel
@@
@@
- ctx.Err()
+ import "context"
+ context.Cause(ctx)
@@
@@
- workerCtx.Err()
+ import "context"
+ context.Cause(workerCtx)
@@
@@
- cancelCtx.Err()
+ import "context"
+ context.Cause(cancelCtx)
@@
var x expression
var ctx identifier
@@
- import "context"
- context.Cause(ctx) == x
+ ctx.Err() == x
```