### PR TITLE
python-sdk - add spout101 example

### DIFF
--- a/python-sdk/examples/opencv/opencv.py
+++ b/python-sdk/examples/opencv/opencv.py
@@ -7,7 +7,6 @@ It makes heavy use of python_pachyderm's higher-level utility functionality
  (`create_python_pipeline`, `put_files`), as well as more run-of-the-mill
  functionality (`create_repo`, `create_pipeline`).
 """
-import os
 import shutil
 import tempfile
 from pachyderm_sdk import Client

--- a/python-sdk/examples/spout/README.md
+++ b/python-sdk/examples/spout/README.md
@@ -1,0 +1,12 @@
+# Spout Pipelines (Python)
+
+This example is a reproduction of the Spouts101 example from the Pachyderm repo. This example uses the pachyderm-sdk analogs for creating pipelines (`spout.py`), which was done using `pachctl` commands in the Spouts101 example. For more information on Spouts, a full walkthrough of the original example, or the pipelines' user code, go *[here](https://github.com/pachyderm/pachyderm/tree/master/examples/spouts/spout101)*.
+
+**Prerequisites:**
+- A running [Pachyderm cluster](https://docs.pachyderm.com/latest/get-started/)
+- Install the latest package of pachyderm-sdk
+
+**To run:**
+```shell
+$ python spout.py
+```

--- a/python-sdk/examples/spout/spout.py
+++ b/python-sdk/examples/spout/spout.py
@@ -1,0 +1,66 @@
+from pachyderm_sdk import Client
+from pachyderm_sdk.api import pps
+
+
+def main(client: Client):
+    spout = pps.Pipeline(name="spout")
+    client.pps.create_pipeline(
+        pipeline=spout,
+        transform=pps.Transform(
+            cmd=["python", "consumer/main.py"],
+            image="pachyderm/example-spout101:2.0.1",
+        ),
+        spout=pps.Spout(),
+        description="A spout pipeline that emulates the reception of data from an external source",
+    )
+
+    processor = pps.Pipeline(name="processor")
+    client.pps.create_pipeline(
+        pipeline=processor,
+        transform=pps.Transform(
+            cmd=["python", "processor/main.py"],
+            image="pachyderm/example-spout101:2.0.1",
+        ),
+        input=pps.Input(
+            pfs=pps.PfsInput(repo="spout", branch="master", glob="/*"),
+        ),
+        description="A pipeline that sorts 1KB vs 2KB files",
+    )
+
+    reducer = pps.Pipeline(name="reducer")
+    client.pps.create_pipeline(
+        pipeline=reducer,
+        transform=pps.Transform(
+            cmd=["bash"],
+            stdin=[
+                "set -x",
+                "FILES=/pfs/processor/*/*",
+                "for f in $FILES",
+                "do",
+                "directory=`dirname $f`",
+                "out=`basename $directory`",
+                "cat $f >> /pfs/out/${out}.txt",
+                "done",
+            ],
+        ),
+        input=pps.Input(
+            pfs=pps.PfsInput(repo="processor", branch="master", glob="/*"),
+        ),
+        description="A pipeline that reduces 1K/ and 2K/ directories",
+    )
+
+
+if __name__ == "__main__":
+    # Connects to a pachyderm cluster using the pachctl config file located
+    # at ~/.pachyderm/config.json. For other setups, you'll want one of the 
+    # alternatives:
+    # 1) To connect to pachyderm when this script is running inside the
+    #    cluster, use `Client.new_in_cluster()`.
+    # 2) To connect to pachyderm via a pachd address, use
+    #    `Client.new_from_pachd_address`.
+    # 3) To explicitly set the host and port, pass parameters into
+    #    `Client()`.
+    # 4) To use a config file located elsewhere, pass in the path to that
+    #    config file to Client.from_config()
+    client = Client.from_config()
+    main(client)

--- a/python-sdk/pachyderm_sdk/api/pps/_additions.py
+++ b/python-sdk/pachyderm_sdk/api/pps/_additions.py
@@ -1,0 +1,10 @@
+from . import CreatePipelineRequest, Service, Spout
+
+def _Create_Pipeline_Request__post_init__(self: "CreatePipelineRequest") -> None:
+    """
+    Ensure that we serialize an empty Spout object
+    """
+    if self.spout and self.spout == Spout():
+        self.spout = Spout(service=Service())
+
+CreatePipelineRequest.__post_init__ = _Create_Pipeline_Request__post_init__

--- a/python-sdk/pachyderm_sdk/api/pps/_additions.py
+++ b/python-sdk/pachyderm_sdk/api/pps/_additions.py
@@ -1,3 +1,10 @@
+""" This file patches methods onto the PPS Noun objects.
+This is done, as opposed to subclassing them, for these methods
+  to automatically be accessible on any objects included in the
+  response from the API.
+Note: These are internally patched and this file should
+  not be imported directly by users.
+"""
 from . import CreatePipelineRequest, Service, Spout
 
 def _Create_Pipeline_Request__post_init__(self: "CreatePipelineRequest") -> None:


### PR DESCRIPTION
adds the spout101 example ported for python-sdk. also updates the default behavior of an empty spout to ensure that it is serialized post init.

[INT-1027](https://pachyderm.atlassian.net/browse/INT-1027)

[INT-1027]: https://pachyderm.atlassian.net/browse/INT-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ