### PR TITLE
[CORE-1734] Implement GRPCStatus for ErrCommitNotFinished

### DIFF
--- a/src/server/pfs/pfs.go
+++ b/src/server/pfs/pfs.go
@@ -5,11 +5,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
-	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 )
 
 // ErrFileNotFound represents a file-not-found error.
@@ -266,6 +268,10 @@ func (e ErrOutputCommitNotFinished) Error() string {
 
 func (e ErrCommitNotFinished) Error() string {
 	return fmt.Sprintf("commit %v not finished", e.Commit)
+}
+
+func (e ErrCommitNotFinished) GRPCStatus() *status.Status {
+	return status.New(codes.Unavailable, e.Error())
 }
 
 func (e ErrBaseCommitNotFinished) Error() string {

--- a/src/server/pfs/pfs_test.go
+++ b/src/server/pfs/pfs_test.go
@@ -5,9 +5,12 @@ package pfs
 import (
 	"testing"
 
+	"google.golang.org/grpc/status"
+
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
 func TestErrorMatching(t *testing.T) {
@@ -24,3 +27,7 @@ func TestErrorMatching(t *testing.T) {
 	require.False(t, IsCommitFinishedErr(ErrCommitDeleted{c}))
 	require.True(t, IsCommitFinishedErr(ErrCommitFinished{c}))
 }
+
+type grpcStatus interface{ GRPCStatus() *status.Status }
+
+var _ grpcStatus = ErrCommitNotFinished{}


### PR DESCRIPTION
Return an UNAVAILABLE, on the principle that the client may retry until the commit is finished.