### PR TITLE
stream: make EOS a function instead of var, include stack trace

### DIFF
--- a/src/internal/grpcutil/iter.go
+++ b/src/internal/grpcutil/iter.go
@@ -28,7 +28,7 @@ func (it iterator[T]) Next(ctx context.Context, dst *T) error {
 	x, err := it.cs.Recv()
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			err = stream.EOS
+			err = stream.EOS()
 		}
 		return err
 	}

--- a/src/internal/stream/from_foreach.go
+++ b/src/internal/stream/from_foreach.go
@@ -45,7 +45,7 @@ func (i *forEach[T]) Next(ctx context.Context, dst *T) error {
 	select {
 	case data, more := <-i.dataChan:
 		if !more {
-			return EOS
+			return EOS()
 		}
 		i.copy(dst, &data)
 		return nil

--- a/src/internal/stream/iterator.go
+++ b/src/internal/stream/iterator.go
@@ -6,11 +6,20 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 )
 
-// EOS signals the end of the stream
-var EOS = errors.New("end of stream")
+type ErrEndOfStream struct{}
 
+func (e ErrEndOfStream) Error() string {
+	return "end of stream"
+}
+
+// EOS returns a new end of stream error
+func EOS() error {
+	return errors.EnsureStack(ErrEndOfStream{})
+}
+
+// IsEOS returns true if the error is an end of stream error.
 func IsEOS(err error) bool {
-	return errors.Is(err, EOS)
+	return errors.As(err, &ErrEndOfStream{})
 }
 
 type Iterator[T any] interface {
@@ -45,7 +54,7 @@ func ForEach[T any](ctx context.Context, it Iterator[T], fn func(t T) error) err
 	var x T
 	for {
 		if err := it.Next(ctx, &x); err != nil {
-			if errors.Is(err, EOS) {
+			if IsEOS(err) {
 				return nil
 			}
 			return err
@@ -104,7 +113,7 @@ func NewSlice[T any](xs []T) *Slice[T] {
 
 func (s *Slice[T]) Next(ctx context.Context, dst *T) error {
 	if s.pos >= len(s.xs) {
-		return errors.EnsureStack(EOS)
+		return EOS()
 	}
 	*dst = s.xs[s.pos]
 	s.pos++
@@ -113,7 +122,7 @@ func (s *Slice[T]) Next(ctx context.Context, dst *T) error {
 
 func (s *Slice[T]) Peek(ctx context.Context, dst *T) error {
 	if s.pos >= len(s.xs) {
-		return errors.EnsureStack(EOS)
+		return EOS()
 	}
 	*dst = s.xs[s.pos]
 	return nil

--- a/src/internal/stream/iterator.go
+++ b/src/internal/stream/iterator.go
@@ -6,20 +6,20 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 )
 
-type ErrEndOfStream struct{}
+type errEndOfStream struct{}
 
-func (e ErrEndOfStream) Error() string {
+func (e errEndOfStream) Error() string {
 	return "end of stream"
 }
 
 // EOS returns a new end of stream error
 func EOS() error {
-	return errors.EnsureStack(ErrEndOfStream{})
+	return errors.EnsureStack(errEndOfStream{})
 }
 
 // IsEOS returns true if the error is an end of stream error.
 func IsEOS(err error) bool {
-	return errors.As(err, &ErrEndOfStream{})
+	return errors.Is(err, &errEndOfStream{})
 }
 
 type Iterator[T any] interface {

--- a/src/internal/stream/merger.go
+++ b/src/internal/stream/merger.go
@@ -77,7 +77,7 @@ func (m *Merger[T]) Next(ctx context.Context, dst *Merged[T]) error {
 	// read into dst
 	me, exists := m.heap.Pop()
 	if !exists {
-		return EOS
+		return EOS()
 	}
 	dst.Indexes = append(dst.Indexes, me.index)
 	if err := appendNext[T](ctx, me.it, &dst.Values); err != nil {


### PR DESCRIPTION
This will add stack traces, so if the end of stream is unexpected, it will be easier to diagnose the problem.