### PR TITLE
[2.6.x] Jupyter Plugin: Add resource limit spec to pipelines

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -134,6 +134,8 @@ class PpsConfig:
     image: str
     requirements: Optional[str]
     port: str
+    gpu_mode: str
+    resource_spec: dict
     input_spec: dict  # We may be able to use the pachyderm SDK to parse and validate.
 
     @classmethod
@@ -176,13 +178,20 @@ class PpsConfig:
         
         port = config.get('port')
 
+        gpu_mode = config.get('gpu_mode')
+        resource_spec_str = config.get('resource_spec')
+
+        resource_spec = dict() if resource_spec_str is None else yaml.safe_load(resource_spec_str)
+
         return cls(
             notebook_path=notebook_path,
             pipeline=pipeline,
             image=image,
             requirements=requirements,
             input_spec=input_spec,
-            port=port
+            port=port,
+            gpu_mode=gpu_mode,
+            resource_spec=resource_spec,
         )
 
     def to_dict(self):
@@ -227,6 +236,18 @@ def create_pipeline_spec(config: PpsConfig, companion_branch: str) -> dict:
             internal_port=config.port,
             type="LoadBalancer"
         )
+    
+    if config.gpu_mode == "Simple":
+        pipelineSpec['resource_limits'] = dict(
+            gpu=dict(
+                type="nvidia.com/gpu",
+                number="1",
+            )
+        )
+    elif config.gpu_mode == "Advanced":
+        pipelineSpec['resource_limits'] = config.resource_spec
+        pass
+
 
     return pipelineSpec
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -424,6 +424,7 @@ def _update_metadata(notebook: Path, project_name: str, repo_name: str, pipeline
     config.pipeline = dict(name=pipeline_name, project=dict(name=project_name))
     # sub in repo_name
     config.input_spec = f"pfs:\n  repo: {repo_name}\n  glob: \"/*\""
+    config.resource_spec = "" # this is currently not being tested so it is set to the empty string
     config.requirements = str(notebook.with_name(config.requirements).relative_to(os.getcwd()))
     notebook_data['metadata'][METADATA_KEY]['config'] = config.to_dict()
     return json.dumps(notebook_data)

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {closeIcon} from '@jupyterlab/ui-components';
 import {usePipeline} from './hooks/usePipeline';
-import {PpsContext, PpsMetadata, MountSettings} from '../../types';
+import {PpsContext, PpsMetadata, MountSettings, GpuMode} from '../../types';
 
 type PipelineProps = {
   ppsContext: PpsContext | undefined;
@@ -11,6 +11,15 @@ type PipelineProps = {
   saveNotebookToDisk: () => Promise<string | null>;
 };
 
+const placeholderAdvancedResourceSpec = `# example:
+gpu:
+  type: nvidia.com/gpu
+  number: 1
+`;
+const placeholderSimpleResourceSpec = `gpu:
+  type: nvidia.com/gpu
+  number: 1
+`;
 const placeholderInputSpec = `# example:
 pfs:
   repo: images
@@ -39,6 +48,10 @@ const Pipeline: React.FC<PipelineProps> = ({
     setInputSpec,
     pipelinePort,
     setPipelinePort,
+    gpuMode,
+    setGpuMode,
+    resourceSpec,
+    setResourceSpec,
     requirements,
     setRequirements,
     callCreatePipeline,
@@ -193,7 +206,45 @@ const Pipeline: React.FC<PipelineProps> = ({
           placeholder={placeholderInputSpec}
         ></textarea>
       </div>
-
+      <div className="pachyderm-pipeline-input-wrapper">
+        <label className="pachyderm-pipeline-input-label" htmlFor="gpuMode">
+          *Gpu Mode:{'  '}
+        </label>
+        <select
+          className="pachyderm-pipeline-input"
+          data-testid="Pipeline__gpuMode"
+          name="gpuMode"
+          value={gpuMode}
+          onChange={(e: any) => {
+            setGpuMode(e.target.value);
+          }}
+        >
+          {(Object.keys(GpuMode) as Array<GpuMode>).map((mode) => (
+            <option value={mode}>{mode}</option>
+          ))}
+        </select>
+      </div>
+      {gpuMode === GpuMode.Advanced && (
+        <div className="pachyderm-pipeline-textarea-wrapper">
+          <label
+            className="pachyderm-pipeline-textarea-label"
+            htmlFor="resourceSpec"
+          >
+            Pipeline Resource Spec:
+          </label>
+          <textarea
+            className="pachyderm-pipeline-textarea pachyderm-input"
+            data-testid="Pipeline__resourceSpecInput"
+            name="resourceSpec"
+            value={resourceSpec}
+            onChange={(e: any) => {
+              setResourceSpec(e.target.value);
+            }}
+            disabled={loading}
+            placeholder={placeholderAdvancedResourceSpec}
+          ></textarea>
+        </div>
+      )}
       <div className="pachyderm-pipeline-spec-preview pachyderm-pipeline-textarea-wrapper">
         <label className="pachyderm-pipeline-preview-label">
           Pipeline Spec Preview: {'  '}
@@ -213,7 +264,20 @@ ${inputSpec
   .split('\n')
   .map((line, _, __) => '  ' + line)
   .join('\n')}
-`}
+${
+  gpuMode === GpuMode.None
+    ? ''
+    : 'resource_limits:\n' +
+      (gpuMode === GpuMode.Simple
+        ? placeholderSimpleResourceSpec
+        : gpuMode === GpuMode.Advanced
+        ? resourceSpec
+        : ''
+      )
+        .split('\n')
+        .map((line, _, __) => '  ' + line)
+        .join('\n')
+}`}
           readOnly={true}
         ></textarea>
       </div>

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -3,6 +3,7 @@ import {ServerConnection} from '@jupyterlab/services';
 
 import {
   CreatePipelineResponse,
+  GpuMode,
   MountSettings,
   PpsContext,
   PpsMetadata,
@@ -23,6 +24,10 @@ export type usePipelineResponse = {
   setInputSpec: (input: string) => void;
   pipelinePort: string;
   setPipelinePort: (input: string) => void;
+  gpuMode: GpuMode;
+  setGpuMode: (input: GpuMode) => void;
+  resourceSpec: string;
+  setResourceSpec: (input: string) => void;
   requirements: string;
   setRequirements: (input: string) => void;
   callCreatePipeline: () => Promise<void>;
@@ -43,6 +48,8 @@ export const usePipeline = (
   const [imageName, setImageName] = useState('');
   const [inputSpec, setInputSpec] = useState('');
   const [pipelinePort, setPipelinePort] = useState('');
+  const [gpuMode, setGpuMode] = useState(GpuMode.None);
+  const [resourceSpec, setResourceSpec] = useState('');
   const [requirements, setRequirements] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [responseMessage, setResponseMessage] = useState('');
@@ -65,6 +72,8 @@ export const usePipeline = (
     }
     setCurrentNotebook(ppsContext?.notebookModel?.name ?? 'None');
     setPipelinePort(ppsContext?.metadata?.config.port ?? '');
+    setGpuMode(ppsContext?.metadata?.config.gpu_mode ?? GpuMode.None);
+    setResourceSpec(ppsContext?.metadata?.config.resource_spec ?? '');
   }, [ppsContext]);
 
   useEffect(() => {
@@ -77,6 +86,8 @@ export const usePipeline = (
     requirements,
     inputSpec,
     pipelinePort,
+    gpuMode,
+    resourceSpec,
   ]);
 
   let callCreatePipeline: () => Promise<void>;
@@ -128,6 +139,8 @@ export const usePipeline = (
         requirements: requirements,
         input_spec: inputSpec,
         port: pipelinePort,
+        gpu_mode: gpuMode,
+        resource_spec: resourceSpec,
       },
     };
   };
@@ -144,6 +157,10 @@ export const usePipeline = (
     setInputSpec,
     pipelinePort,
     setPipelinePort,
+    gpuMode,
+    setGpuMode,
+    resourceSpec,
+    setResourceSpec,
     requirements,
     setRequirements,
     callCreatePipeline,

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -124,6 +124,12 @@ export type PpsMetadata = {
   config: PpsConfig;
 };
 
+export enum GpuMode {
+  None = 'None',
+  Simple = 'Simple',
+  Advanced = 'Advanced',
+}
+
 // If this is updated, make sure to also update the corresponding `useEffect`
 // call in ./components/Pipeline/hooks/usePipeline.tsx that writes this type to
 // the notebook metadata.
@@ -133,6 +139,8 @@ export type PpsConfig = {
   requirements: string | null;
   input_spec: string;
   port: string;
+  gpu_mode: GpuMode;
+  resource_spec: string | null;
 };
 
 export type PpsContext = {


### PR DESCRIPTION
Effectively adds GPU definition support to the jupyter plugin

[INT-1048](https://pachyderm.atlassian.net/browse/INT-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[INT-1048]: https://pachyderm.atlassian.net/browse/INT-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ