### PR TITLE
upgrade goreleaser 1.17.1 (#8757)

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -76,6 +76,7 @@ jobs:
           keys:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run: etc/testing/circle/install.sh
+      - install-go-releaser
       - run:
           no_output_timeout: 20m
           command: |-
@@ -128,6 +129,7 @@ jobs:
           keys:
             - pach-build-dependencies-v2-{{ checksum "etc/testing/circle/install.sh" }}
       - run: etc/testing/circle/install.sh
+      - install-go-releaser
       - go/install:
           version: << pipeline.parameters.go-version >>
       - run:
@@ -235,6 +237,7 @@ jobs:
           keys:
             - pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
       - run: etc/testing/circle/install.sh
+      - install-go-releaser
       - save_cache:
           key: pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
           paths:
@@ -437,6 +440,7 @@ jobs:
       - run:
           command: etc/testing/circle/run_all_load_tests.sh
           no_output_timeout: 1h
+      - install-go-releaser
       - run:
           name: Destroy test env on fail
           command: |
@@ -462,6 +466,7 @@ jobs:
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
             echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
       - run: etc/testing/circle/install.sh
+      - install-go-releaser
       - run:
           name: Collect node stats
           command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
@@ -552,12 +557,9 @@ jobs:
       - run:
           name: Download utilities
           command: |
-            mkdir -p /home/circleci/bin
-            wget https://github.com/goreleaser/goreleaser/releases/download/v1.10.3/goreleaser_Linux_x86_64.tar.gz
-            tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
-            rm -rf goreleaser_Linux_x86_64.tar.gz
             sudo apt update
             sudo apt install qemu binfmt-support qemu-user-static
+      - install-go-releaser
       - run:
           name: pachydermbuildbot docker login
           command: |
@@ -588,9 +590,6 @@ jobs:
           name: Download utilities
           command: |
             mkdir -p /home/circleci/bin
-            wget https://github.com/goreleaser/goreleaser/releases/download/v1.4.1/goreleaser_Linux_x86_64.tar.gz
-            tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
-            rm -rf goreleaser_Linux_x86_64.tar.gz
             wget https://github.com/chainlink/gcsupload/releases/download/v0.2.0/gcsupload_0.2.0_Linux_x86_64.tar.gz
             tar zxvf gcsupload_0.2.0_Linux_x86_64.tar.gz -C /home/circleci/bin gcsupload
             rm -rf gcsupload_0.2.0_Linux_x86_64.tar.gz
@@ -602,6 +601,7 @@ jobs:
           keys:
             - pachctl-build-cache-v1-{{ .Branch }}-{{ checksum "current_week" }}
             - pachctl-build-cache-v1-master-{{ checksum "current_week" }}
+      - install-go-releaser
       - when:
           condition:
             and:
@@ -687,19 +687,8 @@ jobs:
           command: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run:
           name: Check for known security vulnerabilities
-          command: govulncheck ./...
-  push_redhat:
-    executor: docker-go
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-          version: "20.10.12"
-      - run:
-          name: Install Goreleaser
           command: |
-            curl -Lo - https://github.com/goreleaser/goreleaser/releases/download/v1.4.1/goreleaser_Linux_x86_64.tar.gz | sudo tar -C /usr/local/bin -xvzf - goreleaser
-      - run: etc/redhat/push_images.sh
+            find -name go.mod -print0 | xargs -0 -I{} sh -c 'cd $(dirname {}); echo; echo '---'; echo $PWD; exec govulncheck ./...'
   jupyter-extension-test:
     parameters:
       python-version:
@@ -1792,8 +1781,8 @@ commands:
       - run:
           name: Install pachctl and mount-server
           command: |
-            sudo mv ./dist-pach/pachctl/pachctl_linux_amd64/pachctl /usr/local/bin/pachctl
-            sudo mv ./dist-pach/mount-server/mount-server_linux_amd64/mount-server /usr/local/bin/mount-server
+            sudo mv ./dist-pach/pachctl/pachctl_linux_amd64_v1/pachctl /usr/local/bin/pachctl
+            sudo mv ./dist-pach/mount-server/mount-server_linux_amd64_v1/mount-server /usr/local/bin/mount-server
       - run:
           name: Start kind
           command: kind create cluster && kubectl config set current-context kind-kind
@@ -1820,3 +1809,34 @@ commands:
       - pulumi/login
       - run: |
           pulumi plugin install resource eks v0.40.0
+  install-go-releaser:
+    steps:
+      - run:
+          name: install-go-releaser
+          command: |
+            mkdir -p /home/circleci/bin
+            wget https://github.com/goreleaser/goreleaser/releases/download/v<< pipeline.parameters.go-releaser-version >>/goreleaser_Linux_x86_64.tar.gz
+            tar zxvf goreleaser_Linux_x86_64.tar.gz -C /home/circleci/bin goreleaser
+            rm -rf goreleaser_Linux_x86_64.tar.gz
+            goreleaser -v
+  wait-for-docker:
+    steps:
+      - run:
+          name: Wait for docker
+          command: |
+            # wait for docker or timeout
+            timeout=120
+            while ! docker version >/dev/null 2>&1; do
+              timeout=$((timeout - 1))
+              if [ $timeout -eq 0 ]; then
+                echo "Timed out waiting for docker daemon"
+                exit 1
+              fi
+              sleep 1
+            done
+  start-minikube:
+    steps:
+      - run:
+          name: Start minikube
+          command: minikube start --vm-driver=docker --kubernetes-version=v1.19.0 --cpus=7 --memory=12Gi --wait=all
+          background: true

--- a/Makefile
+++ b/Makefile
@@ -85,19 +85,19 @@ release:
 release-helper: release-docker-images docker-push-release
 
 release-docker-images:
-	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --skip-publish --rm-dist -f goreleaser/docker.yml
+	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker.yml
 
 release-pachctl:
-	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --rm-dist -f goreleaser/pachctl.yml
+	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --clean -f goreleaser/pachctl.yml
 
 release-mount-server:
-	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --rm-dist -f goreleaser/mount-server.yml
+	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --clean -f goreleaser/mount-server.yml
 
 docker-build:
-	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --rm-dist -f goreleaser/docker.yml
+	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker.yml
 
 docker-build-amd:
-	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --rm-dist -f goreleaser/docker-amd.yml
+	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker-amd.yml
 
 docker-build-netcat:
 	docker build --network=host -f etc/test-images/Dockerfile.netcat -t pachyderm/ubuntuplusnetcat:local .

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -60,9 +60,3 @@ if [ ! -f cached-deps/helm ]; then
       mv ./linux-${ARCH}/helm cached-deps/helm
 fi
 
-# Install goreleaser
-if [ ! -f cached-deps/goreleaser ]; then
-  GORELEASER_VERSION=0.169.0
-  curl -L https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
-      | tar xzf - -C cached-deps goreleaser
-fi

--- a/etc/testing/circle/run_load_tests.sh
+++ b/etc/testing/circle/run_load_tests.sh
@@ -8,11 +8,6 @@ export GOPATH="${HOME}/go"
 
 go version
 
-# Install goreleaser.
-GORELEASER_VERSION=0.169.0
-curl -L "https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz" \
-    | tar xzf - -C "${HOME}/go/bin" goreleaser
-
 # Build pachctl.
 make install
 pachctl version --client-only

--- a/jupyter-extension/Dockerfile
+++ b/jupyter-extension/Dockerfile
@@ -12,8 +12,8 @@ RUN mkdir -p /pfs
 RUN chown jovyan /pfs
 RUN apt-get update && apt-get -y install curl fuse
 RUN echo "user_allow_other" | sudo tee -a /etc/fuse.conf > /dev/null
-COPY ./dist-pach/pachctl/pachctl_linux_amd64/pachctl /usr/local/bin/pachctl
-COPY ./dist-pach/mount-server/mount-server_linux_amd64/mount-server/ /usr/local/bin/mount-server
+COPY ./dist-pach/pachctl/pachctl_linux_amd64_v1/pachctl /usr/local/bin/pachctl
+COPY ./dist-pach/mount-server/mount-server_linux_amd64_v1/mount-server/ /usr/local/bin/mount-server
 #RUN curl -f -o pachctl.tar.gz -L https://storage.googleapis.com/pachyderm-builds/pachctl_${PACHCTL_VERSION}_linux_amd64.tar.gz
 #RUN tar zxfv pachctl.tar.gz && mv pachctl_${PACHCTL_VERSION}_linux_amd64/pachctl /usr/local/bin/
 #RUN curl -f -o mount-server.tar.gz -L https://storage.googleapis.com/pachyderm-builds/mount-server_${PACHCTL_VERSION}_linux_amd64.tar.gz


### PR DESCRIPTION
we shouldn't have to do anymore 2.5.x releases, but in case we do. [this was missing ](https://pachyderm.atlassian.net/wiki/spaces/CORE/pages/42631737/2023-07-21+Release+Post+Mortem+2.5.7) which will cause a silent missing arm64 bin pachctl in the release. this has already patched long ago, but not back ported to 2.5.x.