### PR TITLE
storage/kv: Add kv.Metered for instrumenting kv.Stores

### DIFF
--- a/src/internal/storage/config.go
+++ b/src/internal/storage/config.go
@@ -51,7 +51,8 @@ func wrapStore(conf *pachconfig.StorageConfiguration, store kv.Store) kv.Store {
 	}
 	if conf.StorageDiskCacheSize > 0 {
 		p := filepath.Join(os.TempDir(), "pss-cache", uuid.NewWithoutDashes())
-		diskCache := kv.NewFSStore(p, maxKeySize, chunk.DefaultMaxChunkSize)
+		var diskCache kv.Store = kv.NewFSStore(p, maxKeySize, chunk.DefaultMaxChunkSize)
+		diskCache = kv.NewMetered(diskCache, "disk")
 		return kv.NewLRUCache(store, diskCache, conf.StorageDiskCacheSize)
 	}
 	return store

--- a/src/internal/storage/kv/kv_test.go
+++ b/src/internal/storage/kv/kv_test.go
@@ -48,3 +48,9 @@ func TestBucket(t *testing.T) {
 		return NewFromBucket(b, 1024, 1<<20)
 	})
 }
+
+func TestMetered(t *testing.T) {
+	TestStore(t, func(t testing.TB) Store {
+		return NewMetered(NewMemStore(), "test-store")
+	})
+}

--- a/src/internal/storage/kv/metered.go
+++ b/src/internal/storage/kv/metered.go
@@ -27,6 +27,7 @@ func (m *Metered) Put(ctx context.Context, key, value []byte) error {
 		return err
 	}
 	meters.Inc(ctx, "put", 1)
+	meters.Inc(ctx, "putBytes", len(value))
 	return nil
 }
 
@@ -42,6 +43,7 @@ func (m *Metered) Get(ctx context.Context, key, buf []byte) (int, error) {
 		return n, err
 	}
 	meters.Inc(ctx, "get", 1)
+	meters.Inc(ctx, "getBytes", n)
 	return n, err
 }
 

--- a/src/internal/storage/kv/metered.go
+++ b/src/internal/storage/kv/metered.go
@@ -1,0 +1,71 @@
+package kv
+
+import (
+	"context"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pacherr"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+)
+
+var _ Store = &Metered{}
+
+type Metered struct {
+	inner Store
+	name  string
+}
+
+func NewMetered(inner Store, name string) *Metered {
+	return &Metered{inner: inner, name: name}
+}
+
+func (m *Metered) Put(ctx context.Context, key, value []byte) error {
+	ctx = pctx.Child(ctx, m.name)
+	if err := m.inner.Put(ctx, key, value); err != nil {
+		meters.Inc(ctx, "putErr", 1)
+		return err
+	}
+	meters.Inc(ctx, "put", 1)
+	return nil
+}
+
+func (m *Metered) Get(ctx context.Context, key, buf []byte) (int, error) {
+	ctx = pctx.Child(ctx, m.name)
+	n, err := m.inner.Get(ctx, key, buf)
+	if err != nil {
+		if pacherr.IsNotExist(err) {
+			meters.Inc(ctx, "notExist", 1)
+		} else {
+			meters.Inc(ctx, "getErr", 1)
+		}
+		return n, err
+	}
+	meters.Inc(ctx, "get", 1)
+	return 0, err
+}
+
+func (m *Metered) Delete(ctx context.Context, key []byte) error {
+	ctx = pctx.Child(ctx, m.name)
+	if err := m.inner.Delete(ctx, key); err != nil {
+		meters.Inc(ctx, "deleteErr", 1)
+		return err
+	}
+	meters.Inc(ctx, "delete", 1)
+	return nil
+}
+
+func (m *Metered) Exists(ctx context.Context, key []byte) (bool, error) {
+	ctx = pctx.Child(ctx, m.name)
+	exists, err := m.inner.Exists(ctx, key)
+	if err != nil {
+		meters.Inc(ctx, "existsErr", 1)
+		return false, err
+	}
+	meters.Inc(ctx, "exists", 1)
+	return exists, nil
+}
+
+func (m *Metered) NewKeyIterator(span Span) stream.Iterator[[]byte] {
+	return m.inner.NewKeyIterator(span)
+}

--- a/src/internal/storage/kv/metered.go
+++ b/src/internal/storage/kv/metered.go
@@ -42,7 +42,7 @@ func (m *Metered) Get(ctx context.Context, key, buf []byte) (int, error) {
 		return n, err
 	}
 	meters.Inc(ctx, "get", 1)
-	return 0, err
+	return n, err
 }
 
 func (m *Metered) Delete(ctx context.Context, key []byte) error {

--- a/src/internal/storage/server.go
+++ b/src/internal/storage/server.go
@@ -56,6 +56,7 @@ func New(env Env, config pachconfig.StorageConfiguration) (*Server, error) {
 	} else {
 		store = kv.NewFromObjectClient(env.ObjectStore, maxKeySize, chunk.DefaultMaxChunkSize)
 	}
+	store = kv.NewMetered(store, "bucket")
 	store = wrapStore(&config, store)
 	store = kv.NewPrefixed(store, []byte(chunkPrefix))
 	chunkStorageOpts := makeChunkOptions(&config)

--- a/src/internal/storage/server_test.go
+++ b/src/internal/storage/server_test.go
@@ -24,6 +24,9 @@ func TestServer(t *testing.T) {
 	fileset.NewTestStorage(ctx, t, db, tracker)
 
 	var config pachconfig.StorageConfiguration
+	config.StorageDiskCacheSize = 3
+	config.StorageDownloadConcurrencyLimit = 3
+	config.StorageUploadConcurrencyLimit = 3
 	s, err := New(Env{
 		DB:     db,
 		Bucket: b,


### PR DESCRIPTION
As part of the changes to move our caching and limiting to the `storage/kv` package, some of the metering was lost in the transition.  This PR adds it back.

Previously we were using prometheus metrics in the `obj` package, but since we have the new `meters` package it didn't make sense to port the prometheus implementation directly.  This PR uses the `meters` package to instrument any `kv.Store`.

As we setup the storage layer, we add metering to two named stores `bucket` which is object storage, and `disk` which is the local on-disk cache.