### PR TITLE
Increase pgbouncer connection limit

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1049,7 +1049,7 @@ pgbouncer:
     #  cpu: "1"
     #  memory: "2G"
   # maxConnections specifies the maximum number of concurrent connections into pgbouncer.
-  maxConnections: 1000
+  maxConnections: 100000
   # defaultPoolSize specifies the maximum number of concurrent connections from pgbouncer to the postgresql database.
   defaultPoolSize: 20
 

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1051,7 +1051,7 @@ pgbouncer:
   # maxConnections specifies the maximum number of concurrent connections into pgbouncer.
   maxConnections: 100000
   # defaultPoolSize specifies the maximum number of concurrent connections from pgbouncer to the postgresql database.
-  defaultPoolSize: 20
+  defaultPoolSize: 80
 
 # Note: Postgres values control the Bitnami Postgresql Subchart
 postgresql:


### PR DESCRIPTION
We can't make this unlimited (`0` means literally 0), but we can make it high.

This comes with the tradeoff of users needing to look for a log line like:

```
kernel file descriptor limit: 1048576 (hard: 1048576); max_client_conn: 100000, max expected fd use: 100012
```

to ensure that their `ulimit -n` is high enough.

Debian seems to default to 10x more than this, so maybe that's common and nobody will have to look at this.