### PR TITLE
pachctl: misc generate-download-url: show a full clickable link if the server knows its address

### DIFF
--- a/src/server/cmd/pachctl/cmd/cmd.go
+++ b/src/server/cmd/pachctl/cmd/cmd.go
@@ -860,7 +860,7 @@ This resets the cluster to its initial state.`,
 	subcommands = append(subcommands, configcmds.Cmds(mainCtx, pachctlCfg)...)
 	subcommands = append(subcommands, configcmds.ConnectCmds(mainCtx, pachctlCfg)...)
 	subcommands = append(subcommands, taskcmds.Cmds(mainCtx, pachctlCfg)...)
-	subcommands = append(subcommands, misccmds.Cmds(mainCtx)...)
+	subcommands = append(subcommands, misccmds.Cmds(mainCtx, pachctlCfg)...)
 
 	cmdutil.MergeCommands(rootCmd, subcommands)
 

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -11,10 +11,12 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/admin"
 	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -145,7 +147,7 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 
 			var info *admin.ClusterInfo
 			getPrefix := func() error {
-				c, err := pachctlCfg.NewOnUserMachine(ctx, false)
+				c, err := pachctlCfg.NewOnUserMachine(ctx, false, client.WithDialTimeout(time.Second))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
A while back we added a proxy_host and proxy_tls field to InspectCluster, populated from the helm chart.  With that, we can generate the full download URL from `pachctl misc generate-download-url`:

```
$ go run ./src/server/cmd/pachctl misc generate-download-url images@master:/
http://192.168.1.70/archive/ASi1L_0EAIEAAGltYWdlc0BtYXN0ZXI6LwDjg9sf.zip
```
If the server isn't around and doesn't have that field set, we just output the `ASi1L_...` part as we did before.