### PR TITLE
Don't set type="user" in test fixture

### DIFF
--- a/python-sdk/tests/fixtures.py
+++ b/python-sdk/tests/fixtures.py
@@ -77,7 +77,7 @@ class TestClient(_Client):
             #   client requests.
             project = pfs.Project(name="")
 
-        repo = pfs.Repo(name=self._generate_name(), type="user", project=project)
+        repo = pfs.Repo(name=self._generate_name(), project=project)
         self.pfs.delete_repo(repo=repo, force=True)
         self.pfs.create_repo(repo=repo, description=self.id)
         self.pfs.create_branch(branch=pfs.Branch.from_uri(f"{repo}@master"))
@@ -99,7 +99,7 @@ class TestClient(_Client):
         )
         self.pipelines.append(pipeline)
 
-        with self.pfs.commit(branch=pfs.Branch(repo=repo, name="master")) as commit:
+        with self.pfs.commit(branch=pfs.Branch(repo=repo)) as commit:
             commit.put_file_from_bytes(path="file.dat", data=b"DATA")
         commit.wait()
 

--- a/python-sdk/tests/fixtures.py
+++ b/python-sdk/tests/fixtures.py
@@ -99,7 +99,7 @@ class TestClient(_Client):
         )
         self.pipelines.append(pipeline)
 
-        with self.pfs.commit(branch=pfs.Branch(repo=repo)) as commit:
+        with self.pfs.commit(branch=pfs.Branch(repo=repo, name="master")) as commit:
             commit.put_file_from_bytes(path="file.dat", data=b"DATA")
         commit.wait()
 


### PR DESCRIPTION
This will expose values that should really be set in `_additions.py` (i.e. this adds test coverage to #9153). ~I identified these by searching `fixtures.py` for the string `="` and removing any matches that were part of setting a default value~. **Update** I've changed this PR to only remove the `type="user"` default from `fixtures.py`, as it's unclear whether we want to assume `"master"` or not (some parts of Pachyderm assume this, some don't. Notably `pachctl inspect commit <repo>` does not work, but `pachctl inspect commit <repo>@master` does). 

Jira: [INT-1072]

[INT-1072]: https://pachyderm.atlassian.net/browse/INT-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ