### PR TITLE
[2.6.x] Wrap DB calls in retries to catch connection flakiness (#9047)

### DIFF
--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -14,10 +14,13 @@ import (
 	"github.com/lib/pq"
 	etcd "go.etcd.io/etcd/client/v3"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/watch"
 	"github.com/pachyderm/pachyderm/v2/src/version"
@@ -188,8 +191,20 @@ type postgresReadOnlyCollection struct {
 func (c *postgresCollection) get(ctx context.Context, key string, q sqlx.QueryerContext) (*model, error) {
 	result := &model{}
 	queryString := fmt.Sprintf("select proto, updatedat from collections.%s where key = $1;", c.table)
-	if err := sqlx.GetContext(ctx, q, result, queryString, key); err != nil {
-		return nil, c.mapSQLError(err, key)
+	// wrap sqlx.GetContext() in a retry to mitigate database connection flakiness.
+	if err := backoff.RetryUntilCancel(ctx, func() error {
+		if err := sqlx.GetContext(ctx, q, result, queryString, key); err != nil {
+			return c.mapSQLError(err, key)
+		}
+		return nil
+	}, backoff.RetryEvery(time.Second), func(err error, d time.Duration) error {
+		if errutil.IsDatabaseDisconnect(err) {
+			log.Info(ctx, "retrying database get query", zap.String("key", key), zap.Error(err))
+			return nil
+		}
+		return err
+	}); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/src/internal/errutil/errutil.go
+++ b/src/internal/errutil/errutil.go
@@ -64,3 +64,8 @@ func IsNetRetryable(err error) bool {
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Temporary() //nolint:staticcheck
 }
+
+// IsDatabseDisconnect returns true if the error represents a database disconnect
+func IsDatabaseDisconnect(err error) bool {
+	return strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "unexpected EOF")
+}

--- a/src/server/worker/pipeline/transform/transform.go
+++ b/src/server/worker/pipeline/transform/transform.go
@@ -1,8 +1,12 @@
 package transform
 
 import (
+	"time"
+
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/driver"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
@@ -15,20 +19,28 @@ func Run(driver driver.Driver, logger logs.TaggedLogger) error {
 		return err
 	}
 	logger.Logf("transform spawner started")
-
-	return driver.PachClient().SubscribeProjectJob(
-		driver.PipelineInfo().Pipeline.Project.GetName(),
-		driver.PipelineInfo().Pipeline.Name,
-		true,
-		func(jobInfo *pps.JobInfo) error {
-			if jobInfo.PipelineVersion != driver.PipelineInfo().Version {
-				// Skip this job - we should be shut down soon, but don't error out in the meantime
-				return nil
+	// wrap SubscribeJob() in a retry to mitigate database connection flakiness.
+	return backoff.RetryUntilCancel(driver.PachClient().Ctx(),
+		func() error {
+			err := driver.PachClient().SubscribeProjectJob(
+				driver.PipelineInfo().Pipeline.Project.GetName(),
+				driver.PipelineInfo().Pipeline.Name,
+				true,
+				func(jobInfo *pps.JobInfo) error {
+					if jobInfo.PipelineVersion != driver.PipelineInfo().Version {
+						// Skip this job - we should be shut down soon, but don't error out in the meantime
+						return nil
+					}
+					if jobInfo.State == pps.JobState_JOB_FINISHING {
+						return nil
+					}
+					return reg.startJob(proto.Clone(jobInfo).(*pps.JobInfo))
+				},
+			)
+			if errutil.IsDatabaseDisconnect(err) {
+				logger.Logf("retry SubscribeProjectJob() in transform.Run(); err: %v", err)
+				return backoff.ErrContinue
 			}
-			if jobInfo.State == pps.JobState_JOB_FINISHING {
-				return nil
-			}
-			return reg.startJob(proto.Clone(jobInfo).(*pps.JobInfo))
-		},
-	)
+			return err
+		}, backoff.RetryEvery(time.Second), nil)
 }


### PR DESCRIPTION
* Wrap DB calls in retries to catch connection falkiness

* only retry collections.get() calls on database connection errors, not all errors

* add IsErrDatabaseConnection

* IsDatabaseDisconnect

* dbutil -> errutil

* use pj.logger

* uno mas

---------