### PR TITLE
Adds Package pachconfig

### DIFF
--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -10,9 +10,9 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
@@ -30,7 +30,7 @@ func PGBouncerHost() string {
 	return postgresHost()
 }
 
-func NewTestDBConfig(t testing.TB) serviceenv.ConfigOption {
+func NewTestDBConfig(t testing.TB) pachconfig.ConfigOption {
 	var (
 		ctx     = context.Background()
 		dbName  = testutil.GenerateEphemeralDBName(t)
@@ -48,7 +48,7 @@ func NewTestDBConfig(t testing.TB) serviceenv.ConfigOption {
 	)
 	testutil.CreateEphemeralDB(t, db, dbName)
 	testutil.CreateEphemeralDB(t, db, dexName)
-	return func(c *serviceenv.Configuration) {
+	return func(c *pachconfig.Configuration) {
 		// common
 		c.PostgresDBName = dbName
 		c.IdentityServerDatabase = dexName

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -1,4 +1,7 @@
-package serviceenv
+// Package pachconfig contains the configuration models for Pachyderm.
+// The various models are parsed from environment variables when pachd starts.
+// This package should be at the bottom of the dependency graph.
+package pachconfig
 
 import "k8s.io/apimachinery/pkg/api/resource"
 

--- a/src/internal/pachconfig/option.go
+++ b/src/internal/pachconfig/option.go
@@ -1,4 +1,4 @@
-package serviceenv
+package pachconfig
 
 import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"

--- a/src/internal/pachd/builder.go
+++ b/src/internal/pachd/builder.go
@@ -29,6 +29,7 @@ import (
 	loggingmw "github.com/pachyderm/pachyderm/v2/src/internal/middleware/logging"
 	version_middleware "github.com/pachyderm/pachyderm/v2/src/internal/middleware/version"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/profileutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -66,7 +67,7 @@ type envBootstrapper interface {
 
 // builder provides the base daemon builder structure.
 type builder struct {
-	config *serviceenv.Configuration
+	config *pachconfig.Configuration
 	name   string
 
 	env                serviceenv.ServiceEnv
@@ -95,7 +96,7 @@ func (b *builder) apply(ctx context.Context, ff ...func(ctx context.Context) err
 
 func newBuilder(config any, name string) (b builder) {
 	b.name = name
-	b.config = serviceenv.NewConfiguration(config)
+	b.config = pachconfig.NewConfiguration(config)
 	b.txnEnv = transactionenv.New()
 	return
 }
@@ -401,7 +402,7 @@ func (b *builder) initPachwController(ctx context.Context) error {
 // setupMemoryLimit sets GOMEMLIMIT.  If not already set through the environment, set GOMEMLIMIT to
 // the container memory request, or if not set, the container memory limit minus some accounting for
 // the runtime (100MiB).
-func setupMemoryLimit(ctx context.Context, config serviceenv.GlobalConfiguration) {
+func setupMemoryLimit(ctx context.Context, config pachconfig.GlobalConfiguration) {
 	if memLimit := debug.SetMemoryLimit(-1); memLimit != math.MaxInt64 {
 		log.Info(ctx, "memlimit: using configured GOMEMLIMIT", zap.String("limit", humanize.IBytes(uint64(memLimit))))
 		return

--- a/src/internal/profileutil/profileutil.go
+++ b/src/internal/profileutil/profileutil.go
@@ -6,7 +6,7 @@ import (
 
 	"cloud.google.com/go/profiler"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/version"
 	"go.uber.org/zap"
 )
@@ -19,7 +19,7 @@ import (
 // Service is the name of this binary (pachd, worker, etc.).
 //
 // If there is a problem starting the cloud profiler, it logs a message but we continue.
-func StartCloudProfiler(ctx context.Context, service string, config *serviceenv.Configuration) {
+func StartCloudProfiler(ctx context.Context, service string, config *pachconfig.Configuration) {
 	if config == nil {
 		log.Error(ctx, "nil configuration passed to StartCloudProfiler; profiling not enabled")
 		return

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
@@ -61,7 +62,7 @@ type ServiceEnv interface {
 	SetEnterpriseServer(enterprise_server.APIServer)
 	SetKubeClient(kube.Interface)
 
-	Config() *Configuration
+	Config() *pachconfig.Configuration
 	GetPachClient(ctx context.Context) *client.APIClient
 	GetEtcdClient() *etcd.Client
 	GetTaskService(string) task.Service
@@ -80,7 +81,7 @@ type ServiceEnv interface {
 // NonblockingServiceEnv is an implementation of ServiceEnv that initializes
 // clients in the background, and blocks in the getters until they're ready.
 type NonblockingServiceEnv struct {
-	config *Configuration
+	config *pachconfig.Configuration
 
 	// pachAddress is the domain name or hostport where pachd can be reached
 	pachAddress string
@@ -155,7 +156,7 @@ func goCtx(eg *errgroup.Group, ctx context.Context, f func(context.Context) erro
 //
 // This call returns immediately, but GetPachClient will block
 // until the client is ready.
-func InitPachOnlyEnv(rctx context.Context, config *Configuration) *NonblockingServiceEnv {
+func InitPachOnlyEnv(rctx context.Context, config *pachconfig.Configuration) *NonblockingServiceEnv {
 	sctx, end := log.SpanContext(rctx, "serviceenv")
 	ctx, cancel := pctx.WithCancel(sctx)
 	env := &NonblockingServiceEnv{config: config, ctx: ctx, cancel: func() { cancel(); end() }}
@@ -170,7 +171,7 @@ func InitPachOnlyEnv(rctx context.Context, config *Configuration) *NonblockingSe
 //
 // This call returns immediately, but GetPachClient and GetEtcdClient block
 // until their respective clients are ready.
-func InitServiceEnv(ctx context.Context, config *Configuration) *NonblockingServiceEnv {
+func InitServiceEnv(ctx context.Context, config *pachconfig.Configuration) *NonblockingServiceEnv {
 	env := InitPachOnlyEnv(ctx, config)
 	env.etcdAddress = fmt.Sprintf("http://%s", net.JoinHostPort(env.config.EtcdHost, env.config.EtcdPort))
 	goCtx(&env.etcdEg, env.ctx, env.initEtcdClient)
@@ -190,13 +191,13 @@ func InitServiceEnv(ctx context.Context, config *Configuration) *NonblockingServ
 
 // InitWithKube is like InitNonblockingServiceEnv, but also assumes that it's run inside
 // a kubernetes cluster and tries to connect to the kubernetes API server.
-func InitWithKube(ctx context.Context, config *Configuration) *NonblockingServiceEnv {
+func InitWithKube(ctx context.Context, config *pachconfig.Configuration) *NonblockingServiceEnv {
 	env := InitServiceEnv(ctx, config)
 	goCtx(&env.kubeEg, env.ctx, env.initKubeClient)
 	return env // env is not ready yet
 }
 
-func (env *NonblockingServiceEnv) Config() *Configuration {
+func (env *NonblockingServiceEnv) Config() *pachconfig.Configuration {
 	return env.config
 }
 

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	auth_server "github.com/pachyderm/pachyderm/v2/src/server/auth"
@@ -24,7 +25,7 @@ import (
 // TestServiceEnv is a simple implementation of ServiceEnv that can be constructed with
 // existing clients.
 type TestServiceEnv struct {
-	Configuration            *Configuration
+	Configuration            *pachconfig.Configuration
 	PachClient               *client.APIClient
 	EtcdClient               *etcd.Client
 	KubeClient               kube.Interface
@@ -55,7 +56,7 @@ type TestServiceEnv struct {
 	Ready chan interface{}
 }
 
-func (s *TestServiceEnv) Config() *Configuration {
+func (s *TestServiceEnv) Config() *pachconfig.Configuration {
 	return s.Configuration
 }
 

--- a/src/internal/storage/chunk/option.go
+++ b/src/internal/storage/chunk/option.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 )
 
@@ -42,7 +42,7 @@ func WithCompression(algo CompressionAlgo) StorageOption {
 }
 
 // StorageOptions returns the chunk storage options for the config.
-func StorageOptions(conf *serviceenv.StorageConfiguration) ([]StorageOption, error) {
+func StorageOptions(conf *pachconfig.StorageConfiguration) ([]StorageOption, error) {
 	var opts []StorageOption
 	if conf.StorageUploadConcurrencyLimit > 0 {
 		opts = append(opts, WithMaxConcurrentObjects(0, conf.StorageUploadConcurrencyLimit))

--- a/src/internal/storage/config.go
+++ b/src/internal/storage/config.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+)
+
+// MakeChunkOptions returns the chunk storage options for the config.
+func makeChunkOptions(conf *pachconfig.StorageConfiguration) ([]chunk.StorageOption, error) {
+	var opts []chunk.StorageOption
+	if conf.StorageUploadConcurrencyLimit > 0 {
+		opts = append(opts, chunk.WithMaxConcurrentObjects(0, conf.StorageUploadConcurrencyLimit))
+	}
+	if conf.StorageDiskCacheSize > 0 {
+		p := filepath.Join(os.TempDir(), "pfs-cache", uuid.NewWithoutDashes())
+		diskCache, err := obj.NewLocalClient(p)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, chunk.WithObjectCache(diskCache, conf.StorageDiskCacheSize))
+	}
+	return opts, nil
+}
+
+func makeFilesetOptions(conf *pachconfig.StorageConfiguration) []fileset.StorageOption {
+	var opts []fileset.StorageOption
+	if conf.StorageMemoryThreshold > 0 {
+		opts = append(opts, fileset.WithMemoryThreshold(conf.StorageMemoryThreshold))
+	}
+	if conf.StorageCompactionShardSizeThreshold > 0 {
+		opts = append(opts, fileset.WithShardSizeThreshold(conf.StorageCompactionShardSizeThreshold))
+	}
+	if conf.StorageCompactionShardCountThreshold > 0 {
+		opts = append(opts, fileset.WithShardCountThreshold(conf.StorageCompactionShardCountThreshold))
+	}
+	if conf.StorageLevelFactor > 0 {
+		opts = append(opts, fileset.WithLevelFactor(conf.StorageLevelFactor))
+	}
+	return opts
+}

--- a/src/internal/storage/fileset/option.go
+++ b/src/internal/storage/fileset/option.go
@@ -3,9 +3,8 @@ package fileset
 import (
 	"time"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 )
 
 // StorageOption configures a storage.
@@ -96,7 +95,7 @@ func WithTTL(ttl time.Duration) WriterOption {
 }
 
 // StorageOptions returns the fileset storage options for the config.
-func StorageOptions(conf *serviceenv.StorageConfiguration) []StorageOption {
+func StorageOptions(conf *pachconfig.StorageConfiguration) []StorageOption {
 	var opts []StorageOption
 	if conf.StorageMemoryThreshold > 0 {
 		opts = append(opts, WithMemoryThreshold(conf.StorageMemoryThreshold))

--- a/src/internal/storage/server.go
+++ b/src/internal/storage/server.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/chunk"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
+	"go.uber.org/zap"
+)
+
+type Env struct {
+	DB          *pachsql.DB
+	ObjectStore obj.Client
+}
+
+// Server contains the storage layer servers.
+// Eventually this will be it's own gRPC server.
+type Server struct {
+	Filesets *fileset.Storage
+	Chunks   *chunk.Storage
+	Tracker  track.Tracker
+}
+
+// New creates a new Server
+func New(env Env, config pachconfig.StorageConfiguration) (*Server, error) {
+	// Setup tracker and chunk / fileset storage.
+	tracker := track.NewPostgresTracker(env.DB)
+	chunkStorageOpts, err := makeChunkOptions(&config)
+	if err != nil {
+		return nil, err
+	}
+	memCache := config.ChunkMemoryCache()
+	keyStore := chunk.NewPostgresKeyStore(env.DB)
+	secret, err := getOrCreateKey(context.TODO(), keyStore, "default")
+	if err != nil {
+		return nil, err
+	}
+	chunkStorageOpts = append(chunkStorageOpts, chunk.WithSecret(secret))
+	chunkStorage := chunk.NewStorage(env.ObjectStore, memCache, env.DB, tracker, chunkStorageOpts...)
+	filesetStorage := fileset.NewStorage(fileset.NewPostgresStore(env.DB), tracker, chunkStorage, makeFilesetOptions(&config)...)
+
+	return &Server{
+		Filesets: filesetStorage,
+		Chunks:   chunkStorage,
+		Tracker:  tracker,
+	}, nil
+}
+
+func getOrCreateKey(ctx context.Context, keyStore chunk.KeyStore, name string) ([]byte, error) {
+	secret, err := keyStore.Get(ctx, name)
+	if !errors.Is(err, sql.ErrNoRows) {
+		return secret, errors.EnsureStack(err)
+	}
+	secret = make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	log.Info(ctx, "generated new secret", zap.String("name", name))
+	if err := keyStore.Create(ctx, name, secret); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	res, err := keyStore.Get(ctx, name)
+	return res, errors.EnsureStack(err)
+}

--- a/src/internal/storage/server_test.go
+++ b/src/internal/storage/server_test.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
+	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
+)
+
+func TestServer(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	db := dockertestenv.NewTestDB(t)
+	objC := dockertestenv.NewTestObjClient(ctx, t)
+
+	tracker := track.NewTestTracker(t, db)
+	fileset.NewTestStorage(ctx, t, db, tracker)
+
+	var config pachconfig.StorageConfiguration
+	s, err := New(Env{
+		DB:          db,
+		ObjectStore: objC,
+	}, config)
+	require.NoError(t, err)
+
+	w := s.Filesets.NewWriter(ctx)
+	w.Add("test.txt", "", strings.NewReader("hello world"))
+	id, err := w.Close()
+	require.NoError(t, err)
+	t.Log(id)
+}

--- a/src/internal/testutil/local/pachd.go
+++ b/src/internal/testutil/local/pachd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	errorsmw "github.com/pachyderm/pachyderm/v2/src/internal/middleware/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tls"
@@ -57,7 +58,7 @@ func RunLocal() (retErr error) {
 	log.InitPachctlLogger()
 	ctx := pctx.Background("local")
 
-	config := &serviceenv.PachdFullConfiguration{}
+	config := &pachconfig.PachdFullConfiguration{}
 	if err := cmdutil.Populate(config); err != nil {
 		return err
 	}
@@ -77,7 +78,7 @@ func RunLocal() (retErr error) {
 	} else {
 		log.Debug(ctx, "no Jaeger collector found (JAEGER_COLLECTOR_SERVICE_HOST not set)")
 	}
-	env := serviceenv.InitWithKube(ctx, serviceenv.NewConfiguration(config))
+	env := serviceenv.InitWithKube(ctx, pachconfig.NewConfiguration(config))
 	debug.SetGCPercent(env.Config().GCPercent)
 	env.InitDexDB()
 	if env.Config().EtcdPrefix == "" {

--- a/src/server/admin/server/api_server.go
+++ b/src/server/admin/server/api_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pachyderm/pachyderm/v2/src/admin"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/version"
 	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
@@ -17,7 +18,7 @@ import (
 // Env is the set of dependencies required by an APIServer
 type Env struct {
 	ClusterID string
-	Config    *serviceenv.Configuration
+	Config    *pachconfig.Configuration
 }
 
 func EnvFromServiceEnv(senv serviceenv.ServiceEnv) Env {

--- a/src/server/auth/server/env.go
+++ b/src/server/auth/server/env.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/identity"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -29,7 +30,7 @@ type Env struct {
 	GetPpsServer        func() pps.APIServer
 
 	BackgroundContext context.Context
-	Config            serviceenv.Configuration
+	Config            pachconfig.Configuration
 }
 
 func EnvFromServiceEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) Env {

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/proc"
@@ -42,7 +43,7 @@ func main() {
 
 	switch {
 	case readiness:
-		cmdutil.Main(ctx, doReadinessCheck, &serviceenv.GlobalConfiguration{})
+		cmdutil.Main(ctx, doReadinessCheck, &pachconfig.GlobalConfiguration{})
 	case mode == "full", mode == "", mode == "$(MODE)":
 		// Because of the way Kubernetes environment substitution works,
 		// a reference to an unset variable is not replaced with the
@@ -50,18 +51,18 @@ func main() {
 		// because of this, '$(MODE)' should be recognized as an unset —
 		// i.e., default — mode.
 		logMode("full")
-		cmdutil.Main(ctx, pachd.FullMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, pachd.FullMode, &pachconfig.PachdFullConfiguration{})
 	case mode == "enterprise":
 		logMode("enterprise")
-		cmdutil.Main(ctx, pachd.EnterpriseMode, &serviceenv.EnterpriseServerConfiguration{})
+		cmdutil.Main(ctx, pachd.EnterpriseMode, &pachconfig.EnterpriseServerConfiguration{})
 	case mode == "sidecar":
 		logMode("sidecar")
-		cmdutil.Main(ctx, pachd.SidecarMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, pachd.SidecarMode, &pachconfig.PachdFullConfiguration{})
 	case mode == "pachw":
-		cmdutil.Main(ctx, pachd.PachwMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, pachd.PachwMode, &pachconfig.PachdFullConfiguration{})
 	case mode == "paused":
 		logMode("paused")
-		cmdutil.Main(ctx, pachd.PausedMode, &serviceenv.PachdFullConfiguration{})
+		cmdutil.Main(ctx, pachd.PausedMode, &pachconfig.PachdFullConfiguration{})
 	default:
 		log.Error(ctx, "pachd: unrecognized mode", zap.String("mode", mode))
 		fmt.Printf("unrecognized mode: %s\n", mode)
@@ -69,6 +70,6 @@ func main() {
 }
 
 func doReadinessCheck(ctx context.Context, config interface{}) error {
-	env := serviceenv.InitPachOnlyEnv(ctx, serviceenv.NewConfiguration(config))
+	env := serviceenv.InitPachOnlyEnv(ctx, pachconfig.NewConfiguration(config))
 	return env.GetPachClient(ctx).Health()
 }

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/logging"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/proc"
@@ -41,13 +42,13 @@ func main() {
 
 	// append pachyderm bins to path to allow use of pachctl
 	os.Setenv("PATH", os.Getenv("PATH")+":/pach-bin")
-	cmdutil.Main(ctx, do, &serviceenv.WorkerFullConfiguration{})
+	cmdutil.Main(ctx, do, &pachconfig.WorkerFullConfiguration{})
 }
 
 func do(ctx context.Context, config interface{}) error {
 	// must run InstallJaegerTracer before InitWithKube/pach client initialization
 	tracing.InstallJaegerTracerFromEnv()
-	env := serviceenv.InitWithKube(ctx, serviceenv.NewConfiguration(config))
+	env := serviceenv.InitWithKube(ctx, pachconfig.NewConfiguration(config))
 
 	// Enable cloud profilers if the configuration allows.
 	profileutil.StartCloudProfiler(ctx, "pachyderm-worker", env.Config())

--- a/src/server/debug/server/log_test.go
+++ b/src/server/debug/server/log_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/api/core/v1"
@@ -133,8 +134,8 @@ func TestSetLogLevel(t *testing.T) {
 							},
 						},
 					),
-					Configuration: &serviceenv.Configuration{
-						GlobalConfiguration: &serviceenv.GlobalConfiguration{
+					Configuration: &pachconfig.Configuration{
+						GlobalConfiguration: &pachconfig.GlobalConfiguration{
 							Port:     1650,
 							PeerPort: 1653,
 						},

--- a/src/server/debug/server/server_test.go
+++ b/src/server/debug/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tarutil"
@@ -493,8 +494,8 @@ metadata:
 					Type: "helm.sh/release.v2",
 				},
 			),
-			Configuration: &serviceenv.Configuration{
-				GlobalConfiguration: &serviceenv.GlobalConfiguration{
+			Configuration: &pachconfig.Configuration{
+				GlobalConfiguration: &pachconfig.GlobalConfiguration{
 					Namespace: "default",
 				},
 			},

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
@@ -32,7 +33,7 @@ type Env struct {
 	namespace         string
 	mode              PauseMode
 	unpausedMode      string
-	Config            serviceenv.Configuration
+	Config            pachconfig.Configuration
 }
 
 // PauseMode represents whether a server is unpaused, paused, a sidecar or an enterprise server.

--- a/src/server/identity/server/dex_web_test.go
+++ b/src/server/identity/server/dex_web_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -31,7 +32,7 @@ func getTestEnv(t *testing.T) serviceenv.ServiceEnv {
 		DBClient:      dockertestenv.NewTestDB(t),
 		DexDB:         dex_memory.New(log.NewLogrus(ctx)),
 		EtcdClient:    testetcd.NewEnv(ctx, t).EtcdClient,
-		Configuration: serviceenv.NewConfiguration(&serviceenv.PachdFullConfiguration{}),
+		Configuration: pachconfig.NewConfiguration(&pachconfig.PachdFullConfiguration{}),
 		Ctx:           ctx,
 	}
 	require.NoError(t, migrations.ApplyMigrations(ctx, env.GetDBClient(), migrations.MakeEnv(nil, env.GetEtcdClient()), clusterstate.DesiredClusterState))

--- a/src/server/identity/server/env.go
+++ b/src/server/identity/server/env.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/dexidp/dex/storage"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -13,7 +14,7 @@ import (
 type Env struct {
 	DB                *pachsql.DB
 	DexStorage        storage.Storage
-	Config            *serviceenv.Configuration
+	Config            *pachconfig.Configuration
 	BackgroundContext context.Context
 }
 

--- a/src/server/license/server/env.go
+++ b/src/server/license/server/env.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/server/enterprise"
@@ -11,7 +12,7 @@ import (
 type Env struct {
 	DB               *pachsql.DB
 	Listener         collection.PostgresListener
-	Config           *serviceenv.Configuration
+	Config           *pachconfig.Configuration
 	EnterpriseServer enterprise.APIServer
 }
 

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
@@ -35,7 +36,7 @@ type Env struct {
 	GetPachClient func(ctx context.Context) *client.APIClient
 
 	BackgroundContext context.Context
-	StorageConfig     serviceenv.StorageConfiguration
+	StorageConfig     pachconfig.StorageConfiguration
 	PachwInSidecar    bool
 }
 

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -41,11 +41,11 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tarutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
@@ -7085,7 +7085,7 @@ func TestPFS(suite *testing.T) {
 	suite.Run("Compaction", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, func(config *serviceenv.Configuration) {
+		env := realenv.NewRealEnv(ctx, t, func(config *pachconfig.Configuration) {
 			config.StorageCompactionMaxFanIn = 10
 		}, dockertestenv.NewTestDBConfig(t))
 

--- a/src/server/pps/server/kube_driver.go
+++ b/src/server/pps/server/kube_driver.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/limit"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing"
 )
 
@@ -26,11 +26,11 @@ type kubeDriver struct {
 	// the limiter intends to guard the k8s API server from being overwhelmed by many concurrent requests
 	// that could arise from many concurrent pipelineController goros.
 	limiter    limit.ConcurrencyLimiter
-	config     serviceenv.Configuration
+	config     pachconfig.Configuration
 	etcdPrefix string
 }
 
-func newKubeDriver(kubeClient kubernetes.Interface, config serviceenv.Configuration) InfraDriver {
+func newKubeDriver(kubeClient kubernetes.Interface, config pachconfig.Configuration) InfraDriver {
 	return &kubeDriver{
 		kubeClient: kubeClient,
 		namespace:  config.Namespace,

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
@@ -37,7 +37,7 @@ func ppsMasterHandles(t *testing.T) (*mockStateDriver, *mockInfraDriver, *testpa
 		GetPachClient: func(ctx context.Context) *client.APIClient {
 			return mockEnv.PachClient.WithCtx(ctx)
 		},
-		Config:      *serviceenv.ConfigFromOptions(),
+		Config:      *pachconfig.ConfigFromOptions(),
 		TaskService: nil,
 		DB:          nil,
 		KubeClient:  nil,

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
@@ -43,7 +44,7 @@ type Env struct {
 
 	Reporter          *metrics.Reporter
 	BackgroundContext context.Context
-	Config            serviceenv.Configuration
+	Config            pachconfig.Configuration
 	PachwInSidecar    bool
 }
 

--- a/src/server/pps/server/worker_rc_test.go
+++ b/src/server/pps/server/worker_rc_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	v1 "k8s.io/api/core/v1"
@@ -233,18 +233,18 @@ func TestGetWorkerOptions(t *testing.T) {
 	// Build a fake kubedriver.
 	kd := &kubeDriver{
 		namespace: "test",
-		config: serviceenv.Configuration{
+		config: pachconfig.Configuration{
 			// Some of these values end up in mergeDefaultOptions above.
-			GlobalConfiguration: &serviceenv.GlobalConfiguration{
+			GlobalConfiguration: &pachconfig.GlobalConfiguration{
 				PipelineDefaultCPURequest:     resource.MustParse("1"),
 				PipelineDefaultMemoryRequest:  resource.MustParse("100M"),
 				PipelineDefaultStorageRequest: resource.MustParse("100M"),
 			},
-			PachdSpecificConfiguration: &serviceenv.PachdSpecificConfiguration{
+			PachdSpecificConfiguration: &pachconfig.PachdSpecificConfiguration{
 				PachdPodName: "pachd",
 			},
-			WorkerSpecificConfiguration:     &serviceenv.WorkerSpecificConfiguration{},
-			EnterpriseSpecificConfiguration: &serviceenv.EnterpriseSpecificConfiguration{},
+			WorkerSpecificConfiguration:     &pachconfig.WorkerSpecificConfiguration{},
+			EnterpriseSpecificConfiguration: &pachconfig.EnterpriseSpecificConfiguration{},
 		},
 		kubeClient: fake.NewSimpleClientset(&v1.Pod{
 			// Minimal pachd pod for some introspection that happens.

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/tarutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -30,7 +30,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
-func setupPachAndWorker(ctx context.Context, t *testing.T, dbConfig serviceenv.ConfigOption, pipelineInfo *pps.PipelineInfo) *testEnv {
+func setupPachAndWorker(ctx context.Context, t *testing.T, dbConfig pachconfig.ConfigOption, pipelineInfo *pps.PipelineInfo) *testEnv {
 	// We only support simple pfs input pipelines in this test suite at the moment
 	require.NotNil(t, pipelineInfo.Details.Input)
 	require.NotNil(t, pipelineInfo.Details.Input.Pfs)


### PR DESCRIPTION
The package dockertestenv should be very close to the bottom of the dependency graph, and available for import in basically every package. However, it's not, because it generates ConfigOptions for the databases it manages. Those ConfigOptions live in serviceenv, which creates a cycle. By moving the configuration portion of serviceenv out into pachconfig, we remove it as a dependency of dockertestenv.