### PR TITLE
jupyter extension flaky test fix - move unmount step until after app is ready

### DIFF
--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -1,8 +1,8 @@
 describe('mount', () => {
   beforeEach(() => {
-    cy.unmountAllRepos();
     cy.resetApp();
     cy.isAppReady();
+    cy.unmountAllRepos();
     cy.openMountPlugin();
     cy.findAllByText('Mount');
   });


### PR DESCRIPTION
the end-to-end tests for the jupyter extension were flaky due to the unmount endpoint serving 404s sometimes. moving the unmount step until after the app is ready appears to fix this.