### PR TITLE
break dependency server/pfs -> server/pps

### DIFF
--- a/src/internal/pfsutil/pfsutil.go
+++ b/src/internal/pfsutil/pfsutil.go
@@ -1,0 +1,10 @@
+package pfsutil
+
+import (
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+func MetaCommit(commit *pfs.Commit) *pfs.Commit {
+	return client.NewSystemRepo(commit.Repo.Project.GetName(), commit.Repo.Name, pfs.MetaRepoType).NewCommit(commit.Branch.Name, commit.Id)
+}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -516,7 +516,7 @@ func (d *driver) canDeleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.
 		}
 		return false, errors.Wrapf(err, "check repo %q is authorized for deletion", userRepo.String())
 	}
-	if _, err := d.env.GetPPS().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
+	if _, err := d.env.GetPipelineInspector().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
 		return false, errors.Errorf("cannot delete a repo associated with a pipeline - delete the pipeline instead")
 	} else if err != nil && !errutil.IsNotFoundError(err) {
 		return false, errors.Wrapf(err, "inspect pipeline %q", pps.RepoPipeline(repo).String())
@@ -908,7 +908,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 		}
 	}
 	if !force && len(commitInfo.DirectProvenance) > 0 {
-		if info, err := d.env.GetPPS().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
+		if info, err := d.env.GetPipelineInspector().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
 			return errors.EnsureStack(err)
 		} else if err == nil && info.Type == pps.PipelineInfo_PIPELINE_TYPE_TRANSFORM {
 			return errors.Errorf("cannot finish a pipeline output or meta commit, use 'stop job' instead")

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -516,7 +516,7 @@ func (d *driver) canDeleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.
 		}
 		return false, errors.Wrapf(err, "check repo %q is authorized for deletion", userRepo.String())
 	}
-	if _, err := d.env.GetPPSServer().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
+	if _, err := d.env.PPS.InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
 		return false, errors.Errorf("cannot delete a repo associated with a pipeline - delete the pipeline instead")
 	} else if err != nil && !errutil.IsNotFoundError(err) {
 		return false, errors.Wrapf(err, "inspect pipeline %q", pps.RepoPipeline(repo).String())
@@ -908,7 +908,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 		}
 	}
 	if !force && len(commitInfo.DirectProvenance) > 0 {
-		if info, err := d.env.GetPPSServer().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
+		if info, err := d.env.PPS.InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
 			return errors.EnsureStack(err)
 		} else if err == nil && info.Type == pps.PipelineInfo_PIPELINE_TYPE_TRANSFORM {
 			return errors.Errorf("cannot finish a pipeline output or meta commit, use 'stop job' instead")

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -516,7 +516,7 @@ func (d *driver) canDeleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.
 		}
 		return false, errors.Wrapf(err, "check repo %q is authorized for deletion", userRepo.String())
 	}
-	if _, err := d.env.PPS.InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
+	if _, err := d.env.GetPPS().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
 		return false, errors.Errorf("cannot delete a repo associated with a pipeline - delete the pipeline instead")
 	} else if err != nil && !errutil.IsNotFoundError(err) {
 		return false, errors.Wrapf(err, "inspect pipeline %q", pps.RepoPipeline(repo).String())
@@ -908,7 +908,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 		}
 	}
 	if !force && len(commitInfo.DirectProvenance) > 0 {
-		if info, err := d.env.PPS.InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
+		if info, err := d.env.GetPPS().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
 			return errors.EnsureStack(err)
 		} else if err == nil && info.Type == pps.PipelineInfo_PIPELINE_TYPE_TRANSFORM {
 			return errors.Errorf("cannot finish a pipeline output or meta commit, use 'stop job' instead")

--- a/src/server/pfs/server/driver_fsck.go
+++ b/src/server/pfs/server/driver_fsck.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"io"
 	"strings"
+
+	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pfsutil"
 
 	"google.golang.org/protobuf/proto"
 
@@ -16,7 +18,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/miscutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
-	"github.com/pachyderm/pachyderm/v2/src/internal/ppsutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
@@ -485,7 +486,7 @@ func (d *driver) detectZombie(ctx context.Context, outputCommit *pfs.Commit, cb 
 		if err != nil {
 			return err
 		}
-		_, metaFS, err := d.openCommit(ctx, ppsutil.MetaCommit(outputCommit))
+		_, metaFS, err := d.openCommit(ctx, pfsutil.MetaCommit(outputCommit))
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -43,6 +43,7 @@ type Env struct {
 	PachwInSidecar    bool
 }
 
+// TODO: move this to serviceenv
 func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) (*Env, error) {
 	// Setup etcd, object storage, and database clients.
 	objClient, err := obj.NewClient(env.Context(), env.Config().StorageBackend, env.Config().StorageRoot)

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -34,7 +34,7 @@ type Env struct {
 	Listener     col.PostgresListener
 
 	AuthServer authserver.APIServer
-	PPS        PPS
+	GetPPS     func() PPS
 	// TODO: remove this, the load tests need a pachClient
 	GetPachClient func(ctx context.Context) *client.APIClient
 
@@ -64,7 +64,7 @@ func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv)
 		TaskService:  env.GetTaskService(etcdPrefix),
 
 		AuthServer:    env.AuthServer(),
-		PPS:           env.PpsServer(),
+		GetPPS:        func() PPS { return env.PpsServer() },
 		GetPachClient: env.GetPachClient,
 
 		BackgroundContext: pctx.Child(env.Context(), "PFS"),

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -19,7 +19,7 @@ import (
 	etcd "go.etcd.io/etcd/client/v3"
 )
 
-type PPS interface {
+type PipelineInspector interface {
 	InspectPipelineInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
 }
 
@@ -33,8 +33,8 @@ type Env struct {
 	TxnEnv       *txnenv.TransactionEnv
 	Listener     col.PostgresListener
 
-	AuthServer authserver.APIServer
-	GetPPS     func() PPS
+	AuthServer           authserver.APIServer
+	GetPipelineInspector func() PipelineInspector
 	// TODO: remove this, the load tests need a pachClient
 	GetPachClient func(ctx context.Context) *client.APIClient
 
@@ -63,9 +63,9 @@ func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv)
 		EtcdClient:   env.GetEtcdClient(),
 		TaskService:  env.GetTaskService(etcdPrefix),
 
-		AuthServer:    env.AuthServer(),
-		GetPPS:        func() PPS { return env.PpsServer() },
-		GetPachClient: env.GetPachClient,
+		AuthServer:           env.AuthServer(),
+		GetPipelineInspector: func() PipelineInspector { return env.PpsServer() },
+		GetPachClient:        env.GetPachClient,
 
 		BackgroundContext: pctx.Child(env.Context(), "PFS"),
 		StorageConfig:     env.Config().StorageConfiguration,


### PR DESCRIPTION
This eliminates one of the cycles that emerges when `serviceenv` depends on `pfsserver`.  There is another involving transactionenv.