### PR TITLE
python sdk - update datum batching ci to build docker image and run tests from it

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1394,6 +1394,52 @@ jobs:
           command: |
             stable=$(if [[ "$CIRCLE_TAG" == *"-"* ]]; then echo 0; else echo 1; fi;)
             ./etc/build/update_homebrew.sh ${CIRCLE_TAG:1} ${stable}
+  python-sdk-build:
+    executor: python
+    working_directory: ~/project/python-sdk
+    steps:
+      - checkout:
+          path: ~/project
+      - setup_remote_docker:
+          version: 19.03.13
+      - run:
+          name: Install Poetry
+          command: |
+            mkdir -p /home/circleci/.local/poetry/venv
+            export POETRY_HOME=/home/circleci/.local/poetry/venv
+            python3 -m venv $POETRY_HOME
+            $POETRY_HOME/bin/pip install poetry==1.4.1
+            $POETRY_HOME/bin/poetry --version
+            ln -s $POETRY_HOME/bin/poetry /home/circleci/bin/poetry
+      - run: #Note: --no-ansi https://github.com/python-poetry/poetry/issues/7184
+          name: Install Python Dependencies with Poetry
+          command: poetry --no-ansi install
+      - run:
+          name: build
+          command: poetry build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist/*
+  python-sdk-testing-docker-build:
+    executor: python
+    working_directory: ~/project/python-sdk
+    steps:
+     - checkout:
+         path: ~/project
+     - attach_workspace:
+         at: .
+     - setup_remote_docker:
+         version: 19.03.13
+     - run:
+         name: docker login
+         command: echo "$DOCKER_PWD" | docker login --username pachydermbuildbot --password-stdin
+     - run:
+         name: docker build
+         command: docker build -t pachyderm/python-sdk-ci-testing:$CIRCLE_SHA1 .
+     - run:
+         name: docker push
+         command: docker push pachyderm/python-sdk-ci-testing:$CIRCLE_SHA1
   test-python-sdk:
     resource_class: xlarge
     machine:
@@ -1422,7 +1468,7 @@ jobs:
           name: Run Tests
           command: |
             nohup pachctl port-forward &
-            poetry run pytest -vvv tests
+            PYTHON_SDK_TESTING_IMAGE=pachyderm/python-sdk-ci-testing:$CIRCLE_SHA1 poetry run pytest -vvv tests
 
 workflows:
   integration-tests:
@@ -1629,7 +1675,12 @@ workflows:
           requires:
             - build-docker-images
             - build-pachctl-bin
+            - python-sdk-testing-docker-build
       - build-docker-images
+      - python-sdk-build
+      - python-sdk-testing-docker-build:
+          requires:
+            - python-sdk-build
       - build-pachctl-bin:
           version: $CIRCLE_SHA1
 

--- a/python-sdk/.dockerignore
+++ b/python-sdk/.dockerignore
@@ -3,3 +3,4 @@
 
 # Allow specified files and directories.
 !entrypoint.sh
+!dist

--- a/python-sdk/Dockerfile
+++ b/python-sdk/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.8-slim
 RUN python3 -m pip install 'grpcio-tools==1.51.3'
 RUN python3 -m pip install 'betterproto[compiler] @ https://github.com/pachyderm/python-betterproto/releases/download/v2.0.0b5%2Bpachv1.0.1/betterproto-2.0.0b5+pachv1.0.1-py3-none-any.whl'
 
+COPY dist dist
+RUN python3 -m pip install `find dist/ -name \*.whl`
 COPY entrypoint.sh /bin
 ENTRYPOINT ["/bin/entrypoint.sh"]
 WORKDIR /work

--- a/python-sdk/Makefile
+++ b/python-sdk/Makefile
@@ -1,6 +1,7 @@
 
 test:
-	poetry run pytest -vvv tests
+	docker build . -t pachyderm/python-sdk-ci-testing:${USER}-local
+	PYTHON_SDK_TESTING_IMAGE=pachyderm/python-sdk-ci-testing:${USER}-local poetry run pytest -vvv tests/test_worker.py
 
 .PHONY: \
 	test

--- a/python-sdk/tests/test_worker.py
+++ b/python-sdk/tests/test_worker.py
@@ -1,4 +1,5 @@
 import io
+import os
 from typing import Callable
 
 from tests.fixtures import *
@@ -6,7 +7,7 @@ from tests.utils import count
 
 from pachyderm_sdk.api import pfs, pps
 
-IMAGE_NAME = "bonenfan5ben/datum_batching:0037"  # TODO: Don't do this.
+IMAGE_NAME = os.environ.get("PYTHON_SDK_TESTING_IMAGE")
 
 
 def generate_stdin(func: Callable[[], None]):


### PR DESCRIPTION
this change updates ci so that it builds and publishes an image on which the datum batching tests can be run, and runs those tests from it.

Jira: [INT-988]

[INT-988]: https://pachyderm.atlassian.net/browse/INT-988