### PR TITLE
Configurable Pachd Probes

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -471,31 +471,31 @@ spec:
             command:
             - /pachd
             - --readiness
-          initialDelaySeconds: {{ .Values.pachd.readinessProbe.initialDelaySeconds | default 0 }}
-          timeoutSeconds: {{ .Values.pachd.readinessProbe.timeoutSeconds | default 1 }}
-          periodSeconds: {{ .Values.pachd.readinessProbe.periodSeconds | default 10 }}
-          successThreshold: {{ .Values.pachd.readinessProbe.successThreshold | default 1 }}
-          failureThreshold: {{ .Values.pachd.readinessProbe.failureThreshold | default 3 }}
+          initialDelaySeconds: {{ .Values.pachd.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.pachd.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.pachd.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pachd.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.pachd.readinessProbe.failureThreshold }}
         livenessProbe:
           exec:
             command:
             - /pachd
             - --readiness
-          initialDelaySeconds: {{ .Values.pachd.livenessProbe.initialDelaySeconds | default 0 }}
-          failureThreshold: {{ .Values.pachd.livenessProbe.failureThreshold | default 10 }}
-          periodSeconds: {{ .Values.pachd.livenessProbe.periodSeconds | default 10 }}
-          successThreshold: {{ .Values.pachd.livenessProbe.successThreshold | default 1 }}
-          timeoutSeconds: {{ .Values.pachd.livenessProbe.timeoutSeconds | default 30 }}
+          initialDelaySeconds: {{ .Values.pachd.livenessProbe.initialDelaySeconds }}
+          failureThreshold: {{ .Values.pachd.livenessProbe.failureThreshold }}
+          periodSeconds: {{ .Values.pachd.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pachd.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pachd.livenessProbe.timeoutSeconds }}
         startupProbe:
           exec:
             command:
             - /pachd
             - --readiness
-          initialDelaySeconds: {{ .Values.pachd.startupProbe.initialDelaySeconds | default 0 }}
-          failureThreshold: {{ .Values.pachd.startupProbe.failureThreshold | default 10 }}
-          periodSeconds: {{ .Values.pachd.startupProbe.periodSeconds | default 10 }}
-          successThreshold: {{ .Values.pachd.startupProbe.successThreshold | default 1 }}
-          timeoutSeconds: {{ .Values.pachd.startupProbe.timeoutSeconds | default 30 }}
+          initialDelaySeconds: {{ .Values.pachd.startupProbe.initialDelaySeconds }}
+          failureThreshold: {{ .Values.pachd.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.pachd.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.pachd.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pachd.startupProbe.timeoutSeconds }}
         {{- if .Values.pachd.resources }}
         resources: {{ toYaml .Values.pachd.resources | nindent 10 }}
         {{- end }}

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -471,20 +471,31 @@ spec:
             command:
             - /pachd
             - --readiness
+          initialDelaySeconds: {{ .Values.pachd.readinessProbe.initialDelaySeconds | default 0 }}
+          timeoutSeconds: {{ .Values.pachd.readinessProbe.timeoutSeconds | default 1 }}
+          periodSeconds: {{ .Values.pachd.readinessProbe.periodSeconds | default 10 }}
+          successThreshold: {{ .Values.pachd.readinessProbe.successThreshold | default 1 }}
+          failureThreshold: {{ .Values.pachd.readinessProbe.failureThreshold | default 3 }}
         livenessProbe:
           exec:
             command:
             - /pachd
             - --readiness
-          failureThreshold: 10
-          timeoutSeconds: 30
+          initialDelaySeconds: {{ .Values.pachd.livenessProbe.initialDelaySeconds | default 0 }}
+          failureThreshold: {{ .Values.pachd.livenessProbe.failureThreshold | default 10 }}
+          periodSeconds: {{ .Values.pachd.livenessProbe.periodSeconds | default 10 }}
+          successThreshold: {{ .Values.pachd.livenessProbe.successThreshold | default 1 }}
+          timeoutSeconds: {{ .Values.pachd.livenessProbe.timeoutSeconds | default 30 }}
         startupProbe:
           exec:
             command:
             - /pachd
             - --readiness
-          failureThreshold: 10
-          timeoutSeconds: 30
+          initialDelaySeconds: {{ .Values.pachd.startupProbe.initialDelaySeconds | default 0 }}
+          failureThreshold: {{ .Values.pachd.startupProbe.failureThreshold | default 10 }}
+          periodSeconds: {{ .Values.pachd.startupProbe.periodSeconds | default 10 }}
+          successThreshold: {{ .Values.pachd.startupProbe.successThreshold | default 1 }}
+          timeoutSeconds: {{ .Values.pachd.startupProbe.timeoutSeconds | default 30 }}
         {{- if .Values.pachd.resources }}
         resources: {{ toYaml .Values.pachd.resources | nindent 10 }}
         {{- end }}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -852,6 +852,26 @@
                         }
                     }
                 },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "localhostIssuer": {
                     "type": "string"
                 },
@@ -918,6 +938,26 @@
                         }
                     }
                 },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "replicas": {
                     "type": "integer"
                 },
@@ -978,6 +1018,26 @@
                 },
                 "sqlQueryLogs": {
                     "type": "boolean"
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
                 },
                 "storage": {
                     "type": "object",

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -721,14 +721,24 @@ pachd:
   # readinessProbe, livenessProbe, startupProbe: Configure the probe settings.
   # Acceptable inputs for each probe include initialDelaySeconds, timeoutSeconds, periodSeconds, successThreshold, and failureThreshold.
   readinessProbe:
-    {}
-    # initialDelaySeconds: 0
-    # timeoutSeconds: 1
-    # periodSeconds: 10
-    # successThreshold: 1
-    # failureThreshold: 3
-  livenessProbe: {}
-  startupProbe: {}
+    initialDelaySeconds: 0
+    timeoutSeconds: 1
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    initialDelaySeconds: 0
+    failureThreshold: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 30
+  startupProbe:
+    initialDelaySeconds: 0
+    failureThreshold: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 30
+
 
 kubeEventTail:
   # Deploys a lightweight app that watches kubernetes events and echos them to logs.

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -739,7 +739,6 @@ pachd:
     successThreshold: 1
     timeoutSeconds: 30
 
-
 kubeEventTail:
   # Deploys a lightweight app that watches kubernetes events and echos them to logs.
   enabled: true

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -718,6 +718,17 @@ pachd:
     # the name of the kubernetes secret containing the credentials for the determined user representing pachyderm.
     # the secret is expected to contain the keys "determined-username" & "determined-password"
     credentialsSecretName: ""
+  # readinessProbe, livenessProbe, startupProbe: Configure the probe settings. 
+  # Acceptable inputs for each probe include initialDelaySeconds, timeoutSeconds, periodSeconds, successThreshold, and failureThreshold.
+    # initialDelaySeconds: 0
+    # timeoutSeconds: 1
+    # periodSeconds: 10
+    # successThreshold: 1
+    # failureThreshold: 3
+  readinessProbe: {}
+  livenessProbe: {}
+  startupProbe: {}
+
 kubeEventTail:
   # Deploys a lightweight app that watches kubernetes events and echos them to logs.
   enabled: true

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -718,14 +718,15 @@ pachd:
     # the name of the kubernetes secret containing the credentials for the determined user representing pachyderm.
     # the secret is expected to contain the keys "determined-username" & "determined-password"
     credentialsSecretName: ""
-  # readinessProbe, livenessProbe, startupProbe: Configure the probe settings. 
+  # readinessProbe, livenessProbe, startupProbe: Configure the probe settings.
   # Acceptable inputs for each probe include initialDelaySeconds, timeoutSeconds, periodSeconds, successThreshold, and failureThreshold.
+  readinessProbe:
+    {}
     # initialDelaySeconds: 0
     # timeoutSeconds: 1
     # periodSeconds: 10
     # successThreshold: 1
     # failureThreshold: 3
-  readinessProbe: {}
   livenessProbe: {}
   startupProbe: {}
 


### PR DESCRIPTION
 I have made changes to the Helm chart to expose the liveness, readiness, and startup probe settings. These settings are now configurable through the `values.yaml` file.

The changes include:
- Adding `readinessProbe`, `livenessProbe`, and `startupProbe` fields under the `pachd` section in the `values.yaml` file.
- Modifying the `deployment.yaml` file to use the values from the `values.yaml` file, or use the current default if a value is not specified.

These changes provide users with the flexibility to customize the probe settings based on their specific needs. This can be particularly useful in environments where the default probe settings may not be suitable, or during longer running upgrades.