### PR TITLE
GoCDKEnabled configuration parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,10 +143,10 @@ require (
 	cloud.google.com/go/iam v0.12.0 // indirect
 	github.com/AppsFlyer/go-sundheit v0.5.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.1.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1
 	github.com/Azure/azure-storage-blob-go v0.14.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -181,7 +181,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.2
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10 // indirect
 	github.com/aws/smithy-go v1.12.0 // indirect

--- a/src/internal/obj/bucket.go
+++ b/src/internal/obj/bucket.go
@@ -1,0 +1,49 @@
+package obj
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/azureblob"
+	"gocloud.dev/blob/fileblob"
+	"gocloud.dev/blob/gcsblob"
+	"gocloud.dev/blob/s3blob"
+	"gocloud.dev/gcp"
+	"golang.org/x/oauth2/google"
+)
+
+// Bucket represents access to a single object storage bucket.
+// Azure calls this a container, because it's not like that word conflicts with anything.
+type Bucket = blob.Bucket
+
+// NewLocalBucket creates a Bucket backed by the local filesystem.
+// Data will be stored at dir.
+func NewLocalBucket(dir string) (*Bucket, error) {
+	return fileblob.OpenBucket(dir, nil)
+}
+
+func NewAmazonBucket(ctx context.Context, s3Opts s3v2.Options, bucketName string) (*Bucket, error) {
+	s3c := s3v2.New(s3Opts)
+	return s3blob.OpenBucketV2(ctx, s3c, bucketName, nil)
+}
+
+func NewGoogleBucket(ctx context.Context, creds *google.Credentials, bucketName string) (*Bucket, error) {
+	tokSrc := gcp.CredentialsTokenSource(creds)
+	gcpClient, err := gcp.NewHTTPClient(http.DefaultClient.Transport, tokSrc)
+	if err != nil {
+		return nil, err
+	}
+	return gcsblob.OpenBucket(ctx, gcpClient, bucketName, nil)
+}
+
+func NewMicrosoftBucket(ctx context.Context, svcURL string, cred azcore.TokenCredential, bucketName string) (*Bucket, error) {
+	svcClient, err := azblob.NewServiceClient(svcURL, cred, nil)
+	if err != nil {
+		return nil, err
+	}
+	return azureblob.OpenBucket(ctx, svcClient, bucketName, nil)
+}

--- a/src/internal/obj/factory.go
+++ b/src/internal/obj/factory.go
@@ -549,3 +549,21 @@ func NewClient(ctx context.Context, storageBackend string, storageRoot string) (
 		return nil, errors.Errorf("unrecognized storage backend: %s", storageBackend)
 	}
 }
+
+// NewBucket creates a Bucket using the given backend and storage root (for
+// local backends).
+// TODO: Not sure if we want to keep the storage root configuration for
+// non-local deployments. If so, we will need to connect it to the object path
+// prefix for chunks.
+func NewBucket(ctx context.Context, storageBackend string, storageRoot string) (*Bucket, error) {
+	var b *Bucket
+	var err error
+	switch storageBackend {
+	case Local:
+		b, err = NewLocalBucket(storageRoot)
+	// TODO: other backends
+	default:
+		return nil, errors.Errorf("unrecognized storage backend: %s", storageBackend)
+	}
+	return b, err
+}

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -117,6 +117,7 @@ type PachdFullConfiguration struct {
 type PachdSpecificConfiguration struct {
 	StorageConfiguration
 	StorageBackend             string `env:"STORAGE_BACKEND,required"`
+	GoCDKEnabled               bool   `env:"GOCDK_ENABLED,default=false"`
 	StorageHostPath            string `env:"STORAGE_HOST_PATH,default="`
 	PFSEtcdPrefix              string `env:"PFS_ETCD_PREFIX,default=pachyderm_pfs"`
 	KubeAddress                string `env:"KUBERNETES_PORT_443_TCP_ADDR,required"`

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -112,7 +112,7 @@ func newDriver(env Env) (*driver, error) {
 		commits:    commits,
 		branches:   branches,
 	}
-	storageSrv, err := storage.New(storage.Env{DB: env.DB, ObjectStore: env.ObjectClient}, env.StorageConfig)
+	storageSrv, err := storage.New(storage.Env{DB: env.DB, ObjectStore: env.ObjectClient, Bucket: env.Bucket}, env.StorageConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -16,11 +16,13 @@ import (
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth"
 	ppsserver "github.com/pachyderm/pachyderm/v2/src/server/pps"
 	etcd "go.etcd.io/etcd/client/v3"
+	"gocloud.dev/blob"
 )
 
 // Env is the dependencies needed to run the PFS API server
 type Env struct {
 	ObjectClient obj.Client
+	Bucket       *blob.Bucket
 	DB           *pachsql.DB
 	EtcdPrefix   string
 	EtcdClient   *etcd.Client
@@ -41,10 +43,25 @@ type Env struct {
 }
 
 func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) (*Env, error) {
-	// Setup etcd, object storage, and database clients.
-	objClient, err := obj.NewClient(env.Context(), env.Config().StorageBackend, env.Config().StorageRoot)
-	if err != nil {
-		return nil, err
+	cfg := env.Config()
+
+	// Only setup the new GoCDK bucket if necessary.  The storage layer will prefer it, if it is non-nil.
+	// Disabling GoCDK will completely bypass the entire setup, and revert to the old obj.Client.
+	// This is designed to be a quick fix in the field, if issues are discovered with Go CDK.
+	var objClient obj.Client
+	var bucket *obj.Bucket
+	if cfg.GoCDKEnabled {
+		var err error
+		bucket, err = obj.NewBucket(env.Context(), cfg.StorageBackend, cfg.StorageRoot)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		objClient, err = obj.NewClient(env.Context(), cfg.StorageBackend, cfg.StorageRoot)
+		if err != nil {
+			return nil, err
+		}
 	}
 	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PFSEtcdPrefix)
 	if env.AuthServer() == nil {
@@ -52,6 +69,7 @@ func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv)
 	}
 	return &Env{
 		ObjectClient: objClient,
+		Bucket:       bucket,
 		DB:           env.GetDBClient(),
 		TxnEnv:       txnEnv,
 		Listener:     env.GetPostgresListener(),


### PR DESCRIPTION
GoCDKEnabled sets whether or not to use the GoCDK library for accessing object storage. The intent here is to gate all of the setup logic on this parameter, so that when GoCDKEnabled=false, no GoCDK code is run as part of setup.