### PR TITLE
Add a /pfs HTTP endpoint that allows browsing files stored in PFS

### DIFF
--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -147,6 +147,16 @@
           timeout: '604800s',
         },
       },
+      {
+        match: {
+          prefix: '/pfs',
+        },
+        route: {
+          cluster: 'pachd-http',
+          idle_timeout: '600s',
+          timeout: '604800s',
+        },
+      },
     ],
     health_check: {
       healthy_threshold: 1,

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -874,6 +874,16 @@
                                        },
                                        {
                                           "match": {
+                                             "prefix": "/pfs"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-http",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
                                              "prefix": "/"
                                           },
                                           "route": {

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -740,6 +740,16 @@
                                        },
                                        {
                                           "match": {
+                                             "prefix": "/pfs"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-http",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
                                              "prefix": "/"
                                           },
                                           "route": {
@@ -1989,6 +1999,16 @@
                                        {
                                           "match": {
                                              "prefix": "/jsonschema/"
+                                          },
+                                          "route": {
+                                             "cluster": "pachd-http",
+                                             "idle_timeout": "600s",
+                                             "timeout": "604800s"
+                                          }
+                                       },
+                                       {
+                                          "match": {
+                                             "prefix": "/pfs"
                                           },
                                           "route": {
                                              "cluster": "pachd-http",

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
+	github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09
 	github.com/uber/jaeger-client-go v2.28.0+incompatible
 	github.com/vbauerster/mpb/v6 v6.0.2
 	github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448

--- a/go.sum
+++ b/go.sum
@@ -1880,6 +1880,8 @@ github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 h1:
 github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tilinna/clock v1.0.2/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
+github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09 h1:QVxbx5l/0pzciWYOynixQMtUhPYC3YKD6EcUlOsgGqw=
+github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09/go.mod h1:Uy/Rnv5WKuOO+PuDhuYLEpUiiKIZtss3z519uk67aF0=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/src/internal/conditionalrequest/conditionalrequest.go
+++ b/src/internal/conditionalrequest/conditionalrequest.go
@@ -36,7 +36,7 @@ func (info *ResourceInfo) ifModifiedSince(httpDate string) error {
 	}
 	// If the selected representation's last modification date is earlier or equal to the
 	// date provided in the field value, the condition is false.
-	if !info.LastModified.After(t) {
+	if info.LastModified.Before(t) || info.LastModified.Equal(t) {
 		return ErrNotModified
 	}
 	// Otherwise, the condition is true.
@@ -54,7 +54,7 @@ func (info *ResourceInfo) ifUnmodifiedSince(httpDate string) error {
 	}
 	// If the selected representation's last modification date is earlier or equal to the
 	// date provided in the field value, the condition is true.
-	if !info.LastModified.After(t) {
+	if info.LastModified.Before(t) || info.LastModified.Equal(t) {
 		return nil
 	}
 	// Otherwise, the condition is false.

--- a/src/internal/conditionalrequest/conditionalrequest.go
+++ b/src/internal/conditionalrequest/conditionalrequest.go
@@ -1,0 +1,191 @@
+// Package conditionalrequest handles HTTP conditional requests based on modification time and
+// etags.
+package conditionalrequest
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+)
+
+var (
+	ErrPreconditionFailed = errors.New("precondition failed")
+	ErrNotModified        = errors.New("not modified")
+)
+
+// ResourceInfo is information about a resource to be tested with conditionals.
+type ResourceInfo struct {
+	LastModified time.Time
+	ETag         string // Includes the quotes.
+}
+
+// https://www.rfc-editor.org/rfc/rfc9110#field.if-modified-since
+func (info *ResourceInfo) ifModifiedSince(httpDate string) error {
+	t, err := http.ParseTime(httpDate)
+	if err != nil {
+		// A recipient MUST ignore the If-Modified-Since header field if the received field
+		// value is not a valid HTTP-date.
+		return nil
+	}
+	if info.LastModified.IsZero() {
+		// A recipient MUST ignore the If-Modified-Since header field if the resource does
+		// not have a modification date available.
+		return nil
+	}
+	// If the selected representation's last modification date is earlier or equal to the
+	// date provided in the field value, the condition is false.
+	if !info.LastModified.After(t) {
+		return ErrNotModified
+	}
+	// Otherwise, the condition is true.
+	return nil
+}
+
+// https://www.rfc-editor.org/rfc/rfc9110#field.if-unmodified-since
+func (info *ResourceInfo) ifUnmodifiedSince(httpDate string) error {
+	t, err := http.ParseTime(httpDate)
+	if err != nil {
+		return nil
+	}
+	if info.LastModified.IsZero() {
+		return nil
+	}
+	// If the selected representation's last modification date is earlier or equal to the
+	// date provided in the field value, the condition is true.
+	if !info.LastModified.After(t) {
+		return nil
+	}
+	// Otherwise, the condition is false.
+	return ErrPreconditionFailed
+}
+
+// https://www.rfc-editor.org/rfc/rfc9110#field.if-match
+func (info *ResourceInfo) ifMatch(etags string) error {
+	if etags == "*" {
+		// If the field value is "*", the condition is true if the origin server has a
+		// current representation for the target resource.
+		return nil
+	}
+	// If the field value is a list of entity tags, the condition is true if any of the listed
+	// tags match the entity tag of the selected representation.
+	for _, part := range strings.Split(etags, ",") {
+		part = strings.TrimSpace(part)
+		if part == info.ETag {
+			return nil
+		}
+	}
+	// Otherwise, the condition is false.
+	return ErrPreconditionFailed
+}
+
+// https://www.rfc-editor.org/rfc/rfc9110#field.if-none-match
+func (info *ResourceInfo) ifNoneMatch(etags string) error {
+	if etags == "*" {
+		// If the field value is "*", the condition is false if the origin server has a
+		// current representation for the target resource.
+		return ErrPreconditionFailed
+	}
+	// If the field value is a list of entity tags, the condition is false if one of the listed
+	// tags matches the entity tag of the selected representation.
+	for _, part := range strings.Split(etags, ",") {
+		part = strings.TrimSpace(part)
+		if part == info.ETag {
+			return ErrPreconditionFailed
+		}
+	}
+	// Otherwise, the condition is true.
+	return nil
+}
+
+// https://www.rfc-editor.org/rfc/rfc9110#name-if-range
+func (info *ResourceInfo) ifRange(value string) error {
+	// A valid entity-tag can be distinguished from a valid HTTP-date by examining the first
+	// three characters for a DQUOTE.
+	if len(value) > 3 && strings.ContainsAny(value, `"`) {
+		// To evaluate a received If-Range header field containing an entity-tag:
+		if value == info.ETag {
+			// 1. If the entity-tag validator provided exactly matches the ETag field
+			// value for the selected representation using the strong comparison
+			// function (Section 8.8.3.2), the condition is true.
+			return nil
+		} else {
+			// 2. Otherwise, the condition is false.
+			return ErrPreconditionFailed
+		}
+	}
+
+	// To evaluate a received If-Range header field containing an HTTP-date:
+
+	// 1. If the HTTP-date validator provided is not a strong validator in the sense
+	// defined by Section 8.8.2.2, the condition is false.
+	// 2. If the HTTP-date validator provided exactly matches the Last-Modified field
+	// value for the selected representation, the condition is true.
+	if value == info.LastModified.UTC().Format(http.TimeFormat) {
+		return nil
+	} else {
+		// 3. Otherwise, the condition is false.
+		return ErrPreconditionFailed
+	}
+}
+
+// Evaluate evaluates an HTTP conditional request, returning 0 if the request should be handled
+// normally, or a status code if it should be aborted.
+func Evaluate(req *http.Request, info *ResourceInfo) int {
+	// https://www.rfc-editor.org/rfc/rfc9110#name-precedence-of-preconditions
+	if ifMatch := req.Header.Get("if-match"); ifMatch != "" {
+		// Step 1: When recipient is the origin server and If-Match is present, evaluate the
+		// If-Match precondition:
+		if err := info.ifMatch(ifMatch); err != nil {
+			// if false, respond 412 (Precondition Failed)
+			return http.StatusPreconditionFailed
+		}
+		// if true, continue to step 3
+	} else if ifUnmodifiedSince := req.Header.Get("if-unmodified-since"); ifUnmodifiedSince != "" {
+		// Step 2: When recipient is the origin server, If-Match is not present, and
+		// If-Unmodified-Since is present, evaluate the If-Unmodified-Since precondition
+		if err := info.ifUnmodifiedSince(ifUnmodifiedSince); err != nil {
+			// if false, respond 412 (Precondition Failed)
+			return http.StatusPreconditionFailed
+		}
+		// if true, continue to step 3
+	}
+	if ifNoneMatch := req.Header.Get("if-none-match"); ifNoneMatch != "" {
+		// Step 3: When If-None-Match is present, evaluate the If-None-Match precondition
+		if err := info.ifNoneMatch(ifNoneMatch); err != nil {
+			switch req.Method {
+			case http.MethodGet, http.MethodHead:
+				// if false for GET/HEAD, respond 304 (Not Modified)
+				return http.StatusNotModified
+			default:
+				// if false for other methods, respond 412 (Precondition Failed)
+				return http.StatusPreconditionFailed
+			}
+		}
+		// if true, continue to step 5
+	} else if ifModifiedSince := req.Header.Get("if-modified-since"); (req.Method == http.MethodGet || req.Method == http.MethodHead) && ifModifiedSince != "" {
+		// Step 4: When the method is GET or HEAD, If-None-Match is not present, and
+		// If-Modified-Since is present, evaluate the If-Modified-Since precondition.
+		if err := info.ifModifiedSince(ifModifiedSince); err != nil {
+			// if false, respond 304 (Not Modified)
+			return http.StatusNotModified
+		}
+		// if true, continue to step 5
+	}
+	if ifRange := req.Header.Get("if-range"); req.Method == http.MethodGet && req.Header.Get("range") != "" && ifRange != "" {
+		// Step 5: When the method is GET and both Range and If-Range are present, evaluate the
+		// If-Range precondition.
+		if err := info.ifRange(ifRange); err == nil {
+			// if true and the Range is applicable to the selected representation,
+			// respond 206 (Partial Content)
+			return http.StatusPartialContent
+		}
+		// otherwise, ignore the Range header field and respond 200 (OK)
+		req.Header.Del("range")
+		return 0
+	}
+	// Step 6: Otherwise, perform the requested method and respond according to its success or
+	// failure.
+	return 0
+}

--- a/src/internal/conditionalrequest/conditionalrequest_test.go
+++ b/src/internal/conditionalrequest/conditionalrequest_test.go
@@ -22,7 +22,7 @@ func TestConditionalRequest(t *testing.T) {
 		{
 			name: "if-modified; not modified",
 			headers: http.Header{
-				"If-Modified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+				"If-Modified-Since": {"Sat, 07 Oct 2023 00:00:00 GMT"},
 			},
 			want: http.StatusNotModified,
 		},
@@ -30,7 +30,7 @@ func TestConditionalRequest(t *testing.T) {
 			name: "if-modified; no modification time known",
 			info: &ResourceInfo{},
 			headers: http.Header{
-				"If-Modified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+				"If-Modified-Since": {"Sat, 07 Oct 2023 00:00:00 GMT"},
 			},
 			want: 0,
 		},
@@ -51,7 +51,7 @@ func TestConditionalRequest(t *testing.T) {
 		{
 			name: "if-unmodified; unmodified",
 			headers: http.Header{
-				"If-Unmodified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+				"If-Unmodified-Since": {"Sat, 07 Oct 2023 00:00:00 GMT"},
 			},
 			want: 0,
 		},
@@ -59,7 +59,7 @@ func TestConditionalRequest(t *testing.T) {
 			name: "if-unmodified; no modification time known",
 			info: &ResourceInfo{},
 			headers: http.Header{
-				"If-Unmodified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+				"If-Unmodified-Since": {"Sat, 07 Oct 2023 00:00:00 GMT"},
 			},
 			want: 0,
 		},

--- a/src/internal/conditionalrequest/conditionalrequest_test.go
+++ b/src/internal/conditionalrequest/conditionalrequest_test.go
@@ -1,0 +1,196 @@
+package conditionalrequest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestConditionalRequest(t *testing.T) {
+	testData := []struct {
+		name    string
+		method  string // defaults to GET
+		info    *ResourceInfo
+		headers http.Header
+		want    int
+	}{
+		{
+			name: "no headers",
+			want: 0,
+		},
+		{
+			name: "if-modified; not modified",
+			headers: http.Header{
+				"If-Modified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name: "if-modified; no modification time known",
+			info: &ResourceInfo{},
+			headers: http.Header{
+				"If-Modified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+			},
+			want: 0,
+		},
+		{
+			name: "if-modified; modified",
+			headers: http.Header{
+				"If-Modified-Since": {"Sun, 01 Dec 2019 00:00:00 GMT"},
+			},
+			want: 0,
+		},
+		{
+			name: "if-modified; unparseable time",
+			headers: http.Header{
+				"If-Modified-Since": {"foo bar"},
+			},
+			want: 0,
+		},
+		{
+			name: "if-unmodified; unmodified",
+			headers: http.Header{
+				"If-Unmodified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+			},
+			want: 0,
+		},
+		{
+			name: "if-unmodified; no modification time known",
+			info: &ResourceInfo{},
+			headers: http.Header{
+				"If-Unmodified-Since": {"Fri, 07 Oct 2023 00:00:00 GMT"},
+			},
+			want: 0,
+		},
+		{
+			name: "if-unmodified; modified",
+			headers: http.Header{
+				"If-Unmodified-Since": {"Sun, 01 Dec 2019 00:00:00 GMT"},
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name: "if-unmodified; unparseable time",
+			headers: http.Header{
+				"If-Unmodified-Since": {"foo bar"},
+			},
+			want: 0,
+		},
+		{
+			name: "if-match; no match",
+			headers: http.Header{
+				"If-Match": {"foobar"},
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name: "if-match; match",
+			headers: http.Header{
+				"If-Match": {`"etag"`},
+			},
+			want: 0,
+		},
+		{
+			name: "if-match; match *",
+			headers: http.Header{
+				"If-Match": {`*`},
+			},
+			want: 0,
+		},
+		{
+			name: "if-none-match; no match",
+			headers: http.Header{
+				"If-None-Match": {`"foobar"`},
+			},
+			want: 0,
+		},
+		{
+			name: "if-none-match; match",
+			headers: http.Header{
+				"If-None-Match": {`"etag"`},
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name:   "if-none-match; match; HEAD",
+			method: http.MethodHead,
+			headers: http.Header{
+				"If-None-Match": {`"etag"`},
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name:   "if-none-match; match; PUT",
+			method: http.MethodPut,
+			headers: http.Header{
+				"If-None-Match": {`"etag"`},
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name: "if-none-match; match *",
+			headers: http.Header{
+				"If-None-Match": {`*`},
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name: "if-range; match",
+			headers: http.Header{
+				"Range":    {"bytes=0-0"},
+				"If-Range": {`"etag"`},
+			},
+			want: http.StatusPartialContent,
+		},
+		{
+			name: "if-range; no match",
+			headers: http.Header{
+				"Range":    {"bytes=0-0"},
+				"If-Range": {`"foo"`},
+			},
+			want: 0,
+		},
+		{
+			name: "if-range; matching date",
+			headers: http.Header{
+				"Range":    {"bytes=0-0"},
+				"If-Range": {`Wed, 01 Jan 2020 00:00:00 GMT`},
+			},
+			want: http.StatusPartialContent,
+		},
+		{
+			name: "if-range; non-matching date",
+			headers: http.Header{
+				"Range":    {"bytes=0-0"},
+				"If-Range": {`Wed, 01 Jan 2020 00:00:01 GMT`},
+			},
+			want: 0,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			if test.method == "" {
+				test.method = http.MethodGet
+			}
+			req := httptest.NewRequest(test.method, "/", nil)
+			for k, vs := range test.headers {
+				for _, v := range vs {
+					req.Header.Add(k, v)
+				}
+			}
+			info := test.info
+			if info == nil {
+				info = &ResourceInfo{
+					LastModified: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+					ETag:         `"etag"`,
+				}
+			}
+			got := Evaluate(req, info)
+			if want := test.want; got != want {
+				t.Errorf("Evaluate(%s):\n  got: %v\n want: %v", info, got, want)
+			}
+		})
+	}
+}

--- a/src/internal/fileserver/fileserver.go
+++ b/src/internal/fileserver/fileserver.go
@@ -47,8 +47,8 @@ var (
 		// current URL path -> URL part after /pfs
 		"path": func(url string) string {
 			parts := strings.Split(url, "/")
-			if len(parts) > 1 {
-				return path.Join(parts[1:]...)
+			if len(parts) > 2 {
+				return path.Join(parts[2:]...)
 			}
 			return url
 		},

--- a/src/internal/fileserver/fileserver.go
+++ b/src/internal/fileserver/fileserver.go
@@ -220,6 +220,7 @@ func (r *Request) displayDirectoryListing(ctx context.Context, info *pfs.FileInf
 	})
 	if err != nil {
 		r.displayGRPCError(ctx, "problem listing directory", err)
+		return
 	}
 	w := r.ResponseWriter
 	if r.HTML {

--- a/src/internal/fileserver/fileserver.go
+++ b/src/internal/fileserver/fileserver.go
@@ -1,0 +1,313 @@
+// Package fileserver implements an HTTP server for uploading and downloading PFS files.
+//
+// See: https://www.notion.so/2023-04-03-HTTP-file-and-archive-downloads-cfb56fac16e54957b015070416b09e94
+package fileserver
+
+import (
+	"context"
+	"embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/constants"
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/conditionalrequest"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth/httpauth"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"github.com/timewasted/go-accept-headers"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	//go:embed templates/*
+	templateFS embed.FS
+	templates  = template.Must(template.ParseFS(templateFS, "templates/*"))
+)
+
+// Server is an http.Handler that can download from and upload to PFS.
+type Server struct {
+	ClientFactory func(context.Context) *client.APIClient
+}
+
+type Request struct {
+	PachClient     *client.APIClient
+	Request        *http.Request
+	ResponseWriter http.ResponseWriter
+	RequestID      string
+}
+
+// ServeHTTP implements http.Handler for the /pfs/ route.
+func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	pachClient := httpauth.ClientWithToken(ctx, s.ClientFactory(ctx), req)
+	ctx = pachClient.Ctx()
+
+	ourRequest := &Request{
+		Request:        req,
+		ResponseWriter: w,
+		PachClient:     pachClient,
+		RequestID:      log.RequestID(ctx),
+	}
+
+	switch req.Method {
+	case http.MethodHead, http.MethodGet:
+		w.Header().Set("vary", constants.ContextTokenKey)
+		ourRequest.get(ctx)
+		return
+	default:
+		ourRequest.displayErrorf(ctx, http.StatusMethodNotAllowed, "unknown HTTP method %q", req.Method)
+		return
+	}
+}
+
+func (r *Request) get(ctx context.Context) {
+	req := r.Request
+	parts := strings.Split(req.URL.Path, "/")
+	switch len(parts) {
+	case 5, 6: // /pfs/project/repo/commit|branch(/path)
+		if len(parts) == 5 {
+			parts = append(parts, "")
+		}
+	default:
+		// Someday we can have a projects page, project repo page, repo commit page, etc.
+		r.displayErrorf(ctx, http.StatusBadRequest,
+			//                     0 1   2         3      4               5
+			"invalid URL; expecting /pfs/<project>/<repo>/<commit|branch>/<path...>, got %v",
+			strings.Join(parts, "/"))
+		return
+	}
+	if got, want := parts[1], "pfs"; got != want {
+		r.displayErrorf(ctx, http.StatusInternalServerError, "unexpectedly handling request not for /pfs; got %v want %v", got, want)
+		return
+	}
+	file := &pfs.File{
+		Path: parts[5],
+	}
+	repo := &pfs.Repo{
+		Name: parts[3],
+		Type: pfs.UserRepoType,
+		Project: &pfs.Project{
+			Name: parts[2],
+		},
+	}
+	if commitish := parts[4]; uuid.IsUUIDWithoutDashes(commitish) {
+		file.Commit = &pfs.Commit{
+			Repo: repo,
+			Id:   commitish,
+		}
+		var finished bool
+		if commit, err := r.PachClient.PfsAPIClient.InspectCommit(ctx, &pfs.InspectCommitRequest{
+			Commit: file.Commit,
+		}); err == nil {
+			finished = commit.GetFinished() != nil
+		}
+		if finished {
+			// If the commit is finished, the user can cache this content
+			// forever.
+			r.ResponseWriter.Header().Set("cache-control", "private")
+		} else {
+			// Open commits can change, so they aren't safe to cache.
+			r.ResponseWriter.Header().Set("cache-control", "no-cache")
+		}
+	} else {
+		file.Commit = &pfs.Commit{
+			Branch: &pfs.Branch{
+				Repo: repo,
+				Name: commitish,
+			},
+		}
+		// Branch references are never cacheable; the branch can move at any time.
+		r.ResponseWriter.Header().Set("cache-control", "no-cache")
+	}
+	info, err := r.PachClient.PfsAPIClient.InspectFile(ctx, &pfs.InspectFileRequest{
+		File: file,
+	})
+	if err != nil {
+		r.displayGRPCError(ctx, "problem inspecting file: ", err)
+		return
+	}
+
+	// Set headers for future conditional requests.
+	etag := `"` + hex.EncodeToString(info.GetHash()) + `"`
+	lastModified := info.GetCommitted().AsTime()
+	if info.GetCommitted() != nil {
+		r.ResponseWriter.Header().Set("last-modified", lastModified.Format(http.TimeFormat))
+	} else {
+		lastModified = time.Time{}
+	}
+	r.ResponseWriter.Header().Set("etag", etag)
+
+	// Evaluate any HTTP conditional request options.
+	status := conditionalrequest.Evaluate(req, &conditionalrequest.ResourceInfo{
+		LastModified: lastModified,
+		ETag:         etag,
+	})
+	if status != 0 && status != http.StatusPartialContent {
+		// Bail out early; the HTTP precondition failed.
+		r.ResponseWriter.WriteHeader(status)
+		return
+	}
+
+	// If a directory, show a directory listing.
+	if info.GetFileType() == pfs.FileType_DIR {
+		r.displayDirectoryListing(ctx, file)
+		return
+	}
+
+	// If a file, send the file.
+	if req.Method == http.MethodHead {
+		// If HEAD, they either got 304 Not Modified from Evaluate above, or just want to
+		// know the size/modifiation time.
+		r.ResponseWriter.Header().Set("content-length", strconv.FormatInt(info.GetSizeBytes(), 10))
+		return
+	}
+	r.sendFile(ctx, info)
+}
+
+func (r *Request) displayDirectoryListing(ctx context.Context, file *pfs.File) {
+	ctx, c := pctx.WithCancel(ctx)
+	defer c()
+
+	res, err := r.PachClient.PfsAPIClient.ListFile(ctx, &pfs.ListFileRequest{
+		File: file,
+	})
+	if err != nil {
+		r.displayGRPCError(ctx, "problem listing directory: ", err)
+	}
+	for {
+		msg, err := res.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			log.Error(ctx, "directory listing stream broke unexpectedly", zap.Error(err))
+			fmt.Fprintf(r.ResponseWriter, "\n\nstream broken: %v", err)
+			return
+		}
+		fmt.Fprintf(r.ResponseWriter, "%s\t%s\t%v\n", msg.GetFile().GetPath(), msg.GetFile().GetDatum(), msg.GetSizeBytes())
+	}
+}
+
+// very limited case of range handling, only 'bytes=0-52', no other formats.  the format is
+// inclusive; 0-499 returns 500 bytes.
+func parseRange(rangeStr string, length int64) (offset, limit int64) {
+	if rangeStr == "" || !strings.HasPrefix(rangeStr, "bytes=") {
+		return 0, length
+	}
+	rangeStr = strings.TrimPrefix(rangeStr, "bytes=")
+	parts := strings.Split(rangeStr, "-")
+	if len(parts) != 2 {
+		return 0, length
+	}
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, length
+	}
+	end, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, length
+	}
+	if end > length {
+		end = length - 1
+	}
+	return start, end - start + 1
+}
+
+func (r *Request) sendFile(ctx context.Context, info *pfs.FileInfo) {
+	ctx, c := pctx.WithCancel(ctx)
+	defer c()
+
+	offset, limit := parseRange(r.Request.Header.Get("range"), info.GetSizeBytes())
+	res, err := r.PachClient.PfsAPIClient.GetFile(ctx, &pfs.GetFileRequest{
+		File:   info.GetFile(),
+		Offset: offset,
+	})
+	if err != nil {
+		r.displayGRPCError(ctx, "problem starting download", err)
+		return
+	}
+	w := r.ResponseWriter
+	w.Header().Set("content-length", strconv.FormatInt(limit, 10))
+	if limit != info.GetSizeBytes() {
+		w.WriteHeader(http.StatusPartialContent)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	for {
+		msg, err := res.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			log.Error(ctx, "download stream broke unexpectedly", zap.Error(err))
+			fmt.Fprintf(w, "\n\nstream broke: %v", err)
+			return
+		}
+		buf := msg.GetValue()
+		if len(buf) > int(limit) {
+			buf = buf[0:limit]
+		}
+		n, err := w.Write(buf)
+		if err != nil {
+			log.Error(ctx, "write error during download", zap.Error(err))
+			return
+		}
+		limit -= int64(n)
+		if limit <= 0 {
+			return
+		}
+	}
+}
+
+func acceptsHTML(req *http.Request) bool {
+	// curl sends "*/*", which is why we prefer text/plain.  browsers explicitly set text/html
+	// above */*, so browsers still get HTML.
+	got, _ := accept.Negotiate(req.Header.Get("accept"), "text/plain", "text/html")
+	return got == "text/html"
+}
+
+func (r *Request) displayGRPCError(ctx context.Context, msg string, err error) {
+	code := http.StatusInternalServerError
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.NotFound:
+			code = http.StatusNotFound
+		case codes.Unauthenticated, codes.PermissionDenied:
+			code = http.StatusForbidden
+		}
+	}
+	r.displayErrorf(ctx, code, "%s%s", msg, err.Error())
+}
+
+func (r *Request) displayErrorf(ctx context.Context, code int, format string, args ...any) {
+	w := r.ResponseWriter
+	msg := fmt.Sprintf(format, args...)
+	var err error
+	if acceptsHTML(r.Request) {
+		w.Header().Set("content-type", "text/html")
+		w.WriteHeader(code)
+		err = templates.ExecuteTemplate(w, "error.html", struct {
+			Message   string
+			RequestID string
+		}{msg, r.RequestID})
+	} else {
+		w.Header().Set("content-type", "text/plain")
+		w.WriteHeader(code)
+		_, err = io.Copy(w, strings.NewReader(msg))
+	}
+	if err != nil {
+		log.Error(ctx, "failed to display error", zap.Error(err), zap.String("message", msg))
+	}
+}

--- a/src/internal/fileserver/fileserver.go
+++ b/src/internal/fileserver/fileserver.go
@@ -1,4 +1,4 @@
-// Package fileserver implements an HTTP server for uploading and downloading PFS files.
+// Package fileserver implements a server for downloading PFS files over plain HTTP (i.e. browser downloads).
 //
 // See: https://www.notion.so/2023-04-03-HTTP-file-and-archive-downloads-cfb56fac16e54957b015070416b09e94
 package fileserver
@@ -167,7 +167,7 @@ func (r *Request) get(ctx context.Context) {
 	etag := `"` + hex.EncodeToString(info.GetHash()) + `"`
 	lastModified := info.GetCommitted().AsTime()
 	if info.GetCommitted() != nil {
-		r.ResponseWriter.Header().Set("last-modified", lastModified.Format(http.TimeFormat))
+		r.ResponseWriter.Header().Set("last-modified", lastModified.In(time.UTC).Format(http.TimeFormat))
 	} else {
 		lastModified = time.Time{}
 	}

--- a/src/internal/fileserver/fileserver.go
+++ b/src/internal/fileserver/fileserver.go
@@ -99,7 +99,10 @@ func (r *Request) get(ctx context.Context) {
 	req := r.Request
 	parts := strings.Split(req.URL.Path, "/")
 	switch {
-	case len(parts) == 5:
+	case len(parts) == 5 && parts[4] != "":
+		// If parts[4] is "", then they are requesting what looks like a "list commits"
+		// page, that we don't implement.  Otherwise, they want the listing of the root
+		// directory, but forgot the trailing /.
 		http.Redirect(r.ResponseWriter, r.Request, r.Request.URL.Path+"/", http.StatusMovedPermanently)
 		return
 	case len(parts) >= 6: // /pfs/project/repo/commit|branch/path/to/some/file

--- a/src/internal/fileserver/fileserver.go
+++ b/src/internal/fileserver/fileserver.go
@@ -143,8 +143,11 @@ func (r *Request) get(ctx context.Context) {
 			// forever.
 			r.ResponseWriter.Header().Set("cache-control", "private")
 		} else {
-			// Open commits can change, so they aren't safe to cache.
-			r.ResponseWriter.Header().Set("cache-control", "no-cache")
+			// Open commits can change, so they aren't safe to cache.  Note that
+			// "no-cache" actually means that the response can be cached, but that the
+			// client has to revalidate (with If-None-Match etc.) before using the
+			// cached result.  That's exactly what we want.
+			r.ResponseWriter.Header().Set("cache-control", "private, no-cache")
 		}
 	} else {
 		file.Commit = &pfs.Commit{
@@ -154,7 +157,7 @@ func (r *Request) get(ctx context.Context) {
 			},
 		}
 		// Branch references are never cacheable; the branch can move at any time.
-		r.ResponseWriter.Header().Set("cache-control", "no-cache")
+		r.ResponseWriter.Header().Set("cache-control", "private, no-cache")
 	}
 	info, err := r.PachClient.PfsAPIClient.InspectFile(ctx, &pfs.InspectFileRequest{
 		File: file,

--- a/src/internal/fileserver/fileserver_test.go
+++ b/src/internal/fileserver/fileserver_test.go
@@ -577,7 +577,7 @@ func TestDownload(t *testing.T) {
 			req.Header.Set(constants.ContextTokenKey, token.GetToken())
 			for k, vs := range test.requestHeader {
 				for _, v := range vs {
-					req.Header.Set(k, v)
+					req.Header.Add(k, v)
 				}
 			}
 			dump, err := httputil.DumpRequest(req, false)

--- a/src/internal/fileserver/fileserver_test.go
+++ b/src/internal/fileserver/fileserver_test.go
@@ -559,14 +559,14 @@ func TestDownload(t *testing.T) {
 			},
 		},
 		{
-			name:        "directory listing of test@done",
+			name:        "directory listing of test@finished",
 			method:      http.MethodGet,
 			url:         fmt.Sprintf("https://example.com/pfs/default/test/%v/", finishedCommit.Id),
 			wantCode:    http.StatusOK,
 			wantContent: "-\t26000\t/big.txt\nd\t13\t/sub/\n",
 		},
 		{
-			name:   "html directory listing of test@done",
+			name:   "html directory listing of test@finished",
 			method: http.MethodGet,
 			requestHeader: http.Header{
 				"Accept": {"text/html"},
@@ -574,6 +574,26 @@ func TestDownload(t *testing.T) {
 			url:         fmt.Sprintf("https://example.com/pfs/default/test/%v/", finishedCommit.Id),
 			wantCode:    http.StatusOK,
 			wantContent: `/(?s)href="big.txt">big.txt</a>.*href="sub">sub</a>/`,
+		},
+		{
+			name:   "html directory listing of test@done:/sub/directory/",
+			method: http.MethodGet,
+			requestHeader: http.Header{
+				"Accept": {"text/html"},
+			},
+			url:         "https://example.com/pfs/default/test/done/sub/directory/",
+			wantCode:    http.StatusOK,
+			wantContent: `/(?s)<h1>default/test/done/sub/directory</h1>.*href="test.txt">test.txt</a>/`,
+		},
+		{
+			name:   "html invalid method error",
+			method: http.MethodPost,
+			requestHeader: http.Header{
+				"Accept": {"text/html"},
+			},
+			url:         "https://example.com/pfs/test/done/sub/directory/",
+			wantCode:    http.StatusMethodNotAllowed,
+			wantContent: `/(?s)<html>.*unknown HTTP method/`,
 		},
 	}
 	for _, test := range testData {

--- a/src/internal/fileserver/fileserver_test.go
+++ b/src/internal/fileserver/fileserver_test.go
@@ -540,6 +540,13 @@ func TestDownload(t *testing.T) {
 			wantContent: "invalid URL; expecting /pfs/<project>/<repo>/<commit|branch>/<path...>, got /pfs/default/test",
 		},
 		{
+			name:        "commit listing page with /, not implemented",
+			method:      http.MethodGet,
+			url:         "https://example.com/pfs/default/test/",
+			wantCode:    http.StatusNotFound,
+			wantContent: "invalid URL; expecting /pfs/<project>/<repo>/<commit|branch>/<path...>, got /pfs/default/test/",
+		},
+		{
 			name:        "branch redirect",
 			method:      http.MethodGet,
 			url:         "https://example.com/pfs/default/test/master",

--- a/src/internal/fileserver/fileserver_test.go
+++ b/src/internal/fileserver/fileserver_test.go
@@ -232,7 +232,7 @@ func TestDownload(t *testing.T) {
 			wantCode:    http.StatusMovedPermanently,
 			wantContent: "<a href=\"/pfs/default/test/master/sub/directory/\">Moved Permanently</a>.\n\n",
 			wantHeader: http.Header{
-				"Cache-Control": {"no-cache"},
+				"Cache-Control": {"private, no-cache"},
 				"Content-Type":  {"text/html; charset=utf-8"},
 				"Etag":          {`"f103067f40b04b3e6e5ad1dbf053d0c68454e623c200a63e400a60de84ad632c"`},
 				"Location":      {"/pfs/default/test/master/sub/directory/"},
@@ -254,7 +254,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "goodbye, world\n",
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"}, // no-cache because "master"
+				"Cache-Control":  {"private, no-cache"}, // no-cache because "master"
 				"Content-Length": {"15"},
 				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
 				"Vary":           {"authn-token"},
@@ -267,7 +267,7 @@ func TestDownload(t *testing.T) {
 			wantCode: http.StatusOK,
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"},
+				"Cache-Control":  {"private, no-cache"},
 				"Content-Length": {"15"},
 				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
 				"Vary":           {"authn-token"},
@@ -281,7 +281,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "goodbye, world\n",
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"}, // no-cache because open commit
+				"Cache-Control":  {"private, no-cache"}, // no-cache because open commit
 				"Content-Length": {"15"},
 				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
 				"Vary":           {"authn-token"},
@@ -294,7 +294,7 @@ func TestDownload(t *testing.T) {
 			wantCode: http.StatusOK,
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"},
+				"Cache-Control":  {"private, no-cache"},
 				"Content-Length": {"15"},
 				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
 				"Vary":           {"authn-token"},
@@ -337,7 +337,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "hello, world\n",
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"}, // not cacheable because branch
+				"Cache-Control":  {"private, no-cache"}, // not cacheable because branch
 				"Content-Length": {"13"},
 				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
@@ -351,7 +351,7 @@ func TestDownload(t *testing.T) {
 			wantCode: http.StatusOK,
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"}, // not cacheable because branch
+				"Cache-Control":  {"private, no-cache"}, // not cacheable because branch
 				"Content-Length": {"13"},
 				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
@@ -369,7 +369,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "",
 			wantHeader: http.Header{
 				"Accept-Ranges": {"bytes"},
-				"Cache-Control": {"no-cache"},
+				"Cache-Control": {"private, no-cache"},
 				"Etag":          {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified": {finishedAt.Format(http.TimeFormat)},
 				"Vary":          {"authn-token"},
@@ -386,7 +386,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "",
 			wantHeader: http.Header{
 				"Accept-Ranges": {"bytes"},
-				"Cache-Control": {"no-cache"},
+				"Cache-Control": {"private, no-cache"},
 				"Etag":          {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified": {finishedAt.Format(http.TimeFormat)},
 				"Vary":          {"authn-token"},
@@ -402,7 +402,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "",
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"},
+				"Cache-Control":  {"private, no-cache"},
 				"Content-Length": {"13"},
 				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
@@ -420,7 +420,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "hello, world\n",
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"},
+				"Cache-Control":  {"private, no-cache"},
 				"Content-Length": {"13"},
 				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
@@ -438,7 +438,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "",
 			wantHeader: http.Header{
 				"Accept-Ranges": {"bytes"},
-				"Cache-Control": {"no-cache"},
+				"Cache-Control": {"private, no-cache"},
 				"Etag":          {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified": {finishedAt.Format(http.TimeFormat)},
 				"Vary":          {"authn-token"},
@@ -455,7 +455,7 @@ func TestDownload(t *testing.T) {
 			wantContent: "hello, world\n",
 			wantHeader: http.Header{
 				"Accept-Ranges":  {"bytes"},
-				"Cache-Control":  {"no-cache"},
+				"Cache-Control":  {"private, no-cache"},
 				"Content-Length": {"13"},
 				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
 				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},

--- a/src/internal/fileserver/fileserver_test.go
+++ b/src/internal/fileserver/fileserver_test.go
@@ -1,0 +1,442 @@
+package fileserver_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/fileserver"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testpachd/realenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestDownload(t *testing.T) {
+	// Setup a PFS server.
+	rctx := pctx.TestContext(t)
+	e := realenv.NewRealEnvWithIdentity(rctx, t, dockertestenv.NewTestDBConfig(t))
+
+	// Fileserver for testing.
+	s := &fileserver.Server{
+		ClientFactory: func(ctx context.Context) *client.APIClient {
+			return e.PachClient.WithCtx(ctx)
+		},
+	}
+
+	// Add test data.  There will be one repo, "default/test", with a branch "master".  "master"
+	// will have two commits, one finished and one open.
+	r := &pfs.Repo{
+		Name: "test",
+		Type: pfs.UserRepoType,
+		Project: &pfs.Project{
+			Name: pfs.DefaultProjectName,
+		},
+	}
+	master := &pfs.Branch{
+		Name: "master",
+		Repo: r,
+	}
+	if _, err := e.PachClient.PfsAPIClient.CreateRepo(rctx, &pfs.CreateRepoRequest{
+		Repo: r,
+	}); err != nil {
+		t.Fatalf("create test repo: %v", err)
+	}
+	// Create a commit that will be finished by the time the tests run.
+	finishedCommit, err := e.PachClient.PfsAPIClient.StartCommit(rctx, &pfs.StartCommitRequest{
+		Branch: master,
+	})
+	if err != nil {
+		t.Fatalf("start commit ('finished commit'): %v", err)
+	}
+	mfc, err := e.PachClient.PfsAPIClient.ModifyFile(rctx)
+	if err != nil {
+		t.Fatalf("start modifyfile ('finished commit'): %v", err)
+	}
+	if err := mfc.Send(&pfs.ModifyFileRequest{
+		Body: &pfs.ModifyFileRequest_SetCommit{
+			SetCommit: finishedCommit,
+		},
+	}); err != nil {
+		t.Fatalf("modify file ('finished commit'): set commit (finished commit): %v", err)
+	}
+	if err := mfc.Send(&pfs.ModifyFileRequest{
+		Body: &pfs.ModifyFileRequest_AddFile{
+			AddFile: &pfs.AddFile{
+				Path: "/sub/directory/test.txt",
+				Source: &pfs.AddFile_Raw{
+					Raw: &wrapperspb.BytesValue{
+						Value: []byte("hello, world\n"),
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("modify file ('finished commit'): add /sub/directory/test.txt: %v", err)
+	}
+	// Create a "big" (26KB) file with predictable data; will be used to test HTTP range
+	// requests.
+	bigData := new(bytes.Buffer)
+	for i := 'A'; i < 'Z'; i++ {
+		for j := 0; j < 1000; j++ {
+			bigData.WriteRune(i)
+		}
+	}
+	if err := mfc.Send(&pfs.ModifyFileRequest{
+		Body: &pfs.ModifyFileRequest_AddFile{
+			AddFile: &pfs.AddFile{
+				Path: "big.txt",
+				Source: &pfs.AddFile_Raw{
+					Raw: &wrapperspb.BytesValue{
+						Value: bigData.Bytes(),
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("modify file ('finished commit'): add big.txt: %v", err)
+	}
+	if _, err := mfc.CloseAndRecv(); err != nil {
+		t.Fatalf("modify file ('finished commit'): CloseAndRecv: %v", err)
+	}
+	if _, err := e.PachClient.PfsAPIClient.FinishCommit(rctx, &pfs.FinishCommitRequest{
+		Commit: finishedCommit,
+	}); err != nil {
+		t.Fatalf("finish commit ('finished commit'): %v", err)
+	}
+	finishedInfo, err := e.PachClient.PfsAPIClient.InspectCommit(rctx, &pfs.InspectCommitRequest{
+		Commit: finishedCommit,
+		Wait:   pfs.CommitState_FINISHED, // This is not true immediately after FinishCommit returns.
+	})
+	if err != nil {
+		t.Fatalf("inspect commit ('finished commit'): %v", err)
+	}
+
+	// File times ("Committed") are based on the finishing time, not the finished time.
+	finishedAt := finishedInfo.GetFinishing().AsTime().In(time.UTC)
+
+	// Create a branch reference to the finished commit; so that the tests can distinguish
+	// between branch-head-open vs. branch-head-closed reads.  These have the same caching
+	// semantics but are different cases.  A closed branch head is un-cacheable because the
+	// branch head can move.  An open branch head is un-cacheable because the commit content can
+	// change.
+	if _, err := e.PachClient.PfsAPIClient.CreateBranch(rctx, &pfs.CreateBranchRequest{
+		Head: finishedCommit,
+		Branch: &pfs.Branch{
+			Repo: r,
+			Name: "done",
+		},
+	}); err != nil {
+		t.Fatalf("create branch done: %v", err)
+	}
+
+	openCommit, err := e.PachClient.PfsAPIClient.StartCommit(rctx, &pfs.StartCommitRequest{
+		Branch: master,
+	})
+	if err != nil {
+		t.Fatalf("start commit ('open commit'): %v", err)
+	}
+	mfc, err = e.PachClient.PfsAPIClient.ModifyFile(rctx)
+	if err != nil {
+		t.Fatalf("modify file ('open commit'): %v", err)
+	}
+	if err := mfc.Send(&pfs.ModifyFileRequest{
+		Body: &pfs.ModifyFileRequest_SetCommit{
+			SetCommit: openCommit,
+		},
+	}); err != nil {
+		t.Fatalf("modify file ('open commit'): set commit: %v", err)
+	}
+	if err := mfc.Send(&pfs.ModifyFileRequest{
+		Body: &pfs.ModifyFileRequest_DeleteFile{
+			DeleteFile: &pfs.DeleteFile{
+				Path: "/sub/directory/test.txt",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("modify file ('open commit'): delete /sub/directory/test.txt: %v", err)
+	}
+	if err := mfc.Send(&pfs.ModifyFileRequest{
+		Body: &pfs.ModifyFileRequest_AddFile{
+			AddFile: &pfs.AddFile{
+				Path: "/sub/directory/test.txt",
+				Source: &pfs.AddFile_Raw{
+					Raw: &wrapperspb.BytesValue{
+						Value: []byte("goodbye, world\n"),
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("modify file ('open commit'): add new /sub/directory/test.txt: %v", err)
+	}
+	if _, err := mfc.CloseAndRecv(); err != nil {
+		t.Fatalf("modify file ('open commit'): CloseAndRecv: %v", err)
+	}
+	testutil.ActivateAuthClient(t, e.PachClient, strconv.Itoa(int(e.ServiceEnv.Config().PeerPort)))
+
+	// The actual test starts here.
+	testData := []struct {
+		name          string
+		method        string
+		url           string
+		requestHeader http.Header
+		wantCode      int
+		wantContent   string
+		wantHeader    http.Header
+	}{
+		{
+			name:        "get master test.txt",
+			method:      http.MethodGet,
+			url:         "https://example.com/pfs/default/test/master/sub/directory/test.txt",
+			wantCode:    http.StatusOK,
+			wantContent: "goodbye, world\n",
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"}, // no-cache because "master"
+				"Content-Length": {"15"},
+				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:     "head master test.txt",
+			method:   http.MethodHead,
+			url:      "https://example.com/pfs/default/test/master/sub/directory/test.txt",
+			wantCode: http.StatusOK,
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"},
+				"Content-Length": {"15"},
+				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:        "get open test.txt",
+			method:      http.MethodGet,
+			url:         fmt.Sprintf("https://example.com/pfs/default/test/%v/sub/directory/test.txt", openCommit.Id),
+			wantCode:    http.StatusOK,
+			wantContent: "goodbye, world\n",
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"}, // no-cache because open commit
+				"Content-Length": {"15"},
+				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:     "head open test.txt",
+			method:   http.MethodHead,
+			url:      fmt.Sprintf("https://example.com/pfs/default/test/%v/sub/directory/test.txt", openCommit.Id),
+			wantCode: http.StatusOK,
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"},
+				"Content-Length": {"15"},
+				"Etag":           {`"7f25604c8f64d4e40377c006dcaa47626e4b1d93b09f1f8252e14e643c8e8f02"`},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:        "get finished test.txt",
+			method:      http.MethodGet,
+			url:         fmt.Sprintf("https://example.com/pfs/default/test/%v/sub/directory/test.txt", finishedCommit.Id),
+			wantCode:    http.StatusOK,
+			wantContent: "hello, world\n",
+			wantHeader: http.Header{
+				"Cache-Control":  {"private"}, // cacheable because finished commit
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:     "head finished test.txt",
+			method:   http.MethodHead,
+			url:      fmt.Sprintf("https://example.com/pfs/default/test/%v/sub/directory/test.txt", finishedCommit.Id),
+			wantCode: http.StatusOK,
+			wantHeader: http.Header{
+				"Cache-Control":  {"private"}, // cacheable because finished commit
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:        "get done test.txt",
+			method:      http.MethodGet,
+			url:         "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			wantCode:    http.StatusOK,
+			wantContent: "hello, world\n",
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"}, // not cacheable because branch
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:     "head done test.txt",
+			method:   http.MethodHead,
+			url:      "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			wantCode: http.StatusOK,
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"}, // not cacheable because branch
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:   "if-none-match head test.txt@done, match",
+			method: http.MethodHead,
+			url:    "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			requestHeader: http.Header{
+				"If-None-Match": {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+			},
+			wantCode:    http.StatusNotModified,
+			wantContent: "",
+			wantHeader: http.Header{
+				"Cache-Control": {"no-cache"},
+				"Etag":          {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified": {finishedAt.Format(http.TimeFormat)},
+				"Vary":          {"authn-token"},
+			},
+		},
+		{
+			name:   "if-none-match get test.txt@done, match",
+			method: http.MethodGet,
+			url:    "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			requestHeader: http.Header{
+				"If-None-Match": {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+			},
+			wantCode:    http.StatusNotModified,
+			wantContent: "",
+			wantHeader: http.Header{
+				"Cache-Control": {"no-cache"},
+				"Etag":          {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified": {finishedAt.Format(http.TimeFormat)},
+				"Vary":          {"authn-token"},
+			},
+		}, {
+			name:   "if-none-match head test.txt@done, no match",
+			method: http.MethodHead,
+			url:    "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			requestHeader: http.Header{
+				"If-None-Match": {`"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`},
+			},
+			wantCode:    http.StatusOK,
+			wantContent: "",
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"},
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:   "if-none-match get test.txt@done, no match",
+			method: http.MethodGet,
+			url:    "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			requestHeader: http.Header{
+				"If-None-Match": {`"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`},
+			},
+			wantCode:    http.StatusOK,
+			wantContent: "hello, world\n",
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"},
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+		{
+			name:   "if-modified-since get test.txt@done, unmodified",
+			method: http.MethodGet,
+			url:    "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			requestHeader: http.Header{
+				"If-Modified-Since": {finishedAt.Add(time.Second).Format(http.TimeFormat)},
+			},
+			wantCode:    http.StatusNotModified,
+			wantContent: "",
+			wantHeader: http.Header{
+				"Cache-Control": {"no-cache"},
+				"Etag":          {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified": {finishedAt.Format(http.TimeFormat)},
+				"Vary":          {"authn-token"},
+			},
+		},
+		{
+			name:   "if-modified-since get test.txt@done, modified",
+			method: http.MethodGet,
+			url:    "https://example.com/pfs/default/test/done/sub/directory/test.txt",
+			requestHeader: http.Header{
+				"If-Modified-Since": {time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Format(http.TimeFormat)},
+			},
+			wantCode:    http.StatusOK,
+			wantContent: "hello, world\n",
+			wantHeader: http.Header{
+				"Cache-Control":  {"no-cache"},
+				"Content-Length": {"13"},
+				"Etag":           {`"918cd0e91afb64becb2d77e7cba9d1e8ea15ad5a26c16bbaf629ef916eaeb414"`},
+				"Last-Modified":  {finishedAt.Format(http.TimeFormat)},
+				"Vary":           {"authn-token"},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(test.method, test.url, nil)
+			if h := test.requestHeader; h != nil {
+				req.Header = h
+			}
+			dump, err := httputil.DumpRequest(req, false)
+			if err != nil {
+				t.Fatalf("dumping request failed: %v", err)
+			}
+			t.Logf("request: %s", dump)
+			s.ServeHTTP(rec, req)
+			dumpBody := true
+			if req.Method == http.MethodHead {
+				// The dumper is mad when the content-length doesn't match the body
+				// size, but RFC9110 says "The server SHOULD send the same header
+				// fields in response to a HEAD request as it would have sent if the
+				// request method had been GET."  We do send content-length for GET
+				// requests, so we also send them for HEAD requests.
+				dumpBody = false
+			}
+			dump, err = httputil.DumpResponse(rec.Result(), dumpBody)
+			if err != nil {
+				t.Fatalf("dumping response failed: %v", err)
+			}
+			t.Logf("response: %s", dump)
+			if got, want := rec.Code, test.wantCode; got != want {
+				t.Errorf("response code:\n  got: %v\n want: %v", got, want)
+			}
+			if diff := cmp.Diff(test.wantContent, rec.Body.String()); diff != "" {
+				t.Errorf("body (-want +got):\n%s", diff)
+			}
+
+			if want := test.wantHeader; want != nil {
+				if diff := cmp.Diff(want, rec.Header()); diff != "" {
+					t.Errorf("headers (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/src/internal/fileserver/templates/directory-listing-footer.html
+++ b/src/internal/fileserver/templates/directory-listing-footer.html
@@ -1,0 +1,4 @@
+            </tbody>
+        </table>
+    </body>
+</html>

--- a/src/internal/fileserver/templates/directory-listing-header.html
+++ b/src/internal/fileserver/templates/directory-listing-header.html
@@ -1,11 +1,13 @@
 <html>
     <head>
-        <title>{{ . | path }} - Pachyderm</title>
+        <title>{{ path .Path }} - Pachyderm</title>
     </head>
     <body>
-        <h1>{{ . | path }}</h1>
-        <a href="/pfs/{{ . | path | dirname }}">Up</a>
-        <p>Committed: {{ .Committed.AsTime | rfc3339 }}</p>
+        <h1>{{ path .Path }}</h1>
+        {{ if hasParent .Info  }}
+        <a href="{{ parent .Path }}">Up</a>
+        {{ end }}
+        <p>Committed: {{ .Info.Committed.AsTime | rfc3339 }}</p>
         <table>
             <thead>
                 <tr>

--- a/src/internal/fileserver/templates/directory-listing-header.html
+++ b/src/internal/fileserver/templates/directory-listing-header.html
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <title>{{ . | path }} - Pachyderm</title>
+    </head>
+    <body>
+        <h1>{{ . | path }}</h1>
+        <a href="/pfs/{{ . | path | dirname }}">Up</a>
+        <p>Committed: {{ .Committed.AsTime | rfc3339 }}</p>
+        <table>
+            <thead>
+                <tr>
+                    <td>Filename</td>
+                    <td>Size</td>
+                    <td>Datum</td>
+                </tr>
+            </thead>
+            <tbody>

--- a/src/internal/fileserver/templates/directory-listing-row.html
+++ b/src/internal/fileserver/templates/directory-listing-row.html
@@ -1,0 +1,5 @@
+<tr>
+    <td><a href="{{ .File.Path | basename }}">{{ .File.Path | basename }}</a></td>
+    <td>{{ .SizeBytes | humanizeBytes }}</td>
+    <td>{{ .File.Datum }}</td>
+</tr>

--- a/src/internal/fileserver/templates/error.html
+++ b/src/internal/fileserver/templates/error.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <title>Pachyderm - Error</title>
+    </head>
+    <body>
+        <h1>Error</h1>
+        <p>{{ .Message }}</p>
+        {{ if .RequestID }}
+        <hr />
+        <p>Error ID: {{ .RequestID }}</p>
+        {{ end }}
+    </body>
+</html>

--- a/src/internal/log/http.go
+++ b/src/internal/log/http.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
@@ -46,4 +47,15 @@ func AddLoggerToHTTPServer(rctx context.Context, name string, s *http.Server) {
 			orig.ServeHTTP(w, r)
 		})
 	}
+}
+
+// RequestID returns the RequestID associated with this HTTP request.  This is added by the
+// middleware above.
+func RequestID(ctx context.Context) string {
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if parts := md.Get("x-request-id"); len(parts) > 0 {
+			return strings.Join(parts, ";")
+		}
+	}
+	return ""
 }

--- a/src/internal/log/uuid.go
+++ b/src/internal/log/uuid.go
@@ -11,6 +11,7 @@ const (
 	backgroundTrace        requestKind = 0x2
 	consoleTrace           requestKind = 0x3
 	envoyTrace             requestKind = 0x4
+	syntheticTrace         requestKind = 0x5
 	envoyServerForcedTrace requestKind = 0xa
 	envoyClientForcedTrace requestKind = 0xb
 )

--- a/src/server/http/http.go
+++ b/src/server/http/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/fileserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/jsonschema"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"go.uber.org/zap"
@@ -35,6 +36,12 @@ func New(port uint16, pachClientFactory func(ctx context.Context) *client.APICli
 		ClientFactory: pachClientFactory,
 	}
 	mux.Handle("/archive/", CSRFWrapper(handler))
+
+	// File server.
+	fileHandler := &fileserver.Server{
+		ClientFactory: pachClientFactory,
+	}
+	mux.Handle("/pfs/", CSRFWrapper(fileHandler))
 
 	// Health check.
 	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -163,7 +163,7 @@ func proxyTest(t *testing.T, httpClient *http.Client, c *client.APIClient, secur
 	// Test PFS download.
 	t.Run("TestHttpDownload", func(t *testing.T) {
 		require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
-			return get(t, httpClient, strings.Join([]string{httpPrefix, addr, "/pfs/", pfs.DefaultProjectName, "/", testRepo, "/master/test.txt"}, ""))
+			return get(t, httpClient, strings.Join([]string{httpPrefix, addr, "/pfs/", pfs.DefaultProjectName, "/", testRepo, "/master/test.txt?authn-token", c.AuthToken()}, ""))
 		})
 	})
 }

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -163,7 +163,7 @@ func proxyTest(t *testing.T, httpClient *http.Client, c *client.APIClient, secur
 	// Test PFS download.
 	t.Run("TestHttpDownload", func(t *testing.T) {
 		require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
-			return get(t, httpClient, strings.Join([]string{httpPrefix, addr, "/pfs/", pfs.DefaultProjectName, "/", testRepo, "/master/test.txt?authn-token", c.AuthToken()}, ""))
+			return get(t, httpClient, strings.Join([]string{httpPrefix, addr, "/pfs/", pfs.DefaultProjectName, "/", testRepo, "/master/test.txt?authn-token=", c.AuthToken()}, ""))
 		})
 	})
 }

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -156,6 +157,13 @@ func proxyTest(t *testing.T, httpClient *http.Client, c *client.APIClient, secur
 			// Refactor.
 			url := httpPrefix + addr + "/archive/" + file + ".zip"
 			return get(t, httpClient, url)
+		})
+	})
+
+	// Test PFS download.
+	t.Run("TestHttpDownload", func(t *testing.T) {
+		require.NoErrorWithinTRetry(t, 60*time.Second, func() error {
+			return get(t, httpClient, strings.Join([]string{httpPrefix, addr, "/pfs/", pfs.DefaultProjectName, "/", testRepo, "/master/test.txt"}, ""))
 		})
 	})
 }


### PR DESCRIPTION
This lets you treat Pachyderm like a webserver; generating HTML in pipelines and then viewing them in the browser:

![Capture](https://github.com/pachyderm/pachyderm/assets/2367/0934f3f3-ebc0-4e48-ba2f-e47ffaaf6943)

There are also basic HTML directory listings:

![Capture](https://github.com/pachyderm/pachyderm/assets/2367/4d904e71-b692-4bd1-851c-0e328a2ddfa7)

The HTTP supported is quite extensive; you can download parts of a file in parallel with `Range` headers, and use conditional requests like `If-None-Match` or `If-Not-Modified`.  `HEAD` requests are also supported.  Caching headers are provided so that your browser knows it's safe to cache immutable files forever, but not cache mutable files (in open commits) at all.

Some details:
* there is more to do here, like adding pages that list projects, repos, branches/commits, etc. so that you don't have to guess a URL to get started.
* we need to OAuth so people don't have to pass authn-token in the URL
* we need to implement PUT for uploading files

