### PR TITLE
proxy: discover endpoints before k8s health check passes

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -805,7 +805,7 @@ jobs:
             find . -maxdepth 10 -name \*.jsonnet | xargs jsonnet-lint
   test-envoy:
     docker:
-      - image: envoyproxy/envoy:v1.25.5
+      - image: envoyproxy/envoy:v1.27.0
         entrypoint: /bin/sh
     steps:
       - run: apt update
@@ -1585,7 +1585,7 @@ jobs:
 
             # Wait for Label Studio server to start
             timeout=300
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/api/projects -H "Authorization: Token $LABEL_STUDIO_USER_TOKEN")" != "200" ]]; do 
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/api/projects -H "Authorization: Token $LABEL_STUDIO_USER_TOKEN")" != "200" ]]; do
               timeout=$((timeout - 5))
               if [ $timeout -eq 0 ]; then
                 echo "Timed out waiting for Label Studio"

--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -187,6 +187,11 @@
           },
         },
       ],
+      access_log_options: {
+        access_log_flush_interval: '10s',  // This prints information about ongoing connections every 10s.
+        flush_access_log_on_new_request: true,
+        flush_log_on_tunnel_successfully_established: true,
+      },
       codec_type: 'auto',
       common_http_protocol_options: {
         headers_with_underscores_action: 'REJECT_REQUEST',

--- a/etc/generate-envoy-config/envoy.libsonnet
+++ b/etc/generate-envoy-config/envoy.libsonnet
@@ -368,15 +368,20 @@
   defaultCluster:: {
     connect_timeout: '10s',
     dns_lookup_family: 'V4_ONLY',
-    dns_refresh_rate: '5s',
+    dns_refresh_rate: '1s',
     dns_failure_refresh_rate: {
-      base_interval: '0.05s',
-      max_interval: '0.1s',
+      base_interval: '0.1s',
+      max_interval: '1s',
     },
     lb_policy: 'random',
     type: 'strict_dns',
     upstream_connection_options: {
       tcp_keepalive: {},
+    },
+    common_lb_config: {
+      healthy_panic_threshold: {
+        value: 0.0,
+      },
     },
   },
 

--- a/etc/generate-envoy-config/pachyderm-services.libsonnet
+++ b/etc/generate-envoy-config/pachyderm-services.libsonnet
@@ -22,7 +22,7 @@
       interval: '10s',
       timeout: '10s',
       unhealthy_threshold: 2,
-      no_traffic_interval: '10s',
+      no_traffic_interval: '1s',
       no_traffic_healthy_interval: '10s',
     },
   },

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -148,13 +148,18 @@
    "static_resources": {
       "clusters": [
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -196,13 +201,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "grpc_health_check": { },
@@ -249,13 +259,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -297,13 +312,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -345,13 +365,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [ ],
             "lb_policy": "random",
             "load_assignment": {
@@ -380,13 +405,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -428,13 +458,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [ ],
             "lb_policy": "random",
             "load_assignment": {

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -219,7 +219,7 @@
                   "healthy_threshold": 1,
                   "interval": "10s",
                   "no_traffic_healthy_interval": "10s",
-                  "no_traffic_interval": "10s",
+                  "no_traffic_interval": "1s",
                   "timeout": "10s",
                   "unhealthy_threshold": 2
                }

--- a/etc/helm/pachyderm/envoy-tls.json
+++ b/etc/helm/pachyderm/envoy-tls.json
@@ -604,6 +604,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -725,6 +730,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -968,6 +978,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -148,13 +148,18 @@
    "static_resources": {
       "clusters": [
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -196,13 +201,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "grpc_health_check": { },
@@ -249,13 +259,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -297,13 +312,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -345,13 +365,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [ ],
             "lb_policy": "random",
             "load_assignment": {
@@ -380,13 +405,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [
                {
                   "healthy_threshold": 1,
@@ -428,13 +458,18 @@
             }
          },
          {
+            "common_lb_config": {
+               "healthy_panic_threshold": {
+                  "value": 0
+               }
+            },
             "connect_timeout": "10s",
             "dns_failure_refresh_rate": {
-               "base_interval": "0.05s",
-               "max_interval": "0.1s"
+               "base_interval": "0.1s",
+               "max_interval": "1s"
             },
             "dns_lookup_family": "V4_ONLY",
-            "dns_refresh_rate": "5s",
+            "dns_refresh_rate": "1s",
             "health_checks": [ ],
             "lb_policy": "random",
             "load_assignment": {

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -604,6 +604,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -860,6 +865,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -1027,6 +1037,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -1219,6 +1234,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -1393,6 +1413,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -1559,6 +1584,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -1725,6 +1755,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -1891,6 +1926,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",
@@ -2057,6 +2097,11 @@
                                  }
                               }
                            ],
+                           "access_log_options": {
+                              "access_log_flush_interval": "10s",
+                              "flush_access_log_on_new_request": true,
+                              "flush_log_on_tunnel_successfully_established": true
+                           },
                            "codec_type": "auto",
                            "common_http_protocol_options": {
                               "headers_with_underscores_action": "REJECT_REQUEST",

--- a/etc/helm/pachyderm/envoy.json
+++ b/etc/helm/pachyderm/envoy.json
@@ -219,7 +219,7 @@
                   "healthy_threshold": 1,
                   "interval": "10s",
                   "no_traffic_healthy_interval": "10s",
-                  "no_traffic_interval": "10s",
+                  "no_traffic_interval": "1s",
                   "timeout": "10s",
                   "unhealthy_threshold": 2
                }

--- a/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
+++ b/etc/helm/pachyderm/templates/proxy/console-proxy-backend-service.yaml
@@ -13,6 +13,7 @@ metadata:
   name: console-proxy-backend
   namespace: {{ .Release.Namespace }}
 spec:
+  publishNotReadyAddresses: true
   ports:
   - name: console-http
     port: 4000

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1218,7 +1218,7 @@ proxy:
   # The envoy image to pull.
   image:
     repository: "envoyproxy/envoy-distroless"
-    tag: "v1.25.5"
+    tag: "v1.27.0"
     pullPolicy: "IfNotPresent"
   # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's
   # a resonable memory limit.  It doesn't need much CPU.

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -126,7 +126,7 @@ func DoOAuthExchange(t testing.TB, pachClient, enterpriseClient *client.APIClien
 	c.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	require.NoErrorWithinTRetry(t, 2*time.Minute, func() error {
+	require.NoErrorWithinTRetryConstant(t, 2*time.Minute, func() error {
 		// Get the initial URL from the grpc, which should point to the dex login page
 		resp, err := c.Get(RewriteURL(t, loginURL, DexHost(enterpriseClient)))
 		if err != nil {
@@ -168,7 +168,7 @@ func DoOAuthExchange(t testing.TB, pachClient, enterpriseClient *client.APIClien
 			return errors.Wrapf(err, "after login redirect status code got %v want %v", got, want)
 		}
 		return nil
-	}, "failed DoOAuthExchange")
+	}, time.Second, "failed DoOAuthExchange")
 }
 
 func GetOIDCTokenForTrustedApp(t testing.TB, testClient *client.APIClient, unitTest bool) string {

--- a/src/internal/testutil/identity.go
+++ b/src/internal/testutil/identity.go
@@ -121,54 +121,59 @@ func DoOAuthExchange(t testing.TB, pachClient, enterpriseClient *client.APIClien
 	// We rewrite the host names for each redirect to avoid issues because
 	// pachd is configured to reach dex with kube dns, but the tests might be
 	// outside the cluster.
+	require.NoErrorWithinTRetryConstant(t, 2*time.Minute, func() error {
+		return DoOAuthExchangeOnce(t, pachClient, enterpriseClient, loginURL)
+	}, time.Second, "failed DoOAuthExchange")
+}
+
+func DoOAuthExchangeOnce(t testing.TB, pachClient, enterpriseClient *client.APIClient, loginURL string) error {
 	c := NewLoggingHTTPClient(t)
 	c.Timeout = 15 * time.Second
 	c.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	require.NoErrorWithinTRetryConstant(t, 2*time.Minute, func() error {
-		// Get the initial URL from the grpc, which should point to the dex login page
-		resp, err := c.Get(RewriteURL(t, loginURL, DexHost(enterpriseClient)))
-		if err != nil {
-			return errors.Wrap(err, "getting dex login page")
-		}
-		if got, want := resp.StatusCode, http.StatusFound; got != want {
-			return errors.Wrapf(err, "getting dex login page status code got %v want %v", got, want)
-		}
-		// Dex login redirects to the provider page, which will generate it's own state
-		resp, err = c.Get(RewriteRedirect(t, resp, DexHost(enterpriseClient)))
-		if err != nil {
-			return errors.Wrap(err, "getting dex login redirect")
-		}
-		if got, want := resp.StatusCode, http.StatusFound; got != want {
-			return errors.Wrapf(err, "getting dex login redirect status code got %v want %v", got, want)
-		}
 
-		// Because we've only configured username/password login, there's a redirect
-		// to the login page. The params have the session state. POST our hard-coded
-		// credentials to the login page.
-		vals := make(url.Values)
-		vals.Add("login", "admin")
-		vals.Add("password", "password")
+	// Get the initial URL from the grpc, which should point to the dex login page
+	resp, err := c.Get(RewriteURL(t, loginURL, DexHost(enterpriseClient)))
+	if err != nil {
+		return errors.Wrap(err, "getting dex login page")
+	}
+	if got, want := resp.StatusCode, http.StatusFound; got != want {
+		return errors.Wrapf(err, "getting dex login page status code got %v want %v", got, want)
+	}
+	// Dex login redirects to the provider page, which will generate it's own state
+	resp, err = c.Get(RewriteRedirect(t, resp, DexHost(enterpriseClient)))
+	if err != nil {
+		return errors.Wrap(err, "getting dex login redirect")
+	}
+	if got, want := resp.StatusCode, http.StatusFound; got != want {
+		return errors.Wrapf(err, "getting dex login redirect status code got %v want %v", got, want)
+	}
 
-		resp, err = c.PostForm(RewriteRedirect(t, resp, DexHost(enterpriseClient)), vals)
-		if err != nil {
-			return errors.Wrap(err, "posting dex login creds")
-		}
-		if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
-			return errors.Wrapf(err, "login status code got %v want %v", got, want)
-		}
+	// Because we've only configured username/password login, there's a redirect
+	// to the login page. The params have the session state. POST our hard-coded
+	// credentials to the login page.
+	vals := make(url.Values)
+	vals.Add("login", "admin")
+	vals.Add("password", "password")
 
-		// Follow the resulting redirect back to pachd to complete the flow
-		resp, err = c.Get(RewriteRedirect(t, resp, pachHost(pachClient)))
-		if err != nil {
-			return errors.Wrap(err, "getting redirect back to pachyderm")
-		}
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			return errors.Wrapf(err, "after login redirect status code got %v want %v", got, want)
-		}
-		return nil
-	}, time.Second, "failed DoOAuthExchange")
+	resp, err = c.PostForm(RewriteRedirect(t, resp, DexHost(enterpriseClient)), vals)
+	if err != nil {
+		return errors.Wrap(err, "posting dex login creds")
+	}
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		return errors.Wrapf(err, "login status code got %v want %v", got, want)
+	}
+
+	// Follow the resulting redirect back to pachd to complete the flow
+	resp, err = c.Get(RewriteRedirect(t, resp, pachHost(pachClient)))
+	if err != nil {
+		return errors.Wrap(err, "getting redirect back to pachyderm")
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		return errors.Wrapf(err, "after login redirect status code got %v want %v", got, want)
+	}
+	return nil
 }
 
 func GetOIDCTokenForTrustedApp(t testing.TB, testClient *client.APIClient, unitTest bool) string {

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -5,9 +5,11 @@ package cmds
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
@@ -15,6 +17,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/minikubetestenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
@@ -117,20 +120,38 @@ func TestLogin(t *testing.T) {
 	// Configure OIDC login
 	require.NoError(t, tu.ConfigureOIDCProvider(t, tu.AuthenticateClient(t, c, auth.RootUser), false))
 
-	cmd := tu.PachctlBashCmd(t, c, "echo '' | pachctl auth use-auth-token && pachctl auth login --no-browser")
-	out, err := cmd.StdoutPipe()
-	require.NoError(t, err)
-
-	c = tu.UnauthenticatedPachClient(t, c)
-	require.NoError(t, cmd.Start())
-	sc := bufio.NewScanner(out)
-	for sc.Scan() {
-		if strings.HasPrefix(strings.TrimSpace(sc.Text()), "http://") {
-			tu.DoOAuthExchange(t, c, c, sc.Text())
-			break
+	require.NoErrorWithinTRetryConstant(t, 5*time.Minute, func() error {
+		defer func() {
+			if err := recover(); err != nil {
+				t.Logf("retrying because of panic: %v", err)
+			}
+		}()
+		ctx, done := context.WithTimeout(pctx.Background("auth.login"), 30*time.Second)
+		defer done()
+		cmd := tu.PachctlBashCmdCtx(ctx, t, c, "echo '' | pachctl auth use-auth-token && pachctl auth login --no-browser")
+		out, err := cmd.StdoutPipe()
+		if err != nil {
+			return errors.Wrap(err, "StdoutPipe")
 		}
-	}
-	require.NoError(t, cmd.Wait())
+
+		c = tu.UnauthenticatedPachClient(t, c)
+		if err := cmd.Start(); err != nil {
+			return errors.Wrap(err, "cmd.Start")
+		}
+		sc := bufio.NewScanner(out)
+		for sc.Scan() {
+			if strings.HasPrefix(strings.TrimSpace(sc.Text()), "http://") {
+				url := sc.Text()
+				t.Logf("doing OAuth exchange against %v", url)
+				tu.DoOAuthExchange(t, c, c, url)
+				break
+			}
+		}
+		if err := cmd.Wait(); err != nil {
+			return errors.Wrap(err, "cmd.Wait")
+		}
+		return nil
+	}, time.Second, "should pachctl auth login")
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
 		pachctl auth whoami | match user:{{.user}}`,
 		"user", tu.DexMockConnectorEmail,
@@ -224,7 +245,7 @@ func TestCheckGetSetProject(t *testing.T) {
 		pachctl auth get project {{.project}} | match projectOwner
 		pachctl auth set project {{.project}} repoReader,projectOwner pach:root
 		pachctl auth get project {{.project}} | match projectOwner | match repoReader
-	
+
 		pachctl auth get robot-auth-token {{.alice}}
 		pachctl auth check project {{.project}} {{.alice}} | match "Roles: \[\]"
 		pachctl auth set project {{.project}} projectOwner {{.alice}}

--- a/src/server/proxy_test.go
+++ b/src/server/proxy_test.go
@@ -187,6 +187,10 @@ func deployFakeConsole(t *testing.T, ns string) {
 
 			access_log  /dev/stdout  main;
 
+			location /health {
+			    return 200 'ok';
+			    add_header Content-Type text/plain;
+			}
 			location / {
 			    root   /usr/share/nginx/html;
 			    index  index.html;


### PR DESCRIPTION
This change publishes k8s endpoints for pachd/console pods as soon as they start, instead of as soon as they pass the readiness check.  This avoids 3 loops; k8s polling for readiness, envoy polling for DNS records existing, envoy polling the readiness.  Instead, the envoy DNS poll returns endpoints as soon as the pod starts, and then it starts health checking the pod every 1s.  This should make traffic route to the proxy much sooner.

I also turned down DNS error handling polls to a more reasonable interval.

Finally, I adjusted the panic threshold so that unhealthy backends are unlikely to be selected.  (Envoy enters "panic mode" when a certain % of backends are unhealthy; in panic mode, health is ignored.  The idea is to prevent cascading failure when under too-high load (broken backends get some of the load this way), but I don't think we care about that.  Rather, we'd prefer additional load on the healthy replica over returning an error response.) 