### PR TITLE
update opencv example stock images

### DIFF
--- a/examples/opencv/images.txt
+++ b/examples/opencv/images.txt
@@ -1,1 +1,1 @@
-http://imgur.com/46Q8nDz.jpg
+https://free-images.com/md/57ee/statue_liberty_usa_new.jpg

--- a/examples/opencv/images2.txt
+++ b/examples/opencv/images2.txt
@@ -1,2 +1,3 @@
-http://imgur.com/g2QnNqa.jpg
-http://imgur.com/8MN9Kg0.jpg
+https://free-images.com/md/b7da/kitten_bengal_kitten_pet_0.jpg
+https://free-images.com/md/7bb2/video_game_gamescom_star.jpg
+

--- a/examples/opencv/images2.txt
+++ b/examples/opencv/images2.txt
@@ -1,3 +1,2 @@
 https://free-images.com/md/b7da/kitten_bengal_kitten_pet_0.jpg
 https://free-images.com/md/7bb2/video_game_gamescom_star.jpg
-

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -195,7 +195,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 				))
 
 			require.NoError(t, c.WithModifyFileClient(client.NewCommit(pfs.DefaultProjectName, imagesRepo, "master", "" /* commitID */), func(mf client.ModifyFile) error {
-				return errors.EnsureStack(mf.PutFileURL("/liberty.png", "http://i.imgur.com/46Q8nDz.png", false))
+				return errors.EnsureStack(mf.PutFileURL("/liberty.png", "https://free-images.com/md/57ee/statue_liberty_usa_new.jpg", false))
 			}))
 
 			commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, montage, "master", "")
@@ -220,7 +220,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, enterprise.State_ACTIVE, state.State)
 			require.NoError(t, c.WithModifyFileClient(client.NewCommit(pfs.DefaultProjectName, imagesRepo, "master", ""), func(mf client.ModifyFile) error {
-				return errors.EnsureStack(mf.PutFileURL("/kitten.png", "https://i.imgur.com/g2QnNqa.png", false))
+				return errors.EnsureStack(mf.PutFileURL("/kitten.png", "https://free-images.com/md/b7da/kitten_bengal_kitten_pet_0.jpg", false))
 			}))
 
 			commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, montage, "master", "")


### PR DESCRIPTION
imgur has decided to rate limit image downloads. The tests need these examples for pipelines to work. 

We should switch to using images with free use licenses like creative commons on a  different host. 

To unblock pipelines I've grabbed some similar images to open cv and linked to those instead. 

Example:
https://free-images.com/display/video_game_gamescom_star.html

I think we should probably host these images ourselves, and we still have a LOT of imgur references so we will need to figure out what to do with this long term.