### PR TITLE
Fix fuse integration test race

### DIFF
--- a/src/server/pfs/fuse/server_integration_test.go
+++ b/src/server/pfs/fuse/server_integration_test.go
@@ -86,6 +86,10 @@ func TestMountDatum(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo", "master", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 	withServerMount(t, c, nil, func(mountPoint string) {
 		input := []byte(fmt.Sprintf(
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/'}}}`,
@@ -141,12 +145,20 @@ func TestCrossDatum(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo1", "master", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "repo2"))
 	commit = client.NewCommit(pfs.DefaultProjectName, "repo2", "dev", "")
 	err = c.PutFile(commit, "dir/file3", strings.NewReader("foo"))
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file4", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commitInfo, err = c.InspectCommit(pfs.DefaultProjectName, "repo2", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
 	require.NoError(t, err)
 
 	withServerMount(t, c, nil, func(mountPoint string) {
@@ -183,12 +195,20 @@ func TestUnionDatum(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo1", "master", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "repo2"))
 	commit = client.NewCommit(pfs.DefaultProjectName, "repo2", "dev", "")
 	err = c.PutFile(commit, "dir/file3", strings.NewReader("foo"))
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file4", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commitInfo, err = c.InspectCommit(pfs.DefaultProjectName, "repo2", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
 	require.NoError(t, err)
 
 	withServerMount(t, c, nil, func(mountPoint string) {
@@ -217,10 +237,18 @@ func TestRepeatedBranchesDatum(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo1", "master", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 	commit = client.NewCommit(pfs.DefaultProjectName, "repo1", "dev", "")
 	err = c.PutFile(commit, "dir/file3", strings.NewReader("foo"))
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file4", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commitInfo, err = c.InspectCommit(pfs.DefaultProjectName, "repo1", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
 	require.NoError(t, err)
 
 	withServerMount(t, c, nil, func(mountPoint string) {
@@ -285,6 +313,10 @@ func TestShowDatum(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 
 	withServerMount(t, c, nil, func(mountPoint string) {
 		input := []byte(fmt.Sprintf(
@@ -333,6 +365,10 @@ func TestGetDatums(t *testing.T) {
 	err := c.PutFile(commit, "dir/file1", strings.NewReader("foo"))
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
 	require.NoError(t, err)
 
 	withServerMount(t, c, nil, func(mountPoint string) {
@@ -411,10 +447,18 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file2", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo1", "master", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 	commit = client.NewCommit(pfs.DefaultProjectName, "repo1", "dev", "")
 	err = c.PutFile(commit, "dir/file3", strings.NewReader("foo"))
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file4", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commitInfo, err = c.InspectCommit(pfs.DefaultProjectName, "repo1", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
 	require.NoError(t, err)
 
 	projectName := tu.UniqueString("p1")
@@ -425,10 +469,18 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file4", strings.NewReader("foo"))
 	require.NoError(t, err)
+	commitInfo, err = c.InspectCommit(projectName, "repo1", "master", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
 	commit = client.NewCommit(projectName, "repo1", "dev", "")
 	err = c.PutFile(commit, "dir/file3", strings.NewReader("foo"))
 	require.NoError(t, err)
 	err = c.PutFile(commit, "file4", strings.NewReader("foo"))
+	require.NoError(t, err)
+	commitInfo, err = c.InspectCommit(projectName, "repo1", "dev", "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
 	require.NoError(t, err)
 
 	withServerMount(t, c, nil, func(mountPoint string) {


### PR DESCRIPTION
This PR fixes a race condition in the fuse integration tests. The race was between the tests reading commits and the PFS master finishing commits (commits are finished asynchronously after finish commit is called or a one-off put file). Although we allow reading open commits that have a finished parent, it is generally not recommended for performance reasons. We don't allow reading open commits that have an unfinished parent for the same performance reasons. The fuse integration tests were getting into a situation where they created a chain of commits then attempted to read the most recent commit without waiting on it to be finished, which would often cause an error due to the most recent commit having an unfinished parent. The fix was just to wait on the commits to be finished before attempting to read them.