### PR TITLE
Show the public IP of a service pipeline workload on deploy

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -285,6 +285,19 @@ class HealthHandler(BaseHandler):
             )
 
 
+class PPSHandler(BaseHandler):
+    @tornado.web.authenticated
+    async def get(self, project_name, name):
+        """Get details for the specified pps"""
+        try:
+            response = await self.pps_client.retrieve(name=name, project_name=project_name)
+            get_logger().debug(f"RetrievePipeline: {response}")
+            await self.finish(response)
+        except Exception as e:
+            get_logger().error(f"couldn't retrieve details for pipeline: {e}")
+            raise tornado.web.HTTPError(status_code=404, reason="Pipeline not found.")
+
+
 class PPSCreateHandler(BaseHandler):
 
     @tornado.web.authenticated
@@ -340,6 +353,7 @@ def setup_handlers(web_app):
         ("/auth/_login", AuthLoginHandler),
         ("/auth/_logout", AuthLogoutHandler),
         ("/health", HealthHandler),
+        (r"/pps/(\w+)/(\w+)", PPSHandler),
         (r"/pps/_create%s" % path_regex, PPSCreateHandler),
     ]
 

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -4,7 +4,7 @@ import {ServerConnection} from '@jupyterlab/services';
 import {
   CreatePipelineResponse,
   GpuMode,
-  MountSettings,
+  MountSettings, PPS,
   PpsContext,
   PpsMetadata,
 } from '../../../types';
@@ -122,12 +122,39 @@ export const usePipeline = (
         }
       }
       setLoading(false);
+      pollForIp(ppsMetadata.config.pipeline.project.name, ppsMetadata.config.pipeline.name).then((s) => setResponseMessage(s));
     };
   } else {
     // If no notebookModel is defined, we cannot create a pipeline.
     callCreatePipeline = async () => {
       setErrorMessage('Error: No notebook in focus');
     };
+  }
+
+  const pollForIp = async (
+    project_name: string,
+    name: string,
+  ): Promise<string> => {
+    try {
+      const response = await requestAPI<PPS>(
+        `pps/${project_name}/${name}`,
+        'GET',
+      );
+      if ((response.details.service.ip !== null) && (response.details.service.ip.length > 0)) {
+        return `Create pipeline request successful. See output at ${response.details.service.ip}.`;
+      }
+    }
+    catch(e) {
+      if (e instanceof ServerConnection.ResponseError) {
+        // statusText is the only place that the user will get yaml parsing
+        // errors (though it will also include Pachyderm errors, e.g.
+        // "missing input repo").
+        setErrorMessage('Error creating pipeline: ' + e.response.statusText);
+      } else {
+        throw e;
+      }
+    }
+    return pollForIp(project_name, name);
   }
 
   const buildMetadata = (): PpsMetadata => {

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -130,6 +130,22 @@ export enum GpuMode {
   Advanced = 'Advanced',
 }
 
+type PPSServiceDetails = {
+  internal_port: number;
+  external_port: number;
+  ip: string | null;
+  type: string;
+};
+
+type PPSDetails = {
+  service: PPSServiceDetails | null;
+};
+
+export type PPS = {
+  pipeline: Pipeline;
+  details: PPSDetails;
+};
+
 // If this is updated, make sure to also update the corresponding `useEffect`
 // call in ./components/Pipeline/hooks/usePipeline.tsx that writes this type to
 // the notebook metadata.


### PR DESCRIPTION
When a service pipeline is created, it does not yet have a k8s loadbalancer IP address. This currently has to be retrieved via `pachctl list pipeline` or similar.

This PR adds a new endpoint at `/v2/pps/$project/$pipeline` and displays the LB IP when it is provisioned. NB there is currently no backoff on the polling and I'm sure the UX could be improved. 