### PR TITLE
don't rerun tests if they all fail

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -209,7 +209,7 @@ jobs:
               --junitfile ${TEST_RESULTS}/gotestsum-report.xml \
               --raw-command \
               --rerun-fails \
-              --rerun-fails-max-failures=100 \
+              --rerun-fails-max-failures=15 \
               --format standard-verbose \
               --jsonfile "${TEST_RESULTS}/go-test-results.jsonl" \
               --format testname \


### PR DESCRIPTION
Circle-ci support brought this job to our attention as an example of long running jobs:
https://app.circleci.com/pipelines/gh/pachyderm/pachyderm/21442/workflows/f0d129aa-f48f-45cb-8a34-81763d363306/jobs/353587/parallel-runs/3?filterBy=FAILED

from logs: `DONE 3 runs, 65 tests, 65 failures in 4908.505s`  D-:

What happened:

1. This job did not pass, the failure was in TestDatabaseStats. I've added this to [CORE-1773](https://pachyderm.atlassian.net/browse/CORE-1773) to fix that test hopefully. Since helm does not interact with persistent volumes, a test flaking with bad data in postgres always cascades to every test until minikube restarts(which doesn't happen in our test flow)  
2. We have re-runs on which is good, but the max total was set to 100. Since there are only ~20 tests per executor, and we re-run each twice by default it is actually impossible for us to hit 100, so every failing test ran 3 time, for a total of ~60 failures. Each test needs a minikube environment, so each test can take 1-2 minutes to fail. This ends up being 1-2 hours of total runtime, even though we are pretty certain that everything is broken.

Follow-up question: 60 * 110 seconds on average is roughly is 6600 seconds so why did it only take 4900 seconds?
Answer: the first run only took 208 seconds. This is because the first run has the cached settings for minikubetestenv, and does not try to re-deploy the pachyderm helm chart, so many tests failed as soon as pachctl failed. Re-runs run individual tests, so they never have helm values set, so re-runs ALWAYS try to reinstall pachyderm charts. so 208 + ~40*110  is a lot closer at ~4600 seconds.

[CORE-1773]: https://pachyderm.atlassian.net/browse/CORE-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ