### PR TITLE
[CORE-1917] Use log.Proto for logging gRPC details

### DIFF
--- a/src/internal/middleware/logging/interceptor.go
+++ b/src/internal/middleware/logging/interceptor.go
@@ -164,7 +164,14 @@ func getResponseLogger(ctx context.Context, res any, sent, rcvd int, err error) 
 	}
 	if dd := s.Details(); len(dd) > 0 {
 		for i, d := range dd {
-			f = append(f, zap.String(fmt.Sprintf("grpc.details[%d]", i), fmt.Sprint(d)))
+			switch d := d.(type) {
+			case error:
+				f = append(f, zap.NamedError(fmt.Sprintf("grpc.details[%d]", i), d))
+			case proto.Message:
+				f = append(f, log.Proto(fmt.Sprintf("grpc.details[%d]", i), d))
+			default:
+				f = append(f, zap.Any(fmt.Sprintf("grpc.details[%d]", i), d))
+			}
 		}
 	}
 	return pctx.Child(ctx, "", pctx.WithFields(f...))


### PR DESCRIPTION
Also log as an error if there were an error, and handle the “impossible” case of being neither an error not a proto message.