### PR TITLE
[Python-SDK] fix incorrect argument type for debug.dump

### DIFF
--- a/python-sdk/pachyderm_sdk/api/debug/extension.py
+++ b/python-sdk/pachyderm_sdk/api/debug/extension.py
@@ -1,4 +1,5 @@
 """Handwritten classes/methods that augment the existing Debug API."""
+from datetime import timedelta
 from typing import Iterator, List, Optional, TYPE_CHECKING
 
 from . import DebugStub
@@ -16,7 +17,7 @@ class ApiStub(DebugStub):
         system: "System" = None,
         pipelines: Optional[List["Pipeline"]] = None,
         input_repos: bool = False,
-        timeout: int = 0,
+        timeout: timedelta = 0,
     ) -> Iterator["DumpChunk"]:
         """Collect a standard set of debugging information using the DumpV2 API
           rather than the now deprecated Dump API.

--- a/python-sdk/tests/test_debug.py
+++ b/python-sdk/tests/test_debug.py
@@ -6,7 +6,7 @@ from pachyderm_sdk.api import debug
 
 
 def test_dump(client: TestClient):
-    message = next(client.debug.dump())
+    message = next(client.debug.dump(timeout=timedelta(seconds=10)))
     assert isinstance(message.content.content, bytes)
     assert message.progress.progress > 0
 


### PR DESCRIPTION
The debug proto was changed before we noticed. The new codeownership rules should allow us to catch changes like this before they introduce bugs.