### PR TITLE
[2.5.x] use images hosted in docs for examples (#8897)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ parameters:
   pachd-latest-version:
     type: string
     default: ""
+  go-version:
+    type: string
+    default: "1.20.5"
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -36,7 +36,10 @@ parameters:
     default: ubuntu-2204:2022.10.1
   go-version:
     type: string
-    default: "1.19"
+    default: "1.20.5"
+  go-releaser-version:
+    type: string
+    default: "1.17.1"
   run_load_tests:
     type: boolean
     default: false

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -810,8 +810,8 @@ jobs:
             echo '{"pachd_address": "grpc://'"$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)":30650'", "source": 2}' | pachctl config set context "mount-server" --overwrite && pachctl config set active-context "mount-server"
 
             pachctl create repo images
-            pachctl put file images@master:liberty.png -f http://imgur.com/46Q8nDz.png
-            pachctl put file images@branch:branch.png -f http://imgur.com/46Q8nDz.png
+            pachctl put file images@master:liberty.png -f https://docs.pachyderm.com/images/opencv/liberty.jpg
+            pachctl put file images@branch:branch.png -f https://docs.pachyderm.com/images/opencv/liberty.jpg
             pachctl list repo
 
             mkdir pfs

--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.19.0
+ARG GOVERSION=golang:1.20.5
 FROM $GOVERSION
 
 LABEL maintainer="msteffen@pachyderm.io"

--- a/etc/testing/kafka/Dockerfile
+++ b/etc/testing/kafka/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.19.0
+ARG GOVERSION=golang:1.20.5
 FROM $GOVERSION
 WORKDIR /app
 ADD . /app/

--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -18,7 +18,7 @@ for file in $(git status --porcelain | grep '^??' | sed 's/^?? //'); do
   skip_paths+=( -o -path "${file%/}" )
 done
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.50.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.51.2
 golangci-lint run --max-same-issues=1000 --
 
 # shellcheck disable=SC2046

--- a/etc/testing/spout/Dockerfile
+++ b/etc/testing/spout/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.19.0
+ARG GOVERSION=golang:1.20.5
 FROM $GOVERSION
 RUN mkdir /app
 ADD . /app/

--- a/examples/deferred-processing/deferred_processing_plus_transactions/images.txt
+++ b/examples/deferred-processing/deferred_processing_plus_transactions/images.txt
@@ -1,1 +1,1 @@
-http://imgur.com/46Q8nDz.jpg
+https://docs.pachyderm.com/images/opencv/liberty.jpg

--- a/examples/deferred-processing/deferred_processing_plus_transactions/images2.txt
+++ b/examples/deferred-processing/deferred_processing_plus_transactions/images2.txt
@@ -1,2 +1,2 @@
-http://imgur.com/g2QnNqa.jpg
-http://imgur.com/8MN9Kg0.jpg
+https://docs.pachyderm.com/images/opencv/kitten.jpg
+https://docs.pachyderm.com/images/opencv/robot.jpg

--- a/examples/globalID/data/images.txt
+++ b/examples/globalID/data/images.txt
@@ -1,1 +1,1 @@
-http://imgur.com/46Q8nDz.jpg
+https://docs.pachyderm.com/images/opencv/liberty.jpg

--- a/examples/globalID/data/images2.txt
+++ b/examples/globalID/data/images2.txt
@@ -1,2 +1,2 @@
-http://imgur.com/g2QnNqa.jpg
-http://imgur.com/8MN9Kg0.jpg
+https://docs.pachyderm.com/images/opencv/kitten.jpg
+https://docs.pachyderm.com/images/opencv/robot.jpg

--- a/examples/opencv/goclient-example/opencv-example.go
+++ b/examples/opencv/goclient-example/opencv-example.go
@@ -35,15 +35,15 @@ func main() {
 		panic(err)
 	}
 
-	if err := c.PutFileURL(imageCommit, "liberty.png", "http://imgur.com/46Q8nDz.png", false); err != nil {
+	if err := c.PutFileURL(imageCommit, "liberty.png", "https://docs.pachyderm.com/images/opencv/liberty.jpg", false); err != nil {
 		panic(err)
 	}
 
-	if err := c.PutFileURL(imageCommit, "AT-AT.png", "http://imgur.com/8MN9Kg0.png", false); err != nil {
+	if err := c.PutFileURL(imageCommit, "robot.png", "https://docs.pachyderm.com/images/opencv/robot.jpg", false); err != nil {
 		panic(err)
 	}
 
-	if err := c.PutFileURL(imageCommit, "kitten.png", "http://imgur.com/g2QnNqa.png", false); err != nil {
+	if err := c.PutFileURL(imageCommit, "kitten.png", "https://docs.pachyderm.com/images/opencv/kitten.jpg", false); err != nil {
 		panic(err)
 	}
 

--- a/examples/opencv/images.txt
+++ b/examples/opencv/images.txt
@@ -1,1 +1,1 @@
-http://imgur.com/46Q8nDz.jpg
+https://docs.pachyderm.com/images/opencv/liberty.jpg

--- a/examples/opencv/images2.txt
+++ b/examples/opencv/images2.txt
@@ -1,2 +1,2 @@
-http://imgur.com/g2QnNqa.jpg
-http://imgur.com/8MN9Kg0.jpg
+https://docs.pachyderm.com/images/opencv/kitten.jpg
+https://docs.pachyderm.com/images/opencv/robot.jpg

--- a/src/internal/sdata/sql.go
+++ b/src/internal/sdata/sql.go
@@ -38,7 +38,7 @@ func (m *SQLTupleWriter) Flush() error {
 	// flatten list of Tuple
 	var values Tuple
 	for r := range m.buf {
-		for c := range m.buf[r] {
+		for c := range m.buf[r] { //nolint:gosimple
 			values = append(values, m.buf[r][c])
 		}
 	}

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -2073,10 +2073,10 @@ func TestPutFileURL(t *testing.T) {
 		require.NoError(t, bucket.WriteAll(ctx, path, []byte(path), nil))
 	}
 	for _, p := range paths {
-		objURL := url + "/" + p
+		objURL := url + p
 		require.NoError(t, aliceClient.PutFileURL(commit, p, objURL, false))
 	}
-	srcURL := url + "/files"
+	srcURL := url + "files"
 	require.NoError(t, aliceClient.PutFileURL(commit, "recursive", srcURL, true))
 	check := func() {
 		cis, err := aliceClient.ListCommit(client.NewProjectRepo(pfs.DefaultProjectName, repo), nil, nil, 0)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4477,6 +4477,7 @@ func TestPFS(suite *testing.T) {
 		},
 		}
 		for i, test := range tests {
+			test := test
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 				t.Parallel()
 				ctx := pctx.TestContext(t)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -5357,10 +5357,10 @@ func TestPFS(suite *testing.T) {
 			require.NoError(t, bucket.WriteAll(ctx, path, []byte(path), nil))
 		}
 		for _, p := range paths {
-			objURL := url + "/" + p
+			objURL := url + p
 			require.NoError(t, env.PachClient.PutFileURL(commit, p, objURL, false))
 		}
-		srcURL := url + "/files"
+		srcURL := url + "files"
 		require.NoError(t, env.PachClient.PutFileURL(commit, "recursive", srcURL, true))
 		check := func() {
 			cis, err := env.PachClient.ListCommit(client.NewProjectRepo(pfs.DefaultProjectName, repo), nil, nil, 0)

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -111,7 +111,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 				))
 
 			require.NoError(t, c.WithModifyFileClient(client.NewProjectCommit(pfs.DefaultProjectName, imagesRepo, "master", "" /* commitID */), func(mf client.ModifyFile) error {
-				return errors.EnsureStack(mf.PutFileURL("/liberty.png", "http://i.imgur.com/46Q8nDz.png", false))
+				return errors.EnsureStack(mf.PutFileURL("/liberty.png", "https://docs.pachyderm.com/images/opencv/liberty.jpg", false))
 			}))
 
 			commitInfo, err := c.InspectProjectCommit(pfs.DefaultProjectName, montage, "master", "")
@@ -136,7 +136,7 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, enterprise.State_ACTIVE, state.State)
 			require.NoError(t, c.WithModifyFileClient(client.NewProjectCommit(pfs.DefaultProjectName, imagesRepo, "master", ""), func(mf client.ModifyFile) error {
-				return errors.EnsureStack(mf.PutFileURL("/kitten.png", "https://i.imgur.com/g2QnNqa.png", false))
+				return errors.EnsureStack(mf.PutFileURL("/kitten.png", "https://docs.pachyderm.com/images/opencv/kitten.jpg", false))
 			}))
 
 			commitInfo, err := c.InspectProjectCommit(pfs.DefaultProjectName, montage, "master", "")


### PR DESCRIPTION
Since we are backporting stuff and imgur still returns 429s, we need this in 2.5.x now.