### PR TITLE
Fix move branch trigger test

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -10993,12 +10993,12 @@ func TestMoveBranchTrigger(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	require.NoError(t, c.PutFile(client.NewCommit(pfs.DefaultProjectName, dataRepo, "master", ""), "foo", strings.NewReader("bar")))
-	_, err = c.WaitCommit(pfs.DefaultProjectName, pipeline, "master", "")
-	require.NoError(t, err)
-
 	// create the trigger source branch
+	require.NoError(t, c.CreateBranch(pfs.DefaultProjectName, dataRepo, "master", "", "", nil))
 	require.NoError(t, c.CreateBranch(pfs.DefaultProjectName, dataRepo, "toMove", "master", "", nil))
+	require.NoError(t, c.PutFile(client.NewCommit(pfs.DefaultProjectName, dataRepo, "toMove", ""), "foo", strings.NewReader("bar")))
+	_, err = c.WaitCommit(pfs.DefaultProjectName, dataRepo, "toMove", "")
+	require.NoError(t, err)
 	_, err = c.WaitCommit(pfs.DefaultProjectName, pipeline, "master", "")
 	require.NoError(t, err)
 


### PR DESCRIPTION
The move branch trigger test was relying on the branch movement operation completing before the asynchronous trigger evaluation to be successful. Recent improvements to trigger performance made this race condition more apparent. Also, the test didn't really reflect the expected behavior after the 2.6 provenance changes. The test was updated to account for both of these issues.