### PR TITLE
test larger runners per circle-ci ticket

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -113,7 +113,7 @@ jobs:
           paths:
             - /home/circleci/go/pkg/mod
   test-pps:
-    resource_class: xlarge
+    resource_class: 2xlarge
     machine:
       image: << pipeline.parameters.machine_image >>
     environment:
@@ -238,7 +238,7 @@ jobs:
     parameters:
       bucket:
         type: string
-    resource_class: xlarge
+    resource_class: 2xlarge
     machine:
       image: << pipeline.parameters.machine_image >>
     environment:
@@ -550,7 +550,7 @@ jobs:
     parameters:
       resource_class:
         type: string
-        default: xlarge
+        default: 2xlarge
       arch:
         type: string
         default: amd64


### PR DESCRIPTION
I sent examples of one of the issues I was tracking to circle-ci to get their thoughts. https://pachyderm.atlassian.net/browse/CORE-1538

Their suggestion was to try 2xlarge to see if it helps since there appeared to be cpu bottlenecks during the jobs I sent them. Preliminary testing seems OK, but it's hard to tell if it worked or if I'm just lucky with this stuff. I think it makes sense to merge it and watch for more failures though since I haven't seen the issue on the 10 or so runs I've tried with the larger machines.