### PR TITLE
timeout loki liveness check in tests

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -33,7 +33,7 @@ orbs:
 parameters:
   machine_image:
     type: string
-    default: ubuntu-2204:2022.10.1
+    default: ubuntu-2204:2023.04.2
   go-version:
     type: string
     default: "1.20.4"
@@ -644,6 +644,8 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/trace.out
       - collect-test-results
       - codecov/upload:
           file: /tmp/test-results/coverage.txt

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1591,11 +1591,11 @@ workflows:
     jobs:
       - deploy-tests:
           name: amd64 deploy tests
-          resource_class: xlarge # amd64
+          resource_class: 2xlarge # amd64
           arch: amd64
       - deploy-tests:
           name: arm64 deploy tests
-          resource_class: arm.xlarge # arm64
+          resource_class: arm.2xlarge # arm64
           arch: arm64
   jupyter-extension:
     when: << pipeline.parameters.run-jupyter-jobs >>

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -238,7 +238,7 @@ jobs:
     parameters:
       bucket:
         type: string
-    resource_class: xlarge
+    resource_class: 2xlarge
     machine:
       image: << pipeline.parameters.machine_image >>
     environment:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -238,7 +238,7 @@ jobs:
     parameters:
       bucket:
         type: string
-    resource_class: 2xlarge
+    resource_class: xlarge
     machine:
       image: << pipeline.parameters.machine_image >>
     environment:
@@ -1593,11 +1593,11 @@ workflows:
     jobs:
       - deploy-tests:
           name: amd64 deploy tests
-          resource_class: 2xlarge # amd64
+          resource_class: xlarge # amd64
           arch: amd64
       - deploy-tests:
           name: arm64 deploy tests
-          resource_class: arm.2xlarge # arm64
+          resource_class: arm.xlarge # arm64
           arch: arm64
   jupyter-extension:
     when: << pipeline.parameters.run-jupyter-jobs >>

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -644,8 +644,6 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/trace.out
       - collect-test-results
       - codecov/upload:
           file: /tmp/test-results/coverage.txt

--- a/etc/testing/circle/deploy_test.sh
+++ b/etc/testing/circle/deploy_test.sh
@@ -33,8 +33,8 @@ then
     if [ "${#test_names}" -gt 0 ]
     then
         test_names="${test_names::-1}" # trim last |
-        go test -v=test2json -run "$test_names" -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
+        go test -v=test2json -trace "/tmp/trace.out" -run "$test_names" -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
     fi
 else
-    go test -v=test2json -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
+    go test -v=test2json -trace "/tmp/trace.out" -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
 fi

--- a/etc/testing/circle/deploy_test.sh
+++ b/etc/testing/circle/deploy_test.sh
@@ -33,8 +33,8 @@ then
     if [ "${#test_names}" -gt 0 ]
     then
         test_names="${test_names::-1}" # trim last |
-        go test -v=test2json -trace "/tmp/trace.out" -run "$test_names" -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
+        go test -v=test2json -run "$test_names" -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
     fi
 else
-    go test -v=test2json -trace "/tmp/trace.out" -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
+    go test -v=test2json -failfast -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
 fi

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -392,6 +392,10 @@ func waitForLoki(t testing.TB, lokiHost string, lokiPort int) {
 		req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:%v/ready", lokiHost, lokiPort), nil)
 		t.Logf("Attempting to connect to loki at lokiHost %v and lokiPort %v", lokiHost, lokiPort)
 		resp, err := client.Do(req)
+		if os.IsTimeout(err) {
+			t.Logf("Timed out connecting to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
+			return errors.Wrap(err, "loki attempt to connect timed out")
+		}
 		if err != nil {
 			t.Logf("Failed to connect to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
 			return errors.Wrap(err, "loki not ready")

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -386,9 +386,12 @@ func waitForPachd(t testing.TB, ctx context.Context, kubeClient *kube.Clientset,
 
 func waitForLoki(t testing.TB, lokiHost string, lokiPort int) {
 	require.NoError(t, backoff.RetryNotify(func() error {
+		client := http.Client{
+			Timeout: 15 * time.Second,
+		}
 		req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:%v/ready", lokiHost, lokiPort), nil)
 		t.Logf("Attempting to connect to loki at lokiHost %v and lokiPort %v", lokiHost, lokiPort)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			t.Logf("Failed to connect to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
 			return errors.Wrap(err, "loki not ready")

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -394,7 +394,8 @@ func waitForLoki(t testing.TB, lokiHost string, lokiPort int) {
 		resp, err := client.Do(req)
 		if os.IsTimeout(err) {
 			t.Logf("Timed out connecting to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
-			return errors.Wrap(err, "loki attempt to connect timed out")
+			t.FailNow() // DNJ TODO remove debug
+			//return errors.Wrap(err, "loki attempt to connect timed out")
 		}
 		if err != nil {
 			t.Logf("Failed to connect to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -396,7 +396,7 @@ func waitForLoki(t testing.TB, lokiHost string, lokiPort int) {
 		t.Logf("Connected to loki at lokiHost %v and lokiPort %v", lokiHost, lokiPort)
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return errors.Errorf("loki not ready")
+			return errors.Errorf("loki not ready. http response code %v", resp.StatusCode)
 		}
 		return nil
 	}, backoff.RetryEvery(5*time.Second).For(5*time.Minute), func(err error, d time.Duration) error {

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -401,7 +401,7 @@ func waitForLoki(t testing.TB, lokiHost string, lokiPort int) {
 		return nil
 	}, backoff.RetryEvery(5*time.Second).For(5*time.Minute), func(err error, d time.Duration) error {
 		t.Logf("Retrying connection to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
-		return err
+		return nil
 	}))
 }
 

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -393,13 +393,10 @@ func waitForLoki(t testing.TB, lokiHost string, lokiPort int) {
 		t.Logf("Attempting to connect to loki at lokiHost %v and lokiPort %v", lokiHost, lokiPort)
 		resp, err := client.Do(req)
 		if os.IsTimeout(err) {
-			t.Logf("Timed out connecting to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
-			t.FailNow() // DNJ TODO remove debug
-			//return errors.Wrap(err, "loki attempt to connect timed out")
+			return errors.Wrap(err, "loki attempt to connect timed out")
 		}
 		if err != nil {
-			t.Logf("Failed to connect to loki at lokiHost %v and lokiPort %v. Error: %v", lokiHost, lokiPort, err)
-			return errors.Wrap(err, "loki not ready")
+			return errors.Wrap(err, "loki not ready due to error")
 		}
 		t.Logf("Connected to loki at lokiHost %v and lokiPort %v", lokiHost, lokiPort)
 		defer resp.Body.Close()

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -276,7 +276,7 @@ validator:
     count: 1
 `
 	var stateID string
-	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) {
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			t.Log("before upgrade: starting load test")

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -76,7 +76,7 @@ func TestUpgradeTrigger(t *testing.T) {
 	}
 	dataRepo := "TestTrigger_data"
 	dataCommit := client.NewCommit(pfs.DefaultProjectName, dataRepo, "master", "")
-	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) { /* preUpgrade */
 			require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, dataRepo))
 			pipeline1 := "TestTrigger1"
@@ -276,7 +276,7 @@ validator:
     count: 1
 `
 	var stateID string
-	upgradeTest(t, context.Background(), false /* parallelOK */, fromVersions,
+	upgradeTest(t, context.Background(), true /* parallelOK */, fromVersions,
 		func(t *testing.T, c *client.APIClient) {
 			c = testutil.AuthenticatedPachClient(t, c, upgradeSubject)
 			t.Log("before upgrade: starting load test")


### PR DESCRIPTION
Working with Circle, I think we identified the specific network issue causing the deploy tests to bomb out. Adding a timeout to the liveness http client we use to connect with loki seems to resolve the issue. I don't have 100% proof yet, but hopefully will when this merges into all the pipelines. (I have detected the error and forced a fail, I haven't detected the error with current code that allows the pipeline to pass)

python sdk tests are failing but they are unaffected by this change(they don't use the machine image I changed)