### PR TITLE
[Console]: update readiness and liveness probe endpoints

### DIFF
--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -177,7 +177,7 @@
       healthy_threshold: 1,
       http_health_check: {
         host: 'localhost',  // This is just the value of the Host: header, not something to connect to.
-        path: '/',
+        path: '/health',
       },
       interval: '30s',
       timeout: '10s',

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -160,7 +160,7 @@
                   "healthy_threshold": 1,
                   "http_health_check": {
                      "host": "localhost",
-                     "path": "/"
+                     "path": "/health"
                   },
                   "interval": "30s",
                   "no_traffic_healthy_interval": "10s",

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -160,7 +160,7 @@
                   "healthy_threshold": 1,
                   "http_health_check": {
                      "host": "localhost",
-                     "path": "/"
+                     "path": "/health"
                   },
                   "interval": "30s",
                   "no_traffic_healthy_interval": "10s",

--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
+            path: /health
             port: console-http
             scheme: HTTP
           periodSeconds: 10
@@ -53,7 +53,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
+            path: /health
             port: console-http
             scheme: HTTP
           periodSeconds: 10


### PR DESCRIPTION
Console now has a `/health` endpoint on master that returns `200` instead of loading the whole page at `/`