### PR TITLE
Return useful errors from most PFS operations

### DIFF
--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -306,7 +306,7 @@ func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *pachsql.Tx, cb 
 	if err != nil {
 		return err
 	}
-	return txnCtx.Finish(ctx)
+	return errors.Wrap(txnCtx.Finish(ctx), "finish transaction")
 }
 
 func (env *TransactionEnv) waitReady(ctx context.Context) error {

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -115,27 +115,28 @@ func (t *TransactionContext) DeleteBranch(branch *pfs.Branch) {
 // Finish applies the deferred logic in the pfsPropagator and ppsPropagator to
 // the transaction
 func (t *TransactionContext) Finish(ctx context.Context) error {
+	var errs error
 	if t.PfsPropagater != nil {
 		if err := t.PfsPropagater.Run(ctx); err != nil {
-			return errors.EnsureStack(err)
+			errors.JoinInto(&errs, errors.Wrap(err, "propagate pfs"))
 		}
 	}
 	if t.PpsPropagater != nil {
 		if err := t.PpsPropagater.Run(ctx); err != nil {
-			return errors.EnsureStack(err)
+			errors.JoinInto(&errs, errors.Wrap(err, "propagate pps"))
 		}
 	}
 	if t.PpsJobStopper != nil {
 		if err := t.PpsJobStopper.Run(ctx); err != nil {
-			return errors.EnsureStack(err)
+			errors.JoinInto(&errs, errors.Wrap(err, "stop pps jobs"))
 		}
 	}
 	if t.PpsJobFinisher != nil {
 		if err := t.PpsJobFinisher.Run(ctx); err != nil {
-			return errors.EnsureStack(err)
+			errors.JoinInto(&errs, errors.Wrap(err, "finish pps jobs"))
 		}
 	}
-	return nil
+	return errs
 }
 
 // PfsPropagater is the interface that PFS implements to propagate commits at

--- a/src/pfs/pfs.go
+++ b/src/pfs/pfs.go
@@ -60,6 +60,9 @@ func (p *Project) Key() string {
 }
 
 func (r *Repo) String() string {
+	if r == nil {
+		return "<nil>"
+	}
 	if r.Type == UserRepoType {
 		if projectName := r.Project.String(); projectName != "" {
 			return projectName + "/" + r.Name
@@ -99,7 +102,7 @@ func (c *Commit) NewFile(path string) *File {
 }
 
 func (c *Commit) String() string {
-	return c.Repo.String() + "@" + c.Id
+	return c.GetRepo().String() + "@" + c.GetId()
 }
 
 func (c *Commit) Key() string {
@@ -123,7 +126,7 @@ func (b *Branch) NewCommit(id string) *Commit {
 }
 
 func (b *Branch) String() string {
-	return b.Repo.String() + "@" + b.Name
+	return b.GetRepo().String() + "@" + b.GetName()
 }
 
 func (b *Branch) Key() string {

--- a/src/pps/pps.go
+++ b/src/pps/pps.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (j *Job) String() string {
+	if j == nil {
+		return "<nil job>"
+	}
 	return fmt.Sprintf("%s@%s", j.Pipeline, j.Id)
 }
 

--- a/src/server/auth/server/testing/auth_integration_test.go
+++ b/src/server/auth/server/testing/auth_integration_test.go
@@ -191,7 +191,6 @@ func TestS3GatewayAuthRequests(t *testing.T) {
 // Need to restructure testing such that we have the implementation of this
 // test in one place while still being able to test auth enabled and disabled clusters.
 func testDebug(t *testing.T, c *client.APIClient, projectName, repoName string) {
-	t.Helper()
 	// Get all the authenticated clients at the beginning of the test.
 	// GetAuthenticatedPachClient will always re-activate auth, which
 	// causes PPS to rotate all the pipeline tokens. This makes the RCs

--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1506,7 +1506,7 @@ func Cmds(mainCtx context.Context, pachCtx *config.Context, pachctlCfg *pachctl.
 				if errutil.IsNotFoundError(err) {
 					return err
 				}
-				return errors.Wrapf(err, "could not inspect repo %s", err, file.Commit.Branch.Repo.Name)
+				return errors.Wrapf(err, "could not inspect repo %s", file.Commit.Branch.Repo.Name)
 			}
 
 			// TODO: Rethink put file parallelism for 2.0.

--- a/src/server/pfs/server/commit_set.go
+++ b/src/server/pfs/server/commit_set.go
@@ -160,14 +160,14 @@ func (d *driver) listCommitSet(ctx context.Context, project *pfs.Project, cb fun
 func (d *driver) dropCommitSet(ctx context.Context, txnCtx *txncontext.TransactionContext, commitset *pfs.CommitSet) error {
 	css, err := d.subvenantCommitSets(txnCtx, commitset)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "get subvenant commitsets")
 	}
 	if len(css) > 0 {
 		return &pfsserver.ErrSquashWithSubvenance{CommitSet: commitset, SubvenantCommitSets: css}
 	}
 	cis, err := d.inspectCommitSetImmediateTx(ctx, txnCtx, commitset, false)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "insepect commitset")
 	}
 	for _, ci := range cis {
 		if ci.Commit.AccessRepo().Type == pfs.SpecRepoType && ci.Origin.Kind == pfs.OriginKind_USER {
@@ -184,7 +184,7 @@ func (d *driver) dropCommitSet(ctx context.Context, txnCtx *txncontext.Transacti
 	// non-head commits (until generalized drop semantics are implemented).
 	for _, ci := range cis {
 		if err := d.deleteCommit(ctx, txnCtx, ci); err != nil {
-			return err
+			return errors.Wrapf(err, "delete commit %v", ci.GetCommit().String())
 		}
 	}
 	// notify PPS that this commitset has been dropped so it can clean up any

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
@@ -69,7 +70,7 @@ func (sd *stateDriver) FetchState(ctx context.Context, pipeline *pps.Pipeline) (
 	// query pipelineInfo
 	var pi *pps.PipelineInfo
 	var err error
-	if pi, err = sd.tryLoadLatestPipelineInfo(ctx, pipeline); err != nil && collection.IsErrNotFound(err) {
+	if pi, err = sd.tryLoadLatestPipelineInfo(ctx, pipeline); err != nil && errutil.IsNotFoundError(err) {
 		// if the pipeline info is not found, interpret the operation as a delete
 		return nil, nil, nil
 	} else if err != nil {


### PR DESCRIPTION
This PR adds error messages for common mistakes by improving validation.

Whenever we reference something, we ensure that it exists.  This way, something like `pachctl list branch foo@master --project=does-not-exist` returns `project "does-not-exist"` does not exist.  Same for a missing repo, `repo default/foo@master not found`.  Previously, we just said that the branch didn't exist.

This is mostly accomplished in two ways; by checking for existence after checking authorization, and by returning more detailed errors when something is not found.  (For example, when we check repo existence, if the database returns ErrNoRows, we also check whether the project exists.  This way, you get "no project" instead of "no repo".)  `resolveCommit` also does this repo check where appropriate.  Eventually the special case in driver to check the repo will go away; the database migration's "lookup branch" function will do this for us (like "lookup repo" does for the project).

Finally, I replaced all instances of `EnsureStack` in the PFS driver with `errors.Wrap`.  Honestly, that's the bulk of the diff.  I was in the mood and error messages should be easier to reference to the code causing them now.

CORE-1902

