### PR TITLE
transaction/pretty: fix ID

### DIFF
--- a/src/server/transaction/pretty/pretty.go
+++ b/src/server/transaction/pretty/pretty.go
@@ -43,7 +43,7 @@ func PrintTransactionInfo(w io.Writer, info *transaction.TransactionInfo, fullTi
 // to stdout.
 func PrintDetailedTransactionInfo(info *PrintableTransactionInfo) error {
 	template, err := template.New("TransactionInfo").Funcs(funcMap).Parse(
-		`ID: {{.Transaction.ID}}{{if .FullTimestamps}}
+		`ID: {{.Transaction.Id}}{{if .FullTimestamps}}
 Started: {{prettyTime .Started}}{{else}}
 Started: {{prettyAgo .Started}}{{end}}
 Requests:


### PR DESCRIPTION
This fixes the pretty template for `pachctl inspect transaction`.

Before:

```
$ go run ./src/server/cmd/pachctl inspect transaction
ID: template: TransactionInfo:1:18: executing "TransactionInfo" at <.Transaction.ID>: can't evaluate field ID in type *transaction.Transaction                                                                                    exit status 1
```

After:
```
ID: 77e678e8499745b8b8abe57f357d65ca
Started: 5 minutes ago
Requests:
  create repo default/foo
```