### PR TITLE
Move archiveserver to a general "PachHTTP" server

### DIFF
--- a/etc/generate-envoy-config/envoy-tls.jsonnet
+++ b/etc/generate-envoy-config/envoy-tls.jsonnet
@@ -16,7 +16,7 @@ Envoy.bootstrap(
     Envoy.httpsListener(
       port=8443,
       name='proxy-https',
-      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-archive', 'console'])
+      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-http', 'console'])
     ),
 
     // Unlike the cleartext configuration, we don't serve direct routes to individual pachd/console

--- a/etc/generate-envoy-config/envoy.jsonnet
+++ b/etc/generate-envoy-config/envoy.jsonnet
@@ -9,7 +9,7 @@ Envoy.bootstrap(
       name='proxy-http',
       // Everything except the metrics service is served on the multiplexed route.  The order of
       // services' routes is important!
-      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-archive', 'console'])
+      routes=std.flatMap(function(name) Services[name].routes, ['pachd-grpc', 'pachd-s3', 'pachd-identity', 'pachd-oidc', 'pachd-http', 'console'])
     ),
 
     // In case someone port-forwards port 8443 because they were expecting TLS to be working, this

--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -123,7 +123,7 @@
       no_traffic_healthy_interval: '10s',
     },
   },
-  'pachd-archive': {
+  'pachd-http': {
     internal_port: 1659,
     service: 'pachd-proxy-backend',
     routes: [
@@ -132,7 +132,7 @@
           prefix: '/archive',
         },
         route: {
-          cluster: 'pachd-archive',
+          cluster: 'pachd-http',
           idle_timeout: '600s',
           timeout: '604800s',
         },

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -205,54 +205,6 @@
             "dns_refresh_rate": "5s",
             "health_checks": [
                {
-                  "healthy_threshold": 1,
-                  "http_health_check": {
-                     "host": "localhost",
-                     "path": "/healthz"
-                  },
-                  "interval": "30s",
-                  "no_traffic_healthy_interval": "10s",
-                  "no_traffic_interval": "10s",
-                  "timeout": "10s",
-                  "unhealthy_threshold": 2
-               }
-            ],
-            "lb_policy": "random",
-            "load_assignment": {
-               "cluster_name": "pachd-archive",
-               "endpoints": [
-                  {
-                     "lb_endpoints": [
-                        {
-                           "endpoint": {
-                              "address": {
-                                 "socket_address": {
-                                    "address": "pachd-proxy-backend",
-                                    "port_value": 1659
-                                 }
-                              }
-                           }
-                        }
-                     ]
-                  }
-               ]
-            },
-            "name": "pachd-archive",
-            "type": "strict_dns",
-            "upstream_connection_options": {
-               "tcp_keepalive": { }
-            }
-         },
-         {
-            "connect_timeout": "10s",
-            "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
-            },
-            "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
-            "health_checks": [
-               {
                   "grpc_health_check": { },
                   "healthy_threshold": 1,
                   "interval": "10s",
@@ -292,6 +244,54 @@
                   }
                }
             },
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/healthz"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-http",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1659
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-http",
+            "type": "strict_dns",
             "upstream_connection_options": {
                "tcp_keepalive": { }
             }
@@ -812,7 +812,7 @@
                                              "prefix": "/archive"
                                           },
                                           "route": {
-                                             "cluster": "pachd-archive",
+                                             "cluster": "pachd-http",
                                              "idle_timeout": "600s",
                                              "timeout": "604800s"
                                           }

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -205,54 +205,6 @@
             "dns_refresh_rate": "5s",
             "health_checks": [
                {
-                  "healthy_threshold": 1,
-                  "http_health_check": {
-                     "host": "localhost",
-                     "path": "/healthz"
-                  },
-                  "interval": "30s",
-                  "no_traffic_healthy_interval": "10s",
-                  "no_traffic_interval": "10s",
-                  "timeout": "10s",
-                  "unhealthy_threshold": 2
-               }
-            ],
-            "lb_policy": "random",
-            "load_assignment": {
-               "cluster_name": "pachd-archive",
-               "endpoints": [
-                  {
-                     "lb_endpoints": [
-                        {
-                           "endpoint": {
-                              "address": {
-                                 "socket_address": {
-                                    "address": "pachd-proxy-backend",
-                                    "port_value": 1659
-                                 }
-                              }
-                           }
-                        }
-                     ]
-                  }
-               ]
-            },
-            "name": "pachd-archive",
-            "type": "strict_dns",
-            "upstream_connection_options": {
-               "tcp_keepalive": { }
-            }
-         },
-         {
-            "connect_timeout": "10s",
-            "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
-            },
-            "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
-            "health_checks": [
-               {
                   "grpc_health_check": { },
                   "healthy_threshold": 1,
                   "interval": "10s",
@@ -292,6 +244,54 @@
                   }
                }
             },
+            "upstream_connection_options": {
+               "tcp_keepalive": { }
+            }
+         },
+         {
+            "connect_timeout": "10s",
+            "dns_failure_refresh_rate": {
+               "base_interval": "0.05s",
+               "max_interval": "0.1s"
+            },
+            "dns_lookup_family": "V4_ONLY",
+            "dns_refresh_rate": "5s",
+            "health_checks": [
+               {
+                  "healthy_threshold": 1,
+                  "http_health_check": {
+                     "host": "localhost",
+                     "path": "/healthz"
+                  },
+                  "interval": "30s",
+                  "no_traffic_healthy_interval": "10s",
+                  "no_traffic_interval": "10s",
+                  "timeout": "10s",
+                  "unhealthy_threshold": 2
+               }
+            ],
+            "lb_policy": "random",
+            "load_assignment": {
+               "cluster_name": "pachd-http",
+               "endpoints": [
+                  {
+                     "lb_endpoints": [
+                        {
+                           "endpoint": {
+                              "address": {
+                                 "socket_address": {
+                                    "address": "pachd-proxy-backend",
+                                    "port_value": 1659
+                                 }
+                              }
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "name": "pachd-http",
+            "type": "strict_dns",
             "upstream_connection_options": {
                "tcp_keepalive": { }
             }
@@ -683,7 +683,7 @@
                                              "prefix": "/archive"
                                           },
                                           "route": {
-                                             "cluster": "pachd-archive",
+                                             "cluster": "pachd-http",
                                              "idle_timeout": "600s",
                                              "timeout": "604800s"
                                           }
@@ -1766,7 +1766,7 @@
                            "duration_ms": "%DURATION%",
                            "grpc_message": "%RESP(GRPC-MESSAGE):64%",
                            "grpc_status_code": "%GRPC_STATUS(SNAKE_STRING)%",
-                           "listener": "direct-pachd-archive",
+                           "listener": "direct-pachd-http",
                            "message": "listener log",
                            "method": "%REQ(:method)%",
                            "pachctl_command": "%REQ(COMMAND):64%",
@@ -1896,7 +1896,7 @@
                                              "prefix": "/archive"
                                           },
                                           "route": {
-                                             "cluster": "pachd-archive",
+                                             "cluster": "pachd-http",
                                              "idle_timeout": "600s",
                                              "timeout": "604800s"
                                           }
@@ -1905,7 +1905,7 @@
                                  }
                               ]
                            },
-                           "stat_prefix": "direct-pachd-archive",
+                           "stat_prefix": "direct-pachd-http",
                            "stream_idle_timeout": "86400s",
                            "use_remote_address": true
                         }
@@ -1913,7 +1913,7 @@
                   ]
                }
             ],
-            "name": "direct-pachd-archive",
+            "name": "direct-pachd-http",
             "per_connection_buffer_limit_bytes": 32768,
             "traffic_direction": "INBOUND"
          },

--- a/src/internal/archiveserver/archiveserver.go
+++ b/src/internal/archiveserver/archiveserver.go
@@ -15,18 +15,18 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/pachyderm/pachyderm/v2/src/constants"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
+	"github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth/httpauth"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"go.uber.org/zap"
 )
 
 // Server is an http.Handler that can download archives of PFS files.
 type Server struct {
-	pachClientFactory func(context.Context) *client.APIClient
+	ClientFactory func(context.Context) *client.APIClient
 }
 
 // ServeHTTP implements http.Handler for the /archive/ route.
@@ -35,13 +35,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if got, want := req.Method, http.MethodGet; got != want {
 		log.Debug(ctx, "invalid method", zap.String("method", got))
 		http.Error(w, fmt.Sprintf("method not supported; got %v, want %v", got, want), http.StatusMethodNotAllowed)
-		return
-	}
-
-	pachClient, err := s.pachClientFromRequest(ctx, req)
-	if err != nil {
-		log.Info(ctx, "problem extracting auth token from request", zap.Error(err))
-		http.Error(w, fmt.Sprintf("problem extracting auth token from request: %v", err), http.StatusBadRequest)
 		return
 	}
 
@@ -58,6 +51,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, fmt.Sprintf("unknown archive format %v requested; only .zip is supported", string(got)), http.StatusBadRequest)
 		return
 	}
+
+	pachClient := s.pachClientFromRequest(ctx, req)
 	if err := s.downloadZip(pachClient.Ctx(), w, pachClient, archive); err != nil {
 		log.Info(ctx, "problem encountered mid-download", zap.Error(err))
 		return
@@ -67,22 +62,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 // pachClientFromRequest uses the server's pachClientFactory to create a pach client with the
 // authentication material in the request.
-func (s *Server) pachClientFromRequest(ctx context.Context, req *http.Request) (*client.APIClient, error) {
-	c := s.pachClientFactory(ctx)
-	if token := req.URL.Query().Get(constants.ContextTokenKey); token != "" {
-		log.Debug(ctx, "using authn-token from URL query", zap.Int("len", len(token)))
-		c.SetAuthToken(token)
-		return c, nil
-	}
-	if token := req.Header.Get(constants.ContextTokenKey); token != "" {
-		log.Debug(ctx, "using authn-token from HTTP header", zap.Int("len", len(token)))
-		c.SetAuthToken(token)
-		return c, nil
-	}
-	return c, nil
+func (s *Server) pachClientFromRequest(ctx context.Context, req *http.Request) *client.APIClient {
+	return httpauth.ClientWithToken(ctx, s.ClientFactory(ctx), req)
 }
 
-// writeFlusher is an io.Writer that flushes the http.Fluher after every write.  It's intended to
+// writeFlusher is an io.Writer that flushes the http.Flusher after every write.  It's intended to
 // back a bufio.Writer to implement reasonable-sized response chunking.
 type writeFlusher struct {
 	io.Writer

--- a/src/internal/middleware/auth/httpauth/httpauth.go
+++ b/src/internal/middleware/auth/httpauth/httpauth.go
@@ -1,0 +1,28 @@
+// Package httpauth extracts auth information from an HTTP request.
+package httpauth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pachyderm/pachyderm/v2/src/constants"
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"go.uber.org/zap"
+)
+
+// ClientWithToken extracts an auth token from the HTTP request (special header or query parameter),
+// and returns a Pach client that will use that token for future requests.
+func ClientWithToken(ctx context.Context, c *client.APIClient, req *http.Request) *client.APIClient {
+	if token := req.URL.Query().Get(constants.ContextTokenKey); token != "" {
+		log.Debug(ctx, "using authn-token from URL query", zap.Int("len", len(token)))
+		c.SetAuthToken(token)
+		return c
+	}
+	if token := req.Header.Get(constants.ContextTokenKey); token != "" {
+		log.Debug(ctx, "using authn-token from HTTP header", zap.Int("len", len(token)))
+		c.SetAuthToken(token)
+		return c
+	}
+	return c
+}

--- a/src/internal/pachd/builder.go
+++ b/src/internal/pachd/builder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	debugclient "github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/identity"
-	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
@@ -43,6 +42,7 @@ import (
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
 	debugserver "github.com/pachyderm/pachyderm/v2/src/server/debug/server"
 	eprsserver "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
+	"github.com/pachyderm/pachyderm/v2/src/server/http"
 	identity_server "github.com/pachyderm/pachyderm/v2/src/server/identity/server"
 	licenseserver "github.com/pachyderm/pachyderm/v2/src/server/license/server"
 	pachw "github.com/pachyderm/pachyderm/v2/src/server/pachw/server"
@@ -382,8 +382,8 @@ func (b *builder) initS3Server(ctx context.Context) error {
 	return nil
 }
 
-func (b *builder) initDownloadServer(ctx context.Context) error {
-	b.daemon.download = archiveserver.NewHTTP(b.env.Config().DownloadPort, b.env.GetPachClient)
+func (b *builder) initPachHTTPServer(ctx context.Context) error {
+	b.daemon.pachhttp = http.New(b.env.Config().DownloadPort, b.env.GetPachClient)
 	return nil
 }
 

--- a/src/internal/pachd/daemon.go
+++ b/src/internal/pachd/daemon.go
@@ -25,11 +25,11 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	pachhttp "github.com/pachyderm/pachyderm/v2/src/server/http"
 )
 
 // daemon is a Pachyderm daemon.
@@ -38,7 +38,7 @@ type daemon struct {
 	internal, external *grpcutil.Server
 	s3                 *s3Server
 	prometheus         *prometheusServer
-	download           *archiveserver.HTTP
+	pachhttp           *pachhttp.Server
 
 	// configuration
 	criticalServersOnly bool
@@ -68,8 +68,8 @@ func (d *daemon) serve(ctx context.Context) (err error) {
 	if d.prometheus != nil {
 		eg.Go(maybeIgnoreErrorFunc(ctx, "Prometheus Server", !d.criticalServersOnly, func() error { return d.prometheus.listenAndServe(ctx, 10*time.Second) }))
 	}
-	if d.download != nil {
-		eg.Go(maybeIgnoreErrorFunc(ctx, "Download Server", true, func() error { return d.download.ListenAndServe(ctx) }))
+	if d.pachhttp != nil {
+		eg.Go(maybeIgnoreErrorFunc(ctx, "PachHTTP Server", true, func() error { return d.pachhttp.ListenAndServe(ctx) }))
 	}
 	eg.Go(func() error {
 		<-ctx.Done() // wait for main context to complete

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -88,7 +88,7 @@ func (fb *fullBuilder) buildAndRun(ctx context.Context) error {
 		fb.registerDebugServer,
 		fb.registerProxyServer,
 		fb.initS3Server,
-		fb.initDownloadServer,
+		fb.initPachHTTPServer,
 		fb.initPrometheusServer,
 		fb.initPachwController,
 

--- a/src/server/cmd/pachhttp/main.go
+++ b/src/server/cmd/pachhttp/main.go
@@ -1,17 +1,16 @@
-// Command local-download-server runs the PFS download server locally, against your current pachctl
-// context.
+// Command pachhttp runs the Pachyderm HTTP server locally, against your current pachctl context.
 package main
 
 import (
 	"context"
 	"os/signal"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachctl"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
+	"github.com/pachyderm/pachyderm/v2/src/server/http"
 	"go.uber.org/zap"
 )
 
@@ -26,9 +25,9 @@ func main() {
 	if err != nil {
 		log.Exit(ctx, "problem creating pachyderm client", zap.Error(err))
 	}
-	http := archiveserver.NewHTTP(1659, func(ctx context.Context) *client.APIClient { return c.WithCtx(ctx) })
-	log.Info(ctx, "starting server")
-	if err := http.ListenAndServe(ctx); err != nil {
+	s := http.New(1659, func(ctx context.Context) *client.APIClient { return c.WithCtx(ctx) })
+	log.Info(ctx, "starting server on port 1659")
+	if err := s.ListenAndServe(ctx); err != nil {
 		log.Exit(ctx, "problem running http server", zap.Error(err))
 	}
 }

--- a/src/server/http/http.go
+++ b/src/server/http/http.go
@@ -1,4 +1,10 @@
-package archiveserver
+// Package http is a browser-targeted HTTP server for Pachyderm.  It includes what used to be called
+// the "archive server" (for /archive/ downloads) and the "file server" (for /pfs/ downloads).  Any
+// future user-facing HTTP services should be added here.
+//
+// The general design here is for the servers to be relatively untrusted.  They build a PachClient
+// based on the HTTP request, and then make ordinary API calls.
+package http
 
 import (
 	"context"
@@ -6,30 +12,36 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"go.uber.org/zap"
 )
 
-// HTTP is an http.Server that serves the archiveserver endpoints.
-type HTTP struct {
+// Server is an http.Server that serves public requests.
+type Server struct {
 	mux    http.Handler // For testing.
 	server *http.Server // For ListenAndServe.
 }
 
-// NewHTTP creates a new Archive Server and an HTTP server to serve it on.
-func NewHTTP(port uint16, pachClientFactory func(ctx context.Context) *client.APIClient) *HTTP {
+// New creates a new API server, with an http.Server to actually serve traffic.
+func New(port uint16, pachClientFactory func(ctx context.Context) *client.APIClient) *Server {
 	mux := http.NewServeMux()
-	handler := &Server{
-		pachClientFactory: pachClientFactory,
+
+	// Archive server.
+	handler := &archiveserver.Server{
+		ClientFactory: pachClientFactory,
 	}
 	mux.Handle("/archive/", CSRFWrapper(handler))
+
+	// Health check.
 	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("healthy\n")) //nolint:errcheck
 	}))
-	return &HTTP{
+
+	return &Server{
 		mux: mux,
 		server: &http.Server{
 			Addr:    fmt.Sprintf(":%d", port),
@@ -82,7 +94,7 @@ func CSRFWrapper(h http.Handler) http.HandlerFunc {
 
 // ListenAndServe begins serving the server, and returns when the context is canceled or the server
 // dies on its own.
-func (h *HTTP) ListenAndServe(ctx context.Context) error {
+func (h *Server) ListenAndServe(ctx context.Context) error {
 	log.AddLoggerToHTTPServer(ctx, "download", h.server)
 	errCh := make(chan error, 1)
 	go func() {

--- a/src/server/http/http.go
+++ b/src/server/http/http.go
@@ -95,14 +95,14 @@ func CSRFWrapper(h http.Handler) http.HandlerFunc {
 // ListenAndServe begins serving the server, and returns when the context is canceled or the server
 // dies on its own.
 func (h *Server) ListenAndServe(ctx context.Context) error {
-	log.AddLoggerToHTTPServer(ctx, "download", h.server)
+	log.AddLoggerToHTTPServer(ctx, "pachhttp", h.server)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- h.server.ListenAndServe()
 	}()
 	select {
 	case <-ctx.Done():
-		log.Info(ctx, "terminating download server", zap.Error(context.Cause(ctx)))
+		log.Info(ctx, "terminating pachhttp server", zap.Error(context.Cause(ctx)))
 		return errors.EnsureStack(h.server.Shutdown(ctx))
 	case err := <-errCh:
 		return err

--- a/src/server/http/http_test.go
+++ b/src/server/http/http_test.go
@@ -1,12 +1,53 @@
-package archiveserver
+package http
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 )
+
+func TestRouting(t *testing.T) {
+	testData := []struct {
+		name     string
+		method   string
+		url      string
+		wantCode int
+	}{
+		{
+			name:     "not found",
+			method:   "GET",
+			url:      "http://pachyderm.example.com/",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "health",
+			method:   "GET",
+			url:      "http://pachyderm.example.com/healthz",
+			wantCode: http.StatusOK,
+		},
+	}
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := pctx.TestContext(t)
+			s := New(0, func(ctx context.Context) *client.APIClient { return nil })
+			log.AddLoggerToHTTPServer(ctx, test.name, s.server)
+
+			req := httptest.NewRequest(test.method, test.url, nil)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			s.server.Handler.ServeHTTP(rec, req)
+			if got, want := rec.Code, test.wantCode; got != want {
+				t.Errorf("response code:\n  got: %v\n want: %v", got, want)
+			}
+		})
+	}
+}
 
 func TestCSRFWrapper(t *testing.T) {
 	testData := []struct {


### PR DESCRIPTION
In another PR, I'm adding a `/pfs` endpoint and refactored the HTTP functionality to be more general.  This PR is that refactoring, so that it can be used for `grpc-gateway` work.