### PR TITLE
use images hosted in docs for examples

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -922,8 +922,8 @@ jobs:
             echo '{"pachd_address": "grpc://'"$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)":30650'", "source": 2}' | pachctl config set context "mount-server" --overwrite && pachctl config set active-context "mount-server"
 
             pachctl create repo images
-            pachctl put file images@master:liberty.png -f https://free-images.com/md/57ee/statue_liberty_usa_new.jpg
-            pachctl put file images@branch:branch.png -f https://free-images.com/md/57ee/statue_liberty_usa_new.jpg
+            pachctl put file images@master:liberty.png -f https://docs.pachyderm.com/images/opencv/liberty.jpg
+            pachctl put file images@branch:branch.png -f https://docs.pachyderm.com/images/opencv/liberty.jpg
             pachctl list repo
 
             mkdir pfs

--- a/examples/deferred-processing/deferred_processing_plus_transactions/images.txt
+++ b/examples/deferred-processing/deferred_processing_plus_transactions/images.txt
@@ -1,1 +1,1 @@
-http://imgur.com/46Q8nDz.jpg
+https://docs.pachyderm.com/images/opencv/liberty.jpg

--- a/examples/deferred-processing/deferred_processing_plus_transactions/images2.txt
+++ b/examples/deferred-processing/deferred_processing_plus_transactions/images2.txt
@@ -1,2 +1,2 @@
-http://imgur.com/g2QnNqa.jpg
-http://imgur.com/8MN9Kg0.jpg
+https://docs.pachyderm.com/images/opencv/kitten.jpg
+https://docs.pachyderm.com/images/opencv/robot.jpg

--- a/examples/globalID/data/images.txt
+++ b/examples/globalID/data/images.txt
@@ -1,1 +1,1 @@
-http://imgur.com/46Q8nDz.jpg
+https://docs.pachyderm.com/images/opencv/liberty.jpg

--- a/examples/globalID/data/images2.txt
+++ b/examples/globalID/data/images2.txt
@@ -1,2 +1,2 @@
-http://imgur.com/g2QnNqa.jpg
-http://imgur.com/8MN9Kg0.jpg
+https://docs.pachyderm.com/images/opencv/kitten.jpg
+https://docs.pachyderm.com/images/opencv/robot.jpg

--- a/examples/opencv/goclient-example/opencv-example.go
+++ b/examples/opencv/goclient-example/opencv-example.go
@@ -35,15 +35,15 @@ func main() {
 		panic(err)
 	}
 
-	if err := c.PutFileURL(imageCommit, "liberty.png", "http://imgur.com/46Q8nDz.png", false); err != nil {
+	if err := c.PutFileURL(imageCommit, "liberty.png", "https://docs.pachyderm.com/images/opencv/liberty.jpg", false); err != nil {
 		panic(err)
 	}
 
-	if err := c.PutFileURL(imageCommit, "AT-AT.png", "http://imgur.com/8MN9Kg0.png", false); err != nil {
+	if err := c.PutFileURL(imageCommit, "robot.png", "https://docs.pachyderm.com/images/opencv/robot.jpg", false); err != nil {
 		panic(err)
 	}
 
-	if err := c.PutFileURL(imageCommit, "kitten.png", "http://imgur.com/g2QnNqa.png", false); err != nil {
+	if err := c.PutFileURL(imageCommit, "kitten.png", "https://docs.pachyderm.com/images/opencv/kitten.jpg", false); err != nil {
 		panic(err)
 	}
 

--- a/examples/opencv/images.txt
+++ b/examples/opencv/images.txt
@@ -1,1 +1,1 @@
-https://free-images.com/md/57ee/statue_liberty_usa_new.jpg
+https://docs.pachyderm.com/images/opencv/liberty.jpg

--- a/examples/opencv/images2.txt
+++ b/examples/opencv/images2.txt
@@ -1,2 +1,2 @@
-https://free-images.com/md/b7da/kitten_bengal_kitten_pet_0.jpg
-https://free-images.com/md/7bb2/video_game_gamescom_star.jpg
+https://docs.pachyderm.com/images/opencv/kitten.jpg
+https://docs.pachyderm.com/images/opencv/robot.jpg

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -195,7 +195,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 				))
 
 			require.NoError(t, c.WithModifyFileClient(client.NewCommit(pfs.DefaultProjectName, imagesRepo, "master", "" /* commitID */), func(mf client.ModifyFile) error {
-				return errors.EnsureStack(mf.PutFileURL("/liberty.png", "https://free-images.com/md/57ee/statue_liberty_usa_new.jpg", false))
+				return errors.EnsureStack(mf.PutFileURL("/liberty.png", "https://docs.pachyderm.com/images/opencv/liberty.jpg", false))
 			}))
 
 			commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, montage, "master", "")
@@ -220,7 +220,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, enterprise.State_ACTIVE, state.State)
 			require.NoError(t, c.WithModifyFileClient(client.NewCommit(pfs.DefaultProjectName, imagesRepo, "master", ""), func(mf client.ModifyFile) error {
-				return errors.EnsureStack(mf.PutFileURL("/kitten.png", "https://free-images.com/md/b7da/kitten_bengal_kitten_pet_0.jpg", false))
+				return errors.EnsureStack(mf.PutFileURL("/kitten.png", "https://docs.pachyderm.com/images/opencv/kitten.jpg", false))
 			}))
 
 			commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, montage, "master", "")


### PR DESCRIPTION
We now have free-to-use images hosted in the docs repo. We should use these rather than pull from another image site that is likely to stop hosting images at some point in the future. 

License notices and images were added in https://github.com/pachyderm/docs-content/pull/2 using the REUSE spec.
