### PR TITLE
[2.6] Re-expose values for external Loki instance

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           value: "$({{ snakecase .Release.Name | upper }}_LOKI_SERVICE_HOST)"
         {{- end }}
         - name: LOKI_SERVICE_PORT
-        {{- if .Values.pachd.lokiPort }}
+        {{- if ne 0 (int .Values.pachd.lokiPort) }}
           value:  {{ .Values.pachd.lokiPort | quote}}
         {{ else }}
           value: "$({{ snakecase .Release.Name | upper }}_LOKI_SERVICE_PORT)"

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -899,8 +899,14 @@
                 "lokiDeploy": {
                     "type": "boolean"
                 },
+                "lokiHost": {
+                    "type": "string"
+                },
                 "lokiLogging": {
                     "type": "boolean"
+                },
+                "lokiPort": {
+                    "type": "integer"
                 },
                 "metrics": {
                     "type": "object",

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -419,6 +419,11 @@ pachd:
   lokiDeploy: true
   # lokiLogging enables Loki logging if set.
   lokiLogging: true
+  # lokiHost and lokiPort should only be set when using an external Loki instance. lokiDeploy should be false.
+  # lokiHost should be the hostname of the Loki instance to use.
+  lokiHost: ""
+  # lokiPort should be the port of the Loki instance to use.
+  lokiPort: 0
   metrics:
     # enabled sets the METRICS environment variable if set.
     enabled: true


### PR DESCRIPTION
At some point the helm schema was changed to not include lokiHost and lokiPort, this PR re-exposes those values to enable the use of an external Loki instance.