### PR TITLE
Update helm values for console

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -112,9 +112,9 @@ spec:
         - name: NO_PROXY
           value:  {{.Values.global.noProxy}}
         {{ end }}
-        - name: PACHYDERM_PUBLIC_HOST
+        - name: REACT_APP_RUNTIME_PACHYDERM_PUBLIC_HOST
           value: {{ include "pachyderm.host" . }}
-        - name: PACHYDERM_PUBLIC_TLS
+        - name: REACT_APP_RUNTIME_PACHYDERM_PUBLIC_TLS
           value: "{{ .Values.proxy.tls.enabled | ternary "true" "false" }}"
         {{- if .Values.console.resources }}
         resources: {{ toYaml .Values.console.resources | nindent 10 }}


### PR DESCRIPTION
We want to prefix `PACHYDERM_PUBLIC_HOST` and `PACHYDERM_PUBLIC_TLS` with `REACT_APP_RUNTIME` so that they can be injected into the react app.