### PR TITLE
[Python-SDK] Catch serialization errors

### DIFF
--- a/python-sdk/pachyderm_sdk/interceptor.py
+++ b/python-sdk/pachyderm_sdk/interceptor.py
@@ -2,11 +2,11 @@
 Implementation of a gRPC interceptor used to set request metadata
 and catch connection errors.
 """
-
 from os import environ
-from typing import Any, Callable, Sequence, Optional, Tuple, Union
+from typing import Callable, Sequence, Optional, Tuple, Union, cast
 
 import grpc
+from betterproto import Message
 from grpc_interceptor import ClientCallDetails, ClientInterceptor
 
 from .errors import AuthServiceNotActivated
@@ -18,18 +18,34 @@ class MetadataClientInterceptor(ClientInterceptor):
     def __init__(self, metadata: MetadataType):
         self.metadata = metadata
 
-    def intercept(self, method: Callable, request: Any, call_details: ClientCallDetails):
+    def intercept(
+        self, method: Callable, request: Message, call_details: ClientCallDetails
+    ):
         call_details_metadata = list(call_details.metadata or [])
         call_details_metadata.extend(self.metadata)
         new_details = call_details._replace(metadata=call_details_metadata)
-        future = method(request, new_details)
-        future.add_done_callback(_check_connection_error)
+
+        # Error handling happens different depending on whether the response
+        #   is Unary or Stream. If the response is a stream, then the error
+        #   will be raised before the "done_callback" is called and will
+        #   therefore be caught by the try-except block. If the response is
+        #   Unary then the error "done_callback" will be called before the
+        #   error is raised.
+        try:
+            future = method(request, new_details)
+            future.add_done_callback(lambda f: _check_errors(f, request))
+        except grpc.RpcError as error:
+            # gRPC error types are confusing - instantiated errors are Futures.
+            # ref: github.com/grpc/grpc/issues/25334#issuecomment-772730080
+            error = cast(error, grpc.Future)
+            _check_errors(error, request)
         return future
 
 
-def _check_connection_error(grpc_future: grpc.Future):
+def _check_errors(grpc_future: grpc.Future, request: Message):
     """Callback function that checks if a gRPC.Future experienced a
-    ConnectionError and attempt to sanitize the error message for the user.
+    ConnectionError or TypeError and attempt to sanitize the error
+    message for the user.
     """
     error: Optional[grpc.Call] = grpc_future.exception()
     if error is not None:
@@ -43,4 +59,14 @@ def _check_connection_error(grpc_future: grpc.Future):
                     " python_pachyderm within the pipeline. "
                 )
             raise ConnectionError(error_message) from error
+        unable_to_serialize = "Exception serializing request" in error.details()
+        if error.code() == grpc.StatusCode.INTERNAL and unable_to_serialize:
+            error_message = (
+                "An error occurred while trying to serialize the following"
+                f" {request.__class__.__qualname__} message.\n "
+                " This is most likely due to one of the fields of"
+                " this message having a value with an incorrect type.\n"
+                f"\tMessage: {request}"
+            )
+            raise TypeError(error_message) from error
         raise AuthServiceNotActivated.try_from(error)

--- a/python-sdk/pachyderm_sdk/interceptor.py
+++ b/python-sdk/pachyderm_sdk/interceptor.py
@@ -33,13 +33,14 @@ class MetadataClientInterceptor(ClientInterceptor):
         #   error is raised.
         try:
             future = method(request, new_details)
-            future.add_done_callback(lambda f: _check_errors(f, request))
         except grpc.RpcError as error:
             # gRPC error types are confusing - instantiated errors are Futures.
             # ref: github.com/grpc/grpc/issues/25334#issuecomment-772730080
             error = cast(error, grpc.Future)
             _check_errors(error, request)
-        return future
+        else:
+            future.add_done_callback(lambda f: _check_errors(f, request))
+            return future
 
 
 def _check_errors(grpc_future: grpc.Future, request: Message):

--- a/python-sdk/tests/test_interceptor.py
+++ b/python-sdk/tests/test_interceptor.py
@@ -18,10 +18,12 @@ def test_bad_connection():
     client = TestClient(nodeid="test_bad_connection", port=9999)
     with pytest.raises(ConnectionError):
         client.get_version()
+
     # Catching a Connection Error from a stream is flaky - sometimes a
     #   grpc.RpcError is raised as expected and other times a
     #   grpc._channel._MultiThreadedRendezvous is raised in a code path
     #   that the interceptor cannot catch.
     from grpc._channel import _MultiThreadedRendezvous
+
     with pytest.raises((ConnectionError, _MultiThreadedRendezvous)):
         list(client.pfs.list_repo())

--- a/python-sdk/tests/test_interceptor.py
+++ b/python-sdk/tests/test_interceptor.py
@@ -1,0 +1,27 @@
+"""Tests for the gRPC interceptor callback."""
+from tests.fixtures import *
+
+
+def test_bad_serialization(client: TestClient):
+    """Test that errors that occur during message serialization are
+    caught and explained to the user."""
+    # Our interceptor raises TypeError from grpc.RpcError.
+    with pytest.raises(TypeError):
+        client.pfs.inspect_repo(repo="banana")  # Field `repo` should be a Repo.
+    with pytest.raises(TypeError):
+        list(client.pfs.list_repo(type=True))  # Field `type` should be a string.
+
+
+def test_bad_connection():
+    """Test that errors which occur due to a failure to connect to
+    the server are explained to the user."""
+    client = TestClient(nodeid="test_bad_connection", port=9999)
+    with pytest.raises(ConnectionError):
+        client.get_version()
+    # Catching a Connection Error from a stream is flaky - sometimes a
+    #   grpc.RpcError is raised as expected and other times a
+    #   grpc._channel._MultiThreadedRendezvous is raised in a code path
+    #   that the interceptor cannot catch.
+    from grpc._channel import _MultiThreadedRendezvous
+    with pytest.raises((ConnectionError, _MultiThreadedRendezvous)):
+        list(client.pfs.list_repo())


### PR DESCRIPTION
We now catch serialization errors and convert the unintuitive error message into something more understandable to the average user. Example (description field has a value to `True`):
```
TypeError: An error occurred while trying to serialize the following CreateRepoRequest message.
  This is most likely due to one of the fields of this message having a value with an incorrect type.
	Message: CreateRepoRequest(repo=Repo(name='sertest', type='user', project=Project(name='default')), description=True, update=False)
```

In writing the test for this feature I discovered that the current interceptor didn't catch errors from a streamed response. In fixing this, I also discovered that catching is connection error from a streamed response is flaky but I could not find a more robust method for doing so. 

[INT-1074] -- To be backported to v2.7.x

[INT-1074]: https://pachyderm.atlassian.net/browse/INT-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ