### PR TITLE
[2.6.x] Jupyter svc pipeline backport

### DIFF
--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -37,6 +37,8 @@ const Pipeline: React.FC<PipelineProps> = ({
     setImageName,
     inputSpec,
     setInputSpec,
+    pipelinePort,
+    setPipelinePort,
     requirements,
     setRequirements,
     callCreatePipeline,
@@ -155,6 +157,21 @@ const Pipeline: React.FC<PipelineProps> = ({
           }}
           disabled={loading}
           placeholder={placeholderRequirements}
+        ></input>
+      </div>
+      <div className="pachyderm-pipeline-input-wrapper">
+        <label className="pachyderm-pipeline-input-label" htmlFor="port">
+          Port:{'  '}
+        </label>
+        <input
+          className="pachyderm-pipeline-input"
+          data-testid="Pipeline__inputPort"
+          name="port"
+          value={pipelinePort}
+          onChange={(e: any) => {
+            setPipelinePort(e.target.value);
+          }}
+          disabled={loading}
         ></input>
       </div>
       <div className="pachyderm-pipeline-textarea-wrapper">

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -21,6 +21,8 @@ export type usePipelineResponse = {
   setImageName: (input: string) => void;
   inputSpec: string;
   setInputSpec: (input: string) => void;
+  pipelinePort: string;
+  setPipelinePort: (input: string) => void;
   requirements: string;
   setRequirements: (input: string) => void;
   callCreatePipeline: () => Promise<void>;
@@ -40,6 +42,7 @@ export const usePipeline = (
   const [pipelineProject, setPipelineProject] = useState('');
   const [imageName, setImageName] = useState('');
   const [inputSpec, setInputSpec] = useState('');
+  const [pipelinePort, setPipelinePort] = useState('');
   const [requirements, setRequirements] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [responseMessage, setResponseMessage] = useState('');
@@ -61,12 +64,20 @@ export const usePipeline = (
       setInputSpec('');
     }
     setCurrentNotebook(ppsContext?.notebookModel?.name ?? 'None');
+    setPipelinePort(ppsContext?.metadata?.config.port ?? '');
   }, [ppsContext]);
 
   useEffect(() => {
     const ppsMetadata: PpsMetadata = buildMetadata();
     saveNotebookMetaData(ppsMetadata);
-  }, [pipelineName, pipelineProject, imageName, requirements, inputSpec]);
+  }, [
+    pipelineName,
+    pipelineProject,
+    imageName,
+    requirements,
+    inputSpec,
+    pipelinePort,
+  ]);
 
   let callCreatePipeline: () => Promise<void>;
   if (ppsContext?.notebookModel) {
@@ -116,6 +127,7 @@ export const usePipeline = (
         image: imageName,
         requirements: requirements,
         input_spec: inputSpec,
+        port: pipelinePort,
       },
     };
   };
@@ -130,6 +142,8 @@ export const usePipeline = (
     setImageName,
     inputSpec,
     setInputSpec,
+    pipelinePort,
+    setPipelinePort,
     requirements,
     setRequirements,
     callCreatePipeline,

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -132,6 +132,7 @@ export type PpsConfig = {
   image: string;
   requirements: string | null;
   input_spec: string;
+  port: string;
 };
 
 export type PpsContext = {


### PR DESCRIPTION
*  Add port to the Jupyter extension to unlock building service pipelines in the extension.

[INT-1043]

[INT-1043]: https://pachyderm.atlassian.net/browse/INT-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ