### PR TITLE
pachctl: add a "misc grpc" command to make arbitrary RPCs

### DIFF
--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -600,11 +600,11 @@ func newOnUserMachine(ctx context.Context, cfg *config.Config, context *config.C
 			// This is an older version check designed to detect 1.x vs. 2.x mismatch.
 			pachdVersion, versErr := client.Version()
 			if err != nil {
-				return nil, errors.Wrap(scrubbedErr, errors.Wrap(versErr, "could not determine pachd version").Error())
+				return nil, errors.Join(scrubbedErr, errors.Wrap(versErr, "could not determine pachd version"))
 			}
 			pachdMajVersion, convErr := strconv.Atoi(strings.Split(pachdVersion, ".")[0])
 			if convErr != nil {
-				return nil, errors.Wrap(scrubbedErr, errors.Wrap(convErr, "could not parse pachd major version").Error())
+				return nil, errors.Join(scrubbedErr, errors.Wrap(convErr, "could not parse pachd major version"))
 			}
 			if pachdMajVersion != int(version.Version.Major) {
 				return nil, errors.Errorf("this client is for pachyderm %d.x, but the server has a version %d.x - please install the correct client for your server", version.Version.Major, pachdMajVersion)
@@ -934,9 +934,16 @@ func (c *APIClient) ClientContextName() string {
 	return c.clientContextName
 }
 
+// ClusterInfo returns information about the cluster that is retrieved at connection time, saving a
+// redundant call to InspectCluster.
 func (c *APIClient) ClusterInfo() (info *admin.ClusterInfo, ok bool) {
 	if c == nil || c.inspectClusterResult == nil {
 		return nil, false
 	}
 	return c.inspectClusterResult, true
+}
+
+// ClientConn returns the current grpc client connection.
+func (c *APIClient) ClientConn() *grpc.ClientConn {
+	return c.clientConn
 }

--- a/src/internal/log/field.go
+++ b/src/internal/log/field.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -41,6 +42,9 @@ func Proto(name string, msg proto.Message) Field {
 			return zap.Any(name, x)
 		}
 		return Proto(name, msg)
+	}
+	if js, err := protojson.Marshal(msg); err == nil {
+		return zap.ByteString(name, js)
 	}
 	return zap.Any(name, msg)
 }

--- a/src/internal/log/field_test.go
+++ b/src/internal/log/field_test.go
@@ -42,11 +42,11 @@ func TestProto(t *testing.T) {
 	}
 	Info(ctx, "bad any", Proto("any", badAny))
 
-	any, err := anypb.New(&versionpb.Version{Major: 42})
+	goodAny, err := anypb.New(&versionpb.Version{Major: 42})
 	if err != nil {
 		t.Fatal(err)
 	}
-	Info(ctx, "good any", Proto("any", any))
+	Info(ctx, "good any", Proto("any", goodAny))
 	Info(ctx, "nil any", Proto("any", (*anypb.Any)(nil)))
 
 	Info(ctx, "empty", Proto("empty", &emptypb.Empty{}))
@@ -65,7 +65,7 @@ func TestProto(t *testing.T) {
 	if err != nil {
 		t.Errorf("protoToJSONMap: %v", err)
 	}
-	if diff := cmp.Diff(map[string]interface{}{"major": float64(3)}, raw); diff != "" {
+	if diff := cmp.Diff(map[string]any{"major": float64(3)}, raw); diff != "" {
 		t.Errorf("protoToJSONMap (-want +got):\n%s", diff)
 	}
 	Info(ctx, "dynamic message", Proto("dynamic", dynamic))

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -227,7 +227,7 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 	grpc := &cobra.Command{
 		Use:   "{{alias}} service.Method {msg}... ",
 		Short: "Call a gRPC method on the server.",
-		Long:  "Call a gRPC method on the server.",
+		Long:  "Call a gRPC method on the server.  With no args; prints all available methods.  With 1 arg; reads messages to send as JSON lines from stdin.  With >1 arg, sends each JSON-encoded argument as a message.",
 		Run: cmdutil.Run(func(args []string) error {
 			return gRPCParams{
 				Address: grpcAddress,

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -10,22 +10,41 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/admin"
+	"github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/debug"
+	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	ci "github.com/pachyderm/pachyderm/v2/src/internal/middleware/logging/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachctl"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/preflight"
 	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
+	"github.com/pachyderm/pachyderm/v2/src/license"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"github.com/pachyderm/pachyderm/v2/src/proxy"
+	"github.com/pachyderm/pachyderm/v2/src/transaction"
+	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
+	"github.com/pachyderm/pachyderm/v2/src/worker"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
@@ -202,7 +221,7 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 		Short: "Runs the database migrations against the supplied database, then rolls them back.",
 		Long:  "Runs the database migrations against the supplied database, then rolls them back.",
 		Run: cmdutil.RunFixedArgs(1, func(args []string) (retErr error) {
-			ctx, c := signal.NotifyContext(pctx.Background(""), signals.TerminationSignals...)
+			ctx, c := signal.NotifyContext(ctx, signals.TerminationSignals...)
 			defer c()
 
 			dsn := args[0]
@@ -220,6 +239,107 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 		}),
 	}
 	commands = append(commands, cmdutil.CreateAlias(testMigrations, "misc test-migrations"))
+
+	var grpcAddress string
+	var grpcTLS bool
+	var grpcHeaders []string
+	grpc := &cobra.Command{
+		Use:   "{{alias}} service.Method {msg}... ",
+		Short: "Call a gRPC method on the server.",
+		Long:  "Call a gRPC method on the server.",
+		Run: cmdutil.Run(func(args []string) error {
+			handlers := buildRPCs(
+				admin.File_admin_admin_proto,
+				auth.File_auth_auth_proto,
+				debug.File_debug_debug_proto,
+				enterprise.File_enterprise_enterprise_proto,
+				identity.File_identity_identity_proto,
+				license.File_license_license_proto,
+				pfs.File_pfs_pfs_proto,
+				pps.File_pps_pps_proto,
+				proxy.File_proxy_proxy_proto,
+				transaction.File_transaction_transaction_proto,
+				versionpb.File_version_versionpb_version_proto,
+				worker.File_worker_worker_proto,
+			)
+
+			// If no args, print all available RPCs.  The names can be difficult to
+			// guess.
+			if len(args) == 0 {
+				// Print RPCs.
+				methods := maps.Keys(handlers)
+				sort.Strings(methods)
+				fmt.Fprintf(os.Stderr, "Specify the RPC you'd like to call:\n%s",
+					strings.Join(methods, "\n"))
+				return nil
+			}
+
+			// If there's an arg, find the method.
+			f, ok := handlers[args[0]]
+			if !ok {
+				return errors.Errorf("no method %v", args[0])
+			}
+
+			ctx, c := signal.NotifyContext(ctx, signals.TerminationSignals...)
+			defer c()
+
+			// Get a client connection.
+			authCtx := ctx
+			var cc grpc.ClientConnInterface
+			if grpcAddress == "" {
+				// If --address isn't set, use the pach context to connect.
+				cl, err := pachctlCfg.NewOnUserMachine(ctx, false)
+				if err != nil {
+					return errors.Wrap(err, "connect")
+				}
+				authCtx = cl.Ctx()
+				cc = cl.ClientConn()
+				defer cl.Close()
+			} else {
+				// If --address is set, just dial the server.
+				creds := insecure.NewCredentials()
+				if grpcTLS {
+					creds = credentials.NewTLS(&tls.Config{
+						InsecureSkipVerify: true,
+					})
+				}
+				var err error
+				cc, err = grpc.Dial(grpcAddress, grpc.WithTransportCredentials(creds), grpc.WithUnaryInterceptor(ci.LogUnary), grpc.WithStreamInterceptor(ci.LogStream))
+				if err != nil {
+					return errors.Wrap(err, "dial --address")
+				}
+			}
+
+			// Add headers
+			md := make(metadata.MD)
+			for _, h := range grpcHeaders {
+				parts := strings.SplitN(h, "=", 2)
+				if len(parts) != 2 {
+					return errors.Errorf("malformed --header %q; use Key=Value", h)
+				}
+				md.Append(parts[0], parts[1])
+			}
+			authCtx = metadata.NewOutgoingContext(authCtx, md)
+
+			// Add a note during "long" RPCs.
+			go func() {
+				select {
+				case <-time.After(5 * time.Second):
+					fmt.Fprintln(os.Stderr, "RPC running; press Control-c to cancel...")
+				case <-ctx.Done():
+					return
+				}
+			}()
+			if err := f(authCtx, cc, os.Stdout, args[1:]...); err != nil {
+				return errors.Wrap(err, "do RPC")
+			}
+			return nil
+		}),
+	}
+	grpc.PersistentFlags().StringVar(&grpcAddress, "address", "", "If set, don't use the pach client to connect, but manually dial the provided GRPC address instead; url must be in a form like dns:/// or passthrough:///, not http:// or grpc://")
+	grpc.PersistentFlags().BoolVar(&grpcTLS, "tls", false, "If set along with --address, use TLS to connect to the server.  The certificate is NOT checked for validity.")
+	grpc.PersistentFlags().StringSliceVarP(&grpcHeaders, "header", "H", nil, "foo")
+	commands = append(commands, cmdutil.CreateAlias(grpc, "misc grpc"))
 
 	misc := &cobra.Command{
 		Short:  "Miscellaneous utilities unrelated to Pachyderm itself.",

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -311,15 +311,13 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 			}
 
 			// Add headers
-			md := make(metadata.MD)
 			for _, h := range grpcHeaders {
 				parts := strings.SplitN(h, "=", 2)
 				if len(parts) != 2 {
 					return errors.Errorf("malformed --header %q; use Key=Value", h)
 				}
-				md.Append(parts[0], parts[1])
+				authCtx = metadata.AppendToOutgoingContext(authCtx, parts[0], parts[1])
 			}
-			authCtx = metadata.NewOutgoingContext(authCtx, md)
 
 			// Add a note during "long" RPCs.
 			go func() {

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -236,9 +236,9 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 			}.Run(ctx, pachctlCfg, os.Stdout, args)
 		}),
 	}
-	grpc.PersistentFlags().StringVar(&grpcAddress, "address", "", "If set, don't use the pach client to connect, but manually dial the provided GRPC address instead; url must be in a form like dns:/// or passthrough:///, not http:// or grpc://")
+	grpc.PersistentFlags().StringVar(&grpcAddress, "address", "", "If set, don't use the pach client to connect, but manually dial the provided GRPC address instead; url must be in a form like dns:/// or passthrough:///, not http:// or grpc://.")
 	grpc.PersistentFlags().BoolVar(&grpcTLS, "tls", false, "If set along with --address, use TLS to connect to the server.  The certificate is NOT checked for validity.")
-	grpc.PersistentFlags().StringSliceVarP(&grpcHeaders, "header", "H", nil, "foo")
+	grpc.PersistentFlags().StringSliceVarP(&grpcHeaders, "header", "H", nil, "Key=Value metadata to add to the request; repeatable.")
 	commands = append(commands, cmdutil.CreateAlias(grpc, "misc grpc"))
 
 	misc := &cobra.Command{

--- a/src/server/misc/cmds/cmds.go
+++ b/src/server/misc/cmds/cmds.go
@@ -10,41 +10,22 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pachyderm/pachyderm/v2/src/admin"
-	"github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/debug"
-	"github.com/pachyderm/pachyderm/v2/src/enterprise"
-	"github.com/pachyderm/pachyderm/v2/src/identity"
 	"github.com/pachyderm/pachyderm/v2/src/internal/archiveserver"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	ci "github.com/pachyderm/pachyderm/v2/src/internal/middleware/logging/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachctl"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/preflight"
 	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
-	"github.com/pachyderm/pachyderm/v2/src/license"
-	"github.com/pachyderm/pachyderm/v2/src/pfs"
-	"github.com/pachyderm/pachyderm/v2/src/pps"
-	"github.com/pachyderm/pachyderm/v2/src/proxy"
-	"github.com/pachyderm/pachyderm/v2/src/transaction"
-	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
-	"github.com/pachyderm/pachyderm/v2/src/worker"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 )
 
 func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
@@ -248,90 +229,11 @@ func Cmds(ctx context.Context, pachctlCfg *pachctl.Config) []*cobra.Command {
 		Short: "Call a gRPC method on the server.",
 		Long:  "Call a gRPC method on the server.",
 		Run: cmdutil.Run(func(args []string) error {
-			handlers := buildRPCs(
-				admin.File_admin_admin_proto,
-				auth.File_auth_auth_proto,
-				debug.File_debug_debug_proto,
-				enterprise.File_enterprise_enterprise_proto,
-				identity.File_identity_identity_proto,
-				license.File_license_license_proto,
-				pfs.File_pfs_pfs_proto,
-				pps.File_pps_pps_proto,
-				proxy.File_proxy_proxy_proto,
-				transaction.File_transaction_transaction_proto,
-				versionpb.File_version_versionpb_version_proto,
-				worker.File_worker_worker_proto,
-			)
-
-			// If no args, print all available RPCs.  The names can be difficult to
-			// guess.
-			if len(args) == 0 {
-				// Print RPCs.
-				methods := maps.Keys(handlers)
-				sort.Strings(methods)
-				fmt.Fprintf(os.Stderr, "Specify the RPC you'd like to call:\n%s",
-					strings.Join(methods, "\n"))
-				return nil
-			}
-
-			// If there's an arg, find the method.
-			f, ok := handlers[args[0]]
-			if !ok {
-				return errors.Errorf("no method %v", args[0])
-			}
-
-			ctx, c := signal.NotifyContext(ctx, signals.TerminationSignals...)
-			defer c()
-
-			// Get a client connection.
-			authCtx := ctx
-			var cc grpc.ClientConnInterface
-			if grpcAddress == "" {
-				// If --address isn't set, use the pach context to connect.
-				cl, err := pachctlCfg.NewOnUserMachine(ctx, false)
-				if err != nil {
-					return errors.Wrap(err, "connect")
-				}
-				authCtx = cl.Ctx()
-				cc = cl.ClientConn()
-				defer cl.Close()
-			} else {
-				// If --address is set, just dial the server.
-				creds := insecure.NewCredentials()
-				if grpcTLS {
-					creds = credentials.NewTLS(&tls.Config{
-						InsecureSkipVerify: true,
-					})
-				}
-				var err error
-				cc, err = grpc.Dial(grpcAddress, grpc.WithTransportCredentials(creds), grpc.WithUnaryInterceptor(ci.LogUnary), grpc.WithStreamInterceptor(ci.LogStream))
-				if err != nil {
-					return errors.Wrap(err, "dial --address")
-				}
-			}
-
-			// Add headers
-			for _, h := range grpcHeaders {
-				parts := strings.SplitN(h, "=", 2)
-				if len(parts) != 2 {
-					return errors.Errorf("malformed --header %q; use Key=Value", h)
-				}
-				authCtx = metadata.AppendToOutgoingContext(authCtx, parts[0], parts[1])
-			}
-
-			// Add a note during "long" RPCs.
-			go func() {
-				select {
-				case <-time.After(5 * time.Second):
-					fmt.Fprintln(os.Stderr, "RPC running; press Control-c to cancel...")
-				case <-ctx.Done():
-					return
-				}
-			}()
-			if err := f(authCtx, cc, os.Stdout, args[1:]...); err != nil {
-				return errors.Wrap(err, "do RPC")
-			}
-			return nil
+			return gRPCParams{
+				Address: grpcAddress,
+				TLS:     grpcTLS,
+				Headers: grpcHeaders,
+			}.Run(ctx, pachctlCfg, os.Stdout, args)
 		}),
 	}
 	grpc.PersistentFlags().StringVar(&grpcAddress, "address", "", "If set, don't use the pach client to connect, but manually dial the provided GRPC address instead; url must be in a form like dns:/// or passthrough:///, not http:// or grpc://")

--- a/src/server/misc/cmds/grpc.go
+++ b/src/server/misc/cmds/grpc.go
@@ -1,0 +1,128 @@
+package cmds
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/admin"
+	"github.com/pachyderm/pachyderm/v2/src/auth"
+	"github.com/pachyderm/pachyderm/v2/src/debug"
+	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/identity"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	ci "github.com/pachyderm/pachyderm/v2/src/internal/middleware/logging/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachctl"
+	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
+	"github.com/pachyderm/pachyderm/v2/src/license"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"github.com/pachyderm/pachyderm/v2/src/proxy"
+	"github.com/pachyderm/pachyderm/v2/src/transaction"
+	"github.com/pachyderm/pachyderm/v2/src/version/versionpb"
+	"github.com/pachyderm/pachyderm/v2/src/worker"
+	"golang.org/x/exp/maps"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+type gRPCParams struct {
+	Address string
+	TLS     bool
+	Headers []string
+}
+
+func (p gRPCParams) Run(ctx context.Context, pachctlCfg *pachctl.Config, w io.Writer, args []string) error {
+	handlers := buildRPCs(
+		admin.File_admin_admin_proto,
+		auth.File_auth_auth_proto,
+		debug.File_debug_debug_proto,
+		enterprise.File_enterprise_enterprise_proto,
+		identity.File_identity_identity_proto,
+		license.File_license_license_proto,
+		pfs.File_pfs_pfs_proto,
+		pps.File_pps_pps_proto,
+		proxy.File_proxy_proxy_proto,
+		transaction.File_transaction_transaction_proto,
+		versionpb.File_version_versionpb_version_proto,
+		worker.File_worker_worker_proto,
+	)
+
+	// If no args, print all available RPCs.  The names can be difficult to
+	// guess.
+	if len(args) == 0 {
+		// Print RPCs.
+		methods := maps.Keys(handlers)
+		sort.Strings(methods)
+		fmt.Fprintf(os.Stderr, "Specify the RPC you'd like to call:\n%s",
+			strings.Join(methods, "\n"))
+		return nil
+	}
+
+	// If there's an arg, find the method.
+	f, ok := handlers[args[0]]
+	if !ok {
+		return errors.Errorf("no method %v", args[0])
+	}
+
+	ctx, c := signal.NotifyContext(ctx, signals.TerminationSignals...)
+	defer c()
+
+	// Get a client connection.
+	authCtx := ctx
+	var cc grpc.ClientConnInterface
+	if p.Address == "" {
+		// If --address isn't set, use the pach context to connect.
+		cl, err := pachctlCfg.NewOnUserMachine(ctx, false)
+		if err != nil {
+			return errors.Wrap(err, "connect")
+		}
+		authCtx = cl.Ctx()
+		cc = cl.ClientConn()
+		defer cl.Close()
+	} else {
+		// If --address is set, just dial the server.
+		creds := insecure.NewCredentials()
+		if p.TLS {
+			creds = credentials.NewTLS(&tls.Config{
+				InsecureSkipVerify: true,
+			})
+		}
+		var err error
+		cc, err = grpc.Dial(p.Address, grpc.WithTransportCredentials(creds), grpc.WithUnaryInterceptor(ci.LogUnary), grpc.WithStreamInterceptor(ci.LogStream))
+		if err != nil {
+			return errors.Wrap(err, "dial --address")
+		}
+	}
+
+	// Add headers
+	for _, h := range p.Headers {
+		parts := strings.SplitN(h, "=", 2)
+		if len(parts) != 2 {
+			return errors.Errorf("malformed --header %q; use Key=Value", h)
+		}
+		authCtx = metadata.AppendToOutgoingContext(authCtx, parts[0], parts[1])
+	}
+
+	// Add a note during "long" RPCs.
+	go func() {
+		select {
+		case <-time.After(5 * time.Second):
+			fmt.Fprintln(os.Stderr, "RPC running; press Control-c to cancel...")
+		case <-ctx.Done():
+			return
+		}
+	}()
+	if err := f(authCtx, cc, w, args[1:]...); err != nil {
+		return errors.Wrap(err, "do RPC")
+	}
+	return nil
+}

--- a/src/server/misc/cmds/grpc.go
+++ b/src/server/misc/cmds/grpc.go
@@ -62,8 +62,9 @@ func (p gRPCParams) Run(ctx context.Context, pachctlCfg *pachctl.Config, w io.Wr
 		// Print RPCs.
 		methods := maps.Keys(handlers)
 		sort.Strings(methods)
-		fmt.Fprintf(os.Stderr, "Specify the RPC you'd like to call:\n%s",
-			strings.Join(methods, "\n"))
+		for _, m := range methods {
+			fmt.Println(m)
+		}
 		return nil
 	}
 

--- a/src/server/misc/cmds/grpc_reflect.go
+++ b/src/server/misc/cmds/grpc_reflect.go
@@ -92,7 +92,9 @@ func makeStreaming(name string, reqType, resType protoreflect.MessageDescriptor,
 					return
 				}
 			}
-			fmt.Fprintln(os.Stderr, "All messages sent")
+			if isClientStreaming {
+				fmt.Fprintln(os.Stderr, "All messages sent")
+			}
 		}()
 
 		for i := 0; ; i++ {

--- a/src/server/misc/cmds/grpc_reflect.go
+++ b/src/server/misc/cmds/grpc_reflect.go
@@ -1,0 +1,158 @@
+package cmds
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type rpcFunc func(context.Context, grpc.ClientConnInterface, io.Writer, ...string) error
+
+func buildRPCs(protos ...protoreflect.FileDescriptor) map[string]rpcFunc {
+	result := make(map[string]rpcFunc)
+	for _, fd := range protos {
+		svcs := fd.Services()
+		for si := 0; si < svcs.Len(); si++ {
+			sd := svcs.Get(si)
+			methods := sd.Methods()
+			for mi := 0; mi < methods.Len(); mi++ {
+				md := methods.Get(mi)
+
+				name := "/" + path.Join(string(sd.FullName()), string(md.Name()))
+				in := md.Input()
+				out := md.Output()
+				switch {
+				case md.IsStreamingClient() || md.IsStreamingServer():
+					result[string(md.FullName())] = makeStreaming(name, in, out, md.IsStreamingServer(), md.IsStreamingClient())
+				default:
+					result[string(md.FullName())] = makeUnary(name, in, out)
+				}
+			}
+		}
+	}
+	return result
+}
+
+func makeStreaming(name string, reqType, resType protoreflect.MessageDescriptor, isServerStreaming, isClientStreaming bool) rpcFunc {
+	return func(ctx context.Context, cc grpc.ClientConnInterface, w io.Writer, req ...string) (retErr error) {
+		if !isClientStreaming && len(req) > 1 {
+			return errors.New("too many messages for a server streaming RPC")
+		}
+		if len(req) == 0 {
+			req = append(req, `{}`)
+		}
+
+		ctx, killRPC := context.WithCancelCause(ctx)
+		defer killRPC(nil)
+		defer func() {
+			select {
+			case <-ctx.Done():
+				errors.JoinInto(&retErr, errors.Wrap(context.Cause(ctx), "context error"))
+			default:
+			}
+		}()
+
+		sd := &grpc.StreamDesc{
+			StreamName: name,
+			// Note that this code doesn't care about whether this is bidirectional or
+			// not; we treat all RPCs as bidirectional except for the input validation
+			// above.
+			ServerStreams: isServerStreaming,
+			ClientStreams: isClientStreaming,
+		}
+		stream, err := cc.NewStream(ctx, sd, name)
+		if err != nil {
+			return errors.Wrap(handleGrpcError(err), "start stream")
+		}
+
+		go func() {
+			defer func() {
+				if err := stream.CloseSend(); err != nil {
+					fmt.Fprintf(os.Stderr, "CloseSend: %v", handleGrpcError(err))
+				}
+			}()
+			for i, msg := range req {
+				req := dynamicpb.NewMessage(reqType)
+				if err := protojson.Unmarshal([]byte(msg), req); err != nil {
+					killRPC(errors.Wrapf(err, "unmarshal message %v of type %v", i, req.Descriptor().FullName()))
+					return
+				}
+				if err := stream.SendMsg(req); err != nil {
+					killRPC(errors.Wrapf(err, "send message %v", i))
+					return
+				}
+			}
+			fmt.Fprintln(os.Stderr, "All messages sent")
+		}()
+
+		for i := 0; ; i++ {
+			msg := dynamicpb.NewMessage(resType)
+			if err := stream.RecvMsg(msg); err != nil {
+				if errors.Is(err, io.EOF) {
+					return nil
+				}
+				return errors.Wrapf(handleGrpcError(err), "receive message %d", i)
+			}
+			js, err := protojson.Marshal(msg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n    (problem marshaling to JSON: %v)", msg.String(), err)
+			}
+			fmt.Fprintf(w, "%s\n", js)
+		}
+	}
+}
+
+func makeUnary(name string, reqType, resType protoreflect.MessageDescriptor) rpcFunc {
+	return func(ctx context.Context, cc grpc.ClientConnInterface, w io.Writer, req ...string) error {
+		if len(req) > 1 {
+			return errors.New("too many messages for a unary RPC")
+		}
+		if len(req) == 0 {
+			req = append(req, `{}`)
+		}
+		in := dynamicpb.NewMessage(reqType)
+		if err := protojson.Unmarshal([]byte(req[0]), in); err != nil {
+			return errors.Wrapf(err, "unmarshal request into %v", in.Descriptor().FullName())
+		}
+
+		out := dynamicpb.NewMessage(resType)
+		if err := cc.Invoke(ctx, name, in, out); err != nil {
+			return errors.Wrap(handleGrpcError(err), "invoke")
+		}
+		js, err := protojson.Marshal(out)
+		if err != nil {
+			return errors.Wrap(err, "marshal response")
+		}
+		fmt.Fprintf(w, "%s\n", js)
+		return nil
+	}
+}
+
+func handleGrpcError(err error) error {
+	s, ok := status.FromError(err)
+	if ok {
+		p := s.Proto()
+		var details []string
+		for _, d := range p.GetDetails() {
+			if js, err := protojson.Marshal(d); err != nil {
+				details = append(details, fmt.Sprintf("    %v (%v)", d.String(), err))
+			} else {
+				details = append(details, "    "+string(js))
+			}
+		}
+		if len(details) > 0 {
+			return errors.Errorf("%v\n  details:\n%s", err, strings.Join(details, "\n"))
+		}
+	}
+	return err
+}

--- a/src/server/misc/cmds/grpc_test.go
+++ b/src/server/misc/cmds/grpc_test.go
@@ -1,0 +1,59 @@
+package cmds
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/admin"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+type fakeAdmin struct {
+	admin.UnimplementedAPIServer
+}
+
+func (fakeAdmin) InspectCluster(ctx context.Context, req *admin.InspectClusterRequest) (*admin.ClusterInfo, error) {
+	if req.GetClientVersion().GetMajor() != 42 {
+		return nil, status.Error(codes.InvalidArgument, "wrong version")
+	}
+	info := new(admin.ClusterInfo)
+	info.WarningsOk = true
+	return info, nil
+}
+
+func TestGRPC(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	s := grpc.NewServer()
+	admin.RegisterAPIServer(s, new(fakeAdmin))
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+	go func() {
+		if err := s.Serve(l); err != nil {
+			panic(err)
+		}
+	}()
+	t.Cleanup(s.Stop)
+	out := new(bytes.Buffer)
+	p := gRPCParams{Address: l.Addr().String()}
+	if err := p.Run(ctx, nil, out, []string{"admin_v2.API.InspectCluster", `{"clientVersion":{"major":42}}`}); err != nil {
+		t.Fatalf("rpc failed: %v", err)
+	}
+	got, want := &admin.ClusterInfo{}, &admin.ClusterInfo{WarningsOk: true}
+	if err := protojson.Unmarshal(out.Bytes(), got); err != nil {
+		t.Fatalf("unmarshal reply: %v", err)
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("reply (-want +got):\n%v", err)
+	}
+}


### PR DESCRIPTION
This allows you to call any RPC with any arguments you want:

Query a worker status:
```
$ pachctl misc grpc pachyderm.worker.Worker.Status --address="passthrough:///localhost:1080"
{"workerId":"default-edges-v1-rmwrv"}
```

Upload a file:
```
$ pachctl misc grpc pfs_v2.API.ModifyFile '{"set_commit":{"repo":{"name":"images","project":{"name":"default"},"type":"user"},"branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"}}}' '{"add_file":{"path":"/test.txt","raw":"aGVsbG8K"}}'
All messages sent
{}
```

List repos and format with jq:
```
$ pachctl misc grpc pfs_v2.API.ListRepo '{"projects":[{"name":"default"}]}' | jq '{name: .repo.name, description}' -c
{"name":"images","description":null}
{"name":"foo","description":null}
{"name":"bar","description":null}
{"name":"edges","description":"Output repo for pipeline default/edges."}
{"name":"edges","description":"Spec repo for pipeline default/edges."}
{"name":"edges","description":"Meta repo for pipeline edges"}
```

I have already found 2 bugs with this 😂 

Finally, I improved `log.Proto` to cleanly marshal things like `dynamicpb.Message`, so that debug logs `pachctl misc grpc ... -v` look normal, even though we aren't using the proto objects that have MarshalLogObject.

Example:

```
$ pachctl misc grpc pfs_v2.API.ModifyFile '{"set_commit":{"repo":{"name":"images","project":{"name":"default"},"type":"user"},"branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"}}}' '{"add_file":{"path":"/test.txt","raw":"aGVsbG8K"}}' -v
...
2023-08-31T14:01:51.715-0400    DEBUG   grpcClient.admin_v2.API/InspectCluster  admin_v2.API/InspectCluster: span start
2023-08-31T14:01:51.715-0400    DEBUG   grpcClient.admin_v2.API/InspectCluster  request {"request": {"client_version": {"major": 0, "minor": 0, "micro": 0, "additional": "", "git_commit": "", "git_tree_modified": "", "build_date": "", "go_version": "go1.21.0", "platform": "amd64"}, "current_project": {"name": "default"}}, "metadata": {"authn-token": "[MASKED]", "command": "..."}}
2023-08-31T14:01:51.724-0400    DEBUG   grpcClient.admin_v2.API/InspectCluster  admin_v2.API/InspectCluster: span finished ok   {"spanDuration": "8.477999ms", "headers": {"content-type": "application/grpc", "date": "Thu, 31 Aug 2023 18:01:51 GMT", "server": "envoy", "x-envoy-upstream-service-time": "7"}, "trailer": {}, "reply": {"id": "976ef26581fc45f8ad963f685cb34b3c", "deployment_id": "dev", "warnings_ok": true, "warnings": [], "proxy_host": "192.168.1.70", "proxy_tls": false, "paused": false, "web_resources": {"archive_download_base_url": "http://192.168.1.70/archive/", "create_pipeline_request_json_schema_url": "http://192.168.1.70/jsonschema/pps_v2/CreatePipelineRequest.schema.json"}}}
2023-08-31T14:01:51.724-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile pfs_v2.API/ModifyFile: span start
2023-08-31T14:01:51.724-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile stream started  {"metadata": {"authn-token": "[MASKED]", "command": "..."}}
2023-08-31T14:01:51.724-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile sent message    {"request": {"setCommit":{"branch":{"name":"master","repo":{"name":"images","project":{"name":"default"},"type":"user"}},"repo":{"name":"images","project":{"name":"default"},"type":"user"}}}}
2023-08-31T14:01:51.724-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile sent message    {"request": {"addFile":{"path":"/test.txt","raw":"aGVsbG8K"}}}
All messages sent
2023-08-31T14:01:51.724-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile send side of stream closed
2023-08-31T14:01:51.765-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile server headers  {"headers": {"content-type": "application/grpc", "date": "Thu, 31 Aug 2023 18:01:51 GMT", "server": "envoy", "x-envoy-upstream-service-time": "40"}}
2023-08-31T14:01:51.765-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile received message        {"reply": {}}
2023-08-31T14:01:51.766-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile pfs_v2.API/ModifyFile: span finished ok {"spanDuration": "41.782179ms", "trailer": {}}
{}
2023-08-31T14:01:51.766-0400    DEBUG   grpcClient.stream.pfs_v2.API/ModifyFile pfs_v2.API/ModifyFile: span finished ok {"spanDuration": "41.802679ms", "trailer": {}}
...
```