### PR TITLE
Lock Required Tables in 2.6 migrations (#9051)

### DIFF
--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -251,6 +251,7 @@ func Cmds(ctx context.Context) []*cobra.Command {
 			states := migrations.CollectStates(nil, clusterstate.DesiredClusterState)
 			env := migrations.MakeEnv(nil, etcdClient)
 			env.Tx = txx
+			env.WithTableLocks = false
 			var errs error
 			for _, s := range states {
 				if err := migrations.ApplyMigrationTx(ctx, env, s); err != nil {


### PR DESCRIPTION
Lock Required Tables in 2.6 migrations