### PR TITLE
pachyderm_sdk: separate config parsing into its own module

### DIFF
--- a/python-sdk/pachyderm_sdk/client.py
+++ b/python-sdk/pachyderm_sdk/client.py
@@ -20,6 +20,7 @@ from .api.pfs.extension import ApiStub as _PfsStub
 from .api.pps.extension import ApiStub as _PpsStub
 from .api.transaction.extension import ApiStub as _TransactionStub
 from .api.version import ApiStub as _VersionStub, Version
+from .config import ConfigFile
 from .constants import (
     AUTH_TOKEN_ENV,
     GRPC_CHANNEL_OPTIONS,
@@ -229,7 +230,7 @@ class Client:
         """
         # TODO: Should config_file be nullable?
         #  If null should we search for the local config?
-        config = _ConfigFile(config_file)
+        config = ConfigFile(config_file)
         active_context = config.active_context
         client = cls.from_pachd_address(
             active_context.active_pachd_address,
@@ -329,97 +330,3 @@ def _create_channel(
         ssl = grpc.ssl_channel_credentials(root_certificates=root_certs)
         return grpc.secure_channel(address, ssl, options=options)
     return grpc.insecure_channel(address, options=options)
-
-
-class _ConfigFile:
-
-    def __init__(self, config_file: Union[Path, str]):
-        config_file = Path(os.path.expanduser(config_file)).resolve()
-        self._config_file_data = json.loads(config_file.read_bytes())
-
-    @classmethod
-    def from_bytes(cls, config_file_data: bytes):
-        with NamedTemporaryFile() as temp_config_file:
-            temp_config_file.write(config_file_data)
-            return cls(temp_config_file.name)
-
-    @property
-    def user_id(self) -> str:
-        return self._config_file_data["user_id"]
-
-    @property
-    def active_context(self) -> "_Context":
-        active_context_name = self._config_file_data["v2"]["active_context"]
-        contexts = self._config_file_data["v2"]["contexts"]
-        if active_context_name not in contexts:
-            raise ConfigError(f"active context not found: {active_context_name}")
-        return _Context(**contexts[active_context_name])
-
-    @property
-    def active_enterprise_context(self) -> "_Context":
-        context_name = self._config_file_data["v2"].get("active_enterprise_context")
-        if context_name is None:
-            raise ConfigError("active enterprise context is not specified")
-        contexts = self._config_file_data["v2"]["contexts"]
-        if context_name not in contexts:
-            raise ConfigError(f"active enterprise context not found: {context_name}")
-        return _Context(**contexts[context_name])
-
-
-@dataclass
-class _Context:
-    source: Optional[int] = None
-    """An integer that specifies where the config came from. 
-    This parameter is for internal use only and should not be modified."""
-
-    pachd_address: Optional[str] = None
-    """A host:port specification for connecting to pachd."""
-
-    server_cas: Optional[str] = None
-    """Trusted root certificates for the cluster, formatted as a 
-    base64-encoded PEM. This is only set when TLS is enabled."""
-
-    session_token: Optional[str] = None
-    """A secret token identifying the current user within their pachyderm
-    cluster. This is included in all RPCs and used to determine if a user's
-    actions are authorized. This is only set when auth is enabled."""
-
-    active_transaction: Optional[str] = None
-    """The currently active transaction for batching together commands."""
-
-    cluster_name: Optional[str] = None
-    """The name of the underlying Kubernetes cluster."""
-
-    auth_info: Optional[str] = None
-    """The name of the underlying Kubernetes cluster’s auth credentials"""
-
-    namespace: Optional[str] = None
-    """The underlying Kubernetes cluster’s namespace"""
-
-    cluster_deployment_id: Optional[str] = None
-    """The pachyderm cluster deployment ID that is used to ensure the
-    operations run on the expected cluster."""
-
-    project: Optional[str] = None
-
-    enterprise_server: bool = False
-    """Whether the context represents an enterprise server."""
-
-    port_forwarders: Dict[str, int] = None
-    """A mapping of service name -> local port."""
-
-    @property
-    def active_pachd_address(self) -> str:
-        """This pachd factors in port-forwarding. """
-        if self.pachd_address is None:
-            port = 30650
-            if self.port_forwarders:
-                port = self.port_forwarders.get('pachd', 30650)
-            return f"grpc://localhost:{port}"
-        return self.pachd_address
-
-    @property
-    def server_cas_decoded(self) -> Optional[bytes]:
-        """The base64 decoded root certificates in PEM format, if they exist."""
-        if self.server_cas:
-            return b64decode(bytes(self.server_cas, "utf-8"))

--- a/python-sdk/pachyderm_sdk/client.py
+++ b/python-sdk/pachyderm_sdk/client.py
@@ -23,6 +23,8 @@ from .api.version import ApiStub as _VersionStub, Version
 from .config import ConfigFile
 from .constants import (
     AUTH_TOKEN_ENV,
+    CONFIG_PATH_LOCAL,
+    CONFIG_PATH_SPOUT,
     GRPC_CHANNEL_OPTIONS,
     OIDC_TOKEN_ENV,
     PACHD_SERVICE_HOST_ENV,
@@ -41,11 +43,6 @@ class Client:
     To see documentation on the methods :class:`.Client` can call, refer to the
     `mixins` module.
     """
-
-    # Class variables for checking config
-    env_config = "PACH_CONFIG"
-    spout_config = Path("/pachctl/config.json")
-    local_config = Path.home().joinpath("pachyderm/config.json")
 
     def __init__(
         self,
@@ -143,9 +140,9 @@ class Client:
         Client
             A python_pachyderm client instance.
         """
-        if cls.spout_config.exists():
+        if CONFIG_PATH_SPOUT.exists():
             # TODO: Should we notify the user that we are using spout config?
-            return cls.from_config(cls.spout_config)
+            return cls.from_config(CONFIG_PATH_SPOUT)
 
         host = os.environ.get(PACHD_SERVICE_HOST_ENV)
         if host is None:

--- a/python-sdk/pachyderm_sdk/config.py
+++ b/python-sdk/pachyderm_sdk/config.py
@@ -1,0 +1,93 @@
+import json
+import os
+from base64 import b64decode
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+from .errors import ConfigError
+
+class ConfigFile:
+    def __init__(self, config_file: Union[Path, str]):
+        config_file = Path(os.path.expanduser(config_file)).resolve()
+        self._config_file_data = json.loads(config_file.read_bytes())
+
+    @property
+    def user_id(self) -> str:
+        return self._config_file_data["user_id"]
+
+    @property
+    def active_context(self) -> "Context":
+        active_context_name = self._config_file_data["v2"]["active_context"]
+        contexts = self._config_file_data["v2"]["contexts"]
+        if active_context_name not in contexts:
+            raise ConfigError(f"active context not found: {active_context_name}")
+        return Context(**contexts[active_context_name])
+
+    @property
+    def active_enterprise_context(self) -> "Context":
+        context_name = self._config_file_data["v2"].get("active_enterprise_context")
+        if context_name is None:
+            raise ConfigError("active enterprise context is not specified")
+        contexts = self._config_file_data["v2"]["contexts"]
+        if context_name not in contexts:
+            raise ConfigError(f"active enterprise context not found: {context_name}")
+        return Context(**contexts[context_name])
+    
+@dataclass
+class Context:
+    source: Optional[int] = None
+    """An integer that specifies where the config came from. 
+    This parameter is for internal use only and should not be modified."""
+
+    pachd_address: Optional[str] = None
+    """A host:port specification for connecting to pachd."""
+
+    server_cas: Optional[str] = None
+    """Trusted root certificates for the cluster, formatted as a 
+    base64-encoded PEM. This is only set when TLS is enabled."""
+
+    session_token: Optional[str] = None
+    """A secret token identifying the current user within their pachyderm
+    cluster. This is included in all RPCs and used to determine if a user's
+    actions are authorized. This is only set when auth is enabled."""
+
+    active_transaction: Optional[str] = None
+    """The currently active transaction for batching together commands."""
+
+    cluster_name: Optional[str] = None
+    """The name of the underlying Kubernetes cluster."""
+
+    auth_info: Optional[str] = None
+    """The name of the underlying Kubernetes cluster’s auth credentials"""
+
+    namespace: Optional[str] = None
+    """The underlying Kubernetes cluster’s namespace"""
+
+    cluster_deployment_id: Optional[str] = None
+    """The pachyderm cluster deployment ID that is used to ensure the
+    operations run on the expected cluster."""
+
+    project: Optional[str] = None
+
+    enterprise_server: bool = False
+    """Whether the context represents an enterprise server."""
+
+    port_forwarders: Dict[str, int] = None
+    """A mapping of service name -> local port."""
+
+    @property
+    def active_pachd_address(self) -> str:
+        """This pachd factors in port-forwarding. """
+        if self.pachd_address is None:
+            port = 30650
+            if self.port_forwarders:
+                port = self.port_forwarders.get('pachd', 30650)
+            return f"grpc://localhost:{port}"
+        return self.pachd_address
+
+    @property
+    def server_cas_decoded(self) -> Optional[bytes]:
+        """The base64 decoded root certificates in PEM format, if they exist."""
+        if self.server_cas:
+            return b64decode(bytes(self.server_cas, "utf-8"))

--- a/python-sdk/tests/test_config.py
+++ b/python-sdk/tests/test_config.py
@@ -1,0 +1,75 @@
+import unittest
+import pytest
+from tempfile import NamedTemporaryFile
+
+from pachyderm_sdk.config import ConfigFile
+from pachyderm_sdk.errors import ConfigError
+
+TEST_CONFIG = bytes("""
+{
+  "user_id": "some_user",
+  "v2": {
+    "active_context": "default",
+    "contexts": {
+      "default": {
+        "session_token": "token",
+        "cluster_deployment_id": "id",
+        "project": "default"
+      },
+      "other_context": {
+        "pachd_address": "grpc://localhost:12345",
+        "session_token": "other_token",
+        "cluster_deployment_id": "other_id",
+        "project": "other_project"
+      }
+    },
+    "metrics": true
+  }
+}
+""", 'utf-8')
+
+TEST_CONFIG_INVALID_CONTEXT = bytes("""
+{
+  "user_id": "some_user",
+  "v2": {
+    "active_context": "invalid_context",
+    "contexts": {
+      "default": {
+        "session_token": "token",
+        "cluster_deployment_id": "id",
+        "project": "default"
+      },
+      "other_context": {
+        "pachd_address": "grpc://localhost:12345",
+        "session_token": "other_token",
+        "cluster_deployment_id": "other_id",
+        "project": "other_project"
+      }
+    },
+    "metrics": true
+  }
+}
+""", 'utf-8')
+
+class TestConfig():
+    @staticmethod
+    def test_from_file():
+        with NamedTemporaryFile() as config_file:
+            config_file.write(TEST_CONFIG)
+            config_file.flush()
+            c = ConfigFile(config_file.name)
+            context = c.active_context
+            assert c.user_id == "some_user"
+            assert context.session_token == "token"
+            assert context.cluster_deployment_id == "id"
+            assert context.project == "default"
+    
+    @staticmethod
+    def test_invalid_context():
+        with NamedTemporaryFile() as config_file:
+            config_file.write(TEST_CONFIG_INVALID_CONTEXT)
+            config_file.flush()
+            with pytest.raises(ConfigError) as e:
+                c = ConfigFile(config_file=config_file.name)
+                context = c.active_context
+            assert("active context not found: invalid_context" in str(e.value))

--- a/python-sdk/tests/test_config.py
+++ b/python-sdk/tests/test_config.py
@@ -1,11 +1,10 @@
-import unittest
 import pytest
 from tempfile import NamedTemporaryFile
 
 from pachyderm_sdk.config import ConfigFile
 from pachyderm_sdk.errors import ConfigError
 
-TEST_CONFIG = bytes("""
+TEST_CONFIG = """
 {
   "user_id": "some_user",
   "v2": {
@@ -26,9 +25,9 @@ TEST_CONFIG = bytes("""
     "metrics": true
   }
 }
-""", 'utf-8')
+"""
 
-TEST_CONFIG_INVALID_CONTEXT = bytes("""
+TEST_CONFIG_INVALID_CONTEXT = """
 {
   "user_id": "some_user",
   "v2": {
@@ -49,12 +48,13 @@ TEST_CONFIG_INVALID_CONTEXT = bytes("""
     "metrics": true
   }
 }
-""", 'utf-8')
+"""
 
 class TestConfig():
     @staticmethod
-    def test_from_file():
-        with NamedTemporaryFile() as config_file:
+    def test_from_file(tmp_path):
+        config_path = tmp_path / "config.json"
+        with open(config_path, "w") as config_file:
             config_file.write(TEST_CONFIG)
             config_file.flush()
             c = ConfigFile(config_file.name)
@@ -65,8 +65,9 @@ class TestConfig():
             assert context.project == "default"
     
     @staticmethod
-    def test_invalid_context():
-        with NamedTemporaryFile() as config_file:
+    def test_invalid_context(tmp_path):
+        config_path = tmp_path / "config.json"
+        with open(config_path, "w") as config_file:
             config_file.write(TEST_CONFIG_INVALID_CONTEXT)
             config_file.flush()
             with pytest.raises(ConfigError) as e:


### PR DESCRIPTION
Moving config parsing out into its own module. This will make testing and extending its capabilities easier. Reserving further improvements on parsing for a future PR.

Jira: [INT-916]

[INT-916]: https://pachyderm.atlassian.net/browse/INT-902