### PR TITLE
debug: avoid retrieving binaries by default

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -117,7 +117,6 @@ func (s *debugServer) GetDumpV2Template(ctx context.Context, request *debug.GetD
 				Describes: apps,
 				Logs:      apps,
 				LokiLogs:  apps,
-				Binaries:  pachApps,
 				Profiles:  pachApps,
 			},
 			InputRepos: true,
@@ -447,7 +446,7 @@ func makeBinariesTask(server debug.Debug_DumpV2Server, apps []*debug.App) taskFu
 				defer rp(ctx)
 				for _, pod := range app.Pods {
 					if pod.Ip == "" {
-						log.Info(ctx, "skipping debug bindary for pod with empty IP", zap.String("pod", pod.Name))
+						log.Info(ctx, "skipping debug binary for pod with empty IP", zap.String("pod", pod.Name))
 						continue
 					}
 					if err := dfs.Write(filepath.Join(appDir(app), "pods", pod.Name, "binary"), func(w io.Writer) (retErr error) {


### PR DESCRIPTION
I feel like most of the time, we don't need these, and they are large.  They end up being the bulk of the bytes on the wire for simple cases.
 
While testing that Loki PR, I noticed that they were slow to download, but not so slow I was going to write my own template 😂 