### PR TITLE
Djanicek/core 1829/det pach testenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,15 @@ launch-dev: check-kubectl check-kubectl-connection
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
 
+launch-dev-determined: check-kubectl check-kubectl-connection
+	$(eval STARTTIME := $(shell date +%s))
+	kubectl apply -f etc/testing/minio.yaml --namespace=default
+	# helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values-with-det.yaml --set pachd.image.tag=local --set determined.detVersion=0.23.1 --set pachd.enterpriseLicenseKey=$(ENT_ACT_CODE)
+	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml
+	# wait for the pachyderm to come up
+	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
+	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"
+
 launch-enterprise: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl create namespace enterprise --dry-run=true -o yaml | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,7 @@ launch-dev: check-kubectl check-kubectl-connection
 launch-dev-determined: check-kubectl check-kubectl-connection
 	$(eval STARTTIME := $(shell date +%s))
 	kubectl apply -f etc/testing/minio.yaml --namespace=default
-	# helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values-with-det.yaml --set pachd.image.tag=local --set determined.detVersion=0.23.1 --set pachd.enterpriseLicenseKey=$(ENT_ACT_CODE)
-	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values.yaml
+	helm install pachyderm etc/helm/pachyderm -f etc/helm/examples/local-dev-values-with-det.yaml --set pachd.image.tag=local --set determined.detVersion=latest --set pachd.enterpriseLicenseKey=$(ENT_ACT_CODE)
 	# wait for the pachyderm to come up
 	kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
 	@echo "pachd launch took $$(($$(date +%s) - $(STARTTIME))) seconds"

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -63,7 +63,7 @@ determined:
   enterpriseEdition: true
   useNodePortForMaster: false
   useNodePortForDB: false
-  detVersion: latest
+  detVersion: 0.23.3
   masterPort: 8282
   masterCpuRequest: 250m
   masterMemRequest: 512M # turn requests way down for automated smoke tests

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -63,7 +63,7 @@ determined:
   enterpriseEdition: true
   useNodePortForMaster: false
   useNodePortForDB: false
-  detVersion: 0.23.1
+  detVersion: latest
   masterPort: 8282
   masterCpuRequest: 250m
   masterMemRequest: 512M # turn requests way down for automated smoke tests
@@ -77,4 +77,3 @@ determined:
     idpSsoUrl: http://pachd.{{.K8sNamespace}}.svc.cluster.local:30658/dex 
     clientId: "determined-local"
     clientSecret: "123"
- 

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+# SPDX-License-Identifier: Apache-2.0
+deployTarget: "CUSTOM"
+
+pachd:
+  image:
+    tag: local
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512M
+  service:
+    type: NodePort
+  metrics:
+    enabled: false
+  clusterDeploymentID: dev
+  pachAuthClusterRoleBindings:
+    allClusterUsers:
+      ["debugger", "projectOwner", "projectCreator", "repoOwner", "robotUser", "secretAdmin", "pachdLogReader"]
+  # to enable enterprise features pass in pachd.activateEnterprise=true, and a valid pachd.enterpriseLicenseKey
+  activateEnterprise: true
+  additionalTrustedPeers:
+    - console-local
+  rootToken: "pizza"
+  enterpriseLicenseKey: ""
+  # oauthRedirectURI: "http://localhost:8283/authorization-code/callback" # TODO :8283
+  storage:
+    backend: MINIO
+    minio:
+      bucket: "pachyderm-test"
+      endpoint: "minio.default.svc.cluster.local:9000"
+      id: "minioadmin"
+      secret: "minioadmin"
+      secure: "false"
+      signature: ""
+
+# proxy:
+#   enabled: true
+#   host: localhost:8283 #10.99.153.241 #10.101.192.237
+#   service:
+#     type: LoadBalancer
+#     httpPort: 8283
+
+# etcd:
+#   service:
+#     type: NodePort
+
+# postgresql:
+#   service:
+#     type: NodePort
+    
+console:
+  enabled: true
+  image:
+    tag: 49648661011fa26986a6f71ffabe77d1f286eef3 
+  config:
+    # oauthRedirectURI: http://localhost:8283/oauth/callback/?inline=true #http://localhost:8283/dex/auth # DNJ TODO
+    disableTelemetry: true
+
+oidc:
+  issuerURI: "http://pachd.test-cluster-1.svc.cluster.local:30658/dex" # DNJ TODO parameterize namespace for tests
+  userAccessibleOauthIssuerHost: "http://localhost:8283"
+  additionalClients:
+    - id: console-local
+      name: console-local
+      secret: "123"
+      redirect_uris:
+        - http://localhost:4000/oauth/callback/?inline=true
+    - id: determined-local
+      name: determined-local
+      secret: "123"
+      redirect_uris:
+        # - http://determined-master-service-pachyderm.default.svc.cluster.local:8282
+        - http://localhost:8282/oauth/callback/?inline=true
+
+determined:
+  imageRegistry: registry-1.docker.io/determinedai
+  imagePullSecretName: detregcred
+  maxSlotsPerPod: 0
+  enabled: true
+  enterpriseEdition: true
+  useNodePortForMaster: false
+  useNodePortForDB: false
+  detVersion: 0.23.1
+  masterPort: 8282
+  oidc:
+    enabled: true 
+    idpRecipientUrl: http://localhost:8282
+    idpSsoUrl: http://pachd.test-cluster-1.svc.cluster.local:30658/dex #"http://localhost:8283" #"http://pachd.default.svc.cluster.local:30658/dex"
+    clientId: "determined-local"
+    clientSecret: "123"
+ 

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -81,7 +81,7 @@ determined:
   enterpriseEdition: true
   useNodePortForMaster: false
   useNodePortForDB: false
-  detVersion: 0.23.1
+  detVersion: 0.23.3
   masterPort: 8282
   oidc:
     enabled: true 

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -65,12 +65,12 @@ determined:
   useNodePortForDB: false
   detVersion: 0.23.1
   masterPort: 8282
-  masterCpuRequest: 2
-  masterMemRequest: 1Gi # turn request way down for automated smoke tests
+  masterCpuRequest: 250m
+  masterMemRequest: 512M # turn requests way down for automated smoke tests
   db:
     storageSize: 2Gi
-    cpuRequest: 1
-    memRequest: 1Gi
+    cpuRequest: 250m
+    memRequest: 512M
   oidc:
     enabled: true 
     idpRecipientUrl: http://localhost:8282

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -65,6 +65,12 @@ determined:
   useNodePortForDB: false
   detVersion: 0.23.1
   masterPort: 8282
+  masterCpuRequest: 2
+  masterMemRequest: 1Gi # turn request way down for automated smoke tests
+  db:
+    storageSize: 2Gi
+    cpuRequest: 1
+    memRequest: 1Gi
   oidc:
     enabled: true 
     idpRecipientUrl: http://localhost:8282

--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -23,7 +23,6 @@ pachd:
     - console-local
   rootToken: "pizza"
   enterpriseLicenseKey: ""
-  # oauthRedirectURI: "http://localhost:8283/authorization-code/callback" # TODO :8283
   storage:
     backend: MINIO
     minio:
@@ -33,32 +32,16 @@ pachd:
       secret: "minioadmin"
       secure: "false"
       signature: ""
-
-# proxy:
-#   enabled: true
-#   host: localhost:8283 #10.99.153.241 #10.101.192.237
-#   service:
-#     type: LoadBalancer
-#     httpPort: 8283
-
-# etcd:
-#   service:
-#     type: NodePort
-
-# postgresql:
-#   service:
-#     type: NodePort
     
 console:
   enabled: true
   image:
     tag: 49648661011fa26986a6f71ffabe77d1f286eef3 
   config:
-    # oauthRedirectURI: http://localhost:8283/oauth/callback/?inline=true #http://localhost:8283/dex/auth # DNJ TODO
     disableTelemetry: true
 
 oidc:
-  issuerURI: "http://pachd.test-cluster-1.svc.cluster.local:30658/dex" # DNJ TODO parameterize namespace for tests
+  issuerURI: "http://pachd.{{.K8sNamespace}}.svc.cluster.local:30658/dex"
   userAccessibleOauthIssuerHost: "http://localhost:8283"
   additionalClients:
     - id: console-local
@@ -70,7 +53,6 @@ oidc:
       name: determined-local
       secret: "123"
       redirect_uris:
-        # - http://determined-master-service-pachyderm.default.svc.cluster.local:8282
         - http://localhost:8282/oauth/callback/?inline=true
 
 determined:
@@ -81,12 +63,12 @@ determined:
   enterpriseEdition: true
   useNodePortForMaster: false
   useNodePortForDB: false
-  detVersion: 0.23.3
+  detVersion: 0.23.1
   masterPort: 8282
   oidc:
     enabled: true 
     idpRecipientUrl: http://localhost:8282
-    idpSsoUrl: http://pachd.test-cluster-1.svc.cluster.local:30658/dex #"http://localhost:8283" #"http://pachd.default.svc.cluster.local:30658/dex"
+    idpSsoUrl: http://pachd.{{.K8sNamespace}}.svc.cluster.local:30658/dex 
     clientId: "determined-local"
     clientSecret: "123"
  

--- a/etc/helm/examples/local-dev-values-with-det.yaml
+++ b/etc/helm/examples/local-dev-values-with-det.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+# SPDX-License-Identifier: Apache-2.0
+deployTarget: "CUSTOM"
+
+pachd:
+  image:
+    tag: local
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512M
+  service:
+    type: NodePort
+  metrics:
+    enabled: false
+  clusterDeploymentID: dev
+  pachAuthClusterRoleBindings:
+    allClusterUsers:
+      ["debugger", "projectOwner", "projectCreator", "repoOwner", "robotUser", "secretAdmin", "pachdLogReader"]
+  # to enable enterprise features pass in pachd.activateEnterprise=true, and a valid pachd.enterpriseLicenseKey
+  activateEnterprise: true
+  additionalTrustedPeers:
+    - console-local
+  rootToken: "pizza"
+  enterpriseLicenseKey: ""
+  oauthRedirectURI: "http://localhost:8283/authorization-code/callback" 
+  storage:
+    backend: MINIO
+    minio:
+      bucket: "pachyderm-test"
+      endpoint: "minio.default.svc.cluster.local:9000"
+      id: "minioadmin"
+      secret: "minioadmin"
+      secure: "false"
+      signature: ""
+
+proxy:
+  enabled: true
+  host: localhost:8283 
+  service:
+    type: LoadBalancer
+    httpPort: 8283
+
+etcd:
+  service:
+    type: NodePort
+
+postgresql:
+  service:
+    type: NodePort
+    
+console:
+  enabled: true
+  image:
+    tag: 49648661011fa26986a6f71ffabe77d1f286eef3 
+  config:
+    oauthRedirectURI: http://localhost:8283/oauth/callback/?inline=true #http://localhost:8283/dex/auth 
+    disableTelemetry: true
+
+oidc:
+  issuerURI: "http://pachd.default.svc.cluster.local:30658/dex" 
+  userAccessibleOauthIssuerHost: "http://localhost:8283"
+  additionalClients:
+    - id: console-local
+      name: console-local
+      secret: "123"
+      redirect_uris:
+        - http://localhost:4000/oauth/callback/?inline=true
+    - id: determined-local
+      name: determined-local
+      secret: "123"
+      redirect_uris:
+        - http://localhost:8282/oauth/callback/?inline=true
+
+determined:
+  imageRegistry: registry-1.docker.io/determinedai
+  imagePullSecretName: detregcred
+  maxSlotsPerPod: 0
+  enabled: true
+  enterpriseEdition: true
+  useNodePortForMaster: false
+  useNodePortForDB: false
+  detVersion: 0.23.1
+  masterPort: 8282
+  oidc:
+    enabled: true 
+    idpRecipientUrl: http://localhost:8282
+    idpSsoUrl: http://pachd.default.svc.cluster.local:30658/dex #"http://localhost:8283" 
+    clientSecret: "123"
+ 

--- a/etc/helm/examples/local-dev-values-with-det.yaml
+++ b/etc/helm/examples/local-dev-values-with-det.yaml
@@ -87,4 +87,3 @@ determined:
     idpRecipientUrl: http://localhost:8282
     idpSsoUrl: http://pachd.default.svc.cluster.local:30658/dex #"http://localhost:8283" 
     clientSecret: "123"
- 

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -84,7 +84,7 @@ data:
       provider: {{ default .Values.determined.oidc.provider "dex"}}
       idp_recipient_url: {{ required "A valid recipient url is required!" .Values.determined.oidc.idpRecipientUrl }}
       idp_sso_url: {{ default .Values.determined.oidc.idpSsoUrl (include "pachyderm.issuerURI" . | quote) }}
-      client_id: {{ default .Values.determined.oidc.clientId "determined" }}
+      client_id: {{ default "determined" .Values.determined.oidc.clientId }}
       {{- if .Values.determined.oidc.authenticationClaim }}
       authentication_claim: {{ .Values.determined.oidc.authenticationClaim }}
       {{- end }}

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -309,7 +309,7 @@ spec:
         {{- end }}
         {{- if and .Values.determined.enabled .Values.determined.enterpriseEdition }}
         - name: DETERMINED_OAUTH_ID
-          value: {{ default .Values.determined.oidc.clientId "determined" }}
+          value: {{ default "determined" .Values.determined.oidc.clientId }}
         - name: DETERMINED_OAUTH_SECRET
           valueFrom:
             secretKeyRef:

--- a/etc/helm/pachyderm/templates/pachd/identity-config.yaml
+++ b/etc/helm/pachyderm/templates/pachd/identity-config.yaml
@@ -22,7 +22,7 @@ data:
       - {{ .Values.console.config.oauthClientID | quote }}
       {{- end }}
       {{- if .Values.determined.enabled}}
-      - {{ default .Values.determined.oidc.clientId "determined" }}
+      - {{ default "determined" .Values.determined.oidc.clientId }}
       {{- end }}
     {{- if .Values.console.enabled }}
     - id: {{ .Values.console.config.oauthClientID }}
@@ -31,8 +31,8 @@ data:
       - {{ include "pachyderm.consoleRedirectURI" . | quote }}
     {{- end }}
     {{- if .Values.determined.enabled }}
-    - id: {{ default .Values.determined.oidc.clientId "determined" }}
-      name: {{ default .Values.determined.oidc.clientId "determined" }}
+    - id: {{ default "determined" .Values.determined.oidc.clientId }}
+      name: {{ default "determined" .Values.determined.oidc.clientId }}
       redirect_uris:
       - {{ required "A valid recipient url is required!" (printf "%s/oidc/callback" .Values.determined.oidc.idpRecipientUrl) }}
     {{- end }}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -221,9 +221,6 @@
                 "masterPort": {
                     "type": "integer"
                 },
-                "maxSlotsPerPod": {
-                    "type": "integer"
-                },
                 "oidc": {
                     "type": "object",
                     "properties": {

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -175,7 +175,7 @@
                     "type": "object",
                     "properties": {
                         "cpuRequest": {
-                            "type": "integer"
+                            "type": "string"
                         },
                         "memRequest": {
                             "type": "string"
@@ -207,13 +207,13 @@
                     "type": "boolean"
                 },
                 "imagePullSecretName": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "imageRegistry": {
                     "type": "string"
                 },
                 "masterCpuRequest": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "masterMemRequest": {
                     "type": "string"
@@ -222,37 +222,37 @@
                     "type": "integer"
                 },
                 "maxSlotsPerPod": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "oidc": {
                     "type": "object",
                     "properties": {
                         "authenticationClaim": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "clientId": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "clientSecretKey": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "clientSecretName": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "enabled": {
-                            "type": "null"
+                            "type": "boolean"
                         },
                         "idpRecipientUrl": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "idpSsoUrl": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "provider": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "scimAuthenticationAttribute": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },
@@ -268,7 +268,18 @@
                     }
                 },
                 "taskContainerDefaults": {
-                    "type": "null"
+                    "type": "object",
+                    "properties": {
+                        "dtrainNetworkInterface": {
+                            "type": "string"
+                        },
+                        "forcePullImage": {
+                            "type": "boolean"
+                        },
+                        "networkMode": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "telemetry": {
                     "type": "object",

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -270,14 +270,8 @@
                 "taskContainerDefaults": {
                     "type": "object",
                     "properties": {
-                        "dtrainNetworkInterface": {
-                            "type": "string"
-                        },
                         "forcePullImage": {
                             "type": "boolean"
-                        },
-                        "networkMode": {
-                            "type": "string"
                         }
                     }
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -219,7 +219,7 @@ determined:
   # Distributed tasks with sizes that are not divisible by `maxSlotsPerPod` are never scheduled. If
   # you have a cluster of different size nodes (e.g., 4 and 8 GPUs per node), set `maxSlotsPerPod` to
   # the greatest common divisor of all the sizes (4, in that case).
-  # maxSlotsPerPod: 
+  # maxSlotsPerPod:
 
   ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
   # slotType: cpu

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -219,7 +219,7 @@ determined:
   # Distributed tasks with sizes that are not divisible by `maxSlotsPerPod` are never scheduled. If
   # you have a cluster of different size nodes (e.g., 4 and 8 GPUs per node), set `maxSlotsPerPod` to
   # the greatest common divisor of all the sizes (4, in that case).
-  maxSlotsPerPod: 0
+  # maxSlotsPerPod: 
 
   ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
   # slotType: cpu

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -69,7 +69,7 @@ determined:
 
   # Should be configured if using the master image in the Determined enterprise edition
   # or private registry.
-  imagePullSecretName:
+  imagePullSecretName: ""
 
   # masterPort configures the port at which the Determined master listens for connections on.
   masterPort: 8080
@@ -113,15 +113,15 @@ determined:
   # is true. It allows users to use single sign-on with their organization’s identity provider.
   # clientSecretKey is the key of the secret contained in the secret.
   oidc:
-    enabled:
-    provider:
-    idpRecipientUrl:
-    idpSsoUrl:
-    clientId:
-    clientSecretKey:
-    clientSecretName:
-    authenticationClaim:
-    scimAuthenticationAttribute:
+    enabled: false
+    provider: ""
+    idpRecipientUrl: ""
+    idpSsoUrl: ""
+    clientId: ""
+    clientSecretKey: ""
+    clientSecretName: ""
+    authenticationClaim: ""
+    scimAuthenticationAttribute: ""
 
   # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
   # only available if enterpriseEdition is true. It allows administrators to easily and securely
@@ -149,7 +149,7 @@ determined:
     # Determined deployed database, as well as the CPU and memory requirements. Should be adjusted for
     # scale.
     storageSize: 30Gi
-    cpuRequest: 2
+    cpuRequest: "2"
     memRequest: 8Gi
     #  cpuLimit: 2
     #  memLimit: 8Gi
@@ -219,7 +219,7 @@ determined:
   # Distributed tasks with sizes that are not divisible by `maxSlotsPerPod` are never scheduled. If
   # you have a cluster of different size nodes (e.g., 4 and 8 GPUs per node), set `maxSlotsPerPod` to
   # the greatest common divisor of all the sizes (4, in that case).
-  maxSlotsPerPod:
+  maxSlotsPerPod: 0
 
   ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
   # slotType: cpu
@@ -230,18 +230,18 @@ determined:
   # cpu: 7
 
   # Memory and CPU requirements for the master instance. Should be adjusted for scale.
-  masterCpuRequest: 2
+  masterCpuRequest: "2"
   masterMemRequest: 8Gi
-  # masterCpuLimit: 2
+  # masterCpuLimit: "2"
   # masterMemLimit: 8Gi
 
   ## Configure the task container defaults. Tasks include trials, commands, TensorBoards, notebooks,
   ## and shells. For all task containers, shm_size_bytes and network_mode are configurable. For
   ## trials, the network interface used by distributed (multi-machine) training is configurable.
   taskContainerDefaults:
-    # networkMode: bridge
-    # dtrainNetworkInterface: <network interface name>
-    # forcePullImage: <true or false>
+    networkMode: bridge
+    dtrainNetworkInterface: "<network interface name>"
+    forcePullImage: false
 
     # Configure a default pod spec for all GPU tasks (experiments, notebooks, commands) and CPU tasks
     # (CPU notebooks, TensorBoards, zero-slot commands). If a pod spec is defined for an individual

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -239,8 +239,8 @@ determined:
   ## and shells. For all task containers, shm_size_bytes and network_mode are configurable. For
   ## trials, the network interface used by distributed (multi-machine) training is configurable.
   taskContainerDefaults:
-    networkMode: bridge
-    dtrainNetworkInterface: "<network interface name>"
+    # networkMode: bridge
+    # dtrainNetworkInterface: "<network interface name>"
     forcePullImage: false
 
     # Configure a default pod spec for all GPU tasks (experiments, notebooks, commands) and CPU tasks

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -88,6 +88,13 @@ func helmLock(f helmPutE) helmPutE {
 }
 
 func helmChartLocalPath(t testing.TB) string {
+	return localPath(t, "etc", "helm", "pachyderm")
+}
+func HelmExamplesValuesLocalPath(t testing.TB, fileName string) string {
+	return localPath(t, "etc", "helm", "examples", fileName)
+}
+
+func localPath(t testing.TB, pathParts ...string) string {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 	parts := strings.Split(dir, string(os.PathSeparator))
@@ -98,7 +105,7 @@ func helmChartLocalPath(t testing.TB) string {
 			break
 		}
 	}
-	relPathParts = append(relPathParts, "etc", "helm", "pachyderm")
+	relPathParts = append(relPathParts, pathParts...)
 	return filepath.Join(relPathParts...)
 }
 

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -103,7 +103,7 @@ func helmLock(f helmPutE) helmPutE {
 func helmChartLocalPath(t testing.TB) string {
 	return localPath(t, "etc", "helm", "pachyderm")
 }
-func ExampleValuesLocalPath(t testing.TB, fileName string) string {
+func exampleValuesLocalPath(t testing.TB, fileName string) string {
 	return localPath(t, "etc", "helm", "examples", fileName)
 }
 
@@ -586,7 +586,7 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 	}
 	if opts.Determined {
 		createSecretDeterminedRegcred(t, ctx, kubeClient, namespace)
-		valuesTemplate, err := template.ParseFiles(ExampleValuesLocalPath(t, "int-test-values-with-det.yaml"))
+		valuesTemplate, err := template.ParseFiles(exampleValuesLocalPath(t, "int-test-values-with-det.yaml"))
 		require.NoError(t, err, "Creating determined values template")
 		valuesFile, err := os.CreateTemp("", "detvalues.*.yaml")
 		require.NoError(t, err, "Creating determined values temp file")

--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -64,6 +64,7 @@ type DeployOpts struct {
 	WaitSeconds      int
 	EnterpriseMember bool
 	EnterpriseServer bool
+	Determined       bool
 	ValueOverrides   map[string]string
 	TLS              bool
 	CertPool         *x509.CertPool
@@ -90,7 +91,7 @@ func helmLock(f helmPutE) helmPutE {
 func helmChartLocalPath(t testing.TB) string {
 	return localPath(t, "etc", "helm", "pachyderm")
 }
-func HelmExamplesValuesLocalPath(t testing.TB, fileName string) string {
+func ExampleValuesLocalPath(t testing.TB, fileName string) string {
 	return localPath(t, "etc", "helm", "examples", fileName)
 }
 
@@ -346,6 +347,25 @@ func withoutProxy(namespace string) *helm.Options {
 	}
 }
 
+func withDetermined() *helm.Options {
+	return &helm.Options{
+		SetValues: map[string]string{
+			// "pachd.clusterDeploymentID":           "dev", DNJ TODO
+			// "pachd.resources.requests.cpu":        "250m",
+			// "pachd.resources.requests.memory":     "512M",
+			// "etcd.resources.requests.cpu":         "250m",
+			// "etcd.resources.requests.memory":      "512M",
+			// "pachd.defaultPipelineCPURequest":     "100m",
+			// "pachd.defaultPipelineMemoryRequest":  "64M",
+			// "pachd.defaultPipelineStorageRequest": "100Mi",
+			// "pachd.defaultSidecarCPURequest":      "100m",
+			// "pachd.defaultSidecarMemoryRequest":   "64M",
+			// "pachd.defaultSidecarStorageRequest":  "100Mi",
+			// "console.enabled":                     "false",
+		},
+	}
+}
+
 func union(a, b *helm.Options) *helm.Options {
 	c := &helm.Options{
 		SetValues:    make(map[string]string),
@@ -543,6 +563,10 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 		helmOpts = union(helmOpts, withPachd(version))
 		// TODO(acohen4): apply minio deployment to this namespace
 		helmOpts = union(helmOpts, withMinio())
+	}
+	if opts.Determined {
+		// install regcred DNJ TODO
+		helmOpts = union(helmOpts, withDetermined())
 	}
 	if opts.PortOffset != 0 {
 		pachAddress.Port += opts.PortOffset

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -28,11 +28,13 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	ns, portOffset := minikubetestenv.ClaimCluster(t)
 	k := testutil.GetKubeClient(t)
 	opts := &minikubetestenv.DeployOpts{
-		AuthUser:   auth.RootUser,
-		Enterprise: true,
-		PortOffset: portOffset,
+		AuthUser:    auth.RootUser,
+		Enterprise:  true,
+		PortOffset:  portOffset,
+		ValuesFiles: []string{minikubetestenv.HelmExamplesValuesLocalPath(t, "int-test-values-with-det.yaml")},
 	}
 	valueOverrides["pachd.replicas"] = "1"
+
 	opts.ValueOverrides = valueOverrides
 	// Test Install
 	minikubetestenv.PutNamespace(t, ns)

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -31,7 +31,7 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 		AuthUser:    auth.RootUser,
 		Enterprise:  true,
 		PortOffset:  portOffset,
-		ValuesFiles: []string{minikubetestenv.HelmExamplesValuesLocalPath(t, "int-test-values-with-det.yaml")},
+		ValuesFiles: []string{minikubetestenv.ExampleValuesLocalPath(t, "int-test-values-with-det.yaml")},
 	}
 	valueOverrides["pachd.replicas"] = "1"
 

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -28,13 +28,12 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	ns, portOffset := minikubetestenv.ClaimCluster(t)
 	k := testutil.GetKubeClient(t)
 	opts := &minikubetestenv.DeployOpts{
-		AuthUser:    auth.RootUser,
-		Enterprise:  true,
-		PortOffset:  portOffset,
-		ValuesFiles: []string{minikubetestenv.ExampleValuesLocalPath(t, "int-test-values-with-det.yaml")},
+		AuthUser:   auth.RootUser,
+		Enterprise: true,
+		PortOffset: portOffset,
+		Determined: true,
 	}
 	valueOverrides["pachd.replicas"] = "1"
-
 	opts.ValueOverrides = valueOverrides
 	// Test Install
 	minikubetestenv.PutNamespace(t, ns)
@@ -52,7 +51,7 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	opts.ValueOverrides = valueOverrides
 	opts.ValueOverrides["pachd.rootToken"] = token
 	// add config file with trusted peers & new clients
-	opts.ValuesFiles = append(opts.ValuesFiles, createAdditionalClientsFile(t), createTrustedPeersFile(t))
+	opts.ValuesFiles = []string{createAdditionalClientsFile(t), createTrustedPeersFile(t)}
 	// apply upgrade
 	c = minikubetestenv.UpgradeRelease(t, context.Background(), ns, k, opts)
 	c.SetAuthToken(token)

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -28,11 +28,10 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	ns, portOffset := minikubetestenv.ClaimCluster(t)
 	k := testutil.GetKubeClient(t)
 	opts := &minikubetestenv.DeployOpts{
-		AuthUser:   auth.RootUser,
-		Enterprise: true,
-		PortOffset: portOffset,
-		Determined: true,
-		// ValuesFiles: []string{minikubetestenv.ExampleValuesLocalPath(t, "int-test-values-with-det.yaml")},
+		AuthUser:    auth.RootUser,
+		Enterprise:  true,
+		PortOffset:  portOffset,
+		ValuesFiles: []string{minikubetestenv.ExampleValuesLocalPath(t, "int-test-values-with-det.yaml")},
 	}
 	valueOverrides["pachd.replicas"] = "1"
 
@@ -68,11 +67,12 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	mockIDPLogin(t, c)
 	// assert new trusted peer and client
 	resp, err := c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "pachd"})
-	t.Logf("DNJ TODO TRUSTED PEERS: %#v", resp.Client)
 	require.NoError(t, err)
 	require.EqualOneOf(t, resp.Client.TrustedPeers, "example-app")
+	require.EqualOneOf(t, resp.Client.TrustedPeers, "determined-local")
 	resp, err = c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "example-app"})
-	t.Logf("DNJ TODO TRUSTED PEERS2: %#v", resp.Client)
+	require.NoError(t, err)
+	resp, err = c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "determined-local"})
 	require.NoError(t, err)
 }
 

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -69,9 +69,9 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualOneOf(t, resp.Client.TrustedPeers, "example-app")
 	require.EqualOneOf(t, resp.Client.TrustedPeers, "determined-local")
-	resp, err = c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "example-app"})
+	_, err = c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "example-app"})
 	require.NoError(t, err)
-	resp, err = c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "determined-local"})
+	_, err = c.IdentityAPIClient.GetOIDCClient(c.Ctx(), &identity.GetOIDCClientRequest{Id: "determined-local"})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This changes minikubetestenv to have an option for deploying MLDE(Determined Enterprise) alongside pachyderm in our integration tests. It includes this deployment in an existing test but does not exercise specific functionality. That comes in the next Ticket.

Additionally I made a change to the determined helm values because I believe the default was in the wrong order. The test change to `TestInstallAndUpgradeEnterpriseWithEnv` confirms the fix acts like I expect. 

Note, because the helm schema was updated some failures started occurring. I change the values file so that none of the fields in determined were null. Leaving them null meant the schema generated a `null` type and those fields were getting flagged by our schema validator after it was updated. I replaced any nulls with "" for string fields. The cpu requests were also listed as integers, so I quoted those to allow us to input milli-cpus like we do in the tests.