### PR TITLE
[CORE-1765] Eliminate double slashes (#8935)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ parameters:
     default: ""
   go-version:
     type: string
-    default: "1.20.2"
+    default: "1.20.5"
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -36,7 +36,7 @@ parameters:
     default: ubuntu-2204:2022.10.1
   go-version:
     type: string
-    default: "1.20.4"
+    default: "1.20.5"
   go-releaser-version:
     type: string
     default: "1.17.1"

--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.4
+ARG GOVERSION=golang:1.20.5
 FROM $GOVERSION
 
 LABEL maintainer="msteffen@pachyderm.io"

--- a/etc/testing/kafka/Dockerfile
+++ b/etc/testing/kafka/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.4
+ARG GOVERSION=golang:1.20.5
 FROM $GOVERSION
 WORKDIR /app
 ADD . /app/

--- a/etc/testing/spout/Dockerfile
+++ b/etc/testing/spout/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.4
+ARG GOVERSION=golang:1.20.5
 FROM $GOVERSION
 RUN mkdir /app
 ADD . /app/

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2102,10 +2102,10 @@ func TestPutFileURL(t *testing.T) {
 		require.NoError(t, bucket.WriteAll(ctx, path, []byte(path), nil))
 	}
 	for _, p := range paths {
-		objURL := url + "/" + p
+		objURL := url + p
 		require.NoError(t, aliceClient.PutFileURL(commit, p, objURL, false))
 	}
-	srcURL := url + "/files"
+	srcURL := url + "files"
 	require.NoError(t, aliceClient.PutFileURL(commit, "recursive", srcURL, true))
 	check := func() {
 		cis, err := aliceClient.ListCommit(client.NewProjectRepo(pfs.DefaultProjectName, repo), nil, nil, 0)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5816,10 +5816,10 @@ func TestPFS(suite *testing.T) {
 			require.NoError(t, bucket.WriteAll(ctx, path, []byte(path), nil))
 		}
 		for _, p := range paths {
-			objURL := url + "/" + p
+			objURL := url + p
 			require.NoError(t, env.PachClient.PutFileURL(commit, p, objURL, false))
 		}
-		srcURL := url + "/files"
+		srcURL := url + "files"
 		require.NoError(t, env.PachClient.PutFileURL(commit, "recursive", srcURL, true))
 		check := func() {
 			cis, err := env.PachClient.ListCommit(client.NewProjectRepo(pfs.DefaultProjectName, repo), nil, nil, 0)


### PR DESCRIPTION
* Eliminate double slashes in test URL paths. This fixes some tests CircleCI had marked as flakey.