### PR TITLE
[2.6.x] Backport the helm parts of the 2.7.x preflight check

### DIFF
--- a/etc/helm/pachyderm/templates/preflight/job.yaml
+++ b/etc/helm/pachyderm/templates/preflight/job.yaml
@@ -1,0 +1,135 @@
+{{- /*
+SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
+SPDX-License-Identifier: Apache-2.0
+*/ -}}
+{{- if .Values.preflightCheckJob.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pachyderm-preflight-check
+  namespace: {{ .Release.Namespace }}
+spec:
+  completions: 1
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.preflightCheckJob.annotations -}}
+        {{ toYaml .Values.preflightCheckJob.annotations | nindent 8 }}
+        {{- end }}
+      labels:
+        app: preflight-check
+        suite: pachyderm
+        {{- if .Values.preflightCheckJob.podLabels }}
+        {{- toYaml .Values.preflightCheckJob.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.preflightCheckJob.priorityClassName }}
+      priorityClassName: {{ .Values.preflightCheckJob.priorityClassName }}
+      {{- end }}
+      {{-  if .Values.preflightCheckJob.affinity }}
+      affinity: {{ toYaml .Values.preflightCheckJob.affinity | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      {{-  if .Values.preflightCheckJob.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.preflightCheckJob.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{-  if .Values.preflightCheckJob.tolerations }}
+      tolerations: {{ toYaml .Values.preflightCheckJob.tolerations | nindent 8 }}
+      {{- end }}
+      containers:
+      - command:
+        - /pachd
+        args:
+        - --mode
+        - preflight
+        env:
+        - name: POSTGRES_HOST
+          value: {{ required "postgresql host required" .Values.global.postgresql.postgresqlHost | quote }}
+        - name: POSTGRES_PORT
+          value:  {{ required "postgresql port required" .Values.global.postgresql.postgresqlPort | quote }}
+        - name: POSTGRES_USER
+          value: {{ required "postgresql username required" .Values.global.postgresql.postgresqlUsername | quote }}
+        - name: POSTGRES_DATABASE
+          value: {{ required "postgresql database name required" .Values.global.postgresql.postgresqlDatabase | quote }}
+        {{- if .Values.global.postgresql.ssl }}
+        - name: POSTGRES_SSL
+          value: "require"
+        {{- end }}
+        {{- if .Values.cloudsqlAuthProxy.iamLogin }}
+        - name: POSTGRES_PASSWORD
+          value: "Using-iamLogin"
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.postgresql.postgresqlExistingSecretName | default "postgres" }}
+              key: {{ .Values.global.postgresql.postgresqlExistingSecretKey | default "postgresql-password" }}
+        {{- end }}
+        - name: PG_BOUNCER_HOST
+          value: pg-bouncer # Must match pgbouncer service name
+        - name: PG_BOUNCER_PORT
+          value: "5432" # Must match pbouncer service port
+        {{- if .Values.preflightCheckJob.disableLogSampling }}
+        - name: PACHYDERM_DISABLE_LOG_SAMPLING
+          value: "1"
+        {{- end }}
+        {{- if .Values.preflightCheckJob.sqlQueryLogs }}
+        - name: POSTGRES_QUERY_LOGGING
+          value: "1"
+        {{- end }}
+        {{ if .Values.global.proxy }}
+        - name: http_proxy
+          value: {{ .Values.global.proxy }}
+        - name: https_proxy
+          value:  {{.Values.global.proxy}}
+        - name: HTTP_PROXY
+          value:  {{.Values.global.proxy}}
+        - name: HTTPS_PROXY
+          value:  {{.Values.global.proxy}}
+        {{ end }}
+        {{ if .Values.global.noProxy }}
+        - name: no_proxy
+          value:  {{.Values.global.noProxy}}
+        - name: NO_PROXY
+          value:  {{.Values.global.noProxy}}
+        {{ end }}
+        - name: K8S_MEMORY_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              containerName: pachd
+              resource: requests.memory
+        - name: K8S_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: pachd
+              resource: limits.memory
+        image: "{{ .Values.preflightCheckJob.image.repository }}:{{ default .Chart.AppVersion .Values.preflightCheckJob.image.tag }}"
+        imagePullPolicy: {{ .Values.preflightCheckJob.image.pullPolicy }}
+        name: pachd
+        {{- if .Values.preflightCheckJob.resources }}
+        resources: {{ toYaml .Values.preflightCheckJob.resources | nindent 10 }}
+        {{- end }}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+              drop:
+              - all
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+status: {}
+{{- end -}}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -148,6 +148,141 @@
         "deployTarget": {
             "type": "string"
         },
+        "determined": {
+            "type": "object",
+            "properties": {
+                "checkpointStorage": {
+                    "type": "object",
+                    "properties": {
+                        "hostPath": {
+                            "type": "string"
+                        },
+                        "saveExperimentBest": {
+                            "type": "integer"
+                        },
+                        "saveTrialBest": {
+                            "type": "integer"
+                        },
+                        "saveTrialLatest": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "db": {
+                    "type": "object",
+                    "properties": {
+                        "cpuRequest": {
+                            "type": "integer"
+                        },
+                        "memRequest": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "storageSize": {
+                            "type": "string"
+                        },
+                        "useNodePortForDB": {
+                            "type": "boolean"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "enterpriseEdition": {
+                    "type": "boolean"
+                },
+                "imagePullSecretName": {
+                    "type": "null"
+                },
+                "imageRegistry": {
+                    "type": "string"
+                },
+                "masterCpuRequest": {
+                    "type": "integer"
+                },
+                "masterMemRequest": {
+                    "type": "string"
+                },
+                "masterPort": {
+                    "type": "integer"
+                },
+                "maxSlotsPerPod": {
+                    "type": "null"
+                },
+                "oidc": {
+                    "type": "object",
+                    "properties": {
+                        "authenticationClaim": {
+                            "type": "null"
+                        },
+                        "clientId": {
+                            "type": "null"
+                        },
+                        "clientSecretKey": {
+                            "type": "null"
+                        },
+                        "clientSecretName": {
+                            "type": "null"
+                        },
+                        "enabled": {
+                            "type": "null"
+                        },
+                        "idpRecipientUrl": {
+                            "type": "null"
+                        },
+                        "idpSsoUrl": {
+                            "type": "null"
+                        },
+                        "provider": {
+                            "type": "null"
+                        },
+                        "scimAuthenticationAttribute": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "resourcePools": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "pool_name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "taskContainerDefaults": {
+                    "type": "null"
+                },
+                "telemetry": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "useNodePortForMaster": {
+                    "type": "boolean"
+                }
+            }
+        },
         "enterpriseServer": {
             "type": "object",
             "properties": {
@@ -1395,6 +1530,55 @@
                             "type": "array"
                         }
                     }
+                }
+            }
+        },
+        "preflightCheckJob": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "disableLogSampling": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "sqlQueryLogs": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": "array"
                 }
             }
         },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1014,3 +1014,34 @@ proxy:
     secretName: ""
     # If set, generate the secret from values here.  This is intended only for unit tests.
     secret: {}
+preflightCheckJob:
+  # If true, install a Kubernetes job that runs preflight checks from the configured Pachyderm
+  # release.
+  enabled: false
+
+  # The version to preflight.  It is totally fine if this is newer than the currently-running pachd
+  # version.
+  image:
+    repository: "pachyderm/pachd"
+    pullPolicy: "IfNotPresent"
+    tag: ""
+
+  # misc k8s settings
+  affinity: {}
+  annotations: {}
+  resources:
+    {}
+    #limits:
+    #  cpu: "1"
+    #  memory: "2G"
+    #requests:
+    #  cpu: "1"
+    #  memory: "2G"
+  priorityClassName: ""
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+
+  # logging settings
+  sqlQueryLogs: false
+  disableLogSampling: false


### PR DESCRIPTION
This way, the latest 2.6.x chart can run the 2.7.x preflight checks.