### PR TITLE
[PFS-112] Add additional logging to the provenance migration

### DIFF
--- a/src/internal/clusterstate/v2.6.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.6.0/pfsdb.go
@@ -118,12 +118,13 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 	if oldCIs, err = listCollectionProtos(ctx, tx, "commits", &v2_5_0.CommitInfo{}); err != nil {
 		return errors.Wrap(err, "populate the pfs.commits table")
 	}
-	for _, ci := range oldCIs {
+	for i, ci := range oldCIs {
 		log.Info(ctx, "add old commit to pfs.commits",
 			zap.String("commit", fmt.Sprintf("%s@%s=%s",
 				repoKey(ci.Commit.Branch.Repo),
 				ci.Commit.Branch.GetName(),
 				ci.Commit.Id)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(oldCIs))),
 		)
 		if err := addCommit(ctx, tx, ci.Commit); err != nil {
 			return err
@@ -134,15 +135,17 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 		oldCIMap[oldCommitKey(ci.Commit)] = struct{}{}
 	}
 	deleteCommits := make(map[string]*v2_5_0.CommitInfo)
-	for _, ci := range oldCIs {
+	for i, ci := range oldCIs {
 		log.Info(ctx, "branch provenance for commit",
 			zap.String("commit", oldCommitKey(ci.Commit)),
 			zap.Any("branch provenance", ci.DirectProvenance),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(oldCIs))),
 		)
-		for _, b := range ci.DirectProvenance {
+		for j, b := range ci.DirectProvenance {
 			log.Info(ctx, "add commit provenance",
 				zap.String("from", oldCommitKey(ci.Commit)),
 				zap.String("to", oldCommitKey(b.NewCommit(ci.Commit.Id))),
+				zap.String("progress", fmt.Sprintf("%v/%v", j, len(ci.DirectProvenance))),
 			)
 			// if the provenant commit's repo was deleted, it's reference may
 			// still exist in the old provenance, so we skip mapping it over to the new model
@@ -161,8 +164,11 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 			deleteCommits[oldCommitKey(ci.Commit)] = proto.Clone(ci).(*v2_5_0.CommitInfo)
 		}
 	}
-	for _, ci := range deleteCommits {
-		log.Info(ctx, "validating deleted alias commit", zap.String("commit", oldCommitKey(ci.Commit)))
+	for i, ci := range deleteCommits {
+		log.Info(ctx, "validating deleted alias commit",
+			zap.String("commit", oldCommitKey(ci.Commit)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(deleteCommits))),
+		)
 		same, err := sameFileSets(ctx, tx, ci.Commit, ci.ParentCommit)
 		if err != nil {
 			return err
@@ -174,8 +180,11 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 	}
 	realAncestors := make(map[string]*v2_5_0.CommitInfo)
 	childToNewParents := make(map[*pfs.Commit]*pfs.Commit)
-	for _, ci := range deleteCommits {
-		log.Info(ctx, "computing parent / children after deleted alias commit", zap.String("commit", oldCommitKey(ci.Commit)))
+	for i, ci := range deleteCommits {
+		log.Info(ctx, "computing parent / children after deleted alias commit",
+			zap.String("commit", oldCommitKey(ci.Commit)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(deleteCommits))),
+		)
 		anctsr := oldestAncestor(ci, deleteCommits)
 		if _, ok := realAncestors[oldCommitKey(anctsr)]; !ok {
 			ci := &v2_5_0.CommitInfo{}
@@ -202,23 +211,34 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 			ancstrInfo.ChildCommits = append(ancstrInfo.ChildCommits, c)
 		}
 	}
-	for _, ci := range realAncestors {
-		log.Info(ctx, "updating children after deleted alias commit", zap.String("commit", oldCommitKey(ci.Commit)))
+	for i, ci := range realAncestors {
+		log.Info(ctx, "updating children after deleted alias commit",
+			zap.String("commit", oldCommitKey(ci.Commit)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(realAncestors))),
+		)
 		if err := resetOldCommitInfo(ctx, tx, ci); err != nil {
 			return errors.Wrapf(err, "reset real ancestor %q", oldCommitKey(ci.Commit))
 		}
 	}
+	var count int
 	for child, parent := range childToNewParents {
-		log.Info(ctx, "updating parent after deleted alias commit", zap.String("commit", oldCommitKey(child)))
+		log.Info(ctx, "updating parent after deleted alias commit",
+			zap.String("commit", oldCommitKey(child)),
+			zap.String("progress", fmt.Sprintf("%v/%v", count, len(childToNewParents))),
+		)
 		if err := updateOldCommit_V2_5(ctx, tx, child, func(ci *v2_5_0.CommitInfo) {
 			ci.ParentCommit = parent
 		}); err != nil {
 			return errors.Wrapf(err, "update child commit %q", oldCommitKey(child))
 		}
+		count++
 	}
 	// now write out realAncestors and childToNewParents
-	for _, ci := range deleteCommits {
-		log.Info(ctx, "deleting alias commit", zap.String("commit", oldCommitKey(ci.Commit)))
+	for i, ci := range deleteCommits {
+		log.Info(ctx, "deleting alias commit",
+			zap.String("commit", oldCommitKey(ci.Commit)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(deleteCommits))),
+		)
 		ancstr := oldestAncestor(ci, deleteCommits)
 		// passing restoreLinks=false because we're already resetting parent/children relationships above
 		if err := deleteCommit(ctx, tx, ci.Commit, ancstr); err != nil {
@@ -230,13 +250,15 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 		return errors.Wrap(err, "recollect commits")
 	}
 	// re-write V2_5 commits to V2_6
-	for _, oldCI := range oldCIs {
+	for i, oldCI := range oldCIs {
 		var err error
 		ci := convertCommitInfoToV2_6_0(oldCI)
 		ci.DirectProvenance, err = commitProvenance(tx, ci.Commit.Repo, ci.Commit.Branch, ci.Commit.Id)
 		log.Info(ctx, "collect commit provenance",
 			zap.String("commit", oldCommitKey(ci.Commit)),
-			zap.Any("provenance", ci.DirectProvenance))
+			zap.Any("provenance", ci.DirectProvenance),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(oldCIs))),
+		)
 		if err != nil {
 			return err
 		}
@@ -480,10 +502,11 @@ func branchlessCommitsPFS(ctx context.Context, tx *pachsql.Tx) error {
 	if cis, err = listCollectionProtos(ctx, tx, "commits", &pfs.CommitInfo{}); err != nil {
 		return err
 	}
-	for _, ci := range cis {
+	for i, ci := range cis {
 		log.Info(ctx, "view commit provenance",
 			zap.String("commit", oldCommitKey(ci.Commit)),
 			zap.Any("branch provenance", ci.DirectProvenance),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(cis))),
 		)
 		// TODO(provenance): is this deferred/trigger handling correct?
 		if ci.ParentCommit != nil && branchKey(ci.ParentCommit.Branch) != branchKey(ci.Commit.Branch) {
@@ -539,8 +562,11 @@ func branchlessCommitsPFS(ctx context.Context, tx *pachsql.Tx) error {
 	if err != nil {
 		return err
 	}
-	for _, oldCommit := range oldCommits {
-		log.Info(ctx, "removing branch from commit", zap.String("commit", oldCommitKey(oldCommit.Commit)))
+	for i, oldCommit := range oldCommits {
+		log.Info(ctx, "removing branch from commit",
+			zap.String("commit", oldCommitKey(oldCommit.Commit)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(oldCommits))),
+		)
 		if oldCommit.Commit.Repo == nil {
 			oldCommit.Commit.Repo = oldCommit.Commit.Branch.Repo
 		}
@@ -760,8 +786,11 @@ func deleteDanglingCommitRefs(ctx context.Context, tx *pachsql.Tx) error {
 	if len(dangCommitKeys) > 0 {
 		log.Info(ctx, "detected dangling commit references", zap.Any("references", dangCommitKeys))
 	}
-	for _, id := range dangCommitKeys {
-		log.Info(ctx, "deleting dangling commit", zap.String("commit", id))
+	for i, id := range dangCommitKeys {
+		log.Info(ctx, "deleting dangling commit",
+			zap.String("commit", id),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(dangCommitKeys))),
+		)
 		if _, err := tx.Exec(`DELETE FROM pfs.commit_totals WHERE commit_id = $1`, id); err != nil {
 			return errors.Wrapf(err, "delete dangling commit reference %q from pfs.commit_totals", id)
 		}

--- a/src/internal/clusterstate/v2.6.0/ppsdb.go
+++ b/src/internal/clusterstate/v2.6.0/ppsdb.go
@@ -2,6 +2,7 @@ package v2_6_0
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	"go.uber.org/zap"
@@ -16,8 +17,11 @@ func branchlessCommitsPPS(ctx context.Context, tx *pachsql.Tx) error {
 	if err != nil {
 		return errors.Wrap(err, "collecting jobs")
 	}
-	for _, ji := range jis {
-		log.Info(ctx, "removing branch from job output commit", zap.String("job", jobKey(ji.Job)))
+	for i, ji := range jis {
+		log.Info(ctx, "removing branch from job output commit",
+			zap.String("job", jobKey(ji.Job)),
+			zap.String("progress", fmt.Sprintf("%v/%v", i, len(jis))),
+		)
 		// TODO(provenance): nil commit.Branch field in storage
 		ji.OutputCommit.Repo = ji.OutputCommit.Branch.Repo
 		if err := updateCollectionProto(ctx, tx, "jobs", jobKey(ji.Job), jobKey(ji.Job), ji); err != nil {

--- a/src/internal/clusterstate/v2.6.0/ppsdb.go
+++ b/src/internal/clusterstate/v2.6.0/ppsdb.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"go.uber.org/zap"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
@@ -15,6 +17,7 @@ func branchlessCommitsPPS(ctx context.Context, tx *pachsql.Tx) error {
 		return errors.Wrap(err, "collecting jobs")
 	}
 	for _, ji := range jis {
+		log.Info(ctx, "removing branch from job output commit", zap.String("job", jobKey(ji.Job)))
 		// TODO(provenance): nil commit.Branch field in storage
 		ji.OutputCommit.Repo = ji.OutputCommit.Branch.Repo
 		if err := updateCollectionProto(ctx, tx, "jobs", jobKey(ji.Job), jobKey(ji.Job), ji); err != nil {

--- a/src/internal/clusterstate/v2.6.0/util.go
+++ b/src/internal/clusterstate/v2.6.0/util.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
@@ -62,6 +64,7 @@ func forEachCollectionProtos[T proto.Message](ctx context.Context, tx *pachsql.T
 }
 
 func listCollectionProtos[T proto.Message](ctx context.Context, tx *pachsql.Tx, table string, val T) ([]T, error) {
+	log.Info(ctx, "listing collection protos", zap.String("table", table))
 	protos := make([]T, 0)
 	if err := forEachCollectionProtos(ctx, tx, table, val, func(T) {
 		protos = append(protos, proto.Clone(val).(T))


### PR DESCRIPTION
This PR adds logging to all of the places in the provenance migration that we expect to be expensive. This primarily applies to operations that are per-commit and per-job. The expectation after this change is that users will generally see a steady supply of logs throughout the entire migration.