### PR TITLE
Record Restart when Worker Master is cancelled

### DIFF
--- a/src/internal/backoff/retry.go
+++ b/src/internal/backoff/retry.go
@@ -121,7 +121,7 @@ func RetryNotify(operation Operation, b BackOff, notify Notify) error {
 }
 
 // RetryUntilCancel is the same as RetryNotify, except that it will not retry if
-// the given context is canceled.
+// the given context is canceled. If the context is cancelled, then notify wll not run.
 func RetryUntilCancel(ctx context.Context, operation Operation, b BackOff, notify Notify) error {
 	var err error
 	var next time.Duration


### PR DESCRIPTION
In the Worker Master, we rely on `RetryUntilCancel` & its `Notify` callback to record job restarts when the job fails. Since `RetryUntilCancel` won't run `Notify` when the context is cancelled, the worker master will restart without recording so