### PR TITLE
txncontext: remove captured context.Context

### DIFF
--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
@@ -47,8 +46,6 @@ type TransactionContext struct {
 	// is checked by isActiveInTransaction.  Other transactions cannot observe this uncommitted
 	// state.
 	AuthBeingActivated atomic.Bool
-
-	ctx context.Context
 }
 
 type identifier interface {
@@ -75,19 +72,11 @@ func New(ctx context.Context, sqlTx *pachsql.Tx, authServer identifier) (*Transa
 		return nil, errors.Wrapf(err, "error getting transaction timestamp")
 	}
 	return &TransactionContext{
-		ctx:         ctx, // TODO(jonathan): Refactor this API to not capture a context.
 		SqlTx:       sqlTx,
 		CommitSetID: uuid.NewWithoutDashes(),
 		Timestamp:   ts,
 		username:    username,
 	}, nil
-}
-
-func (t *TransactionContext) Context() context.Context {
-	if t.ctx == nil {
-		return pctx.TODO()
-	}
-	return t.ctx
 }
 
 func (t *TransactionContext) WhoAmI() (*auth.WhoAmIResponse, error) {


### PR DESCRIPTION
This appears simpler than I thought; the code is simply not used currently, probably from past cleanups.