### PR TITLE
Add alias flag to pachctl connect

### DIFF
--- a/src/server/config/cmds_test.go
+++ b/src/server/config/cmds_test.go
@@ -70,6 +70,19 @@ func TestConnectExisting(t *testing.T) {
 	`))
 }
 
+func TestConnectWithAlias(t *testing.T) {
+	require.NoError(t, run(t, `  
+	pachctl connect blah --alias=aliasName | match "New context 'aliasName' created, will connect to Pachyderm at grpc://blah:30650"  
+	`))
+}
+
+func TestConnectExistingWithAlias(t *testing.T) {
+	require.NoError(t, run(t, `  
+	pachctl connect blah --alias=aliasName 
+	pachctl connect blah --alias=aliasName | match "Context 'aliasName' set as active"  
+	`))
+}
+
 func TestMetrics(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")


### PR DESCRIPTION
adds the ability to set the context's name when using pachctl connect