### PR TITLE
log: log all pgx-added fields as pgx.*

### DIFF
--- a/src/internal/log/pgx.go
+++ b/src/internal/log/pgx.go
@@ -30,7 +30,7 @@ func (pl *pgxLogger) Log(ctx context.Context, level pgx.LogLevel, msg string, da
 
 	fields := []Field{zap.Stringer("pgx.severity", level)}
 	for k, v := range data {
-		fields = append(fields, zap.Any(k, v))
+		fields = append(fields, zap.Any("pgx."+k, v))
 	}
 
 	// We always log at severity debug; pgx has the potential to cause alarm with its own


### PR DESCRIPTION
This is because one of the fields is "time", and that conflicts with our use of "time" to convey the moment that the event happened.  If you parse "time" with query logging enabled, you'll see all of them from 1900.  Oops!  This fixes that.

A log entry now looks like:

```json
{
  "severity": "debug",
  "time": "2023-05-19T21:52:33.073164862Z",
  "logger": "ApplyMigrations.pgx.bouncer",
  "caller": "v4@v4.16.1/conn.go:354",
  "message": "Exec",
  "pgx.severity": "info",
  "pgx.sql": "begin",
  "pgx.args": [],
  "pgx.time": 0.00038781,
  "pgx.commandTag": "BEGIN",
  "pgx.pid": 4034477057
}
```