### PR TITLE
migrations: add Squash

### DIFF
--- a/src/internal/clusterstate/v2.0.0.go
+++ b/src/internal/clusterstate/v2.0.0.go
@@ -27,56 +27,56 @@ var state_2_0_0 migrations.State = migrations.InitialState().
 	Apply("create storage schema", func(ctx context.Context, env migrations.Env) error {
 		_, err := env.Tx.ExecContext(ctx, `CREATE SCHEMA storage`)
 		return errors.EnsureStack(err)
-	}).
+	}, migrations.Squash).
 	Apply("storage tracker v0", func(ctx context.Context, env migrations.Env) error {
 		return track.SetupPostgresTrackerV0(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("storage chunk store v0", func(ctx context.Context, env migrations.Env) error {
 		return chunk.SetupPostgresStoreV0(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("storage fileset store v0", func(ctx context.Context, env migrations.Env) error {
 		return fileset.SetupPostgresStoreV0(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create license schema", func(ctx context.Context, env migrations.Env) error {
 		_, err := env.Tx.ExecContext(ctx, `CREATE SCHEMA license`)
 		return errors.EnsureStack(err)
-	}).
+	}, migrations.Squash).
 	Apply("license clusters v0", func(ctx context.Context, env migrations.Env) error {
 		return license.CreateClustersTableV0(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create pfs schema", func(ctx context.Context, env migrations.Env) error {
 		_, err := env.Tx.ExecContext(ctx, `CREATE SCHEMA pfs`)
 		return errors.EnsureStack(err)
-	}).
+	}, migrations.Squash).
 	Apply("pfs commit store v0", func(ctx context.Context, env migrations.Env) error {
 		return SetupPostgresCommitStoreV0(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create identity schema", func(ctx context.Context, env migrations.Env) error {
 		_, err := env.Tx.ExecContext(ctx, `CREATE SCHEMA identity`)
 		return errors.EnsureStack(err)
-	}).
+	}, migrations.Squash).
 	Apply("create identity users table v0", func(ctx context.Context, env migrations.Env) error {
 		return identity.CreateUsersTable(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create identity config table v0", func(ctx context.Context, env migrations.Env) error {
 		return identity.CreateConfigTable(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create auth schema", func(ctx context.Context, env migrations.Env) error {
 		_, err := env.Tx.ExecContext(ctx, `CREATE SCHEMA auth`)
 		return errors.EnsureStack(err)
-	}).
+	}, migrations.Squash).
 	Apply("create auth tokens table v0", func(ctx context.Context, env migrations.Env) error {
 		return auth.CreateAuthTokensTable(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("license clusters v1", func(ctx context.Context, env migrations.Env) error {
 		return license.AddUserContextsToClustersTable(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create collections schema", func(ctx context.Context, env migrations.Env) error {
 		return col.CreatePostgresSchema(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create collections trigger functions", func(ctx context.Context, env migrations.Env) error {
 		return col.SetupPostgresV0(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create collections", func(ctx context.Context, env migrations.Env) error {
 		collections := []col.PostgresCollection{}
 		collections = append(collections, pfsdb.CollectionsV0()...)
@@ -84,21 +84,21 @@ var state_2_0_0 migrations.State = migrations.InitialState().
 		collections = append(collections, transactiondb.CollectionsV0()...)
 		collections = append(collections, authdb.CollectionsV0()...)
 		return col.SetupPostgresCollections(ctx, env.Tx, collections...)
-	}).
+	}, migrations.Squash).
 	Apply("license clusters client_id column", func(ctx context.Context, env migrations.Env) error {
 		return license.AddClusterClientIdColumn(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("identity config token lifetime", func(ctx context.Context, env migrations.Env) error {
 		return identity.AddTokenExpiryConfig(ctx, env.Tx)
-	}).
+	}, migrations.Squash).
 	Apply("create license collection", func(ctx context.Context, env migrations.Env) error {
 		collections := []col.PostgresCollection{}
 		collections = append(collections, licenseserver.CollectionsV0()...)
 		return col.SetupPostgresCollections(ctx, env.Tx, collections...)
-	}).
+	}, migrations.Squash).
 	Apply("add rotation_token_expiry to identity.config table", func(ctx context.Context, env migrations.Env) error {
 		return identity.AddRotationTokenExpiryConfig(ctx, env.Tx)
-	})
+	}, migrations.Squash)
 
 // DO NOT MODIFY THIS STATE
 // IT HAS ALREADY SHIPPED IN A RELEASE

--- a/src/internal/clusterstate/v2.1.0.go
+++ b/src/internal/clusterstate/v2.1.0.go
@@ -14,7 +14,7 @@ var state_2_1_0 migrations.State = state_2_0_0.
 	}).
 	Apply("Remove old EnterpriseConfig record from etcd", func(ctx context.Context, env migrations.Env) error {
 		return enterpriseserver.DeleteEnterpriseConfigFromEtcd(ctx, env.EtcdClient)
-	}, migrations.Squash).
+	}).
 	Apply("create pfs cache v1", func(ctx context.Context, env migrations.Env) error {
 		return fileset.CreatePostgresCacheV1(ctx, env.Tx)
 	}, migrations.Squash)

--- a/src/internal/clusterstate/v2.1.0.go
+++ b/src/internal/clusterstate/v2.1.0.go
@@ -14,9 +14,9 @@ var state_2_1_0 migrations.State = state_2_0_0.
 	}).
 	Apply("Remove old EnterpriseConfig record from etcd", func(ctx context.Context, env migrations.Env) error {
 		return enterpriseserver.DeleteEnterpriseConfigFromEtcd(ctx, env.EtcdClient)
-	}).
+	}, migrations.Squash).
 	Apply("create pfs cache v1", func(ctx context.Context, env migrations.Env) error {
 		return fileset.CreatePostgresCacheV1(ctx, env.Tx)
-	})
+	}, migrations.Squash)
 	// DO NOT MODIFY THIS STATE
 	// IT HAS ALREADY SHIPPED IN A RELEASE

--- a/src/internal/clusterstate/v2.5.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.5.0/clusterstate.go
@@ -28,7 +28,7 @@ func Migrate(state migrations.State) migrations.State {
 				return errors.Wrap(err, "could not create default project")
 			}
 			return nil
-		}).
+		}, migrations.Squash).
 		Apply("Rename default project to “default”", func(ctx context.Context, env migrations.Env) error {
 			if err := env.LockTables(ctx,
 				"collections.repos",
@@ -54,7 +54,7 @@ func Migrate(state migrations.State) migrations.State {
 				return err
 			}
 			return nil
-		})
+		}, migrations.Squash)
 	// DO NOT MODIFY THIS STATE
 	// IT HAS ALREADY SHIPPED IN A RELEASE
 }

--- a/src/internal/clusterstate/v2.5.4.go
+++ b/src/internal/clusterstate/v2.5.4.go
@@ -15,4 +15,4 @@ var state_2_5_4 migrations.State = state_2_5_0.
 			return errors.Wrap(err, "could not alter column subject in table auth.auth_tokens from varchar(64) to varchar(128)")
 		}
 		return nil
-	})
+	}, migrations.Squash)

--- a/src/internal/clusterstate/v2.6.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.6.0/clusterstate.go
@@ -45,10 +45,10 @@ func Migrate(state migrations.State) migrations.State {
 				return errors.Wrap(err, "list commits for DAG validation")
 			}
 			return validateExistingDAGs(cis)
-		}).
+		}, migrations.Squash).
 		Apply("Add commit_provenance table", func(ctx context.Context, env migrations.Env) error {
 			return pfsdb.SetupCommitProvenanceV0(ctx, env.Tx)
-		}).
+		}, migrations.Squash).
 		Apply("Remove Alias Commits", func(ctx context.Context, env migrations.Env) error {
 			// locking the following tables is necessary for the following 2 migration "Apply"s:
 			// "Remove Alias Commits", "Remove branch from the Commit key"
@@ -71,7 +71,7 @@ func Migrate(state migrations.State) migrations.State {
 				return errors.Wrap(err, "delete dangling commit references")
 			}
 			return removeAliasCommits(ctx, env.Tx)
-		}).
+		}, migrations.Squash).
 		Apply("Remove branch from the Commit key", func(ctx context.Context, env migrations.Env) error {
 			// enforce known DB invariants
 			if err := deleteDanglingCommitRefs(ctx, env.Tx); err != nil {
@@ -81,10 +81,10 @@ func Migrate(state migrations.State) migrations.State {
 				return err
 			}
 			return branchlessCommitsPPS(ctx, env.Tx)
-		}).
+		}, migrations.Squash).
 		Apply("Add foreign key constraints on pfs.commits.commit_id -> collections.commits.key", func(ctx context.Context, env migrations.Env) error {
 			return pfsdb.SetupCommitProvenanceV01(ctx, env.Tx)
-		})
+		}, migrations.Squash)
 
 	// DO NOT MODIFY THIS STATE
 	// IT HAS ALREADY SHIPPED IN A RELEASE

--- a/src/internal/clusterstate/v2.7.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.7.0/clusterstate.go
@@ -22,13 +22,13 @@ func Migrate(state migrations.State) migrations.State {
 				return errors.Wrap(err, "creating core schema")
 			}
 			return nil
-		}).
+		}, migrations.Squash).
 		Apply("Create core.projects table", func(ctx context.Context, env migrations.Env) error {
 			if err := createProjectsTable(ctx, env.Tx); err != nil {
 				return errors.Wrap(err, "creating core.projects table")
 			}
 			return nil
-		}).
+		}, migrations.Squash).
 		Apply("Migrate collections.projects to core.projects", func(ctx context.Context, env migrations.Env) error {
 			if err := env.LockTables(ctx, "collections.projects"); err != nil {
 				return errors.Wrap(err, "acquiring exclusive lock on collections.projects table")
@@ -37,5 +37,5 @@ func Migrate(state migrations.State) migrations.State {
 				return errors.Wrap(err, "migrating collections.projects to core.projects")
 			}
 			return nil
-		})
+		}, migrations.Squash)
 }

--- a/src/internal/preflight/preflight.go
+++ b/src/internal/preflight/preflight.go
@@ -68,7 +68,7 @@ func TestMigrations(ctx context.Context, db *pachsql.DB) (retErr error) {
 		}
 		log.Info(ctx, "txn rolled back ok")
 	}()
-	states := migrations.CollectStates(nil, clusterstate.DesiredClusterState)
+	states := migrations.CollectStates(clusterstate.DesiredClusterState)
 	env := migrations.MakeEnv(nil, etcdClient)
 	env.Tx = txx
 	env.WithTableLocks = false


### PR DESCRIPTION
- Squash includes a migration in a previous transaction.
- Use squash to group migrations into releases.