### PR TITLE
[PFS-106] Fix triggers

### DIFF
--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -397,7 +397,7 @@ func (d *driver) finalizeCommit(ctx context.Context, commit *pfs.Commit, validat
 				txnCtx.FinishJob(commitInfo)
 			}
 			if commitInfo.Error == "" {
-				return d.triggerCommit(txnCtx, commitInfo.Commit)
+				return d.triggerCommit(txnCtx, commitInfo)
 			}
 			return nil
 		})

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -6935,12 +6935,20 @@ func TestPFS(suite *testing.T) {
 				Branch: "b",
 				Size:   "200",
 			}))
+			// Create a trigger separate from the chain and ensure it doesn't fire.
+			require.NoError(t, c.CreateBranchTrigger(pfs.DefaultProjectName, "chain", "d", "", "", &pfs.Trigger{
+				Branch: "z",
+				Size:   "100",
+			}))
+			bi, err := c.InspectBranch(pfs.DefaultProjectName, "chain", "d")
+			require.NoError(t, err)
+			dCommit := bi.Head
 			aCommit := client.NewCommit(pfs.DefaultProjectName, "chain", "a", "")
 			// Triggers nothing
 			require.NoError(t, c.PutFile(aCommit, "file1", strings.NewReader(strings.Repeat("a", 50))))
-			_, err := c.WaitCommit(pfs.DefaultProjectName, "chain", "a", "")
+			_, err = c.WaitCommit(pfs.DefaultProjectName, "chain", "a", "")
 			require.NoError(t, err)
-			bi, err := c.InspectBranch(pfs.DefaultProjectName, "chain", "a")
+			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "a")
 			require.NoError(t, err)
 			head := bi.Head.Id
 			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "b")
@@ -6949,6 +6957,9 @@ func TestPFS(suite *testing.T) {
 			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "c")
 			require.NoError(t, err)
 			require.NotEqual(t, head, bi.Head)
+			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "d")
+			require.NoError(t, err)
+			require.Equal(t, dCommit, bi.Head)
 
 			// Triggers b, but not c
 			require.NoError(t, c.PutFile(aCommit, "file2", strings.NewReader(strings.Repeat("a", 50))))
@@ -6963,6 +6974,9 @@ func TestPFS(suite *testing.T) {
 			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "c")
 			require.NoError(t, err)
 			require.NotEqual(t, head, bi.Head.Id)
+			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "d")
+			require.NoError(t, err)
+			require.Equal(t, dCommit, bi.Head)
 
 			// Triggers nothing
 			require.NoError(t, c.PutFile(aCommit, "file3", strings.NewReader(strings.Repeat("a", 50))))
@@ -6977,6 +6991,9 @@ func TestPFS(suite *testing.T) {
 			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "c")
 			require.NoError(t, err)
 			require.NotEqual(t, head, bi.Head.Id)
+			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "d")
+			require.NoError(t, err)
+			require.Equal(t, dCommit, bi.Head)
 
 			// Triggers b and c
 			require.NoError(t, c.PutFile(aCommit, "file4", strings.NewReader(strings.Repeat("a", 50))))
@@ -6991,6 +7008,9 @@ func TestPFS(suite *testing.T) {
 			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "c")
 			require.NoError(t, err)
 			require.Equal(t, head, bi.Head.Id)
+			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "d")
+			require.NoError(t, err)
+			require.Equal(t, dCommit, bi.Head)
 
 			// Triggers nothing
 			require.NoError(t, c.PutFile(aCommit, "file5", strings.NewReader(strings.Repeat("a", 50))))
@@ -7005,6 +7025,9 @@ func TestPFS(suite *testing.T) {
 			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "c")
 			require.NoError(t, err)
 			require.NotEqual(t, head, bi.Head.Id)
+			bi, err = c.InspectBranch(pfs.DefaultProjectName, "chain", "d")
+			require.NoError(t, err)
+			require.Equal(t, dCommit, bi.Head)
 		})
 
 		t.Run("BranchMovement", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue with triggers that was introduced after the provenance changes and slightly improves the performance. After the provenance changes, triggers no longer filtered by source branch when deciding which triggers to check / fire, so any trigger could fire in a repo if the trigger's condition was met by the new commit. This change reintroduces filtering by source branch and performs the correct traversal for chains of triggers that need to be checked / fired. Also, the trigger tests were tweaked to check for this.