### PR TITLE
[2.7.x] Consistently format full timestamps in pachctl (#9176)

### DIFF
--- a/src/internal/pretty/pretty.go
+++ b/src/internal/pretty/pretty.go
@@ -42,6 +42,14 @@ func Ago(timestamp *timestamppb.Timestamp) string {
 	return fmt.Sprintf("%s ago", since)
 }
 
+// Timestamp pretty-prints a timestamp.
+func Timestamp(timestamp *timestamppb.Timestamp) string {
+	if timestamp == nil {
+		return "-"
+	}
+	return timestamp.AsTime().Format(time.RFC3339)
+}
+
 // TimeDifference pretty-prints the duration of time between from
 // and to as a human-reabable string.
 func TimeDifference(from, to *timestamppb.Timestamp) string {

--- a/src/server/pfs/pretty/pretty.go
+++ b/src/server/pfs/pretty/pretty.go
@@ -51,7 +51,7 @@ func PrintRepoInfo(w io.Writer, repoInfo *pfs.RepoInfo, fullTimestamps bool) {
 		fmt.Fprintf(w, "%s.%s\t", repoInfo.Repo.Name, repoInfo.Repo.Type)
 	}
 	if fullTimestamps {
-		fmt.Fprintf(w, "%s\t", repoInfo.Created.String())
+		fmt.Fprintf(w, "%s\t", pretty.Timestamp(repoInfo.Created))
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(repoInfo.Created))
 	}
@@ -86,7 +86,7 @@ func PrintDetailedRepoInfo(repoInfo *PrintableRepoInfo) error {
 	template, err := template.New("RepoInfo").Funcs(funcMap).Parse(
 		`Name: {{.Repo.Name}}{{if .Description}}
 Description: {{.Description}}{{end}}{{if .FullTimestamps}}
-Created: {{.Created}}{{else}}
+Created: {{prettyTime .Created}}{{else}}
 Created: {{prettyAgo .Created}}{{end}}{{if .Details}}
 Size of HEAD on master: {{prettySize .Details.SizeBytes}}{{end}}{{if .AuthInfo}}
 Roles: {{ .AuthInfo.Roles | commafy }}
@@ -172,7 +172,7 @@ func PrintDetailedBranchInfo(branchInfo *pfs.BranchInfo) error {
 	template, err := template.New("BranchInfo").Funcs(funcMap).Parse(
 		`Name: {{.Branch.Repo.Name}}@{{.Branch.Name}}{{if .Head}}
 Head Commit: {{ .Head.Branch.Repo.Name}}@{{.Head.Id}} {{end}}{{if .Provenance}}
-Provenance: {{range .Provenance}} {{.Repo.Name}}@{{.Name}} {{end}} {{end}}{{if .Trigger}}
+Provenance: {{range .Provenance}}{{.Repo.Name}}@{{.Name}} {{end}}{{end}}{{if .Trigger}}
 Trigger: {{printTrigger .Trigger}} {{end}}
 `)
 	if err != nil {
@@ -189,7 +189,7 @@ func PrintDetailedProjectInfo(projectInfo *pfs.ProjectInfo) error {
 Description: {{ .Description}}
 {{- end -}}
 {{- if .CreatedAt }}
-Created at: {{ .CreatedAt }}
+Created at: {{ prettyTime .CreatedAt }}
 {{- end -}}
 {{- if .AuthInfo }}
 Roles: {{.AuthInfo.Roles | commafy}}
@@ -217,7 +217,7 @@ func PrintCommitInfo(w io.Writer, commitInfo *pfs.CommitInfo, fullTimestamps boo
 		fmt.Fprintf(w, "-\t")
 	} else {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", commitInfo.Finished.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(commitInfo.Finished))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(commitInfo.Finished))
 		}
@@ -266,7 +266,7 @@ func PrintCommitSetInfo(w io.Writer, commitSetInfo *pfs.CommitSetInfo, fullTimes
 	fmt.Fprintf(w, "%s\t", pretty.ProgressBar(8, success, len(commitSetInfo.Commits)-success-failure, failure))
 	if created != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", created.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(created))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(created))
 		}
@@ -275,7 +275,7 @@ func PrintCommitSetInfo(w io.Writer, commitSetInfo *pfs.CommitSetInfo, fullTimes
 	}
 	if modified != nil {
 		if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", modified.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(modified))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(modified))
 		}
@@ -343,9 +343,9 @@ func PrintDetailedCommitInfo(w io.Writer, commitInfo *PrintableCommitInfo) error
 Original Branch: {{.Commit.Branch.Name}}{{if .Description}}
 Description: {{.Description}}{{end}}{{if .ParentCommit}}
 Parent: {{.ParentCommit.Id}}{{end}}{{if .FullTimestamps}}
-Started: {{.Started}}{{else}}
+Started: {{prettyTime .Started}}{{else}}
 Started: {{prettyAgo .Started}}{{end}}{{if .Finished}}{{if .FullTimestamps}}
-Finished: {{.Finished}}{{else}}
+Finished: {{prettyTime .Finished}}{{else}}
 Finished: {{prettyAgo .Finished}}{{end}}{{end}}{{if .Details}}
 Size: {{prettySize .Details.SizeBytes}}{{end}}
 `)
@@ -372,7 +372,7 @@ func PrintFileInfo(w io.Writer, fileInfo *pfs.FileInfo, fullTimestamps, withComm
 		if fileInfo.Committed == nil {
 			fmt.Fprintf(w, "-\t")
 		} else if fullTimestamps {
-			fmt.Fprintf(w, "%s\t", fileInfo.Committed.String())
+			fmt.Fprintf(w, "%s\t", pretty.Timestamp(fileInfo.Committed))
 		} else {
 			fmt.Fprintf(w, "%s\t", pretty.Ago(fileInfo.Committed))
 		}
@@ -415,6 +415,7 @@ func fileType(fileType pfs.FileType) string {
 var funcMap = template.FuncMap{
 	"prettyAgo":    pretty.Ago,
 	"prettySize":   pretty.Size,
+	"prettyTime":   pretty.Timestamp,
 	"fileType":     fileType,
 	"printTrigger": printTrigger,
 	"commafy":      pretty.Commafy,

--- a/src/server/transaction/pretty/pretty.go
+++ b/src/server/transaction/pretty/pretty.go
@@ -32,7 +32,7 @@ type PrintableTransactionInfo struct {
 func PrintTransactionInfo(w io.Writer, info *transaction.TransactionInfo, fullTimestamps bool) {
 	fmt.Fprintf(w, "%s\t", info.Transaction.Id)
 	if fullTimestamps {
-		fmt.Fprintf(w, "%s\t", info.Started.String())
+		fmt.Fprintf(w, "%s\t", pretty.Timestamp(info.Started))
 	} else {
 		fmt.Fprintf(w, "%s\t", pretty.Ago(info.Started))
 	}
@@ -44,7 +44,7 @@ func PrintTransactionInfo(w io.Writer, info *transaction.TransactionInfo, fullTi
 func PrintDetailedTransactionInfo(info *PrintableTransactionInfo) error {
 	template, err := template.New("TransactionInfo").Funcs(funcMap).Parse(
 		`ID: {{.Transaction.ID}}{{if .FullTimestamps}}
-Started: {{.Started}}{{else}}
+Started: {{prettyTime .Started}}{{else}}
 Started: {{prettyAgo .Started}}{{end}}
 Requests:
 {{transactionRequests .Requests .Responses}}
@@ -180,6 +180,7 @@ func transactionRequests(
 
 var funcMap = template.FuncMap{
 	"prettyAgo":           pretty.Ago,
+	"prettyTime":          pretty.Timestamp,
 	"prettySize":          pretty.Size,
 	"transactionRequests": transactionRequests,
 }


### PR DESCRIPTION
This gets all the places where we print times from protos and formats them as RFC3339 without nanoseconds. 

In the past this printed nanoseconds by coincidence, but I don't think anyone needs them and it takes up 9 chracters of space to do so. (Those that want them can run --raw to get it in that form).