### PR TITLE
Djanicek/core 1773/test spout

### DIFF
--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -702,20 +702,6 @@ func (c *APIClient) Close() error {
 // Use with caution, there is no undo.
 // TODO: rewrite this to use transactions
 func (c APIClient) DeleteAll() error {
-	if jobs, err := c.ListJob("", "", []*pfs.Commit{}, 0, false); err == nil {
-		for _, job := range jobs {
-			if _, err := c.WaitCommit(
-				job.OutputCommit.Repo.Project.Name,
-				job.OutputCommit.Repo.Name,
-				job.OutputCommit.Branch.Name,
-				job.OutputCommit.Id,
-			); err != nil {
-				log.Info(c.Ctx(), "Waiting for commits to finish before delete all", zap.Error(err))
-			}
-		}
-	} else {
-		return grpcutil.ScrubGRPC(err)
-	}
 	if _, err := c.IdentityAPIClient.DeleteAll(
 		c.Ctx(),
 		&identity.DeleteAllRequest{},

--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -702,6 +702,20 @@ func (c *APIClient) Close() error {
 // Use with caution, there is no undo.
 // TODO: rewrite this to use transactions
 func (c APIClient) DeleteAll() error {
+	if jobs, err := c.ListJob("", "", []*pfs.Commit{}, 0, false); err == nil {
+		for _, job := range jobs {
+			if _, err := c.WaitCommit(
+				job.OutputCommit.Repo.Project.Name,
+				job.OutputCommit.Repo.Name,
+				job.OutputCommit.Branch.Name,
+				job.OutputCommit.Id,
+			); err != nil {
+				log.Info(c.Ctx(), "Waiting for commits to finish before delete all", zap.Error(err))
+			}
+		}
+	} else {
+		return grpcutil.ScrubGRPC(err)
+	}
 	if _, err := c.IdentityAPIClient.DeleteAll(
 		c.Ctx(),
 		&identity.DeleteAllRequest{},

--- a/src/internal/obj/testsuite.go
+++ b/src/internal/obj/testsuite.go
@@ -55,7 +55,7 @@ func TestSuite(t *testing.T, newClient func(t testing.TB) Client) {
 	t.Run("TestIntegrity", func(t *testing.T) {
 		t.Parallel()
 		client := newClient(t)
-		name := "prefix/test-object"
+		name := randutil.UniqueString("prefix/test-object")
 		expectedData, err := io.ReadAll(io.LimitReader(rand.Reader, 1<<20))
 		require.NoError(t, err)
 		expectedHash := pachhash.Sum(expectedData)

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -288,6 +288,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 			}
 			return nil
 		}))
+		c.WaitCommitSetAll(jobInfos[0].OutputCommit.Id)
 		require.NoError(t, c.DeleteAll())
 	})
 

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -280,7 +280,8 @@ func testSpout(t *testing.T, usePachctl bool) {
 		// 	})
 		// require.NoError(t, err)
 		// require.Equal(t, 3, len(commitInfo.Subvenance))
-
+		_, err = c.WaitCommitSetAll(jobInfos[0].OutputCommit.Id)
+		require.NoError(t, err)
 		// finally, let's make sure that the provenance is in a consistent state after running the spout test
 		require.NoError(t, c.Fsck(false, func(resp *pfs.FsckResponse) error {
 			if resp.Error != "" {
@@ -288,8 +289,7 @@ func testSpout(t *testing.T, usePachctl bool) {
 			}
 			return nil
 		}))
-		_, err = c.WaitCommitSetAll(jobInfos[0].OutputCommit.Id)
-		require.NoError(t, err)
+
 		require.NoError(t, c.DeleteAll())
 	})
 

--- a/src/server/spout_test.go
+++ b/src/server/spout_test.go
@@ -288,7 +288,8 @@ func testSpout(t *testing.T, usePachctl bool) {
 			}
 			return nil
 		}))
-		c.WaitCommitSetAll(jobInfos[0].OutputCommit.Id)
+		_, err = c.WaitCommitSetAll(jobInfos[0].OutputCommit.Id)
+		require.NoError(t, err)
 		require.NoError(t, c.DeleteAll())
 	})
 


### PR DESCRIPTION
Test spout is one of our most commonly failing tests. Running locally I wa able to reproduce therror pretty easily, luckily. It looks like DeleteAll is being called while a commit is finishing. Since DeleteAll force deletes everything I believe this leaves us with the dangling commit errors. This PR waits until commits are done before deleting and I have not seen the error locally since I added it.

Note, because of how these tests are structured, a failed DeleteAll early on tends to cascade into the rest of these tests since they all reuse the same cluster throughout the test series.