### PR TITLE
[Python-SDK] Extension to DebugDump

### DIFF
--- a/python-sdk/pachyderm_sdk/api/debug/extension.py
+++ b/python-sdk/pachyderm_sdk/api/debug/extension.py
@@ -1,0 +1,43 @@
+from typing import Iterator, List, Optional, TYPE_CHECKING
+
+from . import DebugStub
+from . import DumpChunk, System
+
+if TYPE_CHECKING:
+    from ..pps import Pipeline
+
+
+class ApiStub(DebugStub):
+    # noinspection PyMethodOverriding
+    def dump(
+        self,
+        *,
+        system: "System" = None,
+        pipelines: Optional[List["Pipeline"]] = None,
+        input_repos: bool = False,
+        timeout: int = 0,
+    ) -> Iterator["DumpChunk"]:
+        """Collect a standard set of debugging information using the DumpV2 API
+          rather than the now deprecated Dump API.
+
+        This method is intended to be used in tandem with the
+          `debug.get_dump_v2_template` endpoint. However, if no system or pipelines
+          are specified then this call will automatically be performed for the user.
+
+        If no system or pipelines are specified, then debug information for all
+          systems and pipelines will be returned.
+        """
+        if system is None and not pipelines:
+            template = self.get_dump_v2_template()
+            return self.dump_v2(
+                system=template.request.system,
+                pipelines=template.request.pipelines,
+                input_repos=input_repos or template.request.input_repos,
+                timeout=timeout or template.request.timeout,
+            )
+        return self.dump_v2(
+            system=system,
+            pipelines=pipelines,
+            input_repos=input_repos,
+            timeout=timeout,
+        )

--- a/python-sdk/pachyderm_sdk/client.py
+++ b/python-sdk/pachyderm_sdk/client.py
@@ -8,7 +8,7 @@ import grpc
 
 from .api.admin.extension import ApiStub as _AdminStub
 from .api.auth import ApiStub as _AuthStub
-from .api.debug import DebugStub as _DebugStub
+from .api.debug.extension import ApiStub as _DebugStub
 from .api.enterprise import ApiStub as _EnterpriseStub
 from .api.identity import ApiStub as _IdentityStub
 from .api.license import ApiStub as _LicenseStub

--- a/python-sdk/tests/test_debug.py
+++ b/python-sdk/tests/test_debug.py
@@ -6,7 +6,7 @@ from pachyderm_sdk.api import debug
 
 
 def test_dump(client: TestClient):
-    message = next(client.debug.dump_v2())
+    message = next(client.debug.dump())
     assert isinstance(message.content.content, bytes)
     assert len(message.content.content) > 0
 

--- a/python-sdk/tests/test_debug.py
+++ b/python-sdk/tests/test_debug.py
@@ -8,7 +8,7 @@ from pachyderm_sdk.api import debug
 def test_dump(client: TestClient):
     message = next(client.debug.dump())
     assert isinstance(message.content.content, bytes)
-    assert len(message.content.content) > 0
+    assert len(message.progress.progress) > 0
 
 
 def test_profile_cpu(client: TestClient):

--- a/python-sdk/tests/test_debug.py
+++ b/python-sdk/tests/test_debug.py
@@ -8,7 +8,7 @@ from pachyderm_sdk.api import debug
 def test_dump(client: TestClient):
     message = next(client.debug.dump())
     assert isinstance(message.content.content, bytes)
-    assert len(message.progress.progress) > 0
+    assert message.progress.progress > 0
 
 
 def test_profile_cpu(client: TestClient):


### PR DESCRIPTION
Creates api/debug/extension.py that overrides the debug.dump method, routing it to the DumpV2 endpoint and providing a sensible default (matching pachctl).