### PR TITLE
Generate documentation from protos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 src/internal/jsonschema/*/*.schema.json linguist-generated=true
+proto-docs.json linguist-generated=true
+proto-docs.md linguist-generated=true

--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -30,6 +30,9 @@ RUN go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschem
 # Install protoc-gen-validate.
 RUN go install github.com/envoyproxy/protoc-gen-validate@v1.0.2
 
+# Install protoc-gen-doc.
+RUN go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
 # Build the bespoke Pachyderm codegen plugin.
 COPY pachgen ${GOPATH}/src/github.com/pachyderm/pachyderm/etc/proto/pachgen
 WORKDIR ${GOPATH}/src/github.com/pachyderm/pachyderm/etc/proto/pachgen

--- a/etc/proto/run.sh
+++ b/etc/proto/run.sh
@@ -34,6 +34,8 @@ protoc \
     -Isrc \
     --plugin=protoc-gen-zap="${GOPATH}/bin/protoc-gen-zap" \
     --plugin=protoc-gen-pach="${GOPATH}/bin/protoc-gen-pach" \
+    --plugin=protoc-gen-doc="${GOPATH}/bin/protoc-gen-doc" \
+    --plugin=protoc-gen-doc2="${GOPATH}/bin/protoc-gen-doc" \
     --plugin="${GOPATH}/bin/protoc-gen-jsonschema" \
     --plugin="${GOPATH}/bin/protoc-gen-validate" \
     --zap_out=":${GOPATH}/src" \
@@ -42,6 +44,8 @@ protoc \
     --go-grpc_out=":${GOPATH}/src" \
     --jsonschema_out="${GOPATH}/src/github.com/pachyderm/pachyderm/v2/src/internal/jsonschema" \
     --validate_out="lang=go,paths=:${GOPATH}/src" \
+    --doc_out="${GOPATH}/src/github.com/pachyderm/pachyderm/v2" \
+    --doc2_out="${GOPATH}/src/github.com/pachyderm/pachyderm/v2" \
     --jsonschema_opt="enforce_oneof" \
     --jsonschema_opt="file_extension=schema.json" \
     --jsonschema_opt="disallow_additional_properties" \
@@ -49,6 +53,8 @@ protoc \
     --jsonschema_opt="disallow_bigints_as_strings" \
     --jsonschema_opt="prefix_schema_files_with_package" \
     --jsonschema_opt="proto_and_json_fieldnames" \
+    --doc_opt="json,proto-docs.json" \
+    --doc2_opt="markdown,proto-docs.md" \
     "${PROTOS[@]}" > /dev/stderr
 
 pushd v2 > /dev/stderr
@@ -57,4 +63,4 @@ gopatch ./... -p=/proto.patch
 popd > /dev/stderr
 
 gofmt -w . > /dev/stderr
-find . -regextype egrep -regex ".*[.](go|schema.json)$" -print0 | xargs -0 tar cf -
+find . -regextype egrep -regex ".*[.](go|json|md)$" -print0 | xargs -0 tar cf -

--- a/proto-docs.json
+++ b/proto-docs.json
@@ -1,0 +1,25665 @@
+{
+  "files": [
+    {
+      "name": "admin/admin.proto",
+      "description": "",
+      "package": "admin_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ClusterInfo",
+          "longName": "ClusterInfo",
+          "fullName": "admin_v2.ClusterInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "deployment_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "warnings_ok",
+              "description": "True if the server is capable of generating warnings.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "warnings",
+              "description": "Warnings about the client configuration.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "proxy_host",
+              "description": "The configured public URL of Pachyderm.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "proxy_tls",
+              "description": "True if Pachyderm is served over TLS (HTTPS).",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paused",
+              "description": "True if this pachd is in \"paused\" mode.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "web_resources",
+              "description": "Any HTTP links that the client might want to be aware of.",
+              "label": "",
+              "type": "WebResource",
+              "longType": "WebResource",
+              "fullType": "admin_v2.WebResource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectClusterRequest",
+          "longName": "InspectClusterRequest",
+          "fullName": "admin_v2.InspectClusterRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "client_version",
+              "description": "The version of the client that's connecting; used by the server to warn about too-old (or\ntoo-new!) clients.",
+              "label": "",
+              "type": "Version",
+              "longType": "versionpb_v2.Version",
+              "fullType": "versionpb_v2.Version",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "current_project",
+              "description": "If CurrentProject is set, then InspectCluster will return an error if the\nproject does not exist.",
+              "label": "",
+              "type": "Project",
+              "longType": "pfs_v2.Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WebResource",
+          "longName": "WebResource",
+          "fullName": "admin_v2.WebResource",
+          "description": "WebResource contains URL prefixes of common HTTP functions.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "archive_download_base_url",
+              "description": "The base URL of the archive server; append a filename to this.  Empty if the archive server is\nnot exposed.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "create_pipeline_request_json_schema_url",
+              "description": "Where to find the CreatePipelineRequest JSON schema; if this server is not accessible via a\nURL, then a link to Github is provided based on the baked-in version of the server.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "admin_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "InspectCluster",
+              "description": "",
+              "requestType": "InspectClusterRequest",
+              "requestLongType": "InspectClusterRequest",
+              "requestFullType": "admin_v2.InspectClusterRequest",
+              "requestStreaming": false,
+              "responseType": "ClusterInfo",
+              "responseLongType": "ClusterInfo",
+              "responseFullType": "admin_v2.ClusterInfo",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "auth/auth.proto",
+      "description": "",
+      "package": "auth_v2",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "Permission",
+          "longName": "Permission",
+          "fullName": "auth_v2.Permission",
+          "description": "Permission represents the ability to perform a given operation on a Resource",
+          "values": [
+            {
+              "name": "PERMISSION_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_MODIFY_BINDINGS",
+              "number": "100",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_GET_BINDINGS",
+              "number": "101",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_GET_PACHD_LOGS",
+              "number": "148",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_GET_LOKI_LOGS",
+              "number": "150",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_ACTIVATE",
+              "number": "102",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_DEACTIVATE",
+              "number": "103",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_GET_CONFIG",
+              "number": "104",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_SET_CONFIG",
+              "number": "105",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_GET_ROBOT_TOKEN",
+              "number": "139",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_MODIFY_GROUP_MEMBERS",
+              "number": "109",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_GET_GROUPS",
+              "number": "110",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_GET_GROUP_USERS",
+              "number": "111",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_EXTRACT_TOKENS",
+              "number": "112",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_RESTORE_TOKEN",
+              "number": "113",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_GET_PERMISSIONS_FOR_PRINCIPAL",
+              "number": "141",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_DELETE_EXPIRED_TOKENS",
+              "number": "140",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_REVOKE_USER_TOKENS",
+              "number": "142",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_AUTH_ROTATE_ROOT_TOKEN",
+              "number": "147",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_ENTERPRISE_ACTIVATE",
+              "number": "114",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_ENTERPRISE_HEARTBEAT",
+              "number": "115",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_ENTERPRISE_GET_CODE",
+              "number": "116",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_ENTERPRISE_DEACTIVATE",
+              "number": "117",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_ENTERPRISE_PAUSE",
+              "number": "149",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_SET_CONFIG",
+              "number": "118",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_GET_CONFIG",
+              "number": "119",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_CREATE_IDP",
+              "number": "120",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_UPDATE_IDP",
+              "number": "121",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_LIST_IDPS",
+              "number": "122",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_GET_IDP",
+              "number": "123",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_DELETE_IDP",
+              "number": "124",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_CREATE_OIDC_CLIENT",
+              "number": "125",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_UPDATE_OIDC_CLIENT",
+              "number": "126",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_LIST_OIDC_CLIENTS",
+              "number": "127",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_GET_OIDC_CLIENT",
+              "number": "128",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_IDENTITY_DELETE_OIDC_CLIENT",
+              "number": "129",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_DEBUG_DUMP",
+              "number": "131",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_LICENSE_ACTIVATE",
+              "number": "132",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_LICENSE_GET_CODE",
+              "number": "133",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_LICENSE_ADD_CLUSTER",
+              "number": "134",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_LICENSE_UPDATE_CLUSTER",
+              "number": "135",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_LICENSE_DELETE_CLUSTER",
+              "number": "136",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_LICENSE_LIST_CLUSTERS",
+              "number": "137",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_CREATE_SECRET",
+              "number": "143",
+              "description": "TODO(actgardner): Make k8s secrets into nouns and add an Update RPC"
+            },
+            {
+              "name": "CLUSTER_LIST_SECRETS",
+              "number": "144",
+              "description": ""
+            },
+            {
+              "name": "SECRET_DELETE",
+              "number": "145",
+              "description": ""
+            },
+            {
+              "name": "SECRET_INSPECT",
+              "number": "146",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_DELETE_ALL",
+              "number": "138",
+              "description": ""
+            },
+            {
+              "name": "REPO_READ",
+              "number": "200",
+              "description": ""
+            },
+            {
+              "name": "REPO_WRITE",
+              "number": "201",
+              "description": ""
+            },
+            {
+              "name": "REPO_MODIFY_BINDINGS",
+              "number": "202",
+              "description": ""
+            },
+            {
+              "name": "REPO_DELETE",
+              "number": "203",
+              "description": ""
+            },
+            {
+              "name": "REPO_INSPECT_COMMIT",
+              "number": "204",
+              "description": ""
+            },
+            {
+              "name": "REPO_LIST_COMMIT",
+              "number": "205",
+              "description": ""
+            },
+            {
+              "name": "REPO_DELETE_COMMIT",
+              "number": "206",
+              "description": ""
+            },
+            {
+              "name": "REPO_CREATE_BRANCH",
+              "number": "207",
+              "description": ""
+            },
+            {
+              "name": "REPO_LIST_BRANCH",
+              "number": "208",
+              "description": ""
+            },
+            {
+              "name": "REPO_DELETE_BRANCH",
+              "number": "209",
+              "description": ""
+            },
+            {
+              "name": "REPO_INSPECT_FILE",
+              "number": "210",
+              "description": ""
+            },
+            {
+              "name": "REPO_LIST_FILE",
+              "number": "211",
+              "description": ""
+            },
+            {
+              "name": "REPO_ADD_PIPELINE_READER",
+              "number": "212",
+              "description": ""
+            },
+            {
+              "name": "REPO_REMOVE_PIPELINE_READER",
+              "number": "213",
+              "description": ""
+            },
+            {
+              "name": "REPO_ADD_PIPELINE_WRITER",
+              "number": "214",
+              "description": ""
+            },
+            {
+              "name": "PIPELINE_LIST_JOB",
+              "number": "301",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER_SET_DEFAULTS",
+              "number": "302",
+              "description": "CLUSTER_SET_DEFAULTS is part of PPS."
+            },
+            {
+              "name": "PROJECT_CREATE",
+              "number": "400",
+              "description": ""
+            },
+            {
+              "name": "PROJECT_DELETE",
+              "number": "401",
+              "description": ""
+            },
+            {
+              "name": "PROJECT_LIST_REPO",
+              "number": "402",
+              "description": ""
+            },
+            {
+              "name": "PROJECT_CREATE_REPO",
+              "number": "403",
+              "description": ""
+            },
+            {
+              "name": "PROJECT_MODIFY_BINDINGS",
+              "number": "404",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "ResourceType",
+          "longName": "ResourceType",
+          "fullName": "auth_v2.ResourceType",
+          "description": "ResourceType represents the type of a Resource",
+          "values": [
+            {
+              "name": "RESOURCE_TYPE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "CLUSTER",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "REPO",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "SPEC_REPO",
+              "number": "3",
+              "description": ""
+            },
+            {
+              "name": "PROJECT",
+              "number": "4",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ActivateRequest",
+          "longName": "ActivateRequest",
+          "fullName": "auth_v2.ActivateRequest",
+          "description": "ActivateRequest enables authentication on the cluster. It issues an auth token\nwith no expiration for the irrevocable admin user `pach:root`.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "root_token",
+              "description": "If set, this token is used as the root user login token. Otherwise the root token\nis randomly generated and returned in the response.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ActivateResponse",
+          "longName": "ActivateResponse",
+          "fullName": "auth_v2.ActivateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pach_token",
+              "description": "pach_token authenticates the caller with Pachyderm (if you want to perform\nPachyderm operations after auth has been activated as themselves, you must\npresent this token along with your regular request)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AuthenticateRequest",
+          "longName": "AuthenticateRequest",
+          "fullName": "auth_v2.AuthenticateRequest",
+          "description": "Exactly one of 'id_token' or 'one_time_password' must be set:",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "oidc_state",
+              "description": "This is the session state that Pachyderm creates in order to keep track of\ninformation related to the current OIDC session.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id_token",
+              "description": "This is an ID Token issued by the OIDC provider.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AuthenticateResponse",
+          "longName": "AuthenticateResponse",
+          "fullName": "auth_v2.AuthenticateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pach_token",
+              "description": "pach_token authenticates the caller with Pachyderm (if you want to perform\nPachyderm operations after auth has been activated as themselves, you must\npresent this token along with your regular request)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AuthorizeRequest",
+          "longName": "AuthorizeRequest",
+          "fullName": "auth_v2.AuthorizeRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "resource",
+              "description": "",
+              "label": "",
+              "type": "Resource",
+              "longType": "Resource",
+              "fullType": "auth_v2.Resource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "permissions",
+              "description": "permissions are the operations the caller is attempting to perform",
+              "label": "repeated",
+              "type": "Permission",
+              "longType": "Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AuthorizeResponse",
+          "longName": "AuthorizeResponse",
+          "fullName": "auth_v2.AuthorizeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "authorized",
+              "description": "authorized is true if the caller has the require permissions",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "satisfied",
+              "description": "satisfied is the set of permission that the principal has",
+              "label": "repeated",
+              "type": "Permission",
+              "longType": "Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "missing",
+              "description": "missing is the set of permissions that the principal lacks",
+              "label": "repeated",
+              "type": "Permission",
+              "longType": "Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "principal",
+              "description": "principal is the principal the request was evaluated for",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeactivateRequest",
+          "longName": "DeactivateRequest",
+          "fullName": "auth_v2.DeactivateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeactivateResponse",
+          "longName": "DeactivateResponse",
+          "fullName": "auth_v2.DeactivateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteExpiredAuthTokensRequest",
+          "longName": "DeleteExpiredAuthTokensRequest",
+          "fullName": "auth_v2.DeleteExpiredAuthTokensRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteExpiredAuthTokensResponse",
+          "longName": "DeleteExpiredAuthTokensResponse",
+          "fullName": "auth_v2.DeleteExpiredAuthTokensResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ExtractAuthTokensRequest",
+          "longName": "ExtractAuthTokensRequest",
+          "fullName": "auth_v2.ExtractAuthTokensRequest",
+          "description": "ExtractAuthTokens returns all the hashed robot tokens that have been issued.\nUser tokens are not extracted as they can be recreated by logging in.",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ExtractAuthTokensResponse",
+          "longName": "ExtractAuthTokensResponse",
+          "fullName": "auth_v2.ExtractAuthTokensResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tokens",
+              "description": "",
+              "label": "repeated",
+              "type": "TokenInfo",
+              "longType": "TokenInfo",
+              "fullType": "auth_v2.TokenInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetConfigurationRequest",
+          "longName": "GetConfigurationRequest",
+          "fullName": "auth_v2.GetConfigurationRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetConfigurationResponse",
+          "longName": "GetConfigurationResponse",
+          "fullName": "auth_v2.GetConfigurationResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "configuration",
+              "description": "",
+              "label": "",
+              "type": "OIDCConfig",
+              "longType": "OIDCConfig",
+              "fullType": "auth_v2.OIDCConfig",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetGroupsForPrincipalRequest",
+          "longName": "GetGroupsForPrincipalRequest",
+          "fullName": "auth_v2.GetGroupsForPrincipalRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "principal",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetGroupsRequest",
+          "longName": "GetGroupsRequest",
+          "fullName": "auth_v2.GetGroupsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetGroupsResponse",
+          "longName": "GetGroupsResponse",
+          "fullName": "auth_v2.GetGroupsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "groups",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetOIDCLoginRequest",
+          "longName": "GetOIDCLoginRequest",
+          "fullName": "auth_v2.GetOIDCLoginRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetOIDCLoginResponse",
+          "longName": "GetOIDCLoginResponse",
+          "fullName": "auth_v2.GetOIDCLoginResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "login_url",
+              "description": "The login URL generated for the OIDC object",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetPermissionsForPrincipalRequest",
+          "longName": "GetPermissionsForPrincipalRequest",
+          "fullName": "auth_v2.GetPermissionsForPrincipalRequest",
+          "description": "GetPermissionsForPrincipal evaluates an arbitrary principal's permissions\non a resource",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "resource",
+              "description": "",
+              "label": "",
+              "type": "Resource",
+              "longType": "Resource",
+              "fullType": "auth_v2.Resource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "principal",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetPermissionsRequest",
+          "longName": "GetPermissionsRequest",
+          "fullName": "auth_v2.GetPermissionsRequest",
+          "description": "GetPermissions evaluates the current user's permissions on a resource",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "resource",
+              "description": "",
+              "label": "",
+              "type": "Resource",
+              "longType": "Resource",
+              "fullType": "auth_v2.Resource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetPermissionsResponse",
+          "longName": "GetPermissionsResponse",
+          "fullName": "auth_v2.GetPermissionsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "permissions",
+              "description": "permissions is the set of permissions the principal has",
+              "label": "repeated",
+              "type": "Permission",
+              "longType": "Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "roles",
+              "description": "roles is the set of roles the principal has",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetRobotTokenRequest",
+          "longName": "GetRobotTokenRequest",
+          "fullName": "auth_v2.GetRobotTokenRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "robot",
+              "description": "The returned token will allow the caller to access resources as this\nrobot user",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ttl",
+              "description": "ttl indicates the requested (approximate) remaining lifetime of this token,\nin seconds",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetRobotTokenResponse",
+          "longName": "GetRobotTokenResponse",
+          "fullName": "auth_v2.GetRobotTokenResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "token",
+              "description": "A new auth token for the requested robot",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetRoleBindingRequest",
+          "longName": "GetRoleBindingRequest",
+          "fullName": "auth_v2.GetRoleBindingRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "resource",
+              "description": "",
+              "label": "",
+              "type": "Resource",
+              "longType": "Resource",
+              "fullType": "auth_v2.Resource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetRoleBindingResponse",
+          "longName": "GetRoleBindingResponse",
+          "fullName": "auth_v2.GetRoleBindingResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "binding",
+              "description": "",
+              "label": "",
+              "type": "RoleBinding",
+              "longType": "RoleBinding",
+              "fullType": "auth_v2.RoleBinding",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetRolesForPermissionRequest",
+          "longName": "GetRolesForPermissionRequest",
+          "fullName": "auth_v2.GetRolesForPermissionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "permission",
+              "description": "",
+              "label": "",
+              "type": "Permission",
+              "longType": "Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetRolesForPermissionResponse",
+          "longName": "GetRolesForPermissionResponse",
+          "fullName": "auth_v2.GetRolesForPermissionResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "roles",
+              "description": "",
+              "label": "repeated",
+              "type": "Role",
+              "longType": "Role",
+              "fullType": "auth_v2.Role",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetUsersRequest",
+          "longName": "GetUsersRequest",
+          "fullName": "auth_v2.GetUsersRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "group",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetUsersResponse",
+          "longName": "GetUsersResponse",
+          "fullName": "auth_v2.GetUsersResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "usernames",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Groups",
+          "longName": "Groups",
+          "fullName": "auth_v2.Groups",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "groups",
+              "description": "",
+              "label": "repeated",
+              "type": "GroupsEntry",
+              "longType": "Groups.GroupsEntry",
+              "fullType": "auth_v2.Groups.GroupsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GroupsEntry",
+          "longName": "Groups.GroupsEntry",
+          "fullName": "auth_v2.Groups.GroupsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ModifyMembersRequest",
+          "longName": "ModifyMembersRequest",
+          "fullName": "auth_v2.ModifyMembersRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "group",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "add",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "remove",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ModifyMembersResponse",
+          "longName": "ModifyMembersResponse",
+          "fullName": "auth_v2.ModifyMembersResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ModifyRoleBindingRequest",
+          "longName": "ModifyRoleBindingRequest",
+          "fullName": "auth_v2.ModifyRoleBindingRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "resource",
+              "description": "resource is the resource to modify the role bindings on",
+              "label": "",
+              "type": "Resource",
+              "longType": "Resource",
+              "fullType": "auth_v2.Resource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "principal",
+              "description": "principal is the principal to modify the roles binding for",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "roles",
+              "description": "roles is the set of roles for principal - an empty list\nremoves all role bindings",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ModifyRoleBindingResponse",
+          "longName": "ModifyRoleBindingResponse",
+          "fullName": "auth_v2.ModifyRoleBindingResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "OIDCConfig",
+          "longName": "OIDCConfig",
+          "fullName": "auth_v2.OIDCConfig",
+          "description": "Configure Pachyderm's auth system with an OIDC provider",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "issuer",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "client_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "client_secret",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "redirect_uri",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "scopes",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "require_email_verified",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "localhost_issuer",
+              "description": "localhost_issuer ignores the contents of the issuer claim and makes all\nOIDC requests to the embedded OIDC provider. This is necessary to support\nsome network configurations like Minikube.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user_accessible_issuer_host",
+              "description": "user_accessible_issuer_host can be set to override the host used\nin the OAuth2 authorization URL in case the OIDC issuer isn't\naccessible outside the cluster. This requires a fully formed URL with scheme of either http or https.\nThis is necessary to support some configurations like Minikube.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Resource",
+          "longName": "Resource",
+          "fullName": "auth_v2.Resource",
+          "description": "Resource represents any resource that has role-bindings in the system",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "ResourceType",
+              "longType": "ResourceType",
+              "fullType": "auth_v2.ResourceType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RestoreAuthTokenRequest",
+          "longName": "RestoreAuthTokenRequest",
+          "fullName": "auth_v2.RestoreAuthTokenRequest",
+          "description": "RestoreAuthToken inserts a hashed token that has previously been extracted.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "token",
+              "description": "",
+              "label": "",
+              "type": "TokenInfo",
+              "longType": "TokenInfo",
+              "fullType": "auth_v2.TokenInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "RestoreAuthTokenResponse",
+          "longName": "RestoreAuthTokenResponse",
+          "fullName": "auth_v2.RestoreAuthTokenResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "RevokeAuthTokenRequest",
+          "longName": "RevokeAuthTokenRequest",
+          "fullName": "auth_v2.RevokeAuthTokenRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RevokeAuthTokenResponse",
+          "longName": "RevokeAuthTokenResponse",
+          "fullName": "auth_v2.RevokeAuthTokenResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "number",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RevokeAuthTokensForUserRequest",
+          "longName": "RevokeAuthTokensForUserRequest",
+          "fullName": "auth_v2.RevokeAuthTokensForUserRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "username",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RevokeAuthTokensForUserResponse",
+          "longName": "RevokeAuthTokensForUserResponse",
+          "fullName": "auth_v2.RevokeAuthTokensForUserResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "number",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Role",
+          "longName": "Role",
+          "fullName": "auth_v2.Role",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "permissions",
+              "description": "",
+              "label": "repeated",
+              "type": "Permission",
+              "longType": "Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "can_be_bound_to",
+              "description": "Resources this role can be bound to.  For example, you can't apply clusterAdmin to a repo, so\nREPO would not be listed here.",
+              "label": "repeated",
+              "type": "ResourceType",
+              "longType": "ResourceType",
+              "fullType": "auth_v2.ResourceType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "returned_for",
+              "description": "Resources this role is returned for.  For example, a principal might have clusterAdmin\npermissions on the cluster, and this is what allows them to write to a repo.  So, clusterAdmin\nis returned for the repo, even though it cannot be bound to a repo.",
+              "label": "repeated",
+              "type": "ResourceType",
+              "longType": "ResourceType",
+              "fullType": "auth_v2.ResourceType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RoleBinding",
+          "longName": "RoleBinding",
+          "fullName": "auth_v2.RoleBinding",
+          "description": "RoleBinding represents the set of roles principals have on a given Resource",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "entries",
+              "description": "principal -\u003e roles. All principal names include the structured prefix indicating their type.",
+              "label": "repeated",
+              "type": "EntriesEntry",
+              "longType": "RoleBinding.EntriesEntry",
+              "fullType": "auth_v2.RoleBinding.EntriesEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EntriesEntry",
+          "longName": "RoleBinding.EntriesEntry",
+          "fullName": "auth_v2.RoleBinding.EntriesEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "Roles",
+              "longType": "Roles",
+              "fullType": "auth_v2.Roles",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Roles",
+          "longName": "Roles",
+          "fullName": "auth_v2.Roles",
+          "description": "Roles represents the set of roles a principal has",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "roles",
+              "description": "",
+              "label": "repeated",
+              "type": "RolesEntry",
+              "longType": "Roles.RolesEntry",
+              "fullType": "auth_v2.Roles.RolesEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RolesEntry",
+          "longName": "Roles.RolesEntry",
+          "fullName": "auth_v2.Roles.RolesEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RotateRootTokenRequest",
+          "longName": "RotateRootTokenRequest",
+          "fullName": "auth_v2.RotateRootTokenRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "root_token",
+              "description": "root_token is used as the new root token value. If it's unset, then a token will be auto-generated.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RotateRootTokenResponse",
+          "longName": "RotateRootTokenResponse",
+          "fullName": "auth_v2.RotateRootTokenResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "root_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SessionInfo",
+          "longName": "SessionInfo",
+          "fullName": "auth_v2.SessionInfo",
+          "description": "SessionInfo stores information associated with one OIDC authentication\nsession (i.e. a single instance of a single user logging in). Sessions are\nshort-lived and stored in the 'oidc-authns' collection, keyed by the OIDC\n'state' token (30-character CSPRNG-generated string). 'GetOIDCLogin'\ngenerates and inserts entries, then /authorization-code/callback retrieves\nan access token from the ID provider and uses it to retrive the caller's\nemail and store it in 'email', and finally Authorize() returns a Pachyderm\ntoken identified with that email address as a subject in Pachyderm.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "nonce",
+              "description": "nonce is used by /authorization-code/callback to validate session\ncontinuity with the IdP after a user has arrived there from GetOIDCLogin().\nThis is a 30-character CSPRNG-generated string.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "email",
+              "description": "email contains the email adddress associated with a user in their OIDC ID\nprovider. Currently users are identified with their email address rather\nthan their OIDC subject identifier to make switching between OIDC ID\nproviders easier for users, and to make user identities more easily\ncomprehensible in Pachyderm. The OIDC spec doesn't require that users'\nemails be present or unique, but we think this will be preferable in\npractice.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "conversion_err",
+              "description": "conversion_err indicates whether an error was encountered while exchanging\nan auth code for an access token, or while obtaining a user's email (in\n/authorization-code/callback). Storing the error state here allows any\nsibling calls to Authenticate() (i.e. using the same OIDC state token) to\nnotify their caller that an error has occurred. We avoid passing the caller\nany details of the error (which are logged by Pachyderm) to avoid giving\ninformation to a user who has network access to Pachyderm but not an\naccount in the OIDC provider.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetConfigurationRequest",
+          "longName": "SetConfigurationRequest",
+          "fullName": "auth_v2.SetConfigurationRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "configuration",
+              "description": "",
+              "label": "",
+              "type": "OIDCConfig",
+              "longType": "OIDCConfig",
+              "fullType": "auth_v2.OIDCConfig",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetConfigurationResponse",
+          "longName": "SetConfigurationResponse",
+          "fullName": "auth_v2.SetConfigurationResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "SetGroupsForUserRequest",
+          "longName": "SetGroupsForUserRequest",
+          "fullName": "auth_v2.SetGroupsForUserRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "username",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "groups",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetGroupsForUserResponse",
+          "longName": "SetGroupsForUserResponse",
+          "fullName": "auth_v2.SetGroupsForUserResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "TokenInfo",
+          "longName": "TokenInfo",
+          "fullName": "auth_v2.TokenInfo",
+          "description": "TokenInfo is the 'value' of an auth token 'key' in the 'tokens' collection",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "subject",
+              "description": "Subject (i.e. Pachyderm account) that a given token authorizes.\nSee the note at the top of the doc for an explanation of subject structure.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expiration",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hashed_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Users",
+          "longName": "Users",
+          "fullName": "auth_v2.Users",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "usernames",
+              "description": "",
+              "label": "repeated",
+              "type": "UsernamesEntry",
+              "longType": "Users.UsernamesEntry",
+              "fullType": "auth_v2.Users.UsernamesEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UsernamesEntry",
+          "longName": "Users.UsernamesEntry",
+          "fullName": "auth_v2.Users.UsernamesEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WhoAmIRequest",
+          "longName": "WhoAmIRequest",
+          "fullName": "auth_v2.WhoAmIRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "WhoAmIResponse",
+          "longName": "WhoAmIResponse",
+          "fullName": "auth_v2.WhoAmIResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "username",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expiration",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "auth_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "Activate",
+              "description": "Activate/Deactivate the auth API. 'Activate' sets an initial set of admins\nfor the Pachyderm cluster, and 'Deactivate' removes all ACLs, tokens, and\nadmins from the Pachyderm cluster, making all data publicly accessable",
+              "requestType": "ActivateRequest",
+              "requestLongType": "ActivateRequest",
+              "requestFullType": "auth_v2.ActivateRequest",
+              "requestStreaming": false,
+              "responseType": "ActivateResponse",
+              "responseLongType": "ActivateResponse",
+              "responseFullType": "auth_v2.ActivateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Deactivate",
+              "description": "",
+              "requestType": "DeactivateRequest",
+              "requestLongType": "DeactivateRequest",
+              "requestFullType": "auth_v2.DeactivateRequest",
+              "requestStreaming": false,
+              "responseType": "DeactivateResponse",
+              "responseLongType": "DeactivateResponse",
+              "responseFullType": "auth_v2.DeactivateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetConfiguration",
+              "description": "",
+              "requestType": "GetConfigurationRequest",
+              "requestLongType": "GetConfigurationRequest",
+              "requestFullType": "auth_v2.GetConfigurationRequest",
+              "requestStreaming": false,
+              "responseType": "GetConfigurationResponse",
+              "responseLongType": "GetConfigurationResponse",
+              "responseFullType": "auth_v2.GetConfigurationResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "SetConfiguration",
+              "description": "",
+              "requestType": "SetConfigurationRequest",
+              "requestLongType": "SetConfigurationRequest",
+              "requestFullType": "auth_v2.SetConfigurationRequest",
+              "requestStreaming": false,
+              "responseType": "SetConfigurationResponse",
+              "responseLongType": "SetConfigurationResponse",
+              "responseFullType": "auth_v2.SetConfigurationResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Authenticate",
+              "description": "",
+              "requestType": "AuthenticateRequest",
+              "requestLongType": "AuthenticateRequest",
+              "requestFullType": "auth_v2.AuthenticateRequest",
+              "requestStreaming": false,
+              "responseType": "AuthenticateResponse",
+              "responseLongType": "AuthenticateResponse",
+              "responseFullType": "auth_v2.AuthenticateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Authorize",
+              "description": "",
+              "requestType": "AuthorizeRequest",
+              "requestLongType": "AuthorizeRequest",
+              "requestFullType": "auth_v2.AuthorizeRequest",
+              "requestStreaming": false,
+              "responseType": "AuthorizeResponse",
+              "responseLongType": "AuthorizeResponse",
+              "responseFullType": "auth_v2.AuthorizeResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetPermissions",
+              "description": "",
+              "requestType": "GetPermissionsRequest",
+              "requestLongType": "GetPermissionsRequest",
+              "requestFullType": "auth_v2.GetPermissionsRequest",
+              "requestStreaming": false,
+              "responseType": "GetPermissionsResponse",
+              "responseLongType": "GetPermissionsResponse",
+              "responseFullType": "auth_v2.GetPermissionsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetPermissionsForPrincipal",
+              "description": "",
+              "requestType": "GetPermissionsForPrincipalRequest",
+              "requestLongType": "GetPermissionsForPrincipalRequest",
+              "requestFullType": "auth_v2.GetPermissionsForPrincipalRequest",
+              "requestStreaming": false,
+              "responseType": "GetPermissionsResponse",
+              "responseLongType": "GetPermissionsResponse",
+              "responseFullType": "auth_v2.GetPermissionsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "WhoAmI",
+              "description": "",
+              "requestType": "WhoAmIRequest",
+              "requestLongType": "WhoAmIRequest",
+              "requestFullType": "auth_v2.WhoAmIRequest",
+              "requestStreaming": false,
+              "responseType": "WhoAmIResponse",
+              "responseLongType": "WhoAmIResponse",
+              "responseFullType": "auth_v2.WhoAmIResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetRolesForPermission",
+              "description": "",
+              "requestType": "GetRolesForPermissionRequest",
+              "requestLongType": "GetRolesForPermissionRequest",
+              "requestFullType": "auth_v2.GetRolesForPermissionRequest",
+              "requestStreaming": false,
+              "responseType": "GetRolesForPermissionResponse",
+              "responseLongType": "GetRolesForPermissionResponse",
+              "responseFullType": "auth_v2.GetRolesForPermissionResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ModifyRoleBinding",
+              "description": "",
+              "requestType": "ModifyRoleBindingRequest",
+              "requestLongType": "ModifyRoleBindingRequest",
+              "requestFullType": "auth_v2.ModifyRoleBindingRequest",
+              "requestStreaming": false,
+              "responseType": "ModifyRoleBindingResponse",
+              "responseLongType": "ModifyRoleBindingResponse",
+              "responseFullType": "auth_v2.ModifyRoleBindingResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetRoleBinding",
+              "description": "",
+              "requestType": "GetRoleBindingRequest",
+              "requestLongType": "GetRoleBindingRequest",
+              "requestFullType": "auth_v2.GetRoleBindingRequest",
+              "requestStreaming": false,
+              "responseType": "GetRoleBindingResponse",
+              "responseLongType": "GetRoleBindingResponse",
+              "responseFullType": "auth_v2.GetRoleBindingResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetOIDCLogin",
+              "description": "",
+              "requestType": "GetOIDCLoginRequest",
+              "requestLongType": "GetOIDCLoginRequest",
+              "requestFullType": "auth_v2.GetOIDCLoginRequest",
+              "requestStreaming": false,
+              "responseType": "GetOIDCLoginResponse",
+              "responseLongType": "GetOIDCLoginResponse",
+              "responseFullType": "auth_v2.GetOIDCLoginResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetRobotToken",
+              "description": "",
+              "requestType": "GetRobotTokenRequest",
+              "requestLongType": "GetRobotTokenRequest",
+              "requestFullType": "auth_v2.GetRobotTokenRequest",
+              "requestStreaming": false,
+              "responseType": "GetRobotTokenResponse",
+              "responseLongType": "GetRobotTokenResponse",
+              "responseFullType": "auth_v2.GetRobotTokenResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RevokeAuthToken",
+              "description": "",
+              "requestType": "RevokeAuthTokenRequest",
+              "requestLongType": "RevokeAuthTokenRequest",
+              "requestFullType": "auth_v2.RevokeAuthTokenRequest",
+              "requestStreaming": false,
+              "responseType": "RevokeAuthTokenResponse",
+              "responseLongType": "RevokeAuthTokenResponse",
+              "responseFullType": "auth_v2.RevokeAuthTokenResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RevokeAuthTokensForUser",
+              "description": "",
+              "requestType": "RevokeAuthTokensForUserRequest",
+              "requestLongType": "RevokeAuthTokensForUserRequest",
+              "requestFullType": "auth_v2.RevokeAuthTokensForUserRequest",
+              "requestStreaming": false,
+              "responseType": "RevokeAuthTokensForUserResponse",
+              "responseLongType": "RevokeAuthTokensForUserResponse",
+              "responseFullType": "auth_v2.RevokeAuthTokensForUserResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "SetGroupsForUser",
+              "description": "",
+              "requestType": "SetGroupsForUserRequest",
+              "requestLongType": "SetGroupsForUserRequest",
+              "requestFullType": "auth_v2.SetGroupsForUserRequest",
+              "requestStreaming": false,
+              "responseType": "SetGroupsForUserResponse",
+              "responseLongType": "SetGroupsForUserResponse",
+              "responseFullType": "auth_v2.SetGroupsForUserResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ModifyMembers",
+              "description": "",
+              "requestType": "ModifyMembersRequest",
+              "requestLongType": "ModifyMembersRequest",
+              "requestFullType": "auth_v2.ModifyMembersRequest",
+              "requestStreaming": false,
+              "responseType": "ModifyMembersResponse",
+              "responseLongType": "ModifyMembersResponse",
+              "responseFullType": "auth_v2.ModifyMembersResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetGroups",
+              "description": "",
+              "requestType": "GetGroupsRequest",
+              "requestLongType": "GetGroupsRequest",
+              "requestFullType": "auth_v2.GetGroupsRequest",
+              "requestStreaming": false,
+              "responseType": "GetGroupsResponse",
+              "responseLongType": "GetGroupsResponse",
+              "responseFullType": "auth_v2.GetGroupsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetGroupsForPrincipal",
+              "description": "",
+              "requestType": "GetGroupsForPrincipalRequest",
+              "requestLongType": "GetGroupsForPrincipalRequest",
+              "requestFullType": "auth_v2.GetGroupsForPrincipalRequest",
+              "requestStreaming": false,
+              "responseType": "GetGroupsResponse",
+              "responseLongType": "GetGroupsResponse",
+              "responseFullType": "auth_v2.GetGroupsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetUsers",
+              "description": "",
+              "requestType": "GetUsersRequest",
+              "requestLongType": "GetUsersRequest",
+              "requestFullType": "auth_v2.GetUsersRequest",
+              "requestStreaming": false,
+              "responseType": "GetUsersResponse",
+              "responseLongType": "GetUsersResponse",
+              "responseFullType": "auth_v2.GetUsersResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ExtractAuthTokens",
+              "description": "",
+              "requestType": "ExtractAuthTokensRequest",
+              "requestLongType": "ExtractAuthTokensRequest",
+              "requestFullType": "auth_v2.ExtractAuthTokensRequest",
+              "requestStreaming": false,
+              "responseType": "ExtractAuthTokensResponse",
+              "responseLongType": "ExtractAuthTokensResponse",
+              "responseFullType": "auth_v2.ExtractAuthTokensResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RestoreAuthToken",
+              "description": "",
+              "requestType": "RestoreAuthTokenRequest",
+              "requestLongType": "RestoreAuthTokenRequest",
+              "requestFullType": "auth_v2.RestoreAuthTokenRequest",
+              "requestStreaming": false,
+              "responseType": "RestoreAuthTokenResponse",
+              "responseLongType": "RestoreAuthTokenResponse",
+              "responseFullType": "auth_v2.RestoreAuthTokenResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteExpiredAuthTokens",
+              "description": "",
+              "requestType": "DeleteExpiredAuthTokensRequest",
+              "requestLongType": "DeleteExpiredAuthTokensRequest",
+              "requestFullType": "auth_v2.DeleteExpiredAuthTokensRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteExpiredAuthTokensResponse",
+              "responseLongType": "DeleteExpiredAuthTokensResponse",
+              "responseFullType": "auth_v2.DeleteExpiredAuthTokensResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RotateRootToken",
+              "description": "",
+              "requestType": "RotateRootTokenRequest",
+              "requestLongType": "RotateRootTokenRequest",
+              "requestFullType": "auth_v2.RotateRootTokenRequest",
+              "requestStreaming": false,
+              "responseType": "RotateRootTokenResponse",
+              "responseLongType": "RotateRootTokenResponse",
+              "responseFullType": "auth_v2.RotateRootTokenResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "debug/debug.proto",
+      "description": "",
+      "package": "debug_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "LogLevel",
+          "longName": "SetLogLevelRequest.LogLevel",
+          "fullName": "debug_v2.SetLogLevelRequest.LogLevel",
+          "description": "",
+          "values": [
+            {
+              "name": "UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "DEBUG",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "INFO",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "ERROR",
+              "number": "3",
+              "description": ""
+            },
+            {
+              "name": "OFF",
+              "number": "4",
+              "description": "Only GRPC logs can be turned off."
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "App",
+          "longName": "App",
+          "fullName": "debug_v2.App",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pods",
+              "description": "",
+              "label": "repeated",
+              "type": "Pod",
+              "longType": "Pod",
+              "fullType": "debug_v2.Pod",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "debug_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BinaryRequest",
+          "longName": "BinaryRequest",
+          "fullName": "debug_v2.BinaryRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "filter",
+              "description": "",
+              "label": "",
+              "type": "Filter",
+              "longType": "Filter",
+              "fullType": "debug_v2.Filter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DumpChunk",
+          "longName": "DumpChunk",
+          "fullName": "debug_v2.DumpChunk",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "content",
+              "description": "",
+              "label": "",
+              "type": "DumpContent",
+              "longType": "DumpContent",
+              "fullType": "debug_v2.DumpContent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "chunk",
+              "defaultValue": ""
+            },
+            {
+              "name": "progress",
+              "description": "",
+              "label": "",
+              "type": "DumpProgress",
+              "longType": "DumpProgress",
+              "fullType": "debug_v2.DumpProgress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "chunk",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DumpContent",
+          "longName": "DumpContent",
+          "fullName": "debug_v2.DumpContent",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "content",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DumpProgress",
+          "longName": "DumpProgress",
+          "fullName": "debug_v2.DumpProgress",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "task",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "progress",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DumpRequest",
+          "longName": "DumpRequest",
+          "fullName": "debug_v2.DumpRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "filter",
+              "description": "",
+              "label": "",
+              "type": "Filter",
+              "longType": "Filter",
+              "fullType": "debug_v2.Filter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "limit",
+              "description": "Limit sets the limit for the number of commits / jobs that are returned for each repo / pipeline in the dump.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DumpV2Request",
+          "longName": "DumpV2Request",
+          "fullName": "debug_v2.DumpV2Request",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "system",
+              "description": "",
+              "label": "",
+              "type": "System",
+              "longType": "System",
+              "fullType": "debug_v2.System",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipelines",
+              "description": "",
+              "label": "repeated",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "debug_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_repos",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "defaults",
+              "description": "",
+              "label": "",
+              "type": "Defaults",
+              "longType": "DumpV2Request.Defaults",
+              "fullType": "debug_v2.DumpV2Request.Defaults",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Defaults",
+          "longName": "DumpV2Request.Defaults",
+          "fullName": "debug_v2.DumpV2Request.Defaults",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "cluster_defaults",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Filter",
+          "longName": "Filter",
+          "fullName": "debug_v2.Filter",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pachd",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "filter",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "pps_v2.Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "filter",
+              "defaultValue": ""
+            },
+            {
+              "name": "worker",
+              "description": "",
+              "label": "",
+              "type": "Worker",
+              "longType": "Worker",
+              "fullType": "debug_v2.Worker",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "filter",
+              "defaultValue": ""
+            },
+            {
+              "name": "database",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "filter",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetDumpV2TemplateRequest",
+          "longName": "GetDumpV2TemplateRequest",
+          "fullName": "debug_v2.GetDumpV2TemplateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "filters",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetDumpV2TemplateResponse",
+          "longName": "GetDumpV2TemplateResponse",
+          "fullName": "debug_v2.GetDumpV2TemplateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "request",
+              "description": "",
+              "label": "",
+              "type": "DumpV2Request",
+              "longType": "DumpV2Request",
+              "fullType": "debug_v2.DumpV2Request",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Pipeline",
+          "longName": "Pipeline",
+          "fullName": "debug_v2.Pipeline",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Pod",
+          "longName": "Pod",
+          "fullName": "debug_v2.Pod",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ip",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "containers",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Profile",
+          "longName": "Profile",
+          "fullName": "debug_v2.Profile",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "duration",
+              "description": "only meaningful if name == \"cpu\"",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ProfileRequest",
+          "longName": "ProfileRequest",
+          "fullName": "debug_v2.ProfileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "profile",
+              "description": "",
+              "label": "",
+              "type": "Profile",
+              "longType": "Profile",
+              "fullType": "debug_v2.Profile",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "filter",
+              "description": "",
+              "label": "",
+              "type": "Filter",
+              "longType": "Filter",
+              "fullType": "debug_v2.Filter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetLogLevelRequest",
+          "longName": "SetLogLevelRequest",
+          "fullName": "debug_v2.SetLogLevelRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pachyderm",
+              "description": "",
+              "label": "",
+              "type": "LogLevel",
+              "longType": "SetLogLevelRequest.LogLevel",
+              "fullType": "debug_v2.SetLogLevelRequest.LogLevel",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "level",
+              "defaultValue": ""
+            },
+            {
+              "name": "grpc",
+              "description": "",
+              "label": "",
+              "type": "LogLevel",
+              "longType": "SetLogLevelRequest.LogLevel",
+              "fullType": "debug_v2.SetLogLevelRequest.LogLevel",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "level",
+              "defaultValue": ""
+            },
+            {
+              "name": "duration",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "recurse",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetLogLevelResponse",
+          "longName": "SetLogLevelResponse",
+          "fullName": "debug_v2.SetLogLevelResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "affected_pods",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "errored_pods",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "System",
+          "longName": "System",
+          "fullName": "debug_v2.System",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "helm",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "database",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "describes",
+              "description": "",
+              "label": "repeated",
+              "type": "App",
+              "longType": "App",
+              "fullType": "debug_v2.App",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "logs",
+              "description": "",
+              "label": "repeated",
+              "type": "App",
+              "longType": "App",
+              "fullType": "debug_v2.App",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "loki_logs",
+              "description": "",
+              "label": "repeated",
+              "type": "App",
+              "longType": "App",
+              "fullType": "debug_v2.App",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "binaries",
+              "description": "",
+              "label": "repeated",
+              "type": "App",
+              "longType": "App",
+              "fullType": "debug_v2.App",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "profiles",
+              "description": "",
+              "label": "repeated",
+              "type": "App",
+              "longType": "App",
+              "fullType": "debug_v2.App",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Worker",
+          "longName": "Worker",
+          "fullName": "debug_v2.Worker",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pod",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "redirected",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "Debug",
+          "longName": "Debug",
+          "fullName": "debug_v2.Debug",
+          "description": "",
+          "methods": [
+            {
+              "name": "Profile",
+              "description": "",
+              "requestType": "ProfileRequest",
+              "requestLongType": "ProfileRequest",
+              "requestFullType": "debug_v2.ProfileRequest",
+              "requestStreaming": false,
+              "responseType": "BytesValue",
+              "responseLongType": ".google.protobuf.BytesValue",
+              "responseFullType": "google.protobuf.BytesValue",
+              "responseStreaming": true
+            },
+            {
+              "name": "Binary",
+              "description": "",
+              "requestType": "BinaryRequest",
+              "requestLongType": "BinaryRequest",
+              "requestFullType": "debug_v2.BinaryRequest",
+              "requestStreaming": false,
+              "responseType": "BytesValue",
+              "responseLongType": ".google.protobuf.BytesValue",
+              "responseFullType": "google.protobuf.BytesValue",
+              "responseStreaming": true
+            },
+            {
+              "name": "Dump",
+              "description": "",
+              "requestType": "DumpRequest",
+              "requestLongType": "DumpRequest",
+              "requestFullType": "debug_v2.DumpRequest",
+              "requestStreaming": false,
+              "responseType": "BytesValue",
+              "responseLongType": ".google.protobuf.BytesValue",
+              "responseFullType": "google.protobuf.BytesValue",
+              "responseStreaming": true
+            },
+            {
+              "name": "SetLogLevel",
+              "description": "",
+              "requestType": "SetLogLevelRequest",
+              "requestLongType": "SetLogLevelRequest",
+              "requestFullType": "debug_v2.SetLogLevelRequest",
+              "requestStreaming": false,
+              "responseType": "SetLogLevelResponse",
+              "responseLongType": "SetLogLevelResponse",
+              "responseFullType": "debug_v2.SetLogLevelResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetDumpV2Template",
+              "description": "",
+              "requestType": "GetDumpV2TemplateRequest",
+              "requestLongType": "GetDumpV2TemplateRequest",
+              "requestFullType": "debug_v2.GetDumpV2TemplateRequest",
+              "requestStreaming": false,
+              "responseType": "GetDumpV2TemplateResponse",
+              "responseLongType": "GetDumpV2TemplateResponse",
+              "responseFullType": "debug_v2.GetDumpV2TemplateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DumpV2",
+              "description": "",
+              "requestType": "DumpV2Request",
+              "requestLongType": "DumpV2Request",
+              "requestFullType": "debug_v2.DumpV2Request",
+              "requestStreaming": false,
+              "responseType": "DumpChunk",
+              "responseLongType": "DumpChunk",
+              "responseFullType": "debug_v2.DumpChunk",
+              "responseStreaming": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "enterprise/enterprise.proto",
+      "description": "",
+      "package": "enterprise_v2",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "PauseStatus",
+          "longName": "PauseStatusResponse.PauseStatus",
+          "fullName": "enterprise_v2.PauseStatusResponse.PauseStatus",
+          "description": "",
+          "values": [
+            {
+              "name": "UNPAUSED",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "PARTIALLY_PAUSED",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "PAUSED",
+              "number": "2",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "State",
+          "longName": "State",
+          "fullName": "enterprise_v2.State",
+          "description": "",
+          "values": [
+            {
+              "name": "NONE",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "ACTIVE",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "EXPIRED",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "HEARTBEAT_FAILED",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ActivateRequest",
+          "longName": "ActivateRequest",
+          "fullName": "enterprise_v2.ActivateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "license_server",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ActivateResponse",
+          "longName": "ActivateResponse",
+          "fullName": "enterprise_v2.ActivateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeactivateRequest",
+          "longName": "DeactivateRequest",
+          "fullName": "enterprise_v2.DeactivateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeactivateResponse",
+          "longName": "DeactivateResponse",
+          "fullName": "enterprise_v2.DeactivateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "EnterpriseConfig",
+          "longName": "EnterpriseConfig",
+          "fullName": "enterprise_v2.EnterpriseConfig",
+          "description": "EnterpriseConfig is the configuration we store for heartbeating\nto the license server.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "license_server",
+              "description": "license_server is the address of the grpc license service",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id",
+              "description": "id is the unique identifier for this pachd, which is registered\nwith the license service",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "secret is a shared secret between this pachd and the license service",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EnterpriseRecord",
+          "longName": "EnterpriseRecord",
+          "fullName": "enterprise_v2.EnterpriseRecord",
+          "description": "EnterpriseRecord is a protobuf we cache in etcd to store the\nenterprise status.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "license",
+              "description": "license is the cached LicenseRecord retrieved from the most recent\nheartbeat to the license server.",
+              "label": "",
+              "type": "LicenseRecord",
+              "longType": "LicenseRecord",
+              "fullType": "enterprise_v2.LicenseRecord",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_heartbeat",
+              "description": "last_heartbeat is the timestamp of the last successful heartbeat\nto the license server",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "heartbeat_failed",
+              "description": "heartbeat_failed is set if the license is still valid, but\nthe pachd is no longer registered with an enterprise server.\nThis is the same as the expired state, where auth is locked\nbut not disabled.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetActivationCodeRequest",
+          "longName": "GetActivationCodeRequest",
+          "fullName": "enterprise_v2.GetActivationCodeRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetActivationCodeResponse",
+          "longName": "GetActivationCodeResponse",
+          "fullName": "enterprise_v2.GetActivationCodeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "State",
+              "longType": "State",
+              "fullType": "enterprise_v2.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "info",
+              "description": "",
+              "label": "",
+              "type": "TokenInfo",
+              "longType": "TokenInfo",
+              "fullType": "enterprise_v2.TokenInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "activation_code",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetStateRequest",
+          "longName": "GetStateRequest",
+          "fullName": "enterprise_v2.GetStateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetStateResponse",
+          "longName": "GetStateResponse",
+          "fullName": "enterprise_v2.GetStateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "State",
+              "longType": "State",
+              "fullType": "enterprise_v2.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "info",
+              "description": "",
+              "label": "",
+              "type": "TokenInfo",
+              "longType": "TokenInfo",
+              "fullType": "enterprise_v2.TokenInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "activation_code",
+              "description": "activation_code will always be an empty string,\ncall GetEnterpriseCode to get the activation code",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "HeartbeatRequest",
+          "longName": "HeartbeatRequest",
+          "fullName": "enterprise_v2.HeartbeatRequest",
+          "description": "Heartbeat in the enterprise service just triggers a heartbeat for\ntesting purposes. The RPC used to communicate with the license\nservice is defined in the license service.",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "HeartbeatResponse",
+          "longName": "HeartbeatResponse",
+          "fullName": "enterprise_v2.HeartbeatResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "LicenseRecord",
+          "longName": "LicenseRecord",
+          "fullName": "enterprise_v2.LicenseRecord",
+          "description": "LicenseRecord is the record we store in etcd for a Pachyderm enterprise\ntoken that has been provided to a Pachyderm license server",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "activation_code",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expires",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PauseRequest",
+          "longName": "PauseRequest",
+          "fullName": "enterprise_v2.PauseRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "PauseResponse",
+          "longName": "PauseResponse",
+          "fullName": "enterprise_v2.PauseResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "PauseStatusRequest",
+          "longName": "PauseStatusRequest",
+          "fullName": "enterprise_v2.PauseStatusRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "PauseStatusResponse",
+          "longName": "PauseStatusResponse",
+          "fullName": "enterprise_v2.PauseStatusResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "status",
+              "description": "",
+              "label": "",
+              "type": "PauseStatus",
+              "longType": "PauseStatusResponse.PauseStatus",
+              "fullType": "enterprise_v2.PauseStatusResponse.PauseStatus",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TokenInfo",
+          "longName": "TokenInfo",
+          "fullName": "enterprise_v2.TokenInfo",
+          "description": "TokenInfo contains information about the currently active enterprise token",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "expires",
+              "description": "expires indicates when the current token expires (unset if there is no\ncurrent token)",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UnpauseRequest",
+          "longName": "UnpauseRequest",
+          "fullName": "enterprise_v2.UnpauseRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "UnpauseResponse",
+          "longName": "UnpauseResponse",
+          "fullName": "enterprise_v2.UnpauseResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "enterprise_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "Activate",
+              "description": "Provide a Pachyderm enterprise token, enabling Pachyderm enterprise\nfeatures, such as the Pachyderm Dashboard and Auth system",
+              "requestType": "ActivateRequest",
+              "requestLongType": "ActivateRequest",
+              "requestFullType": "enterprise_v2.ActivateRequest",
+              "requestStreaming": false,
+              "responseType": "ActivateResponse",
+              "responseLongType": "ActivateResponse",
+              "responseFullType": "enterprise_v2.ActivateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetState",
+              "description": "",
+              "requestType": "GetStateRequest",
+              "requestLongType": "GetStateRequest",
+              "requestFullType": "enterprise_v2.GetStateRequest",
+              "requestStreaming": false,
+              "responseType": "GetStateResponse",
+              "responseLongType": "GetStateResponse",
+              "responseFullType": "enterprise_v2.GetStateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetActivationCode",
+              "description": "",
+              "requestType": "GetActivationCodeRequest",
+              "requestLongType": "GetActivationCodeRequest",
+              "requestFullType": "enterprise_v2.GetActivationCodeRequest",
+              "requestStreaming": false,
+              "responseType": "GetActivationCodeResponse",
+              "responseLongType": "GetActivationCodeResponse",
+              "responseFullType": "enterprise_v2.GetActivationCodeResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Heartbeat",
+              "description": "Heartbeat is used in testing to trigger a heartbeat on demand. Normally this happens\non a timer.",
+              "requestType": "HeartbeatRequest",
+              "requestLongType": "HeartbeatRequest",
+              "requestFullType": "enterprise_v2.HeartbeatRequest",
+              "requestStreaming": false,
+              "responseType": "HeartbeatResponse",
+              "responseLongType": "HeartbeatResponse",
+              "responseFullType": "enterprise_v2.HeartbeatResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Deactivate",
+              "description": "Deactivate removes a cluster's enterprise activation\ntoken and sets its enterprise state to NONE.",
+              "requestType": "DeactivateRequest",
+              "requestLongType": "DeactivateRequest",
+              "requestFullType": "enterprise_v2.DeactivateRequest",
+              "requestStreaming": false,
+              "responseType": "DeactivateResponse",
+              "responseLongType": "DeactivateResponse",
+              "responseFullType": "enterprise_v2.DeactivateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Pause",
+              "description": "Pause pauses the cluster.",
+              "requestType": "PauseRequest",
+              "requestLongType": "PauseRequest",
+              "requestFullType": "enterprise_v2.PauseRequest",
+              "requestStreaming": false,
+              "responseType": "PauseResponse",
+              "responseLongType": "PauseResponse",
+              "responseFullType": "enterprise_v2.PauseResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Unpause",
+              "description": "Unpause unpauses the cluser.",
+              "requestType": "UnpauseRequest",
+              "requestLongType": "UnpauseRequest",
+              "requestFullType": "enterprise_v2.UnpauseRequest",
+              "requestStreaming": false,
+              "responseType": "UnpauseResponse",
+              "responseLongType": "UnpauseResponse",
+              "responseFullType": "enterprise_v2.UnpauseResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PauseStatus",
+              "description": "",
+              "requestType": "PauseStatusRequest",
+              "requestLongType": "PauseStatusRequest",
+              "requestFullType": "enterprise_v2.PauseStatusRequest",
+              "requestStreaming": false,
+              "responseType": "PauseStatusResponse",
+              "responseLongType": "PauseStatusResponse",
+              "responseFullType": "enterprise_v2.PauseStatusResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "identity/identity.proto",
+      "description": "",
+      "package": "identity_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "CreateIDPConnectorRequest",
+          "longName": "CreateIDPConnectorRequest",
+          "fullName": "identity_v2.CreateIDPConnectorRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "connector",
+              "description": "",
+              "label": "",
+              "type": "IDPConnector",
+              "longType": "IDPConnector",
+              "fullType": "identity_v2.IDPConnector",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "CreateIDPConnectorResponse",
+          "longName": "CreateIDPConnectorResponse",
+          "fullName": "identity_v2.CreateIDPConnectorResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "CreateOIDCClientRequest",
+          "longName": "CreateOIDCClientRequest",
+          "fullName": "identity_v2.CreateOIDCClientRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "client",
+              "description": "",
+              "label": "",
+              "type": "OIDCClient",
+              "longType": "OIDCClient",
+              "fullType": "identity_v2.OIDCClient",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "CreateOIDCClientResponse",
+          "longName": "CreateOIDCClientResponse",
+          "fullName": "identity_v2.CreateOIDCClientResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "client",
+              "description": "",
+              "label": "",
+              "type": "OIDCClient",
+              "longType": "OIDCClient",
+              "fullType": "identity_v2.OIDCClient",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteAllRequest",
+          "longName": "DeleteAllRequest",
+          "fullName": "identity_v2.DeleteAllRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteAllResponse",
+          "longName": "DeleteAllResponse",
+          "fullName": "identity_v2.DeleteAllResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteIDPConnectorRequest",
+          "longName": "DeleteIDPConnectorRequest",
+          "fullName": "identity_v2.DeleteIDPConnectorRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteIDPConnectorResponse",
+          "longName": "DeleteIDPConnectorResponse",
+          "fullName": "identity_v2.DeleteIDPConnectorResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteOIDCClientRequest",
+          "longName": "DeleteOIDCClientRequest",
+          "fullName": "identity_v2.DeleteOIDCClientRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteOIDCClientResponse",
+          "longName": "DeleteOIDCClientResponse",
+          "fullName": "identity_v2.DeleteOIDCClientResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetIDPConnectorRequest",
+          "longName": "GetIDPConnectorRequest",
+          "fullName": "identity_v2.GetIDPConnectorRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetIDPConnectorResponse",
+          "longName": "GetIDPConnectorResponse",
+          "fullName": "identity_v2.GetIDPConnectorResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "connector",
+              "description": "",
+              "label": "",
+              "type": "IDPConnector",
+              "longType": "IDPConnector",
+              "fullType": "identity_v2.IDPConnector",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetIdentityServerConfigRequest",
+          "longName": "GetIdentityServerConfigRequest",
+          "fullName": "identity_v2.GetIdentityServerConfigRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetIdentityServerConfigResponse",
+          "longName": "GetIdentityServerConfigResponse",
+          "fullName": "identity_v2.GetIdentityServerConfigResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "config",
+              "description": "",
+              "label": "",
+              "type": "IdentityServerConfig",
+              "longType": "IdentityServerConfig",
+              "fullType": "identity_v2.IdentityServerConfig",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetOIDCClientRequest",
+          "longName": "GetOIDCClientRequest",
+          "fullName": "identity_v2.GetOIDCClientRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetOIDCClientResponse",
+          "longName": "GetOIDCClientResponse",
+          "fullName": "identity_v2.GetOIDCClientResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "client",
+              "description": "",
+              "label": "",
+              "type": "OIDCClient",
+              "longType": "OIDCClient",
+              "fullType": "identity_v2.OIDCClient",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "IDPConnector",
+          "longName": "IDPConnector",
+          "fullName": "identity_v2.IDPConnector",
+          "description": "IDPConnector represents a connection to an identity provider",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "ID is the unique identifier for this connector.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "Name is the human-readable identifier for this connector,\nwhich will be shown to end users when they're authenticating.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Type is the type of the IDP ex. `saml`, `oidc`, `github`.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "configVersion",
+              "description": "ConfigVersion must be incremented every time a connector is\nupdated, to avoid concurrent updates conflicting.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jsonConfig",
+              "description": "This is left for backwards compatibility, but we want users to use the config defined below.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "config",
+              "description": "Config is the configuration for the upstream IDP, which varies based on the type.\nWe make the assumption that this is either yaml or JSON.",
+              "label": "",
+              "type": "Struct",
+              "longType": "google.protobuf.Struct",
+              "fullType": "google.protobuf.Struct",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "IdentityServerConfig",
+          "longName": "IdentityServerConfig",
+          "fullName": "identity_v2.IdentityServerConfig",
+          "description": "IdentityServerConfig is the configuration for the identity web server.\nWhen the configuration is changed the web server is reloaded automatically.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "issuer",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id_token_expiry",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "rotation_token_expiry",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListIDPConnectorsRequest",
+          "longName": "ListIDPConnectorsRequest",
+          "fullName": "identity_v2.ListIDPConnectorsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ListIDPConnectorsResponse",
+          "longName": "ListIDPConnectorsResponse",
+          "fullName": "identity_v2.ListIDPConnectorsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "connectors",
+              "description": "",
+              "label": "repeated",
+              "type": "IDPConnector",
+              "longType": "IDPConnector",
+              "fullType": "identity_v2.IDPConnector",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListOIDCClientsRequest",
+          "longName": "ListOIDCClientsRequest",
+          "fullName": "identity_v2.ListOIDCClientsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ListOIDCClientsResponse",
+          "longName": "ListOIDCClientsResponse",
+          "fullName": "identity_v2.ListOIDCClientsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "clients",
+              "description": "",
+              "label": "repeated",
+              "type": "OIDCClient",
+              "longType": "OIDCClient",
+              "fullType": "identity_v2.OIDCClient",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OIDCClient",
+          "longName": "OIDCClient",
+          "fullName": "identity_v2.OIDCClient",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "redirect_uris",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trusted_peers",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetIdentityServerConfigRequest",
+          "longName": "SetIdentityServerConfigRequest",
+          "fullName": "identity_v2.SetIdentityServerConfigRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "config",
+              "description": "",
+              "label": "",
+              "type": "IdentityServerConfig",
+              "longType": "IdentityServerConfig",
+              "fullType": "identity_v2.IdentityServerConfig",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "SetIdentityServerConfigResponse",
+          "longName": "SetIdentityServerConfigResponse",
+          "fullName": "identity_v2.SetIdentityServerConfigResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "UpdateIDPConnectorRequest",
+          "longName": "UpdateIDPConnectorRequest",
+          "fullName": "identity_v2.UpdateIDPConnectorRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "connector",
+              "description": "",
+              "label": "",
+              "type": "IDPConnector",
+              "longType": "IDPConnector",
+              "fullType": "identity_v2.IDPConnector",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "UpdateIDPConnectorResponse",
+          "longName": "UpdateIDPConnectorResponse",
+          "fullName": "identity_v2.UpdateIDPConnectorResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "UpdateOIDCClientRequest",
+          "longName": "UpdateOIDCClientRequest",
+          "fullName": "identity_v2.UpdateOIDCClientRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "client",
+              "description": "",
+              "label": "",
+              "type": "OIDCClient",
+              "longType": "OIDCClient",
+              "fullType": "identity_v2.OIDCClient",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "UpdateOIDCClientResponse",
+          "longName": "UpdateOIDCClientResponse",
+          "fullName": "identity_v2.UpdateOIDCClientResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "User",
+          "longName": "User",
+          "fullName": "identity_v2.User",
+          "description": "User represents an IDP user that has authenticated via OIDC",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "email",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_authenticated",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "identity_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "SetIdentityServerConfig",
+              "description": "",
+              "requestType": "SetIdentityServerConfigRequest",
+              "requestLongType": "SetIdentityServerConfigRequest",
+              "requestFullType": "identity_v2.SetIdentityServerConfigRequest",
+              "requestStreaming": false,
+              "responseType": "SetIdentityServerConfigResponse",
+              "responseLongType": "SetIdentityServerConfigResponse",
+              "responseFullType": "identity_v2.SetIdentityServerConfigResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetIdentityServerConfig",
+              "description": "",
+              "requestType": "GetIdentityServerConfigRequest",
+              "requestLongType": "GetIdentityServerConfigRequest",
+              "requestFullType": "identity_v2.GetIdentityServerConfigRequest",
+              "requestStreaming": false,
+              "responseType": "GetIdentityServerConfigResponse",
+              "responseLongType": "GetIdentityServerConfigResponse",
+              "responseFullType": "identity_v2.GetIdentityServerConfigResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "CreateIDPConnector",
+              "description": "",
+              "requestType": "CreateIDPConnectorRequest",
+              "requestLongType": "CreateIDPConnectorRequest",
+              "requestFullType": "identity_v2.CreateIDPConnectorRequest",
+              "requestStreaming": false,
+              "responseType": "CreateIDPConnectorResponse",
+              "responseLongType": "CreateIDPConnectorResponse",
+              "responseFullType": "identity_v2.CreateIDPConnectorResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "UpdateIDPConnector",
+              "description": "",
+              "requestType": "UpdateIDPConnectorRequest",
+              "requestLongType": "UpdateIDPConnectorRequest",
+              "requestFullType": "identity_v2.UpdateIDPConnectorRequest",
+              "requestStreaming": false,
+              "responseType": "UpdateIDPConnectorResponse",
+              "responseLongType": "UpdateIDPConnectorResponse",
+              "responseFullType": "identity_v2.UpdateIDPConnectorResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListIDPConnectors",
+              "description": "",
+              "requestType": "ListIDPConnectorsRequest",
+              "requestLongType": "ListIDPConnectorsRequest",
+              "requestFullType": "identity_v2.ListIDPConnectorsRequest",
+              "requestStreaming": false,
+              "responseType": "ListIDPConnectorsResponse",
+              "responseLongType": "ListIDPConnectorsResponse",
+              "responseFullType": "identity_v2.ListIDPConnectorsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetIDPConnector",
+              "description": "",
+              "requestType": "GetIDPConnectorRequest",
+              "requestLongType": "GetIDPConnectorRequest",
+              "requestFullType": "identity_v2.GetIDPConnectorRequest",
+              "requestStreaming": false,
+              "responseType": "GetIDPConnectorResponse",
+              "responseLongType": "GetIDPConnectorResponse",
+              "responseFullType": "identity_v2.GetIDPConnectorResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteIDPConnector",
+              "description": "",
+              "requestType": "DeleteIDPConnectorRequest",
+              "requestLongType": "DeleteIDPConnectorRequest",
+              "requestFullType": "identity_v2.DeleteIDPConnectorRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteIDPConnectorResponse",
+              "responseLongType": "DeleteIDPConnectorResponse",
+              "responseFullType": "identity_v2.DeleteIDPConnectorResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "CreateOIDCClient",
+              "description": "",
+              "requestType": "CreateOIDCClientRequest",
+              "requestLongType": "CreateOIDCClientRequest",
+              "requestFullType": "identity_v2.CreateOIDCClientRequest",
+              "requestStreaming": false,
+              "responseType": "CreateOIDCClientResponse",
+              "responseLongType": "CreateOIDCClientResponse",
+              "responseFullType": "identity_v2.CreateOIDCClientResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "UpdateOIDCClient",
+              "description": "",
+              "requestType": "UpdateOIDCClientRequest",
+              "requestLongType": "UpdateOIDCClientRequest",
+              "requestFullType": "identity_v2.UpdateOIDCClientRequest",
+              "requestStreaming": false,
+              "responseType": "UpdateOIDCClientResponse",
+              "responseLongType": "UpdateOIDCClientResponse",
+              "responseFullType": "identity_v2.UpdateOIDCClientResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetOIDCClient",
+              "description": "",
+              "requestType": "GetOIDCClientRequest",
+              "requestLongType": "GetOIDCClientRequest",
+              "requestFullType": "identity_v2.GetOIDCClientRequest",
+              "requestStreaming": false,
+              "responseType": "GetOIDCClientResponse",
+              "responseLongType": "GetOIDCClientResponse",
+              "responseFullType": "identity_v2.GetOIDCClientResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListOIDCClients",
+              "description": "",
+              "requestType": "ListOIDCClientsRequest",
+              "requestLongType": "ListOIDCClientsRequest",
+              "requestFullType": "identity_v2.ListOIDCClientsRequest",
+              "requestStreaming": false,
+              "responseType": "ListOIDCClientsResponse",
+              "responseLongType": "ListOIDCClientsResponse",
+              "responseFullType": "identity_v2.ListOIDCClientsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteOIDCClient",
+              "description": "",
+              "requestType": "DeleteOIDCClientRequest",
+              "requestLongType": "DeleteOIDCClientRequest",
+              "requestFullType": "identity_v2.DeleteOIDCClientRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteOIDCClientResponse",
+              "responseLongType": "DeleteOIDCClientResponse",
+              "responseFullType": "identity_v2.DeleteOIDCClientResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteAll",
+              "description": "",
+              "requestType": "DeleteAllRequest",
+              "requestLongType": "DeleteAllRequest",
+              "requestFullType": "identity_v2.DeleteAllRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteAllResponse",
+              "responseLongType": "DeleteAllResponse",
+              "responseFullType": "identity_v2.DeleteAllResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "internal/clusterstate/v2.5.0/commit_info.proto",
+      "description": "",
+      "package": "v2_5_0",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "CommitInfo",
+          "longName": "CommitInfo",
+          "fullName": "v2_5_0.CommitInfo",
+          "description": "CommitInfo is the main data structure representing a commit in etcd",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "origin",
+              "description": "",
+              "label": "",
+              "type": "CommitOrigin",
+              "longType": "pfs_v2.CommitOrigin",
+              "fullType": "pfs_v2.CommitOrigin",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "description is a user-provided script describing this commit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parent_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "child_commits",
+              "description": "",
+              "label": "repeated",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "started",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "finishing",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "finished",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "direct_provenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Branch",
+              "longType": "pfs_v2.Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes_upper_bound",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "Details",
+              "longType": "pfs_v2.CommitInfo.Details",
+              "fullType": "pfs_v2.CommitInfo.Details",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/collection/test.proto",
+      "description": "",
+      "package": "common",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "TestItem",
+          "longName": "TestItem",
+          "fullName": "common.TestItem",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/config/config.proto",
+      "description": "",
+      "package": "config_v2",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "ContextSource",
+          "longName": "ContextSource",
+          "fullName": "config_v2.ContextSource",
+          "description": "",
+          "values": [
+            {
+              "name": "NONE",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "CONFIG_V1",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "HUB",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "IMPORTED",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Config",
+          "longName": "Config",
+          "fullName": "config_v2.Config",
+          "description": "Config specifies the pachyderm config that is read and interpreted by the\npachctl command-line tool. Right now, this is stored at\n$HOME/.pachyderm/config.\n\nDifferent versions of the pachyderm config are specified as subfields of this\nmessage (this allows us to make significant changes to the config structure\nwithout breaking existing users by defining a new config version).\n\nThese structures are stored in a JSON format, so it should be safe to modify\nfields as long as compatibility is ensured with previous versions.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "user_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "v1",
+              "description": "Configuration options. Exactly one of these fields should be set\n(depending on which version of the config is being used)",
+              "label": "",
+              "type": "ConfigV1",
+              "longType": "ConfigV1",
+              "fullType": "config_v2.ConfigV1",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "v2",
+              "description": "",
+              "label": "",
+              "type": "ConfigV2",
+              "longType": "ConfigV2",
+              "fullType": "config_v2.ConfigV2",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ConfigV1",
+          "longName": "ConfigV1",
+          "fullName": "config_v2.ConfigV1",
+          "description": "ConfigV1 specifies v1 of the pachyderm config (June 30 2017 - June 2019)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pachd_address",
+              "description": "A host:port pointing pachd at a pachyderm cluster.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "server_cas",
+              "description": "Trusted root certificates (overrides installed certificates), formatted\nas base64-encoded PEM",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "session_token",
+              "description": "A secret token identifying the current pachctl user within their\npachyderm cluster. This is included in all RPCs sent by pachctl, and used\nto determine if pachctl actions are authorized.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "active_transaction",
+              "description": "The currently active transaction for batching together pachctl commands.\nThis can be set or cleared via many of the `pachctl * transaction` commands.\nThis is the ID of the transaction object stored in the pachyderm etcd.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ConfigV2",
+          "longName": "ConfigV2",
+          "fullName": "config_v2.ConfigV2",
+          "description": "ConfigV2 specifies v2 of the pachyderm config (June 2019 - present)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "active_context",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "active_enterprise_context",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "contexts",
+              "description": "",
+              "label": "repeated",
+              "type": "ContextsEntry",
+              "longType": "ConfigV2.ContextsEntry",
+              "fullType": "config_v2.ConfigV2.ContextsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "metrics",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_shell_completions",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ContextsEntry",
+          "longName": "ConfigV2.ContextsEntry",
+          "fullName": "config_v2.ConfigV2.ContextsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "Context",
+              "longType": "Context",
+              "fullType": "config_v2.Context",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Context",
+          "longName": "Context",
+          "fullName": "config_v2.Context",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "source",
+              "description": "Where this context came from",
+              "label": "",
+              "type": "ContextSource",
+              "longType": "ContextSource",
+              "fullType": "config_v2.ContextSource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pachd_address",
+              "description": "The hostname or IP address pointing pachd at a pachyderm cluster.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "server_cas",
+              "description": "Trusted root certificates (overrides installed certificates), formatted\nas base64-encoded PEM.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "session_token",
+              "description": "A secret token identifying the current pachctl user within their\npachyderm cluster. This is included in all RPCs sent by pachctl, and used\nto determine if pachctl actions are authorized.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "active_transaction",
+              "description": "The currently active transaction for batching together pachctl commands.\nThis can be set or cleared via many of the `pachctl * transaction` commands.\nThis is the ID of the transaction object stored in the pachyderm etcd.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cluster_name",
+              "description": "The k8s cluster name - used to construct a k8s context.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_info",
+              "description": "The k8s auth info - used to construct a k8s context.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "namespace",
+              "description": "The k8s namespace - used to construct a k8s context.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "port_forwarders",
+              "description": "A mapping of service -\u003e port number, when port forwarding is\nrunning for this context.",
+              "label": "repeated",
+              "type": "PortForwardersEntry",
+              "longType": "Context.PortForwardersEntry",
+              "fullType": "config_v2.Context.PortForwardersEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cluster_deployment_id",
+              "description": "A unique ID for the cluster deployment. At client initialization time,\nwe ensure this is the same as what the cluster reports back, to prevent\nus from connecting to the wrong cluster.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enterprise_server",
+              "description": "A boolean that records whether the context points at an enterprise server.\nIf false, the context points at a stand-alone pachd.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "project",
+              "description": "The current project.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PortForwardersEntry",
+          "longName": "Context.PortForwardersEntry",
+          "fullName": "config_v2.Context.PortForwardersEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/metrics/metrics.proto",
+      "description": "",
+      "package": "metrics",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Metrics",
+          "longName": "Metrics",
+          "fullName": "metrics.Metrics",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "cluster_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "nodes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "repos",
+              "description": "Number of repos",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commits",
+              "description": "Number of commits -- not used",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "files",
+              "description": "Number of files -- not used",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "bytes",
+              "description": "Number of bytes in all repos",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jobs",
+              "description": "Number of jobs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipelines",
+              "description": "Number of pipelines in the cluster -- not the same as DAG",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "archived_commits",
+              "description": "Number of archived commit -- not used",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cancelled_commits",
+              "description": "Number of cancelled commits -- not used",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "activation_code",
+              "description": "Activation code",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_branches",
+              "description": "Max branches in across all the repos",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pps_spout",
+              "description": "Number of spout pipelines",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pps_spout_service",
+              "description": "Number of spout services",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cfg_egress",
+              "description": "Number of pipelines with Egress configured",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cfg_standby",
+              "description": "Number of pipelines with Standby congigured",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cfg_s3gateway",
+              "description": "Number of pipelines with S3 Gateway configured",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cfg_services",
+              "description": "Number of pipelines with services configured",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cfg_errcmd",
+              "description": "Number of pipelines with error cmd set",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cfg_tfjob",
+              "description": "Number of pipelines with TFJobs configured",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_group",
+              "description": "Number of pipelines with group inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_join",
+              "description": "Number of pipelines with join inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_cross",
+              "description": "Number of pipelines with cross inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_union",
+              "description": "Number of pipelines with union inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_cron",
+              "description": "Number of pipelines with cron inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_git",
+              "description": "Number of pipelines with git inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_pfs",
+              "description": "Number of pfs inputs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_commit",
+              "description": "Number of pfs inputs with commits",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_join_on",
+              "description": "Number of pfs inputs with join_on",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_outer_join",
+              "description": "Number of pipelines with outer joins",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_lazy",
+              "description": "Number of pipelines with lazy set",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_empty_files",
+              "description": "Number of pipelines with empty files set",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_s3",
+              "description": "Number of pipelines with S3 input",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_trigger",
+              "description": "Number of pipelines with triggers set",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_cpu_req",
+              "description": "Total CPU request across all pipelines",
+              "label": "",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_cpu_req_max",
+              "description": "Max CPU resource requests set",
+              "label": "",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_mem_req",
+              "description": "Sting of memory requests set across all pipelines",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_gpu_req",
+              "description": "Total GPU requests across all pipelines",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_gpu_req_max",
+              "description": "Max GPU request across all pipelines",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_disk_req",
+              "description": "String of disk requests set across all pipelines",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_cpu_limit",
+              "description": "Total CPU limits set across all pipelines",
+              "label": "",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_cpu_limit_max",
+              "description": "Max CPU limit set",
+              "label": "",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_mem_limit",
+              "description": "String of memory limits set",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_gpu_limit",
+              "description": "Number of pipelines with",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_gpu_limit_max",
+              "description": "Max GPU limit set",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_disk_limit",
+              "description": "String of disk limits set across all pipelines",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_parallelism",
+              "description": "Max parallelism set",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_parallelism",
+              "description": "Min parallelism set",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "num_parallelism",
+              "description": "Number of pipelines with parallelism set",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enterprise_failures",
+              "description": "Number of times a command has failed due to an enterprise check",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/pfsload/pfsload.proto",
+      "description": "",
+      "package": "pfsload",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "CommitSpec",
+          "longName": "CommitSpec",
+          "fullName": "pfsload.CommitSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "modifications",
+              "description": "",
+              "label": "repeated",
+              "type": "ModificationSpec",
+              "longType": "ModificationSpec",
+              "fullType": "pfsload.ModificationSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_sources",
+              "description": "",
+              "label": "repeated",
+              "type": "FileSourceSpec",
+              "longType": "FileSourceSpec",
+              "fullType": "pfsload.FileSourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "validator",
+              "description": "",
+              "label": "",
+              "type": "ValidatorSpec",
+              "longType": "ValidatorSpec",
+              "fullType": "pfsload.ValidatorSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FileSourceSpec",
+          "longName": "FileSourceSpec",
+          "fullName": "pfsload.FileSourceSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "random",
+              "description": "",
+              "label": "",
+              "type": "RandomFileSourceSpec",
+              "longType": "RandomFileSourceSpec",
+              "fullType": "pfsload.RandomFileSourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FrequencySpec",
+          "longName": "FrequencySpec",
+          "fullName": "pfsload.FrequencySpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "prob",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ModificationSpec",
+          "longName": "ModificationSpec",
+          "fullName": "pfsload.ModificationSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "put_file",
+              "description": "",
+              "label": "",
+              "type": "PutFileSpec",
+              "longType": "PutFileSpec",
+              "fullType": "pfsload.PutFileSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PutFileSpec",
+          "longName": "PutFileSpec",
+          "fullName": "pfsload.PutFileSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "source",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PutFileTask",
+          "longName": "PutFileTask",
+          "fullName": "pfsload.PutFileTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_source",
+              "description": "",
+              "label": "",
+              "type": "FileSourceSpec",
+              "longType": "FileSourceSpec",
+              "fullType": "pfsload.FileSourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PutFileTaskResult",
+          "longName": "PutFileTaskResult",
+          "fullName": "pfsload.PutFileTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hash",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RandomDirectorySpec",
+          "longName": "RandomDirectorySpec",
+          "fullName": "pfsload.RandomDirectorySpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "depth",
+              "description": "",
+              "label": "",
+              "type": "SizeSpec",
+              "longType": "SizeSpec",
+              "fullType": "pfsload.SizeSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "run",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RandomFileSourceSpec",
+          "longName": "RandomFileSourceSpec",
+          "fullName": "pfsload.RandomFileSourceSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "directory",
+              "description": "",
+              "label": "",
+              "type": "RandomDirectorySpec",
+              "longType": "RandomDirectorySpec",
+              "fullType": "pfsload.RandomDirectorySpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sizes",
+              "description": "",
+              "label": "repeated",
+              "type": "SizeSpec",
+              "longType": "SizeSpec",
+              "fullType": "pfsload.SizeSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "increment_path",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SizeSpec",
+          "longName": "SizeSpec",
+          "fullName": "pfsload.SizeSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "min_size",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_size",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "prob",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "State",
+          "longName": "State",
+          "fullName": "pfsload.State",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commits",
+              "description": "",
+              "label": "repeated",
+              "type": "Commit",
+              "longType": "State.Commit",
+              "fullType": "pfsload.State.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Commit",
+          "longName": "State.Commit",
+          "fullName": "pfsload.State.Commit",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hash",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ValidatorSpec",
+          "longName": "ValidatorSpec",
+          "fullName": "pfsload.ValidatorSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "frequency",
+              "description": "",
+              "label": "",
+              "type": "FrequencySpec",
+              "longType": "FrequencySpec",
+              "fullType": "pfsload.FrequencySpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/ppsdb/ppsdb.proto",
+      "description": "",
+      "package": "pps_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ClusterDefaultsWrapper",
+          "longName": "ClusterDefaultsWrapper",
+          "fullName": "pps_v2.ClusterDefaultsWrapper",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "json",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/ppsload/ppsload.proto",
+      "description": "",
+      "package": "ppsload",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "State",
+          "longName": "State",
+          "fullName": "ppsload.State",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "pfs_v2.Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pfs_state_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/storage/chunk/chunk.proto",
+      "description": "",
+      "package": "chunk",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "CompressionAlgo",
+          "longName": "CompressionAlgo",
+          "fullName": "chunk.CompressionAlgo",
+          "description": "",
+          "values": [
+            {
+              "name": "NONE",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "GZIP_BEST_SPEED",
+              "number": "1",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "EncryptionAlgo",
+          "longName": "EncryptionAlgo",
+          "fullName": "chunk.EncryptionAlgo",
+          "description": "",
+          "values": [
+            {
+              "name": "ENCRYPTION_ALGO_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "CHACHA20",
+              "number": "1",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "DataRef",
+          "longName": "DataRef",
+          "fullName": "chunk.DataRef",
+          "description": "DataRef is a reference to data within a chunk.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "ref",
+              "description": "The chunk the referenced data is located in.",
+              "label": "",
+              "type": "Ref",
+              "longType": "Ref",
+              "fullType": "chunk.Ref",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hash",
+              "description": "The hash of the data being referenced.",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "offset_bytes",
+              "description": "The offset and size used for accessing the data within the chunk.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Ref",
+          "longName": "Ref",
+          "fullName": "chunk.Ref",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "edge",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "dek",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "encryption_algo",
+              "description": "",
+              "label": "",
+              "type": "EncryptionAlgo",
+              "longType": "EncryptionAlgo",
+              "fullType": "chunk.EncryptionAlgo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "compression_algo",
+              "description": "",
+              "label": "",
+              "type": "CompressionAlgo",
+              "longType": "CompressionAlgo",
+              "fullType": "chunk.CompressionAlgo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/storage/fileset/fileset.proto",
+      "description": "",
+      "package": "fileset",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Composite",
+          "longName": "Composite",
+          "fullName": "fileset.Composite",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "layers",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Metadata",
+          "longName": "Metadata",
+          "fullName": "fileset.Metadata",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "primitive",
+              "description": "",
+              "label": "",
+              "type": "Primitive",
+              "longType": "Primitive",
+              "fullType": "fileset.Primitive",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "value",
+              "defaultValue": ""
+            },
+            {
+              "name": "composite",
+              "description": "",
+              "label": "",
+              "type": "Composite",
+              "longType": "Composite",
+              "fullType": "fileset.Composite",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "value",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Primitive",
+          "longName": "Primitive",
+          "fullName": "fileset.Primitive",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "deletive",
+              "description": "",
+              "label": "",
+              "type": "Index",
+              "longType": "index.Index",
+              "fullType": "index.Index",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "additive",
+              "description": "",
+              "label": "",
+              "type": "Index",
+              "longType": "index.Index",
+              "fullType": "index.Index",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TestCacheValue",
+          "longName": "TestCacheValue",
+          "fullName": "fileset.TestCacheValue",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/storage/fileset/index/index.proto",
+      "description": "",
+      "package": "index",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "File",
+          "longName": "File",
+          "fullName": "index.File",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_refs",
+              "description": "",
+              "label": "repeated",
+              "type": "DataRef",
+              "longType": "chunk.DataRef",
+              "fullType": "chunk.DataRef",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Index",
+          "longName": "Index",
+          "fullName": "index.Index",
+          "description": "Index stores an index to and metadata about a range of files or a file.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "range",
+              "description": "NOTE: range and file are mutually exclusive.",
+              "label": "",
+              "type": "Range",
+              "longType": "Range",
+              "fullType": "index.Range",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "index.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "num_files",
+              "description": "NOTE: num_files and size_bytes did not exist in older versions of 2.x, so\nthey will not be set.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Range",
+          "longName": "Range",
+          "fullName": "index.Range",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "offset",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chunk_ref",
+              "description": "",
+              "label": "",
+              "type": "DataRef",
+              "longType": "chunk.DataRef",
+              "fullType": "chunk.DataRef",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/task/task.proto",
+      "description": "",
+      "package": "task",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "State",
+          "longName": "State",
+          "fullName": "task.State",
+          "description": "",
+          "values": [
+            {
+              "name": "STATE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "RUNNING",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "SUCCESS",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "FAILURE",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Claim",
+          "longName": "Claim",
+          "fullName": "task.Claim",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "Group",
+          "longName": "Group",
+          "fullName": "task.Group",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "Task",
+          "longName": "Task",
+          "fullName": "task.Task",
+          "description": "TODO: Consider splitting this up into separate structures for each state in a oneof.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "State",
+              "longType": "State",
+              "fullType": "task.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input",
+              "description": "",
+              "label": "",
+              "type": "Any",
+              "longType": "google.protobuf.Any",
+              "fullType": "google.protobuf.Any",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "output",
+              "description": "",
+              "label": "",
+              "type": "Any",
+              "longType": "google.protobuf.Any",
+              "fullType": "google.protobuf.Any",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "index",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TestTask",
+          "longName": "TestTask",
+          "fullName": "task.TestTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "internal/tracing/extended/extended_trace.proto",
+      "description": "",
+      "package": "extended",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "TraceProto",
+          "longName": "TraceProto",
+          "fullName": "extended.TraceProto",
+          "description": "TraceProto contains information identifying a Jaeger trace. It's used to\npropagate traces that follow the lifetime of a long operation (e.g. creating\na pipeline or running a job), and which live longer than any single RPC.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "serialized_trace",
+              "description": "serialized_trace contains the info identifying a trace in Jaeger (a\n(trace ID, span ID, sampled) tuple, basically)",
+              "label": "repeated",
+              "type": "SerializedTraceEntry",
+              "longType": "TraceProto.SerializedTraceEntry",
+              "fullType": "extended.TraceProto.SerializedTraceEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline",
+              "description": "pipeline specifies the target pipeline of this trace; this would be set for\na trace created by 'pachctl create-pipeline' or 'pachctl update-pipeline'\nand would include the kubernetes RPCs involved in creating a pipeline",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SerializedTraceEntry",
+          "longName": "TraceProto.SerializedTraceEntry",
+          "fullName": "extended.TraceProto.SerializedTraceEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "license/license.proto",
+      "description": "",
+      "package": "license_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ActivateRequest",
+          "longName": "ActivateRequest",
+          "fullName": "license_v2.ActivateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "activation_code",
+              "description": "activation_code is a Pachyderm enterprise activation code. New users can\nobtain trial activation codes",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expires",
+              "description": "expires is a timestamp indicating when this activation code will expire.\nThis should not generally be set (it's primarily used for testing), and is\nonly applied if it's earlier than the signed expiration time in\n'activation_code'.",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ActivateResponse",
+          "longName": "ActivateResponse",
+          "fullName": "license_v2.ActivateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "info",
+              "description": "",
+              "label": "",
+              "type": "TokenInfo",
+              "longType": "enterprise_v2.TokenInfo",
+              "fullType": "enterprise_v2.TokenInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AddClusterRequest",
+          "longName": "AddClusterRequest",
+          "fullName": "license_v2.AddClusterRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "id is the unique, immutable identifier for this cluster",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "address",
+              "description": "address is the public GPRC address where the cluster can be reached",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "If set, secret specifies the shared secret this cluster will use\nto authenticate to the license server. Otherwise a secret will be\ngenerated and returned in the response.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user_address",
+              "description": "The pachd address for users to connect to.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cluster_deployment_id",
+              "description": "The deployment ID value generated by each Cluster",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enterprise_server",
+              "description": "This field indicates whether the address points to an enterprise server",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AddClusterResponse",
+          "longName": "AddClusterResponse",
+          "fullName": "license_v2.AddClusterResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ClusterStatus",
+          "longName": "ClusterStatus",
+          "fullName": "license_v2.ClusterStatus",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "address",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_enabled",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "client_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_heartbeat",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_at",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeactivateRequest",
+          "longName": "DeactivateRequest",
+          "fullName": "license_v2.DeactivateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeactivateResponse",
+          "longName": "DeactivateResponse",
+          "fullName": "license_v2.DeactivateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteAllRequest",
+          "longName": "DeleteAllRequest",
+          "fullName": "license_v2.DeleteAllRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteAllResponse",
+          "longName": "DeleteAllResponse",
+          "fullName": "license_v2.DeleteAllResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteClusterRequest",
+          "longName": "DeleteClusterRequest",
+          "fullName": "license_v2.DeleteClusterRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteClusterResponse",
+          "longName": "DeleteClusterResponse",
+          "fullName": "license_v2.DeleteClusterResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetActivationCodeRequest",
+          "longName": "GetActivationCodeRequest",
+          "fullName": "license_v2.GetActivationCodeRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetActivationCodeResponse",
+          "longName": "GetActivationCodeResponse",
+          "fullName": "license_v2.GetActivationCodeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "State",
+              "longType": "enterprise_v2.State",
+              "fullType": "enterprise_v2.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "info",
+              "description": "",
+              "label": "",
+              "type": "TokenInfo",
+              "longType": "enterprise_v2.TokenInfo",
+              "fullType": "enterprise_v2.TokenInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "activation_code",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "HeartbeatRequest",
+          "longName": "HeartbeatRequest",
+          "fullName": "license_v2.HeartbeatRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_enabled",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "client_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "HeartbeatResponse",
+          "longName": "HeartbeatResponse",
+          "fullName": "license_v2.HeartbeatResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "license",
+              "description": "",
+              "label": "",
+              "type": "LicenseRecord",
+              "longType": "enterprise_v2.LicenseRecord",
+              "fullType": "enterprise_v2.LicenseRecord",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListClustersRequest",
+          "longName": "ListClustersRequest",
+          "fullName": "license_v2.ListClustersRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ListClustersResponse",
+          "longName": "ListClustersResponse",
+          "fullName": "license_v2.ListClustersResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "clusters",
+              "description": "",
+              "label": "repeated",
+              "type": "ClusterStatus",
+              "longType": "ClusterStatus",
+              "fullType": "license_v2.ClusterStatus",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListUserClustersRequest",
+          "longName": "ListUserClustersRequest",
+          "fullName": "license_v2.ListUserClustersRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ListUserClustersResponse",
+          "longName": "ListUserClustersResponse",
+          "fullName": "license_v2.ListUserClustersResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "clusters",
+              "description": "",
+              "label": "repeated",
+              "type": "UserClusterInfo",
+              "longType": "UserClusterInfo",
+              "fullType": "license_v2.UserClusterInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UpdateClusterRequest",
+          "longName": "UpdateClusterRequest",
+          "fullName": "license_v2.UpdateClusterRequest",
+          "description": "Note: Updates of the enterprise-server field are not allowed. In the worst case, a user can recreate their cluster if they need the field updated.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "address",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user_address",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cluster_deployment_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UpdateClusterResponse",
+          "longName": "UpdateClusterResponse",
+          "fullName": "license_v2.UpdateClusterResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "UserClusterInfo",
+          "longName": "UserClusterInfo",
+          "fullName": "license_v2.UserClusterInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cluster_deployment_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "address",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enterprise_server",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "license_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "Activate",
+              "description": "Activate enables the license service by setting the enterprise activation\ncode to serve.",
+              "requestType": "ActivateRequest",
+              "requestLongType": "ActivateRequest",
+              "requestFullType": "license_v2.ActivateRequest",
+              "requestStreaming": false,
+              "responseType": "ActivateResponse",
+              "responseLongType": "ActivateResponse",
+              "responseFullType": "license_v2.ActivateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetActivationCode",
+              "description": "",
+              "requestType": "GetActivationCodeRequest",
+              "requestLongType": "GetActivationCodeRequest",
+              "requestFullType": "license_v2.GetActivationCodeRequest",
+              "requestStreaming": false,
+              "responseType": "GetActivationCodeResponse",
+              "responseLongType": "GetActivationCodeResponse",
+              "responseFullType": "license_v2.GetActivationCodeResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteAll",
+              "description": "DeleteAll deactivates the server and removes all data.",
+              "requestType": "DeleteAllRequest",
+              "requestLongType": "DeleteAllRequest",
+              "requestFullType": "license_v2.DeleteAllRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteAllResponse",
+              "responseLongType": "DeleteAllResponse",
+              "responseFullType": "license_v2.DeleteAllResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "AddCluster",
+              "description": "CRUD operations for the pachds registered with this server.",
+              "requestType": "AddClusterRequest",
+              "requestLongType": "AddClusterRequest",
+              "requestFullType": "license_v2.AddClusterRequest",
+              "requestStreaming": false,
+              "responseType": "AddClusterResponse",
+              "responseLongType": "AddClusterResponse",
+              "responseFullType": "license_v2.AddClusterResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteCluster",
+              "description": "",
+              "requestType": "DeleteClusterRequest",
+              "requestLongType": "DeleteClusterRequest",
+              "requestFullType": "license_v2.DeleteClusterRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteClusterResponse",
+              "responseLongType": "DeleteClusterResponse",
+              "responseFullType": "license_v2.DeleteClusterResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListClusters",
+              "description": "",
+              "requestType": "ListClustersRequest",
+              "requestLongType": "ListClustersRequest",
+              "requestFullType": "license_v2.ListClustersRequest",
+              "requestStreaming": false,
+              "responseType": "ListClustersResponse",
+              "responseLongType": "ListClustersResponse",
+              "responseFullType": "license_v2.ListClustersResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "UpdateCluster",
+              "description": "",
+              "requestType": "UpdateClusterRequest",
+              "requestLongType": "UpdateClusterRequest",
+              "requestFullType": "license_v2.UpdateClusterRequest",
+              "requestStreaming": false,
+              "responseType": "UpdateClusterResponse",
+              "responseLongType": "UpdateClusterResponse",
+              "responseFullType": "license_v2.UpdateClusterResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Heartbeat",
+              "description": "Heartbeat is the RPC registered pachds make to the license server\nto communicate their status and fetch updates.",
+              "requestType": "HeartbeatRequest",
+              "requestLongType": "HeartbeatRequest",
+              "requestFullType": "license_v2.HeartbeatRequest",
+              "requestStreaming": false,
+              "responseType": "HeartbeatResponse",
+              "responseLongType": "HeartbeatResponse",
+              "responseFullType": "license_v2.HeartbeatResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListUserClusters",
+              "description": "Lists all clusters available to user",
+              "requestType": "ListUserClustersRequest",
+              "requestLongType": "ListUserClustersRequest",
+              "requestFullType": "license_v2.ListUserClustersRequest",
+              "requestStreaming": false,
+              "responseType": "ListUserClustersResponse",
+              "responseLongType": "ListUserClustersResponse",
+              "responseFullType": "license_v2.ListUserClustersResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "pfs/pfs.proto",
+      "description": "",
+      "package": "pfs_v2",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "CommitState",
+          "longName": "CommitState",
+          "fullName": "pfs_v2.CommitState",
+          "description": "CommitState describes the states a commit can be in.\nThe states are increasingly specific, i.e. a commit that is FINISHED also counts as STARTED.",
+          "values": [
+            {
+              "name": "COMMIT_STATE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "STARTED",
+              "number": "1",
+              "description": "The commit has been started, all commits satisfy this state."
+            },
+            {
+              "name": "READY",
+              "number": "2",
+              "description": "The commit has been started, and all of its provenant commits have been finished."
+            },
+            {
+              "name": "FINISHING",
+              "number": "3",
+              "description": "The commit is in the process of being finished."
+            },
+            {
+              "name": "FINISHED",
+              "number": "4",
+              "description": "The commit has been finished."
+            }
+          ]
+        },
+        {
+          "name": "Delimiter",
+          "longName": "Delimiter",
+          "fullName": "pfs_v2.Delimiter",
+          "description": "",
+          "values": [
+            {
+              "name": "NONE",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "JSON",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "LINE",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "SQL",
+              "number": "3",
+              "description": ""
+            },
+            {
+              "name": "CSV",
+              "number": "4",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "FileType",
+          "longName": "FileType",
+          "fullName": "pfs_v2.FileType",
+          "description": "",
+          "values": [
+            {
+              "name": "RESERVED",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "FILE",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "DIR",
+              "number": "2",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "OriginKind",
+          "longName": "OriginKind",
+          "fullName": "pfs_v2.OriginKind",
+          "description": "These are the different places where a commit may be originated from",
+          "values": [
+            {
+              "name": "ORIGIN_KIND_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "USER",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "AUTO",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "FSCK",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "Type",
+          "longName": "SQLDatabaseEgress.FileFormat.Type",
+          "fullName": "pfs_v2.SQLDatabaseEgress.FileFormat.Type",
+          "description": "",
+          "values": [
+            {
+              "name": "UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "CSV",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "JSON",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "PARQUET",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ActivateAuthRequest",
+          "longName": "ActivateAuthRequest",
+          "fullName": "pfs_v2.ActivateAuthRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ActivateAuthResponse",
+          "longName": "ActivateAuthResponse",
+          "fullName": "pfs_v2.ActivateAuthResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "AddFile",
+          "longName": "AddFile",
+          "fullName": "pfs_v2.AddFile",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "raw",
+              "description": "",
+              "label": "",
+              "type": "BytesValue",
+              "longType": "google.protobuf.BytesValue",
+              "fullType": "google.protobuf.BytesValue",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "source",
+              "defaultValue": ""
+            },
+            {
+              "name": "url",
+              "description": "",
+              "label": "",
+              "type": "URLSource",
+              "longType": "AddFile.URLSource",
+              "fullType": "pfs_v2.AddFile.URLSource",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "source",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "URLSource",
+          "longName": "AddFile.URLSource",
+          "fullName": "pfs_v2.AddFile.URLSource",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "URL",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "recursive",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "concurrency",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AddFileSetRequest",
+          "longName": "AddFileSetRequest",
+          "fullName": "pfs_v2.AddFileSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AuthInfo",
+          "longName": "AuthInfo",
+          "fullName": "pfs_v2.AuthInfo",
+          "description": "AuthInfo includes the caller's access scope for a resource, and is returned\nby services like ListRepo, InspectRepo, and ListProject, but is not persisted in the database.\nIt's used by the Pachyderm dashboard to render repo access appropriately.\nTo set a user's auth scope for a resource, use the Pachyderm Auth API (in src/auth/auth.proto)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "permissions",
+              "description": "The callers access level to the relevant resource. These are very granular\npermissions - for the end user it makes sense to show them the roles\nthey have instead.",
+              "label": "repeated",
+              "type": "Permission",
+              "longType": "auth_v2.Permission",
+              "fullType": "auth_v2.Permission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "roles",
+              "description": "The caller's roles on the relevant resource. This includes inherited\nroles from the cluster, project, group membership, etc.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Branch",
+          "longName": "Branch",
+          "fullName": "pfs_v2.Branch",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BranchInfo",
+          "longName": "BranchInfo",
+          "fullName": "pfs_v2.BranchInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "head",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "provenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "subvenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "direct_provenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trigger",
+              "description": "",
+              "label": "",
+              "type": "Trigger",
+              "longType": "Trigger",
+              "fullType": "pfs_v2.Trigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CheckStorageRequest",
+          "longName": "CheckStorageRequest",
+          "fullName": "pfs_v2.CheckStorageRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "read_chunk_data",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chunk_begin",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chunk_end",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CheckStorageResponse",
+          "longName": "CheckStorageResponse",
+          "fullName": "pfs_v2.CheckStorageResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "chunk_object_count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ClearCacheRequest",
+          "longName": "ClearCacheRequest",
+          "fullName": "pfs_v2.ClearCacheRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tag_prefix",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ClearCommitRequest",
+          "longName": "ClearCommitRequest",
+          "fullName": "pfs_v2.ClearCommitRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Commit",
+          "longName": "Commit",
+          "fullName": "pfs_v2.Commit",
+          "description": "Commit is a reference to a commit (e.g. the collection of branches and the\ncollection of currently-open commits in etcd are collections of Commit\nprotos)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "only used by the client",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CommitInfo",
+          "longName": "CommitInfo",
+          "fullName": "pfs_v2.CommitInfo",
+          "description": "CommitInfo is the main data structure representing a commit in etcd",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "origin",
+              "description": "",
+              "label": "",
+              "type": "CommitOrigin",
+              "longType": "CommitOrigin",
+              "fullType": "pfs_v2.CommitOrigin",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "description is a user-provided script describing this commit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parent_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "child_commits",
+              "description": "",
+              "label": "repeated",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "started",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "finishing",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "finished",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "direct_provenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes_upper_bound",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "Details",
+              "longType": "CommitInfo.Details",
+              "fullType": "pfs_v2.CommitInfo.Details",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Details",
+          "longName": "CommitInfo.Details",
+          "fullName": "pfs_v2.CommitInfo.Details",
+          "description": "Details are only provided when explicitly requested",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "compacting_time",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "validating_time",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CommitOrigin",
+          "longName": "CommitOrigin",
+          "fullName": "pfs_v2.CommitOrigin",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "kind",
+              "description": "",
+              "label": "",
+              "type": "OriginKind",
+              "longType": "OriginKind",
+              "fullType": "pfs_v2.OriginKind",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CommitSet",
+          "longName": "CommitSet",
+          "fullName": "pfs_v2.CommitSet",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CommitSetInfo",
+          "longName": "CommitSetInfo",
+          "fullName": "pfs_v2.CommitSetInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit_set",
+              "description": "",
+              "label": "",
+              "type": "CommitSet",
+              "longType": "CommitSet",
+              "fullType": "pfs_v2.CommitSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commits",
+              "description": "",
+              "label": "repeated",
+              "type": "CommitInfo",
+              "longType": "CommitInfo",
+              "fullType": "pfs_v2.CommitInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ComposeFileSetRequest",
+          "longName": "ComposeFileSetRequest",
+          "fullName": "pfs_v2.ComposeFileSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_ids",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ttl_seconds",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "compact",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CopyFile",
+          "longName": "CopyFile",
+          "fullName": "pfs_v2.CopyFile",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "dst",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "src",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "append",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateBranchRequest",
+          "longName": "CreateBranchRequest",
+          "fullName": "pfs_v2.CreateBranchRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "head",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "provenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trigger",
+              "description": "",
+              "label": "",
+              "type": "Trigger",
+              "longType": "Trigger",
+              "fullType": "pfs_v2.Trigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "new_commit_set",
+              "description": "overrides the default behavior of using the same CommitSet as 'head'",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateFileSetResponse",
+          "longName": "CreateFileSetResponse",
+          "fullName": "pfs_v2.CreateFileSetResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateProjectRequest",
+          "longName": "CreateProjectRequest",
+          "fullName": "pfs_v2.CreateProjectRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateRepoRequest",
+          "longName": "CreateRepoRequest",
+          "fullName": "pfs_v2.CreateRepoRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteBranchRequest",
+          "longName": "DeleteBranchRequest",
+          "fullName": "pfs_v2.DeleteBranchRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteFile",
+          "longName": "DeleteFile",
+          "fullName": "pfs_v2.DeleteFile",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteProjectRequest",
+          "longName": "DeleteProjectRequest",
+          "fullName": "pfs_v2.DeleteProjectRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteRepoRequest",
+          "longName": "DeleteRepoRequest",
+          "fullName": "pfs_v2.DeleteRepoRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteRepoResponse",
+          "longName": "DeleteRepoResponse",
+          "fullName": "pfs_v2.DeleteRepoResponse",
+          "description": "DeleteRepoResponse returns the repos that were deleted by a DeleteRepo call.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "deleted",
+              "description": "The repos that were deleted, perhaps none.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteReposRequest",
+          "longName": "DeleteReposRequest",
+          "fullName": "pfs_v2.DeleteReposRequest",
+          "description": "DeleteReposRequest is used to delete more than one repo at once.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "projects",
+              "description": "All repos in each project will be deleted if the caller has\npermission.",
+              "label": "repeated",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "all",
+              "description": "If all is set, then all repos in all projects will be deleted if the caller\nhas permission.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteReposResponse",
+          "longName": "DeleteReposResponse",
+          "fullName": "pfs_v2.DeleteReposResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repos",
+              "description": "",
+              "label": "repeated",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DiffFileRequest",
+          "longName": "DiffFileRequest",
+          "fullName": "pfs_v2.DiffFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "new_file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "old_file",
+              "description": "OldFile may be left nil in which case the same path in the parent of\nNewFile's commit will be used.",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "shallow",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DiffFileResponse",
+          "longName": "DiffFileResponse",
+          "fullName": "pfs_v2.DiffFileResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "new_file",
+              "description": "",
+              "label": "",
+              "type": "FileInfo",
+              "longType": "FileInfo",
+              "fullType": "pfs_v2.FileInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "old_file",
+              "description": "",
+              "label": "",
+              "type": "FileInfo",
+              "longType": "FileInfo",
+              "fullType": "pfs_v2.FileInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DropCommitSetRequest",
+          "longName": "DropCommitSetRequest",
+          "fullName": "pfs_v2.DropCommitSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit_set",
+              "description": "",
+              "label": "",
+              "type": "CommitSet",
+              "longType": "CommitSet",
+              "fullType": "pfs_v2.CommitSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "EgressRequest",
+          "longName": "EgressRequest",
+          "fullName": "pfs_v2.EgressRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "object_storage",
+              "description": "",
+              "label": "",
+              "type": "ObjectStorageEgress",
+              "longType": "ObjectStorageEgress",
+              "fullType": "pfs_v2.ObjectStorageEgress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "target",
+              "defaultValue": ""
+            },
+            {
+              "name": "sql_database",
+              "description": "",
+              "label": "",
+              "type": "SQLDatabaseEgress",
+              "longType": "SQLDatabaseEgress",
+              "fullType": "pfs_v2.SQLDatabaseEgress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "target",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EgressResponse",
+          "longName": "EgressResponse",
+          "fullName": "pfs_v2.EgressResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "object_storage",
+              "description": "",
+              "label": "",
+              "type": "ObjectStorageResult",
+              "longType": "EgressResponse.ObjectStorageResult",
+              "fullType": "pfs_v2.EgressResponse.ObjectStorageResult",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "result",
+              "defaultValue": ""
+            },
+            {
+              "name": "sql_database",
+              "description": "",
+              "label": "",
+              "type": "SQLDatabaseResult",
+              "longType": "EgressResponse.SQLDatabaseResult",
+              "fullType": "pfs_v2.EgressResponse.SQLDatabaseResult",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "result",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObjectStorageResult",
+          "longName": "EgressResponse.ObjectStorageResult",
+          "fullName": "pfs_v2.EgressResponse.ObjectStorageResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "bytes_written",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SQLDatabaseResult",
+          "longName": "EgressResponse.SQLDatabaseResult",
+          "fullName": "pfs_v2.EgressResponse.SQLDatabaseResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "rows_written",
+              "description": "",
+              "label": "repeated",
+              "type": "RowsWrittenEntry",
+              "longType": "EgressResponse.SQLDatabaseResult.RowsWrittenEntry",
+              "fullType": "pfs_v2.EgressResponse.SQLDatabaseResult.RowsWrittenEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RowsWrittenEntry",
+          "longName": "EgressResponse.SQLDatabaseResult.RowsWrittenEntry",
+          "fullName": "pfs_v2.EgressResponse.SQLDatabaseResult.RowsWrittenEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "File",
+          "longName": "File",
+          "fullName": "pfs_v2.File",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FileInfo",
+          "longName": "FileInfo",
+          "fullName": "pfs_v2.FileInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_type",
+              "description": "",
+              "label": "",
+              "type": "FileType",
+              "longType": "FileType",
+              "fullType": "pfs_v2.FileType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "committed",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hash",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FindCommitsRequest",
+          "longName": "FindCommitsRequest",
+          "fullName": "pfs_v2.FindCommitsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "start",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "file_path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "limit",
+              "description": "a limit of 0 means there is no upper bound on the limit.",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FindCommitsResponse",
+          "longName": "FindCommitsResponse",
+          "fullName": "pfs_v2.FindCommitsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "found_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "result",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_searched_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "result",
+              "defaultValue": ""
+            },
+            {
+              "name": "commits_searched",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FinishCommitRequest",
+          "longName": "FinishCommitRequest",
+          "fullName": "pfs_v2.FinishCommitRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "description is a user-provided string describing this commit. Setting this\nwill overwrite the description set in StartCommit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FsckRequest",
+          "longName": "FsckRequest",
+          "fullName": "pfs_v2.FsckRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "fix",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "zombie_target",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "zombie_check",
+              "defaultValue": ""
+            },
+            {
+              "name": "zombie_all",
+              "description": "run zombie data detection against all pipelines",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "zombie_check",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FsckResponse",
+          "longName": "FsckResponse",
+          "fullName": "pfs_v2.FsckResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "fix",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetCacheRequest",
+          "longName": "GetCacheRequest",
+          "fullName": "pfs_v2.GetCacheRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetCacheResponse",
+          "longName": "GetCacheResponse",
+          "fullName": "pfs_v2.GetCacheResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "Any",
+              "longType": "google.protobuf.Any",
+              "fullType": "google.protobuf.Any",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetFileRequest",
+          "longName": "GetFileRequest",
+          "fullName": "pfs_v2.GetFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "URL",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "offset",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "TODO:\n int64 size_bytes = 3;",
+              "label": "",
+              "type": "PathRange",
+              "longType": "PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetFileSetRequest",
+          "longName": "GetFileSetRequest",
+          "fullName": "pfs_v2.GetFileSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GlobFileRequest",
+          "longName": "GlobFileRequest",
+          "fullName": "pfs_v2.GlobFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pattern",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectBranchRequest",
+          "longName": "InspectBranchRequest",
+          "fullName": "pfs_v2.InspectBranchRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectCommitRequest",
+          "longName": "InspectCommitRequest",
+          "fullName": "pfs_v2.InspectCommitRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "wait",
+              "description": "Wait causes inspect commit to wait until the commit is in the desired state.",
+              "label": "",
+              "type": "CommitState",
+              "longType": "CommitState",
+              "fullType": "pfs_v2.CommitState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectCommitSetRequest",
+          "longName": "InspectCommitSetRequest",
+          "fullName": "pfs_v2.InspectCommitSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit_set",
+              "description": "",
+              "label": "",
+              "type": "CommitSet",
+              "longType": "CommitSet",
+              "fullType": "pfs_v2.CommitSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "wait",
+              "description": "When true, wait until all commits in the set are finished",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectFileRequest",
+          "longName": "InspectFileRequest",
+          "fullName": "pfs_v2.InspectFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectProjectRequest",
+          "longName": "InspectProjectRequest",
+          "fullName": "pfs_v2.InspectProjectRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "InspectRepoRequest",
+          "longName": "InspectRepoRequest",
+          "fullName": "pfs_v2.InspectRepoRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListBranchRequest",
+          "longName": "ListBranchRequest",
+          "fullName": "pfs_v2.ListBranchRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "Returns branches oldest to newest",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListCommitRequest",
+          "longName": "ListCommitRequest",
+          "fullName": "pfs_v2.ListCommitRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "from",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "to",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "Return commits oldest to newest",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "all",
+              "description": "Return commits of all kinds (without this, aliases are excluded)",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "origin_kind",
+              "description": "Return only commits of this kind (mutually exclusive with all)",
+              "label": "",
+              "type": "OriginKind",
+              "longType": "OriginKind",
+              "fullType": "pfs_v2.OriginKind",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "started_time",
+              "description": "Return commits started before this time",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListCommitSetRequest",
+          "longName": "ListCommitSetRequest",
+          "fullName": "pfs_v2.ListCommitSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListFileRequest",
+          "longName": "ListFileRequest",
+          "fullName": "pfs_v2.ListFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file",
+              "description": "File is the parent directory of the files we want to list. This sets the\nrepo, the commit/branch, and path prefix of files we're interested in\nIf the \"path\" field is omitted, a list of files at the top level of the repo\nis returned",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paginationMarker",
+              "description": "Marker for pagination. If set, the files that come after the marker in\nlexicographical order will be returned. If reverse is also set, the files\nthat come before the marker in lexicographical order will be returned.",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "Number of files to return",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "If true, return files in reverse order",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListProjectRequest",
+          "longName": "ListProjectRequest",
+          "fullName": "pfs_v2.ListProjectRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ListRepoRequest",
+          "longName": "ListRepoRequest",
+          "fullName": "pfs_v2.ListRepoRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "type is the type of (system) repos that should be returned\nan empty string requests all repos",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "projects",
+              "description": "projects filters out repos that do not belong in the list, while no projects means list all repos.",
+              "label": "repeated",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ModifyFileRequest",
+          "longName": "ModifyFileRequest",
+          "fullName": "pfs_v2.ModifyFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "set_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "body",
+              "defaultValue": ""
+            },
+            {
+              "name": "add_file",
+              "description": "",
+              "label": "",
+              "type": "AddFile",
+              "longType": "AddFile",
+              "fullType": "pfs_v2.AddFile",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "body",
+              "defaultValue": ""
+            },
+            {
+              "name": "delete_file",
+              "description": "",
+              "label": "",
+              "type": "DeleteFile",
+              "longType": "DeleteFile",
+              "fullType": "pfs_v2.DeleteFile",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "body",
+              "defaultValue": ""
+            },
+            {
+              "name": "copy_file",
+              "description": "",
+              "label": "",
+              "type": "CopyFile",
+              "longType": "CopyFile",
+              "fullType": "pfs_v2.CopyFile",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "body",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObjectStorageEgress",
+          "longName": "ObjectStorageEgress",
+          "fullName": "pfs_v2.ObjectStorageEgress",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "url",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PathRange",
+          "longName": "PathRange",
+          "fullName": "pfs_v2.PathRange",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "lower",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "upper",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Project",
+          "longName": "Project",
+          "fullName": "pfs_v2.Project",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ProjectInfo",
+          "longName": "ProjectInfo",
+          "fullName": "pfs_v2.ProjectInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_info",
+              "description": "",
+              "label": "",
+              "type": "AuthInfo",
+              "longType": "AuthInfo",
+              "fullType": "pfs_v2.AuthInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_at",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PutCacheRequest",
+          "longName": "PutCacheRequest",
+          "fullName": "pfs_v2.PutCacheRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "Any",
+              "longType": "google.protobuf.Any",
+              "fullType": "google.protobuf.Any",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_set_ids",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tag",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RenewFileSetRequest",
+          "longName": "RenewFileSetRequest",
+          "fullName": "pfs_v2.RenewFileSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ttl_seconds",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Repo",
+          "longName": "Repo",
+          "fullName": "pfs_v2.Repo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RepoInfo",
+          "longName": "RepoInfo",
+          "fullName": "pfs_v2.RepoInfo",
+          "description": "RepoInfo is the main data structure representing a Repo in etcd",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes_upper_bound",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branches",
+              "description": "",
+              "label": "repeated",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_info",
+              "description": "Set by ListRepo and InspectRepo if Pachyderm's auth system is active, but\nnot stored in etcd. To set a user's auth scope for a repo, use the\nPachyderm Auth API (in src/client/auth/auth.proto)",
+              "label": "",
+              "type": "AuthInfo",
+              "longType": "AuthInfo",
+              "fullType": "pfs_v2.AuthInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "Details",
+              "longType": "RepoInfo.Details",
+              "fullType": "pfs_v2.RepoInfo.Details",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Details",
+          "longName": "RepoInfo.Details",
+          "fullName": "pfs_v2.RepoInfo.Details",
+          "description": "Details are only provided when explicitly requested",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RunLoadTestRequest",
+          "longName": "RunLoadTestRequest",
+          "fullName": "pfs_v2.RunLoadTestRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RunLoadTestResponse",
+          "longName": "RunLoadTestResponse",
+          "fullName": "pfs_v2.RunLoadTestResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "duration",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SQLDatabaseEgress",
+          "longName": "SQLDatabaseEgress",
+          "fullName": "pfs_v2.SQLDatabaseEgress",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "url",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_format",
+              "description": "",
+              "label": "",
+              "type": "FileFormat",
+              "longType": "SQLDatabaseEgress.FileFormat",
+              "fullType": "pfs_v2.SQLDatabaseEgress.FileFormat",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "Secret",
+              "longType": "SQLDatabaseEgress.Secret",
+              "fullType": "pfs_v2.SQLDatabaseEgress.Secret",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FileFormat",
+          "longName": "SQLDatabaseEgress.FileFormat",
+          "fullName": "pfs_v2.SQLDatabaseEgress.FileFormat",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "Type",
+              "longType": "SQLDatabaseEgress.FileFormat.Type",
+              "fullType": "pfs_v2.SQLDatabaseEgress.FileFormat.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "columns",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Secret",
+          "longName": "SQLDatabaseEgress.Secret",
+          "fullName": "pfs_v2.SQLDatabaseEgress.Secret",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ShardFileSetRequest",
+          "longName": "ShardFileSetRequest",
+          "fullName": "pfs_v2.ShardFileSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ShardFileSetResponse",
+          "longName": "ShardFileSetResponse",
+          "fullName": "pfs_v2.ShardFileSetResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "shards",
+              "description": "",
+              "label": "repeated",
+              "type": "PathRange",
+              "longType": "PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SquashCommitSetRequest",
+          "longName": "SquashCommitSetRequest",
+          "fullName": "pfs_v2.SquashCommitSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit_set",
+              "description": "",
+              "label": "",
+              "type": "CommitSet",
+              "longType": "CommitSet",
+              "fullType": "pfs_v2.CommitSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "StartCommitRequest",
+          "longName": "StartCommitRequest",
+          "fullName": "pfs_v2.StartCommitRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "parent",
+              "description": "parent may be empty in which case the commit that Branch points to will be used as the parent.\nIf the branch does not exist, the commit will have no parent.",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "description is a user-provided string describing this commit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "Branch",
+              "longType": "Branch",
+              "fullType": "pfs_v2.Branch",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SubscribeCommitRequest",
+          "longName": "SubscribeCommitRequest",
+          "fullName": "pfs_v2.SubscribeCommitRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "Repo",
+              "longType": "Repo",
+              "fullType": "pfs_v2.Repo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "from",
+              "description": "only commits created since this commit are returned",
+              "label": "",
+              "type": "Commit",
+              "longType": "Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "Don't return commits until they're in (at least) the desired state.",
+              "label": "",
+              "type": "CommitState",
+              "longType": "CommitState",
+              "fullType": "pfs_v2.CommitState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "all",
+              "description": "Return commits of all kinds (without this, aliases are excluded)",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "origin_kind",
+              "description": "Return only commits of this kind (mutually exclusive with all)",
+              "label": "",
+              "type": "OriginKind",
+              "longType": "OriginKind",
+              "fullType": "pfs_v2.OriginKind",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Trigger",
+          "longName": "Trigger",
+          "fullName": "pfs_v2.Trigger",
+          "description": "Trigger defines the conditions under which a head is moved, and to which\nbranch it is moved.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "branch",
+              "description": "Which branch this trigger refers to",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "all",
+              "description": "All indicates that all conditions must be satisfied before the trigger\nhappens, otherwise any conditions being satisfied will trigger it.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "rate_limit_spec",
+              "description": "Triggers if the rate limit spec (cron expression) has been satisfied since\nthe last trigger.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size",
+              "description": "Triggers if there's been `size` new data added since the last trigger.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commits",
+              "description": "Triggers if there's been `commits` new commits added since the last trigger.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cron_spec",
+              "description": "Creates a background process which fires the trigger on the schedule\nprovided by the cron spec.\nThis condition is mutually exclusive with respect to the others, so\nsetting this will result with the trigger only firing based on the cron\nschedule.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WalkFileRequest",
+          "longName": "WalkFileRequest",
+          "fullName": "pfs_v2.WalkFileRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paginationMarker",
+              "description": "Marker for pagination. If set, the files that come after the marker in\nlexicographical order will be returned. If reverse is also set, the files\nthat come before the marker in lexicographical order will be returned.",
+              "label": "",
+              "type": "File",
+              "longType": "File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "Number of files to return",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "If true, return files in reverse order",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "pfs_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "CreateRepo",
+              "description": "CreateRepo creates a new repo.",
+              "requestType": "CreateRepoRequest",
+              "requestLongType": "CreateRepoRequest",
+              "requestFullType": "pfs_v2.CreateRepoRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectRepo",
+              "description": "InspectRepo returns info about a repo.",
+              "requestType": "InspectRepoRequest",
+              "requestLongType": "InspectRepoRequest",
+              "requestFullType": "pfs_v2.InspectRepoRequest",
+              "requestStreaming": false,
+              "responseType": "RepoInfo",
+              "responseLongType": "RepoInfo",
+              "responseFullType": "pfs_v2.RepoInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListRepo",
+              "description": "ListRepo returns info about all repos.",
+              "requestType": "ListRepoRequest",
+              "requestLongType": "ListRepoRequest",
+              "requestFullType": "pfs_v2.ListRepoRequest",
+              "requestStreaming": false,
+              "responseType": "RepoInfo",
+              "responseLongType": "RepoInfo",
+              "responseFullType": "pfs_v2.RepoInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "DeleteRepo",
+              "description": "DeleteRepo deletes a repo.",
+              "requestType": "DeleteRepoRequest",
+              "requestLongType": "DeleteRepoRequest",
+              "requestFullType": "pfs_v2.DeleteRepoRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteRepoResponse",
+              "responseLongType": "DeleteRepoResponse",
+              "responseFullType": "pfs_v2.DeleteRepoResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteRepos",
+              "description": "DeleteRepos deletes more than one repo at once.  It attempts to\ndelete every repo matching the DeleteReposRequest.  When deleting\nall repos matching a project, any repos not deletable by the\ncaller will remain, and the project will not be empty; this is\nnot an error.  The returned DeleteReposResponse will contain a\nlist of all actually-deleted repos.",
+              "requestType": "DeleteReposRequest",
+              "requestLongType": "DeleteReposRequest",
+              "requestFullType": "pfs_v2.DeleteReposRequest",
+              "requestStreaming": false,
+              "responseType": "DeleteReposResponse",
+              "responseLongType": "DeleteReposResponse",
+              "responseFullType": "pfs_v2.DeleteReposResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "StartCommit",
+              "description": "StartCommit creates a new write commit from a parent commit.",
+              "requestType": "StartCommitRequest",
+              "requestLongType": "StartCommitRequest",
+              "requestFullType": "pfs_v2.StartCommitRequest",
+              "requestStreaming": false,
+              "responseType": "Commit",
+              "responseLongType": "Commit",
+              "responseFullType": "pfs_v2.Commit",
+              "responseStreaming": false
+            },
+            {
+              "name": "FinishCommit",
+              "description": "FinishCommit turns a write commit into a read commit.",
+              "requestType": "FinishCommitRequest",
+              "requestLongType": "FinishCommitRequest",
+              "requestFullType": "pfs_v2.FinishCommitRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "ClearCommit",
+              "description": "ClearCommit removes all data from the commit.",
+              "requestType": "ClearCommitRequest",
+              "requestLongType": "ClearCommitRequest",
+              "requestFullType": "pfs_v2.ClearCommitRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectCommit",
+              "description": "InspectCommit returns the info about a commit.",
+              "requestType": "InspectCommitRequest",
+              "requestLongType": "InspectCommitRequest",
+              "requestFullType": "pfs_v2.InspectCommitRequest",
+              "requestStreaming": false,
+              "responseType": "CommitInfo",
+              "responseLongType": "CommitInfo",
+              "responseFullType": "pfs_v2.CommitInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListCommit",
+              "description": "ListCommit returns info about all commits.",
+              "requestType": "ListCommitRequest",
+              "requestLongType": "ListCommitRequest",
+              "requestFullType": "pfs_v2.ListCommitRequest",
+              "requestStreaming": false,
+              "responseType": "CommitInfo",
+              "responseLongType": "CommitInfo",
+              "responseFullType": "pfs_v2.CommitInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "SubscribeCommit",
+              "description": "SubscribeCommit subscribes for new commits on a given branch.",
+              "requestType": "SubscribeCommitRequest",
+              "requestLongType": "SubscribeCommitRequest",
+              "requestFullType": "pfs_v2.SubscribeCommitRequest",
+              "requestStreaming": false,
+              "responseType": "CommitInfo",
+              "responseLongType": "CommitInfo",
+              "responseFullType": "pfs_v2.CommitInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "InspectCommitSet",
+              "description": "InspectCommitSet returns the info about a CommitSet.",
+              "requestType": "InspectCommitSetRequest",
+              "requestLongType": "InspectCommitSetRequest",
+              "requestFullType": "pfs_v2.InspectCommitSetRequest",
+              "requestStreaming": false,
+              "responseType": "CommitInfo",
+              "responseLongType": "CommitInfo",
+              "responseFullType": "pfs_v2.CommitInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "ListCommitSet",
+              "description": "ListCommitSet returns info about all CommitSets.",
+              "requestType": "ListCommitSetRequest",
+              "requestLongType": "ListCommitSetRequest",
+              "requestFullType": "pfs_v2.ListCommitSetRequest",
+              "requestStreaming": false,
+              "responseType": "CommitSetInfo",
+              "responseLongType": "CommitSetInfo",
+              "responseFullType": "pfs_v2.CommitSetInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "SquashCommitSet",
+              "description": "SquashCommitSet squashes the commits of a CommitSet into their children.",
+              "requestType": "SquashCommitSetRequest",
+              "requestLongType": "SquashCommitSetRequest",
+              "requestFullType": "pfs_v2.SquashCommitSetRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "DropCommitSet",
+              "description": "DropCommitSet drops the commits of a CommitSet and all data included in the commits.",
+              "requestType": "DropCommitSetRequest",
+              "requestLongType": "DropCommitSetRequest",
+              "requestFullType": "pfs_v2.DropCommitSetRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "FindCommits",
+              "description": "FindCommits searches for commits that reference a supplied file being modified in a branch.",
+              "requestType": "FindCommitsRequest",
+              "requestLongType": "FindCommitsRequest",
+              "requestFullType": "pfs_v2.FindCommitsRequest",
+              "requestStreaming": false,
+              "responseType": "FindCommitsResponse",
+              "responseLongType": "FindCommitsResponse",
+              "responseFullType": "pfs_v2.FindCommitsResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "CreateBranch",
+              "description": "CreateBranch creates a new branch.",
+              "requestType": "CreateBranchRequest",
+              "requestLongType": "CreateBranchRequest",
+              "requestFullType": "pfs_v2.CreateBranchRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectBranch",
+              "description": "InspectBranch returns info about a branch.",
+              "requestType": "InspectBranchRequest",
+              "requestLongType": "InspectBranchRequest",
+              "requestFullType": "pfs_v2.InspectBranchRequest",
+              "requestStreaming": false,
+              "responseType": "BranchInfo",
+              "responseLongType": "BranchInfo",
+              "responseFullType": "pfs_v2.BranchInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListBranch",
+              "description": "ListBranch returns info about the heads of branches.",
+              "requestType": "ListBranchRequest",
+              "requestLongType": "ListBranchRequest",
+              "requestFullType": "pfs_v2.ListBranchRequest",
+              "requestStreaming": false,
+              "responseType": "BranchInfo",
+              "responseLongType": "BranchInfo",
+              "responseFullType": "pfs_v2.BranchInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "DeleteBranch",
+              "description": "DeleteBranch deletes a branch; note that the commits still exist.",
+              "requestType": "DeleteBranchRequest",
+              "requestLongType": "DeleteBranchRequest",
+              "requestFullType": "pfs_v2.DeleteBranchRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "ModifyFile",
+              "description": "ModifyFile performs modifications on a set of files.",
+              "requestType": "ModifyFileRequest",
+              "requestLongType": "ModifyFileRequest",
+              "requestFullType": "pfs_v2.ModifyFileRequest",
+              "requestStreaming": true,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetFile",
+              "description": "GetFile returns the contents of a single file",
+              "requestType": "GetFileRequest",
+              "requestLongType": "GetFileRequest",
+              "requestFullType": "pfs_v2.GetFileRequest",
+              "requestStreaming": false,
+              "responseType": "BytesValue",
+              "responseLongType": ".google.protobuf.BytesValue",
+              "responseFullType": "google.protobuf.BytesValue",
+              "responseStreaming": true
+            },
+            {
+              "name": "GetFileTAR",
+              "description": "GetFileTAR returns a TAR stream of the contents matched by the request",
+              "requestType": "GetFileRequest",
+              "requestLongType": "GetFileRequest",
+              "requestFullType": "pfs_v2.GetFileRequest",
+              "requestStreaming": false,
+              "responseType": "BytesValue",
+              "responseLongType": ".google.protobuf.BytesValue",
+              "responseFullType": "google.protobuf.BytesValue",
+              "responseStreaming": true
+            },
+            {
+              "name": "InspectFile",
+              "description": "InspectFile returns info about a file.",
+              "requestType": "InspectFileRequest",
+              "requestLongType": "InspectFileRequest",
+              "requestFullType": "pfs_v2.InspectFileRequest",
+              "requestStreaming": false,
+              "responseType": "FileInfo",
+              "responseLongType": "FileInfo",
+              "responseFullType": "pfs_v2.FileInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListFile",
+              "description": "ListFile returns info about all files.",
+              "requestType": "ListFileRequest",
+              "requestLongType": "ListFileRequest",
+              "requestFullType": "pfs_v2.ListFileRequest",
+              "requestStreaming": false,
+              "responseType": "FileInfo",
+              "responseLongType": "FileInfo",
+              "responseFullType": "pfs_v2.FileInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "WalkFile",
+              "description": "WalkFile walks over all the files under a directory, including children of children.",
+              "requestType": "WalkFileRequest",
+              "requestLongType": "WalkFileRequest",
+              "requestFullType": "pfs_v2.WalkFileRequest",
+              "requestStreaming": false,
+              "responseType": "FileInfo",
+              "responseLongType": "FileInfo",
+              "responseFullType": "pfs_v2.FileInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "GlobFile",
+              "description": "GlobFile returns info about all files.",
+              "requestType": "GlobFileRequest",
+              "requestLongType": "GlobFileRequest",
+              "requestFullType": "pfs_v2.GlobFileRequest",
+              "requestStreaming": false,
+              "responseType": "FileInfo",
+              "responseLongType": "FileInfo",
+              "responseFullType": "pfs_v2.FileInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "DiffFile",
+              "description": "DiffFile returns the differences between 2 paths at 2 commits.",
+              "requestType": "DiffFileRequest",
+              "requestLongType": "DiffFileRequest",
+              "requestFullType": "pfs_v2.DiffFileRequest",
+              "requestStreaming": false,
+              "responseType": "DiffFileResponse",
+              "responseLongType": "DiffFileResponse",
+              "responseFullType": "pfs_v2.DiffFileResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "ActivateAuth",
+              "description": "ActivateAuth creates a role binding for all existing repos",
+              "requestType": "ActivateAuthRequest",
+              "requestLongType": "ActivateAuthRequest",
+              "requestFullType": "pfs_v2.ActivateAuthRequest",
+              "requestStreaming": false,
+              "responseType": "ActivateAuthResponse",
+              "responseLongType": "ActivateAuthResponse",
+              "responseFullType": "pfs_v2.ActivateAuthResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteAll",
+              "description": "DeleteAll deletes everything.",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "Fsck",
+              "description": "Fsck does a file system consistency check for pfs.",
+              "requestType": "FsckRequest",
+              "requestLongType": "FsckRequest",
+              "requestFullType": "pfs_v2.FsckRequest",
+              "requestStreaming": false,
+              "responseType": "FsckResponse",
+              "responseLongType": "FsckResponse",
+              "responseFullType": "pfs_v2.FsckResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "CreateFileSet",
+              "description": "FileSet API\nCreateFileSet creates a new file set.",
+              "requestType": "ModifyFileRequest",
+              "requestLongType": "ModifyFileRequest",
+              "requestFullType": "pfs_v2.ModifyFileRequest",
+              "requestStreaming": true,
+              "responseType": "CreateFileSetResponse",
+              "responseLongType": "CreateFileSetResponse",
+              "responseFullType": "pfs_v2.CreateFileSetResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetFileSet",
+              "description": "GetFileSet returns a file set with the data from a commit",
+              "requestType": "GetFileSetRequest",
+              "requestLongType": "GetFileSetRequest",
+              "requestFullType": "pfs_v2.GetFileSetRequest",
+              "requestStreaming": false,
+              "responseType": "CreateFileSetResponse",
+              "responseLongType": "CreateFileSetResponse",
+              "responseFullType": "pfs_v2.CreateFileSetResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "AddFileSet",
+              "description": "AddFileSet associates a file set with a commit",
+              "requestType": "AddFileSetRequest",
+              "requestLongType": "AddFileSetRequest",
+              "requestFullType": "pfs_v2.AddFileSetRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "RenewFileSet",
+              "description": "RenewFileSet prevents a file set from being deleted for a set amount of time.",
+              "requestType": "RenewFileSetRequest",
+              "requestLongType": "RenewFileSetRequest",
+              "requestFullType": "pfs_v2.RenewFileSetRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "ComposeFileSet",
+              "description": "ComposeFileSet composes a file set from a list of file sets.",
+              "requestType": "ComposeFileSetRequest",
+              "requestLongType": "ComposeFileSetRequest",
+              "requestFullType": "pfs_v2.ComposeFileSetRequest",
+              "requestStreaming": false,
+              "responseType": "CreateFileSetResponse",
+              "responseLongType": "CreateFileSetResponse",
+              "responseFullType": "pfs_v2.CreateFileSetResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ShardFileSet",
+              "description": "",
+              "requestType": "ShardFileSetRequest",
+              "requestLongType": "ShardFileSetRequest",
+              "requestFullType": "pfs_v2.ShardFileSetRequest",
+              "requestStreaming": false,
+              "responseType": "ShardFileSetResponse",
+              "responseLongType": "ShardFileSetResponse",
+              "responseFullType": "pfs_v2.ShardFileSetResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "CheckStorage",
+              "description": "CheckStorage runs integrity checks for the storage layer.",
+              "requestType": "CheckStorageRequest",
+              "requestLongType": "CheckStorageRequest",
+              "requestFullType": "pfs_v2.CheckStorageRequest",
+              "requestStreaming": false,
+              "responseType": "CheckStorageResponse",
+              "responseLongType": "CheckStorageResponse",
+              "responseFullType": "pfs_v2.CheckStorageResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PutCache",
+              "description": "",
+              "requestType": "PutCacheRequest",
+              "requestLongType": "PutCacheRequest",
+              "requestFullType": "pfs_v2.PutCacheRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetCache",
+              "description": "",
+              "requestType": "GetCacheRequest",
+              "requestLongType": "GetCacheRequest",
+              "requestFullType": "pfs_v2.GetCacheRequest",
+              "requestStreaming": false,
+              "responseType": "GetCacheResponse",
+              "responseLongType": "GetCacheResponse",
+              "responseFullType": "pfs_v2.GetCacheResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ClearCache",
+              "description": "",
+              "requestType": "ClearCacheRequest",
+              "requestLongType": "ClearCacheRequest",
+              "requestFullType": "pfs_v2.ClearCacheRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "RunLoadTest",
+              "description": "RunLoadTest runs a load test.",
+              "requestType": "RunLoadTestRequest",
+              "requestLongType": "RunLoadTestRequest",
+              "requestFullType": "pfs_v2.RunLoadTestRequest",
+              "requestStreaming": false,
+              "responseType": "RunLoadTestResponse",
+              "responseLongType": "RunLoadTestResponse",
+              "responseFullType": "pfs_v2.RunLoadTestResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RunLoadTestDefault",
+              "description": "RunLoadTestDefault runs the default load tests.",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "RunLoadTestResponse",
+              "responseLongType": "RunLoadTestResponse",
+              "responseFullType": "pfs_v2.RunLoadTestResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListTask",
+              "description": "ListTask lists PFS tasks",
+              "requestType": "ListTaskRequest",
+              "requestLongType": ".taskapi.ListTaskRequest",
+              "requestFullType": "taskapi.ListTaskRequest",
+              "requestStreaming": false,
+              "responseType": "TaskInfo",
+              "responseLongType": ".taskapi.TaskInfo",
+              "responseFullType": "taskapi.TaskInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "Egress",
+              "description": "Egress writes data from a commit to an external system",
+              "requestType": "EgressRequest",
+              "requestLongType": "EgressRequest",
+              "requestFullType": "pfs_v2.EgressRequest",
+              "requestStreaming": false,
+              "responseType": "EgressResponse",
+              "responseLongType": "EgressResponse",
+              "responseFullType": "pfs_v2.EgressResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "CreateProject",
+              "description": "Project API\nCreateProject creates a new project.",
+              "requestType": "CreateProjectRequest",
+              "requestLongType": "CreateProjectRequest",
+              "requestFullType": "pfs_v2.CreateProjectRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectProject",
+              "description": "InspectProject returns info about a project.",
+              "requestType": "InspectProjectRequest",
+              "requestLongType": "InspectProjectRequest",
+              "requestFullType": "pfs_v2.InspectProjectRequest",
+              "requestStreaming": false,
+              "responseType": "ProjectInfo",
+              "responseLongType": "ProjectInfo",
+              "responseFullType": "pfs_v2.ProjectInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListProject",
+              "description": "ListProject returns info about all projects.",
+              "requestType": "ListProjectRequest",
+              "requestLongType": "ListProjectRequest",
+              "requestFullType": "pfs_v2.ListProjectRequest",
+              "requestStreaming": false,
+              "responseType": "ProjectInfo",
+              "responseLongType": "ProjectInfo",
+              "responseFullType": "pfs_v2.ProjectInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "DeleteProject",
+              "description": "DeleteProject deletes a project.",
+              "requestType": "DeleteProjectRequest",
+              "requestLongType": "DeleteProjectRequest",
+              "requestFullType": "pfs_v2.DeleteProjectRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "pps/pps.proto",
+      "description": "",
+      "package": "pps_v2",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "DatumState",
+          "longName": "DatumState",
+          "fullName": "pps_v2.DatumState",
+          "description": "",
+          "values": [
+            {
+              "name": "UNKNOWN",
+              "number": "0",
+              "description": "or not part of a job"
+            },
+            {
+              "name": "FAILED",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "SUCCESS",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "SKIPPED",
+              "number": "3",
+              "description": ""
+            },
+            {
+              "name": "STARTING",
+              "number": "4",
+              "description": ""
+            },
+            {
+              "name": "RECOVERED",
+              "number": "5",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "JobState",
+          "longName": "JobState",
+          "fullName": "pps_v2.JobState",
+          "description": "",
+          "values": [
+            {
+              "name": "JOB_STATE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "JOB_CREATED",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "JOB_STARTING",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "JOB_RUNNING",
+              "number": "3",
+              "description": ""
+            },
+            {
+              "name": "JOB_FAILURE",
+              "number": "4",
+              "description": ""
+            },
+            {
+              "name": "JOB_SUCCESS",
+              "number": "5",
+              "description": ""
+            },
+            {
+              "name": "JOB_KILLED",
+              "number": "6",
+              "description": ""
+            },
+            {
+              "name": "JOB_EGRESSING",
+              "number": "7",
+              "description": ""
+            },
+            {
+              "name": "JOB_FINISHING",
+              "number": "8",
+              "description": ""
+            },
+            {
+              "name": "JOB_UNRUNNABLE",
+              "number": "9",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "PipelineType",
+          "longName": "PipelineInfo.PipelineType",
+          "fullName": "pps_v2.PipelineInfo.PipelineType",
+          "description": "The pipeline type is stored here so that we can internally know the type of\nthe pipeline without loading the spec from PFS.",
+          "values": [
+            {
+              "name": "PIPELINT_TYPE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "PIPELINE_TYPE_TRANSFORM",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "PIPELINE_TYPE_SPOUT",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "PIPELINE_TYPE_SERVICE",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "PipelineState",
+          "longName": "PipelineState",
+          "fullName": "pps_v2.PipelineState",
+          "description": "",
+          "values": [
+            {
+              "name": "PIPELINE_STATE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "PIPELINE_STARTING",
+              "number": "1",
+              "description": "There is a PipelineInfo + spec commit, but no RC\nThis happens when a pipeline has been created but not yet picked up by a\nPPS server."
+            },
+            {
+              "name": "PIPELINE_RUNNING",
+              "number": "2",
+              "description": "A pipeline has a spec commit and a service + RC\nThis is the normal state of a pipeline."
+            },
+            {
+              "name": "PIPELINE_RESTARTING",
+              "number": "3",
+              "description": "Equivalent to STARTING (there is a PipelineInfo + commit, but no RC)\nAfter some error caused runPipeline to exit, but before the pipeline is\nre-run. This is when the exponential backoff is in effect."
+            },
+            {
+              "name": "PIPELINE_FAILURE",
+              "number": "4",
+              "description": "The pipeline has encountered unrecoverable errors and is no longer being\nretried. It won't leave this state until the pipeline is updated."
+            },
+            {
+              "name": "PIPELINE_PAUSED",
+              "number": "5",
+              "description": "The pipeline has been explicitly paused by the user (the pipeline spec's\nStopped field should be true if the pipeline is in this state)"
+            },
+            {
+              "name": "PIPELINE_STANDBY",
+              "number": "6",
+              "description": "The pipeline is fully functional, but there are no commits to process."
+            },
+            {
+              "name": "PIPELINE_CRASHING",
+              "number": "7",
+              "description": "The pipeline's workers are crashing, or failing to come up, this may\nresolve itself, the pipeline may make progress while in this state if the\nproblem is only being experienced by some workers."
+            }
+          ]
+        },
+        {
+          "name": "TaintEffect",
+          "longName": "TaintEffect",
+          "fullName": "pps_v2.TaintEffect",
+          "description": "TaintEffect is an effect that can be matched by a toleration.",
+          "values": [
+            {
+              "name": "ALL_EFFECTS",
+              "number": "0",
+              "description": "Empty matches all effects."
+            },
+            {
+              "name": "NO_SCHEDULE",
+              "number": "1",
+              "description": "\"NoSchedule\""
+            },
+            {
+              "name": "PREFER_NO_SCHEDULE",
+              "number": "2",
+              "description": "\"PreferNoSchedule\""
+            },
+            {
+              "name": "NO_EXECUTE",
+              "number": "3",
+              "description": "\"NoExecute\""
+            }
+          ]
+        },
+        {
+          "name": "TolerationOperator",
+          "longName": "TolerationOperator",
+          "fullName": "pps_v2.TolerationOperator",
+          "description": "TolerationOperator relates a Toleration's key to its value.",
+          "values": [
+            {
+              "name": "EMPTY",
+              "number": "0",
+              "description": "K8s doesn't have this, but it's possible to represent something similar."
+            },
+            {
+              "name": "EXISTS",
+              "number": "1",
+              "description": "\"Exists\""
+            },
+            {
+              "name": "EQUAL",
+              "number": "2",
+              "description": "\"Equal\""
+            }
+          ]
+        },
+        {
+          "name": "WorkerState",
+          "longName": "WorkerState",
+          "fullName": "pps_v2.WorkerState",
+          "description": "",
+          "values": [
+            {
+              "name": "WORKER_STATE_UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "POD_RUNNING",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "POD_SUCCESS",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "POD_FAILED",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ActivateAuthRequest",
+          "longName": "ActivateAuthRequest",
+          "fullName": "pps_v2.ActivateAuthRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ActivateAuthResponse",
+          "longName": "ActivateAuthResponse",
+          "fullName": "pps_v2.ActivateAuthResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "Aggregate",
+          "longName": "Aggregate",
+          "fullName": "pps_v2.Aggregate",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "count",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "mean",
+              "description": "",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stddev",
+              "description": "",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "fifth_percentile",
+              "description": "",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ninety_fifth_percentile",
+              "description": "",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AggregateProcessStats",
+          "longName": "AggregateProcessStats",
+          "fullName": "pps_v2.AggregateProcessStats",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "download_time",
+              "description": "",
+              "label": "",
+              "type": "Aggregate",
+              "longType": "Aggregate",
+              "fullType": "pps_v2.Aggregate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "process_time",
+              "description": "",
+              "label": "",
+              "type": "Aggregate",
+              "longType": "Aggregate",
+              "fullType": "pps_v2.Aggregate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "upload_time",
+              "description": "",
+              "label": "",
+              "type": "Aggregate",
+              "longType": "Aggregate",
+              "fullType": "pps_v2.Aggregate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "download_bytes",
+              "description": "",
+              "label": "",
+              "type": "Aggregate",
+              "longType": "Aggregate",
+              "fullType": "pps_v2.Aggregate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "upload_bytes",
+              "description": "",
+              "label": "",
+              "type": "Aggregate",
+              "longType": "Aggregate",
+              "fullType": "pps_v2.Aggregate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ClusterDefaults",
+          "longName": "ClusterDefaults",
+          "fullName": "pps_v2.ClusterDefaults",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "create_pipeline_request",
+              "description": "CreatePipelineRequest contains the default JSON CreatePipelineRequest into\nwhich pipeline specs are merged to form the effective spec used to create a\npipeline.",
+              "label": "",
+              "type": "CreatePipelineRequest",
+              "longType": "CreatePipelineRequest",
+              "fullType": "pps_v2.CreatePipelineRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreatePipelineRequest",
+          "longName": "CreatePipelineRequest",
+          "fullName": "pps_v2.CreatePipelineRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tf_job",
+              "description": "tf_job encodes a Kubeflow TFJob spec. Pachyderm uses this to create TFJobs\nwhen running in a kubernetes cluster on which kubeflow has been installed.\nExactly one of 'tf_job' and 'transform' should be set",
+              "label": "",
+              "type": "TFJob",
+              "longType": "TFJob",
+              "fullType": "pps_v2.TFJob",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "transform",
+              "description": "",
+              "label": "",
+              "type": "Transform",
+              "longType": "Transform",
+              "fullType": "pps_v2.Transform",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parallelism_spec",
+              "description": "",
+              "label": "",
+              "type": "ParallelismSpec",
+              "longType": "ParallelismSpec",
+              "fullType": "pps_v2.ParallelismSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "egress",
+              "description": "",
+              "label": "",
+              "type": "Egress",
+              "longType": "Egress",
+              "fullType": "pps_v2.Egress",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "output_branch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "s3_out",
+              "description": "s3_out, if set, requires a pipeline's user to write to its output repo\nvia Pachyderm's s3 gateway (if set, workers will serve Pachyderm's s3\ngateway API at http://\u003cpipeline\u003e-s3.\u003cnamespace\u003e/\u003cjob id\u003e.out/my/file).\nIn this mode /pfs_v2/out won't be walked or uploaded, and the s3 gateway\nservice in the workers will allow writes to the job's output commit",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_requests",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_limits",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sidecar_resource_limits",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input",
+              "description": "",
+              "label": "",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reprocess",
+              "description": "Reprocess forces the pipeline to reprocess all datums.\nIt only has meaning if Update is true",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "service",
+              "description": "",
+              "label": "",
+              "type": "Service",
+              "longType": "Service",
+              "fullType": "pps_v2.Service",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "spout",
+              "description": "",
+              "label": "",
+              "type": "Spout",
+              "longType": "Spout",
+              "fullType": "pps_v2.Spout",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_set_spec",
+              "description": "",
+              "label": "",
+              "type": "DatumSetSpec",
+              "longType": "DatumSetSpec",
+              "fullType": "pps_v2.DatumSetSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job_timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "salt",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_tries",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "scheduling_spec",
+              "description": "",
+              "label": "",
+              "type": "SchedulingSpec",
+              "longType": "SchedulingSpec",
+              "fullType": "pps_v2.SchedulingSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_spec",
+              "description": "deprecated, use pod_patch below",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_patch",
+              "description": "a json patch will be applied to the pipeline's pod_spec before it's created;",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "spec_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "metadata",
+              "description": "",
+              "label": "",
+              "type": "Metadata",
+              "longType": "Metadata",
+              "fullType": "pps_v2.Metadata",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reprocess_spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "autoscaling",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tolerations",
+              "description": "",
+              "label": "repeated",
+              "type": "Toleration",
+              "longType": "Toleration",
+              "fullType": "pps_v2.Toleration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sidecar_resource_requests",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "dry_run",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "determined",
+              "description": "",
+              "label": "",
+              "type": "Determined",
+              "longType": "Determined",
+              "fullType": "pps_v2.Determined",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreatePipelineTransaction",
+          "longName": "CreatePipelineTransaction",
+          "fullName": "pps_v2.CreatePipelineTransaction",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "create_pipeline_request",
+              "description": "",
+              "label": "",
+              "type": "CreatePipelineRequest",
+              "longType": "CreatePipelineRequest",
+              "fullType": "pps_v2.CreatePipelineRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user_json",
+              "description": "the JSON the user originally submitted",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "effective_json",
+              "description": "the effective spec: the result of merging the user JSON into the cluster defaults",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreatePipelineV2Request",
+          "longName": "CreatePipelineV2Request",
+          "fullName": "pps_v2.CreatePipelineV2Request",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "create_pipeline_request_json",
+              "description": "a JSON-encoded CreatePipelineRequest",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "dry_run",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reprocess",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreatePipelineV2Response",
+          "longName": "CreatePipelineV2Response",
+          "fullName": "pps_v2.CreatePipelineV2Response",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "effective_create_pipeline_request_json",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateSecretRequest",
+          "longName": "CreateSecretRequest",
+          "fullName": "pps_v2.CreateSecretRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CronInput",
+          "longName": "CronInput",
+          "fullName": "pps_v2.CronInput",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "overwrite",
+              "description": "Overwrite, if true, will expose a single datum that gets overwritten each\ntick. If false, it will create a new datum for each tick.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "start",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Datum",
+          "longName": "Datum",
+          "fullName": "pps_v2.Datum",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "ID is the hash computed from all the files",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DatumInfo",
+          "longName": "DatumInfo",
+          "fullName": "pps_v2.DatumInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "Datum",
+              "longType": "Datum",
+              "fullType": "pps_v2.Datum",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "DatumState",
+              "longType": "DatumState",
+              "fullType": "pps_v2.DatumState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "",
+              "label": "",
+              "type": "ProcessStats",
+              "longType": "ProcessStats",
+              "fullType": "pps_v2.ProcessStats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pfs_state",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "pfs_v2.File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data",
+              "description": "",
+              "label": "repeated",
+              "type": "FileInfo",
+              "longType": "pfs_v2.FileInfo",
+              "fullType": "pfs_v2.FileInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "image_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DatumSetSpec",
+          "longName": "DatumSetSpec",
+          "fullName": "pps_v2.DatumSetSpec",
+          "description": "DatumSetSpec specifies how a pipeline should split its datums into datum sets.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "number",
+              "description": "number, if nonzero, specifies that each datum set should contain `number`\ndatums. Datum sets may contain fewer if the total number of datums don't\ndivide evenly.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "size_bytes, if nonzero, specifies a target size for each datum set.\nDatum sets may be larger or smaller than size_bytes, but will usually be\npretty close to size_bytes in size.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "per_worker",
+              "description": "per_worker, if nonzero, specifies how many datum sets should be created\nfor each worker. It can't be set with number or size_bytes.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DatumStatus",
+          "longName": "DatumStatus",
+          "fullName": "pps_v2.DatumStatus",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "started",
+              "description": "Started is the time processing on the current datum began.",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data",
+              "description": "",
+              "label": "repeated",
+              "type": "InputFile",
+              "longType": "InputFile",
+              "fullType": "pps_v2.InputFile",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteJobRequest",
+          "longName": "DeleteJobRequest",
+          "fullName": "pps_v2.DeleteJobRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeletePipelineRequest",
+          "longName": "DeletePipelineRequest",
+          "fullName": "pps_v2.DeletePipelineRequest",
+          "description": "Delete a pipeline.  If the deprecated all member is true, then delete all\npipelines in the default project.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "all",
+              "description": "Deprecated.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "deprecated": true
+              }
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "keep_repo",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "must_exist",
+              "description": "If true, an error will be returned if the pipeline doesn't exist.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeletePipelinesRequest",
+          "longName": "DeletePipelinesRequest",
+          "fullName": "pps_v2.DeletePipelinesRequest",
+          "description": "Delete more than one pipeline.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "projects",
+              "description": "All pipelines in each project will be deleted if the caller has\npermission.",
+              "label": "repeated",
+              "type": "Project",
+              "longType": "pfs_v2.Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "force",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "keep_repo",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "all",
+              "description": "If set, all pipelines in all projects will be deleted if the caller has\npermission.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeletePipelinesResponse",
+          "longName": "DeletePipelinesResponse",
+          "fullName": "pps_v2.DeletePipelinesResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipelines",
+              "description": "",
+              "label": "repeated",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteSecretRequest",
+          "longName": "DeleteSecretRequest",
+          "fullName": "pps_v2.DeleteSecretRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "Secret",
+              "longType": "Secret",
+              "fullType": "pps_v2.Secret",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Determined",
+          "longName": "Determined",
+          "fullName": "pps_v2.Determined",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "workspaces",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Egress",
+          "longName": "Egress",
+          "fullName": "pps_v2.Egress",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "URL",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "object_storage",
+              "description": "",
+              "label": "",
+              "type": "ObjectStorageEgress",
+              "longType": "pfs_v2.ObjectStorageEgress",
+              "fullType": "pfs_v2.ObjectStorageEgress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "target",
+              "defaultValue": ""
+            },
+            {
+              "name": "sql_database",
+              "description": "",
+              "label": "",
+              "type": "SQLDatabaseEgress",
+              "longType": "pfs_v2.SQLDatabaseEgress",
+              "fullType": "pfs_v2.SQLDatabaseEgress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "target",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GPUSpec",
+          "longName": "GPUSpec",
+          "fullName": "pps_v2.GPUSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "The type of GPU (nvidia.com/gpu or amd.com/gpu for example).",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "The number of GPUs to request.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetClusterDefaultsRequest",
+          "longName": "GetClusterDefaultsRequest",
+          "fullName": "pps_v2.GetClusterDefaultsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetClusterDefaultsResponse",
+          "longName": "GetClusterDefaultsResponse",
+          "fullName": "pps_v2.GetClusterDefaultsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "cluster_defaults_json",
+              "description": "A JSON-encoded ClusterDefaults message, this is the verbatim input passed\nto SetClusterDefaults.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetLogsRequest",
+          "longName": "GetLogsRequest",
+          "fullName": "pps_v2.GetLogsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "The pipeline from which we want to get logs (required if the job in 'job'\nwas created as part of a pipeline. To get logs from a non-orphan job\nwithout the pipeline that created it, you need to use ElasticSearch).",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job",
+              "description": "The job from which we want to get logs.",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_filters",
+              "description": "Names of input files from which we want processing logs. This may contain\nmultiple files, to query pipelines that contain multiple inputs. Each\nfilter may be an absolute path of a file within a pps repo, or it may be\na hash for that file (to search for files at specific versions)",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "Datum",
+              "longType": "Datum",
+              "fullType": "pps_v2.Datum",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "master",
+              "description": "If true get logs from the master process",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "follow",
+              "description": "Continue to follow new logs as they become available.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tail",
+              "description": "If nonzero, the number of lines from the end of the logs to return.  Note:\ntail applies per container, so you will get tail * \u003cnumber of pods\u003e total\nlines back.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "use_loki_backend",
+              "description": "UseLokiBackend causes the logs request to go through the loki backend\nrather than through kubernetes. This behavior can also be achieved by\nsetting the LOKI_LOGGING feature flag.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "since",
+              "description": "Since specifies how far in the past to return logs from. It defaults to 24 hours.",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Input",
+          "longName": "Input",
+          "fullName": "pps_v2.Input",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pfs",
+              "description": "",
+              "label": "",
+              "type": "PFSInput",
+              "longType": "PFSInput",
+              "fullType": "pps_v2.PFSInput",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "join",
+              "description": "",
+              "label": "repeated",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "group",
+              "description": "",
+              "label": "repeated",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cross",
+              "description": "",
+              "label": "repeated",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "union",
+              "description": "",
+              "label": "repeated",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cron",
+              "description": "",
+              "label": "",
+              "type": "CronInput",
+              "longType": "CronInput",
+              "fullType": "pps_v2.CronInput",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InputFile",
+          "longName": "InputFile",
+          "fullName": "pps_v2.InputFile",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "path",
+              "description": "This file's absolute path within its pfs repo.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hash",
+              "description": "This file's hash",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectDatumRequest",
+          "longName": "InspectDatumRequest",
+          "fullName": "pps_v2.InspectDatumRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "Datum",
+              "longType": "Datum",
+              "fullType": "pps_v2.Datum",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectJobRequest",
+          "longName": "InspectJobRequest",
+          "fullName": "pps_v2.InspectJobRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "Callers should set either Job or OutputCommit, not both.",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "wait",
+              "description": "wait until state is either FAILURE or SUCCESS",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectJobSetRequest",
+          "longName": "InspectJobSetRequest",
+          "fullName": "pps_v2.InspectJobSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job_set",
+              "description": "",
+              "label": "",
+              "type": "JobSet",
+              "longType": "JobSet",
+              "fullType": "pps_v2.JobSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "wait",
+              "description": "When true, wait until all jobs in the set are finished",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectPipelineRequest",
+          "longName": "InspectPipelineRequest",
+          "fullName": "pps_v2.InspectPipelineRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "details",
+              "description": "When true, return PipelineInfos with the details field, which requires\nloading the pipeline spec from PFS.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InspectSecretRequest",
+          "longName": "InspectSecretRequest",
+          "fullName": "pps_v2.InspectSecretRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "Secret",
+              "longType": "Secret",
+              "fullType": "pps_v2.Secret",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Job",
+          "longName": "Job",
+          "fullName": "pps_v2.Job",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "JobInfo",
+          "longName": "JobInfo",
+          "fullName": "pps_v2.JobInfo",
+          "description": "JobInfo is the data stored in the database regarding a given job.  The\n'details' field contains more information about the job which is expensive to\nfetch, requiring querying workers or loading the pipeline spec from object\nstorage.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline_version",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "output_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "restart",
+              "description": "Job restart count (e.g. due to datum failure)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_processed",
+              "description": "Counts of how many times we processed or skipped a datum",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_skipped",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_total",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_failed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_recovered",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "Download/process/upload time and download/upload bytes",
+              "label": "",
+              "type": "ProcessStats",
+              "longType": "ProcessStats",
+              "fullType": "pps_v2.ProcessStats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "JobState",
+              "longType": "JobState",
+              "fullType": "pps_v2.JobState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "reason explains why the job is in the current state",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "started",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "finished",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "Details",
+              "longType": "JobInfo.Details",
+              "fullType": "pps_v2.JobInfo.Details",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Details",
+          "longName": "JobInfo.Details",
+          "fullName": "pps_v2.JobInfo.Details",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transform",
+              "description": "",
+              "label": "",
+              "type": "Transform",
+              "longType": "Transform",
+              "fullType": "pps_v2.Transform",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parallelism_spec",
+              "description": "",
+              "label": "",
+              "type": "ParallelismSpec",
+              "longType": "ParallelismSpec",
+              "fullType": "pps_v2.ParallelismSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "egress",
+              "description": "",
+              "label": "",
+              "type": "Egress",
+              "longType": "Egress",
+              "fullType": "pps_v2.Egress",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "service",
+              "description": "",
+              "label": "",
+              "type": "Service",
+              "longType": "Service",
+              "fullType": "pps_v2.Service",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "spout",
+              "description": "",
+              "label": "",
+              "type": "Spout",
+              "longType": "Spout",
+              "fullType": "pps_v2.Spout",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "worker_status",
+              "description": "",
+              "label": "repeated",
+              "type": "WorkerStatus",
+              "longType": "WorkerStatus",
+              "fullType": "pps_v2.WorkerStatus",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_requests",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_limits",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sidecar_resource_limits",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input",
+              "description": "",
+              "label": "",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "salt",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_set_spec",
+              "description": "",
+              "label": "",
+              "type": "DatumSetSpec",
+              "longType": "DatumSetSpec",
+              "fullType": "pps_v2.DatumSetSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job_timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_tries",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "scheduling_spec",
+              "description": "",
+              "label": "",
+              "type": "SchedulingSpec",
+              "longType": "SchedulingSpec",
+              "fullType": "pps_v2.SchedulingSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_patch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sidecar_resource_requests",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "JobInput",
+          "longName": "JobInput",
+          "fullName": "pps_v2.JobInput",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "glob",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lazy",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "JobSet",
+          "longName": "JobSet",
+          "fullName": "pps_v2.JobSet",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "JobSetInfo",
+          "longName": "JobSetInfo",
+          "fullName": "pps_v2.JobSetInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job_set",
+              "description": "",
+              "label": "",
+              "type": "JobSet",
+              "longType": "JobSet",
+              "fullType": "pps_v2.JobSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jobs",
+              "description": "",
+              "label": "repeated",
+              "type": "JobInfo",
+              "longType": "JobInfo",
+              "fullType": "pps_v2.JobInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListDatumRequest",
+          "longName": "ListDatumRequest",
+          "fullName": "pps_v2.ListDatumRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "Job and Input are two different ways to specify the datums you want.\nOnly one can be set.\nJob is the job to list datums from.",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input",
+              "description": "Input is the input to list datums from.\nThe datums listed are the ones that would be run if a pipeline was created\nwith the provided input.",
+              "label": "",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "filter",
+              "description": "",
+              "label": "",
+              "type": "Filter",
+              "longType": "ListDatumRequest.Filter",
+              "fullType": "pps_v2.ListDatumRequest.Filter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paginationMarker",
+              "description": "datum id to start from. we do not include this datum in the response",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "Number of datums to return",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "If true, return datums in reverse order",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Filter",
+          "longName": "ListDatumRequest.Filter",
+          "fullName": "pps_v2.ListDatumRequest.Filter",
+          "description": "Filter restricts returned DatumInfo messages to those which match\nall of the filtered attributes.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "state",
+              "description": "Must match one of the given states.",
+              "label": "repeated",
+              "type": "DatumState",
+              "longType": "DatumState",
+              "fullType": "pps_v2.DatumState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListJobRequest",
+          "longName": "ListJobRequest",
+          "fullName": "pps_v2.ListJobRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "projects",
+              "description": "A list of projects to filter jobs on, nil means don't filter.",
+              "label": "repeated",
+              "type": "Project",
+              "longType": "pfs_v2.Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline",
+              "description": "nil means all pipelines",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_commit",
+              "description": "nil means all inputs",
+              "label": "repeated",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "history",
+              "description": "History indicates return jobs from historical versions of pipelines\nsemantics are:\n0: Return jobs from the current version of the pipeline or pipelines.\n1: Return the above and jobs from the next most recent version\n2: etc.\n-1: Return jobs from all historical versions.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "Details indicates whether the result should include all pipeline details in\neach JobInfo, or limited information including name and status, but\nexcluding information in the pipeline spec. Leaving this \"false\" can make\nthe call significantly faster in clusters with a large number of pipelines\nand jobs.\nNote that if 'input_commit' is set, this field is coerced to \"true\"",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jqFilter",
+              "description": "A jq program string for additional result filtering",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paginationMarker",
+              "description": "timestamp that is pagination marker",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "number of results to return",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "flag to indicated if results should be returned in reverse order",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListJobSetRequest",
+          "longName": "ListJobSetRequest",
+          "fullName": "pps_v2.ListJobSetRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "projects",
+              "description": "A list of projects to filter jobs on, nil means don't filter.",
+              "label": "repeated",
+              "type": "Project",
+              "longType": "pfs_v2.Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paginationMarker",
+              "description": "we return job sets created before or after this time based on the reverse flag",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "number of results to return",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reverse",
+              "description": "if true, return results in reverse order",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jqFilter",
+              "description": "A jq program string for additional result filtering",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListPipelineRequest",
+          "longName": "ListPipelineRequest",
+          "fullName": "pps_v2.ListPipelineRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "If non-nil, only return info about a single pipeline, this is redundant\nwith InspectPipeline unless history is non-zero.",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "history",
+              "description": "History indicates how many historical versions you want returned. Its\nsemantics are:\n0: Return the current version of the pipeline or pipelines.\n1: Return the above and the next most recent version\n2: etc.\n-1: Return all historical versions.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "When true, return PipelineInfos with the details field, which requires\nloading the pipeline spec from PFS.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jqFilter",
+              "description": "A jq program string for additional result filtering",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commit_set",
+              "description": "If non-nil, will return all the pipeline infos at this commit set",
+              "label": "",
+              "type": "CommitSet",
+              "longType": "pfs_v2.CommitSet",
+              "fullType": "pfs_v2.CommitSet",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "projects",
+              "description": "Projects to filter on. Empty list means no filter, so return all pipelines.",
+              "label": "repeated",
+              "type": "Project",
+              "longType": "pfs_v2.Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LogMessage",
+          "longName": "LogMessage",
+          "fullName": "pps_v2.LogMessage",
+          "description": "LogMessage is a log line from a PPS worker, annotated with metadata\nindicating when and why the line was logged.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project_name",
+              "description": "The job and pipeline for which a PFS file is being processed (if the job\nis an orphan job, pipeline name and ID will be unset)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline_name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "worker_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "master",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data",
+              "description": "The PFS files being processed (one per pipeline/job input)",
+              "label": "repeated",
+              "type": "InputFile",
+              "longType": "InputFile",
+              "fullType": "pps_v2.InputFile",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user",
+              "description": "User is true if log message comes from the users code.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ts",
+              "description": "The message logged, and the time at which it was logged",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "message",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LokiLogMessage",
+          "longName": "LokiLogMessage",
+          "fullName": "pps_v2.LokiLogMessage",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "message",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LokiRequest",
+          "longName": "LokiRequest",
+          "fullName": "pps_v2.LokiRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "since",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "query",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Metadata",
+          "longName": "Metadata",
+          "fullName": "pps_v2.Metadata",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "annotations",
+              "description": "",
+              "label": "repeated",
+              "type": "AnnotationsEntry",
+              "longType": "Metadata.AnnotationsEntry",
+              "fullType": "pps_v2.Metadata.AnnotationsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "labels",
+              "description": "",
+              "label": "repeated",
+              "type": "LabelsEntry",
+              "longType": "Metadata.LabelsEntry",
+              "fullType": "pps_v2.Metadata.LabelsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AnnotationsEntry",
+          "longName": "Metadata.AnnotationsEntry",
+          "fullName": "pps_v2.Metadata.AnnotationsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LabelsEntry",
+          "longName": "Metadata.LabelsEntry",
+          "fullName": "pps_v2.Metadata.LabelsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PFSInput",
+          "longName": "PFSInput",
+          "fullName": "pps_v2.PFSInput",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "repo",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "repo_type",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "glob",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "join_on",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "outer_join",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "group_by",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lazy",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "empty_files",
+              "description": "EmptyFiles, if true, will cause files from this PFS input to be\npresented as empty files. This is useful in shuffle pipelines where you\nwant to read the names of files and reorganize them using symlinks.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "s3",
+              "description": "S3, if true, will cause the worker to NOT download or link files from this\ninput into the /pfs_v2 directory. Instead, an instance of our S3 gateway\nservice will run on each of the sidecars, and data can be retrieved from\nthis input by querying\nhttp://\u003cpipeline\u003e-s3.\u003cnamespace\u003e/\u003cjob id\u003e.\u003cinput\u003e/my/file",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trigger",
+              "description": "Trigger defines when this input is processed by the pipeline, if it's nil\nthe input is processed anytime something is committed to the input branch.",
+              "label": "",
+              "type": "Trigger",
+              "longType": "pfs_v2.Trigger",
+              "fullType": "pfs_v2.Trigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ParallelismSpec",
+          "longName": "ParallelismSpec",
+          "fullName": "pps_v2.ParallelismSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "constant",
+              "description": "Starts the pipeline/job with a 'constant' workers, unless 'constant' is\nzero. If 'constant' is zero (which is the zero value of ParallelismSpec),\nthen Pachyderm will choose the number of workers that is started,\n(currently it chooses the number of workers in the cluster)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Pipeline",
+          "longName": "Pipeline",
+          "fullName": "pps_v2.Pipeline",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "Project",
+              "longType": "pfs_v2.Project",
+              "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PipelineInfo",
+          "longName": "PipelineInfo",
+          "fullName": "pps_v2.PipelineInfo",
+          "description": "PipelineInfo is proto for each pipeline that Pachd stores in the\ndatabase. It tracks the state of the pipeline, and points to its metadata in\nPFS (and, by pointing to a PFS commit, de facto tracks the pipeline's\nversion).  Any information about the pipeline _not_ stored in the database is\nin the Details object, which requires fetching the spec from PFS or other\npotentially expensive operations.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "spec_commit",
+              "description": "The first spec commit for this version of the pipeline",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stopped",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "state indicates the current state of the pipeline",
+              "label": "",
+              "type": "PipelineState",
+              "longType": "PipelineState",
+              "fullType": "pps_v2.PipelineState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "reason includes any error messages associated with a failed pipeline",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_job_state",
+              "description": "last_job_state indicates the state of the most recently created job",
+              "label": "",
+              "type": "JobState",
+              "longType": "JobState",
+              "fullType": "pps_v2.JobState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parallelism",
+              "description": "parallelism tracks the literal number of workers that this pipeline should\nrun.",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "PipelineType",
+              "longType": "PipelineInfo.PipelineType",
+              "fullType": "pps_v2.PipelineInfo.PipelineType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "",
+              "label": "",
+              "type": "Details",
+              "longType": "PipelineInfo.Details",
+              "fullType": "pps_v2.PipelineInfo.Details",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user_spec_json",
+              "description": "The user-submitted pipeline spec in JSON format.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "effective_spec_json",
+              "description": "The effective spec used to create the pipeline.  Created by merging the user spec into the cluster defaults.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Details",
+          "longName": "PipelineInfo.Details",
+          "fullName": "pps_v2.PipelineInfo.Details",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transform",
+              "description": "",
+              "label": "",
+              "type": "Transform",
+              "longType": "Transform",
+              "fullType": "pps_v2.Transform",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tf_job",
+              "description": "tf_job encodes a Kubeflow TFJob spec. Pachyderm uses this to create TFJobs\nwhen running in a kubernetes cluster on which kubeflow has been installed.\nExactly one of 'tf_job' and 'transform' should be set",
+              "label": "",
+              "type": "TFJob",
+              "longType": "TFJob",
+              "fullType": "pps_v2.TFJob",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parallelism_spec",
+              "description": "",
+              "label": "",
+              "type": "ParallelismSpec",
+              "longType": "ParallelismSpec",
+              "fullType": "pps_v2.ParallelismSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "egress",
+              "description": "",
+              "label": "",
+              "type": "Egress",
+              "longType": "Egress",
+              "fullType": "pps_v2.Egress",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_at",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "recent_error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "workers_requested",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "workers_available",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "output_branch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_requests",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "resource_limits",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sidecar_resource_limits",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input",
+              "description": "",
+              "label": "",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "description",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "salt",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "service",
+              "description": "",
+              "label": "",
+              "type": "Service",
+              "longType": "Service",
+              "fullType": "pps_v2.Service",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "spout",
+              "description": "",
+              "label": "",
+              "type": "Spout",
+              "longType": "Spout",
+              "fullType": "pps_v2.Spout",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_set_spec",
+              "description": "",
+              "label": "",
+              "type": "DatumSetSpec",
+              "longType": "DatumSetSpec",
+              "fullType": "pps_v2.DatumSetSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job_timeout",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_tries",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "scheduling_spec",
+              "description": "",
+              "label": "",
+              "type": "SchedulingSpec",
+              "longType": "SchedulingSpec",
+              "fullType": "pps_v2.SchedulingSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_patch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "s3_out",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "metadata",
+              "description": "",
+              "label": "",
+              "type": "Metadata",
+              "longType": "Metadata",
+              "fullType": "pps_v2.Metadata",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reprocess_spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "unclaimed_tasks",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "worker_rc",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "autoscaling",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tolerations",
+              "description": "",
+              "label": "repeated",
+              "type": "Toleration",
+              "longType": "Toleration",
+              "fullType": "pps_v2.Toleration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sidecar_resource_requests",
+              "description": "",
+              "label": "",
+              "type": "ResourceSpec",
+              "longType": "ResourceSpec",
+              "fullType": "pps_v2.ResourceSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "determined",
+              "description": "",
+              "label": "",
+              "type": "Determined",
+              "longType": "Determined",
+              "fullType": "pps_v2.Determined",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PipelineInfos",
+          "longName": "PipelineInfos",
+          "fullName": "pps_v2.PipelineInfos",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline_info",
+              "description": "",
+              "label": "repeated",
+              "type": "PipelineInfo",
+              "longType": "PipelineInfo",
+              "fullType": "pps_v2.PipelineInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ProcessStats",
+          "longName": "ProcessStats",
+          "fullName": "pps_v2.ProcessStats",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "download_time",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "process_time",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "upload_time",
+              "description": "",
+              "label": "",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "download_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "upload_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RenderTemplateRequest",
+          "longName": "RenderTemplateRequest",
+          "fullName": "pps_v2.RenderTemplateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "template",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "args",
+              "description": "",
+              "label": "repeated",
+              "type": "ArgsEntry",
+              "longType": "RenderTemplateRequest.ArgsEntry",
+              "fullType": "pps_v2.RenderTemplateRequest.ArgsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ArgsEntry",
+          "longName": "RenderTemplateRequest.ArgsEntry",
+          "fullName": "pps_v2.RenderTemplateRequest.ArgsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RenderTemplateResponse",
+          "longName": "RenderTemplateResponse",
+          "fullName": "pps_v2.RenderTemplateResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "json",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "specs",
+              "description": "",
+              "label": "repeated",
+              "type": "CreatePipelineRequest",
+              "longType": "CreatePipelineRequest",
+              "fullType": "pps_v2.CreatePipelineRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ResourceSpec",
+          "longName": "ResourceSpec",
+          "fullName": "pps_v2.ResourceSpec",
+          "description": "ResourceSpec describes the amount of resources that pipeline pods should\nrequest from kubernetes, for scheduling.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "cpu",
+              "description": "The number of CPUs each worker needs (partial values are allowed, and\nencouraged)",
+              "label": "",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "memory",
+              "description": "The amount of memory each worker needs (in bytes, with allowed\nSI suffixes (M, K, G, Mi, Ki, Gi, etc).",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gpu",
+              "description": "The spec for GPU resources.",
+              "label": "",
+              "type": "GPUSpec",
+              "longType": "GPUSpec",
+              "fullType": "pps_v2.GPUSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "disk",
+              "description": "The amount of ephemeral storage each worker needs (in bytes, with allowed\nSI suffixes (M, K, G, Mi, Ki, Gi, etc).",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RestartDatumRequest",
+          "longName": "RestartDatumRequest",
+          "fullName": "pps_v2.RestartDatumRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_filters",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RunCronRequest",
+          "longName": "RunCronRequest",
+          "fullName": "pps_v2.RunCronRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "RunLoadTestRequest",
+          "longName": "RunLoadTestRequest",
+          "fullName": "pps_v2.RunLoadTestRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "dag_spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "load_spec",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "parallelism",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_patch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RunLoadTestResponse",
+          "longName": "RunLoadTestResponse",
+          "fullName": "pps_v2.RunLoadTestResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RunPipelineRequest",
+          "longName": "RunPipelineRequest",
+          "fullName": "pps_v2.RunPipelineRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "provenance",
+              "description": "",
+              "label": "repeated",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SchedulingSpec",
+          "longName": "SchedulingSpec",
+          "fullName": "pps_v2.SchedulingSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "node_selector",
+              "description": "",
+              "label": "repeated",
+              "type": "NodeSelectorEntry",
+              "longType": "SchedulingSpec.NodeSelectorEntry",
+              "fullType": "pps_v2.SchedulingSpec.NodeSelectorEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "priority_class_name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NodeSelectorEntry",
+          "longName": "SchedulingSpec.NodeSelectorEntry",
+          "fullName": "pps_v2.SchedulingSpec.NodeSelectorEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Secret",
+          "longName": "Secret",
+          "fullName": "pps_v2.Secret",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SecretInfo",
+          "longName": "SecretInfo",
+          "fullName": "pps_v2.SecretInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "secret",
+              "description": "",
+              "label": "",
+              "type": "Secret",
+              "longType": "Secret",
+              "fullType": "pps_v2.Secret",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "creation_timestamp",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SecretInfos",
+          "longName": "SecretInfos",
+          "fullName": "pps_v2.SecretInfos",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "secret_info",
+              "description": "",
+              "label": "repeated",
+              "type": "SecretInfo",
+              "longType": "SecretInfo",
+              "fullType": "pps_v2.SecretInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SecretMount",
+          "longName": "SecretMount",
+          "fullName": "pps_v2.SecretMount",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "Name must be the name of the secret in kubernetes.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "key",
+              "description": "Key of the secret to load into env_var, this field only has meaning if EnvVar != \"\".",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "mount_path",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "env_var",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Service",
+          "longName": "Service",
+          "fullName": "pps_v2.Service",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "internal_port",
+              "description": "",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "external_port",
+              "description": "",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ip",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetClusterDefaultsRequest",
+          "longName": "SetClusterDefaultsRequest",
+          "fullName": "pps_v2.SetClusterDefaultsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "regenerate",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reprocess",
+              "description": "must be false if regenerate is false",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "dry_run",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cluster_defaults_json",
+              "description": "A JSON-encoded ClusterDefaults message, this will be stored verbatim.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetClusterDefaultsResponse",
+          "longName": "SetClusterDefaultsResponse",
+          "fullName": "pps_v2.SetClusterDefaultsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "affected_pipelines",
+              "description": "",
+              "label": "repeated",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Spout",
+          "longName": "Spout",
+          "fullName": "pps_v2.Spout",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "service",
+              "description": "",
+              "label": "",
+              "type": "Service",
+              "longType": "Service",
+              "fullType": "pps_v2.Service",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "StartPipelineRequest",
+          "longName": "StartPipelineRequest",
+          "fullName": "pps_v2.StartPipelineRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "StopJobRequest",
+          "longName": "StopJobRequest",
+          "fullName": "pps_v2.StopJobRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "StopPipelineRequest",
+          "longName": "StopPipelineRequest",
+          "fullName": "pps_v2.StopPipelineRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "must_exist",
+              "description": "If true, an error will be returned if the pipeline doesn't exist.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SubscribeJobRequest",
+          "longName": "SubscribeJobRequest",
+          "fullName": "pps_v2.SubscribeJobRequest",
+          "description": "Streams open jobs until canceled",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "Pipeline",
+              "longType": "Pipeline",
+              "fullType": "pps_v2.Pipeline",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "details",
+              "description": "Same as ListJobRequest.Details",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TFJob",
+          "longName": "TFJob",
+          "fullName": "pps_v2.TFJob",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tf_job",
+              "description": "tf_job  is a serialized Kubeflow TFJob spec. Pachyderm sends this directly\nto a kubernetes cluster on which kubeflow has been installed, instead of\ncreating a pipeline ReplicationController as it normally would.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Toleration",
+          "longName": "Toleration",
+          "fullName": "pps_v2.Toleration",
+          "description": "Toleration is a Kubernetes toleration.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "key is the taint key that the toleration applies to.  Empty means match all taint keys.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "operator",
+              "description": "operator represents a key's relationship to the value.",
+              "label": "",
+              "type": "TolerationOperator",
+              "longType": "TolerationOperator",
+              "fullType": "pps_v2.TolerationOperator",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "value is the taint value the toleration matches to.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "effect",
+              "description": "effect indicates the taint effect to match.  Empty means match all taint effects.",
+              "label": "",
+              "type": "TaintEffect",
+              "longType": "TaintEffect",
+              "fullType": "pps_v2.TaintEffect",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "toleration_seconds",
+              "description": "toleration_seconds represents the period of time the toleration (which must be of effect\nNoExecute, otherwise this field is ignored) tolerates the taint.  If not set, tolerate the\ntaint forever.",
+              "label": "",
+              "type": "Int64Value",
+              "longType": "google.protobuf.Int64Value",
+              "fullType": "google.protobuf.Int64Value",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Transform",
+          "longName": "Transform",
+          "fullName": "pps_v2.Transform",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "image",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "cmd",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "err_cmd",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "env",
+              "description": "",
+              "label": "repeated",
+              "type": "EnvEntry",
+              "longType": "Transform.EnvEntry",
+              "fullType": "pps_v2.Transform.EnvEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "secrets",
+              "description": "",
+              "label": "repeated",
+              "type": "SecretMount",
+              "longType": "SecretMount",
+              "fullType": "pps_v2.SecretMount",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "image_pull_secrets",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stdin",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "err_stdin",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "accept_return_code",
+              "description": "",
+              "label": "repeated",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "debug",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "user",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "working_dir",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "dockerfile",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "memory_volume",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_batching",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EnvEntry",
+          "longName": "Transform.EnvEntry",
+          "fullName": "pps_v2.Transform.EnvEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UpdateJobStateRequest",
+          "longName": "UpdateJobStateRequest",
+          "fullName": "pps_v2.UpdateJobStateRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "JobState",
+              "longType": "JobState",
+              "fullType": "pps_v2.JobState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "restart",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_processed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_skipped",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_failed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_recovered",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_total",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "",
+              "label": "",
+              "type": "ProcessStats",
+              "longType": "ProcessStats",
+              "fullType": "pps_v2.ProcessStats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Worker",
+          "longName": "Worker",
+          "fullName": "pps_v2.Worker",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "WorkerState",
+              "longType": "WorkerState",
+              "fullType": "pps_v2.WorkerState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WorkerStatus",
+          "longName": "WorkerStatus",
+          "fullName": "pps_v2.WorkerStatus",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "worker_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum_status",
+              "description": "",
+              "label": "",
+              "type": "DatumStatus",
+              "longType": "DatumStatus",
+              "fullType": "pps_v2.DatumStatus",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "pps_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "InspectJob",
+              "description": "",
+              "requestType": "InspectJobRequest",
+              "requestLongType": "InspectJobRequest",
+              "requestFullType": "pps_v2.InspectJobRequest",
+              "requestStreaming": false,
+              "responseType": "JobInfo",
+              "responseLongType": "JobInfo",
+              "responseFullType": "pps_v2.JobInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectJobSet",
+              "description": "",
+              "requestType": "InspectJobSetRequest",
+              "requestLongType": "InspectJobSetRequest",
+              "requestFullType": "pps_v2.InspectJobSetRequest",
+              "requestStreaming": false,
+              "responseType": "JobInfo",
+              "responseLongType": "JobInfo",
+              "responseFullType": "pps_v2.JobInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "ListJob",
+              "description": "ListJob returns information about current and past Pachyderm jobs.",
+              "requestType": "ListJobRequest",
+              "requestLongType": "ListJobRequest",
+              "requestFullType": "pps_v2.ListJobRequest",
+              "requestStreaming": false,
+              "responseType": "JobInfo",
+              "responseLongType": "JobInfo",
+              "responseFullType": "pps_v2.JobInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "ListJobSet",
+              "description": "",
+              "requestType": "ListJobSetRequest",
+              "requestLongType": "ListJobSetRequest",
+              "requestFullType": "pps_v2.ListJobSetRequest",
+              "requestStreaming": false,
+              "responseType": "JobSetInfo",
+              "responseLongType": "JobSetInfo",
+              "responseFullType": "pps_v2.JobSetInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "SubscribeJob",
+              "description": "",
+              "requestType": "SubscribeJobRequest",
+              "requestLongType": "SubscribeJobRequest",
+              "requestFullType": "pps_v2.SubscribeJobRequest",
+              "requestStreaming": false,
+              "responseType": "JobInfo",
+              "responseLongType": "JobInfo",
+              "responseFullType": "pps_v2.JobInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "DeleteJob",
+              "description": "",
+              "requestType": "DeleteJobRequest",
+              "requestLongType": "DeleteJobRequest",
+              "requestFullType": "pps_v2.DeleteJobRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "StopJob",
+              "description": "",
+              "requestType": "StopJobRequest",
+              "requestLongType": "StopJobRequest",
+              "requestFullType": "pps_v2.StopJobRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectDatum",
+              "description": "",
+              "requestType": "InspectDatumRequest",
+              "requestLongType": "InspectDatumRequest",
+              "requestFullType": "pps_v2.InspectDatumRequest",
+              "requestStreaming": false,
+              "responseType": "DatumInfo",
+              "responseLongType": "DatumInfo",
+              "responseFullType": "pps_v2.DatumInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListDatum",
+              "description": "ListDatum returns information about each datum fed to a Pachyderm job",
+              "requestType": "ListDatumRequest",
+              "requestLongType": "ListDatumRequest",
+              "requestFullType": "pps_v2.ListDatumRequest",
+              "requestStreaming": false,
+              "responseType": "DatumInfo",
+              "responseLongType": "DatumInfo",
+              "responseFullType": "pps_v2.DatumInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "RestartDatum",
+              "description": "",
+              "requestType": "RestartDatumRequest",
+              "requestLongType": "RestartDatumRequest",
+              "requestFullType": "pps_v2.RestartDatumRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "CreatePipeline",
+              "description": "",
+              "requestType": "CreatePipelineRequest",
+              "requestLongType": "CreatePipelineRequest",
+              "requestFullType": "pps_v2.CreatePipelineRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "CreatePipelineV2",
+              "description": "",
+              "requestType": "CreatePipelineV2Request",
+              "requestLongType": "CreatePipelineV2Request",
+              "requestFullType": "pps_v2.CreatePipelineV2Request",
+              "requestStreaming": false,
+              "responseType": "CreatePipelineV2Response",
+              "responseLongType": "CreatePipelineV2Response",
+              "responseFullType": "pps_v2.CreatePipelineV2Response",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectPipeline",
+              "description": "",
+              "requestType": "InspectPipelineRequest",
+              "requestLongType": "InspectPipelineRequest",
+              "requestFullType": "pps_v2.InspectPipelineRequest",
+              "requestStreaming": false,
+              "responseType": "PipelineInfo",
+              "responseLongType": "PipelineInfo",
+              "responseFullType": "pps_v2.PipelineInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListPipeline",
+              "description": "",
+              "requestType": "ListPipelineRequest",
+              "requestLongType": "ListPipelineRequest",
+              "requestFullType": "pps_v2.ListPipelineRequest",
+              "requestStreaming": false,
+              "responseType": "PipelineInfo",
+              "responseLongType": "PipelineInfo",
+              "responseFullType": "pps_v2.PipelineInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "DeletePipeline",
+              "description": "",
+              "requestType": "DeletePipelineRequest",
+              "requestLongType": "DeletePipelineRequest",
+              "requestFullType": "pps_v2.DeletePipelineRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeletePipelines",
+              "description": "",
+              "requestType": "DeletePipelinesRequest",
+              "requestLongType": "DeletePipelinesRequest",
+              "requestFullType": "pps_v2.DeletePipelinesRequest",
+              "requestStreaming": false,
+              "responseType": "DeletePipelinesResponse",
+              "responseLongType": "DeletePipelinesResponse",
+              "responseFullType": "pps_v2.DeletePipelinesResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "StartPipeline",
+              "description": "",
+              "requestType": "StartPipelineRequest",
+              "requestLongType": "StartPipelineRequest",
+              "requestFullType": "pps_v2.StartPipelineRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "StopPipeline",
+              "description": "",
+              "requestType": "StopPipelineRequest",
+              "requestLongType": "StopPipelineRequest",
+              "requestFullType": "pps_v2.StopPipelineRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "RunPipeline",
+              "description": "",
+              "requestType": "RunPipelineRequest",
+              "requestLongType": "RunPipelineRequest",
+              "requestFullType": "pps_v2.RunPipelineRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "RunCron",
+              "description": "",
+              "requestType": "RunCronRequest",
+              "requestLongType": "RunCronRequest",
+              "requestFullType": "pps_v2.RunCronRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "CreateSecret",
+              "description": "",
+              "requestType": "CreateSecretRequest",
+              "requestLongType": "CreateSecretRequest",
+              "requestFullType": "pps_v2.CreateSecretRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteSecret",
+              "description": "",
+              "requestType": "DeleteSecretRequest",
+              "requestLongType": "DeleteSecretRequest",
+              "requestFullType": "pps_v2.DeleteSecretRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListSecret",
+              "description": "",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "SecretInfos",
+              "responseLongType": "SecretInfos",
+              "responseFullType": "pps_v2.SecretInfos",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectSecret",
+              "description": "",
+              "requestType": "InspectSecretRequest",
+              "requestLongType": "InspectSecretRequest",
+              "requestFullType": "pps_v2.InspectSecretRequest",
+              "requestStreaming": false,
+              "responseType": "SecretInfo",
+              "responseLongType": "SecretInfo",
+              "responseFullType": "pps_v2.SecretInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteAll",
+              "description": "DeleteAll deletes everything",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetLogs",
+              "description": "",
+              "requestType": "GetLogsRequest",
+              "requestLongType": "GetLogsRequest",
+              "requestFullType": "pps_v2.GetLogsRequest",
+              "requestStreaming": false,
+              "responseType": "LogMessage",
+              "responseLongType": "LogMessage",
+              "responseFullType": "pps_v2.LogMessage",
+              "responseStreaming": true
+            },
+            {
+              "name": "ActivateAuth",
+              "description": "An internal call that causes PPS to put itself into an auth-enabled state\n(all pipeline have tokens, correct permissions, etcd)",
+              "requestType": "ActivateAuthRequest",
+              "requestLongType": "ActivateAuthRequest",
+              "requestFullType": "pps_v2.ActivateAuthRequest",
+              "requestStreaming": false,
+              "responseType": "ActivateAuthResponse",
+              "responseLongType": "ActivateAuthResponse",
+              "responseFullType": "pps_v2.ActivateAuthResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "UpdateJobState",
+              "description": "An internal call used to move a job from one state to another",
+              "requestType": "UpdateJobStateRequest",
+              "requestLongType": "UpdateJobStateRequest",
+              "requestFullType": "pps_v2.UpdateJobStateRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "RunLoadTest",
+              "description": "RunLoadTest runs a load test.",
+              "requestType": "RunLoadTestRequest",
+              "requestLongType": "RunLoadTestRequest",
+              "requestFullType": "pps_v2.RunLoadTestRequest",
+              "requestStreaming": false,
+              "responseType": "RunLoadTestResponse",
+              "responseLongType": "RunLoadTestResponse",
+              "responseFullType": "pps_v2.RunLoadTestResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RunLoadTestDefault",
+              "description": "RunLoadTestDefault runs the default load test.",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "RunLoadTestResponse",
+              "responseLongType": "RunLoadTestResponse",
+              "responseFullType": "pps_v2.RunLoadTestResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "RenderTemplate",
+              "description": "RenderTemplate renders the provided template and arguments into a list of Pipeline specicifications",
+              "requestType": "RenderTemplateRequest",
+              "requestLongType": "RenderTemplateRequest",
+              "requestFullType": "pps_v2.RenderTemplateRequest",
+              "requestStreaming": false,
+              "responseType": "RenderTemplateResponse",
+              "responseLongType": "RenderTemplateResponse",
+              "responseFullType": "pps_v2.RenderTemplateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListTask",
+              "description": "ListTask lists PPS tasks",
+              "requestType": "ListTaskRequest",
+              "requestLongType": ".taskapi.ListTaskRequest",
+              "requestFullType": "taskapi.ListTaskRequest",
+              "requestStreaming": false,
+              "responseType": "TaskInfo",
+              "responseLongType": ".taskapi.TaskInfo",
+              "responseFullType": "taskapi.TaskInfo",
+              "responseStreaming": true
+            },
+            {
+              "name": "GetKubeEvents",
+              "description": "GetKubeEvents returns a stream of kubernetes events",
+              "requestType": "LokiRequest",
+              "requestLongType": "LokiRequest",
+              "requestFullType": "pps_v2.LokiRequest",
+              "requestStreaming": false,
+              "responseType": "LokiLogMessage",
+              "responseLongType": "LokiLogMessage",
+              "responseFullType": "pps_v2.LokiLogMessage",
+              "responseStreaming": true
+            },
+            {
+              "name": "QueryLoki",
+              "description": "QueryLoki returns a stream of loki log messages given a query string",
+              "requestType": "LokiRequest",
+              "requestLongType": "LokiRequest",
+              "requestFullType": "pps_v2.LokiRequest",
+              "requestStreaming": false,
+              "responseType": "LokiLogMessage",
+              "responseLongType": "LokiLogMessage",
+              "responseFullType": "pps_v2.LokiLogMessage",
+              "responseStreaming": true
+            },
+            {
+              "name": "GetClusterDefaults",
+              "description": "GetClusterDefaults returns the current cluster defaults.",
+              "requestType": "GetClusterDefaultsRequest",
+              "requestLongType": "GetClusterDefaultsRequest",
+              "requestFullType": "pps_v2.GetClusterDefaultsRequest",
+              "requestStreaming": false,
+              "responseType": "GetClusterDefaultsResponse",
+              "responseLongType": "GetClusterDefaultsResponse",
+              "responseFullType": "pps_v2.GetClusterDefaultsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "SetClusterDefaults",
+              "description": "SetClusterDefaults returns the current cluster defaults.",
+              "requestType": "SetClusterDefaultsRequest",
+              "requestLongType": "SetClusterDefaultsRequest",
+              "requestFullType": "pps_v2.SetClusterDefaultsRequest",
+              "requestStreaming": false,
+              "responseType": "SetClusterDefaultsResponse",
+              "responseLongType": "SetClusterDefaultsResponse",
+              "responseFullType": "pps_v2.SetClusterDefaultsResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "protoextensions/json-schema-options.proto",
+      "description": "",
+      "package": "protoc.gen.jsonschema",
+      "hasEnums": false,
+      "hasExtensions": true,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [
+        {
+          "name": "enum_options",
+          "longName": ".google.protobuf.EnumOptions.enum_options",
+          "fullName": ".google.protobuf.EnumOptions.enum_options",
+          "description": "",
+          "label": "",
+          "type": "EnumOptions",
+          "longType": "EnumOptions",
+          "fullType": "protoc.gen.jsonschema.EnumOptions",
+          "number": 1128,
+          "defaultValue": "",
+          "containingType": "EnumOptions",
+          "containingLongType": ".google.protobuf.EnumOptions",
+          "containingFullType": "google.protobuf.EnumOptions"
+        },
+        {
+          "name": "field_options",
+          "longName": ".google.protobuf.FieldOptions.field_options",
+          "fullName": ".google.protobuf.FieldOptions.field_options",
+          "description": "",
+          "label": "",
+          "type": "FieldOptions",
+          "longType": "FieldOptions",
+          "fullType": "protoc.gen.jsonschema.FieldOptions",
+          "number": 1125,
+          "defaultValue": "",
+          "containingType": "FieldOptions",
+          "containingLongType": ".google.protobuf.FieldOptions",
+          "containingFullType": "google.protobuf.FieldOptions"
+        },
+        {
+          "name": "file_options",
+          "longName": ".google.protobuf.FileOptions.file_options",
+          "fullName": ".google.protobuf.FileOptions.file_options",
+          "description": "",
+          "label": "",
+          "type": "FileOptions",
+          "longType": "FileOptions",
+          "fullType": "protoc.gen.jsonschema.FileOptions",
+          "number": 1126,
+          "defaultValue": "",
+          "containingType": "FileOptions",
+          "containingLongType": ".google.protobuf.FileOptions",
+          "containingFullType": "google.protobuf.FileOptions"
+        },
+        {
+          "name": "message_options",
+          "longName": ".google.protobuf.MessageOptions.message_options",
+          "fullName": ".google.protobuf.MessageOptions.message_options",
+          "description": "",
+          "label": "",
+          "type": "MessageOptions",
+          "longType": "MessageOptions",
+          "fullType": "protoc.gen.jsonschema.MessageOptions",
+          "number": 1127,
+          "defaultValue": "",
+          "containingType": "MessageOptions",
+          "containingLongType": ".google.protobuf.MessageOptions",
+          "containingFullType": "google.protobuf.MessageOptions"
+        }
+      ],
+      "messages": [
+        {
+          "name": "EnumOptions",
+          "longName": "EnumOptions",
+          "fullName": "protoc.gen.jsonschema.EnumOptions",
+          "description": "Custom EnumOptions",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "enums_as_constants",
+              "description": "Enums tagged with this will have be encoded to use constants instead of simple types (supports value annotations):",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enums_as_strings_only",
+              "description": "Enums tagged with this will only provide string values as options (not their numerical equivalents):",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enums_trim_prefix",
+              "description": "Enums tagged with this will have enum name prefix removed from values:",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore",
+              "description": "Enums tagged with this will not be processed",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FieldOptions",
+          "longName": "FieldOptions",
+          "fullName": "protoc.gen.jsonschema.FieldOptions",
+          "description": "Custom FieldOptions",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "ignore",
+              "description": "Fields tagged with this will be omitted from generated schemas",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "required",
+              "description": "Fields tagged with this will be marked as \"required\" in generated schemas",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_length",
+              "description": "Fields tagged with this will constrain strings using the \"minLength\" keyword in generated schemas",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_length",
+              "description": "Fields tagged with this will constrain strings using the \"maxLength\" keyword in generated schemas",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pattern",
+              "description": "Fields tagged with this will constrain strings using the \"pattern\" keyword in generated schemas",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FileOptions",
+          "longName": "FileOptions",
+          "fullName": "protoc.gen.jsonschema.FileOptions",
+          "description": "Custom FileOptions",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "ignore",
+              "description": "Files tagged with this will not be processed",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "extension",
+              "description": "Override the default file extension for schemas generated from this file",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MessageOptions",
+          "longName": "MessageOptions",
+          "fullName": "protoc.gen.jsonschema.MessageOptions",
+          "description": "Custom MessageOptions",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "ignore",
+              "description": "Messages tagged with this will not be processed",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "all_fields_required",
+              "description": "Messages tagged with this will have all fields marked as \"required\":",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "allow_null_values",
+              "description": "Messages tagged with this will additionally accept null values for all properties:",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "disallow_additional_properties",
+              "description": "Messages tagged with this will have all fields marked as not allowing additional properties:",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "enums_as_constants",
+              "description": "Messages tagged with this will have all nested enums encoded to use constants instead of simple types (supports value annotations):",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "protoextensions/log.proto",
+      "description": "",
+      "package": "log",
+      "hasEnums": false,
+      "hasExtensions": true,
+      "hasMessages": false,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [
+        {
+          "name": "half",
+          "longName": ".google.protobuf.FieldOptions.half",
+          "fullName": ".google.protobuf.FieldOptions.half",
+          "description": "",
+          "label": "",
+          "type": "bool",
+          "longType": "bool",
+          "fullType": "bool",
+          "number": 50002,
+          "defaultValue": "",
+          "containingType": "FieldOptions",
+          "containingLongType": ".google.protobuf.FieldOptions",
+          "containingFullType": "google.protobuf.FieldOptions"
+        },
+        {
+          "name": "mask",
+          "longName": ".google.protobuf.FieldOptions.mask",
+          "fullName": ".google.protobuf.FieldOptions.mask",
+          "description": "",
+          "label": "",
+          "type": "bool",
+          "longType": "bool",
+          "fullType": "bool",
+          "number": 50001,
+          "defaultValue": "",
+          "containingType": "FieldOptions",
+          "containingLongType": ".google.protobuf.FieldOptions",
+          "containingFullType": "google.protobuf.FieldOptions"
+        }
+      ],
+      "messages": [],
+      "services": []
+    },
+    {
+      "name": "protoextensions/validate.proto",
+      "description": "",
+      "package": "validate",
+      "hasEnums": true,
+      "hasExtensions": true,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "KnownRegex",
+          "longName": "KnownRegex",
+          "fullName": "validate.KnownRegex",
+          "description": "WellKnownRegex contain some well-known patterns.",
+          "values": [
+            {
+              "name": "UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "HTTP_HEADER_NAME",
+              "number": "1",
+              "description": "HTTP header name as defined by RFC 7230."
+            },
+            {
+              "name": "HTTP_HEADER_VALUE",
+              "number": "2",
+              "description": "HTTP header value as defined by RFC 7230."
+            }
+          ]
+        }
+      ],
+      "extensions": [
+        {
+          "name": "rules",
+          "longName": ".google.protobuf.FieldOptions.rules",
+          "fullName": ".google.protobuf.FieldOptions.rules",
+          "description": "Rules specify the validations to be performed on this field. By default,\nno validation is performed against a field.",
+          "label": "optional",
+          "type": "FieldRules",
+          "longType": "FieldRules",
+          "fullType": "validate.FieldRules",
+          "number": 1071,
+          "defaultValue": "",
+          "containingType": "FieldOptions",
+          "containingLongType": ".google.protobuf.FieldOptions",
+          "containingFullType": "google.protobuf.FieldOptions"
+        },
+        {
+          "name": "disabled",
+          "longName": ".google.protobuf.MessageOptions.disabled",
+          "fullName": ".google.protobuf.MessageOptions.disabled",
+          "description": "Disabled nullifies any validation rules for this message, including any\nmessage fields associated with it that do support validation.",
+          "label": "optional",
+          "type": "bool",
+          "longType": "bool",
+          "fullType": "bool",
+          "number": 1071,
+          "defaultValue": "",
+          "containingType": "MessageOptions",
+          "containingLongType": ".google.protobuf.MessageOptions",
+          "containingFullType": "google.protobuf.MessageOptions"
+        },
+        {
+          "name": "ignored",
+          "longName": ".google.protobuf.MessageOptions.ignored",
+          "fullName": ".google.protobuf.MessageOptions.ignored",
+          "description": "Ignore skips generation of validation methods for this message.",
+          "label": "optional",
+          "type": "bool",
+          "longType": "bool",
+          "fullType": "bool",
+          "number": 1072,
+          "defaultValue": "",
+          "containingType": "MessageOptions",
+          "containingLongType": ".google.protobuf.MessageOptions",
+          "containingFullType": "google.protobuf.MessageOptions"
+        },
+        {
+          "name": "required",
+          "longName": ".google.protobuf.OneofOptions.required",
+          "fullName": ".google.protobuf.OneofOptions.required",
+          "description": "Required ensures that exactly one the field options in a oneof is set;\nvalidation fails if no fields in the oneof are set.",
+          "label": "optional",
+          "type": "bool",
+          "longType": "bool",
+          "fullType": "bool",
+          "number": 1071,
+          "defaultValue": "",
+          "containingType": "OneofOptions",
+          "containingLongType": ".google.protobuf.OneofOptions",
+          "containingFullType": "google.protobuf.OneofOptions"
+        }
+      ],
+      "messages": [
+        {
+          "name": "AnyRules",
+          "longName": "AnyRules",
+          "fullName": "validate.AnyRules",
+          "description": "AnyRules describe constraints applied exclusively to the\n`google.protobuf.Any` well-known type",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "required",
+              "description": "Required specifies that this field must be set",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field's `type_url` must be equal to one of the\nspecified values.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field's `type_url` must not be equal to any of\nthe specified values.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BoolRules",
+          "longName": "BoolRules",
+          "fullName": "validate.BoolRules",
+          "description": "BoolRules describes the constraints applied to `bool` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BytesRules",
+          "longName": "BytesRules",
+          "fullName": "validate.BytesRules",
+          "description": "BytesRules describe the constraints applied to `bytes` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "len",
+              "description": "Len specifies that this field must be the specified number of bytes",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_len",
+              "description": "MinLen specifies that this field must be the specified number of bytes\nat a minimum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_len",
+              "description": "MaxLen specifies that this field must be the specified number of bytes\nat a maximum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pattern",
+              "description": "Pattern specifes that this field must match against the specified\nregular expression (RE2 syntax). The included expression should elide\nany delimiters.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "prefix",
+              "description": "Prefix specifies that this field must have the specified bytes at the\nbeginning of the string.",
+              "label": "optional",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "suffix",
+              "description": "Suffix specifies that this field must have the specified bytes at the\nend of the string.",
+              "label": "optional",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "contains",
+              "description": "Contains specifies that this field must have the specified bytes\nanywhere in the string.",
+              "label": "optional",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ip",
+              "description": "Ip specifies that the field must be a valid IP (v4 or v6) address in\nbyte format",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "ipv4",
+              "description": "Ipv4 specifies that the field must be a valid IPv4 address in byte\nformat",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "ipv6",
+              "description": "Ipv6 specifies that the field must be a valid IPv6 address in byte\nformat",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DoubleRules",
+          "longName": "DoubleRules",
+          "fullName": "validate.DoubleRules",
+          "description": "DoubleRules describes the constraints applied to `double` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DurationRules",
+          "longName": "DurationRules",
+          "fullName": "validate.DurationRules",
+          "description": "DurationRules describe the constraints applied exclusively to the\n`google.protobuf.Duration` well-known type",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "required",
+              "description": "Required specifies that this field must be set",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lt specifies that this field must be less than the specified value,\ninclusive",
+              "label": "optional",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than the specified value,\ninclusive",
+              "label": "optional",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EnumRules",
+          "longName": "EnumRules",
+          "fullName": "validate.EnumRules",
+          "description": "EnumRules describe the constraints applied to enum values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "defined_only",
+              "description": "DefinedOnly specifies that this field must be only one of the defined\nvalues for this enum, failing on any undefined value.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FieldRules",
+          "longName": "FieldRules",
+          "fullName": "validate.FieldRules",
+          "description": "FieldRules encapsulates the rules for each type of field. Depending on the\nfield, the correct set should be used to ensure proper validations.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "message",
+              "description": "",
+              "label": "optional",
+              "type": "MessageRules",
+              "longType": "MessageRules",
+              "fullType": "validate.MessageRules",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "float",
+              "description": "Scalar Field Types",
+              "label": "optional",
+              "type": "FloatRules",
+              "longType": "FloatRules",
+              "fullType": "validate.FloatRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "double",
+              "description": "",
+              "label": "optional",
+              "type": "DoubleRules",
+              "longType": "DoubleRules",
+              "fullType": "validate.DoubleRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "int32",
+              "description": "",
+              "label": "optional",
+              "type": "Int32Rules",
+              "longType": "Int32Rules",
+              "fullType": "validate.Int32Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "int64",
+              "description": "",
+              "label": "optional",
+              "type": "Int64Rules",
+              "longType": "Int64Rules",
+              "fullType": "validate.Int64Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "uint32",
+              "description": "",
+              "label": "optional",
+              "type": "UInt32Rules",
+              "longType": "UInt32Rules",
+              "fullType": "validate.UInt32Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "uint64",
+              "description": "",
+              "label": "optional",
+              "type": "UInt64Rules",
+              "longType": "UInt64Rules",
+              "fullType": "validate.UInt64Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "sint32",
+              "description": "",
+              "label": "optional",
+              "type": "SInt32Rules",
+              "longType": "SInt32Rules",
+              "fullType": "validate.SInt32Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "sint64",
+              "description": "",
+              "label": "optional",
+              "type": "SInt64Rules",
+              "longType": "SInt64Rules",
+              "fullType": "validate.SInt64Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "fixed32",
+              "description": "",
+              "label": "optional",
+              "type": "Fixed32Rules",
+              "longType": "Fixed32Rules",
+              "fullType": "validate.Fixed32Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "fixed64",
+              "description": "",
+              "label": "optional",
+              "type": "Fixed64Rules",
+              "longType": "Fixed64Rules",
+              "fullType": "validate.Fixed64Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "sfixed32",
+              "description": "",
+              "label": "optional",
+              "type": "SFixed32Rules",
+              "longType": "SFixed32Rules",
+              "fullType": "validate.SFixed32Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "sfixed64",
+              "description": "",
+              "label": "optional",
+              "type": "SFixed64Rules",
+              "longType": "SFixed64Rules",
+              "fullType": "validate.SFixed64Rules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "bool",
+              "description": "",
+              "label": "optional",
+              "type": "BoolRules",
+              "longType": "BoolRules",
+              "fullType": "validate.BoolRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "string",
+              "description": "",
+              "label": "optional",
+              "type": "StringRules",
+              "longType": "StringRules",
+              "fullType": "validate.StringRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "bytes",
+              "description": "",
+              "label": "optional",
+              "type": "BytesRules",
+              "longType": "BytesRules",
+              "fullType": "validate.BytesRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "enum",
+              "description": "Complex Field Types",
+              "label": "optional",
+              "type": "EnumRules",
+              "longType": "EnumRules",
+              "fullType": "validate.EnumRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "repeated",
+              "description": "",
+              "label": "optional",
+              "type": "RepeatedRules",
+              "longType": "RepeatedRules",
+              "fullType": "validate.RepeatedRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "map",
+              "description": "",
+              "label": "optional",
+              "type": "MapRules",
+              "longType": "MapRules",
+              "fullType": "validate.MapRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "any",
+              "description": "Well-Known Field Types",
+              "label": "optional",
+              "type": "AnyRules",
+              "longType": "AnyRules",
+              "fullType": "validate.AnyRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "duration",
+              "description": "",
+              "label": "optional",
+              "type": "DurationRules",
+              "longType": "DurationRules",
+              "fullType": "validate.DurationRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            },
+            {
+              "name": "timestamp",
+              "description": "",
+              "label": "optional",
+              "type": "TimestampRules",
+              "longType": "TimestampRules",
+              "fullType": "validate.TimestampRules",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "type",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Fixed32Rules",
+          "longName": "Fixed32Rules",
+          "fullName": "validate.Fixed32Rules",
+          "description": "Fixed32Rules describes the constraints applied to `fixed32` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "fixed32",
+              "longType": "fixed32",
+              "fullType": "fixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Fixed64Rules",
+          "longName": "Fixed64Rules",
+          "fullName": "validate.Fixed64Rules",
+          "description": "Fixed64Rules describes the constraints applied to `fixed64` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "fixed64",
+              "longType": "fixed64",
+              "fullType": "fixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FloatRules",
+          "longName": "FloatRules",
+          "fullName": "validate.FloatRules",
+          "description": "FloatRules describes the constraints applied to `float` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "float",
+              "longType": "float",
+              "fullType": "float",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Int32Rules",
+          "longName": "Int32Rules",
+          "fullName": "validate.Int32Rules",
+          "description": "Int32Rules describes the constraints applied to `int32` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Int64Rules",
+          "longName": "Int64Rules",
+          "fullName": "validate.Int64Rules",
+          "description": "Int64Rules describes the constraints applied to `int64` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MapRules",
+          "longName": "MapRules",
+          "fullName": "validate.MapRules",
+          "description": "MapRules describe the constraints applied to `map` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "min_pairs",
+              "description": "MinPairs specifies that this field must have the specified number of\nKVs at a minimum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_pairs",
+              "description": "MaxPairs specifies that this field must have the specified number of\nKVs at a maximum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "no_sparse",
+              "description": "NoSparse specifies values in this field cannot be unset. This only\napplies to map's with message value types.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "keys",
+              "description": "Keys specifies the constraints to be applied to each key in the field.",
+              "label": "optional",
+              "type": "FieldRules",
+              "longType": "FieldRules",
+              "fullType": "validate.FieldRules",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "values",
+              "description": "Values specifies the constraints to be applied to the value of each key\nin the field. Message values will still have their validations evaluated\nunless skip is specified here.",
+              "label": "optional",
+              "type": "FieldRules",
+              "longType": "FieldRules",
+              "fullType": "validate.FieldRules",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MessageRules",
+          "longName": "MessageRules",
+          "fullName": "validate.MessageRules",
+          "description": "MessageRules describe the constraints applied to embedded message values.\nFor message-type fields, validation is performed recursively.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "skip",
+              "description": "Skip specifies that the validation rules of this field should not be\nevaluated",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "required",
+              "description": "Required specifies that this field must be set",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RepeatedRules",
+          "longName": "RepeatedRules",
+          "fullName": "validate.RepeatedRules",
+          "description": "RepeatedRules describe the constraints applied to `repeated` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "min_items",
+              "description": "MinItems specifies that this field must have the specified number of\nitems at a minimum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_items",
+              "description": "MaxItems specifies that this field must have the specified number of\nitems at a maximum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "unique",
+              "description": "Unique specifies that all elements in this field must be unique. This\ncontraint is only applicable to scalar and enum types (messages are not\nsupported).",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "items",
+              "description": "Items specifies the contraints to be applied to each item in the field.\nRepeated message fields will still execute validation against each item\nunless skip is specified here.",
+              "label": "optional",
+              "type": "FieldRules",
+              "longType": "FieldRules",
+              "fullType": "validate.FieldRules",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SFixed32Rules",
+          "longName": "SFixed32Rules",
+          "fullName": "validate.SFixed32Rules",
+          "description": "SFixed32Rules describes the constraints applied to `sfixed32` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sfixed32",
+              "longType": "sfixed32",
+              "fullType": "sfixed32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SFixed64Rules",
+          "longName": "SFixed64Rules",
+          "fullName": "validate.SFixed64Rules",
+          "description": "SFixed64Rules describes the constraints applied to `sfixed64` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sfixed64",
+              "longType": "sfixed64",
+              "fullType": "sfixed64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SInt32Rules",
+          "longName": "SInt32Rules",
+          "fullName": "validate.SInt32Rules",
+          "description": "SInt32Rules describes the constraints applied to `sint32` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sint32",
+              "longType": "sint32",
+              "fullType": "sint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SInt64Rules",
+          "longName": "SInt64Rules",
+          "fullName": "validate.SInt64Rules",
+          "description": "SInt64Rules describes the constraints applied to `sint64` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "sint64",
+              "longType": "sint64",
+              "fullType": "sint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "StringRules",
+          "longName": "StringRules",
+          "fullName": "validate.StringRules",
+          "description": "StringRules describe the constraints applied to `string` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "len",
+              "description": "Len specifies that this field must be the specified number of\ncharacters (Unicode code points). Note that the number of\ncharacters may differ from the number of bytes in the string.",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_len",
+              "description": "MinLen specifies that this field must be the specified number of\ncharacters (Unicode code points) at a minimum. Note that the number of\ncharacters may differ from the number of bytes in the string.",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_len",
+              "description": "MaxLen specifies that this field must be the specified number of\ncharacters (Unicode code points) at a maximum. Note that the number of\ncharacters may differ from the number of bytes in the string.",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "len_bytes",
+              "description": "LenBytes specifies that this field must be the specified number of bytes",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_bytes",
+              "description": "MinBytes specifies that this field must be the specified number of bytes\nat a minimum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_bytes",
+              "description": "MaxBytes specifies that this field must be the specified number of bytes\nat a maximum",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pattern",
+              "description": "Pattern specifes that this field must match against the specified\nregular expression (RE2 syntax). The included expression should elide\nany delimiters.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "prefix",
+              "description": "Prefix specifies that this field must have the specified substring at\nthe beginning of the string.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "suffix",
+              "description": "Suffix specifies that this field must have the specified substring at\nthe end of the string.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "contains",
+              "description": "Contains specifies that this field must have the specified substring\nanywhere in the string.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_contains",
+              "description": "NotContains specifies that this field cannot have the specified substring\nanywhere in the string.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "email",
+              "description": "Email specifies that the field must be a valid email address as\ndefined by RFC 5322",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "hostname",
+              "description": "Hostname specifies that the field must be a valid hostname as\ndefined by RFC 1034. This constraint does not support\ninternationalized domain names (IDNs).",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "ip",
+              "description": "Ip specifies that the field must be a valid IP (v4 or v6) address.\nValid IPv6 addresses should not include surrounding square brackets.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "ipv4",
+              "description": "Ipv4 specifies that the field must be a valid IPv4 address.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "ipv6",
+              "description": "Ipv6 specifies that the field must be a valid IPv6 address. Valid\nIPv6 addresses should not include surrounding square brackets.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "uri",
+              "description": "Uri specifies that the field must be a valid, absolute URI as defined\nby RFC 3986",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "uri_ref",
+              "description": "UriRef specifies that the field must be a valid URI as defined by RFC\n3986 and may be relative or absolute.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "address",
+              "description": "Address specifies that the field must be either a valid hostname as\ndefined by RFC 1034 (which does not support internationalized domain\nnames or IDNs), or it can be a valid IP (v4 or v6).",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "uuid",
+              "description": "Uuid specifies that the field must be a valid UUID as defined by\nRFC 4122",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "well_known_regex",
+              "description": "WellKnownRegex specifies a common well known pattern defined as a regex.",
+              "label": "optional",
+              "type": "KnownRegex",
+              "longType": "KnownRegex",
+              "fullType": "validate.KnownRegex",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "well_known",
+              "defaultValue": ""
+            },
+            {
+              "name": "strict",
+              "description": "This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable\nstrict header validation.\nBy default, this is true, and HTTP header validations are RFC-compliant.\nSetting to false will enable a looser validations that only disallows\n\\r\\n\\0 characters, which can be used to bypass header matching rules.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "true"
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TimestampRules",
+          "longName": "TimestampRules",
+          "fullName": "validate.TimestampRules",
+          "description": "TimestampRules describe the constraints applied exclusively to the\n`google.protobuf.Timestamp` well-known type",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "required",
+              "description": "Required specifies that this field must be set",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than the specified value,\ninclusive",
+              "label": "optional",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than the specified value,\ninclusive",
+              "label": "optional",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt_now",
+              "description": "LtNow specifies that this must be less than the current time. LtNow\ncan only be used with the Within rule.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt_now",
+              "description": "GtNow specifies that this must be greater than the current time. GtNow\ncan only be used with the Within rule.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "within",
+              "description": "Within specifies that this field must be within this duration of the\ncurrent time. This constraint can be used alone or with the LtNow and\nGtNow rules.",
+              "label": "optional",
+              "type": "Duration",
+              "longType": "google.protobuf.Duration",
+              "fullType": "google.protobuf.Duration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UInt32Rules",
+          "longName": "UInt32Rules",
+          "fullName": "validate.UInt32Rules",
+          "description": "UInt32Rules describes the constraints applied to `uint32` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UInt64Rules",
+          "longName": "UInt64Rules",
+          "fullName": "validate.UInt64Rules",
+          "description": "UInt64Rules describes the constraints applied to `uint64` values",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "const",
+              "description": "Const specifies that this field must be exactly the specified value",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lt",
+              "description": "Lt specifies that this field must be less than the specified value,\nexclusive",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lte",
+              "description": "Lte specifies that this field must be less than or equal to the\nspecified value, inclusive",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gt",
+              "description": "Gt specifies that this field must be greater than the specified value,\nexclusive. If the value of Gt is larger than a specified Lt or Lte, the\nrange is reversed.",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gte",
+              "description": "Gte specifies that this field must be greater than or equal to the\nspecified value, inclusive. If the value of Gte is larger than a\nspecified Lt or Lte, the range is reversed.",
+              "label": "optional",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "in",
+              "description": "In specifies that this field must be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "not_in",
+              "description": "NotIn specifies that this field cannot be equal to one of the specified\nvalues",
+              "label": "repeated",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ignore_empty",
+              "description": "IgnoreEmpty specifies that the validation rules of this field should be\nevaluated only if the field is not empty",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "proxy/proxy.proto",
+      "description": "",
+      "package": "proxy",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ListenRequest",
+          "longName": "ListenRequest",
+          "fullName": "proxy.ListenRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "channel",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "string.min_bytes",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ListenResponse",
+          "longName": "ListenResponse",
+          "fullName": "proxy.ListenResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "extra",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "proxy.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "Listen",
+              "description": "Listen streams database events.\nIt signals that it is internally set up by sending an initial empty ListenResponse.",
+              "requestType": "ListenRequest",
+              "requestLongType": "ListenRequest",
+              "requestFullType": "proxy.ListenRequest",
+              "requestStreaming": false,
+              "responseType": "ListenResponse",
+              "responseLongType": "ListenResponse",
+              "responseFullType": "proxy.ListenResponse",
+              "responseStreaming": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "server/pfs/server/pfsserver.proto",
+      "description": "",
+      "package": "pfsserver",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "CompactTask",
+          "longName": "CompactTask",
+          "fullName": "pfsserver.CompactTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "inputs",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "PathRange",
+              "fullType": "pfsserver.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CompactTaskResult",
+          "longName": "CompactTaskResult",
+          "fullName": "pfsserver.CompactTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ConcatTask",
+          "longName": "ConcatTask",
+          "fullName": "pfsserver.ConcatTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "inputs",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ConcatTaskResult",
+          "longName": "ConcatTaskResult",
+          "fullName": "pfsserver.ConcatTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetFileURLTask",
+          "longName": "GetFileURLTask",
+          "fullName": "pfsserver.GetFileURLTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "URL",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file",
+              "description": "",
+              "label": "",
+              "type": "File",
+              "longType": "pfs_v2.File",
+              "fullType": "pfs_v2.File",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetFileURLTaskResult",
+          "longName": "GetFileURLTaskResult",
+          "fullName": "pfsserver.GetFileURLTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "PathRange",
+          "longName": "PathRange",
+          "fullName": "pfsserver.PathRange",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "lower",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "upper",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PutFileURLTask",
+          "longName": "PutFileURLTask",
+          "fullName": "pfsserver.PutFileURLTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "dst",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "URL",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "paths",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "start_offset",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "end_offset",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PutFileURLTaskResult",
+          "longName": "PutFileURLTaskResult",
+          "fullName": "pfsserver.PutFileURLTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ShardTask",
+          "longName": "ShardTask",
+          "fullName": "pfsserver.ShardTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "inputs",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "PathRange",
+              "fullType": "pfsserver.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ShardTaskResult",
+          "longName": "ShardTaskResult",
+          "fullName": "pfsserver.ShardTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "compact_tasks",
+              "description": "",
+              "label": "repeated",
+              "type": "CompactTask",
+              "longType": "CompactTask",
+              "fullType": "pfsserver.CompactTask",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ValidateTask",
+          "longName": "ValidateTask",
+          "fullName": "pfsserver.ValidateTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "PathRange",
+              "fullType": "pfsserver.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ValidateTaskResult",
+          "longName": "ValidateTaskResult",
+          "fullName": "pfsserver.ValidateTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "first",
+              "description": "",
+              "label": "",
+              "type": "Index",
+              "longType": "index.Index",
+              "fullType": "index.Index",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last",
+              "description": "",
+              "label": "",
+              "type": "Index",
+              "longType": "index.Index",
+              "fullType": "index.Index",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "server/worker/common/common.proto",
+      "description": "",
+      "package": "common",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Input",
+          "longName": "Input",
+          "fullName": "common.Input",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_info",
+              "description": "",
+              "label": "",
+              "type": "FileInfo",
+              "longType": "pfs_v2.FileInfo",
+              "fullType": "pfs_v2.FileInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "join_on",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "outer_join",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "group_by",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "lazy",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "branch",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "empty_files",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "s3",
+              "description": "If set, workers won't create an input directory for this input",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "server/worker/datum/datum.proto",
+      "description": "",
+      "package": "datum",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "Type",
+          "longName": "KeyTask.Type",
+          "fullName": "datum.KeyTask.Type",
+          "description": "",
+          "values": [
+            {
+              "name": "JOIN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "GROUP",
+              "number": "1",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "Type",
+          "longName": "MergeTask.Type",
+          "fullName": "datum.MergeTask.Type",
+          "description": "",
+          "values": [
+            {
+              "name": "JOIN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "GROUP",
+              "number": "1",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "State",
+          "longName": "State",
+          "fullName": "datum.State",
+          "description": "",
+          "values": [
+            {
+              "name": "PROCESSED",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "FAILED",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "RECOVERED",
+              "number": "2",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ComposeTask",
+          "longName": "ComposeTask",
+          "fullName": "datum.ComposeTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_ids",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ComposeTaskResult",
+          "longName": "ComposeTaskResult",
+          "fullName": "datum.ComposeTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CrossTask",
+          "longName": "CrossTask",
+          "fullName": "datum.CrossTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_ids",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "base_file_set_index",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "base_file_set_path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "base_index",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CrossTaskResult",
+          "longName": "CrossTaskResult",
+          "fullName": "datum.CrossTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "KeyTask",
+          "longName": "KeyTask",
+          "fullName": "datum.KeyTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "Type",
+              "longType": "KeyTask.Type",
+              "fullType": "datum.KeyTask.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "KeyTaskResult",
+          "longName": "KeyTaskResult",
+          "fullName": "datum.KeyTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MergeTask",
+          "longName": "MergeTask",
+          "fullName": "datum.MergeTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_ids",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "Type",
+              "longType": "MergeTask.Type",
+              "fullType": "datum.MergeTask.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MergeTaskResult",
+          "longName": "MergeTaskResult",
+          "fullName": "datum.MergeTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Meta",
+          "longName": "Meta",
+          "fullName": "datum.Meta",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "pps_v2.Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "inputs",
+              "description": "",
+              "label": "repeated",
+              "type": "Input",
+              "longType": "common.Input",
+              "fullType": "common.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "hash",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "State",
+              "longType": "State",
+              "fullType": "datum.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "",
+              "label": "",
+              "type": "ProcessStats",
+              "longType": "pps_v2.ProcessStats",
+              "fullType": "pps_v2.ProcessStats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "index",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "image_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PFSTask",
+          "longName": "PFSTask",
+          "fullName": "datum.PFSTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "input",
+              "description": "",
+              "label": "",
+              "type": "PFSInput",
+              "longType": "pps_v2.PFSInput",
+              "fullType": "pps_v2.PFSInput",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "base_index",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PFSTaskResult",
+          "longName": "PFSTaskResult",
+          "fullName": "datum.PFSTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SetSpec",
+          "longName": "SetSpec",
+          "fullName": "datum.SetSpec",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "number",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Stats",
+          "longName": "Stats",
+          "fullName": "datum.Stats",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "process_stats",
+              "description": "",
+              "label": "",
+              "type": "ProcessStats",
+              "longType": "pps_v2.ProcessStats",
+              "fullType": "pps_v2.ProcessStats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "processed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "skipped",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "failed",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "recovered",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "failed_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "server/worker/pipeline/transform/transform.proto",
+      "description": "",
+      "package": "pachyderm.worker.pipeline.transform",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "CreateDatumSetsTask",
+          "longName": "CreateDatumSetsTask",
+          "fullName": "pachyderm.worker.pipeline.transform.CreateDatumSetsTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "set_spec",
+              "description": "",
+              "label": "",
+              "type": "SetSpec",
+              "longType": "datum.SetSpec",
+              "fullType": "datum.SetSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateDatumSetsTaskResult",
+          "longName": "CreateDatumSetsTaskResult",
+          "fullName": "pachyderm.worker.pipeline.transform.CreateDatumSetsTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "datum_sets",
+              "description": "",
+              "label": "repeated",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateParallelDatumsTask",
+          "longName": "CreateParallelDatumsTask",
+          "fullName": "pachyderm.worker.pipeline.transform.CreateParallelDatumsTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "pps_v2.Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "salt",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "base_file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateParallelDatumsTaskResult",
+          "longName": "CreateParallelDatumsTaskResult",
+          "fullName": "pachyderm.worker.pipeline.transform.CreateParallelDatumsTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "",
+              "label": "",
+              "type": "Stats",
+              "longType": "datum.Stats",
+              "fullType": "datum.Stats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateSerialDatumsTask",
+          "longName": "CreateSerialDatumsTask",
+          "fullName": "pachyderm.worker.pipeline.transform.CreateSerialDatumsTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "pps_v2.Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "salt",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "base_meta_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "no_skip",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateSerialDatumsTaskResult",
+          "longName": "CreateSerialDatumsTaskResult",
+          "fullName": "pachyderm.worker.pipeline.transform.CreateSerialDatumsTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "output_delete_file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "meta_delete_file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "",
+              "label": "",
+              "type": "Stats",
+              "longType": "datum.Stats",
+              "fullType": "datum.Stats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DatumSetTask",
+          "longName": "DatumSetTask",
+          "fullName": "pachyderm.worker.pipeline.transform.DatumSetTask",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "Job",
+              "longType": "pps_v2.Job",
+              "fullType": "pps_v2.Job",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "path_range",
+              "description": "",
+              "label": "",
+              "type": "PathRange",
+              "longType": "pfs_v2.PathRange",
+              "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "output_commit",
+              "description": "",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DatumSetTaskResult",
+          "longName": "DatumSetTaskResult",
+          "fullName": "pachyderm.worker.pipeline.transform.DatumSetTaskResult",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "output_file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "meta_file_set_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stats",
+              "description": "",
+              "label": "",
+              "type": "Stats",
+              "longType": "datum.Stats",
+              "fullType": "datum.Stats",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "task/task.proto",
+      "description": "",
+      "package": "taskapi",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "State",
+          "longName": "State",
+          "fullName": "taskapi.State",
+          "description": "",
+          "values": [
+            {
+              "name": "UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "RUNNING",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "SUCCESS",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "FAILURE",
+              "number": "3",
+              "description": ""
+            },
+            {
+              "name": "CLAIMED",
+              "number": "4",
+              "description": "not a real state used by task logic"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Group",
+          "longName": "Group",
+          "fullName": "taskapi.Group",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "namespace",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "group",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ListTaskRequest",
+          "longName": "ListTaskRequest",
+          "fullName": "taskapi.ListTaskRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "group",
+              "description": "",
+              "label": "",
+              "type": "Group",
+              "longType": "Group",
+              "fullType": "taskapi.Group",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "TaskInfo",
+          "longName": "TaskInfo",
+          "fullName": "taskapi.TaskInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "group",
+              "description": "",
+              "label": "",
+              "type": "Group",
+              "longType": "Group",
+              "fullType": "taskapi.Group",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "",
+              "label": "",
+              "type": "State",
+              "longType": "State",
+              "fullType": "taskapi.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_type",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "input_data",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "transaction/transaction.proto",
+      "description": "",
+      "package": "transaction_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "BatchTransactionRequest",
+          "longName": "BatchTransactionRequest",
+          "fullName": "transaction_v2.BatchTransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "requests",
+              "description": "",
+              "label": "repeated",
+              "type": "TransactionRequest",
+              "longType": "TransactionRequest",
+              "fullType": "transaction_v2.TransactionRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DeleteAllRequest",
+          "longName": "DeleteAllRequest",
+          "fullName": "transaction_v2.DeleteAllRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "DeleteTransactionRequest",
+          "longName": "DeleteTransactionRequest",
+          "fullName": "transaction_v2.DeleteTransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transaction",
+              "description": "",
+              "label": "",
+              "type": "Transaction",
+              "longType": "Transaction",
+              "fullType": "transaction_v2.Transaction",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "FinishTransactionRequest",
+          "longName": "FinishTransactionRequest",
+          "fullName": "transaction_v2.FinishTransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transaction",
+              "description": "",
+              "label": "",
+              "type": "Transaction",
+              "longType": "Transaction",
+              "fullType": "transaction_v2.Transaction",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "InspectTransactionRequest",
+          "longName": "InspectTransactionRequest",
+          "fullName": "transaction_v2.InspectTransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transaction",
+              "description": "",
+              "label": "",
+              "type": "Transaction",
+              "longType": "Transaction",
+              "fullType": "transaction_v2.Transaction",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validate.rules": [
+                  {
+                    "name": "message.required",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ListTransactionRequest",
+          "longName": "ListTransactionRequest",
+          "fullName": "transaction_v2.ListTransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "StartTransactionRequest",
+          "longName": "StartTransactionRequest",
+          "fullName": "transaction_v2.StartTransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "Transaction",
+          "longName": "Transaction",
+          "fullName": "transaction_v2.Transaction",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransactionInfo",
+          "longName": "TransactionInfo",
+          "fullName": "transaction_v2.TransactionInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transaction",
+              "description": "",
+              "label": "",
+              "type": "Transaction",
+              "longType": "Transaction",
+              "fullType": "transaction_v2.Transaction",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "requests",
+              "description": "",
+              "label": "repeated",
+              "type": "TransactionRequest",
+              "longType": "TransactionRequest",
+              "fullType": "transaction_v2.TransactionRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "responses",
+              "description": "",
+              "label": "repeated",
+              "type": "TransactionResponse",
+              "longType": "TransactionResponse",
+              "fullType": "transaction_v2.TransactionResponse",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "started",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransactionInfos",
+          "longName": "TransactionInfos",
+          "fullName": "transaction_v2.TransactionInfos",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transaction_info",
+              "description": "",
+              "label": "repeated",
+              "type": "TransactionInfo",
+              "longType": "TransactionInfo",
+              "fullType": "transaction_v2.TransactionInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransactionRequest",
+          "longName": "TransactionRequest",
+          "fullName": "transaction_v2.TransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "create_repo",
+              "description": "Exactly one of these fields should be set",
+              "label": "",
+              "type": "CreateRepoRequest",
+              "longType": "pfs_v2.CreateRepoRequest",
+              "fullType": "pfs_v2.CreateRepoRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "delete_repo",
+              "description": "",
+              "label": "",
+              "type": "DeleteRepoRequest",
+              "longType": "pfs_v2.DeleteRepoRequest",
+              "fullType": "pfs_v2.DeleteRepoRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "start_commit",
+              "description": "",
+              "label": "",
+              "type": "StartCommitRequest",
+              "longType": "pfs_v2.StartCommitRequest",
+              "fullType": "pfs_v2.StartCommitRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "finish_commit",
+              "description": "",
+              "label": "",
+              "type": "FinishCommitRequest",
+              "longType": "pfs_v2.FinishCommitRequest",
+              "fullType": "pfs_v2.FinishCommitRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "squash_commit_set",
+              "description": "",
+              "label": "",
+              "type": "SquashCommitSetRequest",
+              "longType": "pfs_v2.SquashCommitSetRequest",
+              "fullType": "pfs_v2.SquashCommitSetRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "create_branch",
+              "description": "",
+              "label": "",
+              "type": "CreateBranchRequest",
+              "longType": "pfs_v2.CreateBranchRequest",
+              "fullType": "pfs_v2.CreateBranchRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "delete_branch",
+              "description": "",
+              "label": "",
+              "type": "DeleteBranchRequest",
+              "longType": "pfs_v2.DeleteBranchRequest",
+              "fullType": "pfs_v2.DeleteBranchRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update_job_state",
+              "description": "",
+              "label": "",
+              "type": "UpdateJobStateRequest",
+              "longType": "pps_v2.UpdateJobStateRequest",
+              "fullType": "pps_v2.UpdateJobStateRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "stop_job",
+              "description": "",
+              "label": "",
+              "type": "StopJobRequest",
+              "longType": "pps_v2.StopJobRequest",
+              "fullType": "pps_v2.StopJobRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "create_pipeline_v2",
+              "description": "",
+              "label": "",
+              "type": "CreatePipelineTransaction",
+              "longType": "pps_v2.CreatePipelineTransaction",
+              "fullType": "pps_v2.CreatePipelineTransaction",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransactionResponse",
+          "longName": "TransactionResponse",
+          "fullName": "transaction_v2.TransactionResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commit",
+              "description": "At most, one of these fields should be set (most responses are empty)\n\nOnly used for StartCommit - any way we can deterministically provide this before finishing the transaction?",
+              "label": "",
+              "type": "Commit",
+              "longType": "pfs_v2.Commit",
+              "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "transaction_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "BatchTransaction",
+              "description": "Transaction rpcs",
+              "requestType": "BatchTransactionRequest",
+              "requestLongType": "BatchTransactionRequest",
+              "requestFullType": "transaction_v2.BatchTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "TransactionInfo",
+              "responseLongType": "TransactionInfo",
+              "responseFullType": "transaction_v2.TransactionInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "StartTransaction",
+              "description": "",
+              "requestType": "StartTransactionRequest",
+              "requestLongType": "StartTransactionRequest",
+              "requestFullType": "transaction_v2.StartTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "Transaction",
+              "responseLongType": "Transaction",
+              "responseFullType": "transaction_v2.Transaction",
+              "responseStreaming": false
+            },
+            {
+              "name": "InspectTransaction",
+              "description": "",
+              "requestType": "InspectTransactionRequest",
+              "requestLongType": "InspectTransactionRequest",
+              "requestFullType": "transaction_v2.InspectTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "TransactionInfo",
+              "responseLongType": "TransactionInfo",
+              "responseFullType": "transaction_v2.TransactionInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteTransaction",
+              "description": "",
+              "requestType": "DeleteTransactionRequest",
+              "requestLongType": "DeleteTransactionRequest",
+              "requestFullType": "transaction_v2.DeleteTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            },
+            {
+              "name": "ListTransaction",
+              "description": "",
+              "requestType": "ListTransactionRequest",
+              "requestLongType": "ListTransactionRequest",
+              "requestFullType": "transaction_v2.ListTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "TransactionInfos",
+              "responseLongType": "TransactionInfos",
+              "responseFullType": "transaction_v2.TransactionInfos",
+              "responseStreaming": false
+            },
+            {
+              "name": "FinishTransaction",
+              "description": "",
+              "requestType": "FinishTransactionRequest",
+              "requestLongType": "FinishTransactionRequest",
+              "requestFullType": "transaction_v2.FinishTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "TransactionInfo",
+              "responseLongType": "TransactionInfo",
+              "responseFullType": "transaction_v2.TransactionInfo",
+              "responseStreaming": false
+            },
+            {
+              "name": "DeleteAll",
+              "description": "",
+              "requestType": "DeleteAllRequest",
+              "requestLongType": "DeleteAllRequest",
+              "requestFullType": "transaction_v2.DeleteAllRequest",
+              "requestStreaming": false,
+              "responseType": "Empty",
+              "responseLongType": ".google.protobuf.Empty",
+              "responseFullType": "google.protobuf.Empty",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "version/versionpb/version.proto",
+      "description": "",
+      "package": "versionpb_v2",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Version",
+          "longName": "Version",
+          "fullName": "versionpb_v2.Version",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "major",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "minor",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "micro",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "additional",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "git_commit",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "git_tree_modified",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "build_date",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "go_version",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "platform",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "versionpb_v2.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "GetVersion",
+              "description": "",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "Version",
+              "responseLongType": "Version",
+              "responseFullType": "versionpb_v2.Version",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "worker/worker.proto",
+      "description": "",
+      "package": "pachyderm.worker",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "CancelRequest",
+          "longName": "CancelRequest",
+          "fullName": "pachyderm.worker.CancelRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "job_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data_filters",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CancelResponse",
+          "longName": "CancelResponse",
+          "fullName": "pachyderm.worker.CancelResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "success",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NextDatumRequest",
+          "longName": "NextDatumRequest",
+          "fullName": "pachyderm.worker.NextDatumRequest",
+          "description": "Error indicates that the processing of the current datum errored.\nDatum error semantics with datum batching enabled are similar to datum error\nsemantics without datum batching enabled in that the datum may be retried,\nrecovered, or result with a job failure.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "error",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NextDatumResponse",
+          "longName": "NextDatumResponse",
+          "fullName": "pachyderm.worker.NextDatumResponse",
+          "description": "Env is a list of environment variables that should be set for the processing\nof the next datum.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "env",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "Worker",
+          "longName": "Worker",
+          "fullName": "pachyderm.worker.Worker",
+          "description": "",
+          "methods": [
+            {
+              "name": "Status",
+              "description": "",
+              "requestType": "Empty",
+              "requestLongType": ".google.protobuf.Empty",
+              "requestFullType": "google.protobuf.Empty",
+              "requestStreaming": false,
+              "responseType": "WorkerStatus",
+              "responseLongType": ".pps_v2.WorkerStatus",
+              "responseFullType": "pps_v2.WorkerStatus",
+              "responseStreaming": false
+            },
+            {
+              "name": "Cancel",
+              "description": "",
+              "requestType": "CancelRequest",
+              "requestLongType": "CancelRequest",
+              "requestFullType": "pachyderm.worker.CancelRequest",
+              "requestStreaming": false,
+              "responseType": "CancelResponse",
+              "responseLongType": "CancelResponse",
+              "responseFullType": "pachyderm.worker.CancelResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "NextDatum",
+              "description": "NextDatum should only be called by user code running in a pipeline with\ndatum batching enabled.\nNextDatum will signal to the worker code that the user code is ready to\nproceed to the next datum. This generally means setting up the next\ndatum's filesystem state and updating internal metadata similarly to datum\nprocessing in a normal pipeline.\nNextDatum is a synchronous operation, so user code should expect to block\non this until the next datum is set up for processing.\nUser code should generally be migratable to datum batching by wrapping it\nin a loop that calls next datum.",
+              "requestType": "NextDatumRequest",
+              "requestLongType": "NextDatumRequest",
+              "requestFullType": "pachyderm.worker.NextDatumRequest",
+              "requestStreaming": false,
+              "responseType": "NextDatumResponse",
+              "responseLongType": "NextDatumResponse",
+              "responseFullType": "pachyderm.worker.NextDatumResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scalarValueTypes": [
+    {
+      "protoType": "double",
+      "notes": "",
+      "cppType": "double",
+      "csType": "double",
+      "goType": "float64",
+      "javaType": "double",
+      "phpType": "float",
+      "pythonType": "float",
+      "rubyType": "Float"
+    },
+    {
+      "protoType": "float",
+      "notes": "",
+      "cppType": "float",
+      "csType": "float",
+      "goType": "float32",
+      "javaType": "float",
+      "phpType": "float",
+      "pythonType": "float",
+      "rubyType": "Float"
+    },
+    {
+      "protoType": "int32",
+      "notes": "Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead.",
+      "cppType": "int32",
+      "csType": "int",
+      "goType": "int32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "int64",
+      "notes": "Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead.",
+      "cppType": "int64",
+      "csType": "long",
+      "goType": "int64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "uint32",
+      "notes": "Uses variable-length encoding.",
+      "cppType": "uint32",
+      "csType": "uint",
+      "goType": "uint32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int/long",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "uint64",
+      "notes": "Uses variable-length encoding.",
+      "cppType": "uint64",
+      "csType": "ulong",
+      "goType": "uint64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "sint32",
+      "notes": "Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s.",
+      "cppType": "int32",
+      "csType": "int",
+      "goType": "int32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "sint64",
+      "notes": "Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s.",
+      "cppType": "int64",
+      "csType": "long",
+      "goType": "int64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "fixed32",
+      "notes": "Always four bytes. More efficient than uint32 if values are often greater than 2^28.",
+      "cppType": "uint32",
+      "csType": "uint",
+      "goType": "uint32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "fixed64",
+      "notes": "Always eight bytes. More efficient than uint64 if values are often greater than 2^56.",
+      "cppType": "uint64",
+      "csType": "ulong",
+      "goType": "uint64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "sfixed32",
+      "notes": "Always four bytes.",
+      "cppType": "int32",
+      "csType": "int",
+      "goType": "int32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "sfixed64",
+      "notes": "Always eight bytes.",
+      "cppType": "int64",
+      "csType": "long",
+      "goType": "int64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "bool",
+      "notes": "",
+      "cppType": "bool",
+      "csType": "bool",
+      "goType": "bool",
+      "javaType": "boolean",
+      "phpType": "boolean",
+      "pythonType": "boolean",
+      "rubyType": "TrueClass/FalseClass"
+    },
+    {
+      "protoType": "string",
+      "notes": "A string must always contain UTF-8 encoded or 7-bit ASCII text.",
+      "cppType": "string",
+      "csType": "string",
+      "goType": "string",
+      "javaType": "String",
+      "phpType": "string",
+      "pythonType": "str/unicode",
+      "rubyType": "String (UTF-8)"
+    },
+    {
+      "protoType": "bytes",
+      "notes": "May contain any arbitrary sequence of bytes.",
+      "cppType": "string",
+      "csType": "ByteString",
+      "goType": "[]byte",
+      "javaType": "ByteString",
+      "phpType": "string",
+      "pythonType": "str",
+      "rubyType": "String (ASCII-8BIT)"
+    }
+  ]
+}

--- a/proto-docs.md
+++ b/proto-docs.md
@@ -1,0 +1,9339 @@
+# Protocol Documentation
+<a name="top"></a>
+
+## Table of Contents
+
+- [admin/admin.proto](#admin_admin-proto)
+    - [ClusterInfo](#admin_v2-ClusterInfo)
+    - [InspectClusterRequest](#admin_v2-InspectClusterRequest)
+    - [WebResource](#admin_v2-WebResource)
+  
+    - [API](#admin_v2-API)
+  
+- [auth/auth.proto](#auth_auth-proto)
+    - [ActivateRequest](#auth_v2-ActivateRequest)
+    - [ActivateResponse](#auth_v2-ActivateResponse)
+    - [AuthenticateRequest](#auth_v2-AuthenticateRequest)
+    - [AuthenticateResponse](#auth_v2-AuthenticateResponse)
+    - [AuthorizeRequest](#auth_v2-AuthorizeRequest)
+    - [AuthorizeResponse](#auth_v2-AuthorizeResponse)
+    - [DeactivateRequest](#auth_v2-DeactivateRequest)
+    - [DeactivateResponse](#auth_v2-DeactivateResponse)
+    - [DeleteExpiredAuthTokensRequest](#auth_v2-DeleteExpiredAuthTokensRequest)
+    - [DeleteExpiredAuthTokensResponse](#auth_v2-DeleteExpiredAuthTokensResponse)
+    - [ExtractAuthTokensRequest](#auth_v2-ExtractAuthTokensRequest)
+    - [ExtractAuthTokensResponse](#auth_v2-ExtractAuthTokensResponse)
+    - [GetConfigurationRequest](#auth_v2-GetConfigurationRequest)
+    - [GetConfigurationResponse](#auth_v2-GetConfigurationResponse)
+    - [GetGroupsForPrincipalRequest](#auth_v2-GetGroupsForPrincipalRequest)
+    - [GetGroupsRequest](#auth_v2-GetGroupsRequest)
+    - [GetGroupsResponse](#auth_v2-GetGroupsResponse)
+    - [GetOIDCLoginRequest](#auth_v2-GetOIDCLoginRequest)
+    - [GetOIDCLoginResponse](#auth_v2-GetOIDCLoginResponse)
+    - [GetPermissionsForPrincipalRequest](#auth_v2-GetPermissionsForPrincipalRequest)
+    - [GetPermissionsRequest](#auth_v2-GetPermissionsRequest)
+    - [GetPermissionsResponse](#auth_v2-GetPermissionsResponse)
+    - [GetRobotTokenRequest](#auth_v2-GetRobotTokenRequest)
+    - [GetRobotTokenResponse](#auth_v2-GetRobotTokenResponse)
+    - [GetRoleBindingRequest](#auth_v2-GetRoleBindingRequest)
+    - [GetRoleBindingResponse](#auth_v2-GetRoleBindingResponse)
+    - [GetRolesForPermissionRequest](#auth_v2-GetRolesForPermissionRequest)
+    - [GetRolesForPermissionResponse](#auth_v2-GetRolesForPermissionResponse)
+    - [GetUsersRequest](#auth_v2-GetUsersRequest)
+    - [GetUsersResponse](#auth_v2-GetUsersResponse)
+    - [Groups](#auth_v2-Groups)
+    - [Groups.GroupsEntry](#auth_v2-Groups-GroupsEntry)
+    - [ModifyMembersRequest](#auth_v2-ModifyMembersRequest)
+    - [ModifyMembersResponse](#auth_v2-ModifyMembersResponse)
+    - [ModifyRoleBindingRequest](#auth_v2-ModifyRoleBindingRequest)
+    - [ModifyRoleBindingResponse](#auth_v2-ModifyRoleBindingResponse)
+    - [OIDCConfig](#auth_v2-OIDCConfig)
+    - [Resource](#auth_v2-Resource)
+    - [RestoreAuthTokenRequest](#auth_v2-RestoreAuthTokenRequest)
+    - [RestoreAuthTokenResponse](#auth_v2-RestoreAuthTokenResponse)
+    - [RevokeAuthTokenRequest](#auth_v2-RevokeAuthTokenRequest)
+    - [RevokeAuthTokenResponse](#auth_v2-RevokeAuthTokenResponse)
+    - [RevokeAuthTokensForUserRequest](#auth_v2-RevokeAuthTokensForUserRequest)
+    - [RevokeAuthTokensForUserResponse](#auth_v2-RevokeAuthTokensForUserResponse)
+    - [Role](#auth_v2-Role)
+    - [RoleBinding](#auth_v2-RoleBinding)
+    - [RoleBinding.EntriesEntry](#auth_v2-RoleBinding-EntriesEntry)
+    - [Roles](#auth_v2-Roles)
+    - [Roles.RolesEntry](#auth_v2-Roles-RolesEntry)
+    - [RotateRootTokenRequest](#auth_v2-RotateRootTokenRequest)
+    - [RotateRootTokenResponse](#auth_v2-RotateRootTokenResponse)
+    - [SessionInfo](#auth_v2-SessionInfo)
+    - [SetConfigurationRequest](#auth_v2-SetConfigurationRequest)
+    - [SetConfigurationResponse](#auth_v2-SetConfigurationResponse)
+    - [SetGroupsForUserRequest](#auth_v2-SetGroupsForUserRequest)
+    - [SetGroupsForUserResponse](#auth_v2-SetGroupsForUserResponse)
+    - [TokenInfo](#auth_v2-TokenInfo)
+    - [Users](#auth_v2-Users)
+    - [Users.UsernamesEntry](#auth_v2-Users-UsernamesEntry)
+    - [WhoAmIRequest](#auth_v2-WhoAmIRequest)
+    - [WhoAmIResponse](#auth_v2-WhoAmIResponse)
+  
+    - [Permission](#auth_v2-Permission)
+    - [ResourceType](#auth_v2-ResourceType)
+  
+    - [API](#auth_v2-API)
+  
+- [debug/debug.proto](#debug_debug-proto)
+    - [App](#debug_v2-App)
+    - [BinaryRequest](#debug_v2-BinaryRequest)
+    - [DumpChunk](#debug_v2-DumpChunk)
+    - [DumpContent](#debug_v2-DumpContent)
+    - [DumpProgress](#debug_v2-DumpProgress)
+    - [DumpRequest](#debug_v2-DumpRequest)
+    - [DumpV2Request](#debug_v2-DumpV2Request)
+    - [DumpV2Request.Defaults](#debug_v2-DumpV2Request-Defaults)
+    - [Filter](#debug_v2-Filter)
+    - [GetDumpV2TemplateRequest](#debug_v2-GetDumpV2TemplateRequest)
+    - [GetDumpV2TemplateResponse](#debug_v2-GetDumpV2TemplateResponse)
+    - [Pipeline](#debug_v2-Pipeline)
+    - [Pod](#debug_v2-Pod)
+    - [Profile](#debug_v2-Profile)
+    - [ProfileRequest](#debug_v2-ProfileRequest)
+    - [SetLogLevelRequest](#debug_v2-SetLogLevelRequest)
+    - [SetLogLevelResponse](#debug_v2-SetLogLevelResponse)
+    - [System](#debug_v2-System)
+    - [Worker](#debug_v2-Worker)
+  
+    - [SetLogLevelRequest.LogLevel](#debug_v2-SetLogLevelRequest-LogLevel)
+  
+    - [Debug](#debug_v2-Debug)
+  
+- [enterprise/enterprise.proto](#enterprise_enterprise-proto)
+    - [ActivateRequest](#enterprise_v2-ActivateRequest)
+    - [ActivateResponse](#enterprise_v2-ActivateResponse)
+    - [DeactivateRequest](#enterprise_v2-DeactivateRequest)
+    - [DeactivateResponse](#enterprise_v2-DeactivateResponse)
+    - [EnterpriseConfig](#enterprise_v2-EnterpriseConfig)
+    - [EnterpriseRecord](#enterprise_v2-EnterpriseRecord)
+    - [GetActivationCodeRequest](#enterprise_v2-GetActivationCodeRequest)
+    - [GetActivationCodeResponse](#enterprise_v2-GetActivationCodeResponse)
+    - [GetStateRequest](#enterprise_v2-GetStateRequest)
+    - [GetStateResponse](#enterprise_v2-GetStateResponse)
+    - [HeartbeatRequest](#enterprise_v2-HeartbeatRequest)
+    - [HeartbeatResponse](#enterprise_v2-HeartbeatResponse)
+    - [LicenseRecord](#enterprise_v2-LicenseRecord)
+    - [PauseRequest](#enterprise_v2-PauseRequest)
+    - [PauseResponse](#enterprise_v2-PauseResponse)
+    - [PauseStatusRequest](#enterprise_v2-PauseStatusRequest)
+    - [PauseStatusResponse](#enterprise_v2-PauseStatusResponse)
+    - [TokenInfo](#enterprise_v2-TokenInfo)
+    - [UnpauseRequest](#enterprise_v2-UnpauseRequest)
+    - [UnpauseResponse](#enterprise_v2-UnpauseResponse)
+  
+    - [PauseStatusResponse.PauseStatus](#enterprise_v2-PauseStatusResponse-PauseStatus)
+    - [State](#enterprise_v2-State)
+  
+    - [API](#enterprise_v2-API)
+  
+- [identity/identity.proto](#identity_identity-proto)
+    - [CreateIDPConnectorRequest](#identity_v2-CreateIDPConnectorRequest)
+    - [CreateIDPConnectorResponse](#identity_v2-CreateIDPConnectorResponse)
+    - [CreateOIDCClientRequest](#identity_v2-CreateOIDCClientRequest)
+    - [CreateOIDCClientResponse](#identity_v2-CreateOIDCClientResponse)
+    - [DeleteAllRequest](#identity_v2-DeleteAllRequest)
+    - [DeleteAllResponse](#identity_v2-DeleteAllResponse)
+    - [DeleteIDPConnectorRequest](#identity_v2-DeleteIDPConnectorRequest)
+    - [DeleteIDPConnectorResponse](#identity_v2-DeleteIDPConnectorResponse)
+    - [DeleteOIDCClientRequest](#identity_v2-DeleteOIDCClientRequest)
+    - [DeleteOIDCClientResponse](#identity_v2-DeleteOIDCClientResponse)
+    - [GetIDPConnectorRequest](#identity_v2-GetIDPConnectorRequest)
+    - [GetIDPConnectorResponse](#identity_v2-GetIDPConnectorResponse)
+    - [GetIdentityServerConfigRequest](#identity_v2-GetIdentityServerConfigRequest)
+    - [GetIdentityServerConfigResponse](#identity_v2-GetIdentityServerConfigResponse)
+    - [GetOIDCClientRequest](#identity_v2-GetOIDCClientRequest)
+    - [GetOIDCClientResponse](#identity_v2-GetOIDCClientResponse)
+    - [IDPConnector](#identity_v2-IDPConnector)
+    - [IdentityServerConfig](#identity_v2-IdentityServerConfig)
+    - [ListIDPConnectorsRequest](#identity_v2-ListIDPConnectorsRequest)
+    - [ListIDPConnectorsResponse](#identity_v2-ListIDPConnectorsResponse)
+    - [ListOIDCClientsRequest](#identity_v2-ListOIDCClientsRequest)
+    - [ListOIDCClientsResponse](#identity_v2-ListOIDCClientsResponse)
+    - [OIDCClient](#identity_v2-OIDCClient)
+    - [SetIdentityServerConfigRequest](#identity_v2-SetIdentityServerConfigRequest)
+    - [SetIdentityServerConfigResponse](#identity_v2-SetIdentityServerConfigResponse)
+    - [UpdateIDPConnectorRequest](#identity_v2-UpdateIDPConnectorRequest)
+    - [UpdateIDPConnectorResponse](#identity_v2-UpdateIDPConnectorResponse)
+    - [UpdateOIDCClientRequest](#identity_v2-UpdateOIDCClientRequest)
+    - [UpdateOIDCClientResponse](#identity_v2-UpdateOIDCClientResponse)
+    - [User](#identity_v2-User)
+  
+    - [API](#identity_v2-API)
+  
+- [internal/clusterstate/v2.5.0/commit_info.proto](#internal_clusterstate_v2-5-0_commit_info-proto)
+    - [CommitInfo](#v2_5_0-CommitInfo)
+  
+- [internal/collection/test.proto](#internal_collection_test-proto)
+    - [TestItem](#common-TestItem)
+  
+- [internal/config/config.proto](#internal_config_config-proto)
+    - [Config](#config_v2-Config)
+    - [ConfigV1](#config_v2-ConfigV1)
+    - [ConfigV2](#config_v2-ConfigV2)
+    - [ConfigV2.ContextsEntry](#config_v2-ConfigV2-ContextsEntry)
+    - [Context](#config_v2-Context)
+    - [Context.PortForwardersEntry](#config_v2-Context-PortForwardersEntry)
+  
+    - [ContextSource](#config_v2-ContextSource)
+  
+- [internal/metrics/metrics.proto](#internal_metrics_metrics-proto)
+    - [Metrics](#metrics-Metrics)
+  
+- [internal/pfsload/pfsload.proto](#internal_pfsload_pfsload-proto)
+    - [CommitSpec](#pfsload-CommitSpec)
+    - [FileSourceSpec](#pfsload-FileSourceSpec)
+    - [FrequencySpec](#pfsload-FrequencySpec)
+    - [ModificationSpec](#pfsload-ModificationSpec)
+    - [PutFileSpec](#pfsload-PutFileSpec)
+    - [PutFileTask](#pfsload-PutFileTask)
+    - [PutFileTaskResult](#pfsload-PutFileTaskResult)
+    - [RandomDirectorySpec](#pfsload-RandomDirectorySpec)
+    - [RandomFileSourceSpec](#pfsload-RandomFileSourceSpec)
+    - [SizeSpec](#pfsload-SizeSpec)
+    - [State](#pfsload-State)
+    - [State.Commit](#pfsload-State-Commit)
+    - [ValidatorSpec](#pfsload-ValidatorSpec)
+  
+- [internal/ppsdb/ppsdb.proto](#internal_ppsdb_ppsdb-proto)
+    - [ClusterDefaultsWrapper](#pps_v2-ClusterDefaultsWrapper)
+  
+- [internal/ppsload/ppsload.proto](#internal_ppsload_ppsload-proto)
+    - [State](#ppsload-State)
+  
+- [internal/storage/chunk/chunk.proto](#internal_storage_chunk_chunk-proto)
+    - [DataRef](#chunk-DataRef)
+    - [Ref](#chunk-Ref)
+  
+    - [CompressionAlgo](#chunk-CompressionAlgo)
+    - [EncryptionAlgo](#chunk-EncryptionAlgo)
+  
+- [internal/storage/fileset/fileset.proto](#internal_storage_fileset_fileset-proto)
+    - [Composite](#fileset-Composite)
+    - [Metadata](#fileset-Metadata)
+    - [Primitive](#fileset-Primitive)
+    - [TestCacheValue](#fileset-TestCacheValue)
+  
+- [internal/storage/fileset/index/index.proto](#internal_storage_fileset_index_index-proto)
+    - [File](#index-File)
+    - [Index](#index-Index)
+    - [Range](#index-Range)
+  
+- [internal/task/task.proto](#internal_task_task-proto)
+    - [Claim](#task-Claim)
+    - [Group](#task-Group)
+    - [Task](#task-Task)
+    - [TestTask](#task-TestTask)
+  
+    - [State](#task-State)
+  
+- [internal/tracing/extended/extended_trace.proto](#internal_tracing_extended_extended_trace-proto)
+    - [TraceProto](#extended-TraceProto)
+    - [TraceProto.SerializedTraceEntry](#extended-TraceProto-SerializedTraceEntry)
+  
+- [license/license.proto](#license_license-proto)
+    - [ActivateRequest](#license_v2-ActivateRequest)
+    - [ActivateResponse](#license_v2-ActivateResponse)
+    - [AddClusterRequest](#license_v2-AddClusterRequest)
+    - [AddClusterResponse](#license_v2-AddClusterResponse)
+    - [ClusterStatus](#license_v2-ClusterStatus)
+    - [DeactivateRequest](#license_v2-DeactivateRequest)
+    - [DeactivateResponse](#license_v2-DeactivateResponse)
+    - [DeleteAllRequest](#license_v2-DeleteAllRequest)
+    - [DeleteAllResponse](#license_v2-DeleteAllResponse)
+    - [DeleteClusterRequest](#license_v2-DeleteClusterRequest)
+    - [DeleteClusterResponse](#license_v2-DeleteClusterResponse)
+    - [GetActivationCodeRequest](#license_v2-GetActivationCodeRequest)
+    - [GetActivationCodeResponse](#license_v2-GetActivationCodeResponse)
+    - [HeartbeatRequest](#license_v2-HeartbeatRequest)
+    - [HeartbeatResponse](#license_v2-HeartbeatResponse)
+    - [ListClustersRequest](#license_v2-ListClustersRequest)
+    - [ListClustersResponse](#license_v2-ListClustersResponse)
+    - [ListUserClustersRequest](#license_v2-ListUserClustersRequest)
+    - [ListUserClustersResponse](#license_v2-ListUserClustersResponse)
+    - [UpdateClusterRequest](#license_v2-UpdateClusterRequest)
+    - [UpdateClusterResponse](#license_v2-UpdateClusterResponse)
+    - [UserClusterInfo](#license_v2-UserClusterInfo)
+  
+    - [API](#license_v2-API)
+  
+- [pfs/pfs.proto](#pfs_pfs-proto)
+    - [ActivateAuthRequest](#pfs_v2-ActivateAuthRequest)
+    - [ActivateAuthResponse](#pfs_v2-ActivateAuthResponse)
+    - [AddFile](#pfs_v2-AddFile)
+    - [AddFile.URLSource](#pfs_v2-AddFile-URLSource)
+    - [AddFileSetRequest](#pfs_v2-AddFileSetRequest)
+    - [AuthInfo](#pfs_v2-AuthInfo)
+    - [Branch](#pfs_v2-Branch)
+    - [BranchInfo](#pfs_v2-BranchInfo)
+    - [CheckStorageRequest](#pfs_v2-CheckStorageRequest)
+    - [CheckStorageResponse](#pfs_v2-CheckStorageResponse)
+    - [ClearCacheRequest](#pfs_v2-ClearCacheRequest)
+    - [ClearCommitRequest](#pfs_v2-ClearCommitRequest)
+    - [Commit](#pfs_v2-Commit)
+    - [CommitInfo](#pfs_v2-CommitInfo)
+    - [CommitInfo.Details](#pfs_v2-CommitInfo-Details)
+    - [CommitOrigin](#pfs_v2-CommitOrigin)
+    - [CommitSet](#pfs_v2-CommitSet)
+    - [CommitSetInfo](#pfs_v2-CommitSetInfo)
+    - [ComposeFileSetRequest](#pfs_v2-ComposeFileSetRequest)
+    - [CopyFile](#pfs_v2-CopyFile)
+    - [CreateBranchRequest](#pfs_v2-CreateBranchRequest)
+    - [CreateFileSetResponse](#pfs_v2-CreateFileSetResponse)
+    - [CreateProjectRequest](#pfs_v2-CreateProjectRequest)
+    - [CreateRepoRequest](#pfs_v2-CreateRepoRequest)
+    - [DeleteBranchRequest](#pfs_v2-DeleteBranchRequest)
+    - [DeleteFile](#pfs_v2-DeleteFile)
+    - [DeleteProjectRequest](#pfs_v2-DeleteProjectRequest)
+    - [DeleteRepoRequest](#pfs_v2-DeleteRepoRequest)
+    - [DeleteRepoResponse](#pfs_v2-DeleteRepoResponse)
+    - [DeleteReposRequest](#pfs_v2-DeleteReposRequest)
+    - [DeleteReposResponse](#pfs_v2-DeleteReposResponse)
+    - [DiffFileRequest](#pfs_v2-DiffFileRequest)
+    - [DiffFileResponse](#pfs_v2-DiffFileResponse)
+    - [DropCommitSetRequest](#pfs_v2-DropCommitSetRequest)
+    - [EgressRequest](#pfs_v2-EgressRequest)
+    - [EgressResponse](#pfs_v2-EgressResponse)
+    - [EgressResponse.ObjectStorageResult](#pfs_v2-EgressResponse-ObjectStorageResult)
+    - [EgressResponse.SQLDatabaseResult](#pfs_v2-EgressResponse-SQLDatabaseResult)
+    - [EgressResponse.SQLDatabaseResult.RowsWrittenEntry](#pfs_v2-EgressResponse-SQLDatabaseResult-RowsWrittenEntry)
+    - [File](#pfs_v2-File)
+    - [FileInfo](#pfs_v2-FileInfo)
+    - [FindCommitsRequest](#pfs_v2-FindCommitsRequest)
+    - [FindCommitsResponse](#pfs_v2-FindCommitsResponse)
+    - [FinishCommitRequest](#pfs_v2-FinishCommitRequest)
+    - [FsckRequest](#pfs_v2-FsckRequest)
+    - [FsckResponse](#pfs_v2-FsckResponse)
+    - [GetCacheRequest](#pfs_v2-GetCacheRequest)
+    - [GetCacheResponse](#pfs_v2-GetCacheResponse)
+    - [GetFileRequest](#pfs_v2-GetFileRequest)
+    - [GetFileSetRequest](#pfs_v2-GetFileSetRequest)
+    - [GlobFileRequest](#pfs_v2-GlobFileRequest)
+    - [InspectBranchRequest](#pfs_v2-InspectBranchRequest)
+    - [InspectCommitRequest](#pfs_v2-InspectCommitRequest)
+    - [InspectCommitSetRequest](#pfs_v2-InspectCommitSetRequest)
+    - [InspectFileRequest](#pfs_v2-InspectFileRequest)
+    - [InspectProjectRequest](#pfs_v2-InspectProjectRequest)
+    - [InspectRepoRequest](#pfs_v2-InspectRepoRequest)
+    - [ListBranchRequest](#pfs_v2-ListBranchRequest)
+    - [ListCommitRequest](#pfs_v2-ListCommitRequest)
+    - [ListCommitSetRequest](#pfs_v2-ListCommitSetRequest)
+    - [ListFileRequest](#pfs_v2-ListFileRequest)
+    - [ListProjectRequest](#pfs_v2-ListProjectRequest)
+    - [ListRepoRequest](#pfs_v2-ListRepoRequest)
+    - [ModifyFileRequest](#pfs_v2-ModifyFileRequest)
+    - [ObjectStorageEgress](#pfs_v2-ObjectStorageEgress)
+    - [PathRange](#pfs_v2-PathRange)
+    - [Project](#pfs_v2-Project)
+    - [ProjectInfo](#pfs_v2-ProjectInfo)
+    - [PutCacheRequest](#pfs_v2-PutCacheRequest)
+    - [RenewFileSetRequest](#pfs_v2-RenewFileSetRequest)
+    - [Repo](#pfs_v2-Repo)
+    - [RepoInfo](#pfs_v2-RepoInfo)
+    - [RepoInfo.Details](#pfs_v2-RepoInfo-Details)
+    - [RunLoadTestRequest](#pfs_v2-RunLoadTestRequest)
+    - [RunLoadTestResponse](#pfs_v2-RunLoadTestResponse)
+    - [SQLDatabaseEgress](#pfs_v2-SQLDatabaseEgress)
+    - [SQLDatabaseEgress.FileFormat](#pfs_v2-SQLDatabaseEgress-FileFormat)
+    - [SQLDatabaseEgress.Secret](#pfs_v2-SQLDatabaseEgress-Secret)
+    - [ShardFileSetRequest](#pfs_v2-ShardFileSetRequest)
+    - [ShardFileSetResponse](#pfs_v2-ShardFileSetResponse)
+    - [SquashCommitSetRequest](#pfs_v2-SquashCommitSetRequest)
+    - [StartCommitRequest](#pfs_v2-StartCommitRequest)
+    - [SubscribeCommitRequest](#pfs_v2-SubscribeCommitRequest)
+    - [Trigger](#pfs_v2-Trigger)
+    - [WalkFileRequest](#pfs_v2-WalkFileRequest)
+  
+    - [CommitState](#pfs_v2-CommitState)
+    - [Delimiter](#pfs_v2-Delimiter)
+    - [FileType](#pfs_v2-FileType)
+    - [OriginKind](#pfs_v2-OriginKind)
+    - [SQLDatabaseEgress.FileFormat.Type](#pfs_v2-SQLDatabaseEgress-FileFormat-Type)
+  
+    - [API](#pfs_v2-API)
+  
+- [pps/pps.proto](#pps_pps-proto)
+    - [ActivateAuthRequest](#pps_v2-ActivateAuthRequest)
+    - [ActivateAuthResponse](#pps_v2-ActivateAuthResponse)
+    - [Aggregate](#pps_v2-Aggregate)
+    - [AggregateProcessStats](#pps_v2-AggregateProcessStats)
+    - [ClusterDefaults](#pps_v2-ClusterDefaults)
+    - [CreatePipelineRequest](#pps_v2-CreatePipelineRequest)
+    - [CreatePipelineTransaction](#pps_v2-CreatePipelineTransaction)
+    - [CreatePipelineV2Request](#pps_v2-CreatePipelineV2Request)
+    - [CreatePipelineV2Response](#pps_v2-CreatePipelineV2Response)
+    - [CreateSecretRequest](#pps_v2-CreateSecretRequest)
+    - [CronInput](#pps_v2-CronInput)
+    - [Datum](#pps_v2-Datum)
+    - [DatumInfo](#pps_v2-DatumInfo)
+    - [DatumSetSpec](#pps_v2-DatumSetSpec)
+    - [DatumStatus](#pps_v2-DatumStatus)
+    - [DeleteJobRequest](#pps_v2-DeleteJobRequest)
+    - [DeletePipelineRequest](#pps_v2-DeletePipelineRequest)
+    - [DeletePipelinesRequest](#pps_v2-DeletePipelinesRequest)
+    - [DeletePipelinesResponse](#pps_v2-DeletePipelinesResponse)
+    - [DeleteSecretRequest](#pps_v2-DeleteSecretRequest)
+    - [Determined](#pps_v2-Determined)
+    - [Egress](#pps_v2-Egress)
+    - [GPUSpec](#pps_v2-GPUSpec)
+    - [GetClusterDefaultsRequest](#pps_v2-GetClusterDefaultsRequest)
+    - [GetClusterDefaultsResponse](#pps_v2-GetClusterDefaultsResponse)
+    - [GetLogsRequest](#pps_v2-GetLogsRequest)
+    - [Input](#pps_v2-Input)
+    - [InputFile](#pps_v2-InputFile)
+    - [InspectDatumRequest](#pps_v2-InspectDatumRequest)
+    - [InspectJobRequest](#pps_v2-InspectJobRequest)
+    - [InspectJobSetRequest](#pps_v2-InspectJobSetRequest)
+    - [InspectPipelineRequest](#pps_v2-InspectPipelineRequest)
+    - [InspectSecretRequest](#pps_v2-InspectSecretRequest)
+    - [Job](#pps_v2-Job)
+    - [JobInfo](#pps_v2-JobInfo)
+    - [JobInfo.Details](#pps_v2-JobInfo-Details)
+    - [JobInput](#pps_v2-JobInput)
+    - [JobSet](#pps_v2-JobSet)
+    - [JobSetInfo](#pps_v2-JobSetInfo)
+    - [ListDatumRequest](#pps_v2-ListDatumRequest)
+    - [ListDatumRequest.Filter](#pps_v2-ListDatumRequest-Filter)
+    - [ListJobRequest](#pps_v2-ListJobRequest)
+    - [ListJobSetRequest](#pps_v2-ListJobSetRequest)
+    - [ListPipelineRequest](#pps_v2-ListPipelineRequest)
+    - [LogMessage](#pps_v2-LogMessage)
+    - [LokiLogMessage](#pps_v2-LokiLogMessage)
+    - [LokiRequest](#pps_v2-LokiRequest)
+    - [Metadata](#pps_v2-Metadata)
+    - [Metadata.AnnotationsEntry](#pps_v2-Metadata-AnnotationsEntry)
+    - [Metadata.LabelsEntry](#pps_v2-Metadata-LabelsEntry)
+    - [PFSInput](#pps_v2-PFSInput)
+    - [ParallelismSpec](#pps_v2-ParallelismSpec)
+    - [Pipeline](#pps_v2-Pipeline)
+    - [PipelineInfo](#pps_v2-PipelineInfo)
+    - [PipelineInfo.Details](#pps_v2-PipelineInfo-Details)
+    - [PipelineInfos](#pps_v2-PipelineInfos)
+    - [ProcessStats](#pps_v2-ProcessStats)
+    - [RenderTemplateRequest](#pps_v2-RenderTemplateRequest)
+    - [RenderTemplateRequest.ArgsEntry](#pps_v2-RenderTemplateRequest-ArgsEntry)
+    - [RenderTemplateResponse](#pps_v2-RenderTemplateResponse)
+    - [ResourceSpec](#pps_v2-ResourceSpec)
+    - [RestartDatumRequest](#pps_v2-RestartDatumRequest)
+    - [RunCronRequest](#pps_v2-RunCronRequest)
+    - [RunLoadTestRequest](#pps_v2-RunLoadTestRequest)
+    - [RunLoadTestResponse](#pps_v2-RunLoadTestResponse)
+    - [RunPipelineRequest](#pps_v2-RunPipelineRequest)
+    - [SchedulingSpec](#pps_v2-SchedulingSpec)
+    - [SchedulingSpec.NodeSelectorEntry](#pps_v2-SchedulingSpec-NodeSelectorEntry)
+    - [Secret](#pps_v2-Secret)
+    - [SecretInfo](#pps_v2-SecretInfo)
+    - [SecretInfos](#pps_v2-SecretInfos)
+    - [SecretMount](#pps_v2-SecretMount)
+    - [Service](#pps_v2-Service)
+    - [SetClusterDefaultsRequest](#pps_v2-SetClusterDefaultsRequest)
+    - [SetClusterDefaultsResponse](#pps_v2-SetClusterDefaultsResponse)
+    - [Spout](#pps_v2-Spout)
+    - [StartPipelineRequest](#pps_v2-StartPipelineRequest)
+    - [StopJobRequest](#pps_v2-StopJobRequest)
+    - [StopPipelineRequest](#pps_v2-StopPipelineRequest)
+    - [SubscribeJobRequest](#pps_v2-SubscribeJobRequest)
+    - [TFJob](#pps_v2-TFJob)
+    - [Toleration](#pps_v2-Toleration)
+    - [Transform](#pps_v2-Transform)
+    - [Transform.EnvEntry](#pps_v2-Transform-EnvEntry)
+    - [UpdateJobStateRequest](#pps_v2-UpdateJobStateRequest)
+    - [Worker](#pps_v2-Worker)
+    - [WorkerStatus](#pps_v2-WorkerStatus)
+  
+    - [DatumState](#pps_v2-DatumState)
+    - [JobState](#pps_v2-JobState)
+    - [PipelineInfo.PipelineType](#pps_v2-PipelineInfo-PipelineType)
+    - [PipelineState](#pps_v2-PipelineState)
+    - [TaintEffect](#pps_v2-TaintEffect)
+    - [TolerationOperator](#pps_v2-TolerationOperator)
+    - [WorkerState](#pps_v2-WorkerState)
+  
+    - [API](#pps_v2-API)
+  
+- [protoextensions/json-schema-options.proto](#protoextensions_json-schema-options-proto)
+    - [EnumOptions](#protoc-gen-jsonschema-EnumOptions)
+    - [FieldOptions](#protoc-gen-jsonschema-FieldOptions)
+    - [FileOptions](#protoc-gen-jsonschema-FileOptions)
+    - [MessageOptions](#protoc-gen-jsonschema-MessageOptions)
+  
+    - [File-level Extensions](#protoextensions_json-schema-options-proto-extensions)
+    - [File-level Extensions](#protoextensions_json-schema-options-proto-extensions)
+    - [File-level Extensions](#protoextensions_json-schema-options-proto-extensions)
+    - [File-level Extensions](#protoextensions_json-schema-options-proto-extensions)
+  
+- [protoextensions/log.proto](#protoextensions_log-proto)
+    - [File-level Extensions](#protoextensions_log-proto-extensions)
+    - [File-level Extensions](#protoextensions_log-proto-extensions)
+  
+- [protoextensions/validate.proto](#protoextensions_validate-proto)
+    - [AnyRules](#validate-AnyRules)
+    - [BoolRules](#validate-BoolRules)
+    - [BytesRules](#validate-BytesRules)
+    - [DoubleRules](#validate-DoubleRules)
+    - [DurationRules](#validate-DurationRules)
+    - [EnumRules](#validate-EnumRules)
+    - [FieldRules](#validate-FieldRules)
+    - [Fixed32Rules](#validate-Fixed32Rules)
+    - [Fixed64Rules](#validate-Fixed64Rules)
+    - [FloatRules](#validate-FloatRules)
+    - [Int32Rules](#validate-Int32Rules)
+    - [Int64Rules](#validate-Int64Rules)
+    - [MapRules](#validate-MapRules)
+    - [MessageRules](#validate-MessageRules)
+    - [RepeatedRules](#validate-RepeatedRules)
+    - [SFixed32Rules](#validate-SFixed32Rules)
+    - [SFixed64Rules](#validate-SFixed64Rules)
+    - [SInt32Rules](#validate-SInt32Rules)
+    - [SInt64Rules](#validate-SInt64Rules)
+    - [StringRules](#validate-StringRules)
+    - [TimestampRules](#validate-TimestampRules)
+    - [UInt32Rules](#validate-UInt32Rules)
+    - [UInt64Rules](#validate-UInt64Rules)
+  
+    - [KnownRegex](#validate-KnownRegex)
+  
+    - [File-level Extensions](#protoextensions_validate-proto-extensions)
+    - [File-level Extensions](#protoextensions_validate-proto-extensions)
+    - [File-level Extensions](#protoextensions_validate-proto-extensions)
+    - [File-level Extensions](#protoextensions_validate-proto-extensions)
+  
+- [proxy/proxy.proto](#proxy_proxy-proto)
+    - [ListenRequest](#proxy-ListenRequest)
+    - [ListenResponse](#proxy-ListenResponse)
+  
+    - [API](#proxy-API)
+  
+- [server/pfs/server/pfsserver.proto](#server_pfs_server_pfsserver-proto)
+    - [CompactTask](#pfsserver-CompactTask)
+    - [CompactTaskResult](#pfsserver-CompactTaskResult)
+    - [ConcatTask](#pfsserver-ConcatTask)
+    - [ConcatTaskResult](#pfsserver-ConcatTaskResult)
+    - [GetFileURLTask](#pfsserver-GetFileURLTask)
+    - [GetFileURLTaskResult](#pfsserver-GetFileURLTaskResult)
+    - [PathRange](#pfsserver-PathRange)
+    - [PutFileURLTask](#pfsserver-PutFileURLTask)
+    - [PutFileURLTaskResult](#pfsserver-PutFileURLTaskResult)
+    - [ShardTask](#pfsserver-ShardTask)
+    - [ShardTaskResult](#pfsserver-ShardTaskResult)
+    - [ValidateTask](#pfsserver-ValidateTask)
+    - [ValidateTaskResult](#pfsserver-ValidateTaskResult)
+  
+- [server/worker/common/common.proto](#server_worker_common_common-proto)
+    - [Input](#common-Input)
+  
+- [server/worker/datum/datum.proto](#server_worker_datum_datum-proto)
+    - [ComposeTask](#datum-ComposeTask)
+    - [ComposeTaskResult](#datum-ComposeTaskResult)
+    - [CrossTask](#datum-CrossTask)
+    - [CrossTaskResult](#datum-CrossTaskResult)
+    - [KeyTask](#datum-KeyTask)
+    - [KeyTaskResult](#datum-KeyTaskResult)
+    - [MergeTask](#datum-MergeTask)
+    - [MergeTaskResult](#datum-MergeTaskResult)
+    - [Meta](#datum-Meta)
+    - [PFSTask](#datum-PFSTask)
+    - [PFSTaskResult](#datum-PFSTaskResult)
+    - [SetSpec](#datum-SetSpec)
+    - [Stats](#datum-Stats)
+  
+    - [KeyTask.Type](#datum-KeyTask-Type)
+    - [MergeTask.Type](#datum-MergeTask-Type)
+    - [State](#datum-State)
+  
+- [server/worker/pipeline/transform/transform.proto](#server_worker_pipeline_transform_transform-proto)
+    - [CreateDatumSetsTask](#pachyderm-worker-pipeline-transform-CreateDatumSetsTask)
+    - [CreateDatumSetsTaskResult](#pachyderm-worker-pipeline-transform-CreateDatumSetsTaskResult)
+    - [CreateParallelDatumsTask](#pachyderm-worker-pipeline-transform-CreateParallelDatumsTask)
+    - [CreateParallelDatumsTaskResult](#pachyderm-worker-pipeline-transform-CreateParallelDatumsTaskResult)
+    - [CreateSerialDatumsTask](#pachyderm-worker-pipeline-transform-CreateSerialDatumsTask)
+    - [CreateSerialDatumsTaskResult](#pachyderm-worker-pipeline-transform-CreateSerialDatumsTaskResult)
+    - [DatumSetTask](#pachyderm-worker-pipeline-transform-DatumSetTask)
+    - [DatumSetTaskResult](#pachyderm-worker-pipeline-transform-DatumSetTaskResult)
+  
+- [task/task.proto](#task_task-proto)
+    - [Group](#taskapi-Group)
+    - [ListTaskRequest](#taskapi-ListTaskRequest)
+    - [TaskInfo](#taskapi-TaskInfo)
+  
+    - [State](#taskapi-State)
+  
+- [transaction/transaction.proto](#transaction_transaction-proto)
+    - [BatchTransactionRequest](#transaction_v2-BatchTransactionRequest)
+    - [DeleteAllRequest](#transaction_v2-DeleteAllRequest)
+    - [DeleteTransactionRequest](#transaction_v2-DeleteTransactionRequest)
+    - [FinishTransactionRequest](#transaction_v2-FinishTransactionRequest)
+    - [InspectTransactionRequest](#transaction_v2-InspectTransactionRequest)
+    - [ListTransactionRequest](#transaction_v2-ListTransactionRequest)
+    - [StartTransactionRequest](#transaction_v2-StartTransactionRequest)
+    - [Transaction](#transaction_v2-Transaction)
+    - [TransactionInfo](#transaction_v2-TransactionInfo)
+    - [TransactionInfos](#transaction_v2-TransactionInfos)
+    - [TransactionRequest](#transaction_v2-TransactionRequest)
+    - [TransactionResponse](#transaction_v2-TransactionResponse)
+  
+    - [API](#transaction_v2-API)
+  
+- [version/versionpb/version.proto](#version_versionpb_version-proto)
+    - [Version](#versionpb_v2-Version)
+  
+    - [API](#versionpb_v2-API)
+  
+- [worker/worker.proto](#worker_worker-proto)
+    - [CancelRequest](#pachyderm-worker-CancelRequest)
+    - [CancelResponse](#pachyderm-worker-CancelResponse)
+    - [NextDatumRequest](#pachyderm-worker-NextDatumRequest)
+    - [NextDatumResponse](#pachyderm-worker-NextDatumResponse)
+  
+    - [Worker](#pachyderm-worker-Worker)
+  
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="admin_admin-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## admin/admin.proto
+
+
+
+<a name="admin_v2-ClusterInfo"></a>
+
+### ClusterInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| deployment_id | [string](#string) |  |  |
+| warnings_ok | [bool](#bool) |  | True if the server is capable of generating warnings. |
+| warnings | [string](#string) | repeated | Warnings about the client configuration. |
+| proxy_host | [string](#string) |  | The configured public URL of Pachyderm. |
+| proxy_tls | [bool](#bool) |  | True if Pachyderm is served over TLS (HTTPS). |
+| paused | [bool](#bool) |  | True if this pachd is in &#34;paused&#34; mode. |
+| web_resources | [WebResource](#admin_v2-WebResource) |  | Any HTTP links that the client might want to be aware of. |
+
+
+
+
+
+
+<a name="admin_v2-InspectClusterRequest"></a>
+
+### InspectClusterRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| client_version | [versionpb_v2.Version](#versionpb_v2-Version) |  | The version of the client that&#39;s connecting; used by the server to warn about too-old (or too-new!) clients. |
+| current_project | [pfs_v2.Project](#pfs_v2-Project) |  | If CurrentProject is set, then InspectCluster will return an error if the project does not exist. |
+
+
+
+
+
+
+<a name="admin_v2-WebResource"></a>
+
+### WebResource
+WebResource contains URL prefixes of common HTTP functions.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| archive_download_base_url | [string](#string) |  | The base URL of the archive server; append a filename to this. Empty if the archive server is not exposed. |
+| create_pipeline_request_json_schema_url | [string](#string) |  | Where to find the CreatePipelineRequest JSON schema; if this server is not accessible via a URL, then a link to Github is provided based on the baked-in version of the server. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="admin_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| InspectCluster | [InspectClusterRequest](#admin_v2-InspectClusterRequest) | [ClusterInfo](#admin_v2-ClusterInfo) |  |
+
+ 
+
+
+
+<a name="auth_auth-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## auth/auth.proto
+
+
+
+<a name="auth_v2-ActivateRequest"></a>
+
+### ActivateRequest
+ActivateRequest enables authentication on the cluster. It issues an auth token
+with no expiration for the irrevocable admin user `pach:root`.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| root_token | [string](#string) |  | If set, this token is used as the root user login token. Otherwise the root token is randomly generated and returned in the response. |
+
+
+
+
+
+
+<a name="auth_v2-ActivateResponse"></a>
+
+### ActivateResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pach_token | [string](#string) |  | pach_token authenticates the caller with Pachyderm (if you want to perform Pachyderm operations after auth has been activated as themselves, you must present this token along with your regular request) |
+
+
+
+
+
+
+<a name="auth_v2-AuthenticateRequest"></a>
+
+### AuthenticateRequest
+Exactly one of &#39;id_token&#39; or &#39;one_time_password&#39; must be set:
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| oidc_state | [string](#string) |  | This is the session state that Pachyderm creates in order to keep track of information related to the current OIDC session. |
+| id_token | [string](#string) |  | This is an ID Token issued by the OIDC provider. |
+
+
+
+
+
+
+<a name="auth_v2-AuthenticateResponse"></a>
+
+### AuthenticateResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pach_token | [string](#string) |  | pach_token authenticates the caller with Pachyderm (if you want to perform Pachyderm operations after auth has been activated as themselves, you must present this token along with your regular request) |
+
+
+
+
+
+
+<a name="auth_v2-AuthorizeRequest"></a>
+
+### AuthorizeRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| resource | [Resource](#auth_v2-Resource) |  |  |
+| permissions | [Permission](#auth_v2-Permission) | repeated | permissions are the operations the caller is attempting to perform |
+
+
+
+
+
+
+<a name="auth_v2-AuthorizeResponse"></a>
+
+### AuthorizeResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| authorized | [bool](#bool) |  | authorized is true if the caller has the require permissions |
+| satisfied | [Permission](#auth_v2-Permission) | repeated | satisfied is the set of permission that the principal has |
+| missing | [Permission](#auth_v2-Permission) | repeated | missing is the set of permissions that the principal lacks |
+| principal | [string](#string) |  | principal is the principal the request was evaluated for |
+
+
+
+
+
+
+<a name="auth_v2-DeactivateRequest"></a>
+
+### DeactivateRequest
+
+
+
+
+
+
+
+<a name="auth_v2-DeactivateResponse"></a>
+
+### DeactivateResponse
+
+
+
+
+
+
+
+<a name="auth_v2-DeleteExpiredAuthTokensRequest"></a>
+
+### DeleteExpiredAuthTokensRequest
+
+
+
+
+
+
+
+<a name="auth_v2-DeleteExpiredAuthTokensResponse"></a>
+
+### DeleteExpiredAuthTokensResponse
+
+
+
+
+
+
+
+<a name="auth_v2-ExtractAuthTokensRequest"></a>
+
+### ExtractAuthTokensRequest
+ExtractAuthTokens returns all the hashed robot tokens that have been issued.
+User tokens are not extracted as they can be recreated by logging in.
+
+
+
+
+
+
+<a name="auth_v2-ExtractAuthTokensResponse"></a>
+
+### ExtractAuthTokensResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| tokens | [TokenInfo](#auth_v2-TokenInfo) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-GetConfigurationRequest"></a>
+
+### GetConfigurationRequest
+
+
+
+
+
+
+
+<a name="auth_v2-GetConfigurationResponse"></a>
+
+### GetConfigurationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| configuration | [OIDCConfig](#auth_v2-OIDCConfig) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetGroupsForPrincipalRequest"></a>
+
+### GetGroupsForPrincipalRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| principal | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetGroupsRequest"></a>
+
+### GetGroupsRequest
+
+
+
+
+
+
+
+<a name="auth_v2-GetGroupsResponse"></a>
+
+### GetGroupsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| groups | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-GetOIDCLoginRequest"></a>
+
+### GetOIDCLoginRequest
+
+
+
+
+
+
+
+<a name="auth_v2-GetOIDCLoginResponse"></a>
+
+### GetOIDCLoginResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| login_url | [string](#string) |  | The login URL generated for the OIDC object |
+| state | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetPermissionsForPrincipalRequest"></a>
+
+### GetPermissionsForPrincipalRequest
+GetPermissionsForPrincipal evaluates an arbitrary principal&#39;s permissions
+on a resource
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| resource | [Resource](#auth_v2-Resource) |  |  |
+| principal | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetPermissionsRequest"></a>
+
+### GetPermissionsRequest
+GetPermissions evaluates the current user&#39;s permissions on a resource
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| resource | [Resource](#auth_v2-Resource) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetPermissionsResponse"></a>
+
+### GetPermissionsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| permissions | [Permission](#auth_v2-Permission) | repeated | permissions is the set of permissions the principal has |
+| roles | [string](#string) | repeated | roles is the set of roles the principal has |
+
+
+
+
+
+
+<a name="auth_v2-GetRobotTokenRequest"></a>
+
+### GetRobotTokenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| robot | [string](#string) |  | The returned token will allow the caller to access resources as this robot user |
+| ttl | [int64](#int64) |  | ttl indicates the requested (approximate) remaining lifetime of this token, in seconds |
+
+
+
+
+
+
+<a name="auth_v2-GetRobotTokenResponse"></a>
+
+### GetRobotTokenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) |  | A new auth token for the requested robot |
+
+
+
+
+
+
+<a name="auth_v2-GetRoleBindingRequest"></a>
+
+### GetRoleBindingRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| resource | [Resource](#auth_v2-Resource) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetRoleBindingResponse"></a>
+
+### GetRoleBindingResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| binding | [RoleBinding](#auth_v2-RoleBinding) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetRolesForPermissionRequest"></a>
+
+### GetRolesForPermissionRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| permission | [Permission](#auth_v2-Permission) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetRolesForPermissionResponse"></a>
+
+### GetRolesForPermissionResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| roles | [Role](#auth_v2-Role) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-GetUsersRequest"></a>
+
+### GetUsersRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| group | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-GetUsersResponse"></a>
+
+### GetUsersResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| usernames | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-Groups"></a>
+
+### Groups
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| groups | [Groups.GroupsEntry](#auth_v2-Groups-GroupsEntry) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-Groups-GroupsEntry"></a>
+
+### Groups.GroupsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-ModifyMembersRequest"></a>
+
+### ModifyMembersRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| group | [string](#string) |  |  |
+| add | [string](#string) | repeated |  |
+| remove | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-ModifyMembersResponse"></a>
+
+### ModifyMembersResponse
+
+
+
+
+
+
+
+<a name="auth_v2-ModifyRoleBindingRequest"></a>
+
+### ModifyRoleBindingRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| resource | [Resource](#auth_v2-Resource) |  | resource is the resource to modify the role bindings on |
+| principal | [string](#string) |  | principal is the principal to modify the roles binding for |
+| roles | [string](#string) | repeated | roles is the set of roles for principal - an empty list removes all role bindings |
+
+
+
+
+
+
+<a name="auth_v2-ModifyRoleBindingResponse"></a>
+
+### ModifyRoleBindingResponse
+
+
+
+
+
+
+
+<a name="auth_v2-OIDCConfig"></a>
+
+### OIDCConfig
+Configure Pachyderm&#39;s auth system with an OIDC provider
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| issuer | [string](#string) |  |  |
+| client_id | [string](#string) |  |  |
+| client_secret | [string](#string) |  |  |
+| redirect_uri | [string](#string) |  |  |
+| scopes | [string](#string) | repeated |  |
+| require_email_verified | [bool](#bool) |  |  |
+| localhost_issuer | [bool](#bool) |  | localhost_issuer ignores the contents of the issuer claim and makes all OIDC requests to the embedded OIDC provider. This is necessary to support some network configurations like Minikube. |
+| user_accessible_issuer_host | [string](#string) |  | user_accessible_issuer_host can be set to override the host used in the OAuth2 authorization URL in case the OIDC issuer isn&#39;t accessible outside the cluster. This requires a fully formed URL with scheme of either http or https. This is necessary to support some configurations like Minikube. |
+
+
+
+
+
+
+<a name="auth_v2-Resource"></a>
+
+### Resource
+Resource represents any resource that has role-bindings in the system
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [ResourceType](#auth_v2-ResourceType) |  |  |
+| name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-RestoreAuthTokenRequest"></a>
+
+### RestoreAuthTokenRequest
+RestoreAuthToken inserts a hashed token that has previously been extracted.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [TokenInfo](#auth_v2-TokenInfo) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-RestoreAuthTokenResponse"></a>
+
+### RestoreAuthTokenResponse
+
+
+
+
+
+
+
+<a name="auth_v2-RevokeAuthTokenRequest"></a>
+
+### RevokeAuthTokenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-RevokeAuthTokenResponse"></a>
+
+### RevokeAuthTokenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-RevokeAuthTokensForUserRequest"></a>
+
+### RevokeAuthTokensForUserRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| username | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-RevokeAuthTokensForUserResponse"></a>
+
+### RevokeAuthTokensForUserResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-Role"></a>
+
+### Role
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| permissions | [Permission](#auth_v2-Permission) | repeated |  |
+| can_be_bound_to | [ResourceType](#auth_v2-ResourceType) | repeated | Resources this role can be bound to. For example, you can&#39;t apply clusterAdmin to a repo, so REPO would not be listed here. |
+| returned_for | [ResourceType](#auth_v2-ResourceType) | repeated | Resources this role is returned for. For example, a principal might have clusterAdmin permissions on the cluster, and this is what allows them to write to a repo. So, clusterAdmin is returned for the repo, even though it cannot be bound to a repo. |
+
+
+
+
+
+
+<a name="auth_v2-RoleBinding"></a>
+
+### RoleBinding
+RoleBinding represents the set of roles principals have on a given Resource
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [RoleBinding.EntriesEntry](#auth_v2-RoleBinding-EntriesEntry) | repeated | principal -&gt; roles. All principal names include the structured prefix indicating their type. |
+
+
+
+
+
+
+<a name="auth_v2-RoleBinding-EntriesEntry"></a>
+
+### RoleBinding.EntriesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [Roles](#auth_v2-Roles) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-Roles"></a>
+
+### Roles
+Roles represents the set of roles a principal has
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| roles | [Roles.RolesEntry](#auth_v2-Roles-RolesEntry) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-Roles-RolesEntry"></a>
+
+### Roles.RolesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-RotateRootTokenRequest"></a>
+
+### RotateRootTokenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| root_token | [string](#string) |  | root_token is used as the new root token value. If it&#39;s unset, then a token will be auto-generated. |
+
+
+
+
+
+
+<a name="auth_v2-RotateRootTokenResponse"></a>
+
+### RotateRootTokenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| root_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-SessionInfo"></a>
+
+### SessionInfo
+SessionInfo stores information associated with one OIDC authentication
+session (i.e. a single instance of a single user logging in). Sessions are
+short-lived and stored in the &#39;oidc-authns&#39; collection, keyed by the OIDC
+&#39;state&#39; token (30-character CSPRNG-generated string). &#39;GetOIDCLogin&#39;
+generates and inserts entries, then /authorization-code/callback retrieves
+an access token from the ID provider and uses it to retrive the caller&#39;s
+email and store it in &#39;email&#39;, and finally Authorize() returns a Pachyderm
+token identified with that email address as a subject in Pachyderm.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| nonce | [string](#string) |  | nonce is used by /authorization-code/callback to validate session continuity with the IdP after a user has arrived there from GetOIDCLogin(). This is a 30-character CSPRNG-generated string. |
+| email | [string](#string) |  | email contains the email adddress associated with a user in their OIDC ID provider. Currently users are identified with their email address rather than their OIDC subject identifier to make switching between OIDC ID providers easier for users, and to make user identities more easily comprehensible in Pachyderm. The OIDC spec doesn&#39;t require that users&#39; emails be present or unique, but we think this will be preferable in practice. |
+| conversion_err | [bool](#bool) |  | conversion_err indicates whether an error was encountered while exchanging an auth code for an access token, or while obtaining a user&#39;s email (in /authorization-code/callback). Storing the error state here allows any sibling calls to Authenticate() (i.e. using the same OIDC state token) to notify their caller that an error has occurred. We avoid passing the caller any details of the error (which are logged by Pachyderm) to avoid giving information to a user who has network access to Pachyderm but not an account in the OIDC provider. |
+
+
+
+
+
+
+<a name="auth_v2-SetConfigurationRequest"></a>
+
+### SetConfigurationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| configuration | [OIDCConfig](#auth_v2-OIDCConfig) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-SetConfigurationResponse"></a>
+
+### SetConfigurationResponse
+
+
+
+
+
+
+
+<a name="auth_v2-SetGroupsForUserRequest"></a>
+
+### SetGroupsForUserRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| username | [string](#string) |  |  |
+| groups | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-SetGroupsForUserResponse"></a>
+
+### SetGroupsForUserResponse
+
+
+
+
+
+
+
+<a name="auth_v2-TokenInfo"></a>
+
+### TokenInfo
+TokenInfo is the &#39;value&#39; of an auth token &#39;key&#39; in the &#39;tokens&#39; collection
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| subject | [string](#string) |  | Subject (i.e. Pachyderm account) that a given token authorizes. See the note at the top of the doc for an explanation of subject structure. |
+| expiration | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| hashed_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-Users"></a>
+
+### Users
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| usernames | [Users.UsernamesEntry](#auth_v2-Users-UsernamesEntry) | repeated |  |
+
+
+
+
+
+
+<a name="auth_v2-Users-UsernamesEntry"></a>
+
+### Users.UsernamesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="auth_v2-WhoAmIRequest"></a>
+
+### WhoAmIRequest
+
+
+
+
+
+
+
+<a name="auth_v2-WhoAmIResponse"></a>
+
+### WhoAmIResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| username | [string](#string) |  |  |
+| expiration | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="auth_v2-Permission"></a>
+
+### Permission
+Permission represents the ability to perform a given operation on a Resource
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PERMISSION_UNKNOWN | 0 |  |
+| CLUSTER_MODIFY_BINDINGS | 100 |  |
+| CLUSTER_GET_BINDINGS | 101 |  |
+| CLUSTER_GET_PACHD_LOGS | 148 |  |
+| CLUSTER_GET_LOKI_LOGS | 150 |  |
+| CLUSTER_AUTH_ACTIVATE | 102 |  |
+| CLUSTER_AUTH_DEACTIVATE | 103 |  |
+| CLUSTER_AUTH_GET_CONFIG | 104 |  |
+| CLUSTER_AUTH_SET_CONFIG | 105 |  |
+| CLUSTER_AUTH_GET_ROBOT_TOKEN | 139 |  |
+| CLUSTER_AUTH_MODIFY_GROUP_MEMBERS | 109 |  |
+| CLUSTER_AUTH_GET_GROUPS | 110 |  |
+| CLUSTER_AUTH_GET_GROUP_USERS | 111 |  |
+| CLUSTER_AUTH_EXTRACT_TOKENS | 112 |  |
+| CLUSTER_AUTH_RESTORE_TOKEN | 113 |  |
+| CLUSTER_AUTH_GET_PERMISSIONS_FOR_PRINCIPAL | 141 |  |
+| CLUSTER_AUTH_DELETE_EXPIRED_TOKENS | 140 |  |
+| CLUSTER_AUTH_REVOKE_USER_TOKENS | 142 |  |
+| CLUSTER_AUTH_ROTATE_ROOT_TOKEN | 147 |  |
+| CLUSTER_ENTERPRISE_ACTIVATE | 114 |  |
+| CLUSTER_ENTERPRISE_HEARTBEAT | 115 |  |
+| CLUSTER_ENTERPRISE_GET_CODE | 116 |  |
+| CLUSTER_ENTERPRISE_DEACTIVATE | 117 |  |
+| CLUSTER_ENTERPRISE_PAUSE | 149 |  |
+| CLUSTER_IDENTITY_SET_CONFIG | 118 |  |
+| CLUSTER_IDENTITY_GET_CONFIG | 119 |  |
+| CLUSTER_IDENTITY_CREATE_IDP | 120 |  |
+| CLUSTER_IDENTITY_UPDATE_IDP | 121 |  |
+| CLUSTER_IDENTITY_LIST_IDPS | 122 |  |
+| CLUSTER_IDENTITY_GET_IDP | 123 |  |
+| CLUSTER_IDENTITY_DELETE_IDP | 124 |  |
+| CLUSTER_IDENTITY_CREATE_OIDC_CLIENT | 125 |  |
+| CLUSTER_IDENTITY_UPDATE_OIDC_CLIENT | 126 |  |
+| CLUSTER_IDENTITY_LIST_OIDC_CLIENTS | 127 |  |
+| CLUSTER_IDENTITY_GET_OIDC_CLIENT | 128 |  |
+| CLUSTER_IDENTITY_DELETE_OIDC_CLIENT | 129 |  |
+| CLUSTER_DEBUG_DUMP | 131 |  |
+| CLUSTER_LICENSE_ACTIVATE | 132 |  |
+| CLUSTER_LICENSE_GET_CODE | 133 |  |
+| CLUSTER_LICENSE_ADD_CLUSTER | 134 |  |
+| CLUSTER_LICENSE_UPDATE_CLUSTER | 135 |  |
+| CLUSTER_LICENSE_DELETE_CLUSTER | 136 |  |
+| CLUSTER_LICENSE_LIST_CLUSTERS | 137 |  |
+| CLUSTER_CREATE_SECRET | 143 | TODO(actgardner): Make k8s secrets into nouns and add an Update RPC |
+| CLUSTER_LIST_SECRETS | 144 |  |
+| SECRET_DELETE | 145 |  |
+| SECRET_INSPECT | 146 |  |
+| CLUSTER_DELETE_ALL | 138 |  |
+| REPO_READ | 200 |  |
+| REPO_WRITE | 201 |  |
+| REPO_MODIFY_BINDINGS | 202 |  |
+| REPO_DELETE | 203 |  |
+| REPO_INSPECT_COMMIT | 204 |  |
+| REPO_LIST_COMMIT | 205 |  |
+| REPO_DELETE_COMMIT | 206 |  |
+| REPO_CREATE_BRANCH | 207 |  |
+| REPO_LIST_BRANCH | 208 |  |
+| REPO_DELETE_BRANCH | 209 |  |
+| REPO_INSPECT_FILE | 210 |  |
+| REPO_LIST_FILE | 211 |  |
+| REPO_ADD_PIPELINE_READER | 212 |  |
+| REPO_REMOVE_PIPELINE_READER | 213 |  |
+| REPO_ADD_PIPELINE_WRITER | 214 |  |
+| PIPELINE_LIST_JOB | 301 |  |
+| CLUSTER_SET_DEFAULTS | 302 | CLUSTER_SET_DEFAULTS is part of PPS. |
+| PROJECT_CREATE | 400 |  |
+| PROJECT_DELETE | 401 |  |
+| PROJECT_LIST_REPO | 402 |  |
+| PROJECT_CREATE_REPO | 403 |  |
+| PROJECT_MODIFY_BINDINGS | 404 |  |
+
+
+
+<a name="auth_v2-ResourceType"></a>
+
+### ResourceType
+ResourceType represents the type of a Resource
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| RESOURCE_TYPE_UNKNOWN | 0 |  |
+| CLUSTER | 1 |  |
+| REPO | 2 |  |
+| SPEC_REPO | 3 |  |
+| PROJECT | 4 |  |
+
+
+ 
+
+ 
+
+
+<a name="auth_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Activate | [ActivateRequest](#auth_v2-ActivateRequest) | [ActivateResponse](#auth_v2-ActivateResponse) | Activate/Deactivate the auth API. &#39;Activate&#39; sets an initial set of admins for the Pachyderm cluster, and &#39;Deactivate&#39; removes all ACLs, tokens, and admins from the Pachyderm cluster, making all data publicly accessable |
+| Deactivate | [DeactivateRequest](#auth_v2-DeactivateRequest) | [DeactivateResponse](#auth_v2-DeactivateResponse) |  |
+| GetConfiguration | [GetConfigurationRequest](#auth_v2-GetConfigurationRequest) | [GetConfigurationResponse](#auth_v2-GetConfigurationResponse) |  |
+| SetConfiguration | [SetConfigurationRequest](#auth_v2-SetConfigurationRequest) | [SetConfigurationResponse](#auth_v2-SetConfigurationResponse) |  |
+| Authenticate | [AuthenticateRequest](#auth_v2-AuthenticateRequest) | [AuthenticateResponse](#auth_v2-AuthenticateResponse) |  |
+| Authorize | [AuthorizeRequest](#auth_v2-AuthorizeRequest) | [AuthorizeResponse](#auth_v2-AuthorizeResponse) |  |
+| GetPermissions | [GetPermissionsRequest](#auth_v2-GetPermissionsRequest) | [GetPermissionsResponse](#auth_v2-GetPermissionsResponse) |  |
+| GetPermissionsForPrincipal | [GetPermissionsForPrincipalRequest](#auth_v2-GetPermissionsForPrincipalRequest) | [GetPermissionsResponse](#auth_v2-GetPermissionsResponse) |  |
+| WhoAmI | [WhoAmIRequest](#auth_v2-WhoAmIRequest) | [WhoAmIResponse](#auth_v2-WhoAmIResponse) |  |
+| GetRolesForPermission | [GetRolesForPermissionRequest](#auth_v2-GetRolesForPermissionRequest) | [GetRolesForPermissionResponse](#auth_v2-GetRolesForPermissionResponse) |  |
+| ModifyRoleBinding | [ModifyRoleBindingRequest](#auth_v2-ModifyRoleBindingRequest) | [ModifyRoleBindingResponse](#auth_v2-ModifyRoleBindingResponse) |  |
+| GetRoleBinding | [GetRoleBindingRequest](#auth_v2-GetRoleBindingRequest) | [GetRoleBindingResponse](#auth_v2-GetRoleBindingResponse) |  |
+| GetOIDCLogin | [GetOIDCLoginRequest](#auth_v2-GetOIDCLoginRequest) | [GetOIDCLoginResponse](#auth_v2-GetOIDCLoginResponse) |  |
+| GetRobotToken | [GetRobotTokenRequest](#auth_v2-GetRobotTokenRequest) | [GetRobotTokenResponse](#auth_v2-GetRobotTokenResponse) |  |
+| RevokeAuthToken | [RevokeAuthTokenRequest](#auth_v2-RevokeAuthTokenRequest) | [RevokeAuthTokenResponse](#auth_v2-RevokeAuthTokenResponse) |  |
+| RevokeAuthTokensForUser | [RevokeAuthTokensForUserRequest](#auth_v2-RevokeAuthTokensForUserRequest) | [RevokeAuthTokensForUserResponse](#auth_v2-RevokeAuthTokensForUserResponse) |  |
+| SetGroupsForUser | [SetGroupsForUserRequest](#auth_v2-SetGroupsForUserRequest) | [SetGroupsForUserResponse](#auth_v2-SetGroupsForUserResponse) |  |
+| ModifyMembers | [ModifyMembersRequest](#auth_v2-ModifyMembersRequest) | [ModifyMembersResponse](#auth_v2-ModifyMembersResponse) |  |
+| GetGroups | [GetGroupsRequest](#auth_v2-GetGroupsRequest) | [GetGroupsResponse](#auth_v2-GetGroupsResponse) |  |
+| GetGroupsForPrincipal | [GetGroupsForPrincipalRequest](#auth_v2-GetGroupsForPrincipalRequest) | [GetGroupsResponse](#auth_v2-GetGroupsResponse) |  |
+| GetUsers | [GetUsersRequest](#auth_v2-GetUsersRequest) | [GetUsersResponse](#auth_v2-GetUsersResponse) |  |
+| ExtractAuthTokens | [ExtractAuthTokensRequest](#auth_v2-ExtractAuthTokensRequest) | [ExtractAuthTokensResponse](#auth_v2-ExtractAuthTokensResponse) |  |
+| RestoreAuthToken | [RestoreAuthTokenRequest](#auth_v2-RestoreAuthTokenRequest) | [RestoreAuthTokenResponse](#auth_v2-RestoreAuthTokenResponse) |  |
+| DeleteExpiredAuthTokens | [DeleteExpiredAuthTokensRequest](#auth_v2-DeleteExpiredAuthTokensRequest) | [DeleteExpiredAuthTokensResponse](#auth_v2-DeleteExpiredAuthTokensResponse) |  |
+| RotateRootToken | [RotateRootTokenRequest](#auth_v2-RotateRootTokenRequest) | [RotateRootTokenResponse](#auth_v2-RotateRootTokenResponse) |  |
+
+ 
+
+
+
+<a name="debug_debug-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## debug/debug.proto
+
+
+
+<a name="debug_v2-App"></a>
+
+### App
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| pods | [Pod](#debug_v2-Pod) | repeated |  |
+| timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| pipeline | [Pipeline](#debug_v2-Pipeline) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-BinaryRequest"></a>
+
+### BinaryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| filter | [Filter](#debug_v2-Filter) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-DumpChunk"></a>
+
+### DumpChunk
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| content | [DumpContent](#debug_v2-DumpContent) |  |  |
+| progress | [DumpProgress](#debug_v2-DumpProgress) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-DumpContent"></a>
+
+### DumpContent
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| content | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-DumpProgress"></a>
+
+### DumpProgress
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| task | [string](#string) |  |  |
+| total | [int64](#int64) |  |  |
+| progress | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-DumpRequest"></a>
+
+### DumpRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| filter | [Filter](#debug_v2-Filter) |  |  |
+| limit | [int64](#int64) |  | Limit sets the limit for the number of commits / jobs that are returned for each repo / pipeline in the dump. |
+
+
+
+
+
+
+<a name="debug_v2-DumpV2Request"></a>
+
+### DumpV2Request
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| system | [System](#debug_v2-System) |  |  |
+| pipelines | [Pipeline](#debug_v2-Pipeline) | repeated |  |
+| input_repos | [bool](#bool) |  |  |
+| timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| defaults | [DumpV2Request.Defaults](#debug_v2-DumpV2Request-Defaults) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-DumpV2Request-Defaults"></a>
+
+### DumpV2Request.Defaults
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| cluster_defaults | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-Filter"></a>
+
+### Filter
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pachd | [bool](#bool) |  |  |
+| pipeline | [pps_v2.Pipeline](#pps_v2-Pipeline) |  |  |
+| worker | [Worker](#debug_v2-Worker) |  |  |
+| database | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-GetDumpV2TemplateRequest"></a>
+
+### GetDumpV2TemplateRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| filters | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="debug_v2-GetDumpV2TemplateResponse"></a>
+
+### GetDumpV2TemplateResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request | [DumpV2Request](#debug_v2-DumpV2Request) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-Pipeline"></a>
+
+### Pipeline
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [string](#string) |  |  |
+| name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-Pod"></a>
+
+### Pod
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| ip | [string](#string) |  |  |
+| containers | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="debug_v2-Profile"></a>
+
+### Profile
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| duration | [google.protobuf.Duration](#google-protobuf-Duration) |  | only meaningful if name == &#34;cpu&#34; |
+
+
+
+
+
+
+<a name="debug_v2-ProfileRequest"></a>
+
+### ProfileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| profile | [Profile](#debug_v2-Profile) |  |  |
+| filter | [Filter](#debug_v2-Filter) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-SetLogLevelRequest"></a>
+
+### SetLogLevelRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pachyderm | [SetLogLevelRequest.LogLevel](#debug_v2-SetLogLevelRequest-LogLevel) |  |  |
+| grpc | [SetLogLevelRequest.LogLevel](#debug_v2-SetLogLevelRequest-LogLevel) |  |  |
+| duration | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| recurse | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="debug_v2-SetLogLevelResponse"></a>
+
+### SetLogLevelResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| affected_pods | [string](#string) | repeated |  |
+| errored_pods | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="debug_v2-System"></a>
+
+### System
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| helm | [bool](#bool) |  |  |
+| database | [bool](#bool) |  |  |
+| version | [bool](#bool) |  |  |
+| describes | [App](#debug_v2-App) | repeated |  |
+| logs | [App](#debug_v2-App) | repeated |  |
+| loki_logs | [App](#debug_v2-App) | repeated |  |
+| binaries | [App](#debug_v2-App) | repeated |  |
+| profiles | [App](#debug_v2-App) | repeated |  |
+
+
+
+
+
+
+<a name="debug_v2-Worker"></a>
+
+### Worker
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pod | [string](#string) |  |  |
+| redirected | [bool](#bool) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="debug_v2-SetLogLevelRequest-LogLevel"></a>
+
+### SetLogLevelRequest.LogLevel
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 |  |
+| DEBUG | 1 |  |
+| INFO | 2 |  |
+| ERROR | 3 |  |
+| OFF | 4 | Only GRPC logs can be turned off. |
+
+
+ 
+
+ 
+
+
+<a name="debug_v2-Debug"></a>
+
+### Debug
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Profile | [ProfileRequest](#debug_v2-ProfileRequest) | [.google.protobuf.BytesValue](#google-protobuf-BytesValue) stream |  |
+| Binary | [BinaryRequest](#debug_v2-BinaryRequest) | [.google.protobuf.BytesValue](#google-protobuf-BytesValue) stream |  |
+| Dump | [DumpRequest](#debug_v2-DumpRequest) | [.google.protobuf.BytesValue](#google-protobuf-BytesValue) stream |  |
+| SetLogLevel | [SetLogLevelRequest](#debug_v2-SetLogLevelRequest) | [SetLogLevelResponse](#debug_v2-SetLogLevelResponse) |  |
+| GetDumpV2Template | [GetDumpV2TemplateRequest](#debug_v2-GetDumpV2TemplateRequest) | [GetDumpV2TemplateResponse](#debug_v2-GetDumpV2TemplateResponse) |  |
+| DumpV2 | [DumpV2Request](#debug_v2-DumpV2Request) | [DumpChunk](#debug_v2-DumpChunk) stream |  |
+
+ 
+
+
+
+<a name="enterprise_enterprise-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## enterprise/enterprise.proto
+
+
+
+<a name="enterprise_v2-ActivateRequest"></a>
+
+### ActivateRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| license_server | [string](#string) |  |  |
+| id | [string](#string) |  |  |
+| secret | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="enterprise_v2-ActivateResponse"></a>
+
+### ActivateResponse
+
+
+
+
+
+
+
+<a name="enterprise_v2-DeactivateRequest"></a>
+
+### DeactivateRequest
+
+
+
+
+
+
+
+<a name="enterprise_v2-DeactivateResponse"></a>
+
+### DeactivateResponse
+
+
+
+
+
+
+
+<a name="enterprise_v2-EnterpriseConfig"></a>
+
+### EnterpriseConfig
+EnterpriseConfig is the configuration we store for heartbeating
+to the license server.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| license_server | [string](#string) |  | license_server is the address of the grpc license service |
+| id | [string](#string) |  | id is the unique identifier for this pachd, which is registered with the license service |
+| secret | [string](#string) |  | secret is a shared secret between this pachd and the license service |
+
+
+
+
+
+
+<a name="enterprise_v2-EnterpriseRecord"></a>
+
+### EnterpriseRecord
+EnterpriseRecord is a protobuf we cache in etcd to store the
+enterprise status.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| license | [LicenseRecord](#enterprise_v2-LicenseRecord) |  | license is the cached LicenseRecord retrieved from the most recent heartbeat to the license server. |
+| last_heartbeat | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | last_heartbeat is the timestamp of the last successful heartbeat to the license server |
+| heartbeat_failed | [bool](#bool) |  | heartbeat_failed is set if the license is still valid, but the pachd is no longer registered with an enterprise server. This is the same as the expired state, where auth is locked but not disabled. |
+
+
+
+
+
+
+<a name="enterprise_v2-GetActivationCodeRequest"></a>
+
+### GetActivationCodeRequest
+
+
+
+
+
+
+
+<a name="enterprise_v2-GetActivationCodeResponse"></a>
+
+### GetActivationCodeResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| state | [State](#enterprise_v2-State) |  |  |
+| info | [TokenInfo](#enterprise_v2-TokenInfo) |  |  |
+| activation_code | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="enterprise_v2-GetStateRequest"></a>
+
+### GetStateRequest
+
+
+
+
+
+
+
+<a name="enterprise_v2-GetStateResponse"></a>
+
+### GetStateResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| state | [State](#enterprise_v2-State) |  |  |
+| info | [TokenInfo](#enterprise_v2-TokenInfo) |  |  |
+| activation_code | [string](#string) |  | activation_code will always be an empty string, call GetEnterpriseCode to get the activation code |
+
+
+
+
+
+
+<a name="enterprise_v2-HeartbeatRequest"></a>
+
+### HeartbeatRequest
+Heartbeat in the enterprise service just triggers a heartbeat for
+testing purposes. The RPC used to communicate with the license
+service is defined in the license service.
+
+
+
+
+
+
+<a name="enterprise_v2-HeartbeatResponse"></a>
+
+### HeartbeatResponse
+
+
+
+
+
+
+
+<a name="enterprise_v2-LicenseRecord"></a>
+
+### LicenseRecord
+LicenseRecord is the record we store in etcd for a Pachyderm enterprise
+token that has been provided to a Pachyderm license server
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| activation_code | [string](#string) |  |  |
+| expires | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+
+<a name="enterprise_v2-PauseRequest"></a>
+
+### PauseRequest
+
+
+
+
+
+
+
+<a name="enterprise_v2-PauseResponse"></a>
+
+### PauseResponse
+
+
+
+
+
+
+
+<a name="enterprise_v2-PauseStatusRequest"></a>
+
+### PauseStatusRequest
+
+
+
+
+
+
+
+<a name="enterprise_v2-PauseStatusResponse"></a>
+
+### PauseStatusResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| status | [PauseStatusResponse.PauseStatus](#enterprise_v2-PauseStatusResponse-PauseStatus) |  |  |
+
+
+
+
+
+
+<a name="enterprise_v2-TokenInfo"></a>
+
+### TokenInfo
+TokenInfo contains information about the currently active enterprise token
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| expires | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | expires indicates when the current token expires (unset if there is no current token) |
+
+
+
+
+
+
+<a name="enterprise_v2-UnpauseRequest"></a>
+
+### UnpauseRequest
+
+
+
+
+
+
+
+<a name="enterprise_v2-UnpauseResponse"></a>
+
+### UnpauseResponse
+
+
+
+
+
+
+ 
+
+
+<a name="enterprise_v2-PauseStatusResponse-PauseStatus"></a>
+
+### PauseStatusResponse.PauseStatus
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNPAUSED | 0 |  |
+| PARTIALLY_PAUSED | 1 |  |
+| PAUSED | 2 |  |
+
+
+
+<a name="enterprise_v2-State"></a>
+
+### State
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 |  |
+| ACTIVE | 1 |  |
+| EXPIRED | 2 |  |
+| HEARTBEAT_FAILED | 3 |  |
+
+
+ 
+
+ 
+
+
+<a name="enterprise_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Activate | [ActivateRequest](#enterprise_v2-ActivateRequest) | [ActivateResponse](#enterprise_v2-ActivateResponse) | Provide a Pachyderm enterprise token, enabling Pachyderm enterprise features, such as the Pachyderm Dashboard and Auth system |
+| GetState | [GetStateRequest](#enterprise_v2-GetStateRequest) | [GetStateResponse](#enterprise_v2-GetStateResponse) |  |
+| GetActivationCode | [GetActivationCodeRequest](#enterprise_v2-GetActivationCodeRequest) | [GetActivationCodeResponse](#enterprise_v2-GetActivationCodeResponse) |  |
+| Heartbeat | [HeartbeatRequest](#enterprise_v2-HeartbeatRequest) | [HeartbeatResponse](#enterprise_v2-HeartbeatResponse) | Heartbeat is used in testing to trigger a heartbeat on demand. Normally this happens on a timer. |
+| Deactivate | [DeactivateRequest](#enterprise_v2-DeactivateRequest) | [DeactivateResponse](#enterprise_v2-DeactivateResponse) | Deactivate removes a cluster&#39;s enterprise activation token and sets its enterprise state to NONE. |
+| Pause | [PauseRequest](#enterprise_v2-PauseRequest) | [PauseResponse](#enterprise_v2-PauseResponse) | Pause pauses the cluster. |
+| Unpause | [UnpauseRequest](#enterprise_v2-UnpauseRequest) | [UnpauseResponse](#enterprise_v2-UnpauseResponse) | Unpause unpauses the cluser. |
+| PauseStatus | [PauseStatusRequest](#enterprise_v2-PauseStatusRequest) | [PauseStatusResponse](#enterprise_v2-PauseStatusResponse) |  |
+
+ 
+
+
+
+<a name="identity_identity-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## identity/identity.proto
+
+
+
+<a name="identity_v2-CreateIDPConnectorRequest"></a>
+
+### CreateIDPConnectorRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| connector | [IDPConnector](#identity_v2-IDPConnector) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-CreateIDPConnectorResponse"></a>
+
+### CreateIDPConnectorResponse
+
+
+
+
+
+
+
+<a name="identity_v2-CreateOIDCClientRequest"></a>
+
+### CreateOIDCClientRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| client | [OIDCClient](#identity_v2-OIDCClient) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-CreateOIDCClientResponse"></a>
+
+### CreateOIDCClientResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| client | [OIDCClient](#identity_v2-OIDCClient) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-DeleteAllRequest"></a>
+
+### DeleteAllRequest
+
+
+
+
+
+
+
+<a name="identity_v2-DeleteAllResponse"></a>
+
+### DeleteAllResponse
+
+
+
+
+
+
+
+<a name="identity_v2-DeleteIDPConnectorRequest"></a>
+
+### DeleteIDPConnectorRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-DeleteIDPConnectorResponse"></a>
+
+### DeleteIDPConnectorResponse
+
+
+
+
+
+
+
+<a name="identity_v2-DeleteOIDCClientRequest"></a>
+
+### DeleteOIDCClientRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-DeleteOIDCClientResponse"></a>
+
+### DeleteOIDCClientResponse
+
+
+
+
+
+
+
+<a name="identity_v2-GetIDPConnectorRequest"></a>
+
+### GetIDPConnectorRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-GetIDPConnectorResponse"></a>
+
+### GetIDPConnectorResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| connector | [IDPConnector](#identity_v2-IDPConnector) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-GetIdentityServerConfigRequest"></a>
+
+### GetIdentityServerConfigRequest
+
+
+
+
+
+
+
+<a name="identity_v2-GetIdentityServerConfigResponse"></a>
+
+### GetIdentityServerConfigResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| config | [IdentityServerConfig](#identity_v2-IdentityServerConfig) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-GetOIDCClientRequest"></a>
+
+### GetOIDCClientRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-GetOIDCClientResponse"></a>
+
+### GetOIDCClientResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| client | [OIDCClient](#identity_v2-OIDCClient) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-IDPConnector"></a>
+
+### IDPConnector
+IDPConnector represents a connection to an identity provider
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | ID is the unique identifier for this connector. |
+| name | [string](#string) |  | Name is the human-readable identifier for this connector, which will be shown to end users when they&#39;re authenticating. |
+| type | [string](#string) |  | Type is the type of the IDP ex. `saml`, `oidc`, `github`. |
+| configVersion | [int64](#int64) |  | ConfigVersion must be incremented every time a connector is updated, to avoid concurrent updates conflicting. |
+| jsonConfig | [string](#string) |  | This is left for backwards compatibility, but we want users to use the config defined below. |
+| config | [google.protobuf.Struct](#google-protobuf-Struct) |  | Config is the configuration for the upstream IDP, which varies based on the type. We make the assumption that this is either yaml or JSON. |
+
+
+
+
+
+
+<a name="identity_v2-IdentityServerConfig"></a>
+
+### IdentityServerConfig
+IdentityServerConfig is the configuration for the identity web server.
+When the configuration is changed the web server is reloaded automatically.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| issuer | [string](#string) |  |  |
+| id_token_expiry | [string](#string) |  |  |
+| rotation_token_expiry | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-ListIDPConnectorsRequest"></a>
+
+### ListIDPConnectorsRequest
+
+
+
+
+
+
+
+<a name="identity_v2-ListIDPConnectorsResponse"></a>
+
+### ListIDPConnectorsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| connectors | [IDPConnector](#identity_v2-IDPConnector) | repeated |  |
+
+
+
+
+
+
+<a name="identity_v2-ListOIDCClientsRequest"></a>
+
+### ListOIDCClientsRequest
+
+
+
+
+
+
+
+<a name="identity_v2-ListOIDCClientsResponse"></a>
+
+### ListOIDCClientsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| clients | [OIDCClient](#identity_v2-OIDCClient) | repeated |  |
+
+
+
+
+
+
+<a name="identity_v2-OIDCClient"></a>
+
+### OIDCClient
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| redirect_uris | [string](#string) | repeated |  |
+| trusted_peers | [string](#string) | repeated |  |
+| name | [string](#string) |  |  |
+| secret | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-SetIdentityServerConfigRequest"></a>
+
+### SetIdentityServerConfigRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| config | [IdentityServerConfig](#identity_v2-IdentityServerConfig) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-SetIdentityServerConfigResponse"></a>
+
+### SetIdentityServerConfigResponse
+
+
+
+
+
+
+
+<a name="identity_v2-UpdateIDPConnectorRequest"></a>
+
+### UpdateIDPConnectorRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| connector | [IDPConnector](#identity_v2-IDPConnector) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-UpdateIDPConnectorResponse"></a>
+
+### UpdateIDPConnectorResponse
+
+
+
+
+
+
+
+<a name="identity_v2-UpdateOIDCClientRequest"></a>
+
+### UpdateOIDCClientRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| client | [OIDCClient](#identity_v2-OIDCClient) |  |  |
+
+
+
+
+
+
+<a name="identity_v2-UpdateOIDCClientResponse"></a>
+
+### UpdateOIDCClientResponse
+
+
+
+
+
+
+
+<a name="identity_v2-User"></a>
+
+### User
+User represents an IDP user that has authenticated via OIDC
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| email | [string](#string) |  |  |
+| last_authenticated | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="identity_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| SetIdentityServerConfig | [SetIdentityServerConfigRequest](#identity_v2-SetIdentityServerConfigRequest) | [SetIdentityServerConfigResponse](#identity_v2-SetIdentityServerConfigResponse) |  |
+| GetIdentityServerConfig | [GetIdentityServerConfigRequest](#identity_v2-GetIdentityServerConfigRequest) | [GetIdentityServerConfigResponse](#identity_v2-GetIdentityServerConfigResponse) |  |
+| CreateIDPConnector | [CreateIDPConnectorRequest](#identity_v2-CreateIDPConnectorRequest) | [CreateIDPConnectorResponse](#identity_v2-CreateIDPConnectorResponse) |  |
+| UpdateIDPConnector | [UpdateIDPConnectorRequest](#identity_v2-UpdateIDPConnectorRequest) | [UpdateIDPConnectorResponse](#identity_v2-UpdateIDPConnectorResponse) |  |
+| ListIDPConnectors | [ListIDPConnectorsRequest](#identity_v2-ListIDPConnectorsRequest) | [ListIDPConnectorsResponse](#identity_v2-ListIDPConnectorsResponse) |  |
+| GetIDPConnector | [GetIDPConnectorRequest](#identity_v2-GetIDPConnectorRequest) | [GetIDPConnectorResponse](#identity_v2-GetIDPConnectorResponse) |  |
+| DeleteIDPConnector | [DeleteIDPConnectorRequest](#identity_v2-DeleteIDPConnectorRequest) | [DeleteIDPConnectorResponse](#identity_v2-DeleteIDPConnectorResponse) |  |
+| CreateOIDCClient | [CreateOIDCClientRequest](#identity_v2-CreateOIDCClientRequest) | [CreateOIDCClientResponse](#identity_v2-CreateOIDCClientResponse) |  |
+| UpdateOIDCClient | [UpdateOIDCClientRequest](#identity_v2-UpdateOIDCClientRequest) | [UpdateOIDCClientResponse](#identity_v2-UpdateOIDCClientResponse) |  |
+| GetOIDCClient | [GetOIDCClientRequest](#identity_v2-GetOIDCClientRequest) | [GetOIDCClientResponse](#identity_v2-GetOIDCClientResponse) |  |
+| ListOIDCClients | [ListOIDCClientsRequest](#identity_v2-ListOIDCClientsRequest) | [ListOIDCClientsResponse](#identity_v2-ListOIDCClientsResponse) |  |
+| DeleteOIDCClient | [DeleteOIDCClientRequest](#identity_v2-DeleteOIDCClientRequest) | [DeleteOIDCClientResponse](#identity_v2-DeleteOIDCClientResponse) |  |
+| DeleteAll | [DeleteAllRequest](#identity_v2-DeleteAllRequest) | [DeleteAllResponse](#identity_v2-DeleteAllResponse) |  |
+
+ 
+
+
+
+<a name="internal_clusterstate_v2-5-0_commit_info-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/clusterstate/v2.5.0/commit_info.proto
+
+
+
+<a name="v2_5_0-CommitInfo"></a>
+
+### CommitInfo
+CommitInfo is the main data structure representing a commit in etcd
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| origin | [pfs_v2.CommitOrigin](#pfs_v2-CommitOrigin) |  |  |
+| description | [string](#string) |  | description is a user-provided script describing this commit |
+| parent_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| child_commits | [pfs_v2.Commit](#pfs_v2-Commit) | repeated |  |
+| started | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| finishing | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| finished | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| direct_provenance | [pfs_v2.Branch](#pfs_v2-Branch) | repeated |  |
+| error | [string](#string) |  |  |
+| size_bytes_upper_bound | [int64](#int64) |  |  |
+| details | [pfs_v2.CommitInfo.Details](#pfs_v2-CommitInfo-Details) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_collection_test-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/collection/test.proto
+
+
+
+<a name="common-TestItem"></a>
+
+### TestItem
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+| data | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_config_config-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/config/config.proto
+
+
+
+<a name="config_v2-Config"></a>
+
+### Config
+Config specifies the pachyderm config that is read and interpreted by the
+pachctl command-line tool. Right now, this is stored at
+$HOME/.pachyderm/config.
+
+Different versions of the pachyderm config are specified as subfields of this
+message (this allows us to make significant changes to the config structure
+without breaking existing users by defining a new config version).
+
+These structures are stored in a JSON format, so it should be safe to modify
+fields as long as compatibility is ensured with previous versions.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| user_id | [string](#string) |  |  |
+| v1 | [ConfigV1](#config_v2-ConfigV1) |  | Configuration options. Exactly one of these fields should be set (depending on which version of the config is being used) |
+| v2 | [ConfigV2](#config_v2-ConfigV2) |  |  |
+
+
+
+
+
+
+<a name="config_v2-ConfigV1"></a>
+
+### ConfigV1
+ConfigV1 specifies v1 of the pachyderm config (June 30 2017 - June 2019)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pachd_address | [string](#string) |  | A host:port pointing pachd at a pachyderm cluster. |
+| server_cas | [string](#string) |  | Trusted root certificates (overrides installed certificates), formatted as base64-encoded PEM |
+| session_token | [string](#string) |  | A secret token identifying the current pachctl user within their pachyderm cluster. This is included in all RPCs sent by pachctl, and used to determine if pachctl actions are authorized. |
+| active_transaction | [string](#string) |  | The currently active transaction for batching together pachctl commands. This can be set or cleared via many of the `pachctl * transaction` commands. This is the ID of the transaction object stored in the pachyderm etcd. |
+
+
+
+
+
+
+<a name="config_v2-ConfigV2"></a>
+
+### ConfigV2
+ConfigV2 specifies v2 of the pachyderm config (June 2019 - present)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| active_context | [string](#string) |  |  |
+| active_enterprise_context | [string](#string) |  |  |
+| contexts | [ConfigV2.ContextsEntry](#config_v2-ConfigV2-ContextsEntry) | repeated |  |
+| metrics | [bool](#bool) |  |  |
+| max_shell_completions | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="config_v2-ConfigV2-ContextsEntry"></a>
+
+### ConfigV2.ContextsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [Context](#config_v2-Context) |  |  |
+
+
+
+
+
+
+<a name="config_v2-Context"></a>
+
+### Context
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| source | [ContextSource](#config_v2-ContextSource) |  | Where this context came from |
+| pachd_address | [string](#string) |  | The hostname or IP address pointing pachd at a pachyderm cluster. |
+| server_cas | [string](#string) |  | Trusted root certificates (overrides installed certificates), formatted as base64-encoded PEM. |
+| session_token | [string](#string) |  | A secret token identifying the current pachctl user within their pachyderm cluster. This is included in all RPCs sent by pachctl, and used to determine if pachctl actions are authorized. |
+| active_transaction | [string](#string) |  | The currently active transaction for batching together pachctl commands. This can be set or cleared via many of the `pachctl * transaction` commands. This is the ID of the transaction object stored in the pachyderm etcd. |
+| cluster_name | [string](#string) |  | The k8s cluster name - used to construct a k8s context. |
+| auth_info | [string](#string) |  | The k8s auth info - used to construct a k8s context. |
+| namespace | [string](#string) |  | The k8s namespace - used to construct a k8s context. |
+| port_forwarders | [Context.PortForwardersEntry](#config_v2-Context-PortForwardersEntry) | repeated | A mapping of service -&gt; port number, when port forwarding is running for this context. |
+| cluster_deployment_id | [string](#string) |  | A unique ID for the cluster deployment. At client initialization time, we ensure this is the same as what the cluster reports back, to prevent us from connecting to the wrong cluster. |
+| enterprise_server | [bool](#bool) |  | A boolean that records whether the context points at an enterprise server. If false, the context points at a stand-alone pachd. |
+| project | [string](#string) |  | The current project. |
+
+
+
+
+
+
+<a name="config_v2-Context-PortForwardersEntry"></a>
+
+### Context.PortForwardersEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [uint32](#uint32) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="config_v2-ContextSource"></a>
+
+### ContextSource
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 |  |
+| CONFIG_V1 | 1 |  |
+| HUB | 2 |  |
+| IMPORTED | 3 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_metrics_metrics-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/metrics/metrics.proto
+
+
+
+<a name="metrics-Metrics"></a>
+
+### Metrics
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| cluster_id | [string](#string) |  |  |
+| pod_id | [string](#string) |  |  |
+| nodes | [int64](#int64) |  |  |
+| version | [string](#string) |  |  |
+| repos | [int64](#int64) |  | Number of repos |
+| commits | [int64](#int64) |  | Number of commits -- not used |
+| files | [int64](#int64) |  | Number of files -- not used |
+| bytes | [uint64](#uint64) |  | Number of bytes in all repos |
+| jobs | [int64](#int64) |  | Number of jobs |
+| pipelines | [int64](#int64) |  | Number of pipelines in the cluster -- not the same as DAG |
+| archived_commits | [int64](#int64) |  | Number of archived commit -- not used |
+| cancelled_commits | [int64](#int64) |  | Number of cancelled commits -- not used |
+| activation_code | [string](#string) |  | Activation code |
+| max_branches | [uint64](#uint64) |  | Max branches in across all the repos |
+| pps_spout | [int64](#int64) |  | Number of spout pipelines |
+| pps_spout_service | [int64](#int64) |  | Number of spout services |
+| cfg_egress | [int64](#int64) |  | Number of pipelines with Egress configured |
+| cfg_standby | [int64](#int64) |  | Number of pipelines with Standby congigured |
+| cfg_s3gateway | [int64](#int64) |  | Number of pipelines with S3 Gateway configured |
+| cfg_services | [int64](#int64) |  | Number of pipelines with services configured |
+| cfg_errcmd | [int64](#int64) |  | Number of pipelines with error cmd set |
+| cfg_tfjob | [int64](#int64) |  | Number of pipelines with TFJobs configured |
+| input_group | [int64](#int64) |  | Number of pipelines with group inputs |
+| input_join | [int64](#int64) |  | Number of pipelines with join inputs |
+| input_cross | [int64](#int64) |  | Number of pipelines with cross inputs |
+| input_union | [int64](#int64) |  | Number of pipelines with union inputs |
+| input_cron | [int64](#int64) |  | Number of pipelines with cron inputs |
+| input_git | [int64](#int64) |  | Number of pipelines with git inputs |
+| input_pfs | [int64](#int64) |  | Number of pfs inputs |
+| input_commit | [int64](#int64) |  | Number of pfs inputs with commits |
+| input_join_on | [int64](#int64) |  | Number of pfs inputs with join_on |
+| input_outer_join | [int64](#int64) |  | Number of pipelines with outer joins |
+| input_lazy | [int64](#int64) |  | Number of pipelines with lazy set |
+| input_empty_files | [int64](#int64) |  | Number of pipelines with empty files set |
+| input_s3 | [int64](#int64) |  | Number of pipelines with S3 input |
+| input_trigger | [int64](#int64) |  | Number of pipelines with triggers set |
+| resource_cpu_req | [float](#float) |  | Total CPU request across all pipelines |
+| resource_cpu_req_max | [float](#float) |  | Max CPU resource requests set |
+| resource_mem_req | [string](#string) |  | Sting of memory requests set across all pipelines |
+| resource_gpu_req | [int64](#int64) |  | Total GPU requests across all pipelines |
+| resource_gpu_req_max | [int64](#int64) |  | Max GPU request across all pipelines |
+| resource_disk_req | [string](#string) |  | String of disk requests set across all pipelines |
+| resource_cpu_limit | [float](#float) |  | Total CPU limits set across all pipelines |
+| resource_cpu_limit_max | [float](#float) |  | Max CPU limit set |
+| resource_mem_limit | [string](#string) |  | String of memory limits set |
+| resource_gpu_limit | [int64](#int64) |  | Number of pipelines with |
+| resource_gpu_limit_max | [int64](#int64) |  | Max GPU limit set |
+| resource_disk_limit | [string](#string) |  | String of disk limits set across all pipelines |
+| max_parallelism | [uint64](#uint64) |  | Max parallelism set |
+| min_parallelism | [uint64](#uint64) |  | Min parallelism set |
+| num_parallelism | [uint64](#uint64) |  | Number of pipelines with parallelism set |
+| enterprise_failures | [int64](#int64) |  | Number of times a command has failed due to an enterprise check |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_pfsload_pfsload-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/pfsload/pfsload.proto
+
+
+
+<a name="pfsload-CommitSpec"></a>
+
+### CommitSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int64](#int64) |  |  |
+| modifications | [ModificationSpec](#pfsload-ModificationSpec) | repeated |  |
+| file_sources | [FileSourceSpec](#pfsload-FileSourceSpec) | repeated |  |
+| validator | [ValidatorSpec](#pfsload-ValidatorSpec) |  |  |
+
+
+
+
+
+
+<a name="pfsload-FileSourceSpec"></a>
+
+### FileSourceSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| random | [RandomFileSourceSpec](#pfsload-RandomFileSourceSpec) |  |  |
+
+
+
+
+
+
+<a name="pfsload-FrequencySpec"></a>
+
+### FrequencySpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int64](#int64) |  |  |
+| prob | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfsload-ModificationSpec"></a>
+
+### ModificationSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int64](#int64) |  |  |
+| put_file | [PutFileSpec](#pfsload-PutFileSpec) |  |  |
+
+
+
+
+
+
+<a name="pfsload-PutFileSpec"></a>
+
+### PutFileSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int64](#int64) |  |  |
+| source | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfsload-PutFileTask"></a>
+
+### PutFileTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int64](#int64) |  |  |
+| file_source | [FileSourceSpec](#pfsload-FileSourceSpec) |  |  |
+| seed | [int64](#int64) |  |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfsload-PutFileTaskResult"></a>
+
+### PutFileTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+| hash | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="pfsload-RandomDirectorySpec"></a>
+
+### RandomDirectorySpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| depth | [SizeSpec](#pfsload-SizeSpec) |  |  |
+| run | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfsload-RandomFileSourceSpec"></a>
+
+### RandomFileSourceSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| directory | [RandomDirectorySpec](#pfsload-RandomDirectorySpec) |  |  |
+| sizes | [SizeSpec](#pfsload-SizeSpec) | repeated |  |
+| increment_path | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfsload-SizeSpec"></a>
+
+### SizeSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| min_size | [int64](#int64) |  |  |
+| max_size | [int64](#int64) |  |  |
+| prob | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfsload-State"></a>
+
+### State
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commits | [State.Commit](#pfsload-State-Commit) | repeated |  |
+
+
+
+
+
+
+<a name="pfsload-State-Commit"></a>
+
+### State.Commit
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| hash | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="pfsload-ValidatorSpec"></a>
+
+### ValidatorSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| frequency | [FrequencySpec](#pfsload-FrequencySpec) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_ppsdb_ppsdb-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/ppsdb/ppsdb.proto
+
+
+
+<a name="pps_v2-ClusterDefaultsWrapper"></a>
+
+### ClusterDefaultsWrapper
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| json | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_ppsload_ppsload-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/ppsload/ppsload.proto
+
+
+
+<a name="ppsload-State"></a>
+
+### State
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| branch | [pfs_v2.Branch](#pfs_v2-Branch) |  |  |
+| pfs_state_id | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_storage_chunk_chunk-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/storage/chunk/chunk.proto
+
+
+
+<a name="chunk-DataRef"></a>
+
+### DataRef
+DataRef is a reference to data within a chunk.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ref | [Ref](#chunk-Ref) |  | The chunk the referenced data is located in. |
+| hash | [bytes](#bytes) |  | The hash of the data being referenced. |
+| offset_bytes | [int64](#int64) |  | The offset and size used for accessing the data within the chunk. |
+| size_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="chunk-Ref"></a>
+
+### Ref
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [bytes](#bytes) |  |  |
+| size_bytes | [int64](#int64) |  |  |
+| edge | [bool](#bool) |  |  |
+| dek | [bytes](#bytes) |  |  |
+| encryption_algo | [EncryptionAlgo](#chunk-EncryptionAlgo) |  |  |
+| compression_algo | [CompressionAlgo](#chunk-CompressionAlgo) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="chunk-CompressionAlgo"></a>
+
+### CompressionAlgo
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 |  |
+| GZIP_BEST_SPEED | 1 |  |
+
+
+
+<a name="chunk-EncryptionAlgo"></a>
+
+### EncryptionAlgo
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| ENCRYPTION_ALGO_UNKNOWN | 0 |  |
+| CHACHA20 | 1 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_storage_fileset_fileset-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/storage/fileset/fileset.proto
+
+
+
+<a name="fileset-Composite"></a>
+
+### Composite
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| layers | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="fileset-Metadata"></a>
+
+### Metadata
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| primitive | [Primitive](#fileset-Primitive) |  |  |
+| composite | [Composite](#fileset-Composite) |  |  |
+
+
+
+
+
+
+<a name="fileset-Primitive"></a>
+
+### Primitive
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| deletive | [index.Index](#index-Index) |  |  |
+| additive | [index.Index](#index-Index) |  |  |
+| size_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="fileset-TestCacheValue"></a>
+
+### TestCacheValue
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_storage_fileset_index_index-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/storage/fileset/index/index.proto
+
+
+
+<a name="index-File"></a>
+
+### File
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| datum | [string](#string) |  |  |
+| data_refs | [chunk.DataRef](#chunk-DataRef) | repeated |  |
+
+
+
+
+
+
+<a name="index-Index"></a>
+
+### Index
+Index stores an index to and metadata about a range of files or a file.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | [string](#string) |  |  |
+| range | [Range](#index-Range) |  | NOTE: range and file are mutually exclusive. |
+| file | [File](#index-File) |  |  |
+| num_files | [int64](#int64) |  | NOTE: num_files and size_bytes did not exist in older versions of 2.x, so they will not be set. |
+| size_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="index-Range"></a>
+
+### Range
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| offset | [int64](#int64) |  |  |
+| last_path | [string](#string) |  |  |
+| chunk_ref | [chunk.DataRef](#chunk-DataRef) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_task_task-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/task/task.proto
+
+
+
+<a name="task-Claim"></a>
+
+### Claim
+
+
+
+
+
+
+
+<a name="task-Group"></a>
+
+### Group
+
+
+
+
+
+
+
+<a name="task-Task"></a>
+
+### Task
+TODO: Consider splitting this up into separate structures for each state in a oneof.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| state | [State](#task-State) |  |  |
+| input | [google.protobuf.Any](#google-protobuf-Any) |  |  |
+| output | [google.protobuf.Any](#google-protobuf-Any) |  |  |
+| reason | [string](#string) |  |  |
+| index | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="task-TestTask"></a>
+
+### TestTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="task-State"></a>
+
+### State
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| STATE_UNKNOWN | 0 |  |
+| RUNNING | 1 |  |
+| SUCCESS | 2 |  |
+| FAILURE | 3 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="internal_tracing_extended_extended_trace-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## internal/tracing/extended/extended_trace.proto
+
+
+
+<a name="extended-TraceProto"></a>
+
+### TraceProto
+TraceProto contains information identifying a Jaeger trace. It&#39;s used to
+propagate traces that follow the lifetime of a long operation (e.g. creating
+a pipeline or running a job), and which live longer than any single RPC.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| serialized_trace | [TraceProto.SerializedTraceEntry](#extended-TraceProto-SerializedTraceEntry) | repeated | serialized_trace contains the info identifying a trace in Jaeger (a (trace ID, span ID, sampled) tuple, basically) |
+| project | [string](#string) |  |  |
+| pipeline | [string](#string) |  | pipeline specifies the target pipeline of this trace; this would be set for a trace created by &#39;pachctl create-pipeline&#39; or &#39;pachctl update-pipeline&#39; and would include the kubernetes RPCs involved in creating a pipeline |
+
+
+
+
+
+
+<a name="extended-TraceProto-SerializedTraceEntry"></a>
+
+### TraceProto.SerializedTraceEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="license_license-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## license/license.proto
+
+
+
+<a name="license_v2-ActivateRequest"></a>
+
+### ActivateRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| activation_code | [string](#string) |  | activation_code is a Pachyderm enterprise activation code. New users can obtain trial activation codes |
+| expires | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | expires is a timestamp indicating when this activation code will expire. This should not generally be set (it&#39;s primarily used for testing), and is only applied if it&#39;s earlier than the signed expiration time in &#39;activation_code&#39;. |
+
+
+
+
+
+
+<a name="license_v2-ActivateResponse"></a>
+
+### ActivateResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| info | [enterprise_v2.TokenInfo](#enterprise_v2-TokenInfo) |  |  |
+
+
+
+
+
+
+<a name="license_v2-AddClusterRequest"></a>
+
+### AddClusterRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | id is the unique, immutable identifier for this cluster |
+| address | [string](#string) |  | address is the public GPRC address where the cluster can be reached |
+| secret | [string](#string) |  | If set, secret specifies the shared secret this cluster will use to authenticate to the license server. Otherwise a secret will be generated and returned in the response. |
+| user_address | [string](#string) |  | The pachd address for users to connect to. |
+| cluster_deployment_id | [string](#string) |  | The deployment ID value generated by each Cluster |
+| enterprise_server | [bool](#bool) |  | This field indicates whether the address points to an enterprise server |
+
+
+
+
+
+
+<a name="license_v2-AddClusterResponse"></a>
+
+### AddClusterResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| secret | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="license_v2-ClusterStatus"></a>
+
+### ClusterStatus
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| address | [string](#string) |  |  |
+| version | [string](#string) |  |  |
+| auth_enabled | [bool](#bool) |  |  |
+| client_id | [string](#string) |  |  |
+| last_heartbeat | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| created_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+
+<a name="license_v2-DeactivateRequest"></a>
+
+### DeactivateRequest
+
+
+
+
+
+
+
+<a name="license_v2-DeactivateResponse"></a>
+
+### DeactivateResponse
+
+
+
+
+
+
+
+<a name="license_v2-DeleteAllRequest"></a>
+
+### DeleteAllRequest
+
+
+
+
+
+
+
+<a name="license_v2-DeleteAllResponse"></a>
+
+### DeleteAllResponse
+
+
+
+
+
+
+
+<a name="license_v2-DeleteClusterRequest"></a>
+
+### DeleteClusterRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="license_v2-DeleteClusterResponse"></a>
+
+### DeleteClusterResponse
+
+
+
+
+
+
+
+<a name="license_v2-GetActivationCodeRequest"></a>
+
+### GetActivationCodeRequest
+
+
+
+
+
+
+
+<a name="license_v2-GetActivationCodeResponse"></a>
+
+### GetActivationCodeResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| state | [enterprise_v2.State](#enterprise_v2-State) |  |  |
+| info | [enterprise_v2.TokenInfo](#enterprise_v2-TokenInfo) |  |  |
+| activation_code | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="license_v2-HeartbeatRequest"></a>
+
+### HeartbeatRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| secret | [string](#string) |  |  |
+| version | [string](#string) |  |  |
+| auth_enabled | [bool](#bool) |  |  |
+| client_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="license_v2-HeartbeatResponse"></a>
+
+### HeartbeatResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| license | [enterprise_v2.LicenseRecord](#enterprise_v2-LicenseRecord) |  |  |
+
+
+
+
+
+
+<a name="license_v2-ListClustersRequest"></a>
+
+### ListClustersRequest
+
+
+
+
+
+
+
+<a name="license_v2-ListClustersResponse"></a>
+
+### ListClustersResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| clusters | [ClusterStatus](#license_v2-ClusterStatus) | repeated |  |
+
+
+
+
+
+
+<a name="license_v2-ListUserClustersRequest"></a>
+
+### ListUserClustersRequest
+
+
+
+
+
+
+
+<a name="license_v2-ListUserClustersResponse"></a>
+
+### ListUserClustersResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| clusters | [UserClusterInfo](#license_v2-UserClusterInfo) | repeated |  |
+
+
+
+
+
+
+<a name="license_v2-UpdateClusterRequest"></a>
+
+### UpdateClusterRequest
+Note: Updates of the enterprise-server field are not allowed. In the worst case, a user can recreate their cluster if they need the field updated.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| address | [string](#string) |  |  |
+| user_address | [string](#string) |  |  |
+| cluster_deployment_id | [string](#string) |  |  |
+| secret | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="license_v2-UpdateClusterResponse"></a>
+
+### UpdateClusterResponse
+
+
+
+
+
+
+
+<a name="license_v2-UserClusterInfo"></a>
+
+### UserClusterInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| cluster_deployment_id | [string](#string) |  |  |
+| address | [string](#string) |  |  |
+| enterprise_server | [bool](#bool) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="license_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Activate | [ActivateRequest](#license_v2-ActivateRequest) | [ActivateResponse](#license_v2-ActivateResponse) | Activate enables the license service by setting the enterprise activation code to serve. |
+| GetActivationCode | [GetActivationCodeRequest](#license_v2-GetActivationCodeRequest) | [GetActivationCodeResponse](#license_v2-GetActivationCodeResponse) |  |
+| DeleteAll | [DeleteAllRequest](#license_v2-DeleteAllRequest) | [DeleteAllResponse](#license_v2-DeleteAllResponse) | DeleteAll deactivates the server and removes all data. |
+| AddCluster | [AddClusterRequest](#license_v2-AddClusterRequest) | [AddClusterResponse](#license_v2-AddClusterResponse) | CRUD operations for the pachds registered with this server. |
+| DeleteCluster | [DeleteClusterRequest](#license_v2-DeleteClusterRequest) | [DeleteClusterResponse](#license_v2-DeleteClusterResponse) |  |
+| ListClusters | [ListClustersRequest](#license_v2-ListClustersRequest) | [ListClustersResponse](#license_v2-ListClustersResponse) |  |
+| UpdateCluster | [UpdateClusterRequest](#license_v2-UpdateClusterRequest) | [UpdateClusterResponse](#license_v2-UpdateClusterResponse) |  |
+| Heartbeat | [HeartbeatRequest](#license_v2-HeartbeatRequest) | [HeartbeatResponse](#license_v2-HeartbeatResponse) | Heartbeat is the RPC registered pachds make to the license server to communicate their status and fetch updates. |
+| ListUserClusters | [ListUserClustersRequest](#license_v2-ListUserClustersRequest) | [ListUserClustersResponse](#license_v2-ListUserClustersResponse) | Lists all clusters available to user |
+
+ 
+
+
+
+<a name="pfs_pfs-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## pfs/pfs.proto
+
+
+
+<a name="pfs_v2-ActivateAuthRequest"></a>
+
+### ActivateAuthRequest
+
+
+
+
+
+
+
+<a name="pfs_v2-ActivateAuthResponse"></a>
+
+### ActivateAuthResponse
+
+
+
+
+
+
+
+<a name="pfs_v2-AddFile"></a>
+
+### AddFile
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | [string](#string) |  |  |
+| datum | [string](#string) |  |  |
+| raw | [google.protobuf.BytesValue](#google-protobuf-BytesValue) |  |  |
+| url | [AddFile.URLSource](#pfs_v2-AddFile-URLSource) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-AddFile-URLSource"></a>
+
+### AddFile.URLSource
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| URL | [string](#string) |  |  |
+| recursive | [bool](#bool) |  |  |
+| concurrency | [uint32](#uint32) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-AddFileSetRequest"></a>
+
+### AddFileSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-AuthInfo"></a>
+
+### AuthInfo
+AuthInfo includes the caller&#39;s access scope for a resource, and is returned
+by services like ListRepo, InspectRepo, and ListProject, but is not persisted in the database.
+It&#39;s used by the Pachyderm dashboard to render repo access appropriately.
+To set a user&#39;s auth scope for a resource, use the Pachyderm Auth API (in src/auth/auth.proto)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| permissions | [auth_v2.Permission](#auth_v2-Permission) | repeated | The callers access level to the relevant resource. These are very granular permissions - for the end user it makes sense to show them the roles they have instead. |
+| roles | [string](#string) | repeated | The caller&#39;s roles on the relevant resource. This includes inherited roles from the cluster, project, group membership, etc. |
+
+
+
+
+
+
+<a name="pfs_v2-Branch"></a>
+
+### Branch
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-BranchInfo"></a>
+
+### BranchInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+| head | [Commit](#pfs_v2-Commit) |  |  |
+| provenance | [Branch](#pfs_v2-Branch) | repeated |  |
+| subvenance | [Branch](#pfs_v2-Branch) | repeated |  |
+| direct_provenance | [Branch](#pfs_v2-Branch) | repeated |  |
+| trigger | [Trigger](#pfs_v2-Trigger) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CheckStorageRequest"></a>
+
+### CheckStorageRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| read_chunk_data | [bool](#bool) |  |  |
+| chunk_begin | [bytes](#bytes) |  |  |
+| chunk_end | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CheckStorageResponse"></a>
+
+### CheckStorageResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| chunk_object_count | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ClearCacheRequest"></a>
+
+### ClearCacheRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| tag_prefix | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ClearCommitRequest"></a>
+
+### ClearCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-Commit"></a>
+
+### Commit
+Commit is a reference to a commit (e.g. the collection of branches and the
+collection of currently-open commits in etcd are collections of Commit
+protos)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| id | [string](#string) |  |  |
+| branch | [Branch](#pfs_v2-Branch) |  | only used by the client |
+
+
+
+
+
+
+<a name="pfs_v2-CommitInfo"></a>
+
+### CommitInfo
+CommitInfo is the main data structure representing a commit in etcd
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| origin | [CommitOrigin](#pfs_v2-CommitOrigin) |  |  |
+| description | [string](#string) |  | description is a user-provided script describing this commit |
+| parent_commit | [Commit](#pfs_v2-Commit) |  |  |
+| child_commits | [Commit](#pfs_v2-Commit) | repeated |  |
+| started | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| finishing | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| finished | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| direct_provenance | [Commit](#pfs_v2-Commit) | repeated |  |
+| error | [string](#string) |  |  |
+| size_bytes_upper_bound | [int64](#int64) |  |  |
+| details | [CommitInfo.Details](#pfs_v2-CommitInfo-Details) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CommitInfo-Details"></a>
+
+### CommitInfo.Details
+Details are only provided when explicitly requested
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| size_bytes | [int64](#int64) |  |  |
+| compacting_time | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| validating_time | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CommitOrigin"></a>
+
+### CommitOrigin
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| kind | [OriginKind](#pfs_v2-OriginKind) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CommitSet"></a>
+
+### CommitSet
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CommitSetInfo"></a>
+
+### CommitSetInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit_set | [CommitSet](#pfs_v2-CommitSet) |  |  |
+| commits | [CommitInfo](#pfs_v2-CommitInfo) | repeated |  |
+
+
+
+
+
+
+<a name="pfs_v2-ComposeFileSetRequest"></a>
+
+### ComposeFileSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_ids | [string](#string) | repeated |  |
+| ttl_seconds | [int64](#int64) |  |  |
+| compact | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CopyFile"></a>
+
+### CopyFile
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| dst | [string](#string) |  |  |
+| datum | [string](#string) |  |  |
+| src | [File](#pfs_v2-File) |  |  |
+| append | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CreateBranchRequest"></a>
+
+### CreateBranchRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| head | [Commit](#pfs_v2-Commit) |  |  |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+| provenance | [Branch](#pfs_v2-Branch) | repeated |  |
+| trigger | [Trigger](#pfs_v2-Trigger) |  |  |
+| new_commit_set | [bool](#bool) |  | overrides the default behavior of using the same CommitSet as &#39;head&#39; |
+
+
+
+
+
+
+<a name="pfs_v2-CreateFileSetResponse"></a>
+
+### CreateFileSetResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CreateProjectRequest"></a>
+
+### CreateProjectRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#pfs_v2-Project) |  |  |
+| description | [string](#string) |  |  |
+| update | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-CreateRepoRequest"></a>
+
+### CreateRepoRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| description | [string](#string) |  |  |
+| update | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteBranchRequest"></a>
+
+### DeleteBranchRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+| force | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteFile"></a>
+
+### DeleteFile
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | [string](#string) |  |  |
+| datum | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteProjectRequest"></a>
+
+### DeleteProjectRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#pfs_v2-Project) |  |  |
+| force | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteRepoRequest"></a>
+
+### DeleteRepoRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| force | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteRepoResponse"></a>
+
+### DeleteRepoResponse
+DeleteRepoResponse returns the repos that were deleted by a DeleteRepo call.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| deleted | [bool](#bool) |  | The repos that were deleted, perhaps none. |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteReposRequest"></a>
+
+### DeleteReposRequest
+DeleteReposRequest is used to delete more than one repo at once.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| projects | [Project](#pfs_v2-Project) | repeated | All repos in each project will be deleted if the caller has permission. |
+| force | [bool](#bool) |  |  |
+| all | [bool](#bool) |  | If all is set, then all repos in all projects will be deleted if the caller has permission. |
+
+
+
+
+
+
+<a name="pfs_v2-DeleteReposResponse"></a>
+
+### DeleteReposResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repos | [Repo](#pfs_v2-Repo) | repeated |  |
+
+
+
+
+
+
+<a name="pfs_v2-DiffFileRequest"></a>
+
+### DiffFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| new_file | [File](#pfs_v2-File) |  |  |
+| old_file | [File](#pfs_v2-File) |  | OldFile may be left nil in which case the same path in the parent of NewFile&#39;s commit will be used. |
+| shallow | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DiffFileResponse"></a>
+
+### DiffFileResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| new_file | [FileInfo](#pfs_v2-FileInfo) |  |  |
+| old_file | [FileInfo](#pfs_v2-FileInfo) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-DropCommitSetRequest"></a>
+
+### DropCommitSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit_set | [CommitSet](#pfs_v2-CommitSet) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-EgressRequest"></a>
+
+### EgressRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| object_storage | [ObjectStorageEgress](#pfs_v2-ObjectStorageEgress) |  |  |
+| sql_database | [SQLDatabaseEgress](#pfs_v2-SQLDatabaseEgress) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-EgressResponse"></a>
+
+### EgressResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| object_storage | [EgressResponse.ObjectStorageResult](#pfs_v2-EgressResponse-ObjectStorageResult) |  |  |
+| sql_database | [EgressResponse.SQLDatabaseResult](#pfs_v2-EgressResponse-SQLDatabaseResult) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-EgressResponse-ObjectStorageResult"></a>
+
+### EgressResponse.ObjectStorageResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bytes_written | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-EgressResponse-SQLDatabaseResult"></a>
+
+### EgressResponse.SQLDatabaseResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| rows_written | [EgressResponse.SQLDatabaseResult.RowsWrittenEntry](#pfs_v2-EgressResponse-SQLDatabaseResult-RowsWrittenEntry) | repeated |  |
+
+
+
+
+
+
+<a name="pfs_v2-EgressResponse-SQLDatabaseResult-RowsWrittenEntry"></a>
+
+### EgressResponse.SQLDatabaseResult.RowsWrittenEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-File"></a>
+
+### File
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| path | [string](#string) |  |  |
+| datum | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-FileInfo"></a>
+
+### FileInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file | [File](#pfs_v2-File) |  |  |
+| file_type | [FileType](#pfs_v2-FileType) |  |  |
+| committed | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| size_bytes | [int64](#int64) |  |  |
+| hash | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-FindCommitsRequest"></a>
+
+### FindCommitsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| start | [Commit](#pfs_v2-Commit) |  |  |
+| file_path | [string](#string) |  |  |
+| limit | [uint32](#uint32) |  | a limit of 0 means there is no upper bound on the limit. |
+
+
+
+
+
+
+<a name="pfs_v2-FindCommitsResponse"></a>
+
+### FindCommitsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| found_commit | [Commit](#pfs_v2-Commit) |  |  |
+| last_searched_commit | [Commit](#pfs_v2-Commit) |  |  |
+| commits_searched | [uint32](#uint32) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-FinishCommitRequest"></a>
+
+### FinishCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| description | [string](#string) |  | description is a user-provided string describing this commit. Setting this will overwrite the description set in StartCommit |
+| error | [string](#string) |  |  |
+| force | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-FsckRequest"></a>
+
+### FsckRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| fix | [bool](#bool) |  |  |
+| zombie_target | [Commit](#pfs_v2-Commit) |  |  |
+| zombie_all | [bool](#bool) |  | run zombie data detection against all pipelines |
+
+
+
+
+
+
+<a name="pfs_v2-FsckResponse"></a>
+
+### FsckResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| fix | [string](#string) |  |  |
+| error | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-GetCacheRequest"></a>
+
+### GetCacheRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-GetCacheResponse"></a>
+
+### GetCacheResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [google.protobuf.Any](#google-protobuf-Any) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-GetFileRequest"></a>
+
+### GetFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file | [File](#pfs_v2-File) |  |  |
+| URL | [string](#string) |  |  |
+| offset | [int64](#int64) |  |  |
+| path_range | [PathRange](#pfs_v2-PathRange) |  | TODO: int64 size_bytes = 3; |
+
+
+
+
+
+
+<a name="pfs_v2-GetFileSetRequest"></a>
+
+### GetFileSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-GlobFileRequest"></a>
+
+### GlobFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| pattern | [string](#string) |  |  |
+| path_range | [PathRange](#pfs_v2-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-InspectBranchRequest"></a>
+
+### InspectBranchRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-InspectCommitRequest"></a>
+
+### InspectCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [Commit](#pfs_v2-Commit) |  |  |
+| wait | [CommitState](#pfs_v2-CommitState) |  | Wait causes inspect commit to wait until the commit is in the desired state. |
+
+
+
+
+
+
+<a name="pfs_v2-InspectCommitSetRequest"></a>
+
+### InspectCommitSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit_set | [CommitSet](#pfs_v2-CommitSet) |  |  |
+| wait | [bool](#bool) |  | When true, wait until all commits in the set are finished |
+
+
+
+
+
+
+<a name="pfs_v2-InspectFileRequest"></a>
+
+### InspectFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file | [File](#pfs_v2-File) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-InspectProjectRequest"></a>
+
+### InspectProjectRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#pfs_v2-Project) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-InspectRepoRequest"></a>
+
+### InspectRepoRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ListBranchRequest"></a>
+
+### ListBranchRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| reverse | [bool](#bool) |  | Returns branches oldest to newest |
+
+
+
+
+
+
+<a name="pfs_v2-ListCommitRequest"></a>
+
+### ListCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| from | [Commit](#pfs_v2-Commit) |  |  |
+| to | [Commit](#pfs_v2-Commit) |  |  |
+| number | [int64](#int64) |  |  |
+| reverse | [bool](#bool) |  | Return commits oldest to newest |
+| all | [bool](#bool) |  | Return commits of all kinds (without this, aliases are excluded) |
+| origin_kind | [OriginKind](#pfs_v2-OriginKind) |  | Return only commits of this kind (mutually exclusive with all) |
+| started_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Return commits started before this time |
+
+
+
+
+
+
+<a name="pfs_v2-ListCommitSetRequest"></a>
+
+### ListCommitSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#pfs_v2-Project) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ListFileRequest"></a>
+
+### ListFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file | [File](#pfs_v2-File) |  | File is the parent directory of the files we want to list. This sets the repo, the commit/branch, and path prefix of files we&#39;re interested in If the &#34;path&#34; field is omitted, a list of files at the top level of the repo is returned |
+| paginationMarker | [File](#pfs_v2-File) |  | Marker for pagination. If set, the files that come after the marker in lexicographical order will be returned. If reverse is also set, the files that come before the marker in lexicographical order will be returned. |
+| number | [int64](#int64) |  | Number of files to return |
+| reverse | [bool](#bool) |  | If true, return files in reverse order |
+
+
+
+
+
+
+<a name="pfs_v2-ListProjectRequest"></a>
+
+### ListProjectRequest
+
+
+
+
+
+
+
+<a name="pfs_v2-ListRepoRequest"></a>
+
+### ListRepoRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [string](#string) |  | type is the type of (system) repos that should be returned an empty string requests all repos |
+| projects | [Project](#pfs_v2-Project) | repeated | projects filters out repos that do not belong in the list, while no projects means list all repos. |
+
+
+
+
+
+
+<a name="pfs_v2-ModifyFileRequest"></a>
+
+### ModifyFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| set_commit | [Commit](#pfs_v2-Commit) |  |  |
+| add_file | [AddFile](#pfs_v2-AddFile) |  |  |
+| delete_file | [DeleteFile](#pfs_v2-DeleteFile) |  |  |
+| copy_file | [CopyFile](#pfs_v2-CopyFile) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ObjectStorageEgress"></a>
+
+### ObjectStorageEgress
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| url | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-PathRange"></a>
+
+### PathRange
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| lower | [string](#string) |  |  |
+| upper | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-Project"></a>
+
+### Project
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ProjectInfo"></a>
+
+### ProjectInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#pfs_v2-Project) |  |  |
+| description | [string](#string) |  |  |
+| auth_info | [AuthInfo](#pfs_v2-AuthInfo) |  |  |
+| created_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-PutCacheRequest"></a>
+
+### PutCacheRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google-protobuf-Any) |  |  |
+| file_set_ids | [string](#string) | repeated |  |
+| tag | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-RenewFileSetRequest"></a>
+
+### RenewFileSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+| ttl_seconds | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-Repo"></a>
+
+### Repo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| type | [string](#string) |  |  |
+| project | [Project](#pfs_v2-Project) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-RepoInfo"></a>
+
+### RepoInfo
+RepoInfo is the main data structure representing a Repo in etcd
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| created | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| size_bytes_upper_bound | [int64](#int64) |  |  |
+| description | [string](#string) |  |  |
+| branches | [Branch](#pfs_v2-Branch) | repeated |  |
+| auth_info | [AuthInfo](#pfs_v2-AuthInfo) |  | Set by ListRepo and InspectRepo if Pachyderm&#39;s auth system is active, but not stored in etcd. To set a user&#39;s auth scope for a repo, use the Pachyderm Auth API (in src/client/auth/auth.proto) |
+| details | [RepoInfo.Details](#pfs_v2-RepoInfo-Details) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-RepoInfo-Details"></a>
+
+### RepoInfo.Details
+Details are only provided when explicitly requested
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| size_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-RunLoadTestRequest"></a>
+
+### RunLoadTestRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spec | [string](#string) |  |  |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+| seed | [int64](#int64) |  |  |
+| state_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-RunLoadTestResponse"></a>
+
+### RunLoadTestResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spec | [string](#string) |  |  |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+| seed | [int64](#int64) |  |  |
+| error | [string](#string) |  |  |
+| duration | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| state_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-SQLDatabaseEgress"></a>
+
+### SQLDatabaseEgress
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| url | [string](#string) |  |  |
+| file_format | [SQLDatabaseEgress.FileFormat](#pfs_v2-SQLDatabaseEgress-FileFormat) |  |  |
+| secret | [SQLDatabaseEgress.Secret](#pfs_v2-SQLDatabaseEgress-Secret) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-SQLDatabaseEgress-FileFormat"></a>
+
+### SQLDatabaseEgress.FileFormat
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [SQLDatabaseEgress.FileFormat.Type](#pfs_v2-SQLDatabaseEgress-FileFormat-Type) |  |  |
+| columns | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="pfs_v2-SQLDatabaseEgress-Secret"></a>
+
+### SQLDatabaseEgress.Secret
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| key | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ShardFileSetRequest"></a>
+
+### ShardFileSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-ShardFileSetResponse"></a>
+
+### ShardFileSetResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| shards | [PathRange](#pfs_v2-PathRange) | repeated |  |
+
+
+
+
+
+
+<a name="pfs_v2-SquashCommitSetRequest"></a>
+
+### SquashCommitSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit_set | [CommitSet](#pfs_v2-CommitSet) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-StartCommitRequest"></a>
+
+### StartCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| parent | [Commit](#pfs_v2-Commit) |  | parent may be empty in which case the commit that Branch points to will be used as the parent. If the branch does not exist, the commit will have no parent. |
+| description | [string](#string) |  | description is a user-provided string describing this commit |
+| branch | [Branch](#pfs_v2-Branch) |  |  |
+
+
+
+
+
+
+<a name="pfs_v2-SubscribeCommitRequest"></a>
+
+### SubscribeCommitRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| repo | [Repo](#pfs_v2-Repo) |  |  |
+| branch | [string](#string) |  |  |
+| from | [Commit](#pfs_v2-Commit) |  | only commits created since this commit are returned |
+| state | [CommitState](#pfs_v2-CommitState) |  | Don&#39;t return commits until they&#39;re in (at least) the desired state. |
+| all | [bool](#bool) |  | Return commits of all kinds (without this, aliases are excluded) |
+| origin_kind | [OriginKind](#pfs_v2-OriginKind) |  | Return only commits of this kind (mutually exclusive with all) |
+
+
+
+
+
+
+<a name="pfs_v2-Trigger"></a>
+
+### Trigger
+Trigger defines the conditions under which a head is moved, and to which
+branch it is moved.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| branch | [string](#string) |  | Which branch this trigger refers to |
+| all | [bool](#bool) |  | All indicates that all conditions must be satisfied before the trigger happens, otherwise any conditions being satisfied will trigger it. |
+| rate_limit_spec | [string](#string) |  | Triggers if the rate limit spec (cron expression) has been satisfied since the last trigger. |
+| size | [string](#string) |  | Triggers if there&#39;s been `size` new data added since the last trigger. |
+| commits | [int64](#int64) |  | Triggers if there&#39;s been `commits` new commits added since the last trigger. |
+| cron_spec | [string](#string) |  | Creates a background process which fires the trigger on the schedule provided by the cron spec. This condition is mutually exclusive with respect to the others, so setting this will result with the trigger only firing based on the cron schedule. |
+
+
+
+
+
+
+<a name="pfs_v2-WalkFileRequest"></a>
+
+### WalkFileRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file | [File](#pfs_v2-File) |  |  |
+| paginationMarker | [File](#pfs_v2-File) |  | Marker for pagination. If set, the files that come after the marker in lexicographical order will be returned. If reverse is also set, the files that come before the marker in lexicographical order will be returned. |
+| number | [int64](#int64) |  | Number of files to return |
+| reverse | [bool](#bool) |  | If true, return files in reverse order |
+
+
+
+
+
+ 
+
+
+<a name="pfs_v2-CommitState"></a>
+
+### CommitState
+CommitState describes the states a commit can be in.
+The states are increasingly specific, i.e. a commit that is FINISHED also counts as STARTED.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| COMMIT_STATE_UNKNOWN | 0 |  |
+| STARTED | 1 | The commit has been started, all commits satisfy this state. |
+| READY | 2 | The commit has been started, and all of its provenant commits have been finished. |
+| FINISHING | 3 | The commit is in the process of being finished. |
+| FINISHED | 4 | The commit has been finished. |
+
+
+
+<a name="pfs_v2-Delimiter"></a>
+
+### Delimiter
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 |  |
+| JSON | 1 |  |
+| LINE | 2 |  |
+| SQL | 3 |  |
+| CSV | 4 |  |
+
+
+
+<a name="pfs_v2-FileType"></a>
+
+### FileType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| RESERVED | 0 |  |
+| FILE | 1 |  |
+| DIR | 2 |  |
+
+
+
+<a name="pfs_v2-OriginKind"></a>
+
+### OriginKind
+These are the different places where a commit may be originated from
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| ORIGIN_KIND_UNKNOWN | 0 |  |
+| USER | 1 |  |
+| AUTO | 2 |  |
+| FSCK | 3 |  |
+
+
+
+<a name="pfs_v2-SQLDatabaseEgress-FileFormat-Type"></a>
+
+### SQLDatabaseEgress.FileFormat.Type
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 |  |
+| CSV | 1 |  |
+| JSON | 2 |  |
+| PARQUET | 3 |  |
+
+
+ 
+
+ 
+
+
+<a name="pfs_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateRepo | [CreateRepoRequest](#pfs_v2-CreateRepoRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | CreateRepo creates a new repo. |
+| InspectRepo | [InspectRepoRequest](#pfs_v2-InspectRepoRequest) | [RepoInfo](#pfs_v2-RepoInfo) | InspectRepo returns info about a repo. |
+| ListRepo | [ListRepoRequest](#pfs_v2-ListRepoRequest) | [RepoInfo](#pfs_v2-RepoInfo) stream | ListRepo returns info about all repos. |
+| DeleteRepo | [DeleteRepoRequest](#pfs_v2-DeleteRepoRequest) | [DeleteRepoResponse](#pfs_v2-DeleteRepoResponse) | DeleteRepo deletes a repo. |
+| DeleteRepos | [DeleteReposRequest](#pfs_v2-DeleteReposRequest) | [DeleteReposResponse](#pfs_v2-DeleteReposResponse) | DeleteRepos deletes more than one repo at once. It attempts to delete every repo matching the DeleteReposRequest. When deleting all repos matching a project, any repos not deletable by the caller will remain, and the project will not be empty; this is not an error. The returned DeleteReposResponse will contain a list of all actually-deleted repos. |
+| StartCommit | [StartCommitRequest](#pfs_v2-StartCommitRequest) | [Commit](#pfs_v2-Commit) | StartCommit creates a new write commit from a parent commit. |
+| FinishCommit | [FinishCommitRequest](#pfs_v2-FinishCommitRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | FinishCommit turns a write commit into a read commit. |
+| ClearCommit | [ClearCommitRequest](#pfs_v2-ClearCommitRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | ClearCommit removes all data from the commit. |
+| InspectCommit | [InspectCommitRequest](#pfs_v2-InspectCommitRequest) | [CommitInfo](#pfs_v2-CommitInfo) | InspectCommit returns the info about a commit. |
+| ListCommit | [ListCommitRequest](#pfs_v2-ListCommitRequest) | [CommitInfo](#pfs_v2-CommitInfo) stream | ListCommit returns info about all commits. |
+| SubscribeCommit | [SubscribeCommitRequest](#pfs_v2-SubscribeCommitRequest) | [CommitInfo](#pfs_v2-CommitInfo) stream | SubscribeCommit subscribes for new commits on a given branch. |
+| InspectCommitSet | [InspectCommitSetRequest](#pfs_v2-InspectCommitSetRequest) | [CommitInfo](#pfs_v2-CommitInfo) stream | InspectCommitSet returns the info about a CommitSet. |
+| ListCommitSet | [ListCommitSetRequest](#pfs_v2-ListCommitSetRequest) | [CommitSetInfo](#pfs_v2-CommitSetInfo) stream | ListCommitSet returns info about all CommitSets. |
+| SquashCommitSet | [SquashCommitSetRequest](#pfs_v2-SquashCommitSetRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | SquashCommitSet squashes the commits of a CommitSet into their children. |
+| DropCommitSet | [DropCommitSetRequest](#pfs_v2-DropCommitSetRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | DropCommitSet drops the commits of a CommitSet and all data included in the commits. |
+| FindCommits | [FindCommitsRequest](#pfs_v2-FindCommitsRequest) | [FindCommitsResponse](#pfs_v2-FindCommitsResponse) stream | FindCommits searches for commits that reference a supplied file being modified in a branch. |
+| CreateBranch | [CreateBranchRequest](#pfs_v2-CreateBranchRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | CreateBranch creates a new branch. |
+| InspectBranch | [InspectBranchRequest](#pfs_v2-InspectBranchRequest) | [BranchInfo](#pfs_v2-BranchInfo) | InspectBranch returns info about a branch. |
+| ListBranch | [ListBranchRequest](#pfs_v2-ListBranchRequest) | [BranchInfo](#pfs_v2-BranchInfo) stream | ListBranch returns info about the heads of branches. |
+| DeleteBranch | [DeleteBranchRequest](#pfs_v2-DeleteBranchRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | DeleteBranch deletes a branch; note that the commits still exist. |
+| ModifyFile | [ModifyFileRequest](#pfs_v2-ModifyFileRequest) stream | [.google.protobuf.Empty](#google-protobuf-Empty) | ModifyFile performs modifications on a set of files. |
+| GetFile | [GetFileRequest](#pfs_v2-GetFileRequest) | [.google.protobuf.BytesValue](#google-protobuf-BytesValue) stream | GetFile returns the contents of a single file |
+| GetFileTAR | [GetFileRequest](#pfs_v2-GetFileRequest) | [.google.protobuf.BytesValue](#google-protobuf-BytesValue) stream | GetFileTAR returns a TAR stream of the contents matched by the request |
+| InspectFile | [InspectFileRequest](#pfs_v2-InspectFileRequest) | [FileInfo](#pfs_v2-FileInfo) | InspectFile returns info about a file. |
+| ListFile | [ListFileRequest](#pfs_v2-ListFileRequest) | [FileInfo](#pfs_v2-FileInfo) stream | ListFile returns info about all files. |
+| WalkFile | [WalkFileRequest](#pfs_v2-WalkFileRequest) | [FileInfo](#pfs_v2-FileInfo) stream | WalkFile walks over all the files under a directory, including children of children. |
+| GlobFile | [GlobFileRequest](#pfs_v2-GlobFileRequest) | [FileInfo](#pfs_v2-FileInfo) stream | GlobFile returns info about all files. |
+| DiffFile | [DiffFileRequest](#pfs_v2-DiffFileRequest) | [DiffFileResponse](#pfs_v2-DiffFileResponse) stream | DiffFile returns the differences between 2 paths at 2 commits. |
+| ActivateAuth | [ActivateAuthRequest](#pfs_v2-ActivateAuthRequest) | [ActivateAuthResponse](#pfs_v2-ActivateAuthResponse) | ActivateAuth creates a role binding for all existing repos |
+| DeleteAll | [.google.protobuf.Empty](#google-protobuf-Empty) | [.google.protobuf.Empty](#google-protobuf-Empty) | DeleteAll deletes everything. |
+| Fsck | [FsckRequest](#pfs_v2-FsckRequest) | [FsckResponse](#pfs_v2-FsckResponse) stream | Fsck does a file system consistency check for pfs. |
+| CreateFileSet | [ModifyFileRequest](#pfs_v2-ModifyFileRequest) stream | [CreateFileSetResponse](#pfs_v2-CreateFileSetResponse) | FileSet API CreateFileSet creates a new file set. |
+| GetFileSet | [GetFileSetRequest](#pfs_v2-GetFileSetRequest) | [CreateFileSetResponse](#pfs_v2-CreateFileSetResponse) | GetFileSet returns a file set with the data from a commit |
+| AddFileSet | [AddFileSetRequest](#pfs_v2-AddFileSetRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | AddFileSet associates a file set with a commit |
+| RenewFileSet | [RenewFileSetRequest](#pfs_v2-RenewFileSetRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | RenewFileSet prevents a file set from being deleted for a set amount of time. |
+| ComposeFileSet | [ComposeFileSetRequest](#pfs_v2-ComposeFileSetRequest) | [CreateFileSetResponse](#pfs_v2-CreateFileSetResponse) | ComposeFileSet composes a file set from a list of file sets. |
+| ShardFileSet | [ShardFileSetRequest](#pfs_v2-ShardFileSetRequest) | [ShardFileSetResponse](#pfs_v2-ShardFileSetResponse) |  |
+| CheckStorage | [CheckStorageRequest](#pfs_v2-CheckStorageRequest) | [CheckStorageResponse](#pfs_v2-CheckStorageResponse) | CheckStorage runs integrity checks for the storage layer. |
+| PutCache | [PutCacheRequest](#pfs_v2-PutCacheRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| GetCache | [GetCacheRequest](#pfs_v2-GetCacheRequest) | [GetCacheResponse](#pfs_v2-GetCacheResponse) |  |
+| ClearCache | [ClearCacheRequest](#pfs_v2-ClearCacheRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| RunLoadTest | [RunLoadTestRequest](#pfs_v2-RunLoadTestRequest) | [RunLoadTestResponse](#pfs_v2-RunLoadTestResponse) | RunLoadTest runs a load test. |
+| RunLoadTestDefault | [.google.protobuf.Empty](#google-protobuf-Empty) | [RunLoadTestResponse](#pfs_v2-RunLoadTestResponse) | RunLoadTestDefault runs the default load tests. |
+| ListTask | [.taskapi.ListTaskRequest](#taskapi-ListTaskRequest) | [.taskapi.TaskInfo](#taskapi-TaskInfo) stream | ListTask lists PFS tasks |
+| Egress | [EgressRequest](#pfs_v2-EgressRequest) | [EgressResponse](#pfs_v2-EgressResponse) | Egress writes data from a commit to an external system |
+| CreateProject | [CreateProjectRequest](#pfs_v2-CreateProjectRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | Project API CreateProject creates a new project. |
+| InspectProject | [InspectProjectRequest](#pfs_v2-InspectProjectRequest) | [ProjectInfo](#pfs_v2-ProjectInfo) | InspectProject returns info about a project. |
+| ListProject | [ListProjectRequest](#pfs_v2-ListProjectRequest) | [ProjectInfo](#pfs_v2-ProjectInfo) stream | ListProject returns info about all projects. |
+| DeleteProject | [DeleteProjectRequest](#pfs_v2-DeleteProjectRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | DeleteProject deletes a project. |
+
+ 
+
+
+
+<a name="pps_pps-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## pps/pps.proto
+
+
+
+<a name="pps_v2-ActivateAuthRequest"></a>
+
+### ActivateAuthRequest
+
+
+
+
+
+
+
+<a name="pps_v2-ActivateAuthResponse"></a>
+
+### ActivateAuthResponse
+
+
+
+
+
+
+
+<a name="pps_v2-Aggregate"></a>
+
+### Aggregate
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| count | [int64](#int64) |  |  |
+| mean | [double](#double) |  |  |
+| stddev | [double](#double) |  |  |
+| fifth_percentile | [double](#double) |  |  |
+| ninety_fifth_percentile | [double](#double) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-AggregateProcessStats"></a>
+
+### AggregateProcessStats
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| download_time | [Aggregate](#pps_v2-Aggregate) |  |  |
+| process_time | [Aggregate](#pps_v2-Aggregate) |  |  |
+| upload_time | [Aggregate](#pps_v2-Aggregate) |  |  |
+| download_bytes | [Aggregate](#pps_v2-Aggregate) |  |  |
+| upload_bytes | [Aggregate](#pps_v2-Aggregate) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-ClusterDefaults"></a>
+
+### ClusterDefaults
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| create_pipeline_request | [CreatePipelineRequest](#pps_v2-CreatePipelineRequest) |  | CreatePipelineRequest contains the default JSON CreatePipelineRequest into which pipeline specs are merged to form the effective spec used to create a pipeline. |
+
+
+
+
+
+
+<a name="pps_v2-CreatePipelineRequest"></a>
+
+### CreatePipelineRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| tf_job | [TFJob](#pps_v2-TFJob) |  | tf_job encodes a Kubeflow TFJob spec. Pachyderm uses this to create TFJobs when running in a kubernetes cluster on which kubeflow has been installed. Exactly one of &#39;tf_job&#39; and &#39;transform&#39; should be set |
+| transform | [Transform](#pps_v2-Transform) |  |  |
+| parallelism_spec | [ParallelismSpec](#pps_v2-ParallelismSpec) |  |  |
+| egress | [Egress](#pps_v2-Egress) |  |  |
+| update | [bool](#bool) |  |  |
+| output_branch | [string](#string) |  |  |
+| s3_out | [bool](#bool) |  | s3_out, if set, requires a pipeline&#39;s user to write to its output repo via Pachyderm&#39;s s3 gateway (if set, workers will serve Pachyderm&#39;s s3 gateway API at http://&lt;pipeline&gt;-s3.&lt;namespace&gt;/&lt;job id&gt;.out/my/file). In this mode /pfs_v2/out won&#39;t be walked or uploaded, and the s3 gateway service in the workers will allow writes to the job&#39;s output commit |
+| resource_requests | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| resource_limits | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| sidecar_resource_limits | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| input | [Input](#pps_v2-Input) |  |  |
+| description | [string](#string) |  |  |
+| reprocess | [bool](#bool) |  | Reprocess forces the pipeline to reprocess all datums. It only has meaning if Update is true |
+| service | [Service](#pps_v2-Service) |  |  |
+| spout | [Spout](#pps_v2-Spout) |  |  |
+| datum_set_spec | [DatumSetSpec](#pps_v2-DatumSetSpec) |  |  |
+| datum_timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| job_timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| salt | [string](#string) |  |  |
+| datum_tries | [int64](#int64) |  |  |
+| scheduling_spec | [SchedulingSpec](#pps_v2-SchedulingSpec) |  |  |
+| pod_spec | [string](#string) |  | deprecated, use pod_patch below |
+| pod_patch | [string](#string) |  | a json patch will be applied to the pipeline&#39;s pod_spec before it&#39;s created; |
+| spec_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| metadata | [Metadata](#pps_v2-Metadata) |  |  |
+| reprocess_spec | [string](#string) |  |  |
+| autoscaling | [bool](#bool) |  |  |
+| tolerations | [Toleration](#pps_v2-Toleration) | repeated |  |
+| sidecar_resource_requests | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| dry_run | [bool](#bool) |  |  |
+| determined | [Determined](#pps_v2-Determined) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-CreatePipelineTransaction"></a>
+
+### CreatePipelineTransaction
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| create_pipeline_request | [CreatePipelineRequest](#pps_v2-CreatePipelineRequest) |  |  |
+| user_json | [string](#string) |  | the JSON the user originally submitted |
+| effective_json | [string](#string) |  | the effective spec: the result of merging the user JSON into the cluster defaults |
+
+
+
+
+
+
+<a name="pps_v2-CreatePipelineV2Request"></a>
+
+### CreatePipelineV2Request
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| create_pipeline_request_json | [string](#string) |  | a JSON-encoded CreatePipelineRequest |
+| dry_run | [bool](#bool) |  |  |
+| update | [bool](#bool) |  |  |
+| reprocess | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-CreatePipelineV2Response"></a>
+
+### CreatePipelineV2Response
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| effective_create_pipeline_request_json | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-CreateSecretRequest"></a>
+
+### CreateSecretRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-CronInput"></a>
+
+### CronInput
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| project | [string](#string) |  |  |
+| repo | [string](#string) |  |  |
+| commit | [string](#string) |  |  |
+| spec | [string](#string) |  |  |
+| overwrite | [bool](#bool) |  | Overwrite, if true, will expose a single datum that gets overwritten each tick. If false, it will create a new datum for each tick. |
+| start | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Datum"></a>
+
+### Datum
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  | ID is the hash computed from all the files |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-DatumInfo"></a>
+
+### DatumInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| datum | [Datum](#pps_v2-Datum) |  |  |
+| state | [DatumState](#pps_v2-DatumState) |  |  |
+| stats | [ProcessStats](#pps_v2-ProcessStats) |  |  |
+| pfs_state | [pfs_v2.File](#pfs_v2-File) |  |  |
+| data | [pfs_v2.FileInfo](#pfs_v2-FileInfo) | repeated |  |
+| image_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-DatumSetSpec"></a>
+
+### DatumSetSpec
+DatumSetSpec specifies how a pipeline should split its datums into datum sets.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [int64](#int64) |  | number, if nonzero, specifies that each datum set should contain `number` datums. Datum sets may contain fewer if the total number of datums don&#39;t divide evenly. |
+| size_bytes | [int64](#int64) |  | size_bytes, if nonzero, specifies a target size for each datum set. Datum sets may be larger or smaller than size_bytes, but will usually be pretty close to size_bytes in size. |
+| per_worker | [int64](#int64) |  | per_worker, if nonzero, specifies how many datum sets should be created for each worker. It can&#39;t be set with number or size_bytes. |
+
+
+
+
+
+
+<a name="pps_v2-DatumStatus"></a>
+
+### DatumStatus
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| started | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Started is the time processing on the current datum began. |
+| data | [InputFile](#pps_v2-InputFile) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-DeleteJobRequest"></a>
+
+### DeleteJobRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-DeletePipelineRequest"></a>
+
+### DeletePipelineRequest
+Delete a pipeline.  If the deprecated all member is true, then delete all
+pipelines in the default project.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| all | [bool](#bool) |  | **Deprecated.** Deprecated. |
+| force | [bool](#bool) |  |  |
+| keep_repo | [bool](#bool) |  |  |
+| must_exist | [bool](#bool) |  | If true, an error will be returned if the pipeline doesn&#39;t exist. |
+
+
+
+
+
+
+<a name="pps_v2-DeletePipelinesRequest"></a>
+
+### DeletePipelinesRequest
+Delete more than one pipeline.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| projects | [pfs_v2.Project](#pfs_v2-Project) | repeated | All pipelines in each project will be deleted if the caller has permission. |
+| force | [bool](#bool) |  |  |
+| keep_repo | [bool](#bool) |  |  |
+| all | [bool](#bool) |  | If set, all pipelines in all projects will be deleted if the caller has permission. |
+
+
+
+
+
+
+<a name="pps_v2-DeletePipelinesResponse"></a>
+
+### DeletePipelinesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipelines | [Pipeline](#pps_v2-Pipeline) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-DeleteSecretRequest"></a>
+
+### DeleteSecretRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| secret | [Secret](#pps_v2-Secret) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Determined"></a>
+
+### Determined
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspaces | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-Egress"></a>
+
+### Egress
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| URL | [string](#string) |  |  |
+| object_storage | [pfs_v2.ObjectStorageEgress](#pfs_v2-ObjectStorageEgress) |  |  |
+| sql_database | [pfs_v2.SQLDatabaseEgress](#pfs_v2-SQLDatabaseEgress) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-GPUSpec"></a>
+
+### GPUSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [string](#string) |  | The type of GPU (nvidia.com/gpu or amd.com/gpu for example). |
+| number | [int64](#int64) |  | The number of GPUs to request. |
+
+
+
+
+
+
+<a name="pps_v2-GetClusterDefaultsRequest"></a>
+
+### GetClusterDefaultsRequest
+
+
+
+
+
+
+
+<a name="pps_v2-GetClusterDefaultsResponse"></a>
+
+### GetClusterDefaultsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| cluster_defaults_json | [string](#string) |  | A JSON-encoded ClusterDefaults message, this is the verbatim input passed to SetClusterDefaults. |
+
+
+
+
+
+
+<a name="pps_v2-GetLogsRequest"></a>
+
+### GetLogsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  | The pipeline from which we want to get logs (required if the job in &#39;job&#39; was created as part of a pipeline. To get logs from a non-orphan job without the pipeline that created it, you need to use ElasticSearch). |
+| job | [Job](#pps_v2-Job) |  | The job from which we want to get logs. |
+| data_filters | [string](#string) | repeated | Names of input files from which we want processing logs. This may contain multiple files, to query pipelines that contain multiple inputs. Each filter may be an absolute path of a file within a pps repo, or it may be a hash for that file (to search for files at specific versions) |
+| datum | [Datum](#pps_v2-Datum) |  |  |
+| master | [bool](#bool) |  | If true get logs from the master process |
+| follow | [bool](#bool) |  | Continue to follow new logs as they become available. |
+| tail | [int64](#int64) |  | If nonzero, the number of lines from the end of the logs to return. Note: tail applies per container, so you will get tail * &lt;number of pods&gt; total lines back. |
+| use_loki_backend | [bool](#bool) |  | UseLokiBackend causes the logs request to go through the loki backend rather than through kubernetes. This behavior can also be achieved by setting the LOKI_LOGGING feature flag. |
+| since | [google.protobuf.Duration](#google-protobuf-Duration) |  | Since specifies how far in the past to return logs from. It defaults to 24 hours. |
+
+
+
+
+
+
+<a name="pps_v2-Input"></a>
+
+### Input
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pfs | [PFSInput](#pps_v2-PFSInput) |  |  |
+| join | [Input](#pps_v2-Input) | repeated |  |
+| group | [Input](#pps_v2-Input) | repeated |  |
+| cross | [Input](#pps_v2-Input) | repeated |  |
+| union | [Input](#pps_v2-Input) | repeated |  |
+| cron | [CronInput](#pps_v2-CronInput) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-InputFile"></a>
+
+### InputFile
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| path | [string](#string) |  | This file&#39;s absolute path within its pfs repo. |
+| hash | [bytes](#bytes) |  | This file&#39;s hash |
+
+
+
+
+
+
+<a name="pps_v2-InspectDatumRequest"></a>
+
+### InspectDatumRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| datum | [Datum](#pps_v2-Datum) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-InspectJobRequest"></a>
+
+### InspectJobRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  | Callers should set either Job or OutputCommit, not both. |
+| wait | [bool](#bool) |  | wait until state is either FAILURE or SUCCESS |
+| details | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-InspectJobSetRequest"></a>
+
+### InspectJobSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job_set | [JobSet](#pps_v2-JobSet) |  |  |
+| wait | [bool](#bool) |  | When true, wait until all jobs in the set are finished |
+| details | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-InspectPipelineRequest"></a>
+
+### InspectPipelineRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| details | [bool](#bool) |  | When true, return PipelineInfos with the details field, which requires loading the pipeline spec from PFS. |
+
+
+
+
+
+
+<a name="pps_v2-InspectSecretRequest"></a>
+
+### InspectSecretRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| secret | [Secret](#pps_v2-Secret) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Job"></a>
+
+### Job
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-JobInfo"></a>
+
+### JobInfo
+JobInfo is the data stored in the database regarding a given job.  The
+&#39;details&#39; field contains more information about the job which is expensive to
+fetch, requiring querying workers or loading the pipeline spec from object
+storage.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  |  |
+| pipeline_version | [uint64](#uint64) |  |  |
+| output_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| restart | [uint64](#uint64) |  | Job restart count (e.g. due to datum failure) |
+| data_processed | [int64](#int64) |  | Counts of how many times we processed or skipped a datum |
+| data_skipped | [int64](#int64) |  |  |
+| data_total | [int64](#int64) |  |  |
+| data_failed | [int64](#int64) |  |  |
+| data_recovered | [int64](#int64) |  |  |
+| stats | [ProcessStats](#pps_v2-ProcessStats) |  | Download/process/upload time and download/upload bytes |
+| state | [JobState](#pps_v2-JobState) |  |  |
+| reason | [string](#string) |  | reason explains why the job is in the current state |
+| created | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| started | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| finished | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| details | [JobInfo.Details](#pps_v2-JobInfo-Details) |  |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-JobInfo-Details"></a>
+
+### JobInfo.Details
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transform | [Transform](#pps_v2-Transform) |  |  |
+| parallelism_spec | [ParallelismSpec](#pps_v2-ParallelismSpec) |  |  |
+| egress | [Egress](#pps_v2-Egress) |  |  |
+| service | [Service](#pps_v2-Service) |  |  |
+| spout | [Spout](#pps_v2-Spout) |  |  |
+| worker_status | [WorkerStatus](#pps_v2-WorkerStatus) | repeated |  |
+| resource_requests | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| resource_limits | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| sidecar_resource_limits | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| input | [Input](#pps_v2-Input) |  |  |
+| salt | [string](#string) |  |  |
+| datum_set_spec | [DatumSetSpec](#pps_v2-DatumSetSpec) |  |  |
+| datum_timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| job_timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| datum_tries | [int64](#int64) |  |  |
+| scheduling_spec | [SchedulingSpec](#pps_v2-SchedulingSpec) |  |  |
+| pod_spec | [string](#string) |  |  |
+| pod_patch | [string](#string) |  |  |
+| sidecar_resource_requests | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-JobInput"></a>
+
+### JobInput
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| glob | [string](#string) |  |  |
+| lazy | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-JobSet"></a>
+
+### JobSet
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-JobSetInfo"></a>
+
+### JobSetInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job_set | [JobSet](#pps_v2-JobSet) |  |  |
+| jobs | [JobInfo](#pps_v2-JobInfo) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-ListDatumRequest"></a>
+
+### ListDatumRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  | Job and Input are two different ways to specify the datums you want. Only one can be set. Job is the job to list datums from. |
+| input | [Input](#pps_v2-Input) |  | Input is the input to list datums from. The datums listed are the ones that would be run if a pipeline was created with the provided input. |
+| filter | [ListDatumRequest.Filter](#pps_v2-ListDatumRequest-Filter) |  |  |
+| paginationMarker | [string](#string) |  | datum id to start from. we do not include this datum in the response |
+| number | [int64](#int64) |  | Number of datums to return |
+| reverse | [bool](#bool) |  | If true, return datums in reverse order |
+
+
+
+
+
+
+<a name="pps_v2-ListDatumRequest-Filter"></a>
+
+### ListDatumRequest.Filter
+Filter restricts returned DatumInfo messages to those which match
+all of the filtered attributes.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| state | [DatumState](#pps_v2-DatumState) | repeated | Must match one of the given states. |
+
+
+
+
+
+
+<a name="pps_v2-ListJobRequest"></a>
+
+### ListJobRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| projects | [pfs_v2.Project](#pfs_v2-Project) | repeated | A list of projects to filter jobs on, nil means don&#39;t filter. |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  | nil means all pipelines |
+| input_commit | [pfs_v2.Commit](#pfs_v2-Commit) | repeated | nil means all inputs |
+| history | [int64](#int64) |  | History indicates return jobs from historical versions of pipelines semantics are: 0: Return jobs from the current version of the pipeline or pipelines. 1: Return the above and jobs from the next most recent version 2: etc. -1: Return jobs from all historical versions. |
+| details | [bool](#bool) |  | Details indicates whether the result should include all pipeline details in each JobInfo, or limited information including name and status, but excluding information in the pipeline spec. Leaving this &#34;false&#34; can make the call significantly faster in clusters with a large number of pipelines and jobs. Note that if &#39;input_commit&#39; is set, this field is coerced to &#34;true&#34; |
+| jqFilter | [string](#string) |  | A jq program string for additional result filtering |
+| paginationMarker | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | timestamp that is pagination marker |
+| number | [int64](#int64) |  | number of results to return |
+| reverse | [bool](#bool) |  | flag to indicated if results should be returned in reverse order |
+
+
+
+
+
+
+<a name="pps_v2-ListJobSetRequest"></a>
+
+### ListJobSetRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| details | [bool](#bool) |  |  |
+| projects | [pfs_v2.Project](#pfs_v2-Project) | repeated | A list of projects to filter jobs on, nil means don&#39;t filter. |
+| paginationMarker | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | we return job sets created before or after this time based on the reverse flag |
+| number | [int64](#int64) |  | number of results to return |
+| reverse | [bool](#bool) |  | if true, return results in reverse order |
+| jqFilter | [string](#string) |  | A jq program string for additional result filtering |
+
+
+
+
+
+
+<a name="pps_v2-ListPipelineRequest"></a>
+
+### ListPipelineRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  | If non-nil, only return info about a single pipeline, this is redundant with InspectPipeline unless history is non-zero. |
+| history | [int64](#int64) |  | History indicates how many historical versions you want returned. Its semantics are: 0: Return the current version of the pipeline or pipelines. 1: Return the above and the next most recent version 2: etc. -1: Return all historical versions. |
+| details | [bool](#bool) |  | When true, return PipelineInfos with the details field, which requires loading the pipeline spec from PFS. |
+| jqFilter | [string](#string) |  | A jq program string for additional result filtering |
+| commit_set | [pfs_v2.CommitSet](#pfs_v2-CommitSet) |  | If non-nil, will return all the pipeline infos at this commit set |
+| projects | [pfs_v2.Project](#pfs_v2-Project) | repeated | Projects to filter on. Empty list means no filter, so return all pipelines. |
+
+
+
+
+
+
+<a name="pps_v2-LogMessage"></a>
+
+### LogMessage
+LogMessage is a log line from a PPS worker, annotated with metadata
+indicating when and why the line was logged.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_name | [string](#string) |  | The job and pipeline for which a PFS file is being processed (if the job is an orphan job, pipeline name and ID will be unset) |
+| pipeline_name | [string](#string) |  |  |
+| job_id | [string](#string) |  |  |
+| worker_id | [string](#string) |  |  |
+| datum_id | [string](#string) |  |  |
+| master | [bool](#bool) |  |  |
+| data | [InputFile](#pps_v2-InputFile) | repeated | The PFS files being processed (one per pipeline/job input) |
+| user | [bool](#bool) |  | User is true if log message comes from the users code. |
+| ts | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | The message logged, and the time at which it was logged |
+| message | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-LokiLogMessage"></a>
+
+### LokiLogMessage
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| message | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-LokiRequest"></a>
+
+### LokiRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| since | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| query | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Metadata"></a>
+
+### Metadata
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| annotations | [Metadata.AnnotationsEntry](#pps_v2-Metadata-AnnotationsEntry) | repeated |  |
+| labels | [Metadata.LabelsEntry](#pps_v2-Metadata-LabelsEntry) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-Metadata-AnnotationsEntry"></a>
+
+### Metadata.AnnotationsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Metadata-LabelsEntry"></a>
+
+### Metadata.LabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-PFSInput"></a>
+
+### PFSInput
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [string](#string) |  |  |
+| name | [string](#string) |  |  |
+| repo | [string](#string) |  |  |
+| repo_type | [string](#string) |  |  |
+| branch | [string](#string) |  |  |
+| commit | [string](#string) |  |  |
+| glob | [string](#string) |  |  |
+| join_on | [string](#string) |  |  |
+| outer_join | [bool](#bool) |  |  |
+| group_by | [string](#string) |  |  |
+| lazy | [bool](#bool) |  |  |
+| empty_files | [bool](#bool) |  | EmptyFiles, if true, will cause files from this PFS input to be presented as empty files. This is useful in shuffle pipelines where you want to read the names of files and reorganize them using symlinks. |
+| s3 | [bool](#bool) |  | S3, if true, will cause the worker to NOT download or link files from this input into the /pfs_v2 directory. Instead, an instance of our S3 gateway service will run on each of the sidecars, and data can be retrieved from this input by querying http://&lt;pipeline&gt;-s3.&lt;namespace&gt;/&lt;job id&gt;.&lt;input&gt;/my/file |
+| trigger | [pfs_v2.Trigger](#pfs_v2-Trigger) |  | Trigger defines when this input is processed by the pipeline, if it&#39;s nil the input is processed anytime something is committed to the input branch. |
+
+
+
+
+
+
+<a name="pps_v2-ParallelismSpec"></a>
+
+### ParallelismSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| constant | [uint64](#uint64) |  | Starts the pipeline/job with a &#39;constant&#39; workers, unless &#39;constant&#39; is zero. If &#39;constant&#39; is zero (which is the zero value of ParallelismSpec), then Pachyderm will choose the number of workers that is started, (currently it chooses the number of workers in the cluster) |
+
+
+
+
+
+
+<a name="pps_v2-Pipeline"></a>
+
+### Pipeline
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [pfs_v2.Project](#pfs_v2-Project) |  |  |
+| name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-PipelineInfo"></a>
+
+### PipelineInfo
+PipelineInfo is proto for each pipeline that Pachd stores in the
+database. It tracks the state of the pipeline, and points to its metadata in
+PFS (and, by pointing to a PFS commit, de facto tracks the pipeline&#39;s
+version).  Any information about the pipeline _not_ stored in the database is
+in the Details object, which requires fetching the spec from PFS or other
+potentially expensive operations.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| version | [uint64](#uint64) |  |  |
+| spec_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  | The first spec commit for this version of the pipeline |
+| stopped | [bool](#bool) |  |  |
+| state | [PipelineState](#pps_v2-PipelineState) |  | state indicates the current state of the pipeline |
+| reason | [string](#string) |  | reason includes any error messages associated with a failed pipeline |
+| last_job_state | [JobState](#pps_v2-JobState) |  | last_job_state indicates the state of the most recently created job |
+| parallelism | [uint64](#uint64) |  | parallelism tracks the literal number of workers that this pipeline should run. |
+| type | [PipelineInfo.PipelineType](#pps_v2-PipelineInfo-PipelineType) |  |  |
+| auth_token | [string](#string) |  |  |
+| details | [PipelineInfo.Details](#pps_v2-PipelineInfo-Details) |  |  |
+| user_spec_json | [string](#string) |  | The user-submitted pipeline spec in JSON format. |
+| effective_spec_json | [string](#string) |  | The effective spec used to create the pipeline. Created by merging the user spec into the cluster defaults. |
+
+
+
+
+
+
+<a name="pps_v2-PipelineInfo-Details"></a>
+
+### PipelineInfo.Details
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transform | [Transform](#pps_v2-Transform) |  |  |
+| tf_job | [TFJob](#pps_v2-TFJob) |  | tf_job encodes a Kubeflow TFJob spec. Pachyderm uses this to create TFJobs when running in a kubernetes cluster on which kubeflow has been installed. Exactly one of &#39;tf_job&#39; and &#39;transform&#39; should be set |
+| parallelism_spec | [ParallelismSpec](#pps_v2-ParallelismSpec) |  |  |
+| egress | [Egress](#pps_v2-Egress) |  |  |
+| created_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| recent_error | [string](#string) |  |  |
+| workers_requested | [int64](#int64) |  |  |
+| workers_available | [int64](#int64) |  |  |
+| output_branch | [string](#string) |  |  |
+| resource_requests | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| resource_limits | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| sidecar_resource_limits | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| input | [Input](#pps_v2-Input) |  |  |
+| description | [string](#string) |  |  |
+| salt | [string](#string) |  |  |
+| reason | [string](#string) |  |  |
+| service | [Service](#pps_v2-Service) |  |  |
+| spout | [Spout](#pps_v2-Spout) |  |  |
+| datum_set_spec | [DatumSetSpec](#pps_v2-DatumSetSpec) |  |  |
+| datum_timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| job_timeout | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| datum_tries | [int64](#int64) |  |  |
+| scheduling_spec | [SchedulingSpec](#pps_v2-SchedulingSpec) |  |  |
+| pod_spec | [string](#string) |  |  |
+| pod_patch | [string](#string) |  |  |
+| s3_out | [bool](#bool) |  |  |
+| metadata | [Metadata](#pps_v2-Metadata) |  |  |
+| reprocess_spec | [string](#string) |  |  |
+| unclaimed_tasks | [int64](#int64) |  |  |
+| worker_rc | [string](#string) |  |  |
+| autoscaling | [bool](#bool) |  |  |
+| tolerations | [Toleration](#pps_v2-Toleration) | repeated |  |
+| sidecar_resource_requests | [ResourceSpec](#pps_v2-ResourceSpec) |  |  |
+| determined | [Determined](#pps_v2-Determined) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-PipelineInfos"></a>
+
+### PipelineInfos
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline_info | [PipelineInfo](#pps_v2-PipelineInfo) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-ProcessStats"></a>
+
+### ProcessStats
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| download_time | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| process_time | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| upload_time | [google.protobuf.Duration](#google-protobuf-Duration) |  |  |
+| download_bytes | [int64](#int64) |  |  |
+| upload_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-RenderTemplateRequest"></a>
+
+### RenderTemplateRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| template | [string](#string) |  |  |
+| args | [RenderTemplateRequest.ArgsEntry](#pps_v2-RenderTemplateRequest-ArgsEntry) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-RenderTemplateRequest-ArgsEntry"></a>
+
+### RenderTemplateRequest.ArgsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-RenderTemplateResponse"></a>
+
+### RenderTemplateResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| json | [string](#string) |  |  |
+| specs | [CreatePipelineRequest](#pps_v2-CreatePipelineRequest) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-ResourceSpec"></a>
+
+### ResourceSpec
+ResourceSpec describes the amount of resources that pipeline pods should
+request from kubernetes, for scheduling.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| cpu | [float](#float) |  | The number of CPUs each worker needs (partial values are allowed, and encouraged) |
+| memory | [string](#string) |  | The amount of memory each worker needs (in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc). |
+| gpu | [GPUSpec](#pps_v2-GPUSpec) |  | The spec for GPU resources. |
+| disk | [string](#string) |  | The amount of ephemeral storage each worker needs (in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc). |
+
+
+
+
+
+
+<a name="pps_v2-RestartDatumRequest"></a>
+
+### RestartDatumRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  |  |
+| data_filters | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-RunCronRequest"></a>
+
+### RunCronRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-RunLoadTestRequest"></a>
+
+### RunLoadTestRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| dag_spec | [string](#string) |  |  |
+| load_spec | [string](#string) |  |  |
+| seed | [int64](#int64) |  |  |
+| parallelism | [int64](#int64) |  |  |
+| pod_patch | [string](#string) |  |  |
+| state_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-RunLoadTestResponse"></a>
+
+### RunLoadTestResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| error | [string](#string) |  |  |
+| state_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-RunPipelineRequest"></a>
+
+### RunPipelineRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| provenance | [pfs_v2.Commit](#pfs_v2-Commit) | repeated |  |
+| job_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-SchedulingSpec"></a>
+
+### SchedulingSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_selector | [SchedulingSpec.NodeSelectorEntry](#pps_v2-SchedulingSpec-NodeSelectorEntry) | repeated |  |
+| priority_class_name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-SchedulingSpec-NodeSelectorEntry"></a>
+
+### SchedulingSpec.NodeSelectorEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Secret"></a>
+
+### Secret
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-SecretInfo"></a>
+
+### SecretInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| secret | [Secret](#pps_v2-Secret) |  |  |
+| type | [string](#string) |  |  |
+| creation_timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-SecretInfos"></a>
+
+### SecretInfos
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| secret_info | [SecretInfo](#pps_v2-SecretInfo) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-SecretMount"></a>
+
+### SecretMount
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Name must be the name of the secret in kubernetes. |
+| key | [string](#string) |  | Key of the secret to load into env_var, this field only has meaning if EnvVar != &#34;&#34;. |
+| mount_path | [string](#string) |  |  |
+| env_var | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Service"></a>
+
+### Service
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| internal_port | [int32](#int32) |  |  |
+| external_port | [int32](#int32) |  |  |
+| ip | [string](#string) |  |  |
+| type | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-SetClusterDefaultsRequest"></a>
+
+### SetClusterDefaultsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| regenerate | [bool](#bool) |  |  |
+| reprocess | [bool](#bool) |  | must be false if regenerate is false |
+| dry_run | [bool](#bool) |  |  |
+| cluster_defaults_json | [string](#string) |  | A JSON-encoded ClusterDefaults message, this will be stored verbatim. |
+
+
+
+
+
+
+<a name="pps_v2-SetClusterDefaultsResponse"></a>
+
+### SetClusterDefaultsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| affected_pipelines | [Pipeline](#pps_v2-Pipeline) | repeated |  |
+
+
+
+
+
+
+<a name="pps_v2-Spout"></a>
+
+### Spout
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| service | [Service](#pps_v2-Service) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-StartPipelineRequest"></a>
+
+### StartPipelineRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-StopJobRequest"></a>
+
+### StopJobRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  |  |
+| reason | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-StopPipelineRequest"></a>
+
+### StopPipelineRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| must_exist | [bool](#bool) |  | If true, an error will be returned if the pipeline doesn&#39;t exist. |
+
+
+
+
+
+
+<a name="pps_v2-SubscribeJobRequest"></a>
+
+### SubscribeJobRequest
+Streams open jobs until canceled
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [Pipeline](#pps_v2-Pipeline) |  |  |
+| details | [bool](#bool) |  | Same as ListJobRequest.Details |
+
+
+
+
+
+
+<a name="pps_v2-TFJob"></a>
+
+### TFJob
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| tf_job | [string](#string) |  | tf_job is a serialized Kubeflow TFJob spec. Pachyderm sends this directly to a kubernetes cluster on which kubeflow has been installed, instead of creating a pipeline ReplicationController as it normally would. |
+
+
+
+
+
+
+<a name="pps_v2-Toleration"></a>
+
+### Toleration
+Toleration is a Kubernetes toleration.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  | key is the taint key that the toleration applies to. Empty means match all taint keys. |
+| operator | [TolerationOperator](#pps_v2-TolerationOperator) |  | operator represents a key&#39;s relationship to the value. |
+| value | [string](#string) |  | value is the taint value the toleration matches to. |
+| effect | [TaintEffect](#pps_v2-TaintEffect) |  | effect indicates the taint effect to match. Empty means match all taint effects. |
+| toleration_seconds | [google.protobuf.Int64Value](#google-protobuf-Int64Value) |  | toleration_seconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. If not set, tolerate the taint forever. |
+
+
+
+
+
+
+<a name="pps_v2-Transform"></a>
+
+### Transform
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| image | [string](#string) |  |  |
+| cmd | [string](#string) | repeated |  |
+| err_cmd | [string](#string) | repeated |  |
+| env | [Transform.EnvEntry](#pps_v2-Transform-EnvEntry) | repeated |  |
+| secrets | [SecretMount](#pps_v2-SecretMount) | repeated |  |
+| image_pull_secrets | [string](#string) | repeated |  |
+| stdin | [string](#string) | repeated |  |
+| err_stdin | [string](#string) | repeated |  |
+| accept_return_code | [int64](#int64) | repeated |  |
+| debug | [bool](#bool) |  |  |
+| user | [string](#string) |  |  |
+| working_dir | [string](#string) |  |  |
+| dockerfile | [string](#string) |  |  |
+| memory_volume | [bool](#bool) |  |  |
+| datum_batching | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Transform-EnvEntry"></a>
+
+### Transform.EnvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-UpdateJobStateRequest"></a>
+
+### UpdateJobStateRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [Job](#pps_v2-Job) |  |  |
+| state | [JobState](#pps_v2-JobState) |  |  |
+| reason | [string](#string) |  |  |
+| restart | [uint64](#uint64) |  |  |
+| data_processed | [int64](#int64) |  |  |
+| data_skipped | [int64](#int64) |  |  |
+| data_failed | [int64](#int64) |  |  |
+| data_recovered | [int64](#int64) |  |  |
+| data_total | [int64](#int64) |  |  |
+| stats | [ProcessStats](#pps_v2-ProcessStats) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-Worker"></a>
+
+### Worker
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| state | [WorkerState](#pps_v2-WorkerState) |  |  |
+
+
+
+
+
+
+<a name="pps_v2-WorkerStatus"></a>
+
+### WorkerStatus
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| worker_id | [string](#string) |  |  |
+| job_id | [string](#string) |  |  |
+| datum_status | [DatumStatus](#pps_v2-DatumStatus) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="pps_v2-DatumState"></a>
+
+### DatumState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 | or not part of a job |
+| FAILED | 1 |  |
+| SUCCESS | 2 |  |
+| SKIPPED | 3 |  |
+| STARTING | 4 |  |
+| RECOVERED | 5 |  |
+
+
+
+<a name="pps_v2-JobState"></a>
+
+### JobState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| JOB_STATE_UNKNOWN | 0 |  |
+| JOB_CREATED | 1 |  |
+| JOB_STARTING | 2 |  |
+| JOB_RUNNING | 3 |  |
+| JOB_FAILURE | 4 |  |
+| JOB_SUCCESS | 5 |  |
+| JOB_KILLED | 6 |  |
+| JOB_EGRESSING | 7 |  |
+| JOB_FINISHING | 8 |  |
+| JOB_UNRUNNABLE | 9 |  |
+
+
+
+<a name="pps_v2-PipelineInfo-PipelineType"></a>
+
+### PipelineInfo.PipelineType
+The pipeline type is stored here so that we can internally know the type of
+the pipeline without loading the spec from PFS.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PIPELINT_TYPE_UNKNOWN | 0 |  |
+| PIPELINE_TYPE_TRANSFORM | 1 |  |
+| PIPELINE_TYPE_SPOUT | 2 |  |
+| PIPELINE_TYPE_SERVICE | 3 |  |
+
+
+
+<a name="pps_v2-PipelineState"></a>
+
+### PipelineState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PIPELINE_STATE_UNKNOWN | 0 |  |
+| PIPELINE_STARTING | 1 | There is a PipelineInfo &#43; spec commit, but no RC This happens when a pipeline has been created but not yet picked up by a PPS server. |
+| PIPELINE_RUNNING | 2 | A pipeline has a spec commit and a service &#43; RC This is the normal state of a pipeline. |
+| PIPELINE_RESTARTING | 3 | Equivalent to STARTING (there is a PipelineInfo &#43; commit, but no RC) After some error caused runPipeline to exit, but before the pipeline is re-run. This is when the exponential backoff is in effect. |
+| PIPELINE_FAILURE | 4 | The pipeline has encountered unrecoverable errors and is no longer being retried. It won&#39;t leave this state until the pipeline is updated. |
+| PIPELINE_PAUSED | 5 | The pipeline has been explicitly paused by the user (the pipeline spec&#39;s Stopped field should be true if the pipeline is in this state) |
+| PIPELINE_STANDBY | 6 | The pipeline is fully functional, but there are no commits to process. |
+| PIPELINE_CRASHING | 7 | The pipeline&#39;s workers are crashing, or failing to come up, this may resolve itself, the pipeline may make progress while in this state if the problem is only being experienced by some workers. |
+
+
+
+<a name="pps_v2-TaintEffect"></a>
+
+### TaintEffect
+TaintEffect is an effect that can be matched by a toleration.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| ALL_EFFECTS | 0 | Empty matches all effects. |
+| NO_SCHEDULE | 1 | &#34;NoSchedule&#34; |
+| PREFER_NO_SCHEDULE | 2 | &#34;PreferNoSchedule&#34; |
+| NO_EXECUTE | 3 | &#34;NoExecute&#34; |
+
+
+
+<a name="pps_v2-TolerationOperator"></a>
+
+### TolerationOperator
+TolerationOperator relates a Toleration&#39;s key to its value.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| EMPTY | 0 | K8s doesn&#39;t have this, but it&#39;s possible to represent something similar. |
+| EXISTS | 1 | &#34;Exists&#34; |
+| EQUAL | 2 | &#34;Equal&#34; |
+
+
+
+<a name="pps_v2-WorkerState"></a>
+
+### WorkerState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| WORKER_STATE_UNKNOWN | 0 |  |
+| POD_RUNNING | 1 |  |
+| POD_SUCCESS | 2 |  |
+| POD_FAILED | 3 |  |
+
+
+ 
+
+ 
+
+
+<a name="pps_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| InspectJob | [InspectJobRequest](#pps_v2-InspectJobRequest) | [JobInfo](#pps_v2-JobInfo) |  |
+| InspectJobSet | [InspectJobSetRequest](#pps_v2-InspectJobSetRequest) | [JobInfo](#pps_v2-JobInfo) stream |  |
+| ListJob | [ListJobRequest](#pps_v2-ListJobRequest) | [JobInfo](#pps_v2-JobInfo) stream | ListJob returns information about current and past Pachyderm jobs. |
+| ListJobSet | [ListJobSetRequest](#pps_v2-ListJobSetRequest) | [JobSetInfo](#pps_v2-JobSetInfo) stream |  |
+| SubscribeJob | [SubscribeJobRequest](#pps_v2-SubscribeJobRequest) | [JobInfo](#pps_v2-JobInfo) stream |  |
+| DeleteJob | [DeleteJobRequest](#pps_v2-DeleteJobRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| StopJob | [StopJobRequest](#pps_v2-StopJobRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| InspectDatum | [InspectDatumRequest](#pps_v2-InspectDatumRequest) | [DatumInfo](#pps_v2-DatumInfo) |  |
+| ListDatum | [ListDatumRequest](#pps_v2-ListDatumRequest) | [DatumInfo](#pps_v2-DatumInfo) stream | ListDatum returns information about each datum fed to a Pachyderm job |
+| RestartDatum | [RestartDatumRequest](#pps_v2-RestartDatumRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| CreatePipeline | [CreatePipelineRequest](#pps_v2-CreatePipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| CreatePipelineV2 | [CreatePipelineV2Request](#pps_v2-CreatePipelineV2Request) | [CreatePipelineV2Response](#pps_v2-CreatePipelineV2Response) |  |
+| InspectPipeline | [InspectPipelineRequest](#pps_v2-InspectPipelineRequest) | [PipelineInfo](#pps_v2-PipelineInfo) |  |
+| ListPipeline | [ListPipelineRequest](#pps_v2-ListPipelineRequest) | [PipelineInfo](#pps_v2-PipelineInfo) stream |  |
+| DeletePipeline | [DeletePipelineRequest](#pps_v2-DeletePipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| DeletePipelines | [DeletePipelinesRequest](#pps_v2-DeletePipelinesRequest) | [DeletePipelinesResponse](#pps_v2-DeletePipelinesResponse) |  |
+| StartPipeline | [StartPipelineRequest](#pps_v2-StartPipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| StopPipeline | [StopPipelineRequest](#pps_v2-StopPipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| RunPipeline | [RunPipelineRequest](#pps_v2-RunPipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| RunCron | [RunCronRequest](#pps_v2-RunCronRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| CreateSecret | [CreateSecretRequest](#pps_v2-CreateSecretRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| DeleteSecret | [DeleteSecretRequest](#pps_v2-DeleteSecretRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| ListSecret | [.google.protobuf.Empty](#google-protobuf-Empty) | [SecretInfos](#pps_v2-SecretInfos) |  |
+| InspectSecret | [InspectSecretRequest](#pps_v2-InspectSecretRequest) | [SecretInfo](#pps_v2-SecretInfo) |  |
+| DeleteAll | [.google.protobuf.Empty](#google-protobuf-Empty) | [.google.protobuf.Empty](#google-protobuf-Empty) | DeleteAll deletes everything |
+| GetLogs | [GetLogsRequest](#pps_v2-GetLogsRequest) | [LogMessage](#pps_v2-LogMessage) stream |  |
+| ActivateAuth | [ActivateAuthRequest](#pps_v2-ActivateAuthRequest) | [ActivateAuthResponse](#pps_v2-ActivateAuthResponse) | An internal call that causes PPS to put itself into an auth-enabled state (all pipeline have tokens, correct permissions, etcd) |
+| UpdateJobState | [UpdateJobStateRequest](#pps_v2-UpdateJobStateRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) | An internal call used to move a job from one state to another |
+| RunLoadTest | [RunLoadTestRequest](#pps_v2-RunLoadTestRequest) | [RunLoadTestResponse](#pps_v2-RunLoadTestResponse) | RunLoadTest runs a load test. |
+| RunLoadTestDefault | [.google.protobuf.Empty](#google-protobuf-Empty) | [RunLoadTestResponse](#pps_v2-RunLoadTestResponse) | RunLoadTestDefault runs the default load test. |
+| RenderTemplate | [RenderTemplateRequest](#pps_v2-RenderTemplateRequest) | [RenderTemplateResponse](#pps_v2-RenderTemplateResponse) | RenderTemplate renders the provided template and arguments into a list of Pipeline specicifications |
+| ListTask | [.taskapi.ListTaskRequest](#taskapi-ListTaskRequest) | [.taskapi.TaskInfo](#taskapi-TaskInfo) stream | ListTask lists PPS tasks |
+| GetKubeEvents | [LokiRequest](#pps_v2-LokiRequest) | [LokiLogMessage](#pps_v2-LokiLogMessage) stream | GetKubeEvents returns a stream of kubernetes events |
+| QueryLoki | [LokiRequest](#pps_v2-LokiRequest) | [LokiLogMessage](#pps_v2-LokiLogMessage) stream | QueryLoki returns a stream of loki log messages given a query string |
+| GetClusterDefaults | [GetClusterDefaultsRequest](#pps_v2-GetClusterDefaultsRequest) | [GetClusterDefaultsResponse](#pps_v2-GetClusterDefaultsResponse) | GetClusterDefaults returns the current cluster defaults. |
+| SetClusterDefaults | [SetClusterDefaultsRequest](#pps_v2-SetClusterDefaultsRequest) | [SetClusterDefaultsResponse](#pps_v2-SetClusterDefaultsResponse) | SetClusterDefaults returns the current cluster defaults. |
+
+ 
+
+
+
+<a name="protoextensions_json-schema-options-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## protoextensions/json-schema-options.proto
+
+
+
+<a name="protoc-gen-jsonschema-EnumOptions"></a>
+
+### EnumOptions
+Custom EnumOptions
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| enums_as_constants | [bool](#bool) |  | Enums tagged with this will have be encoded to use constants instead of simple types (supports value annotations): |
+| enums_as_strings_only | [bool](#bool) |  | Enums tagged with this will only provide string values as options (not their numerical equivalents): |
+| enums_trim_prefix | [bool](#bool) |  | Enums tagged with this will have enum name prefix removed from values: |
+| ignore | [bool](#bool) |  | Enums tagged with this will not be processed |
+
+
+
+
+
+
+<a name="protoc-gen-jsonschema-FieldOptions"></a>
+
+### FieldOptions
+Custom FieldOptions
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ignore | [bool](#bool) |  | Fields tagged with this will be omitted from generated schemas |
+| required | [bool](#bool) |  | Fields tagged with this will be marked as &#34;required&#34; in generated schemas |
+| min_length | [int32](#int32) |  | Fields tagged with this will constrain strings using the &#34;minLength&#34; keyword in generated schemas |
+| max_length | [int32](#int32) |  | Fields tagged with this will constrain strings using the &#34;maxLength&#34; keyword in generated schemas |
+| pattern | [string](#string) |  | Fields tagged with this will constrain strings using the &#34;pattern&#34; keyword in generated schemas |
+
+
+
+
+
+
+<a name="protoc-gen-jsonschema-FileOptions"></a>
+
+### FileOptions
+Custom FileOptions
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ignore | [bool](#bool) |  | Files tagged with this will not be processed |
+| extension | [string](#string) |  | Override the default file extension for schemas generated from this file |
+
+
+
+
+
+
+<a name="protoc-gen-jsonschema-MessageOptions"></a>
+
+### MessageOptions
+Custom MessageOptions
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ignore | [bool](#bool) |  | Messages tagged with this will not be processed |
+| all_fields_required | [bool](#bool) |  | Messages tagged with this will have all fields marked as &#34;required&#34;: |
+| allow_null_values | [bool](#bool) |  | Messages tagged with this will additionally accept null values for all properties: |
+| disallow_additional_properties | [bool](#bool) |  | Messages tagged with this will have all fields marked as not allowing additional properties: |
+| enums_as_constants | [bool](#bool) |  | Messages tagged with this will have all nested enums encoded to use constants instead of simple types (supports value annotations): |
+
+
+
+
+
+ 
+
+ 
+
+
+<a name="protoextensions_json-schema-options-proto-extensions"></a>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+| enum_options | EnumOptions | .google.protobuf.EnumOptions | 1128 |  |
+| field_options | FieldOptions | .google.protobuf.FieldOptions | 1125 |  |
+| file_options | FileOptions | .google.protobuf.FileOptions | 1126 |  |
+| message_options | MessageOptions | .google.protobuf.MessageOptions | 1127 |  |
+
+ 
+
+ 
+
+
+
+<a name="protoextensions_log-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## protoextensions/log.proto
+
+
+ 
+
+ 
+
+
+<a name="protoextensions_log-proto-extensions"></a>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+| half | bool | .google.protobuf.FieldOptions | 50002 |  |
+| mask | bool | .google.protobuf.FieldOptions | 50001 |  |
+
+ 
+
+ 
+
+
+
+<a name="protoextensions_validate-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## protoextensions/validate.proto
+
+
+
+<a name="validate-AnyRules"></a>
+
+### AnyRules
+AnyRules describe constraints applied exclusively to the
+`google.protobuf.Any` well-known type
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| required | [bool](#bool) | optional | Required specifies that this field must be set |
+| in | [string](#string) | repeated | In specifies that this field&#39;s `type_url` must be equal to one of the specified values. |
+| not_in | [string](#string) | repeated | NotIn specifies that this field&#39;s `type_url` must not be equal to any of the specified values. |
+
+
+
+
+
+
+<a name="validate-BoolRules"></a>
+
+### BoolRules
+BoolRules describes the constraints applied to `bool` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [bool](#bool) | optional | Const specifies that this field must be exactly the specified value |
+
+
+
+
+
+
+<a name="validate-BytesRules"></a>
+
+### BytesRules
+BytesRules describe the constraints applied to `bytes` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [bytes](#bytes) | optional | Const specifies that this field must be exactly the specified value |
+| len | [uint64](#uint64) | optional | Len specifies that this field must be the specified number of bytes |
+| min_len | [uint64](#uint64) | optional | MinLen specifies that this field must be the specified number of bytes at a minimum |
+| max_len | [uint64](#uint64) | optional | MaxLen specifies that this field must be the specified number of bytes at a maximum |
+| pattern | [string](#string) | optional | Pattern specifes that this field must match against the specified regular expression (RE2 syntax). The included expression should elide any delimiters. |
+| prefix | [bytes](#bytes) | optional | Prefix specifies that this field must have the specified bytes at the beginning of the string. |
+| suffix | [bytes](#bytes) | optional | Suffix specifies that this field must have the specified bytes at the end of the string. |
+| contains | [bytes](#bytes) | optional | Contains specifies that this field must have the specified bytes anywhere in the string. |
+| in | [bytes](#bytes) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [bytes](#bytes) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ip | [bool](#bool) | optional | Ip specifies that the field must be a valid IP (v4 or v6) address in byte format |
+| ipv4 | [bool](#bool) | optional | Ipv4 specifies that the field must be a valid IPv4 address in byte format |
+| ipv6 | [bool](#bool) | optional | Ipv6 specifies that the field must be a valid IPv6 address in byte format |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-DoubleRules"></a>
+
+### DoubleRules
+DoubleRules describes the constraints applied to `double` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [double](#double) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [double](#double) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [double](#double) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [double](#double) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [double](#double) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [double](#double) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [double](#double) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-DurationRules"></a>
+
+### DurationRules
+DurationRules describe the constraints applied exclusively to the
+`google.protobuf.Duration` well-known type
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| required | [bool](#bool) | optional | Required specifies that this field must be set |
+| const | [google.protobuf.Duration](#google-protobuf-Duration) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [google.protobuf.Duration](#google-protobuf-Duration) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [google.protobuf.Duration](#google-protobuf-Duration) | optional | Lt specifies that this field must be less than the specified value, inclusive |
+| gt | [google.protobuf.Duration](#google-protobuf-Duration) | optional | Gt specifies that this field must be greater than the specified value, exclusive |
+| gte | [google.protobuf.Duration](#google-protobuf-Duration) | optional | Gte specifies that this field must be greater than the specified value, inclusive |
+| in | [google.protobuf.Duration](#google-protobuf-Duration) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [google.protobuf.Duration](#google-protobuf-Duration) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+
+
+
+
+
+
+<a name="validate-EnumRules"></a>
+
+### EnumRules
+EnumRules describe the constraints applied to enum values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [int32](#int32) | optional | Const specifies that this field must be exactly the specified value |
+| defined_only | [bool](#bool) | optional | DefinedOnly specifies that this field must be only one of the defined values for this enum, failing on any undefined value. |
+| in | [int32](#int32) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [int32](#int32) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+
+
+
+
+
+
+<a name="validate-FieldRules"></a>
+
+### FieldRules
+FieldRules encapsulates the rules for each type of field. Depending on the
+field, the correct set should be used to ensure proper validations.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| message | [MessageRules](#validate-MessageRules) | optional |  |
+| float | [FloatRules](#validate-FloatRules) | optional | Scalar Field Types |
+| double | [DoubleRules](#validate-DoubleRules) | optional |  |
+| int32 | [Int32Rules](#validate-Int32Rules) | optional |  |
+| int64 | [Int64Rules](#validate-Int64Rules) | optional |  |
+| uint32 | [UInt32Rules](#validate-UInt32Rules) | optional |  |
+| uint64 | [UInt64Rules](#validate-UInt64Rules) | optional |  |
+| sint32 | [SInt32Rules](#validate-SInt32Rules) | optional |  |
+| sint64 | [SInt64Rules](#validate-SInt64Rules) | optional |  |
+| fixed32 | [Fixed32Rules](#validate-Fixed32Rules) | optional |  |
+| fixed64 | [Fixed64Rules](#validate-Fixed64Rules) | optional |  |
+| sfixed32 | [SFixed32Rules](#validate-SFixed32Rules) | optional |  |
+| sfixed64 | [SFixed64Rules](#validate-SFixed64Rules) | optional |  |
+| bool | [BoolRules](#validate-BoolRules) | optional |  |
+| string | [StringRules](#validate-StringRules) | optional |  |
+| bytes | [BytesRules](#validate-BytesRules) | optional |  |
+| enum | [EnumRules](#validate-EnumRules) | optional | Complex Field Types |
+| repeated | [RepeatedRules](#validate-RepeatedRules) | optional |  |
+| map | [MapRules](#validate-MapRules) | optional |  |
+| any | [AnyRules](#validate-AnyRules) | optional | Well-Known Field Types |
+| duration | [DurationRules](#validate-DurationRules) | optional |  |
+| timestamp | [TimestampRules](#validate-TimestampRules) | optional |  |
+
+
+
+
+
+
+<a name="validate-Fixed32Rules"></a>
+
+### Fixed32Rules
+Fixed32Rules describes the constraints applied to `fixed32` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [fixed32](#fixed32) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [fixed32](#fixed32) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [fixed32](#fixed32) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [fixed32](#fixed32) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [fixed32](#fixed32) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [fixed32](#fixed32) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [fixed32](#fixed32) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-Fixed64Rules"></a>
+
+### Fixed64Rules
+Fixed64Rules describes the constraints applied to `fixed64` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [fixed64](#fixed64) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [fixed64](#fixed64) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [fixed64](#fixed64) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [fixed64](#fixed64) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [fixed64](#fixed64) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [fixed64](#fixed64) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [fixed64](#fixed64) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-FloatRules"></a>
+
+### FloatRules
+FloatRules describes the constraints applied to `float` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [float](#float) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [float](#float) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [float](#float) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [float](#float) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [float](#float) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [float](#float) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [float](#float) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-Int32Rules"></a>
+
+### Int32Rules
+Int32Rules describes the constraints applied to `int32` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [int32](#int32) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [int32](#int32) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [int32](#int32) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [int32](#int32) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [int32](#int32) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [int32](#int32) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [int32](#int32) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-Int64Rules"></a>
+
+### Int64Rules
+Int64Rules describes the constraints applied to `int64` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [int64](#int64) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [int64](#int64) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [int64](#int64) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [int64](#int64) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [int64](#int64) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [int64](#int64) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [int64](#int64) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-MapRules"></a>
+
+### MapRules
+MapRules describe the constraints applied to `map` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| min_pairs | [uint64](#uint64) | optional | MinPairs specifies that this field must have the specified number of KVs at a minimum |
+| max_pairs | [uint64](#uint64) | optional | MaxPairs specifies that this field must have the specified number of KVs at a maximum |
+| no_sparse | [bool](#bool) | optional | NoSparse specifies values in this field cannot be unset. This only applies to map&#39;s with message value types. |
+| keys | [FieldRules](#validate-FieldRules) | optional | Keys specifies the constraints to be applied to each key in the field. |
+| values | [FieldRules](#validate-FieldRules) | optional | Values specifies the constraints to be applied to the value of each key in the field. Message values will still have their validations evaluated unless skip is specified here. |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-MessageRules"></a>
+
+### MessageRules
+MessageRules describe the constraints applied to embedded message values.
+For message-type fields, validation is performed recursively.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| skip | [bool](#bool) | optional | Skip specifies that the validation rules of this field should not be evaluated |
+| required | [bool](#bool) | optional | Required specifies that this field must be set |
+
+
+
+
+
+
+<a name="validate-RepeatedRules"></a>
+
+### RepeatedRules
+RepeatedRules describe the constraints applied to `repeated` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| min_items | [uint64](#uint64) | optional | MinItems specifies that this field must have the specified number of items at a minimum |
+| max_items | [uint64](#uint64) | optional | MaxItems specifies that this field must have the specified number of items at a maximum |
+| unique | [bool](#bool) | optional | Unique specifies that all elements in this field must be unique. This contraint is only applicable to scalar and enum types (messages are not supported). |
+| items | [FieldRules](#validate-FieldRules) | optional | Items specifies the contraints to be applied to each item in the field. Repeated message fields will still execute validation against each item unless skip is specified here. |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-SFixed32Rules"></a>
+
+### SFixed32Rules
+SFixed32Rules describes the constraints applied to `sfixed32` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [sfixed32](#sfixed32) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [sfixed32](#sfixed32) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [sfixed32](#sfixed32) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [sfixed32](#sfixed32) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [sfixed32](#sfixed32) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [sfixed32](#sfixed32) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [sfixed32](#sfixed32) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-SFixed64Rules"></a>
+
+### SFixed64Rules
+SFixed64Rules describes the constraints applied to `sfixed64` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [sfixed64](#sfixed64) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [sfixed64](#sfixed64) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [sfixed64](#sfixed64) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [sfixed64](#sfixed64) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [sfixed64](#sfixed64) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [sfixed64](#sfixed64) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [sfixed64](#sfixed64) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-SInt32Rules"></a>
+
+### SInt32Rules
+SInt32Rules describes the constraints applied to `sint32` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [sint32](#sint32) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [sint32](#sint32) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [sint32](#sint32) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [sint32](#sint32) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [sint32](#sint32) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [sint32](#sint32) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [sint32](#sint32) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-SInt64Rules"></a>
+
+### SInt64Rules
+SInt64Rules describes the constraints applied to `sint64` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [sint64](#sint64) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [sint64](#sint64) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [sint64](#sint64) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [sint64](#sint64) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [sint64](#sint64) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [sint64](#sint64) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [sint64](#sint64) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-StringRules"></a>
+
+### StringRules
+StringRules describe the constraints applied to `string` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [string](#string) | optional | Const specifies that this field must be exactly the specified value |
+| len | [uint64](#uint64) | optional | Len specifies that this field must be the specified number of characters (Unicode code points). Note that the number of characters may differ from the number of bytes in the string. |
+| min_len | [uint64](#uint64) | optional | MinLen specifies that this field must be the specified number of characters (Unicode code points) at a minimum. Note that the number of characters may differ from the number of bytes in the string. |
+| max_len | [uint64](#uint64) | optional | MaxLen specifies that this field must be the specified number of characters (Unicode code points) at a maximum. Note that the number of characters may differ from the number of bytes in the string. |
+| len_bytes | [uint64](#uint64) | optional | LenBytes specifies that this field must be the specified number of bytes |
+| min_bytes | [uint64](#uint64) | optional | MinBytes specifies that this field must be the specified number of bytes at a minimum |
+| max_bytes | [uint64](#uint64) | optional | MaxBytes specifies that this field must be the specified number of bytes at a maximum |
+| pattern | [string](#string) | optional | Pattern specifes that this field must match against the specified regular expression (RE2 syntax). The included expression should elide any delimiters. |
+| prefix | [string](#string) | optional | Prefix specifies that this field must have the specified substring at the beginning of the string. |
+| suffix | [string](#string) | optional | Suffix specifies that this field must have the specified substring at the end of the string. |
+| contains | [string](#string) | optional | Contains specifies that this field must have the specified substring anywhere in the string. |
+| not_contains | [string](#string) | optional | NotContains specifies that this field cannot have the specified substring anywhere in the string. |
+| in | [string](#string) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [string](#string) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| email | [bool](#bool) | optional | Email specifies that the field must be a valid email address as defined by RFC 5322 |
+| hostname | [bool](#bool) | optional | Hostname specifies that the field must be a valid hostname as defined by RFC 1034. This constraint does not support internationalized domain names (IDNs). |
+| ip | [bool](#bool) | optional | Ip specifies that the field must be a valid IP (v4 or v6) address. Valid IPv6 addresses should not include surrounding square brackets. |
+| ipv4 | [bool](#bool) | optional | Ipv4 specifies that the field must be a valid IPv4 address. |
+| ipv6 | [bool](#bool) | optional | Ipv6 specifies that the field must be a valid IPv6 address. Valid IPv6 addresses should not include surrounding square brackets. |
+| uri | [bool](#bool) | optional | Uri specifies that the field must be a valid, absolute URI as defined by RFC 3986 |
+| uri_ref | [bool](#bool) | optional | UriRef specifies that the field must be a valid URI as defined by RFC 3986 and may be relative or absolute. |
+| address | [bool](#bool) | optional | Address specifies that the field must be either a valid hostname as defined by RFC 1034 (which does not support internationalized domain names or IDNs), or it can be a valid IP (v4 or v6). |
+| uuid | [bool](#bool) | optional | Uuid specifies that the field must be a valid UUID as defined by RFC 4122 |
+| well_known_regex | [KnownRegex](#validate-KnownRegex) | optional | WellKnownRegex specifies a common well known pattern defined as a regex. |
+| strict | [bool](#bool) | optional | This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable strict header validation. By default, this is true, and HTTP header validations are RFC-compliant. Setting to false will enable a looser validations that only disallows \r\n\0 characters, which can be used to bypass header matching rules. Default: true |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-TimestampRules"></a>
+
+### TimestampRules
+TimestampRules describe the constraints applied exclusively to the
+`google.protobuf.Timestamp` well-known type
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| required | [bool](#bool) | optional | Required specifies that this field must be set |
+| const | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional | Lte specifies that this field must be less than the specified value, inclusive |
+| gt | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional | Gt specifies that this field must be greater than the specified value, exclusive |
+| gte | [google.protobuf.Timestamp](#google-protobuf-Timestamp) | optional | Gte specifies that this field must be greater than the specified value, inclusive |
+| lt_now | [bool](#bool) | optional | LtNow specifies that this must be less than the current time. LtNow can only be used with the Within rule. |
+| gt_now | [bool](#bool) | optional | GtNow specifies that this must be greater than the current time. GtNow can only be used with the Within rule. |
+| within | [google.protobuf.Duration](#google-protobuf-Duration) | optional | Within specifies that this field must be within this duration of the current time. This constraint can be used alone or with the LtNow and GtNow rules. |
+
+
+
+
+
+
+<a name="validate-UInt32Rules"></a>
+
+### UInt32Rules
+UInt32Rules describes the constraints applied to `uint32` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [uint32](#uint32) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [uint32](#uint32) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [uint32](#uint32) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [uint32](#uint32) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [uint32](#uint32) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [uint32](#uint32) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [uint32](#uint32) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+
+<a name="validate-UInt64Rules"></a>
+
+### UInt64Rules
+UInt64Rules describes the constraints applied to `uint64` values
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| const | [uint64](#uint64) | optional | Const specifies that this field must be exactly the specified value |
+| lt | [uint64](#uint64) | optional | Lt specifies that this field must be less than the specified value, exclusive |
+| lte | [uint64](#uint64) | optional | Lte specifies that this field must be less than or equal to the specified value, inclusive |
+| gt | [uint64](#uint64) | optional | Gt specifies that this field must be greater than the specified value, exclusive. If the value of Gt is larger than a specified Lt or Lte, the range is reversed. |
+| gte | [uint64](#uint64) | optional | Gte specifies that this field must be greater than or equal to the specified value, inclusive. If the value of Gte is larger than a specified Lt or Lte, the range is reversed. |
+| in | [uint64](#uint64) | repeated | In specifies that this field must be equal to one of the specified values |
+| not_in | [uint64](#uint64) | repeated | NotIn specifies that this field cannot be equal to one of the specified values |
+| ignore_empty | [bool](#bool) | optional | IgnoreEmpty specifies that the validation rules of this field should be evaluated only if the field is not empty |
+
+
+
+
+
+ 
+
+
+<a name="validate-KnownRegex"></a>
+
+### KnownRegex
+WellKnownRegex contain some well-known patterns.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 |  |
+| HTTP_HEADER_NAME | 1 | HTTP header name as defined by RFC 7230. |
+| HTTP_HEADER_VALUE | 2 | HTTP header value as defined by RFC 7230. |
+
+
+ 
+
+
+<a name="protoextensions_validate-proto-extensions"></a>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+| rules | FieldRules | .google.protobuf.FieldOptions | 1071 | Rules specify the validations to be performed on this field. By default, no validation is performed against a field. |
+| disabled | bool | .google.protobuf.MessageOptions | 1071 | Disabled nullifies any validation rules for this message, including any message fields associated with it that do support validation. |
+| ignored | bool | .google.protobuf.MessageOptions | 1072 | Ignore skips generation of validation methods for this message. |
+| required | bool | .google.protobuf.OneofOptions | 1071 | Required ensures that exactly one the field options in a oneof is set; validation fails if no fields in the oneof are set. |
+
+ 
+
+ 
+
+
+
+<a name="proxy_proxy-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## proxy/proxy.proto
+
+
+
+<a name="proxy-ListenRequest"></a>
+
+### ListenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| channel | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="proxy-ListenResponse"></a>
+
+### ListenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| extra | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="proxy-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Listen | [ListenRequest](#proxy-ListenRequest) | [ListenResponse](#proxy-ListenResponse) stream | Listen streams database events. It signals that it is internally set up by sending an initial empty ListenResponse. |
+
+ 
+
+
+
+<a name="server_pfs_server_pfsserver-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## server/pfs/server/pfsserver.proto
+
+
+
+<a name="pfsserver-CompactTask"></a>
+
+### CompactTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| inputs | [string](#string) | repeated |  |
+| path_range | [PathRange](#pfsserver-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-CompactTaskResult"></a>
+
+### CompactTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-ConcatTask"></a>
+
+### ConcatTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| inputs | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="pfsserver-ConcatTaskResult"></a>
+
+### ConcatTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-GetFileURLTask"></a>
+
+### GetFileURLTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| URL | [string](#string) |  |  |
+| file | [pfs_v2.File](#pfs_v2-File) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-GetFileURLTaskResult"></a>
+
+### GetFileURLTaskResult
+
+
+
+
+
+
+
+<a name="pfsserver-PathRange"></a>
+
+### PathRange
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| lower | [string](#string) |  |  |
+| upper | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-PutFileURLTask"></a>
+
+### PutFileURLTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| dst | [string](#string) |  |  |
+| datum | [string](#string) |  |  |
+| URL | [string](#string) |  |  |
+| paths | [string](#string) | repeated |  |
+| start_offset | [int64](#int64) |  |  |
+| end_offset | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-PutFileURLTaskResult"></a>
+
+### PutFileURLTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-ShardTask"></a>
+
+### ShardTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| inputs | [string](#string) | repeated |  |
+| path_range | [PathRange](#pfsserver-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-ShardTaskResult"></a>
+
+### ShardTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| compact_tasks | [CompactTask](#pfsserver-CompactTask) | repeated |  |
+
+
+
+
+
+
+<a name="pfsserver-ValidateTask"></a>
+
+### ValidateTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| path_range | [PathRange](#pfsserver-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pfsserver-ValidateTaskResult"></a>
+
+### ValidateTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| first | [index.Index](#index-Index) |  |  |
+| last | [index.Index](#index-Index) |  |  |
+| error | [string](#string) |  |  |
+| size_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="server_worker_common_common-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## server/worker/common/common.proto
+
+
+
+<a name="common-Input"></a>
+
+### Input
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_info | [pfs_v2.FileInfo](#pfs_v2-FileInfo) |  |  |
+| name | [string](#string) |  |  |
+| join_on | [string](#string) |  |  |
+| outer_join | [bool](#bool) |  |  |
+| group_by | [string](#string) |  |  |
+| lazy | [bool](#bool) |  |  |
+| branch | [string](#string) |  |  |
+| empty_files | [bool](#bool) |  |  |
+| s3 | [bool](#bool) |  | If set, workers won&#39;t create an input directory for this input |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="server_worker_datum_datum-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## server/worker/datum/datum.proto
+
+
+
+<a name="datum-ComposeTask"></a>
+
+### ComposeTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_ids | [string](#string) | repeated |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-ComposeTaskResult"></a>
+
+### ComposeTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-CrossTask"></a>
+
+### CrossTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_ids | [string](#string) | repeated |  |
+| base_file_set_index | [int64](#int64) |  |  |
+| base_file_set_path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| base_index | [int64](#int64) |  |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-CrossTaskResult"></a>
+
+### CrossTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-KeyTask"></a>
+
+### KeyTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| type | [KeyTask.Type](#datum-KeyTask-Type) |  |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-KeyTaskResult"></a>
+
+### KeyTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-MergeTask"></a>
+
+### MergeTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_ids | [string](#string) | repeated |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| type | [MergeTask.Type](#datum-MergeTask-Type) |  |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-MergeTaskResult"></a>
+
+### MergeTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-Meta"></a>
+
+### Meta
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [pps_v2.Job](#pps_v2-Job) |  |  |
+| inputs | [common.Input](#common-Input) | repeated |  |
+| hash | [string](#string) |  |  |
+| state | [State](#datum-State) |  |  |
+| reason | [string](#string) |  |  |
+| stats | [pps_v2.ProcessStats](#pps_v2-ProcessStats) |  |  |
+| index | [int64](#int64) |  |  |
+| image_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-PFSTask"></a>
+
+### PFSTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| input | [pps_v2.PFSInput](#pps_v2-PFSInput) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| base_index | [int64](#int64) |  |  |
+| auth_token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-PFSTaskResult"></a>
+
+### PFSTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="datum-SetSpec"></a>
+
+### SetSpec
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [int64](#int64) |  |  |
+| size_bytes | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="datum-Stats"></a>
+
+### Stats
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| process_stats | [pps_v2.ProcessStats](#pps_v2-ProcessStats) |  |  |
+| processed | [int64](#int64) |  |  |
+| skipped | [int64](#int64) |  |  |
+| total | [int64](#int64) |  |  |
+| failed | [int64](#int64) |  |  |
+| recovered | [int64](#int64) |  |  |
+| failed_id | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="datum-KeyTask-Type"></a>
+
+### KeyTask.Type
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| JOIN | 0 |  |
+| GROUP | 1 |  |
+
+
+
+<a name="datum-MergeTask-Type"></a>
+
+### MergeTask.Type
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| JOIN | 0 |  |
+| GROUP | 1 |  |
+
+
+
+<a name="datum-State"></a>
+
+### State
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PROCESSED | 0 |  |
+| FAILED | 1 |  |
+| RECOVERED | 2 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="server_worker_pipeline_transform_transform-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## server/worker/pipeline/transform/transform.proto
+
+
+
+<a name="pachyderm-worker-pipeline-transform-CreateDatumSetsTask"></a>
+
+### CreateDatumSetsTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| set_spec | [datum.SetSpec](#datum-SetSpec) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-CreateDatumSetsTaskResult"></a>
+
+### CreateDatumSetsTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| datum_sets | [pfs_v2.PathRange](#pfs_v2-PathRange) | repeated |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-CreateParallelDatumsTask"></a>
+
+### CreateParallelDatumsTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [pps_v2.Job](#pps_v2-Job) |  |  |
+| salt | [string](#string) |  |  |
+| file_set_id | [string](#string) |  |  |
+| base_file_set_id | [string](#string) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-CreateParallelDatumsTaskResult"></a>
+
+### CreateParallelDatumsTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+| stats | [datum.Stats](#datum-Stats) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-CreateSerialDatumsTask"></a>
+
+### CreateSerialDatumsTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [pps_v2.Job](#pps_v2-Job) |  |  |
+| salt | [string](#string) |  |  |
+| file_set_id | [string](#string) |  |  |
+| base_meta_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+| no_skip | [bool](#bool) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-CreateSerialDatumsTaskResult"></a>
+
+### CreateSerialDatumsTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| file_set_id | [string](#string) |  |  |
+| output_delete_file_set_id | [string](#string) |  |  |
+| meta_delete_file_set_id | [string](#string) |  |  |
+| stats | [datum.Stats](#datum-Stats) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-DatumSetTask"></a>
+
+### DatumSetTask
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [pps_v2.Job](#pps_v2-Job) |  |  |
+| file_set_id | [string](#string) |  |  |
+| path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| output_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-pipeline-transform-DatumSetTaskResult"></a>
+
+### DatumSetTaskResult
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| output_file_set_id | [string](#string) |  |  |
+| meta_file_set_id | [string](#string) |  |  |
+| stats | [datum.Stats](#datum-Stats) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="task_task-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## task/task.proto
+
+
+
+<a name="taskapi-Group"></a>
+
+### Group
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| namespace | [string](#string) |  |  |
+| group | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="taskapi-ListTaskRequest"></a>
+
+### ListTaskRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| group | [Group](#taskapi-Group) |  |  |
+
+
+
+
+
+
+<a name="taskapi-TaskInfo"></a>
+
+### TaskInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+| group | [Group](#taskapi-Group) |  |  |
+| state | [State](#taskapi-State) |  |  |
+| reason | [string](#string) |  |  |
+| input_type | [string](#string) |  |  |
+| input_data | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="taskapi-State"></a>
+
+### State
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 |  |
+| RUNNING | 1 |  |
+| SUCCESS | 2 |  |
+| FAILURE | 3 |  |
+| CLAIMED | 4 | not a real state used by task logic |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="transaction_transaction-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## transaction/transaction.proto
+
+
+
+<a name="transaction_v2-BatchTransactionRequest"></a>
+
+### BatchTransactionRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| requests | [TransactionRequest](#transaction_v2-TransactionRequest) | repeated |  |
+
+
+
+
+
+
+<a name="transaction_v2-DeleteAllRequest"></a>
+
+### DeleteAllRequest
+
+
+
+
+
+
+
+<a name="transaction_v2-DeleteTransactionRequest"></a>
+
+### DeleteTransactionRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transaction | [Transaction](#transaction_v2-Transaction) |  |  |
+
+
+
+
+
+
+<a name="transaction_v2-FinishTransactionRequest"></a>
+
+### FinishTransactionRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transaction | [Transaction](#transaction_v2-Transaction) |  |  |
+
+
+
+
+
+
+<a name="transaction_v2-InspectTransactionRequest"></a>
+
+### InspectTransactionRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transaction | [Transaction](#transaction_v2-Transaction) |  |  |
+
+
+
+
+
+
+<a name="transaction_v2-ListTransactionRequest"></a>
+
+### ListTransactionRequest
+
+
+
+
+
+
+
+<a name="transaction_v2-StartTransactionRequest"></a>
+
+### StartTransactionRequest
+
+
+
+
+
+
+
+<a name="transaction_v2-Transaction"></a>
+
+### Transaction
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="transaction_v2-TransactionInfo"></a>
+
+### TransactionInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transaction | [Transaction](#transaction_v2-Transaction) |  |  |
+| requests | [TransactionRequest](#transaction_v2-TransactionRequest) | repeated |  |
+| responses | [TransactionResponse](#transaction_v2-TransactionResponse) | repeated |  |
+| started | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+| version | [uint64](#uint64) |  |  |
+
+
+
+
+
+
+<a name="transaction_v2-TransactionInfos"></a>
+
+### TransactionInfos
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transaction_info | [TransactionInfo](#transaction_v2-TransactionInfo) | repeated |  |
+
+
+
+
+
+
+<a name="transaction_v2-TransactionRequest"></a>
+
+### TransactionRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| create_repo | [pfs_v2.CreateRepoRequest](#pfs_v2-CreateRepoRequest) |  | Exactly one of these fields should be set |
+| delete_repo | [pfs_v2.DeleteRepoRequest](#pfs_v2-DeleteRepoRequest) |  |  |
+| start_commit | [pfs_v2.StartCommitRequest](#pfs_v2-StartCommitRequest) |  |  |
+| finish_commit | [pfs_v2.FinishCommitRequest](#pfs_v2-FinishCommitRequest) |  |  |
+| squash_commit_set | [pfs_v2.SquashCommitSetRequest](#pfs_v2-SquashCommitSetRequest) |  |  |
+| create_branch | [pfs_v2.CreateBranchRequest](#pfs_v2-CreateBranchRequest) |  |  |
+| delete_branch | [pfs_v2.DeleteBranchRequest](#pfs_v2-DeleteBranchRequest) |  |  |
+| update_job_state | [pps_v2.UpdateJobStateRequest](#pps_v2-UpdateJobStateRequest) |  |  |
+| stop_job | [pps_v2.StopJobRequest](#pps_v2-StopJobRequest) |  |  |
+| create_pipeline_v2 | [pps_v2.CreatePipelineTransaction](#pps_v2-CreatePipelineTransaction) |  |  |
+
+
+
+
+
+
+<a name="transaction_v2-TransactionResponse"></a>
+
+### TransactionResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| commit | [pfs_v2.Commit](#pfs_v2-Commit) |  | At most, one of these fields should be set (most responses are empty)
+
+Only used for StartCommit - any way we can deterministically provide this before finishing the transaction? |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="transaction_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| BatchTransaction | [BatchTransactionRequest](#transaction_v2-BatchTransactionRequest) | [TransactionInfo](#transaction_v2-TransactionInfo) | Transaction rpcs |
+| StartTransaction | [StartTransactionRequest](#transaction_v2-StartTransactionRequest) | [Transaction](#transaction_v2-Transaction) |  |
+| InspectTransaction | [InspectTransactionRequest](#transaction_v2-InspectTransactionRequest) | [TransactionInfo](#transaction_v2-TransactionInfo) |  |
+| DeleteTransaction | [DeleteTransactionRequest](#transaction_v2-DeleteTransactionRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+| ListTransaction | [ListTransactionRequest](#transaction_v2-ListTransactionRequest) | [TransactionInfos](#transaction_v2-TransactionInfos) |  |
+| FinishTransaction | [FinishTransactionRequest](#transaction_v2-FinishTransactionRequest) | [TransactionInfo](#transaction_v2-TransactionInfo) |  |
+| DeleteAll | [DeleteAllRequest](#transaction_v2-DeleteAllRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
+
+ 
+
+
+
+<a name="version_versionpb_version-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## version/versionpb/version.proto
+
+
+
+<a name="versionpb_v2-Version"></a>
+
+### Version
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| major | [uint32](#uint32) |  |  |
+| minor | [uint32](#uint32) |  |  |
+| micro | [uint32](#uint32) |  |  |
+| additional | [string](#string) |  |  |
+| git_commit | [string](#string) |  |  |
+| git_tree_modified | [string](#string) |  |  |
+| build_date | [string](#string) |  |  |
+| go_version | [string](#string) |  |  |
+| platform | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="versionpb_v2-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| GetVersion | [.google.protobuf.Empty](#google-protobuf-Empty) | [Version](#versionpb_v2-Version) |  |
+
+ 
+
+
+
+<a name="worker_worker-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## worker/worker.proto
+
+
+
+<a name="pachyderm-worker-CancelRequest"></a>
+
+### CancelRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job_id | [string](#string) |  |  |
+| data_filters | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-CancelResponse"></a>
+
+### CancelResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| success | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-NextDatumRequest"></a>
+
+### NextDatumRequest
+Error indicates that the processing of the current datum errored.
+Datum error semantics with datum batching enabled are similar to datum error
+semantics without datum batching enabled in that the datum may be retried,
+recovered, or result with a job failure.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| error | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="pachyderm-worker-NextDatumResponse"></a>
+
+### NextDatumResponse
+Env is a list of environment variables that should be set for the processing
+of the next datum.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| env | [string](#string) | repeated |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="pachyderm-worker-Worker"></a>
+
+### Worker
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Status | [.google.protobuf.Empty](#google-protobuf-Empty) | [.pps_v2.WorkerStatus](#pps_v2-WorkerStatus) |  |
+| Cancel | [CancelRequest](#pachyderm-worker-CancelRequest) | [CancelResponse](#pachyderm-worker-CancelResponse) |  |
+| NextDatum | [NextDatumRequest](#pachyderm-worker-NextDatumRequest) | [NextDatumResponse](#pachyderm-worker-NextDatumResponse) | NextDatum should only be called by user code running in a pipeline with datum batching enabled. NextDatum will signal to the worker code that the user code is ready to proceed to the next datum. This generally means setting up the next datum&#39;s filesystem state and updating internal metadata similarly to datum processing in a normal pipeline. NextDatum is a synchronous operation, so user code should expect to block on this until the next datum is set up for processing. User code should generally be migratable to datum batching by wrapping it in a loop that calls next datum. |
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
+


### PR DESCRIPTION
This adds protoc-gen-doc to `make proto`, outputting JSON and Markdown documentation.

The JSON could be used as input when the friendly docs are being created, so it can be maintained here but displayed on docs.pachyderm.com.  The Markdown is just nice if you're browsing our repo.

One note: the fields are output in "proto" format and not "JSON" format.  We would like users writing a CreatePipelineRequest to use the JSON format, so we might need to adjust that during doc generation.