### PR TITLE
Validate PFS requests against live data

### DIFF
--- a/src/internal/coredb/projects.go
+++ b/src/internal/coredb/projects.go
@@ -35,7 +35,7 @@ func (err ErrProjectNotFound) Error() string {
 	if id := err.ID; id != 0 {
 		return fmt.Sprintf("project id=%d not found", id)
 	}
-	return "project not found"
+	return "project (unspecified) not found"
 }
 
 func (err ErrProjectNotFound) Is(other error) bool {

--- a/src/internal/pfsdb/repos.go
+++ b/src/internal/pfsdb/repos.go
@@ -380,3 +380,21 @@ func UpdateRepo(ctx context.Context, tx *pachsql.Tx, id RepoID, repo *pfs.RepoIn
 	}
 	return nil
 }
+
+// RepoExistsByName returns nil if the repo exists, or an error otherwise.
+func RepoExistsByName(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repoType string) error {
+	row := tx.QueryRowContext(ctx, `SELECT 1 FROM pfs.repos r LEFT JOIN core.projects p ON p.id = r.project_id `+
+		`WHERE p.name=$1 AND r.name=$2 AND r.type=$3::pfs.repo_type`,
+		repoProject, repoName, repoType)
+	var n int
+	if err := row.Scan(&n); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrRepoNotFound{Project: repoProject, Name: repoName, Type: repoType}
+		}
+		return errors.Wrap(err, "Scan")
+	}
+	if n != 1 {
+		return errors.Errorf("scanning dummy row returned unexpected value %v", n)
+	}
+	return nil
+}

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -439,7 +439,7 @@ func GetWorkerPipelineInfo(pachClient *client.APIClient, db *pachsql.DB, l col.P
 func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, txnEnv transactionenv.TransactionEnv, pipeline *pps.Pipeline) (*pfs.Commit, error) {
 	var commit *pfs.Commit
 	if err := txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) (err error) {
-		commit, err = FindPipelineSpecCommitInTransaction(txnCtx, pfsServer, pipeline, "")
+		commit, err = FindPipelineSpecCommitInTransaction(ctx, txnCtx, pfsServer, pipeline, "")
 		return
 	}); err != nil {
 		return nil, err
@@ -449,13 +449,13 @@ func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, 
 
 // FindPipelineSpecCommitInTransaction finds the spec commit corresponding to the pipeline version present in the commit given
 // by startID. If startID is blank, find the current pipeline version
-func FindPipelineSpecCommitInTransaction(txnCtx *txncontext.TransactionContext, pfsServer pfsServer.APIServer, pipeline *pps.Pipeline, startID string) (*pfs.Commit, error) {
+func FindPipelineSpecCommitInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pfsServer pfsServer.APIServer, pipeline *pps.Pipeline, startID string) (*pfs.Commit, error) {
 	curr := (&pfs.Repo{
 		Project: pipeline.Project,
 		Name:    pipeline.Name,
 		Type:    pfs.SpecRepoType,
 	}).NewCommit("master", startID)
-	commitInfo, err := pfsServer.InspectCommitInTransaction(txnCtx,
+	commitInfo, err := pfsServer.InspectCommitInTransaction(ctx, txnCtx,
 		&pfs.InspectCommitRequest{Commit: curr})
 	if err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/internal/testpachd/mock_transaction.go
+++ b/src/internal/testpachd/mock_transaction.go
@@ -39,7 +39,7 @@ func (mock *mockNewJobFinisher) Use(cb newJobFinisherFunc) {
 	mock.handler = cb
 }
 
-type stopJobInTransactionFunc func(*txncontext.TransactionContext, *pps.StopJobRequest) error
+type stopJobInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.StopJobRequest) error
 
 type mockStopJobInTransaction struct {
 	handler stopJobInTransactionFunc
@@ -69,7 +69,7 @@ func (mock *mockCreatePipelineInTransaction) Use(cb createPipelineInTransactionF
 	mock.handler = cb
 }
 
-type inspectPipelineInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
+type inspectPipelineInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
 
 type mockInspectPipelineInTransaction struct {
 	handler inspectPipelineInTransactionFunc
@@ -79,7 +79,7 @@ func (mock *mockInspectPipelineInTransaction) Use(cb inspectPipelineInTransactio
 	mock.handler = cb
 }
 
-type activateAuthInTransactionFunc func(*txncontext.TransactionContext, *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error)
+type activateAuthInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error)
 
 type mockActivateAuthInTransaction struct {
 	handler activateAuthInTransactionFunc
@@ -110,8 +110,8 @@ type MockPPSTransactionServer struct {
 
 type MockPPSPropagater struct{}
 
-func (mpp *MockPPSPropagater) PropagateJobs() {}
-func (mpp *MockPPSPropagater) Run() error     { return nil }
+func (mpp *MockPPSPropagater) PropagateJobs()            {}
+func (mpp *MockPPSPropagater) Run(context.Context) error { return nil }
 
 func (api *ppsTransactionAPI) NewPropagater(txnCtx *txncontext.TransactionContext) txncontext.PpsPropagater {
 	if api.mock.NewPropagater.handler != nil {
@@ -122,8 +122,8 @@ func (api *ppsTransactionAPI) NewPropagater(txnCtx *txncontext.TransactionContex
 
 type MockPPSJobStopper struct{}
 
-func (mpp *MockPPSJobStopper) StopJobs(*pfs.CommitSet) {}
-func (mpp *MockPPSJobStopper) Run() error              { return nil }
+func (mpp *MockPPSJobStopper) StopJobs(*pfs.CommitSet)   {}
+func (mpp *MockPPSJobStopper) Run(context.Context) error { return nil }
 
 func (api *ppsTransactionAPI) NewJobStopper(txnCtx *txncontext.TransactionContext) txncontext.PpsJobStopper {
 	if api.mock.NewJobStopper.handler != nil {
@@ -135,7 +135,7 @@ func (api *ppsTransactionAPI) NewJobStopper(txnCtx *txncontext.TransactionContex
 type MockPPSJobFinisher struct{}
 
 func (mpp *MockPPSJobFinisher) FinishJob(*pfs.CommitInfo) {}
-func (mpp *MockPPSJobFinisher) Run() error                { return nil }
+func (mpp *MockPPSJobFinisher) Run(context.Context) error { return nil }
 
 func (api *ppsTransactionAPI) NewJobFinisher(txnCtx *txncontext.TransactionContext) txncontext.PpsJobFinisher {
 	if api.mock.NewJobFinisher.handler != nil {
@@ -144,9 +144,9 @@ func (api *ppsTransactionAPI) NewJobFinisher(txnCtx *txncontext.TransactionConte
 	return &MockPPSJobFinisher{}
 }
 
-func (api *ppsTransactionAPI) StopJobInTransaction(txnCtx *txncontext.TransactionContext, req *pps.StopJobRequest) error {
+func (api *ppsTransactionAPI) StopJobInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.StopJobRequest) error {
 	if api.mock.StopJobInTransaction.handler != nil {
-		return api.mock.StopJobInTransaction.handler(txnCtx, req)
+		return api.mock.StopJobInTransaction.handler(ctx, txnCtx, req)
 	}
 	return errors.Errorf("unhandled pachd mock: pps.StopJobInTransaction")
 }
@@ -165,16 +165,16 @@ func (api *ppsTransactionAPI) CreatePipelineInTransaction(ctx context.Context, t
 	return errors.Errorf("unhandled pachd mock: pps.CreatePipelineInTransaction")
 }
 
-func (api *ppsTransactionAPI) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
+func (api *ppsTransactionAPI) InspectPipelineInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 	if api.mock.InspectPipelineInTransaction.handler != nil {
-		return api.mock.InspectPipelineInTransaction.handler(txnCtx, pipeline)
+		return api.mock.InspectPipelineInTransaction.handler(ctx, txnCtx, pipeline)
 	}
 	return nil, errors.Errorf("unhandled pachd mock: pps.InspectPipelineInTransaction")
 }
 
-func (api *ppsTransactionAPI) ActivateAuthInTransaction(txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error) {
+func (api *ppsTransactionAPI) ActivateAuthInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error) {
 	if api.mock.ActivateAuthInTransaction.handler != nil {
-		return api.mock.ActivateAuthInTransaction.handler(txnCtx, req)
+		return api.mock.ActivateAuthInTransaction.handler(ctx, txnCtx, req)
 	}
 	return nil, errors.Errorf("unhandled pachd mock: pps.AcivateAuthInTransaction")
 }

--- a/src/internal/testpachd/realenv/real_env.go
+++ b/src/internal/testpachd/realenv/real_env.go
@@ -202,7 +202,7 @@ func newRealEnv(ctx context.Context, t testing.TB, mockPPSTransactionServer bool
 		realEnv.MockPPSTransactionServer = testpachd.NewMockPPSTransactionServer()
 		realEnv.ServiceEnv.SetPpsServer(&realEnv.MockPPSTransactionServer.Api)
 		realEnv.MockPPSTransactionServer.InspectPipelineInTransaction.
-			Use(func(txnctx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
+			Use(func(ctx context.Context, txnctx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 				return nil, col.ErrNotFound{
 					Type: "pipelines",
 					Key:  pipeline.String(),

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -143,7 +143,7 @@ func (t *directTransaction) StartCommit(original *pfs.StartCommitRequest) (*pfs.
 
 func (t *directTransaction) FinishCommit(original *pfs.FinishCommitRequest) error {
 	req := proto.Clone(original).(*pfs.FinishCommitRequest)
-	return errors.EnsureStack(t.txnEnv.serviceEnv.PfsServer().FinishCommitInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.serviceEnv.PfsServer().FinishCommitInTransaction(t.ctx, t.txnCtx, req))
 }
 
 func (t *directTransaction) SquashCommitSet(original *pfs.SquashCommitSetRequest) error {
@@ -163,7 +163,7 @@ func (t *directTransaction) DeleteBranch(original *pfs.DeleteBranchRequest) erro
 
 func (t *directTransaction) StopJob(original *pps.StopJobRequest) error {
 	req := proto.Clone(original).(*pps.StopJobRequest)
-	return errors.EnsureStack(t.txnEnv.serviceEnv.PpsServer().StopJobInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.serviceEnv.PpsServer().StopJobInTransaction(t.ctx, t.txnCtx, req))
 }
 
 func (t *directTransaction) UpdateJobState(original *pps.UpdateJobStateRequest) error {
@@ -302,7 +302,7 @@ func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *pachsql.Tx, cb 
 	if err != nil {
 		return err
 	}
-	return txnCtx.Finish()
+	return txnCtx.Finish(ctx)
 }
 
 func (env *TransactionEnv) waitReady(ctx context.Context) error {

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -114,24 +114,24 @@ func (t *TransactionContext) DeleteBranch(branch *pfs.Branch) {
 
 // Finish applies the deferred logic in the pfsPropagator and ppsPropagator to
 // the transaction
-func (t *TransactionContext) Finish() error {
+func (t *TransactionContext) Finish(ctx context.Context) error {
 	if t.PfsPropagater != nil {
-		if err := t.PfsPropagater.Run(); err != nil {
+		if err := t.PfsPropagater.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
 	if t.PpsPropagater != nil {
-		if err := t.PpsPropagater.Run(); err != nil {
+		if err := t.PpsPropagater.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
 	if t.PpsJobStopper != nil {
-		if err := t.PpsJobStopper.Run(); err != nil {
+		if err := t.PpsJobStopper.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
 	if t.PpsJobFinisher != nil {
-		if err := t.PpsJobFinisher.Run(); err != nil {
+		if err := t.PpsJobFinisher.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
@@ -143,14 +143,14 @@ func (t *TransactionContext) Finish() error {
 type PfsPropagater interface {
 	PropagateBranch(branch *pfs.Branch) error
 	DeleteBranch(branch *pfs.Branch)
-	Run() error
+	Run(context.Context) error
 }
 
 // PpsPropagater is the interface that PPS implements to start jobs at the end
 // of a transaction.  It is defined here to avoid a circular dependency.
 type PpsPropagater interface {
 	PropagateJobs()
-	Run() error
+	Run(context.Context) error
 }
 
 // PpsJobStopper is the interface that PPS implements to stop jobs of deleted
@@ -158,10 +158,10 @@ type PpsPropagater interface {
 // circular dependency.
 type PpsJobStopper interface {
 	StopJobs(commitset *pfs.CommitSet)
-	Run() error
+	Run(context.Context) error
 }
 
 type PpsJobFinisher interface {
 	FinishJob(commitInfo *pfs.CommitInfo)
-	Run() error
+	Run(context.Context) error
 }

--- a/src/pfs/pfs.pb.go
+++ b/src/pfs/pfs.pb.go
@@ -2627,7 +2627,7 @@ type ListBranchRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Repo    *Repo `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
+	Repo    *Repo `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`        // If nil, list all branches.  Doesn't work if auth is enabled.
 	Reverse bool  `protobuf:"varint,2,opt,name=reverse,proto3" json:"reverse,omitempty"` // Returns branches oldest to newest
 }
 

--- a/src/pfs/pfs.proto
+++ b/src/pfs/pfs.proto
@@ -324,7 +324,7 @@ message InspectBranchRequest {
 }
 
 message ListBranchRequest {
-  Repo repo = 1;
+  Repo repo = 1; // If nil, list all branches.  Doesn't work if auth is enabled.
   bool reverse = 2; // Returns branches oldest to newest
 }
 

--- a/src/pfs/validate.go
+++ b/src/pfs/validate.go
@@ -1,0 +1,240 @@
+package pfs
+
+import (
+	"fmt"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+)
+
+type LiveValidator interface {
+	ValidateRepoExists(*Repo) error
+	ValidateProjectExists(*Project) error
+}
+
+type LiveValidationError struct {
+	Path string
+	Err  error
+}
+
+var _ error = new(LiveValidationError)
+
+func (err *LiveValidationError) Error() string {
+	return "field " + err.Path + ": " + err.Err.Error()
+}
+
+func (err *LiveValidationError) Unwrap() error {
+	return err.Err
+}
+
+func validationError(path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &LiveValidationError{Path: path, Err: err}
+}
+
+func (x *CreateRepoRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("repo.project", v.ValidateProjectExists(x.GetRepo().GetProject()))
+}
+
+func (x *InspectRepoRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("repo.project", v.ValidateProjectExists(x.GetRepo().GetProject()))
+}
+
+func (x *ListRepoRequest) ValidatePFS(v LiveValidator) error {
+	var errs error
+	for i, p := range x.GetProjects() {
+		errors.JoinInto(&errs, validationError(fmt.Sprintf("projects[%d]", i), v.ValidateProjectExists(p)))
+	}
+	return errs
+}
+
+func (x *DeleteRepoRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("repo.project", v.ValidateProjectExists(x.GetRepo().GetProject()))
+}
+
+func (x *DeleteReposRequest) ValidatePFS(v LiveValidator) error {
+	var errs error
+	for i, p := range x.GetProjects() {
+		errors.JoinInto(&errs, validationError(fmt.Sprintf("projects[%d]", i), v.ValidateProjectExists(p)))
+	}
+	return errs
+}
+
+func (x *StartCommitRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("branch.repo", v.ValidateRepoExists(x.GetBranch().GetRepo()))
+}
+
+func (x *FinishCommitRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("commit.repo", v.ValidateRepoExists(x.GetCommit().GetRepo()))
+}
+
+func (x *InspectCommitRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("commit.repo", v.ValidateRepoExists(x.GetCommit().GetRepo()))
+}
+
+func (x *ListCommitRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("repo", v.ValidateRepoExists(x.GetRepo()))
+}
+
+func (x *InspectCommitSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *ListCommitSetRequest) ValidatePFS(v LiveValidator) error {
+	if p := x.Project; p != nil {
+		return validationError("project", v.ValidateProjectExists(p))
+	}
+	return nil
+}
+
+func (x *SquashCommitSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *DropCommitSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *SubscribeCommitRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("repo", v.ValidateRepoExists(x.GetRepo()))
+}
+
+func (x *ClearCommitRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("commit.repo", v.ValidateRepoExists(x.GetCommit().GetRepo()))
+}
+
+func (x *CreateBranchRequest) ValidatePFS(v LiveValidator) error {
+	var errs error
+	errors.JoinInto(&errs, validationError("branch.repo", v.ValidateRepoExists(x.GetBranch().GetRepo())))
+	for i, b := range x.GetProvenance() {
+		errors.JoinInto(&errs, validationError(fmt.Sprintf("provenance[%d].repo", i), v.ValidateRepoExists(b.GetRepo())))
+	}
+	return errs
+}
+
+func (x *FindCommitsRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("start.repo", v.ValidateRepoExists(x.GetStart().GetRepo()))
+}
+
+func (x *InspectBranchRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("branch.repo", v.ValidateRepoExists(x.GetBranch().GetRepo()))
+}
+
+func (x *ListBranchRequest) ValidatePFS(v LiveValidator) error {
+	if x.Repo != nil {
+		return validationError("repo", v.ValidateRepoExists(x.GetRepo()))
+	}
+	return nil
+}
+
+func (x *DeleteBranchRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("branch.repo.project", v.ValidateProjectExists(x.GetBranch().GetRepo().GetProject()))
+}
+
+func (x *CreateProjectRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *InspectProjectRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("project", v.ValidateProjectExists(x.GetProject()))
+}
+
+func (x *ListProjectRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *DeleteProjectRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *GetFileRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("file.commit.repo", v.ValidateRepoExists(x.GetFile().GetCommit().GetRepo()))
+}
+
+func (x *InspectFileRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("file.commit.repo", v.ValidateRepoExists(x.GetFile().GetCommit().GetRepo()))
+}
+
+func (x *ListFileRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("file.commit.repo", v.ValidateRepoExists(x.GetFile().GetCommit().GetRepo()))
+}
+
+func (x *WalkFileRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("file.commit.repo", v.ValidateRepoExists(x.GetFile().GetCommit().GetRepo()))
+}
+
+func (x *GlobFileRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("commit.repo", v.ValidateRepoExists(x.GetCommit().GetRepo()))
+}
+
+func (x *DiffFileRequest) ValidatePFS(v LiveValidator) error {
+	var errs error
+	errors.JoinInto(&errs, validationError("new_file.commit.repo", v.ValidateRepoExists(x.GetNewFile().GetCommit().GetRepo())))
+	errors.JoinInto(&errs, validationError("old_file.commit.repo", v.ValidateRepoExists(x.GetOldFile().GetCommit().GetRepo())))
+	return errs
+}
+
+func (x *FsckRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *CreateFileSetResponse) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *GetFileSetRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("commit.repo", v.ValidateRepoExists(x.GetCommit().GetRepo()))
+}
+
+func (x *AddFileSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *RenewFileSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *ComposeFileSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *ShardFileSetRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *CheckStorageRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *PutCacheRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *GetCacheRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *ClearCacheRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *ActivateAuthRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *RunLoadTestRequest) ValidatePFS(v LiveValidator) error {
+	return nil
+}
+
+func (x *EgressRequest) ValidatePFS(v LiveValidator) error {
+	return validationError("commit.repo", v.ValidateRepoExists(x.GetCommit().GetRepo()))
+}
+
+func (x *ModifyFileRequest) ValidatePFS(v LiveValidator) error {
+	switch x := x.GetBody().(type) {
+	case *ModifyFileRequest_SetCommit:
+		return validationError("body.set_commit.repo", v.ValidateRepoExists(x.SetCommit.GetRepo()))
+	}
+	return nil
+}

--- a/src/pfs/validate.go
+++ b/src/pfs/validate.go
@@ -137,7 +137,7 @@ func (x *CreateProjectRequest) ValidatePFS(v LiveValidator) error {
 }
 
 func (x *InspectProjectRequest) ValidatePFS(v LiveValidator) error {
-	return validationError("project", v.ValidateProjectExists(x.GetProject()))
+	return nil
 }
 
 func (x *ListProjectRequest) ValidatePFS(v LiveValidator) error {

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -178,7 +178,7 @@ func (a *apiServer) ActivateAuthEverywhere(ctx context.Context, scopes []Activat
 				}
 			case ActivationScopePPS:
 				log.Debug(ctx, "attempting to activate PPS auth")
-				if _, err := a.env.GetPpsServer().ActivateAuthInTransaction(txCtx, &pps.ActivateAuthRequest{}); err != nil {
+				if _, err := a.env.GetPpsServer().ActivateAuthInTransaction(ctx, txCtx, &pps.ActivateAuthRequest{}); err != nil {
 					return errors.Wrap(err, "activate auth for pps")
 				}
 			}

--- a/src/server/pfs/iface.go
+++ b/src/server/pfs/iface.go
@@ -21,16 +21,16 @@ type APIServer interface {
 	DeleteReposInTransaction(context.Context, *txncontext.TransactionContext, []*pfs_client.Repo, bool) error
 
 	StartCommitInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.StartCommitRequest) (*pfs_client.Commit, error)
-	FinishCommitInTransaction(*txncontext.TransactionContext, *pfs_client.FinishCommitRequest) error
-	InspectCommitInTransaction(*txncontext.TransactionContext, *pfs_client.InspectCommitRequest) (*pfs_client.CommitInfo, error)
+	FinishCommitInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.FinishCommitRequest) error
+	InspectCommitInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.InspectCommitRequest) (*pfs_client.CommitInfo, error)
 
-	InspectCommitSetInTransaction(*txncontext.TransactionContext, *pfs_client.CommitSet, bool) ([]*pfs_client.CommitInfo, error)
+	InspectCommitSetInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.CommitSet, bool) ([]*pfs_client.CommitInfo, error)
 	SquashCommitSetInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.SquashCommitSetRequest) error
 
 	CreateBranchInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.CreateBranchRequest) error
-	InspectBranchInTransaction(*txncontext.TransactionContext, *pfs_client.InspectBranchRequest) (*pfs_client.BranchInfo, error)
+	InspectBranchInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.InspectBranchRequest) (*pfs_client.BranchInfo, error)
 	DeleteBranchInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.DeleteBranchRequest) error
 
-	AddFileSetInTransaction(*txncontext.TransactionContext, *pfs_client.AddFileSetRequest) error
+	AddFileSetInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.AddFileSetRequest) error
 	ActivateAuthInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.ActivateAuthRequest) (*pfs_client.ActivateAuthResponse, error)
 }

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -75,7 +75,7 @@ func (d *driver) oneOffModifyFile(ctx context.Context, renewer *fileset.Renewer,
 		if err := d.commitStore.AddFileSetTx(txnCtx.SqlTx, commit, *id); err != nil {
 			return errors.EnsureStack(err)
 		}
-		return d.finishCommit(txnCtx, commit, "", "", false)
+		return d.finishCommit(ctx, txnCtx, commit, "", "", false)
 	})
 }
 

--- a/src/server/pfs/server/live_validation.go
+++ b/src/server/pfs/server/live_validation.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+
+	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/coredb"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type validatable interface {
+	ValidatePFS(pfs.LiveValidator) error
+}
+
+// ValidateRequest performs live validation on PFS messages.  This indirects through newValidator so
+// that RPC methods don't have to care about the somewhat-complicated implementation.  (The
+// complexity comes from avoiding an apiServer and txncontext depedency inside the PFS protos.)
+func (a *apiServer) ValidateRequest(ctx context.Context, txnCtx *txncontext.TransactionContext, req validatable) error {
+	var tx *pachsql.Tx
+	if txnCtx != nil {
+		tx = txnCtx.SqlTx
+	} else {
+		// Not everything that needs to validate quite follows the convention of having X
+		// call XInTransaction; work around that.
+		var err error
+		tx, err = a.env.DB.BeginTxx(ctx, &sql.TxOptions{
+			ReadOnly: true,
+		})
+		if err != nil {
+			return errors.Wrap(err, "validate request: StartTxx")
+		}
+		defer tx.Rollback()
+	}
+	err := req.ValidatePFS(a.newValidator(ctx, tx))
+	if err == nil {
+		return nil
+	}
+
+	// Accumulate all the field violations.
+	var fieldViolations []*errdetails.BadRequest_FieldViolation
+	var visit func(err error)
+	visit = func(err error) {
+		var lvErr *pfs.LiveValidationError
+		if errors.As(err, &lvErr) {
+			fieldViolations = append(fieldViolations, &errdetails.BadRequest_FieldViolation{
+				Field:       lvErr.Path,
+				Description: lvErr.Err.Error(),
+			})
+			return
+		}
+		if x, ok := err.(interface{ Unwrap() error }); ok {
+			visit(x.Unwrap())
+			return
+		}
+		if x, ok := err.(interface{ Unwrap() []error }); ok {
+			for _, err := range x.Unwrap() {
+				visit(err)
+			}
+		}
+	}
+	visit(err)
+
+	// Finally return a detailed RPC error.
+	s := status.New(codes.FailedPrecondition, "validate request: "+err.Error())
+	s, _ = s.WithDetails(&errdetails.BadRequest{
+		FieldViolations: fieldViolations,
+	})
+	return s.Err()
+}
+
+// validator remembers the context and transaction context so the PFS package doesn't have to depend
+// on txncontext.
+type validator struct {
+	ctx context.Context
+	tx  *pachsql.Tx
+	d   *driver
+}
+
+// Ensure that a validator is a pfs.Validator.
+var _ pfs.LiveValidator = new(validator)
+
+// ValidateRepoExists implements pfs.LiveValidator.
+func (v *validator) ValidateRepoExists(repo *pfs.Repo) error {
+	if err := v.ValidateProjectExists(repo.GetProject()); err != nil {
+		return errors.EnsureStack(err)
+	}
+
+	var repoInfo pfs.RepoInfo
+	if err := v.d.repos.ReadWrite(v.tx).Get(repo, &repoInfo); err != nil {
+		if col.IsErrNotFound(err) {
+			return pfsserver.ErrRepoNotFound{Repo: repo}
+		}
+		return err
+	}
+	return nil
+}
+
+// ValidateProjectExists implements pfs.LiveValidator.
+func (v *validator) ValidateProjectExists(project *pfs.Project) error {
+	if _, err := coredb.GetProjectByName(v.ctx, v.tx, project.GetName()); err != nil {
+		return errors.EnsureStack(err)
+	}
+	return nil
+}
+
+// newValidator creates a validator.  We use indirect though ValidateRequest so that code in this
+// package can't easily hold on to a validator{} and abuse the embedded context.
+//
+// txnCtx may be nil if a non-transactional collections read is acceptable.
+func (a *apiServer) newValidator(ctx context.Context, tx *pachsql.Tx) *validator {
+	return &validator{ctx: pctx.Child(ctx, "validate"), tx: tx, d: a.driver}
+}

--- a/src/server/pfs/server/live_validation_test.go
+++ b/src/server/pfs/server/live_validation_test.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/coredb"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+type negativeValidator struct{}
+
+func (negativeValidator) ValidateRepoExists(r *pfs.Repo) error {
+	return pfsdb.ErrRepoNotFound{
+		Project: r.GetProject().GetName(),
+		Type:    r.GetType(),
+		Name:    r.GetName(),
+	}
+}
+
+func (negativeValidator) ValidateProjectExists(p *pfs.Project) error {
+	return coredb.ErrProjectNotFound{
+		Name: p.GetName(),
+	}
+}
+
+func fieldViolations(vs ...*errdetails.BadRequest_FieldViolation) []*anypb.Any {
+	any, err := anypb.New(&errdetails.BadRequest{
+		FieldViolations: vs,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return []*anypb.Any{any}
+}
+
+func TestValidateRequest(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	tx := &pachsql.Tx{}
+
+	testData := []struct {
+		name string
+		req  validatable
+		want *spb.Status
+	}{
+		{
+			name: "InspectProject",
+			req: &pfs.InspectProjectRequest{
+				Project: &pfs.Project{
+					Name: "default",
+				},
+			},
+			want: &spb.Status{
+				Code:    int32(codes.FailedPrecondition),
+				Message: `validate request: field project: project "default" not found`,
+				Details: fieldViolations(&errdetails.BadRequest_FieldViolation{
+					Field:       "project",
+					Description: `project "default" not found`,
+				}),
+			},
+		},
+		{
+			name: "InspectRepo",
+			req: &pfs.InspectRepoRequest{
+				Repo: &pfs.Repo{
+					Project: &pfs.Project{
+						Name: "default",
+					},
+					Name: "repo",
+					Type: pfs.UserRepoType,
+				},
+			},
+			want: &spb.Status{
+				Code:    int32(codes.FailedPrecondition),
+				Message: `validate request: field repo.project: project "default" not found`,
+				Details: fieldViolations(&errdetails.BadRequest_FieldViolation{
+					Field:       "repo.project",
+					Description: `project "default" not found`,
+				}),
+			},
+		},
+		{
+			name: "DeleteRepos",
+			req: &pfs.DeleteReposRequest{
+				Projects: []*pfs.Project{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+				},
+			},
+			want: &spb.Status{
+				Code:    int32(codes.FailedPrecondition),
+				Message: "validate request: field projects[0]: project \"foo\" not found\nfield projects[1]: project \"bar\" not found",
+				Details: fieldViolations(
+					&errdetails.BadRequest_FieldViolation{
+						Field:       "projects[0]",
+						Description: `project "foo" not found`,
+					},
+					&errdetails.BadRequest_FieldViolation{
+						Field:       "projects[1]",
+						Description: `project "bar" not found`,
+					},
+				),
+			},
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			got := validateRequest(ctx, tx, test.req, negativeValidator{}).Proto()
+			if diff := cmp.Diff(got, test.want, protocmp.Transform()); diff != "" {
+				t.Errorf("diff (+got -want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/src/server/pfs/server/transaction_defer.go
+++ b/src/server/pfs/server/transaction_defer.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -44,7 +46,7 @@ func (t *Propagater) DeleteBranch(branch *pfs.Branch) {
 
 // Run performs any final tasks and cleanup tasks in the transaction, such as
 // propagating branches
-func (t *Propagater) Run() error {
+func (t *Propagater) Run(ctx context.Context) error {
 	branches := make([]*pfs.Branch, 0, len(t.branches))
 	for _, branch := range t.branches {
 		branches = append(branches, branch)

--- a/src/server/pfs/server/val_server.go
+++ b/src/server/pfs/server/val_server.go
@@ -38,7 +38,7 @@ func (a *validatedAPIServer) DeleteRepoInTransaction(ctx context.Context, txnCtx
 
 // FinishCommitInTransaction is identical to FinishCommit except that it can run
 // inside an existing postgres transaction.  This is not an RPC.
-func (a *validatedAPIServer) FinishCommitInTransaction(txnCtx *txncontext.TransactionContext, request *pfs.FinishCommitRequest) error {
+func (a *validatedAPIServer) FinishCommitInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pfs.FinishCommitRequest) error {
 	userCommit := request.Commit
 	// Validate arguments
 	if err := checkCommit(userCommit); err != nil {
@@ -47,7 +47,7 @@ func (a *validatedAPIServer) FinishCommitInTransaction(txnCtx *txncontext.Transa
 	if err := a.auth.CheckRepoIsAuthorizedInTransaction(txnCtx, userCommit.Repo, auth.Permission_REPO_WRITE); err != nil {
 		return errors.EnsureStack(err)
 	}
-	return a.apiServer.FinishCommitInTransaction(txnCtx, request)
+	return a.apiServer.FinishCommitInTransaction(ctx, txnCtx, request)
 }
 
 // InspectFile implements the protobuf pfs.InspectFile RPC

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -18,12 +18,12 @@ type APIServer interface {
 	NewJobStopper(*txncontext.TransactionContext) txncontext.PpsJobStopper
 	NewJobFinisher(*txncontext.TransactionContext) txncontext.PpsJobFinisher
 
-	StopJobInTransaction(*txncontext.TransactionContext, *pps_client.StopJobRequest) error
+	StopJobInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.StopJobRequest) error
 	UpdateJobStateInTransaction(*txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
 	CreatePipelineInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.CreatePipelineTransaction) error
 	// InspectPipelineInTransaction returns the pipeline information for a
 	// pipeline.  Note that the pipeline name may include ancestry syntax.
-	InspectPipelineInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (*pps_client.PipelineInfo, error)
-	ActivateAuthInTransaction(*txncontext.TransactionContext, *pps_client.ActivateAuthRequest) (*pps_client.ActivateAuthResponse, error)
+	InspectPipelineInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (*pps_client.PipelineInfo, error)
+	ActivateAuthInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.ActivateAuthRequest) (*pps_client.ActivateAuthResponse, error)
 	CreateDetPipelineSideEffects(context.Context, *pps.Pipeline, []string) error
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -979,7 +979,7 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 	}
 	ensurePipelineProject(request.Job.Pipeline)
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		return a.deleteJobInTransaction(txnCtx, request)
+		return a.deleteJobInTransaction(ctx, txnCtx, request)
 	}); err != nil {
 		return nil, err
 	}
@@ -987,8 +987,8 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 	return &emptypb.Empty{}, nil
 }
 
-func (a *apiServer) deleteJobInTransaction(txnCtx *txncontext.TransactionContext, request *pps.DeleteJobRequest) error {
-	if err := a.stopJob(txnCtx, request.Job, "job deleted"); err != nil {
+func (a *apiServer) deleteJobInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pps.DeleteJobRequest) error {
+	if err := a.stopJob(ctx, txnCtx, request.Job, "job deleted"); err != nil {
 		return err
 	}
 	return errors.EnsureStack(a.jobs.ReadWrite(txnCtx.SqlTx).Delete(ppsdb.JobKey(request.Job)))
@@ -1017,15 +1017,15 @@ func clearJobCache(pachClient *client.APIClient, tagPrefix string) {
 
 // StopJobInTransaction is identical to StopJob except that it can run inside an
 // existing postgres transaction.  This is not an RPC.
-func (a *apiServer) StopJobInTransaction(txnCtx *txncontext.TransactionContext, request *pps.StopJobRequest) error {
+func (a *apiServer) StopJobInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pps.StopJobRequest) error {
 	reason := request.Reason
 	if reason == "" {
 		reason = "job stopped"
 	}
-	return a.stopJob(txnCtx, request.Job, reason)
+	return a.stopJob(ctx, txnCtx, request.Job, reason)
 }
 
-func (a *apiServer) stopJob(txnCtx *txncontext.TransactionContext, job *pps.Job, reason string) error {
+func (a *apiServer) stopJob(ctx context.Context, txnCtx *txncontext.TransactionContext, job *pps.Job, reason string) error {
 	jobs := a.jobs.ReadWrite(txnCtx.SqlTx)
 	if job == nil {
 		return errors.New("Job must be specified")
@@ -1036,7 +1036,7 @@ func (a *apiServer) stopJob(txnCtx *txncontext.TransactionContext, job *pps.Job,
 		return errors.EnsureStack(err)
 	}
 
-	commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(txnCtx, &pfs.InspectCommitRequest{
+	commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(ctx, txnCtx, &pfs.InspectCommitRequest{
 		Commit: jobInfo.OutputCommit,
 	})
 	if err != nil && !pfsServer.IsCommitNotFoundErr(err) && !pfsServer.IsCommitDeletedErr(err) {
@@ -1046,14 +1046,14 @@ func (a *apiServer) stopJob(txnCtx *txncontext.TransactionContext, job *pps.Job,
 	// TODO: Leaning on the reason rather than state for commit errors seems a bit sketchy, but we don't
 	// store commit states.
 	if commitInfo != nil {
-		if err := a.env.PFSServer.FinishCommitInTransaction(txnCtx, &pfs.FinishCommitRequest{
+		if err := a.env.PFSServer.FinishCommitInTransaction(ctx, txnCtx, &pfs.FinishCommitRequest{
 			Commit: ppsutil.MetaCommit(commitInfo.Commit),
 			Error:  reason,
 			Force:  true,
 		}); err != nil && !pfsServer.IsCommitNotFoundErr(err) && !pfsServer.IsCommitDeletedErr(err) && !pfsServer.IsCommitFinishedErr(err) {
 			return errors.EnsureStack(err)
 		}
-		if err := a.env.PFSServer.FinishCommitInTransaction(txnCtx, &pfs.FinishCommitRequest{
+		if err := a.env.PFSServer.FinishCommitInTransaction(ctx, txnCtx, &pfs.FinishCommitRequest{
 			Commit: commitInfo.Commit,
 			Error:  reason,
 			Force:  true,
@@ -2362,7 +2362,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 	var (
 		projectName          = request.Pipeline.Project.GetName()
 		pipelineName         = request.Pipeline.Name
-		oldPipelineInfo, err = a.InspectPipelineInTransaction(txnCtx, request.Pipeline)
+		oldPipelineInfo, err = a.InspectPipelineInTransaction(ctx, txnCtx, request.Pipeline)
 	)
 	if err != nil && !errutil.IsNotFoundError(err) {
 		// silently ignore pipeline not found, old info will be nil
@@ -2461,7 +2461,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 			return errors.New("Cannot update a pipeline and provide a spec commit at the same time")
 		}
 		// Check if there is an existing spec commit
-		commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(txnCtx, &pfs.InspectCommitRequest{
+		commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(ctx, txnCtx, &pfs.InspectCommitRequest{
 			Commit: request.SpecCommit,
 		})
 		if err != nil {
@@ -2477,7 +2477,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := a.env.PFSServer.FinishCommitInTransaction(txnCtx, &pfs.FinishCommitRequest{
+		if err := a.env.PFSServer.FinishCommitInTransaction(ctx, txnCtx, &pfs.FinishCommitRequest{
 			Commit: newPipelineInfo.SpecCommit,
 		}); err != nil {
 			return errors.EnsureStack(err)
@@ -2511,7 +2511,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 	if update {
 		// Kill all unfinished jobs (as those are for the previous version and will
 		// no longer be completed)
-		if err := a.stopAllJobsInPipeline(txnCtx, request.Pipeline, "all jobs killed because pipeline was updated"); err != nil {
+		if err := a.stopAllJobsInPipeline(ctx, txnCtx, request.Pipeline, "all jobs killed because pipeline was updated"); err != nil {
 			return err
 		}
 
@@ -2547,7 +2547,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 	if visitErr := pps.VisitInput(request.Input, func(input *pps.Input) error {
 		if input.Pfs != nil && input.Pfs.Trigger != nil {
 			var prevHead *pfs.Commit
-			if branchInfo, err := a.env.PFSServer.InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{
+			if branchInfo, err := a.env.PFSServer.InspectBranchInTransaction(ctx, txnCtx, &pfs.InspectBranchRequest{
 				Branch: client.NewBranch(input.Pfs.Project, input.Pfs.Repo, input.Pfs.Branch),
 			}); err != nil {
 				if !errutil.IsNotFoundError(err) {
@@ -2661,7 +2661,7 @@ func setInputDefaults(pipelineName string, input *pps.Input) {
 	})
 }
 
-func (a *apiServer) stopAllJobsInPipeline(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline, reason string) error {
+func (a *apiServer) stopAllJobsInPipeline(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline, reason string) error {
 	// Using ReadWrite here may load a large number of jobs inline in the
 	// transaction, but doing an inconsistent read outside of the transaction
 	// would be pretty sketchy (and we'd have to worry about trying to get another
@@ -2674,19 +2674,20 @@ func (a *apiServer) stopAllJobsInPipeline(txnCtx *txncontext.TransactionContext,
 	}
 	reason += " for user " + username
 	err := a.jobs.ReadWrite(txnCtx.SqlTx).GetByIndex(ppsdb.JobsTerminalIndex, ppsdb.JobsTerminalKey(pipeline, false), jobInfo, sort, func(string) error {
-		return a.stopJob(txnCtx, jobInfo.Job, reason)
+		return a.stopJob(ctx, txnCtx, jobInfo.Job, reason)
 	})
 	return errors.EnsureStack(err)
 }
 
 func (a *apiServer) updatePipeline(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	pipeline *pps.Pipeline,
 	info *pps.PipelineInfo,
 	cb func() error) error {
 
 	// get most recent pipeline key
-	key, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, pipeline, "")
+	key, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, pipeline, "")
 	if err != nil {
 		return err
 	}
@@ -2707,7 +2708,7 @@ func (a *apiServer) inspectPipeline(ctx context.Context, pipeline *pps.Pipeline,
 	var info *pps.PipelineInfo
 	if err := a.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		info, err = a.InspectPipelineInTransaction(txnCtx, pipeline)
+		info, err = a.InspectPipelineInTransaction(ctx, txnCtx, pipeline)
 		return err
 	}); err != nil {
 		return nil, err
@@ -2762,7 +2763,7 @@ func (a *apiServer) inspectPipeline(ctx context.Context, pipeline *pps.Pipeline,
 }
 
 // InspectPipelineInTransaction implements the APIServer interface.
-func (a *apiServer) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
+func (a *apiServer) InspectPipelineInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 	// The pipeline pipelineName arrived in ancestry format; need to turn it into a simple pipelineName.
 	pipelineName, ancestors, err := ancestry.Parse(pipeline.Name)
 	if err != nil {
@@ -2774,7 +2775,7 @@ func (a *apiServer) InspectPipelineInTransaction(txnCtx *txncontext.TransactionC
 	}
 
 	pipeline.Name = pipelineName
-	commit, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, pipeline, "")
+	commit, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, pipeline, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "pipeline was not inspected: couldn't find up to date spec for pipeline %q", pipeline)
 	}
@@ -2848,7 +2849,7 @@ func (a *apiServer) listPipeline(ctx context.Context, request *pps.ListPipelineR
 
 	loadPipelineAtCommit := func(pi *pps.PipelineInfo, commitSetID string) error { // mutates pi
 		return a.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-			key, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, pi.Pipeline, commitSetID)
+			key, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, pi.Pipeline, commitSetID)
 			if err != nil {
 				return errors.Wrapf(err, "couldn't find up to date spec for pipeline %q", pi.Pipeline)
 			}
@@ -2969,7 +2970,7 @@ func (a *apiServer) deletePipelineInTransaction(ctx context.Context, txnCtx *txn
 	pipelineInfo := &pps.PipelineInfo{}
 	// Try to retrieve PipelineInfo for this pipeline. If we see a not found error,
 	// we will still try to delete what we can because we know there is a pipeline
-	if specCommit, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, request.Pipeline, ""); err == nil {
+	if specCommit, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, request.Pipeline, ""); err == nil {
 		if err := a.pipelines.ReadWrite(txnCtx.SqlTx).Get(specCommit, pipelineInfo); err != nil && !col.IsErrNotFound(err) {
 			return nil, errors.EnsureStack(err)
 		}
@@ -3009,7 +3010,7 @@ func (a *apiServer) deletePipelineInTransaction(ctx context.Context, txnCtx *txn
 	jobInfo := &pps.JobInfo{}
 	if err := a.jobs.ReadWrite(txnCtx.SqlTx).GetByIndex(ppsdb.JobsPipelineIndex, ppsdb.JobsPipelineKey(request.Pipeline), jobInfo, col.DefaultOptions(), func(string) error {
 		job := proto.Clone(jobInfo.Job).(*pps.Job)
-		err := a.deleteJobInTransaction(txnCtx, &pps.DeleteJobRequest{Job: job})
+		err := a.deleteJobInTransaction(ctx, txnCtx, &pps.DeleteJobRequest{Job: job})
 		if errutil.IsNotFoundError(err) || auth.IsErrNoRoleBinding(err) {
 			return nil
 		}
@@ -3124,7 +3125,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 	ensurePipelineProject(request.Pipeline)
 
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		pipelineInfo, err := a.InspectPipelineInTransaction(txnCtx, request.Pipeline)
+		pipelineInfo, err := a.InspectPipelineInTransaction(ctx, txnCtx, request.Pipeline)
 		if err != nil {
 			return err
 		}
@@ -3154,7 +3155,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 		}
 
 		newPipelineInfo := &pps.PipelineInfo{}
-		return a.updatePipeline(txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
+		return a.updatePipeline(ctx, txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
 			newPipelineInfo.Stopped = false
 			return nil
 		})
@@ -3171,7 +3172,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 	}
 	ensurePipelineProject(request.Pipeline)
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		if pipelineInfo, err := a.InspectPipelineInTransaction(txnCtx, request.Pipeline); err == nil {
+		if pipelineInfo, err := a.InspectPipelineInTransaction(ctx, txnCtx, request.Pipeline); err == nil {
 			// check if the caller is authorized to update this pipeline
 			// don't pass in the input - stopping the pipeline means they won't be read anymore,
 			// so we don't need to check any permissions
@@ -3196,7 +3197,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 			}
 
 			newPipelineInfo := &pps.PipelineInfo{}
-			if err := a.updatePipeline(txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
+			if err := a.updatePipeline(ctx, txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
 				newPipelineInfo.Stopped = true
 				return nil
 			}); err != nil {
@@ -3209,7 +3210,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 		// Kill any remaining jobs
 		// if the pipeline output repo doesn't exist, we technically run this without authorization,
 		// but it's not clear what authorization means in that case, and those jobs are doomed, anyway
-		return a.stopAllJobsInPipeline(txnCtx, request.Pipeline, "all jobs killed because pipeline was stopped")
+		return a.stopAllJobsInPipeline(ctx, txnCtx, request.Pipeline, "all jobs killed because pipeline was stopped")
 	}); err != nil {
 		return nil, err
 	}
@@ -3259,8 +3260,8 @@ func (a *apiServer) RunCron(ctx context.Context, request *pps.RunCronRequest) (r
 	return &emptypb.Empty{}, nil
 }
 
-func (a *apiServer) propagateJobs(txnCtx *txncontext.TransactionContext) error {
-	commitInfos, err := a.env.PFSServer.InspectCommitSetInTransaction(txnCtx, client.NewCommitSet(txnCtx.CommitSetID), false)
+func (a *apiServer) propagateJobs(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
+	commitInfos, err := a.env.PFSServer.InspectCommitSetInTransaction(ctx, txnCtx, client.NewCommitSet(txnCtx.CommitSetID), false)
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
@@ -3275,7 +3276,7 @@ func (a *apiServer) propagateJobs(txnCtx *txncontext.TransactionContext) error {
 		}
 		// Skip commits from repos that have no associated pipeline
 		var pipelineInfo *pps.PipelineInfo
-		if pipelineInfo, err = a.InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil {
+		if pipelineInfo, err = a.InspectPipelineInTransaction(ctx, txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil {
 			if col.IsErrNotFound(err) {
 				continue
 			}
@@ -3426,7 +3427,7 @@ func (a *apiServer) ActivateAuth(ctx context.Context, req *pps.ActivateAuthReque
 	var resp *pps.ActivateAuthResponse
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		resp, err = a.ActivateAuthInTransaction(txnCtx, req)
+		resp, err = a.ActivateAuthInTransaction(ctx, txnCtx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -3434,7 +3435,7 @@ func (a *apiServer) ActivateAuth(ctx context.Context, req *pps.ActivateAuthReque
 	return resp, nil
 }
 
-func (a *apiServer) ActivateAuthInTransaction(txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (resp *pps.ActivateAuthResponse, retErr error) {
+func (a *apiServer) ActivateAuthInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (resp *pps.ActivateAuthResponse, retErr error) {
 	// Unauthenticated users can't create new pipelines or repos, and users can't
 	// log in while auth is in an intermediate state, so 'pipelines' is exhaustive
 	pi := &pps.PipelineInfo{}
@@ -3445,7 +3446,7 @@ func (a *apiServer) ActivateAuthInTransaction(txnCtx *txncontext.TransactionCont
 		if err != nil {
 			return errors.Wrapf(grpcutil.ScrubGRPC(err), "could not generate pipeline auth token")
 		}
-		if err := a.updatePipeline(txnCtx, pi.Pipeline, pi, func() error {
+		if err := a.updatePipeline(ctx, txnCtx, pi.Pipeline, pi, func() error {
 			pi.AuthToken = token
 			return nil
 		}); err != nil {


### PR DESCRIPTION
A feature request has come in to end most PFS/PPS RPCs with an error like "project 'x' does not exist" instead of "repo x/whatever not found".  This PR adds a way to let proto messages, mostly RPC requests, declare that they need to be validated against live data.  We then do this validation for all requests in the PFS API server.   PPS needs similar treatment (no new rules, probably, but the same PFS validations); this will be in a follow-up PR.

The end result is that every RPC will return the same messages under the same circumstances, so we don't have to one-off handle this basic validation in a different way every time.

The basic idea is that the PFS API server declares a struct containing validation utilities like `ValidateProjectExists`, and it passes them to any message that does `ValidatePFS(v Validator) error`.  Then you can declare your validation rules right in the proto, and not modify every RPC to add your custom validation rules.  The RPC handler does have to call `ValidateRequest` however.  This is because if we did it in an interceptor automatically, we wouldn't have the right transaction environment setup, and we'd occasionally return incorrect results.  I also wanted to make sure that cross-server calls were also validated (so when PPS is looking for a spec commit, it will return errors about the project not existing, instead of "repo invalid-project/foo.spec doesn't exist"), and those don't go through the interceptor machinery.  (But should, of course.  PPS shouldn't be calling into PFS directly.)

Since this all happens in the apiserver, this doesn't affect appendTransaction; if you `pachctl start transaction; pachctl delete repo x; pachctl create branch x@foo` we SHOULD say `repo x does not exist`, but we don't.  (Obviously when you commit the transaction, you'll get that error; the validations run in the same database transaction as the underlying operations.)

This only handles "live" validation, it doesn't have any validation for the content of messages that *doesn't* depend on the current state of the system.  So there is still a lot of one-off validation throughout PFS/api_server, PFS/driver, etc.  We should replace this with a similar mechanism, but we probably want to use codegen for that, so I didn't do it in this PR.  I might be tempted to move the rules in `val_server.go` to a `ValidateMessage` method on each request type, and manually call that from `api_server.ValidateRequest`, though.

I considered doing codegen for this; annotate fields in your request with `[require_project_exists=true]`, and then we generate code that looks through that message and generates a validator for the project that message contains.  But because of all the runtime recursion (consider pps.Input; which includes pps.Input; how far down do you generate checking code for?), this ended up being mostly special cases.  So, we just do it manually.  I'll probably do a pass and generate `var _ interface { ValidatePFS(Validator) error } = new(SomeRequest) for each message ending in Request.  That way, nobody can forget to write `ValidatePFS`.  The compile error is a good reminder that the RPC handler should call `ValidateRequest`. 

Since some I/O happens during previously I/O-less requests, there is a performance impact to this.  But, since you write the validators for your RPC, if something is so critical that we can't check if the project exists, you can just not write that code.  So it should be OK.  That said, a LOT of stuff has to take contexts now.  It probably needed to before, but there is a lot of churn in this PR to add them.