### PR TITLE
Consistently format full timestamps in pachctl

### DIFF
--- a/src/internal/pretty/pretty.go
+++ b/src/internal/pretty/pretty.go
@@ -42,6 +42,14 @@ func Ago(timestamp *timestamppb.Timestamp) string {
 	return fmt.Sprintf("%s ago", since)
 }
 
+// Timestamp pretty-prints a timestamp.
+func Timestamp(timestamp *timestamppb.Timestamp) string {
+	if timestamp == nil {
+		return "-"
+	}
+	return timestamp.AsTime().Format(time.RFC3339)
+}
+
 // TimeDifference pretty-prints the duration of time between from
 // and to as a human-reabable string.
 func TimeDifference(from, to *timestamppb.Timestamp) string {

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -172,7 +172,7 @@ func PrintDetailedBranchInfo(branchInfo *pfs.BranchInfo) error {
 	template, err := template.New("BranchInfo").Funcs(funcMap).Parse(
 		`Name: {{.Branch.Repo.Name}}@{{.Branch.Name}}{{if .Head}}
 Head Commit: {{ .Head.Branch.Repo.Name}}@{{.Head.Id}} {{end}}{{if .Provenance}}
-Provenance: {{range .Provenance}} {{.Repo.Name}}@{{.Name}} {{end}} {{end}}{{if .Trigger}}
+Provenance: {{range .Provenance}}{{.Repo.Name}}@{{.Name}} {{end}}{{end}}{{if .Trigger}}
 Trigger: {{printTrigger .Trigger}} {{end}}
 `)
 	if err != nil {

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -51,7 +51,7 @@ func PrintRepoInfo(w io.Writer, repoInfo *pfs.RepoInfo, fullTimestamps bool) {
 		fmt.Fprintf(w, "%s.%s\t", repoInfo.Repo.Name, repoInfo.Repo.Type)
 	}
 	if fullTimestamps {
-		fmt.Fprintf(w, "%s\t", repoInfo.Created.String())
+		fmt.Fprintf(w, "%s\t", pretty.Timestamp(repoInfo.Created))
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(repoInfo.Created))
 	}
@@ -86,7 +86,7 @@ func PrintDetailedRepoInfo(repoInfo *PrintableRepoInfo) error {
 	template, err := template.New("RepoInfo").Funcs(funcMap).Parse(
 		`Name: {{.Repo.Name}}{{if .Description}}
 Description: {{.Description}}{{end}}{{if .FullTimestamps}}
-Created: {{.Created}}{{else}}
+Created: {{prettyTime .Created}}{{else}}
 Created: {{prettyAgo .Created}}{{end}}{{if .Details}}
 Size of HEAD on master: {{prettySize .Details.SizeBytes}}{{end}}{{if .AuthInfo}}
 Roles: {{ .AuthInfo.Roles | commafy }}
@@ -217,7 +217,7 @@ func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps boo
 		fmt.Fprintf(w, "-\t")
 	} else {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", commitInfo.Finished.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(commitInfo.Finished))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(commitInfo.Finished))
 		}
@@ -266,7 +266,7 @@ func PrintCommitSetInfo(w io.Writer, commitSetInfo *pfs.CommitSetInfo, fullTimes
 	fmt.Fprintf(w, "%s\t", pretty.ProgressBar(8, success, len(commitSetInfo.Commits)-success-failure, failure))
 	if created != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", created.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(created))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(created))
 		}
@@ -275,7 +275,7 @@ func PrintCommitSetInfo(w io.Writer, commitSetInfo *pfs.CommitSetInfo, fullTimes
 	}
 	if modified != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", modified.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(modified))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(modified))
 		}
@@ -343,9 +343,9 @@ func PrintDetailedCommitInfo(w io.Writer, commitInfo *PrintableCommitInfo) error
 Original Branch: {{.Commit.Branch.Name}}{{if .Description}}
 Description: {{.Description}}{{end}}{{if .ParentCommit}}
 Parent: {{.ParentCommit.Id}}{{end}}{{if .FullTimestamps}}
-Started: {{.Started}}{{else}}
+Started: {{prettyTime .Started}}{{else}}
 Started: {{prettyAgo .Started}}{{end}}{{if .Finished}}{{if .FullTimestamps}}
-Finished: {{.Finished}}{{else}}
+Finished: {{prettyTime .Finished}}{{else}}
 Finished: {{prettyAgo .Finished}}{{end}}{{end}}{{if .Details}}
 Size: {{prettySize .Details.SizeBytes}}{{end}}
 `)
@@ -372,7 +372,7 @@ func PrintFileInfo(w io.Writer, fileInfo *pfs.FileInfo, fullTimestamps, withComm
 		if fileInfo.Committed == nil {
 			fmt.Fprintf(w, "-\t")
 		} else if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", fileInfo.Committed.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(fileInfo.Committed))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(fileInfo.Committed))
 		}
@@ -415,6 +415,7 @@ func fileType(fileType pfs.FileType) string {
 var funcMap = template.FuncMap{
 	"prettyAgo":    pretty.Ago,
 	"prettySize":   pretty.Size,
+	"prettyTime":   pretty.Timestamp,
 	"fileType":     fileType,
 	"printTrigger": printTrigger,
 	"commafy":      pretty.Commafy,

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -189,7 +189,7 @@ func PrintDetailedProjectInfo(projectInfo *pfs.ProjectInfo) error {
 Description: {{ .Description}}
 {{- end -}}
 {{- if .CreatedAt }}
-Created at: {{ .CreatedAt }}
+Created at: {{ prettyTime .CreatedAt }}
 {{- end -}}
 {{- if .AuthInfo }}
 Roles: {{.AuthInfo.Roles | commafy}}

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -274,27 +274,31 @@ Job Timeout: {{.Details.JobTimeout}}
 Worker Status:
 {{workerStatus .}}Restarts: {{.Restart}}
 ParallelismSpec: {{.Details.ParallelismSpec}}
-{{ if .Details.ResourceRequests }}ResourceRequests:
+{{- if .Details.ResourceRequests }}
+ResourceRequests:
   CPU: {{ .Details.ResourceRequests.Cpu }}
   Memory: {{ .Details.ResourceRequests.Memory }} {{end}}
-{{ if .Details.ResourceLimits }}ResourceLimits:
+{{- if .Details.ResourceLimits }}
+ResourceLimits:
   CPU: {{ .Details.ResourceLimits.Cpu }}
   Memory: {{ .Details.ResourceLimits.Memory }}
   {{ if .Details.ResourceLimits.Gpu }}GPU:
     Type: {{ .Details.ResourceLimits.Gpu.Type }}
     Number: {{ .Details.ResourceLimits.Gpu.Number }} {{end}} {{end}}
-{{ if .Details.SidecarResourceRequests }}SidecarResourceRequests:
+{{- if .Details.SidecarResourceRequests }}
+SidecarResourceRequests:
   CPU: {{ .Details.SidecarResourceRequests.Cpu }}
   Memory: {{ .Details.SidecarResourceRequests.Memory }} {{end}}
-{{ if .Details.SidecarResourceLimits }}SidecarResourceLimits:
+{{- if .Details.SidecarResourceLimits }}
+SidecarResourceLimits:
   CPU: {{ .Details.SidecarResourceLimits.Cpu }}
   Memory: {{ .Details.SidecarResourceLimits.Memory }} {{end}}
-{{ if .Details.Service }}Service:
+{{- if .Details.Service }}
+Service:
 	{{ if .Details.Service.InternalPort }}InternalPort: {{ .Details.Service.InternalPort }} {{end}}
-	{{ if .Details.Service.ExternalPort }}ExternalPort: {{ .Details.Service.ExternalPort }} {{end}} {{end}}Input:
-{{jobInput .}}
-Transform:
-{{prettyTransform .Details.Transform}} {{if .OutputCommit}}
+	{{ if .Details.Service.ExternalPort }}ExternalPort: {{ .Details.Service.ExternalPort }} {{end}} {{end}}
+Input: {{jobInput . }}
+Transform: {{prettyTransform .Details.Transform}} {{if .OutputCommit}}
 Output Commit: {{.OutputCommit.Id}} {{end}}{{ if .Details.Egress }}
 Egress: {{egress .Details.Egress}} {{end}}
 `)
@@ -501,7 +505,7 @@ func jobInput(pji PrintableJobInfo) string {
 	if err != nil {
 		panic(errors.Wrapf(err, "error marshalling input"))
 	}
-	return string(input) + "\n"
+	return string(input)
 }
 
 func workerStatus(pji PrintableJobInfo) string {

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -327,17 +327,19 @@ func PrintDetailedPipelineInfo(w io.Writer, pipelineInfo *PrintablePipelineInfo)
 	template, err := template.New("PipelineInfo").Funcs(funcMap).Parse(
 		`Name: {{.Pipeline.Name}}{{if .Details.Description}}
 Description: {{.Details.Description}}{{end}}{{if .FullTimestamps }}
-Created: {{.Details.CreatedAt}}{{ else }}
+Created: {{prettyTime .Details.CreatedAt}}{{ else }}
 Created: {{prettyAgo .Details.CreatedAt}} {{end}}
 State: {{pipelineState .State}}
 Reason: {{.Reason}}
 Workers Available: {{.Details.WorkersAvailable}}/{{.Details.WorkersRequested}}
 Stopped: {{ .Stopped }}
 Parallelism Spec: {{.Details.ParallelismSpec}}
-{{ if .Details.ResourceRequests }}ResourceRequests:
+{{- if .Details.ResourceRequests }}
+ResourceRequests:
   CPU: {{ .Details.ResourceRequests.Cpu }}
   Memory: {{ .Details.ResourceRequests.Memory }} {{end}}
-{{ if .Details.ResourceLimits }}ResourceLimits:
+{{- if .Details.ResourceLimits }}
+ResourceLimits:
   CPU: {{ .Details.ResourceLimits.Cpu }}
   Memory: {{ .Details.ResourceLimits.Memory }}
   {{ if .Details.ResourceLimits.Gpu }}GPU:
@@ -345,11 +347,9 @@ Parallelism Spec: {{.Details.ParallelismSpec}}
     Number: {{ .Details.ResourceLimits.Gpu.Number }} {{end}} {{end}}
 Datum Timeout: {{.Details.DatumTimeout}}
 Job Timeout: {{.Details.JobTimeout}}
-Input:
-{{pipelineInput .PipelineInfo}}
+Input: {{pipelineInput .PipelineInfo}}
 Output Branch: {{.Details.OutputBranch}}
-Transform:
-{{prettyTransform .Details.Transform}}
+Transform: {{prettyTransform .Details.Transform}}
 {{ if .Details.Egress }}Egress: {{egress .Details.Egress}} {{end}}
 {{if .Details.RecentError}} Recent Error: {{.Details.RecentError}} {{end}}
 `)
@@ -528,7 +528,7 @@ func pipelineInput(pipelineInfo *ppsclient.PipelineInfo) string {
 	if err != nil {
 		panic(errors.Wrapf(err, "error marshalling input"))
 	}
-	return string(input) + "\n"
+	return string(input)
 }
 
 func prettyTransform(transform *ppsclient.Transform) (string, error) {

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -107,7 +107,7 @@ func PrintJobInfo(w io.Writer, jobInfo *ppsclient.JobInfo, fullTimestamps bool) 
 	fmt.Fprintf(w, "%s\t", jobInfo.Job.Id)
 	if jobInfo.Started != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", jobInfo.Started.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(jobInfo.Started))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(jobInfo.Started))
 		}
@@ -167,7 +167,7 @@ func PrintJobSetInfo(w io.Writer, jobSetInfo *ppsclient.JobSetInfo, fullTimestam
 	fmt.Fprintf(w, "%s\t", pretty.ProgressBar(8, success, len(jobSetInfo.Jobs)-success-failure, failure))
 	if created != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", created.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(created))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(created))
 		}
@@ -176,7 +176,7 @@ func PrintJobSetInfo(w io.Writer, jobSetInfo *ppsclient.JobSetInfo, fullTimestam
 	}
 	if modified != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", modified.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(modified))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(modified))
 		}
@@ -199,7 +199,7 @@ func PrintPipelineInfo(w io.Writer, pipelineInfo *ppsclient.PipelineInfo, fullTi
 	} else {
 		fmt.Fprintf(w, "%s\t", ShorthandInput(pipelineInfo.Details.Input))
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", pipelineInfo.Details.CreatedAt.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(pipelineInfo.Details.CreatedAt))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(pipelineInfo.Details.CreatedAt))
 		}
@@ -225,7 +225,7 @@ func PrintWorkerStatus(w io.Writer, workerStatus *ppsclient.WorkerStatus, fullTi
 		}
 		fmt.Fprintf(w, "\t")
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", datumStatus.Started.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(datumStatus.Started))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(datumStatus.Started))
 		}
@@ -254,7 +254,7 @@ func PrintDetailedJobInfo(w io.Writer, jobInfo *PrintableJobInfo) error {
 		`ID: {{.Job.Id}}
 Pipeline: {{.Job.Pipeline.Name}}
 Project: {{.Job.Pipeline.Project.Name}}{{if .FullTimestamps}}
-Started: {{jobStarted .Started}}{{else}}
+Started: {{prettyTime .Started}}{{else}}
 Started: {{prettyAgo .Started}} {{end}}{{if .Finished}}
 Duration: {{prettyTimeDifference .Started .Finished}} {{end}}
 State: {{jobState .State}}
@@ -465,13 +465,6 @@ func JobState(jobState ppsclient.JobState) string {
 	return "-"
 }
 
-func jobStarted(started *timestamppb.Timestamp) string {
-	if started == nil {
-		return "-"
-	}
-	return started.AsTime().GoString()
-}
-
 // Progress pretty prints the datum progress of a job.
 func Progress(ji *ppsclient.JobInfo) string {
 	if ji.DataRecovered != 0 {
@@ -593,16 +586,16 @@ func egress(e *ppsclient.Egress) string {
 
 var funcMap = template.FuncMap{
 	"pipelineState":        pipelineState,
-	"jobStarted":           jobStarted,
 	"jobState":             JobState,
 	"datumState":           datumState,
 	"workerStatus":         workerStatus,
 	"pipelineInput":        pipelineInput,
 	"jobInput":             jobInput,
 	"prettyAgo":            pretty.Ago,
-	"prettyTimeDifference": pretty.TimeDifference,
 	"prettyDuration":       pretty.Duration,
 	"prettySize":           pretty.Size,
+	"prettyTime":           pretty.Timestamp,
+	"prettyTimeDifference": pretty.TimeDifference,
 	"prettyTransform":      prettyTransform,
 	"egress":               egress,
 }

--- a/src/server/transaction/pretty/pretty.go
+++ b/src/server/transaction/pretty/pretty.go
@@ -32,7 +32,7 @@ type PrintableTransactionInfo struct {
 func PrintTransactionInfo(w io.Writer, info *transaction.TransactionInfo, fullTimestamps bool) {
 	fmt.Fprintf(w, "%s\t", info.Transaction.Id)
 	if fullTimestamps {
-		fmt.Fprintf(w, "%s\t", info.Started.String())
+		fmt.Fprintf(w, "%s\t", pretty.Timestamp(info.Started))
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(info.Started))
 	}
@@ -44,7 +44,7 @@ func PrintTransactionInfo(w io.Writer, info *transaction.TransactionInfo, fullTi
 func PrintDetailedTransactionInfo(info *PrintableTransactionInfo) error {
 	template, err := template.New("TransactionInfo").Funcs(funcMap).Parse(
 		`ID: {{.Transaction.ID}}{{if .FullTimestamps}}
-Started: {{.Started}}{{else}}
+Started: {{prettyTime .Started}}{{else}}
 Started: {{prettyAgo .Started}}{{end}}
 Requests:
 {{transactionRequests .Requests .Responses}}
@@ -180,6 +180,7 @@ func transactionRequests(
 
 var funcMap = template.FuncMap{
 	"prettyAgo":           pretty.Ago,
+	"prettyTime":          pretty.Timestamp,
 	"prettySize":          pretty.Size,
 	"transactionRequests": transactionRequests,
 }


### PR DESCRIPTION
This gets all the places where we print times from protos and formats them as RFC3339 without nanoseconds.  In the past this printed nanoseconds by coincidence, but I don't think anyone needs them and it takes up 9 chracters of space to do so.  (Those that want them can run --raw to get it in that form).