### PR TITLE
[Python][2.7.x] Add default type for Repo

### DIFF
--- a/python-sdk/.gitignore
+++ b/python-sdk/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 dist
 docs/*.zip
 docs/pachyderm_sdk
+.python-version

--- a/python-sdk/pachyderm_sdk/api/pfs/_additions.py
+++ b/python-sdk/pachyderm_sdk/api/pfs/_additions.py
@@ -44,6 +44,8 @@ def _Repo_as_uri(self: "Repo") -> str:
 def _Repo___post_init__(self: "Repo") -> None:
     if not self.project or not self.project.name:
         self.project = Project(name="default")
+    if not self.type:
+        self.type = "user"
     super(self.__class__, self).__post_init__()
 
 


### PR DESCRIPTION
If an `InspectRepo` request is made where the repo argument doesn't have the `type` field set, the pachd server doesn't default the value to "user". This causes a `repo not found` error, even if the repo does exist. This PR makes it so the python sdk adds a default value for `field`.

Jira: [INT-1070]

[INT-1070]: https://pachyderm.atlassian.net/browse/INT-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ