### PR TITLE
add extra pps executors

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -119,7 +119,7 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
       GOPROXY: https://proxy.golang.org
-    parallelism: 8
+    parallelism: 10
     steps:
       - checkout
       - run:


### PR DESCRIPTION
test-pps has enough tests that it is timing out. This is mostly due to the fact that uneven test splitting of sub-tests loads some executors more than others. This PR is Adding more executors so a single executor doesn't take longer than 10 minutes.

We could alternatively increase the timeout to 15 minutes, but I don't think we should accept longer running tests as the workaround.