### PR TITLE
storage/kv: add kv.BucketStore for Go CDK blob.Buckets

### DIFF
--- a/src/internal/obj/key_iterator.go
+++ b/src/internal/obj/key_iterator.go
@@ -1,0 +1,31 @@
+package obj
+
+import (
+	"context"
+	"io"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+	"gocloud.dev/blob"
+)
+
+type keyIterator struct {
+	it blob.ListIterator
+}
+
+// NewKeyIterator iterates over the keys in a blob.Bucket.
+func NewKeyIterator(b *blob.Bucket, prefix string) stream.Iterator[string] {
+	return &keyIterator{it: *b.List(&blob.ListOptions{Prefix: prefix})}
+}
+
+func (it *keyIterator) Next(ctx context.Context, dst *string) error {
+	lo, err := it.it.Next(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return stream.EOS()
+		}
+		return err
+	}
+	*dst = lo.Key
+	return nil
+}

--- a/src/internal/obj/key_iterator.go
+++ b/src/internal/obj/key_iterator.go
@@ -24,7 +24,7 @@ func (it *keyIterator) Next(ctx context.Context, dst *string) error {
 		if errors.Is(err, io.EOF) {
 			return stream.EOS()
 		}
-		return err
+		return errors.EnsureStack(err)
 	}
 	*dst = lo.Key
 	return nil

--- a/src/internal/storage/kv/kv_test.go
+++ b/src/internal/storage/kv/kv_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+	"gocloud.dev/blob/fileblob"
 )
 
 func TestMemStore(t *testing.T) {
@@ -37,5 +38,13 @@ func TestObjectClient(t *testing.T) {
 		c, err := obj.NewLocalClient(t.TempDir())
 		require.NoError(t, err)
 		return NewFromObjectClient(c, 1024, 1<<20)
+	})
+}
+
+func TestBucket(t *testing.T) {
+	TestStore(t, func(t testing.TB) Store {
+		b, err := fileblob.OpenBucket(t.TempDir(), &fileblob.Options{})
+		require.NoError(t, err)
+		return NewFromBucket(b, 1034, 1<<20)
 	})
 }

--- a/src/internal/storage/kv/kv_test.go
+++ b/src/internal/storage/kv/kv_test.go
@@ -45,6 +45,6 @@ func TestBucket(t *testing.T) {
 	TestStore(t, func(t testing.TB) Store {
 		b, err := fileblob.OpenBucket(t.TempDir(), &fileblob.Options{})
 		require.NoError(t, err)
-		return NewFromBucket(b, 1034, 1<<20)
+		return NewFromBucket(b, 1024, 1<<20)
 	})
 }

--- a/src/internal/storage/kv/obj_adapter2.go
+++ b/src/internal/storage/kv/obj_adapter2.go
@@ -71,7 +71,6 @@ func (s *BucketStore) Delete(ctx context.Context, key []byte) error {
 }
 
 func (s *BucketStore) Exists(ctx context.Context, key []byte) (bool, error) {
-	return s.b.Exists(ctx, string(key))
 	exists, err := s.b.Exists(ctx, string(key))
 	return exists, errors.EnsureStack(err)
 }

--- a/src/internal/storage/kv/obj_adapter2.go
+++ b/src/internal/storage/kv/obj_adapter2.go
@@ -1,0 +1,87 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+	"gocloud.dev/blob"
+)
+
+type ObjectStore2 struct {
+	b                        *blob.Bucket
+	maxKeySize, maxValueSise int
+}
+
+func NewFromBucket(b *blob.Bucket, maxKeySize, maxValueSize int) *ObjectStore2 {
+	return &ObjectStore2{
+		b:            b,
+		maxKeySize:   maxKeySize,
+		maxValueSise: maxValueSize,
+	}
+}
+
+func (s *ObjectStore2) Get(ctx context.Context, key []byte, buf []byte) (int, error) {
+	ctx, cf := context.WithCancel(ctx)
+	defer cf()
+	r, err := s.b.NewReader(ctx, string(key), nil)
+	if err != nil {
+		return 0, err
+	}
+	defer r.Close()
+	return miscutil.ReadInto(buf, r)
+}
+
+func (s *ObjectStore2) Put(ctx context.Context, key []byte, value []byte) (int, error) {
+	// TODO: add checks for keys and values exceeding max size.
+	ctx, cf := context.WithCancel(ctx)
+	defer cf()
+	w, err := s.b.NewWriter(ctx, string(key), &blob.WriterOptions{
+		MaxConcurrency: 1,
+		BufferSize:     s.maxValueSise,
+	})
+	if err != nil {
+		return 0, err
+	}
+	n, err := w.Write(value)
+	if err != nil {
+		return 0, err
+	}
+	return n, w.Close()
+}
+
+func (s *ObjectStore2) Delete(ctx context.Context, key []byte, buf []byte) error {
+	return s.b.Delete(ctx, string(key))
+}
+
+func (s *ObjectStore2) Exists(ctx context.Context, key []byte) (bool, error) {
+	return s.b.Exists(ctx, string(key))
+}
+
+func (s *ObjectStore2) NewKeyIterator(span Span) stream.Iterator[[]byte] {
+	it1 := s.b.List(&blob.ListOptions{})
+	return &objIterator{it: it1, span: span}
+}
+
+type objIterator struct {
+	it   *blob.ListIterator
+	span Span
+}
+
+func (it *objIterator) Next(ctx context.Context, dst *[]byte) error {
+	if it.span.End != nil || it.span.Begin != nil {
+		// TODO: we might be able to do this efficiently by enumerating prefixes in a span.
+		return errors.New("kv.ObjectStore2: span iteration not supported")
+	}
+	x, err := it.it.Next(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return stream.EOS
+		}
+		return err
+	}
+	*dst = append((*dst)[:0], x.Key...)
+	return nil
+}

--- a/src/internal/storage/kv/pool.go
+++ b/src/internal/storage/kv/pool.go
@@ -36,7 +36,7 @@ func (p *Pool) GetF(ctx context.Context, s Getter, key []byte, cb ValueCallback)
 }
 
 func (p *Pool) acquire() *[]byte {
-	return (p.pool.Get().(*[]byte))
+	return p.pool.Get().(*[]byte)
 }
 
 func (p *Pool) release(x *[]byte) {

--- a/src/internal/storage/server_test.go
+++ b/src/internal/storage/server_test.go
@@ -5,25 +5,28 @@ import (
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
 )
 
 func TestServer(t *testing.T) {
 	ctx := pctx.TestContext(t)
 	db := dockertestenv.NewTestDB(t)
-	objC := dockertestenv.NewTestObjClient(ctx, t)
+	b, buckURL := dockertestenv.NewTestBucket(ctx, t)
+	t.Log("bucket", buckURL)
 
 	tracker := track.NewTestTracker(t, db)
 	fileset.NewTestStorage(ctx, t, db, tracker)
 
 	var config pachconfig.StorageConfiguration
 	s, err := New(Env{
-		DB:          db,
-		ObjectStore: objC,
+		DB:     db,
+		Bucket: b,
 	}, config)
 	require.NoError(t, err)
 
@@ -33,7 +36,7 @@ func TestServer(t *testing.T) {
 	require.NoError(t, err)
 	t.Log(id)
 
-	require.NoError(t, objC.Walk(ctx, chunkPrefix, func(k string) error {
+	require.NoError(t, stream.ForEach(ctx, obj.NewKeyIterator(b, ""), func(k string) error {
 		if !strings.HasPrefix(k, chunkPrefix) {
 			t.Errorf("object key %q does not have prefix %q", k, chunkPrefix)
 		}


### PR DESCRIPTION
- Adds adapter from Go CDK's `blob.Bucket` to `kv.Store`.
- Adds Bucket field to `storage.Env`
- Storage server setup now uses the `blob.Bucket` if it is available.  Change storage integration test to use this.