### PR TITLE
add user agent to pachyderm_sdk

### DIFF
--- a/python-sdk/pachyderm_sdk/constants.py
+++ b/python-sdk/pachyderm_sdk/constants.py
@@ -11,6 +11,10 @@ CONFIG_PATH_SPOUT = Path("/").joinpath("pachctl", "config.json")
 CONFIG_PATH_LOCAL = Path.home().joinpath(".pachyderm", "config.json")
 
 MAX_RECEIVE_MESSAGE_SIZE = 20 * 1024**2  # 20MB
+PRIMARY_USER_AGENT = "pachyderm-sdk"
+SECONDARY_USER_AGENT = "v0.0.0"  # TODO: populate this programmatically
 GRPC_CHANNEL_OPTIONS = [
     ("grpc.max_receive_message_length", MAX_RECEIVE_MESSAGE_SIZE),
+    ("grpc.primary_user_agent", PRIMARY_USER_AGENT),
+    ("grpc.secondary_user_agent", SECONDARY_USER_AGENT),
 ]

--- a/python-sdk/pachyderm_sdk/constants.py
+++ b/python-sdk/pachyderm_sdk/constants.py
@@ -12,9 +12,9 @@ CONFIG_PATH_LOCAL = Path.home().joinpath(".pachyderm", "config.json")
 
 MAX_RECEIVE_MESSAGE_SIZE = 20 * 1024**2  # 20MB
 PRIMARY_USER_AGENT = "pachyderm-sdk"
-SECONDARY_USER_AGENT = "v0.0.0"  # TODO: populate this programmatically
+#SECONDARY_USER_AGENT = "v0.0.0"  # TODO: populate this programmatically
 GRPC_CHANNEL_OPTIONS = [
     ("grpc.max_receive_message_length", MAX_RECEIVE_MESSAGE_SIZE),
     ("grpc.primary_user_agent", PRIMARY_USER_AGENT),
-    ("grpc.secondary_user_agent", SECONDARY_USER_AGENT),
+#    ("grpc.secondary_user_agent", SECONDARY_USER_AGENT),
 ]


### PR DESCRIPTION
this updates the user-agent to specify that the client is the pachyderm-sdk. 

verified this works by looking at the envoy logs:
`{"response_code_details":"via_upstream","severity":"info","response_flags":"-","timestamp":"2023-05-16T22:08:29.349Z","upstream":"pachd-grpc","upstream_protocol":"HTTP/2","xff":"192.168.65.4","request_headers_bytes":388,"rx_bytes":22,"upstream_local_address":"10.1.8.205:60530","upstream_service_time_ms":"15","user_agent":"pachyderm-sdk grpc-python/1.51.3 grpc-c/29.0.0 (osx; chttp2) v0.0.0","message":"http response","response_code":200,"upstream_host":"10.1.8.207:1650","x-request-id":"3c07b727-e481-4793-b937-b37e10fc345f","method":"POST","grpc_status_code":"OK","downstream_remote_address":"192.168.65.4","tx_bytes":5,"protocol":"HTTP/2","connection_id":2210,"path":"/pfs_v2.API/CreateProject","request_attempt_count":1,"duration_ms":19}`

Jira: [INT-896]

[INT-896]: https://pachyderm.atlassian.net/browse/INT-896