### PR TITLE
[CORE-1652] oidc determined helm template 

### DIFF
--- a/etc/helm/pachyderm/scripts/k8s-password-change.py
+++ b/etc/helm/pachyderm/scripts/k8s-password-change.py
@@ -1,0 +1,103 @@
+import json
+import sys
+import time
+from typing import List
+
+import requests
+
+
+def pwChange(user: str, password: str, entrypoint: str) -> None:
+    print(f"Trying to change {user}'s password", flush=True)
+    while True:
+        try:
+            resp = requests.post(
+                url=f"http://{entrypoint}/api/v1/auth/login",
+                json={"username": user, "password": ""},
+                verify=False,
+            )
+            data = json.loads(resp.text)
+            requests.post(
+                url=f"http://{entrypoint}/api/v1/users/{data['user']['id']}/password",
+                json=password,
+                headers={"Authorization": f"Bearer {data['token']}"},
+                verify=False,
+            )
+            print(f"Sucessfully changed {user}'s password", flush=True)
+            return
+        except Exception as e:
+            print(f"Encountered exception: {e}", flush=True)
+            return
+
+
+def checkPortAlive(entrypoint: str) -> None:
+    while True:
+        try:
+            requests.get(
+                url=f"http://{entrypoint}/api/v1/master",
+                verify=False,
+            )
+            return
+        except Exception as e:
+            print(f"Encountered exception: {e}")
+            continue
+
+
+def getMasterAddress(
+    namespace: str,
+    service_name: str,
+    master_port: str,
+    node_port: str,
+    service_host: str,
+    service_port: str,
+    token: str,
+) -> str:
+    target_service = f"determined-master-service-{service_name}"
+
+    if node_port != "true":
+        while True:
+            services = requests.get(
+                url=f"https://{service_host}:{service_port}/api/v1/namespaces/{namespace}/services",
+                headers={"Authorization": f"Bearer {token}"},
+                verify=False,
+            ).json()
+            for svc in services["items"]:
+                if target_service in svc["metadata"]["name"]:
+                    status = svc["status"]["loadBalancer"]
+                    if "ingress" not in svc["status"]["loadBalancer"] or status["ingress"] is None:
+                        time.sleep(1)
+                        break
+                    if status["ingress"][0].get("hostname"):
+                        # use hostname over ip address, if available
+                        return f"{status['ingress'][0]['hostname']}:{master_port}"
+                    else:
+                        return f"{status['ingress'][0]['ip']}:{master_port}"
+
+    services = requests.get(
+        url=f"https://{service_host}:{service_port}/api/v1/namespaces/{namespace}/services",
+        headers={"Authorization": f"Bearer {token}"},
+        verify=False,
+    ).json()
+    for svc in services["items"]:
+        if target_service in svc["metadata"]["name"]:
+            entrypoint = f"{svc['spec']['cluster_ip']}:{master_port}"
+            checkPortAlive(entrypoint)
+
+            return entrypoint
+    return ""
+
+
+def main(argv: List[str]) -> None:
+    if len(argv) < 7:
+        raise Exception("not enough args")
+    if argv[7] == "":
+        raise Exception("no password supplied")
+
+    for i in range(len(argv)):
+        argv[i] = argv[i].strip()
+    addr = getMasterAddress(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6])
+    pwChange("determined", argv[7], addr)
+    pwChange("admin", argv[7], addr)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/etc/helm/pachyderm/templates/determined/NOTES.txt
+++ b/etc/helm/pachyderm/templates/determined/NOTES.txt
@@ -1,0 +1,48 @@
+Thank you for installing {{ .Chart.Name }}. Your release is named: {{ .Release.Name }}.
+It may take several minutes for your deployment to start up.
+
+{{- if .Values.useNodePortForMaster }}
+
+You have configured Determined to deploy the master with a NodePort service. To make the
+Determined master accessible from outside the cluster you will likely need to configure
+an Ingress for: determined-master-service-{{ .Release.Name }}.
+
+To have Determined configure an externally accessible load balancer for the
+maser, please set "Values.useNodePortForMaster" to false.
+{{ else }}
+
+The IP address of the Determined master is the external IP of determined-master-service-{{ .Release.Name }},
+which you can lookup by running (it may take a few minutes for the ip address to be assigned):
+
+kubectl get service determined-master-service-{{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{ end -}}
+
+{{ $httpOrHttps := "http" }}
+{{- if .Values.tlsSecret -}}
+  {{ $httpOrHttps = "https" }}
+  {{ $secret := (lookup "v1" "Secret" .Release.Namespace (.Values.tlsSecret | toString) ) }}
+  {{- if eq (len $secret) 0 }}
+ERROR: Secret {{ .Values.tlsSecret }} does not exist in namespace: {{ .Release.Namespace }}. Please update ".Values.tlsSecret".
+  {{ end }}
+{{ end -}}
+
+{{- if (and (not .Values.detVersion) (contains "dev" .Chart.AppVersion)) }}
+ERROR: Installing a non-released version of Determined: {{ .Chart.AppVersion }}.
+Determined does not publish Docker images for non-release version; attempts to
+install a non-release version will lead to a `ImagePullBackOff` error.
+Please update `appVersion` in Chart.yaml to an official release version in the
+format X.Y.Z (e.g., 0.13.6).
+
+{{ end -}}
+
+{{- if .Values.defaultScheduler }}
+      {{- $schedulerType := .Values.defaultScheduler | trim}}
+      {{- if not (or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption"))}}
+WARNING: defaultScheduler has been set to an unsupported value. The cluster default scheduler will be set to the Kubernetes scheduler.
+      {{ end }}
+{{ end -}}
+
+Once you have the IP address, configure master address locally by running: `export DET_MASTER=<ip address>:{{ .Values.masterPort }}`.
+To submit experiments please install the Determined CLI locally: `pip install determined`.
+To access the WebUI go to: {{ $httpOrHttps }}://<ip address>:{{ .Values.masterPort }}.

--- a/etc/helm/pachyderm/templates/determined/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/determined/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "determined.secretPath" -}}
+/mount/determined/secrets/
+{{- end -}}
+
+{{- define "determined.masterPort" -}}
+8081
+{{- end -}}

--- a/etc/helm/pachyderm/templates/determined/change-password.yaml
+++ b/etc/helm/pachyderm/templates/determined/change-password.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.determined.defaultPassword }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: determined-pw-change-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-pw-change
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  template:
+    metadata:
+      name: determined-pw-change
+      labels:
+        app: determined-pw-change
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccount: determined-master-{{ .Release.Name }}
+      restartPolicy: OnFailure
+      {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809")._1}}
+      containers:
+      - name: change-password
+        image: {{ .Values.determined.imageRegistry }}/{{ $cpuImage }}
+        imagePullPolicy: "Always"
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - >-
+            echo -e {{ .Files.Get "scripts/k8s-password-change.py" | quote }} > /tmp/change-pw.py &&
+            KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&
+            python3 /tmp/change-pw.py
+            {{ .Release.Namespace | quote }} \
+            {{ .Release.Name | quote }} \
+            {{ .Values.determined.masterPort | quote }} \
+            {{ .Values.determined.useNodePortForMaster | quote }} \
+            $KUBERNETES_SERVICE_HOST \
+            $KUBERNETES_PORT_443_TCP_PORT \
+            $KUBE_TOKEN \
+            {{ .Values.determined.defaultPassword | default ""}}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/change-password.yaml
+++ b/etc/helm/pachyderm/templates/determined/change-password.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.determined.defaultPassword }}
+{{- if and .Values.determined.defaultPassword .Values.determined.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/etc/helm/pachyderm/templates/determined/db-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/db-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.determined.db.hostAddress }}
+{{ else }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: determined-db-deployment-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-db-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: determined-db-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: determined-db-{{ .Release.Name }}
+        determined-system: db
+    spec:
+      priorityClassName: determined-system-priority
+      containers:
+      - name: determined-db-{{ .Release.Name }}
+        image: postgres:10.14
+        imagePullPolicy: "Always"
+        resources:
+          requests:
+            {{- if .Values.determined.db.cpuRequest }}
+            cpu: {{ .Values.determined.db.cpuRequest | quote }}
+            {{- end }}
+            {{- if .Values.determined.db.memRequest }}
+            memory: {{ .Values.determined.db.memRequest | quote }}
+            {{- end}}
+
+          {{- if or .Values.determined.db.cpuLimit .Values.determined.db.memLimit }}
+          limits:
+            {{- if .Values.determined.db.cpuLimit }}
+            cpu: {{ .Values.determined.db.cpuLimit | quote }}
+            {{- end }}
+            {{- if .Values.determined.db.memLimit }}
+            memory: {{ .Values.determined.db.memLimit | quote }}
+            {{- end}}
+          {{- end}}
+        env:
+          - name: POSTGRES_DB
+            value: {{ .Values.determined.db.name | quote }}
+          - name: POSTGRES_USER
+            value: {{ .Values.determined.db.user | quote }}
+          - name: POSTGRES_PASSWORD
+            value: {{ .Values.determined.db.password | quote }}
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+        args: ["--max_connections=96", "--shared_buffers=512MB"]
+      {{- if not .Values.determined.db.disablePVC }}
+        volumeMounts:
+          - mountPath: "/var/lib/postgresql/data"
+            name: determined-db-storage
+      volumes:
+        - name: determined-db-storage
+          persistentVolumeClaim:
+            claimName: determined-db-pvc-{{ .Release.Name }}
+      {{ end }}
+{{ end}}

--- a/etc/helm/pachyderm/templates/determined/db-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/db-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.determined.db.hostAddress }}
 {{ else }}
+{{- if .Values.determined.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,5 +61,6 @@ spec:
         - name: determined-db-storage
           persistentVolumeClaim:
             claimName: determined-db-pvc-{{ .Release.Name }}
+            {{ end }}
       {{ end }}
 {{ end}}

--- a/etc/helm/pachyderm/templates/determined/db-persistent-volume-claim.yaml
+++ b/etc/helm/pachyderm/templates/determined/db-persistent-volume-claim.yaml
@@ -1,0 +1,20 @@
+{{- if or .Values.determined.db.hostAddress .Values.determined.db.disablePVC }}
+{{ else }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: determined-db-pvc-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-db-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ required  "A valid Values.db.storageSize entry is required!" .Values.determined.db.storageSize }}
+  {{- if .Values.determined.db.storageClassName }}
+  storageClassName: {{ .Values.determined.db.storageClassName }}
+  {{ end }}
+{{ end }}

--- a/etc/helm/pachyderm/templates/determined/db-persistent-volume-claim.yaml
+++ b/etc/helm/pachyderm/templates/determined/db-persistent-volume-claim.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 {{- if or .Values.determined.db.hostAddress .Values.determined.db.disablePVC }}
 {{ else }}
 apiVersion: v1
@@ -17,4 +18,5 @@ spec:
   {{- if .Values.determined.db.storageClassName }}
   storageClassName: {{ .Values.determined.db.storageClassName }}
   {{ end }}
+{{ end }}
 {{ end }}

--- a/etc/helm/pachyderm/templates/determined/db-service.yaml
+++ b/etc/helm/pachyderm/templates/determined/db-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.determined.db.hostAddress }}
+{{ else}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: determined-db-service-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-db-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - port: {{ .Values.determined.db.port }}
+    protocol: TCP
+  type: {{ if (.Values.determined.db.useNodePortForDB | default false) }}NodePort{{ else }}ClusterIP{{ end }}
+  selector:
+    app: determined-db-{{ .Release.Name }}
+{{ end }}

--- a/etc/helm/pachyderm/templates/determined/db-service.yaml
+++ b/etc/helm/pachyderm/templates/determined/db-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 {{- if .Values.determined.db.hostAddress }}
 {{ else}}
 apiVersion: v1
@@ -15,4 +16,5 @@ spec:
   type: {{ if (.Values.determined.db.useNodePortForDB | default false) }}NodePort{{ else }}ClusterIP{{ end }}
   selector:
     app: determined-db-{{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -240,3 +241,4 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
+{{- end }

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -107,7 +107,9 @@ data:
     resource_manager:
       type: "kubernetes"
       namespace: {{ .Release.Namespace }}
+      {{- if .Values.determined.enabled }}
       max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.determined.maxSlotsPerPod }}
+      {{- end }}
       master_service_name: determined-master-service-{{ .Release.Name }}
       {{- if .Values.determined.defaultScheduler}}
       {{- $schedulerType := .Values.determined.defaultScheduler | trim}}

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -1,0 +1,238 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+   name: determined-master-config-{{ .Release.Name }}
+   namespace: {{ .Release.Namespace }}
+   labels:
+     app: determined-master-{{ .Release.Name }}
+     release: {{ .Release.Name }}
+data:
+  master.yaml: |
+    checkpoint_storage:
+      type: {{ required "A valid Values.checkpointStorage.type entry is required!" .Values.determined.checkpointStorage.type | quote}}
+      {{- if eq .Values.determined.checkpointStorage.type "shared_fs" }}
+      host_path: {{ required "A valid Values.checkpointStorage.hostPath entry is required!" .Values.determined.checkpointStorage.hostPath | quote }}
+      {{- else if eq .Values.determined.checkpointStorage.type "gcs" }}
+      bucket: {{ required "A valid Values.checkpointStorage.bucket entry is required!" .Values.determined.checkpointStorage.bucket }}
+      prefix: {{ .Values.determined.checkpointStorage.prefix | quote }}
+      {{- else if eq .Values.determined.checkpointStorage.type "s3" }}
+      bucket: {{ required "A valid Values.checkpointStorage.bucket entry is required!" .Values.determined.checkpointStorage.bucket }}
+      access_key: {{ .Values.determined.checkpointStorage.accessKey | quote }}
+      secret_key: {{ .Values.determined.checkpointStorage.secretKey | quote }}
+      endpoint_url: {{ .Values.determined.checkpointStorage.endpointUrl | quote }}
+      prefix: {{ .Values.determined.checkpointStorage.prefix | quote }}
+      {{- else if eq .Values.determined.checkpointStorage.type "azure" }}
+      {{- if and .Values.determined.checkpointStorage.connection_string .Values.determined.checkpointStorage.account_url }}
+      {{ required "Exactly one of .Values.determined.checkpointStorage.connection_string or .Values.determined.checkpointStorage.account_url must be specified!" "" }}
+      {{- else if and .Values.determined.checkpointStorage.connection_string .Values.determined.checkpointStorage.credential }}
+      {{ required ".Values.determined.checkpointStorage.connection_string and .Values.determined.checkpointStorage.credential must not both be specified!" "" }}
+      {{- else }}
+      container: {{ required "A valid Values.checkpointStorage.container entry is required!" .Values.determined.checkpointStorage.container }}
+      connection_string: {{ .Values.determined.checkpointStorage.connection_string }}
+      account_url: {{ .Values.determined.checkpointStorage.account_url }}
+      credential: {{ .Values.determined.checkpointStorage.credential }}
+      {{- end }}
+      {{- end }}
+      save_experiment_best: {{ .Values.determined.checkpointStorage.saveExperimentBest | default 0 }}
+      save_trial_best: {{ .Values.determined.checkpointStorage.saveTrialBest | default 1 }}
+      save_trial_latest: {{ .Values.determined.checkpointStorage.saveTrialLatest | default 1 }}
+
+    db:
+      user: {{ required "A valid Values.db.user entry required!" .Values.determined.db.user | quote }}
+      password: {{ required "A valid Values.db.password entry required!" .Values.determined.db.password | quote }}
+      {{- if .Values.determined.db.hostAddress }}
+      host: {{ .Values.determined.db.hostAddress }}
+      {{- else }}
+      host: determined-db-service-{{ .Release.Name }}
+      {{- end  }}
+      port: {{ .Values.determined.db.port }}
+      name: {{ .Values.determined.db.name | quote }}
+      {{- if .Values.determined.db.sslMode }}
+      ssl_mode: {{ .Values.determined.db.sslMode }}
+      {{- $rootCert := (required "A valid .Values.determined.db.sslRootCert entry required!" .Values.determined.db.sslRootCert )}}
+      ssl_root_cert: {{ include "determined.secretPath" . }}{{ $rootCert }}
+      {{- end }}
+
+    security:
+      {{- if .Values.determined.tlsSecret }}
+      tls:
+        cert: {{ include "determined.secretPath" . }}tls.crt
+        key: {{ include "determined.secretPath" . }}tls.key
+      {{- end }}
+      {{- if .Values.determined.security }}
+      {{- if .Values.determined.security.defaultTask }}
+      default_task:
+        user: {{ .Values.determined.security.defaultTask.user }}
+        uid: {{ .Values.determined.security.defaultTask.uid }}
+        group: {{ .Values.determined.security.defaultTask.group }}
+        gid: {{ .Values.determined.security.defaultTask.gid }}
+      {{- end }}
+      {{- if .Values.determined.security.authz }}
+      authz:
+        {{- toYaml .Values.determined.security.authz | nindent 8}}
+      {{- end }}
+      {{- end }}
+    port: {{ include "determined.masterPort" . }}
+
+    {{- if .Values.determined.enterpriseEdition }}
+    {{- if .Values.determined.oidc }}
+    oidc:
+      enabled: {{ .Values.determined.oidc.enabled | default true }}
+      provider: {{ required "A valid provider entry is required!" .Values.determined.oidc.provider}}
+      idp_recipient_url: {{ required "A valid recipient url is required!" .Values.determined.oidc.idpRecipientUrl }}
+      idp_sso_url: {{ required "A valid sso url is required!" .Values.determined.oidc.idpSsoUrl }}
+      client_id: {{ required "A valid client ID is required!" .Values.determined.oidc.clientId }}
+      {{- if .Values.determined.oidc.authenticationClaim }}
+      authentication_claim: {{ .Values.determined.oidc.authenticationClaim }}
+      {{- end }}
+      {{- if .Values.determined.oidc.scimAuthenticationAttribute }}
+      scim_authentication_attribute: {{ .Values.determined.oidc.scimAuthenticationAttribute }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .Values.determined.scim }}
+    scim:
+      enabled: {{ .Values.determined.scim.enabled | default true }}
+      auth:
+        type: {{ required "A valid authentication type is required!" .Values.determined.scim.auth.type }}
+        {{- if eq .Values.determined.scim.auth.type "basic" }}
+        username: {{ required "A valid username is required!" .Values.determined.scim.auth.username }}
+        password: {{ required "A valid password type is required!" .Values.determined.scim.auth.password }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
+    resource_manager:
+      type: "kubernetes"
+      namespace: {{ .Release.Namespace }}
+      max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.determined.maxSlotsPerPod }}
+      master_service_name: determined-master-service-{{ .Release.Name }}
+      {{- if .Values.determined.defaultScheduler}}
+      {{- $schedulerType := .Values.determined.defaultScheduler | trim}}
+      {{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
+      default_scheduler: {{ $schedulerType }}
+      {{- end }}
+      {{- end }}
+      {{- if (ne (default "gpu" .Values.determined.slotType) "gpu") }}
+      slot_type: {{ .Values.determined.slotType }}
+      slot_resource_requests:
+        cpu: {{ .Values.determined.slotResourceRequests.cpu }}
+      {{- end }}
+      {{- if .Values.determined.fluent }}
+      fluent:
+        {{- toYaml .Values.determined.fluent | nindent 8}}
+      {{- end }}
+
+      default_aux_resource_pool: {{.Values.determined.defaultAuxResourcePool}}
+      default_compute_resource_pool: {{.Values.determined.defaultComputeResourcePool}}
+
+    {{- if .Values.determined.resourcePools}}
+    resource_pools:
+      {{- toYaml .Values.determined.resourcePools | nindent 6}}
+    {{- end }}
+
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-6eceaca")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-6eceaca")._1 -}}
+    {{ if .Values.determined.taskContainerDefaults -}}
+    task_container_defaults:
+      {{- if .Values.determined.taskContainerDefaults.networkMode }}
+      network_mode: {{ .Values.determined.taskContainerDefaults.networkMode }}
+      {{- end }}
+      {{- if .Values.determined.taskContainerDefaults.dtrainNetworkInterface }}
+      dtrain_network_interface: {{ .Values.determined.taskContainerDefaults.dtrainNetworkInterface }}
+      {{- end }}
+      {{- if .Values.determined.taskContainerDefaults.cpuPodSpec }}
+      cpu_pod_spec: {{ .Values.determined.taskContainerDefaults.cpuPodSpec | toJson }}
+      {{- end }}
+      {{- if .Values.determined.taskContainerDefaults.gpuPodSpec }}
+      gpu_pod_spec: {{ .Values.determined.taskContainerDefaults.gpuPodSpec | toJson }}
+      {{- end }}
+      {{- if and .Values.determined.taskContainerDefaults.cpuImage .Values.determined.taskContainerDefaults.gpuImage }}
+      image:
+         cpu: {{ .Values.determined.taskContainerDefaults.cpuImage | quote }}
+         gpu: {{ .Values.determined.taskContainerDefaults.gpuImage | quote }}
+      {{- else if .Values.determined.imageRegistry }}
+      image:
+         cpu: {{ .Values.determined.imageRegistry }}/{{ $cpuImage }}
+         gpu: {{ .Values.determined.imageRegistry }}/{{ $gpuImage }}
+      {{- if or .Values.determined.taskContainerDefaults.cpuImage .Values.determined.taskContainerDefaults.gpuImage }}
+        {{ required "A valid .Values.determined.taskContainerDefaults.cpuImage entry is required if setting .Values.determined.taskContainerDefaults.gpuImage!" .Values.determined.taskContainerDefaults.cpuImage }}
+        {{ required "A valid .Values.determined.taskContainerDefaults.gpuImage entry is required if setting .Values.determined.taskContainerDefaults.cpuImage!" .Values.determined.taskContainerDefaults.gpuImage }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.determined.taskContainerDefaults.forcePullImage }}
+      force_pull_image: {{ .Values.determined.taskContainerDefaults.forcePullImage }}
+      {{- end }}
+    {{ else if .Values.determined.imageRegistry }}
+    task_container_defaults:
+      image:
+         cpu: {{ .Values.determined.imageRegistry }}/{{ $cpuImage }}
+         gpu: {{ .Values.determined.imageRegistry }}/{{ $gpuImage }}
+    {{ end }}
+
+    {{- if .Values.determined.telemetry }}
+    telemetry:
+      enabled: {{ .Values.determined.telemetry.enabled }}
+    {{- end }}
+
+    {{- if .Values.determined.observability }}
+    observability:
+      enable_prometheus: {{ required "A valid .Values.determined.observability.enable_prometheus must be provided if setting .Values.determined.observability!" .Values.determined.observability.enable_prometheus }}
+    {{- end }}
+
+    {{- if .Values.determined.clusterName }}
+    cluster_name: {{ .Values.determined.clusterName }}
+    {{- end }}
+
+    {{- if .Values.determined.tensorboardTimeout }}
+    tensorboard_timeout: {{ .Values.determined.tensorboardTimeout }}
+    {{- end }}
+
+    {{- if .Values.determined.notebookTimeout }}
+    notebook_timeout: {{ .Values.determined.notebookTimeout }}
+    {{- end }}
+
+    {{- if .Values.determined.logging }}
+    logging:
+      {{- if .Values.determined.logging.type }}
+      type: {{ .Values.determined.logging.type }}
+      {{- end }}
+
+      {{- if (eq (default "" .Values.determined.logging.type) "elastic") }}
+      host: {{ required "A valid host must be provided if logging to Elasticsearch!" .Values.determined.logging.host }}
+      port: {{ required "A valid port must be provided if logging to Elasticsearch!" .Values.determined.logging.port }}
+      {{- if .Values.determined.logging.security }}
+      security:
+        {{- if .Values.determined.logging.security.username }}
+        username: {{ .Values.determined.logging.security.username }}
+        {{- end }}
+        {{- if .Values.determined.logging.security.password }}
+        password: {{ .Values.determined.logging.security.password }}
+        {{- end }}
+        {{- if .Values.determined.logging.security.tls }}
+        tls:
+          {{- if .Values.determined.logging.security.tls.enabled }}
+          enabled: {{ .Values.determined.logging.security.tls.enabled }}
+          {{- end }}
+          {{- if .Values.determined.logging.security.tls.skipVerify }}
+          skip_verify: {{ .Values.determined.logging.security.tls.skipVerify }}
+          {{- end }}
+          {{- if .Values.determined.logging.security.tls.certificate }}
+          certificate: /etc/determined/elastic.crt
+          {{- end }}
+          {{- if .Values.determined.logging.security.tls.certificateName }}
+          certificate_name: {{ .Values.determined.logging.security.tls.certificateName }}
+          {{- end }}
+        {{- end}}
+      {{- end }}
+      {{- end }}
+    {{- end}}
+  {{- if .Values.determined.logging }}
+  {{- if .Values.determined.logging.security }}
+  {{- if .Values.determined.logging.security.tls }}
+  {{- if .Values.determined.logging.security.tls.certificate }}
+  elastic.crt: |{{ nindent 4 .Values.determined.logging.security.tls.certificate }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -8,6 +8,8 @@ metadata:
      release: {{ .Release.Name }}
 data:
   master.yaml: |
+    log:
+      level: debug
     checkpoint_storage:
       type: {{ required "A valid Values.checkpointStorage.type entry is required!" .Values.determined.checkpointStorage.type | quote}}
       {{- if eq .Values.determined.checkpointStorage.type "shared_fs" }}
@@ -78,10 +80,10 @@ data:
     {{- if .Values.determined.oidc }}
     oidc:
       enabled: {{ .Values.determined.oidc.enabled | default true }}
-      provider: {{ required "A valid provider entry is required!" .Values.determined.oidc.provider}}
+      provider: {{ default .Values.determined.oidc.provider "dex"}}
       idp_recipient_url: {{ required "A valid recipient url is required!" .Values.determined.oidc.idpRecipientUrl }}
-      idp_sso_url: {{ required "A valid sso url is required!" .Values.determined.oidc.idpSsoUrl }}
-      client_id: {{ required "A valid client ID is required!" .Values.determined.oidc.clientId }}
+      idp_sso_url: {{ default .Values.determined.oidc.idpSsoUrl (include "pachyderm.issuerURI" . | quote) }}
+      client_id: {{ default .Values.determined.oidc.clientId "determined" }}
       {{- if .Values.determined.oidc.authenticationClaim }}
       authentication_claim: {{ .Values.determined.oidc.authenticationClaim }}
       {{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -241,4 +241,4 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
-{{- end }
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -103,3 +104,4 @@ spec:
             secretName: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.determined.db.certResourceName }}
           {{- end }}
         {{ end }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-deployment.yaml
@@ -42,8 +42,8 @@ spec:
           - name: DETERMINED_OIDC_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ required "A valid client secret name is required!" .Values.determined.oidc.clientSecretName }}
-                key: {{ required "A valid client secret filename is required!" .Values.determined.oidc.clientSecretKey }}
+                name: {{ default .Values.determined.oidc.clientSecretName "det-oidc-client-secret" }}
+                key: {{ default .Values.determined.oidc.clientSecretKey "oidc-client-secret" }}
                 optional: false
         {{- end }}
         {{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: determined-master-deployment-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-master-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: determined-master-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: determined-master-{{ .Release.Name }}
+        determined-system: master
+      annotations:
+        # This is added so that the master deployment restarts when an upgrade occurs that
+        # changes the master-config.yaml.
+        checksum/config: {{ include (print $.Template.BasePath "/determined/master-config.yaml") . | sha256sum }}
+    spec:
+      priorityClassName: determined-system-priority
+      serviceAccount: determined-master-{{ .Release.Name }}
+      containers:
+      - name: determined-master-{{ .Release.Name }}
+        {{ $image := "determined-master" }}
+        {{- if .Values.determined.enterpriseEdition -}}
+          {{ $image = "hpe-mlde-master" }}
+        {{- end -}}
+        {{ $tag := (required "A valid Chart.AppVersion entry required!" .Chart.AppVersion) }}
+        {{- /* detVersion is used for CI to override the appVersion. */ -}}
+        {{- if .Values.determined.detVersion -}}
+          {{ $tag = .Values.determined.detVersion }}
+        {{- end -}}
+        image: {{ .Values.determined.imageRegistry }}/{{ $image }}:{{ $tag }}
+        imagePullPolicy: "Always"
+        {{- if .Values.determined.enterpriseEdition }}
+        {{- if .Values.determined.oidc }}
+        env:
+          - name: DETERMINED_OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "A valid client secret name is required!" .Values.determined.oidc.clientSecretName }}
+                key: {{ required "A valid client secret filename is required!" .Values.determined.oidc.clientSecretKey }}
+                optional: false
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+          - name: master-config
+            mountPath: /etc/determined/
+            readOnly: true
+          {{- if .Values.determined.tlsSecret }}
+          - name: tls-secret
+            mountPath: {{ include "determined.secretPath" . }}
+            readOnly: true
+          {{ end }}
+          {{- if .Values.determined.db.certResourceName }}
+          - name: database-cert
+            mountPath: {{ include "determined.secretPath" . }}
+            readOnly: true
+          {{ end }}
+        resources:
+          requests:
+            {{- if .Values.determined.masterCpuRequest }}
+            cpu: {{ .Values.determined.masterCpuRequest  | quote }}
+            {{- end }}
+            {{- if .Values.determined.masterMemRequest }}
+            memory: {{ .Values.determined.masterMemRequest  | quote }}
+            {{- end}}
+
+          {{- if or .Values.determined.masterCpuLimit .Values.determined.masterMemLimit }}
+          limits:
+            {{- if .Values.determined.masterCpuLimit }}
+            cpu: {{ .Values.determined.masterCpuLimit  | quote }}
+            {{- end }}
+            {{- if .Values.determined.masterMemLimit }}
+            memory: {{ .Values.determined.masterMemLimit  | quote }}
+            {{- end}}
+          {{- end}}
+      {{- if .Values.determined.imagePullSecretName}}
+      imagePullSecrets:
+        - name: {{ .Values.determined.imagePullSecretName }}
+      {{- end}}
+      volumes:
+        - name: master-config
+          configMap:
+            name: determined-master-config-{{ .Release.Name }}
+        {{- if .Values.determined.tlsSecret }}
+        - name: tls-secret
+          secret:
+            secretName: {{ .Values.determined.tlsSecret }}
+        {{ end }}
+        {{- if .Values.determined.db.sslMode }}
+        - name: database-cert
+          {{- $resourceType := (required "A valid .Values.determined.db.resourceType entry required!" .Values.determined.db.resourceType | trim)}}
+          {{- if eq $resourceType "configMap"}}
+          configMap:
+            name: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.determined.db.certResourceName }}
+          {{- else }}
+          secret:
+            secretName: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.determined.db.certResourceName }}
+          {{- end }}
+        {{ end }}

--- a/etc/helm/pachyderm/templates/determined/master-permissions.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-permissions.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: determined-master-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+     app: determined-master-{{ .Release.Name }}
+     release: {{ .Release.Name }}
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: determined-master-{{ .Release.Name }}
+  labels:
+     app: determined-master-{{ .Release.Name }}
+     release: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/status", "pods/log", "configmaps"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "resourcequotas"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["watch", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes", "events"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["create", "get", "list", "delete"]
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: determined-master-{{ .Release.Name }}
+  labels:
+     app: determined-master-{{ .Release.Name }}
+     release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: determined-master-{{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: determined-master-{{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/etc/helm/pachyderm/templates/determined/master-permissions.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-permissions.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -50,3 +51,4 @@ roleRef:
   kind: ClusterRole
   name: determined-master-{{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-route.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-route.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.determined.openshiftRoute }}
+{{- if .Values.determined.openshiftRoute.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-master-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+  name: determined-master-route-{{ .Release.Name }}
+spec:
+  {{- if .Values.determined.openshiftRoute.host }}
+  host: {{ .Values.determined.openshiftRoute.host }}
+  {{- end }}
+  tls:
+    termination: {{ .Values.determined.openshiftRoute.termination }}
+  to:
+    kind: Service
+    name: determined-master-service-{{ .Release.Name }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-route.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-route.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 {{- if .Values.determined.openshiftRoute }}
 {{- if .Values.determined.openshiftRoute.enabled }}
 apiVersion: route.openshift.io/v1
@@ -19,5 +20,6 @@ spec:
     name: determined-master-service-{{ .Release.Name }}
     weight: 100
   wildcardPolicy: None
+{{- end }}
 {{- end }}
 {{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-service.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: determined-master-service-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: determined-master-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - port: {{ required "A valid Values.masterPort entry required!" .Values.determined.masterPort }}
+    targetPort: {{- include "determined.masterPort" . | indent 1 }}
+    protocol: TCP
+  type: {{ if (.Values.determined.useNodePortForMaster | default false) }}NodePort{{ else }}LoadBalancer{{ end }}
+  selector:
+    app: determined-master-{{ .Release.Name }}

--- a/etc/helm/pachyderm/templates/determined/master-service.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   type: {{ if (.Values.determined.useNodePortForMaster | default false) }}NodePort{{ else }}LoadBalancer{{ end }}
   selector:
     app: determined-master-{{ .Release.Name }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/priority-classes.yaml
+++ b/etc/helm/pachyderm/templates/determined/priority-classes.yaml
@@ -1,0 +1,17 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: determined-system-priority
+value: 1000000
+preemptionPolicy: Never
+globalDefault: false
+description: "This priority class should be used for Determined system pods only."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: determined-medium-priority
+value: 50
+preemptionPolicy: Never
+globalDefault: false
+description: "This priority class should be used for medium priority Determined jobs."

--- a/etc/helm/pachyderm/templates/determined/priority-classes.yaml
+++ b/etc/helm/pachyderm/templates/determined/priority-classes.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.determined.enabled -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -15,3 +16,4 @@ value: 50
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for medium priority Determined jobs."
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/scheduler-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/scheduler-config.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.determined.defaultScheduler}}
+{{- $schedulerType := .Values.determined.defaultScheduler | trim}}
+{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1alpha2
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
+    profiles:
+    - schedulerName: {{ $schedulerType }}
+      plugins:
+        queueSort:
+          enabled:
+            - name: Coscheduling
+          disabled:
+            - name: "*"
+        {{- if eq $schedulerType "preemption"}}
+        preFilter:
+          enabled:
+            - name: Coscheduling
+        {{- end }}
+        permit:
+          enabled:
+            - name: Coscheduling
+        unreserve:
+          enabled:
+            - name: Coscheduling
+        score:
+          enabled:
+            - name: Coscheduling
+    # optional plugin configs
+      pluginConfig: 
+      - name: Coscheduling
+        args:
+          permitWaitingTimeSeconds: 1
+          podGroupGCIntervalSeconds: 10
+          podGroupExpirationTimeSeconds: 30
+{{- end }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/scheduler-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/scheduler-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.determined.defaultScheduler}}
+{{- $schedulerType := .Values.determined.defaultScheduler | trim}}
+{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: scheduler
+    tier: control-plane
+    release: {{ $schedulerType }}-{{ .Release.Name }}
+  name: {{ $schedulerType }}
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      component: scheduler
+      tier: control-plane
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        tier: control-plane
+    spec:
+      serviceAccountName: {{ $schedulerType }}
+      containers:
+      - command:
+        - kube-scheduler
+        - -v=3
+        - --leader-elect=false
+        - --scheduler-name=coscheduler
+        - --config=/etc/config/config.yaml
+        name: {{ $schedulerType }}
+        {{- if eq $schedulerType "preemption"}}
+        image: determinedai/kube-scheduler:0.17.0
+        {{- else }}
+        image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9
+        {{- end}}
+        imagePullPolicy: "Always"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10251
+          initialDelaySeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10251
+        resources:
+          requests:
+            cpu: '0.1'
+        securityContext:
+          privileged: false
+        volumeMounts:
+          - name: scheduler-config-volume
+            mountPath: /etc/config
+      hostNetwork: false
+      hostPID: false
+      volumes:
+        - name: scheduler-config-volume
+          configMap:
+            name: scheduler-config
+{{- end }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/scheduler-permissions.yaml
+++ b/etc/helm/pachyderm/templates/determined/scheduler-permissions.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.determined.defaultScheduler}}
+{{- $schedulerType := .Values.determined.defaultScheduler | trim}}
+{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $schedulerType }}
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $schedulerType }}-pod-permissions
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $schedulerType }}-pod-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ $schedulerType }}
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: {{ $schedulerType }}-pod-permissions
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $schedulerType }}-extention-apiserver
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: {{ $schedulerType }}
+roleRef:
+  kind: Role
+  name: extension-apiserver-authentication-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $schedulerType }}-as-kube-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ $schedulerType }}
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $schedulerType }}-as-volume-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ $schedulerType }}
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/determined/secret.yaml
+++ b/etc/helm/pachyderm/templates/determined/secret.yaml
@@ -1,0 +1,16 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if and .Values.determined.enabled .Values.determined.enterpriseEdition   (not .Values.determined.oidc.clientSecretName) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: determined
+    suite: pachyderm
+  name: det-oidc-client-secret
+  namespace: {{ .Release.Namespace }}
+data:
+  oidc-client-secret: {{ (randAlphaNum 32) | toString | b64enc | quote }}
+{{- end }}

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -307,7 +307,7 @@ spec:
               name: {{ default ("pachyderm-console-secret") .Values.console.config.oauthClientSecretSecretName  }}
               key: OAUTH_CLIENT_SECRET
         {{- end }}
-        {{- if .Values.determined.enabled }}
+        {{- if and .Values.determined.enabled .Values.determined.enterpriseEdition   (not .Values.determined.oidc.clientSecretName) -}}
         - name: DETERMINED_OAUTH_ID
           value: {{ default .Values.determined.oidc.clientId "determined" }}
         - name: DETERMINED_OAUTH_SECRET

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -307,6 +307,15 @@ spec:
               name: {{ default ("pachyderm-console-secret") .Values.console.config.oauthClientSecretSecretName  }}
               key: OAUTH_CLIENT_SECRET
         {{- end }}
+        {{- if .Values.determined.enabled }}
+        - name: DETERMINED_OAUTH_ID
+          value: {{ default .Values.determined.oidc.clientId "determined" }}
+        - name: DETERMINED_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ default .Values.determined.oidc.clientSecretName "det-oidc-client-secret" }}
+              key: {{ default .Values.determined.oidc.clientSecretKey "oidc-client-secret" }}
+        {{- end }}
         {{ if .Values.global.proxy }}
         - name: http_proxy
           value: {{ .Values.global.proxy }}

--- a/etc/helm/pachyderm/templates/pachd/identity-config.yaml
+++ b/etc/helm/pachyderm/templates/pachd/identity-config.yaml
@@ -34,7 +34,7 @@ data:
     - id: {{ default .Values.determined.oidc.clientId "determined" }}
       name: {{ default .Values.determined.oidc.clientId "determined" }}
       redirect_uris:
-      - {{ required "A valid recipient url is required!" .Values.determined.oidc.idpRecipientUrl }}
+      - {{ required "A valid recipient url is required!" (printf "%s/oidc/callback" .Values.determined.oidc.idpRecipientUrl) }}
     {{- end }}
   trusted-peers: |
 {{ toYaml .Values.pachd.additionalTrustedPeers | indent 4 }}

--- a/etc/helm/pachyderm/templates/pachd/identity-config.yaml
+++ b/etc/helm/pachyderm/templates/pachd/identity-config.yaml
@@ -17,15 +17,24 @@ data:
       name: {{ .Values.pachd.oauthClientID }}
       redirect_uris:
       - {{ include "pachyderm.pachdRedirectURI" . }}
-      {{- if .Values.console.enabled}}
       trusted_peers:
+      {{- if .Values.console.enabled}}
       - {{ .Values.console.config.oauthClientID | quote }}
+      {{- end }}
+      {{- if .Values.determined.enabled}}
+      - {{ default .Values.determined.oidc.clientId "determined" }}
       {{- end }}
     {{- if .Values.console.enabled }}
     - id: {{ .Values.console.config.oauthClientID }}
       name: {{ .Values.console.config.oauthClientID  }}
       redirect_uris:
       - {{ include "pachyderm.consoleRedirectURI" . | quote }}
+    {{- end }}
+    {{- if .Values.determined.enabled }}
+    - id: {{ default .Values.determined.oidc.clientId "determined" }}
+      name: {{ default .Values.determined.oidc.clientId "determined" }}
+      redirect_uris:
+      - {{ required "A valid recipient url is required!" .Values.determined.oidc.idpRecipientUrl }}
     {{- end }}
   trusted-peers: |
 {{ toYaml .Values.pachd.additionalTrustedPeers | indent 4 }}

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -84,9 +84,9 @@ determined:
 
   # Enable route support for Openshift by setting enabled to true. Configure tls termination (i.e edge) if needed.
   # openshiftRoute:
-    # enabled:
-    # host:
-    # termination:
+  # enabled:
+  # host:
+  # termination:
 
   # tlsSecret enables TLS encryption for all communication made to the Determined master (TLS
   # termination is performed in the Determined master). This includes communication between the
@@ -96,18 +96,18 @@ determined:
   # tlsSecret:
 
   # security:
-    # defaultTask sets the user and group that tasks will run as. For convenience, the default Determined
-    # environments contain an unprivileged user named det-nobody, which does have a writable HOME
-    # directory. The det-nobody user is a suitable default user when using the default Determined
-    # environment images and when running containers as root is not desired.
-    # defaultTask:
-    #   user: det-nobody
-    #   uid: 65533
-    #   group: det-nobody
-    #   gid: 65533
-    # authz option (EE-only) sets the authorization mode.
-    # authz:
-    #   type: rbac
+  # defaultTask sets the user and group that tasks will run as. For convenience, the default Determined
+  # environments contain an unprivileged user named det-nobody, which does have a writable HOME
+  # directory. The det-nobody user is a suitable default user when using the default Determined
+  # environment images and when running containers as root is not desired.
+  # defaultTask:
+  #   user: det-nobody
+  #   uid: 65533
+  #   group: det-nobody
+  #   gid: 65533
+  # authz option (EE-only) sets the authorization mode.
+  # authz:
+  #   type: rbac
 
   # oidc (EE-only) enables OpenID Connect Integration, which is only available if enterpriseEdition
   # is true. It allows users to use single sign-on with their organization’s identity provider.
@@ -172,7 +172,6 @@ determined:
     # resourceType: <secret/configMap>
     # certResourceName: <secret/configMap name>
 
-
   # checkpointStorage controls where checkpoints are stored. Supported types include `shared_fs`,
   # `gcs`, and `s3`.
   checkpointStorage:
@@ -180,7 +179,6 @@ determined:
     saveExperimentBest: 0
     saveTrialBest: 1
     saveTrialLatest: 1
-
 
     # Comment out if not using `shared_fs`. Users are strongly discouraged from using `shared_fs` for
     # storage beyond initial testing as most Kubernetes cluster nodes do not have a shared file
@@ -226,10 +224,10 @@ determined:
   ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
   # slotType: cpu
   # slotResourceRequests:
-    ## Number of cpu units requested for compute slots. Note: since kubernetes may schedule some
-    ## system tasks on the nodes which take up some resources, 8-core node may not always fit
-    ## a `cpu: 8` task container.
-    # cpu: 7
+  ## Number of cpu units requested for compute slots. Note: since kubernetes may schedule some
+  ## system tasks on the nodes which take up some resources, 8-core node may not always fit
+  ## a `cpu: 8` task container.
+  # cpu: 7
 
   # Memory and CPU requirements for the master instance. Should be adjusted for scale.
   masterCpuRequest: 2
@@ -251,7 +249,6 @@ determined:
     # https://docs:determined.ai/latest/topic-guides/custom-pod-specs.html for more details.
     # cpuPodSpec:
     # gpuPodSpec:
-
 
     # Configure default Docker images for all GPU tasks (experiments, notebooks, commands) and
     # CPU tasks (CPU notebooks, TensorBoards, zero-slot commands). If a Docker image is defined
@@ -286,31 +283,31 @@ determined:
 
   ## Configure how trial logs are stored.
   # logging:
-    ## The backend to use. Can be `default` to send logs to the master to store in the PostgreSQL
-    ## database or `elastic` to store logs in an Elasticsearch cluster (without going through the
-    ## master).
-    # type: default
+  ## The backend to use. Can be `default` to send logs to the master to store in the PostgreSQL
+  ## database or `elastic` to store logs in an Elasticsearch cluster (without going through the
+  ## master).
+  # type: default
 
-    ## The remaining options should be provided only for the `elastic` backend.
+  ## The remaining options should be provided only for the `elastic` backend.
 
-    ## The host and port to use to connect to the Elasticsearch cluster.
-    # host: <host>
-    # port: <port>
+  ## The host and port to use to connect to the Elasticsearch cluster.
+  # host: <host>
+  # port: <port>
 
-    ## Authentication and TLS options for making the connection to Elasticsearch.
-    # security:
-      # username: <username>
-      # password: <password>
-      # tls:
-        # enabled: true
-        # skipVerify: false
+  ## Authentication and TLS options for making the connection to Elasticsearch.
+  # security:
+  # username: <username>
+  # password: <password>
+  # tls:
+  # enabled: true
+  # skipVerify: false
 
-        ## The name to use when verifying the certificate, if different from the name used to connect.
-        # certificateName: <name>
+  ## The name to use when verifying the certificate, if different from the name used to connect.
+  # certificateName: <name>
 
-        ## This value must contain the contents of the certificate file, not a path. It may be set
-        ## directly or using `helm install --set-file logging.security.tls.certificate=<path>`.
-        # certificate: <certificate contents>
+  ## This value must contain the contents of the certificate file, not a path. It may be set
+  ## directly or using `helm install --set-file logging.security.tls.certificate=<path>`.
+  # certificate: <certificate contents>
 
   ## Configure the default Determined scheduler
   ## Currently supports "coscheduler" for gang scheduling and "preemption" for priority based
@@ -328,7 +325,6 @@ determined:
     - pool_name: default
   # defaultAuxResourcePool: default
   # defaultComputeResourcePool: default
-
 
 console:
   # enabled controls whether the console manifests are created or not.

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -59,6 +59,276 @@ global:
   securityContexts:
     enabled: true
 
+determined:
+  # The image registry to use. Defaults to the determinedai repository in DockerHub.
+  imageRegistry: determinedai
+
+  # Install Determined enterprise edition.
+  enterpriseEdition: false
+
+  # Should be configured if using the master image in the Determined enterprise edition
+  # or private registry.
+  imagePullSecretName:
+
+  # masterPort configures the port at which the Determined master listens for connections on.
+  masterPort: 8080
+
+  # When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed to make
+  # the Determined master reachable from outside the cluster. When useNodePortForMaster is set to
+  # true, the master will instead be exposed behind a NodePort service. When using a NodePort service
+  # users will typically have to configure an Ingress to make the Determined master reachable from
+  # outside the cluster. NodePort service is recommended when configuring TLS termination in a
+  # load-balancer.
+  useNodePortForMaster: false
+
+  # Enable route support for Openshift by setting enabled to true. Configure tls termination (i.e edge) if needed.
+  # openshiftRoute:
+    # enabled:
+    # host:
+    # termination:
+
+  # tlsSecret enables TLS encryption for all communication made to the Determined master (TLS
+  # termination is performed in the Determined master). This includes communication between the
+  # Determined master and the task containers it launches, but does not include communication between
+  # the task containers (distributed training). The specified Secret of type tls must already exist in
+  # the same namespace in which Determined is being installed.
+  # tlsSecret:
+
+  # security:
+    # defaultTask sets the user and group that tasks will run as. For convenience, the default Determined
+    # environments contain an unprivileged user named det-nobody, which does have a writable HOME
+    # directory. The det-nobody user is a suitable default user when using the default Determined
+    # environment images and when running containers as root is not desired.
+    # defaultTask:
+    #   user: det-nobody
+    #   uid: 65533
+    #   group: det-nobody
+    #   gid: 65533
+    # authz option (EE-only) sets the authorization mode.
+    # authz:
+    #   type: rbac
+
+  # oidc (EE-only) enables OpenID Connect Integration, which is only available if enterpriseEdition
+  # is true. It allows users to use single sign-on with their organization’s identity provider.
+  # clientSecretKey is the key of the secret contained in the secret.
+  # oidc:
+  #   enabled:
+  #   provider:
+  #   idpRecipientUrl:
+  #   idpSsoUrl:
+  #   clientId:
+  #   clientSecretKey:
+  #   clientSecretName:
+  #   authenticationClaim:
+  #   scimAuthenticationAttribute:
+
+  # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
+  # only available if enterpriseEdition is true. It allows administrators to easily and securely
+  # provision users and groups through their standard identity provider (IdP).
+  # scim:
+  #   enabled: true
+  #   auth:
+  #     type: basic
+  #     username: determined
+  #     password: password
+
+  # db sets the configurations for the database.
+  db:
+    # To deploy your own Postgres DB, provide a hostAddress. If hostAddress is provided, Determined
+    # will skip deploying a Postgres DB.
+    # hostAddress:
+
+    # Required parameters, whether you are using your own DB or a Determined DB.
+    name: determined
+    user: postgres
+    password: postgres
+    port: 5432
+
+    # Only used for Determined DB deployment. Configures the size of the PersistentVolumeClaim for the
+    # Determined deployed database, as well as the CPU and memory requirements. Should be adjusted for
+    # scale.
+    storageSize: 30Gi
+    cpuRequest: 2
+    memRequest: 8Gi
+    #  cpuLimit: 2
+    #  memLimit: 8Gi
+
+    # useNodePortForDB configures whether ClusterIP or NodePort service type is used for the
+    # Determined deployed DB. By default ClusterIP is used.
+    useNodePortForDB: false
+
+    # storageClassName configures the StorageClass used by the PersistentVolumeClaim for the
+    # Determined deployed database. This can be left blank if a default storage class is specified in
+    # the cluster. If dynamic provisioning of PersistentVolumes is disabled, users must manually
+    # create a PersistentVolume that will match the PersistentVolumeClaim.
+    # storageClassName:
+
+    # ssl_mode and ssl_root_cert configure the TLS connection to the database. Users must first
+    # create a kubernetes secret or configMap containing their certificate and specify its name in
+    # certResourceName. For sslRootCert, specify the name of the file only (not path).
+    # sslMode: verify-ca
+    # sslRootCert: <cert_name>
+    # resourceType: <secret/configMap>
+    # certResourceName: <secret/configMap name>
+
+
+  # checkpointStorage controls where checkpoints are stored. Supported types include `shared_fs`,
+  # `gcs`, and `s3`.
+  checkpointStorage:
+    # Applicable to all checkpointStorage types.
+    saveExperimentBest: 0
+    saveTrialBest: 1
+    saveTrialLatest: 1
+
+
+    # Comment out if not using `shared_fs`. Users are strongly discouraged from using `shared_fs` for
+    # storage beyond initial testing as most Kubernetes cluster nodes do not have a shared file
+    # system.
+    type: shared_fs
+    hostPath: /checkpoints
+
+    # For storing in GCS.
+    # type: gcs
+    # bucket: <bucket_name>
+    # prefix: <prefix>
+
+    # For storing in S3.
+    # type: s3
+    # bucket: <bucket_name>
+    # accessKey: <access_key>
+    # secretKey: <secret_key>
+    # endpointUrl: <endpoint_url>
+    # prefix: <prefix>
+
+    # For storing in Azure Blob Storage with a connection string.
+    # Do NOT use if already using Azure Blob Storage with account URL
+    # type: azure
+    # container: <container_name>
+    # connection_string: <connection_string>
+
+    # For storing in Azure Blob Storage with an account URL.
+    # Do NOT use if already using Azure Blob Storage with connection string.
+    # The `credential` field is optional.
+    # type: azure
+    # container: <container_name>
+    # account_url: <account_url>
+    # credential: <credential>
+
+  # This is the number of GPUs there are per machine. Determined uses this information when scheduling
+  # multi-GPU tasks. Each multi-GPU (distributed training) task will be scheduled as a set of
+  # `slotsPerTask / maxSlotsPerPod` separate pods, with each pod assigned up to `maxSlotsPerPod` GPUs.
+  # Distributed tasks with sizes that are not divisible by `maxSlotsPerPod` are never scheduled. If
+  # you have a cluster of different size nodes (e.g., 4 and 8 GPUs per node), set `maxSlotsPerPod` to
+  # the greatest common divisor of all the sizes (4, in that case).
+  maxSlotsPerPod:
+
+  ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
+  # slotType: cpu
+  # slotResourceRequests:
+    ## Number of cpu units requested for compute slots. Note: since kubernetes may schedule some
+    ## system tasks on the nodes which take up some resources, 8-core node may not always fit
+    ## a `cpu: 8` task container.
+    # cpu: 7
+
+  # Memory and CPU requirements for the master instance. Should be adjusted for scale.
+  masterCpuRequest: 2
+  masterMemRequest: 8Gi
+  # masterCpuLimit: 2
+  # masterMemLimit: 8Gi
+
+  ## Configure the task container defaults. Tasks include trials, commands, TensorBoards, notebooks,
+  ## and shells. For all task containers, shm_size_bytes and network_mode are configurable. For
+  ## trials, the network interface used by distributed (multi-machine) training is configurable.
+  taskContainerDefaults:
+    # networkMode: bridge
+    # dtrainNetworkInterface: <network interface name>
+    # forcePullImage: <true or false>
+
+    # Configure a default pod spec for all GPU tasks (experiments, notebooks, commands) and CPU tasks
+    # (CPU notebooks, TensorBoards, zero-slot commands). If a pod spec is defined for an individual
+    # task, that pod spec will replace the default one that is defined here. See
+    # https://docs:determined.ai/latest/topic-guides/custom-pod-specs.html for more details.
+    # cpuPodSpec:
+    # gpuPodSpec:
+
+
+    # Configure default Docker images for all GPU tasks (experiments, notebooks, commands) and
+    # CPU tasks (CPU notebooks, TensorBoards, zero-slot commands). If a Docker image is defined
+    # for an individual task, that image will replace the default one that is defined here.
+    # If specifying a default image, both GPU and CPU default images must be defined.
+    # cpuImage:
+    # gpuImage:
+
+  ## Configure whether we collect anonymous information about the usage of Determined.
+  telemetry:
+    enabled: true
+
+  ## Configure Prometheus endpoints for monitoring.
+  # observability:
+  #   enable_prometheus: true
+
+  ## A user-friendly name to identify this cluster by.
+  # clusterName: Dev
+
+  ## Specifies the duration in seconds before idle
+  ## TensorBoard instances are automatically terminated.
+  ## A TensorBoard instance is considered to be idle if
+  ## it does not receive any HTTP traffic. The default timeout is 300 seconds (5 minutes).
+  # tensorboardTimeout: 300
+
+  ## Specifies the duration in seconds before idle notebook instances are automatically terminated.
+  ## This behavior is disabled by default.
+  # notebookTimeout: 1800
+
+  # defaultPassword sets the password for the admin and determined user accounts.
+  # defaultPassword:
+
+  ## Configure how trial logs are stored.
+  # logging:
+    ## The backend to use. Can be `default` to send logs to the master to store in the PostgreSQL
+    ## database or `elastic` to store logs in an Elasticsearch cluster (without going through the
+    ## master).
+    # type: default
+
+    ## The remaining options should be provided only for the `elastic` backend.
+
+    ## The host and port to use to connect to the Elasticsearch cluster.
+    # host: <host>
+    # port: <port>
+
+    ## Authentication and TLS options for making the connection to Elasticsearch.
+    # security:
+      # username: <username>
+      # password: <password>
+      # tls:
+        # enabled: true
+        # skipVerify: false
+
+        ## The name to use when verifying the certificate, if different from the name used to connect.
+        # certificateName: <name>
+
+        ## This value must contain the contents of the certificate file, not a path. It may be set
+        ## directly or using `helm install --set-file logging.security.tls.certificate=<path>`.
+        # certificate: <certificate contents>
+
+  ## Configure the default Determined scheduler
+  ## Currently supports "coscheduler" for gang scheduling and "preemption" for priority based
+  ## scheduling with preemption
+  # defaultScheduler: preemption
+
+  ## Configure settings about how Determined launches the Fluent Bit sidecar.
+  # fluent:
+  #   image: fluent/fluent-bit:1.6
+  #   uid: 0
+  #   gid: 0
+
+  ## Configure the resource pools in the Determined cluster.
+  resourcePools:
+    - pool_name: default
+  # defaultAuxResourcePool: default
+  # defaultComputeResourcePool: default
+
+
 console:
   # enabled controls whether the console manifests are created or not.
   enabled: true

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -113,15 +113,15 @@ determined:
   # is true. It allows users to use single sign-on with their organization’s identity provider.
   # clientSecretKey is the key of the secret contained in the secret.
   oidc:
-    enabled: ""
-    provider: ""
-    idpRecipientUrl: ""
-    idpSsoUrl: ""
-    clientId: ""
-    clientSecretKey: ""
-    clientSecretName: ""
-    authenticationClaim: ""
-    scimAuthenticationAttribute: ""
+    enabled:
+    provider:
+    idpRecipientUrl:
+    idpSsoUrl:
+    clientId:
+    clientSecretKey:
+    clientSecretName:
+    authenticationClaim:
+    scimAuthenticationAttribute:
 
   # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
   # only available if enterpriseEdition is true. It allows administrators to easily and securely

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -60,6 +60,7 @@ global:
     enabled: true
 
 determined:
+  enabled: false
   # The image registry to use. Defaults to the determinedai repository in DockerHub.
   imageRegistry: determinedai
 

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -112,16 +112,16 @@ determined:
   # oidc (EE-only) enables OpenID Connect Integration, which is only available if enterpriseEdition
   # is true. It allows users to use single sign-on with their organization’s identity provider.
   # clientSecretKey is the key of the secret contained in the secret.
-  # oidc:
-  #   enabled:
-  #   provider:
-  #   idpRecipientUrl:
-  #   idpSsoUrl:
-  #   clientId:
-  #   clientSecretKey:
-  #   clientSecretName:
-  #   authenticationClaim:
-  #   scimAuthenticationAttribute:
+  oidc:
+    enabled: ""
+    provider: ""
+    idpRecipientUrl: ""
+    idpSsoUrl: ""
+    clientId: ""
+    clientSecretKey: ""
+    clientSecretName: ""
+    authenticationClaim: ""
+    scimAuthenticationAttribute: ""
 
   # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
   # only available if enterpriseEdition is true. It allows administrators to easily and securely

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -171,6 +171,8 @@ type EnterpriseSpecificConfiguration struct {
 	TrustedPeers              string `env:"TRUSTED_PEERS,default="`
 	ConsoleOAuthID            string `env:"CONSOLE_OAUTH_ID,default="`
 	ConsoleOAuthSecret        string `env:"CONSOLE_OAUTH_SECRET,default="`
+	DeterminedOAuthID         string `env:"DETERMINED_OAUTH_ID,default="`
+	DeterminedOAuthSecret     string `env:"DETERMINED_OAUTH_SECRET,default="`
 }
 
 // StorageConfiguration contains the storage configuration.

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -247,6 +247,9 @@ func (a *apiServer) EnvBootstrap(ctx context.Context) error {
 				if c.Id == a.env.Config.ConsoleOAuthID {
 					c.Secret = a.env.Config.ConsoleOAuthSecret
 				}
+				if c.Id == a.env.Config.DeterminedOAuthID {
+					c.Secret = a.env.Config.DeterminedOAuthSecret
+				}
 				if !a.env.Config.EnterpriseMember {
 					if _, err := a.env.GetIdentityServer().CreateOIDCClient(ctx, &identity.CreateOIDCClientRequest{Client: c}); err != nil {
 						if !identity.IsErrAlreadyExists(err) {


### PR DESCRIPTION
adds the determined application as a template in the pachyderm helm chart. this is a `0.23.0` snapshot. future PRs will provide an automated integration. 

default `enabled` `false`

example helm values needed to deploy community version:

```yaml
 determined:
    detVersion: 0.23.0
    enabled: true
    maxSlotsPerPod: 1
```

example helm values needed to deploy enterprise with single auth.

```yaml
determined:
  detVersion: 7171979aaae64cd8ea16b0001a0ca21ebedc0695
  enabled: true
  enterpriseEdition: true
  imagePullSecretName: # secret to access your enterprise determined image
  maxSlotsPerPod: 1
  oidc:
    clientID: # your oidc client id
    enabled: true
    idpRecipientUrl: # your determined hostname  
    idpSsoUrl: # your provider url
    provider: auth0
  tlsSecret: # your tls secret name
  
oidc:
  mockIDP: false
  upstreamIDPs:
  - config:
      clientID: # your oidc client id
      clientSecret: # your oidc client secret
      insecureEnableGroups: true
      insecureSkipEmailVerified: true
      insecureSkipIssuerCallbackDomainCheck: false
      issuer: # your provider url
      redirectURI: # your host with /dex/callback at the end
    id: auth0
    name: Auth0
    type: oidc
```