### PR TITLE
Expand Integrations CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,5 @@
 # Integrations
 /src/server/pfs/s3       @pachyderm/INT
 /src/server/pfs/fuse     @pachyderm/INT
+/src/*/*.proto           @pachyderm/INT
+/python-sdk              @pachyderm/INT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+# All
+/src/*/*.proto           @pachyderm/CORE @pachyderm/INT @pachyderm/PFS
 
 # PFS
 /src/pfs/                @pachyderm/PFS
@@ -6,5 +8,4 @@
 # Integrations
 /src/server/pfs/s3       @pachyderm/INT
 /src/server/pfs/fuse     @pachyderm/INT
-/src/*/*.proto           @pachyderm/INT
 /python-sdk              @pachyderm/INT


### PR DESCRIPTION
Provide the integrations team with visibility into changes to the external-facing proto files and changes to the python-sdk when regenerating from the proto files.