### PR TITLE
Add a job to perform preflight checks

### DIFF
--- a/etc/helm/pachyderm/templates/preflight/job.yaml
+++ b/etc/helm/pachyderm/templates/preflight/job.yaml
@@ -1,0 +1,135 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if .Values.preflightCheckJob.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pachyderm-preflight-check
+  namespace: {{ .Release.Namespace }}
+spec:
+  completions: 1
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.preflightCheckJob.annotations -}}
+        {{ toYaml .Values.preflightCheckJob.annotations | nindent 8 }}
+        {{- end }}
+      labels:
+        app: preflight-check
+        suite: pachyderm
+        {{- if .Values.preflightCheckJob.podLabels }}
+        {{- toYaml .Values.preflightCheckJob.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.preflightCheckJob.priorityClassName }}
+      priorityClassName: {{ .Values.preflightCheckJob.priorityClassName }}
+      {{- end }}
+      {{-  if .Values.preflightCheckJob.affinity }}
+      affinity: {{ toYaml .Values.preflightCheckJob.affinity | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      {{-  if .Values.preflightCheckJob.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.preflightCheckJob.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{-  if .Values.preflightCheckJob.tolerations }}
+      tolerations: {{ toYaml .Values.preflightCheckJob.tolerations | nindent 8 }}
+      {{- end }}
+      containers:
+      - command:
+        - /pachd
+        args:
+        - --mode
+        - preflight
+        env:
+        - name: POSTGRES_HOST
+          value: {{ required "postgresql host required" .Values.global.postgresql.postgresqlHost | quote }}
+        - name: POSTGRES_PORT
+          value:  {{ required "postgresql port required" .Values.global.postgresql.postgresqlPort | quote }}
+        - name: POSTGRES_USER
+          value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
+        - name: POSTGRES_DATABASE
+          value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
+        {{- if .Values.global.postgresql.ssl }}
+        - name: POSTGRES_SSL
+          value: "require"
+        {{- end }}
+        {{- if .Values.cloudsqlAuthProxy.iamLogin }}
+        - name: POSTGRES_PASSWORD
+          value: "Using-iamLogin"
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
+              key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
+        {{- end }}
+        - name: PG_BOUNCER_HOST
+          value: pg-bouncer # Must match pgbouncer service name
+        - name: PG_BOUNCER_PORT
+          value: "5432" # Must match pbouncer service port
+        {{- if .Values.preflightCheckJob.disableLogSampling }}
+        - name: PACHYDERM_DISABLE_LOG_SAMPLING
+          value: "1"
+        {{- end }}
+        {{- if .Values.preflightCheckJob.sqlQueryLogs }}
+        - name: POSTGRES_QUERY_LOGGING
+          value: "1"
+        {{- end }}
+        {{ if .Values.global.proxy }}
+        - name: http_proxy
+          value: {{ .Values.global.proxy }}
+        - name: https_proxy
+          value:  {{.Values.global.proxy}}
+        - name: HTTP_PROXY
+          value:  {{.Values.global.proxy}}
+        - name: HTTPS_PROXY
+          value:  {{.Values.global.proxy}}
+        {{ end }}
+        {{ if .Values.global.noProxy }}
+        - name: no_proxy
+          value:  {{.Values.global.noProxy}}
+        - name: NO_PROXY
+          value:  {{.Values.global.noProxy}}
+        {{ end }}
+        - name: K8S_MEMORY_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              containerName: pachd
+              resource: requests.memory
+        - name: K8S_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: pachd
+              resource: limits.memory
+        image: "{{ .Values.preflightCheckJob.image.repository }}:{{ default .Chart.AppVersion .Values.preflightCheckJob.image.tag }}"
+        imagePullPolicy: {{ .Values.preflightCheckJob.image.pullPolicy }}
+        name: pachd
+        {{- if .Values.preflightCheckJob.resources }}
+        resources: {{ toYaml .Values.preflightCheckJob.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+              drop:
+              - all
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+status: {}
+{{- end -}}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -148,6 +148,141 @@
         "deployTarget": {
             "type": "string"
         },
+        "determined": {
+            "type": "object",
+            "properties": {
+                "checkpointStorage": {
+                    "type": "object",
+                    "properties": {
+                        "hostPath": {
+                            "type": "string"
+                        },
+                        "saveExperimentBest": {
+                            "type": "integer"
+                        },
+                        "saveTrialBest": {
+                            "type": "integer"
+                        },
+                        "saveTrialLatest": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "db": {
+                    "type": "object",
+                    "properties": {
+                        "cpuRequest": {
+                            "type": "integer"
+                        },
+                        "memRequest": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "storageSize": {
+                            "type": "string"
+                        },
+                        "useNodePortForDB": {
+                            "type": "boolean"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "enterpriseEdition": {
+                    "type": "boolean"
+                },
+                "imagePullSecretName": {
+                    "type": "null"
+                },
+                "imageRegistry": {
+                    "type": "string"
+                },
+                "masterCpuRequest": {
+                    "type": "integer"
+                },
+                "masterMemRequest": {
+                    "type": "string"
+                },
+                "masterPort": {
+                    "type": "integer"
+                },
+                "maxSlotsPerPod": {
+                    "type": "null"
+                },
+                "oidc": {
+                    "type": "object",
+                    "properties": {
+                        "authenticationClaim": {
+                            "type": "null"
+                        },
+                        "clientId": {
+                            "type": "null"
+                        },
+                        "clientSecretKey": {
+                            "type": "null"
+                        },
+                        "clientSecretName": {
+                            "type": "null"
+                        },
+                        "enabled": {
+                            "type": "null"
+                        },
+                        "idpRecipientUrl": {
+                            "type": "null"
+                        },
+                        "idpSsoUrl": {
+                            "type": "null"
+                        },
+                        "provider": {
+                            "type": "null"
+                        },
+                        "scimAuthenticationAttribute": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "resourcePools": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "pool_name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "taskContainerDefaults": {
+                    "type": "null"
+                },
+                "telemetry": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "useNodePortForMaster": {
+                    "type": "boolean"
+                }
+            }
+        },
         "enterpriseServer": {
             "type": "object",
             "properties": {
@@ -1394,6 +1529,55 @@
                             "type": "array"
                         }
                     }
+                }
+            }
+        },
+        "preflightCheckJob": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "disableLogSampling": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "sqlQueryLogs": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": "array"
                 }
             }
         },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1287,3 +1287,34 @@ proxy:
     secretName: ""
     # If set, generate the secret from values here.  This is intended only for unit tests.
     secret: {}
+preflightCheckJob:
+  # If true, install a Kubernetes job that runs preflight checks from the configured Pachyderm
+  # release.
+  enabled: false
+
+  # The version to preflight.  It is totally fine if this is newer than the currently-running pachd
+  # version.
+  image:
+    repository: "pachyderm/pachd"
+    pullPolicy: "IfNotPresent"
+    tag: ""
+
+  # misc k8s settings
+  affinity: {}
+  annotations: {}
+  resources:
+    {}
+    #limits:
+    #  cpu: "1"
+    #  memory: "2G"
+    #requests:
+    #  cpu: "1"
+    #  memory: "2G"
+  priorityClassName: ""
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+
+  # logging settings
+  sqlQueryLogs: false
+  disableLogSampling: false

--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -27,7 +27,7 @@ func Populate(object interface{}, decoders ...Decoder) error {
 // Main runs the common functionality needed in a go main function.
 // appEnv will be populated and passed to do, defaultEnv can be nil
 // if there is an error, os.Exit(1) will be called.
-func Main(ctx context.Context, do func(context.Context, interface{}) error, appEnv interface{}, decoders ...Decoder) {
+func Main[T any](ctx context.Context, do func(context.Context, T) error, appEnv T, decoders ...Decoder) {
 	if err := Populate(appEnv, decoders...); err != nil {
 		mainError(err)
 	}

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -18,42 +18,29 @@ type Configuration struct {
 // src/internal/log package for those.
 type GlobalConfiguration struct {
 	FeatureFlags
-	EtcdHost                       string `env:"ETCD_SERVICE_HOST,required"`
-	EtcdPort                       string `env:"ETCD_SERVICE_PORT,required"`
-	PPSWorkerPort                  uint16 `env:"PPS_WORKER_GRPC_PORT,default=1080"`
-	Port                           uint16 `env:"PORT,default=1650"`
-	PrometheusPort                 uint16 `env:"PROMETHEUS_PORT,default=1656"`
-	PeerPort                       uint16 `env:"PEER_PORT,default=1653"`
-	S3GatewayPort                  uint16 `env:"S3GATEWAY_PORT,default=1600"`
-	DownloadPort                   uint16 `env:"DOWNLOAD_PORT,default=1659"`
-	PPSEtcdPrefix                  string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
-	Namespace                      string `env:"PACH_NAMESPACE,default=default"`
-	StorageRoot                    string `env:"PACH_ROOT,default=/pach"`
-	GCPercent                      int    `env:"GC_PERCENT,default=100"`
-	LokiHost                       string `env:"LOKI_SERVICE_HOST"`
-	LokiPort                       string `env:"LOKI_SERVICE_PORT"`
-	OidcPort                       uint16 `env:"OIDC_PORT,default=1657"`
-	IsPachw                        bool   `env:"IS_PACHW,default=false"`
-	PachwInSidecars                bool   `env:"PACHW_IN_SIDECARS,default=true"`
-	PachwMinReplicas               int    `env:"PACHW_MIN_REPLICAS"`
-	PachwMaxReplicas               int    `env:"PACHW_MAX_REPLICAS,default=1"`
-	PGBouncerHost                  string `env:"PG_BOUNCER_HOST,required"`
-	PGBouncerPort                  int    `env:"PG_BOUNCER_PORT,required"`
-	PostgresSSL                    string `env:"POSTGRES_SSL,default=disable"`
-	PostgresHost                   string `env:"POSTGRES_HOST"`
-	PostgresPort                   int    `env:"POSTGRES_PORT"`
-	PostgresDBName                 string `env:"POSTGRES_DATABASE"`
-	PostgresUser                   string `env:"POSTGRES_USER"`
-	PostgresPassword               string `env:"POSTGRES_PASSWORD"`
-	PostgresMaxOpenConns           int    `env:"POSTGRES_MAX_OPEN_CONNS,default=10"`
-	PostgresMaxIdleConns           int    `env:"POSTGRES_MAX_IDLE_CONNS,default=10"`
-	PGBouncerMaxOpenConns          int    `env:"PG_BOUNCER_MAX_OPEN_CONNS,default=10"`
-	PGBouncerMaxIdleConns          int    `env:"PG_BOUNCER_MAX_IDLE_CONNS,default=10"`
-	PostgresConnMaxLifetimeSeconds int    `env:"POSTGRES_CONN_MAX_LIFETIME_SECONDS,default=0"`
-	PostgresConnMaxIdleSeconds     int    `env:"POSTGRES_CONN_MAX_IDLE_SECONDS,default=0"`
-	PostgresQueryLogging           bool   `env:"POSTGRES_QUERY_LOGGING,default=false"`
-	PachdServiceHost               string `env:"PACHD_SERVICE_HOST"`
-	PachdServicePort               string `env:"PACHD_SERVICE_PORT"`
+	PostgresConfiguration
+
+	EtcdHost         string `env:"ETCD_SERVICE_HOST,required"`
+	EtcdPort         string `env:"ETCD_SERVICE_PORT,required"`
+	PPSWorkerPort    uint16 `env:"PPS_WORKER_GRPC_PORT,default=1080"`
+	Port             uint16 `env:"PORT,default=1650"`
+	PrometheusPort   uint16 `env:"PROMETHEUS_PORT,default=1656"`
+	PeerPort         uint16 `env:"PEER_PORT,default=1653"`
+	S3GatewayPort    uint16 `env:"S3GATEWAY_PORT,default=1600"`
+	DownloadPort     uint16 `env:"DOWNLOAD_PORT,default=1659"`
+	PPSEtcdPrefix    string `env:"PPS_ETCD_PREFIX,default=pachyderm_pps"`
+	Namespace        string `env:"PACH_NAMESPACE,default=default"`
+	StorageRoot      string `env:"PACH_ROOT,default=/pach"`
+	GCPercent        int    `env:"GC_PERCENT,default=100"`
+	LokiHost         string `env:"LOKI_SERVICE_HOST"`
+	LokiPort         string `env:"LOKI_SERVICE_PORT"`
+	OidcPort         uint16 `env:"OIDC_PORT,default=1657"`
+	IsPachw          bool   `env:"IS_PACHW,default=false"`
+	PachwInSidecars  bool   `env:"PACHW_IN_SIDECARS,default=true"`
+	PachwMinReplicas int    `env:"PACHW_MIN_REPLICAS"`
+	PachwMaxReplicas int    `env:"PACHW_MAX_REPLICAS,default=1"`
+	PachdServiceHost string `env:"PACHD_SERVICE_HOST"`
+	PachdServicePort string `env:"PACHD_SERVICE_PORT"`
 
 	EtcdPrefix           string `env:"ETCD_PREFIX,default="`
 	DeploymentID         string `env:"CLUSTER_DEPLOYMENT_ID,default="`
@@ -104,6 +91,26 @@ type GlobalConfiguration struct {
 	SidecarDefaultMemoryRequest  resource.Quantity `env:"SIDECAR_DEFAULT_MEMORY_REQUEST,default=256Mi"`
 	SidecarDefaultCPURequest     resource.Quantity `env:"SIDECAR_DEFAULT_CPU_REQUEST,default=1"`
 	SidecarDefaultStorageRequest resource.Quantity `env:"SIDECAR_DEFAULT_STORAGE_REQUEST,default=1Gi"`
+}
+
+// PostgresConfiguration configures postgres and pg-bouncer.
+type PostgresConfiguration struct {
+	PostgresSSL                    string `env:"POSTGRES_SSL,default=disable"`
+	PostgresHost                   string `env:"POSTGRES_HOST"`
+	PostgresPort                   int    `env:"POSTGRES_PORT"`
+	PostgresDBName                 string `env:"POSTGRES_DATABASE"`
+	PostgresUser                   string `env:"POSTGRES_USER"`
+	PostgresPassword               string `env:"POSTGRES_PASSWORD"`
+	PostgresMaxOpenConns           int    `env:"POSTGRES_MAX_OPEN_CONNS,default=10"`
+	PostgresMaxIdleConns           int    `env:"POSTGRES_MAX_IDLE_CONNS,default=10"`
+	PostgresConnMaxLifetimeSeconds int    `env:"POSTGRES_CONN_MAX_LIFETIME_SECONDS,default=0"`
+	PostgresConnMaxIdleSeconds     int    `env:"POSTGRES_CONN_MAX_IDLE_SECONDS,default=0"`
+	PostgresQueryLogging           bool   `env:"POSTGRES_QUERY_LOGGING,default=false"`
+
+	PGBouncerMaxOpenConns int    `env:"PG_BOUNCER_MAX_OPEN_CONNS,default=10"`
+	PGBouncerMaxIdleConns int    `env:"PG_BOUNCER_MAX_IDLE_CONNS,default=10"`
+	PGBouncerHost         string `env:"PG_BOUNCER_HOST,required"`
+	PGBouncerPort         int    `env:"PG_BOUNCER_PORT,required"`
 }
 
 // PachdFullConfiguration contains the full pachd configuration.
@@ -218,8 +225,13 @@ type FeatureFlags struct {
 	IdentityServerEnabled        bool `env:"IDENTITY_SERVER_ENABLED,default=false"`
 }
 
+// PachdPreflightConfiguration is configuration for the preflight checks.
+type PachdPreflightConfiguration struct {
+	PostgresConfiguration
+}
+
 // NewConfiguration creates a generic configuration from a specific type of configuration.
-func NewConfiguration(config interface{}) *Configuration {
+func NewConfiguration(config any) *Configuration {
 	configuration := &Configuration{}
 	switch v := config.(type) {
 	case *GlobalConfiguration:
@@ -237,6 +249,11 @@ func NewConfiguration(config interface{}) *Configuration {
 	case *EnterpriseServerConfiguration:
 		configuration.GlobalConfiguration = &v.GlobalConfiguration
 		configuration.EnterpriseSpecificConfiguration = &v.EnterpriseSpecificConfiguration
+		return configuration
+	case *PachdPreflightConfiguration:
+		configuration.GlobalConfiguration = &GlobalConfiguration{
+			PostgresConfiguration: v.PostgresConfiguration,
+		}
 		return configuration
 	default:
 		return nil

--- a/src/internal/pachd/enterprise.go
+++ b/src/internal/pachd/enterprise.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	eprsserver "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
 )
 
@@ -84,6 +85,6 @@ func (eb *enterpriseBuilder) buildAndRun(ctx context.Context) error {
 //
 // Enterprise mode is the enterprise server which is used to manage multiple
 // Pachyderm installations.
-func EnterpriseMode(ctx context.Context, config any) error {
+func EnterpriseMode(ctx context.Context, config *pachconfig.EnterpriseServerConfiguration) error {
 	return newEnterpriseBuilder(config).buildAndRun(ctx)
 }

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	eprsserver "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
 )
 
@@ -104,6 +105,6 @@ func (fb *fullBuilder) buildAndRun(ctx context.Context) error {
 //
 // Full mode is that standard pachd which users interact with using pachctl and
 // which manages pipelines, files and so forth.
-func FullMode(ctx context.Context, config any) error {
+func FullMode(ctx context.Context, config *pachconfig.PachdFullConfiguration) error {
 	return newFullBuilder(config).buildAndRun(ctx)
 }

--- a/src/internal/pachd/pachw.go
+++ b/src/internal/pachd/pachw.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
 	debugserver "github.com/pachyderm/pachyderm/v2/src/server/debug/server"
@@ -113,6 +114,6 @@ func (pachwb *pachwBuilder) buildAndRun(ctx context.Context) error {
 
 // PachwMode runs a pachw-mode pachd.
 // When in pachw mode, the pachd instance processes storage and url tasks.
-func PachwMode(ctx context.Context, config any) error {
+func PachwMode(ctx context.Context, config *pachconfig.PachdFullConfiguration) error {
 	return newPachwBuilder(config).buildAndRun(ctx)
 }

--- a/src/internal/pachd/paused.go
+++ b/src/internal/pachd/paused.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	eprsserver "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
 )
 
@@ -99,6 +100,6 @@ func (pb *pausedBuilder) buildAndRun(ctx context.Context) error {
 //
 // Paused mode is a restricted mode which runs Pachyderm read-only in order to
 // take offline backups.
-func PausedMode(ctx context.Context, config any) error {
+func PausedMode(ctx context.Context, config *pachconfig.PachdFullConfiguration) error {
 	return newPausedBuilder(config).buildAndRun(ctx)
 }

--- a/src/internal/pachd/preflight.go
+++ b/src/internal/pachd/preflight.go
@@ -1,0 +1,52 @@
+package pachd
+
+import (
+	"context"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/preflight"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/version"
+)
+
+// preflightBuilder builds a preflight-mode pachd instance.
+type preflightBuilder struct {
+	builder
+}
+
+func (pb *preflightBuilder) initServiceEnv(ctx context.Context) error {
+	pb.env = serviceenv.InitDBOnlyEnv(ctx, pb.config)
+	return nil
+}
+
+func (pb *preflightBuilder) setupDB(ctx context.Context) error {
+	if err := dbutil.WaitUntilReady(ctx, pb.env.GetDBClient()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (pb *preflightBuilder) testMigrations(ctx context.Context) error {
+	return preflight.TestMigrations(ctx, pb.env.GetDBClient())
+}
+
+func (pb *preflightBuilder) everythingOK(ctx context.Context) error {
+	log.Info(ctx, "all preflight checks OK; it is safe to upgrade this environment to Pachyderm "+version.Version.Canonical())
+	return nil
+}
+
+func (pb *preflightBuilder) buildAndRun(ctx context.Context) error {
+	return pb.apply(ctx, pb.printVersion, pb.initServiceEnv, pb.setupDB, pb.testMigrations, pb.everythingOK)
+}
+
+// PreflightMode runs pachd's preflight checks.  It is safe to run these at any time, even for a
+// version different than the currently-running full pachd version.
+func PreflightMode(ctx context.Context, config *pachconfig.PachdPreflightConfiguration) error {
+	log.SetLevel(log.DebugLevel)
+	b := &preflightBuilder{
+		builder: newBuilder(config, "pachyderm-pachd-preflight"),
+	}
+	return b.buildAndRun(ctx)
+}

--- a/src/internal/pachd/preflight.go
+++ b/src/internal/pachd/preflight.go
@@ -38,7 +38,7 @@ func (pb *preflightBuilder) everythingOK(ctx context.Context) error {
 }
 
 func (pb *preflightBuilder) buildAndRun(ctx context.Context) error {
-	return pb.apply(ctx, pb.printVersion, pb.initServiceEnv, pb.setupDB, pb.testMigrations, pb.everythingOK)
+	return pb.apply(ctx, pb.printVersion, pb.tweakResources, pb.initServiceEnv, pb.setupDB, pb.testMigrations, pb.everythingOK)
 }
 
 // PreflightMode runs pachd's preflight checks.  It is safe to run these at any time, even for a

--- a/src/internal/pachd/sidecar.go
+++ b/src/internal/pachd/sidecar.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
@@ -119,6 +120,6 @@ func (sb *sidecarBuilder) buildAndRun(ctx context.Context) error {
 //
 // Sidecar mode is run as a sidecar in a pipeline pod; it provides services to
 // the pipeline worker code running in that pod.
-func SidecarMode(ctx context.Context, config any) error {
+func SidecarMode(ctx context.Context, config *pachconfig.PachdFullConfiguration) error {
 	return newSidecarBuilder(config).buildAndRun(ctx)
 }

--- a/src/internal/preflight/preflight.go
+++ b/src/internal/preflight/preflight.go
@@ -72,7 +72,6 @@ func TestMigrations(ctx context.Context, db *pachsql.DB) (retErr error) {
 	env := migrations.MakeEnv(nil, etcdClient)
 	env.Tx = txx
 	env.WithTableLocks = false
-	var errs error
 	for _, s := range states {
 		if err := migrations.ApplyMigrationTx(ctx, env, s); err != nil {
 			log.Error(ctx, "migration did not apply; continuing", zap.Error(err))
@@ -80,5 +79,5 @@ func TestMigrations(ctx context.Context, db *pachsql.DB) (retErr error) {
 		}
 	}
 	log.Info(ctx, "done applying migrations")
-	return errs
+	return
 }

--- a/src/internal/preflight/preflight.go
+++ b/src/internal/preflight/preflight.go
@@ -1,0 +1,84 @@
+// Package preflight offers checks that can be run by pachd in preflight mode.
+package preflight
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.uber.org/zap"
+)
+
+func TestMigrations(ctx context.Context, db *pachsql.DB) (retErr error) {
+	// Create test dirs for etcd data
+	dir, err := os.MkdirTemp("", "test-migrations")
+	if err != nil {
+		return errors.Wrap(err, "create etcd server tmpdir")
+	}
+	defer os.RemoveAll(dir)
+
+	etcdConfig := embed.NewConfig()
+	etcdConfig.MaxTxnOps = 10000
+	etcdConfig.Dir = filepath.Join(dir, "dir")
+	etcdConfig.WalDir = filepath.Join(dir, "wal")
+	etcdConfig.InitialElectionTickAdvance = false
+	etcdConfig.TickMs = 10
+	etcdConfig.ElectionMs = 50
+	etcdConfig.ListenPeerUrls = []url.URL{}
+	etcdConfig.ListenClientUrls = []url.URL{{
+		Scheme: "http",
+		Host:   "localhost:7777",
+	}}
+	log.AddLoggerToEtcdServer(ctx, etcdConfig)
+	etcd, err := embed.StartEtcd(etcdConfig)
+	if err != nil {
+		return errors.Wrap(err, "start etcd")
+	}
+	defer etcd.Close()
+
+	etcdCfg := log.GetEtcdClientConfig(ctx)
+	etcdCfg.Endpoints = []string{"http://localhost:7777"}
+	etcdCfg.DialOptions = client.DefaultDialOptions()
+	etcdClient, err := clientv3.New(etcdCfg)
+	if err != nil {
+		return errors.Wrap(err, "connect to etcd")
+	}
+	defer etcdClient.Close()
+
+	txx, err := db.BeginTxx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	})
+	if err != nil {
+		return errors.Wrap(err, "start tx")
+	}
+	defer func() {
+		if err := txx.Rollback(); err != nil {
+			errors.JoinInto(&retErr, errors.Wrap(err, "rollback"))
+			return
+		}
+		log.Info(ctx, "txn rolled back ok")
+	}()
+	states := migrations.CollectStates(nil, clusterstate.DesiredClusterState)
+	env := migrations.MakeEnv(nil, etcdClient)
+	env.Tx = txx
+	env.WithTableLocks = false
+	var errs error
+	for _, s := range states {
+		if err := migrations.ApplyMigrationTx(ctx, env, s); err != nil {
+			log.Error(ctx, "migration did not apply; continuing", zap.Error(err))
+			errors.JoinInto(&retErr, errors.Wrapf(err, "migration %v", s.Number()))
+		}
+	}
+	log.Info(ctx, "done applying migrations")
+	return errs
+}

--- a/src/internal/preflight/preflight_test.go
+++ b/src/internal/preflight/preflight_test.go
@@ -1,0 +1,31 @@
+package preflight
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+)
+
+func TestTestMigrations(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	opts := dockertestenv.NewTestDBOptions(t)
+	opts = append(opts, dbutil.WithQueryLog(true, "migrations"))
+	db := testutil.OpenDB(t, opts...)
+	if err := TestMigrations(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	row := db.QueryRow(`select count(1) from migrations`)
+	var rows int
+	err := row.Scan(&row)
+	want := `relation "migrations" does not exist`
+	if err == nil {
+		t.Fatalf("should get an error when querying the migrations table\n got migration row count: %v", rows)
+	} else if got := err.Error(); !strings.Contains(got, want) {
+		t.Fatalf("unexpected error:\n  got: %v\n want: %v", got, want)
+	}
+
+}

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -197,6 +197,15 @@ func InitWithKube(ctx context.Context, config *pachconfig.Configuration) *Nonblo
 	return env // env is not ready yet
 }
 
+// InitDBOnlyEnv is like InitServiceEnv, but only connects to the database.
+func InitDBOnlyEnv(rctx context.Context, config *pachconfig.Configuration) *NonblockingServiceEnv {
+	sctx, end := log.SpanContext(rctx, "serviceenv")
+	ctx, cancel := pctx.WithCancel(sctx)
+	env := &NonblockingServiceEnv{config: config, ctx: ctx, cancel: func() { cancel(); end() }}
+	goCtx(&env.dbEg, env.ctx, env.initDBClient)
+	return env
+}
+
 func (env *NonblockingServiceEnv) Config() *pachconfig.Configuration {
 	return env.config
 }

--- a/src/server/cmd/pachctl-doc/main.go
+++ b/src/server/cmd/pachctl-doc/main.go
@@ -25,7 +25,7 @@ func main() {
 	cmdutil.Main(context.Background(), do, &appEnv{})
 }
 
-func do(ctx context.Context, appEnvObj interface{}) error {
+func do(ctx context.Context, appEnvObj *appEnv) error {
 	path := "./docs/"
 
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -62,13 +62,16 @@ func main() {
 	case mode == "paused":
 		logMode("paused")
 		cmdutil.Main(ctx, pachd.PausedMode, &pachconfig.PachdFullConfiguration{})
+	case mode == "preflight":
+		logMode("preflight")
+		cmdutil.Main(ctx, pachd.PreflightMode, &pachconfig.PachdPreflightConfiguration{})
 	default:
 		log.Error(ctx, "pachd: unrecognized mode", zap.String("mode", mode))
 		fmt.Printf("unrecognized mode: %s\n", mode)
 	}
 }
 
-func doReadinessCheck(ctx context.Context, config interface{}) error {
+func doReadinessCheck(ctx context.Context, config *pachconfig.GlobalConfiguration) error {
 	env := serviceenv.InitPachOnlyEnv(ctx, pachconfig.NewConfiguration(config))
 	return env.GetPachClient(ctx).Health()
 }

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -45,7 +45,7 @@ func main() {
 	cmdutil.Main(ctx, do, &pachconfig.WorkerFullConfiguration{})
 }
 
-func do(ctx context.Context, config interface{}) error {
+func do(ctx context.Context, config *pachconfig.WorkerFullConfiguration) error {
 	// must run InstallJaegerTracer before InitWithKube/pach client initialization
 	tracing.InstallJaegerTracerFromEnv()
 	env := serviceenv.InitWithKube(ctx, pachconfig.NewConfiguration(config))

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -3,7 +3,6 @@ package cmds
 import (
 	"context"
 	"crypto/tls"
-	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,24 +10,19 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pachyderm/pachyderm/v2/src/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
-	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/preflight"
 	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
 	"github.com/spf13/cobra"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/zap"
 )
 
@@ -198,66 +192,10 @@ func Cmds(ctx context.Context) []*cobra.Command {
 			if err := dbutil.WaitUntilReady(ctx, db); err != nil {
 				return errors.Wrap(err, "wait for database ready")
 			}
-
-			// Create test dirs for etcd data
-			dir, err := os.MkdirTemp("", "test-migrations")
-			if err != nil {
-				return errors.Wrap(err, "create etcd server tmpdir")
+			if err := preflight.TestMigrations(ctx, db); err != nil {
+				return errors.Wrap(err, "apply migrations")
 			}
-			defer os.RemoveAll(dir)
-
-			etcdConfig := embed.NewConfig()
-			etcdConfig.MaxTxnOps = 10000
-			etcdConfig.Dir = filepath.Join(dir, "dir")
-			etcdConfig.WalDir = filepath.Join(dir, "wal")
-			etcdConfig.InitialElectionTickAdvance = false
-			etcdConfig.TickMs = 10
-			etcdConfig.ElectionMs = 50
-			etcdConfig.ListenPeerUrls = []url.URL{}
-			etcdConfig.ListenClientUrls = []url.URL{{
-				Scheme: "http",
-				Host:   "localhost:7777",
-			}}
-			log.AddLoggerToEtcdServer(ctx, etcdConfig)
-			etcd, err := embed.StartEtcd(etcdConfig)
-			if err != nil {
-				return errors.Wrap(err, "start etcd")
-			}
-			defer etcd.Close()
-
-			etcdCfg := log.GetEtcdClientConfig(ctx)
-			etcdCfg.Endpoints = []string{"http://localhost:7777"}
-			etcdCfg.DialOptions = client.DefaultDialOptions()
-			etcdClient, err := clientv3.New(etcdCfg)
-			if err != nil {
-				return errors.Wrap(err, "connect to etcd")
-			}
-			defer etcdClient.Close()
-
-			txx, err := db.BeginTxx(ctx, &sql.TxOptions{
-				Isolation: sql.LevelSerializable,
-			})
-			if err != nil {
-				return errors.Wrap(err, "start tx")
-			}
-			defer func() {
-				if err := txx.Rollback(); err != nil {
-					errors.JoinInto(&retErr, errors.Wrap(err, "rollback"))
-				}
-			}()
-			states := migrations.CollectStates(nil, clusterstate.DesiredClusterState)
-			env := migrations.MakeEnv(nil, etcdClient)
-			env.Tx = txx
-			env.WithTableLocks = false
-			var errs error
-			for _, s := range states {
-				if err := migrations.ApplyMigrationTx(ctx, env, s); err != nil {
-					log.Error(ctx, "migration did not apply; continuing", zap.Error(err))
-					errors.JoinInto(&retErr, errors.Wrapf(err, "migration %v", s.Number()))
-				}
-			}
-			log.Info(ctx, "done applying migrations")
-			return errs
+			return nil
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(testMigrations, "misc test-migrations"))


### PR DESCRIPTION
This adds a new pachd mode `preflight` that runs preflight checks.  Currently, the preflight checks are running `TestMigrations` that makes sure the migrations apply OK.

Preflight checks run as a Kubernetes job, and can use a different version of Pachyderm than the rest of the chart (obviously).  Configure it like:

```yaml
preflightCheckJob:
    enabled: true
    image:
        tag: "2.10.42"
  ```

After the job runs, the last log line should be:

```json
{"severity":"info","time":"2023-07-20T00:12:09.955940599Z","caller":"pachd/preflight.go:36","message":"all preflight checks OK; it is safe to upgrade this environment to Pachyderm v0.0.0-1689811896"}
```

Users have to manually `kubectl delete job pachyderm-preflight-checks` after setting `enabled: false`.  If they try changing the image tag manually, it will fail, because that's just how k8s jobs are.

You can also run this locally like: `POSTGRES_USER=postgres POSTGRES_DATABASE=test PG_BOUNCER_HOST=localhost PG_BOUNCER_PORT=5432 go run ./src/server/cmd/pachd --mode=preflight`.  Although we create a ServiceEnv, the preflight checks only consume the environment variables it needs, so it's easier to run locally than a full pachd.  (It makes its own etcd so it doesn't mess with the real data in etcd.  Thus it does not need to connect to one.)

That would run the preflight checks for 2.10.42 against the current database that pachd uses.

Some notes:
* People haven't run the helm JSON schema generator for a while, so this adds a bunch of stuff unrelated to the PR.
* I was debugging some issue involving cmdutil.Main and made it type safe.  That is not necessary here, but I decided to keep it.
* I factored out the database config into its own object.  Through the magic of Go, no code changes as a result.  I'm not sure if that's good or bad.
* pachctl now calls `preflight.TestMigrations` instead of implementing the test migrations itself.
* I added a test to make sure the database is not mutated.