### PR TITLE
Replace “it’s” with “its”

### DIFF
--- a/src/internal/clusterstate/v2.6.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.6.0/pfsdb.go
@@ -167,7 +167,7 @@ func removeAliasCommits(ctx context.Context, tx *pachsql.Tx) error {
 			return err
 		}
 		if !same {
-			return errors.Errorf("commit %q is listed as ALIAS but has a different ID than it's first real ancestor.",
+			return errors.Errorf("commit %q is listed as ALIAS but has a different ID than its first real ancestor",
 				oldCommitKey(ci.Commit))
 		}
 	}


### PR DESCRIPTION
And also remove extraneous full stop at end of error message.