### PR TITLE
pfs/pps: make everything take a context

### DIFF
--- a/src/internal/testpachd/mock_transaction.go
+++ b/src/internal/testpachd/mock_transaction.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
-type newPropagaterFunc func(context.Context, *txncontext.TransactionContext) txncontext.PpsPropagater
+type newPropagaterFunc func(*txncontext.TransactionContext) txncontext.PpsPropagater
 
 type mockNewPropagater struct {
 	handler newPropagaterFunc
@@ -39,7 +39,7 @@ func (mock *mockNewJobFinisher) Use(cb newJobFinisherFunc) {
 	mock.handler = cb
 }
 
-type stopJobInTransactionFunc func(*txncontext.TransactionContext, *pps.StopJobRequest) error
+type stopJobInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.StopJobRequest) error
 
 type mockStopJobInTransaction struct {
 	handler stopJobInTransactionFunc
@@ -49,7 +49,7 @@ func (mock *mockStopJobInTransaction) Use(cb stopJobInTransactionFunc) {
 	mock.handler = cb
 }
 
-type updateJobStateInTransactionFunc func(*txncontext.TransactionContext, *pps.UpdateJobStateRequest) error
+type updateJobStateInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.UpdateJobStateRequest) error
 
 type mockUpdateJobStateInTransaction struct {
 	handler updateJobStateInTransactionFunc
@@ -69,7 +69,7 @@ func (mock *mockCreatePipelineInTransaction) Use(cb createPipelineInTransactionF
 	mock.handler = cb
 }
 
-type inspectPipelineInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
+type inspectPipelineInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
 
 type mockInspectPipelineInTransaction struct {
 	handler inspectPipelineInTransactionFunc
@@ -79,7 +79,7 @@ func (mock *mockInspectPipelineInTransaction) Use(cb inspectPipelineInTransactio
 	mock.handler = cb
 }
 
-type activateAuthInTransactionFunc func(*txncontext.TransactionContext, *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error)
+type activateAuthInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error)
 
 type mockActivateAuthInTransaction struct {
 	handler activateAuthInTransactionFunc
@@ -110,20 +110,20 @@ type MockPPSTransactionServer struct {
 
 type MockPPSPropagater struct{}
 
-func (mpp *MockPPSPropagater) PropagateJobs() {}
-func (mpp *MockPPSPropagater) Run() error     { return nil }
+func (mpp *MockPPSPropagater) PropagateJobs()            {}
+func (mpp *MockPPSPropagater) Run(context.Context) error { return nil }
 
-func (api *ppsTransactionAPI) NewPropagater(ctx context.Context, txnCtx *txncontext.TransactionContext) txncontext.PpsPropagater {
+func (api *ppsTransactionAPI) NewPropagater(txnCtx *txncontext.TransactionContext) txncontext.PpsPropagater {
 	if api.mock.NewPropagater.handler != nil {
-		return api.mock.NewPropagater.handler(ctx, txnCtx)
+		return api.mock.NewPropagater.handler(txnCtx)
 	}
 	return &MockPPSPropagater{}
 }
 
 type MockPPSJobStopper struct{}
 
-func (mpp *MockPPSJobStopper) StopJobs(*pfs.CommitSet) {}
-func (mpp *MockPPSJobStopper) Run() error              { return nil }
+func (mpp *MockPPSJobStopper) StopJobs(*pfs.CommitSet)   {}
+func (mpp *MockPPSJobStopper) Run(context.Context) error { return nil }
 
 func (api *ppsTransactionAPI) NewJobStopper(txnCtx *txncontext.TransactionContext) txncontext.PpsJobStopper {
 	if api.mock.NewJobStopper.handler != nil {
@@ -135,7 +135,7 @@ func (api *ppsTransactionAPI) NewJobStopper(txnCtx *txncontext.TransactionContex
 type MockPPSJobFinisher struct{}
 
 func (mpp *MockPPSJobFinisher) FinishJob(*pfs.CommitInfo) {}
-func (mpp *MockPPSJobFinisher) Run() error                { return nil }
+func (mpp *MockPPSJobFinisher) Run(context.Context) error { return nil }
 
 func (api *ppsTransactionAPI) NewJobFinisher(txnCtx *txncontext.TransactionContext) txncontext.PpsJobFinisher {
 	if api.mock.NewJobFinisher.handler != nil {
@@ -144,16 +144,16 @@ func (api *ppsTransactionAPI) NewJobFinisher(txnCtx *txncontext.TransactionConte
 	return &MockPPSJobFinisher{}
 }
 
-func (api *ppsTransactionAPI) StopJobInTransaction(txnCtx *txncontext.TransactionContext, req *pps.StopJobRequest) error {
+func (api *ppsTransactionAPI) StopJobInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.StopJobRequest) error {
 	if api.mock.StopJobInTransaction.handler != nil {
-		return api.mock.StopJobInTransaction.handler(txnCtx, req)
+		return api.mock.StopJobInTransaction.handler(ctx, txnCtx, req)
 	}
 	return errors.Errorf("unhandled pachd mock: pps.StopJobInTransaction")
 }
 
-func (api *ppsTransactionAPI) UpdateJobStateInTransaction(txnCtx *txncontext.TransactionContext, req *pps.UpdateJobStateRequest) error {
+func (api *ppsTransactionAPI) UpdateJobStateInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.UpdateJobStateRequest) error {
 	if api.mock.UpdateJobStateInTransaction.handler != nil {
-		return api.mock.UpdateJobStateInTransaction.handler(txnCtx, req)
+		return api.mock.UpdateJobStateInTransaction.handler(ctx, txnCtx, req)
 	}
 	return errors.Errorf("unhandled pachd mock: pps.UpdateJobStateInTransaction")
 }
@@ -165,16 +165,16 @@ func (api *ppsTransactionAPI) CreatePipelineInTransaction(ctx context.Context, t
 	return errors.Errorf("unhandled pachd mock: pps.CreatePipelineInTransaction")
 }
 
-func (api *ppsTransactionAPI) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
+func (api *ppsTransactionAPI) InspectPipelineInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 	if api.mock.InspectPipelineInTransaction.handler != nil {
-		return api.mock.InspectPipelineInTransaction.handler(txnCtx, pipeline)
+		return api.mock.InspectPipelineInTransaction.handler(ctx, txnCtx, pipeline)
 	}
 	return nil, errors.Errorf("unhandled pachd mock: pps.InspectPipelineInTransaction")
 }
 
-func (api *ppsTransactionAPI) ActivateAuthInTransaction(txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error) {
+func (api *ppsTransactionAPI) ActivateAuthInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (*pps.ActivateAuthResponse, error) {
 	if api.mock.ActivateAuthInTransaction.handler != nil {
-		return api.mock.ActivateAuthInTransaction.handler(txnCtx, req)
+		return api.mock.ActivateAuthInTransaction.handler(ctx, txnCtx, req)
 	}
 	return nil, errors.Errorf("unhandled pachd mock: pps.AcivateAuthInTransaction")
 }

--- a/src/internal/testpachd/realenv/real_env.go
+++ b/src/internal/testpachd/realenv/real_env.go
@@ -202,7 +202,7 @@ func newRealEnv(ctx context.Context, t testing.TB, mockPPSTransactionServer bool
 		realEnv.MockPPSTransactionServer = testpachd.NewMockPPSTransactionServer()
 		realEnv.ServiceEnv.SetPpsServer(&realEnv.MockPPSTransactionServer.Api)
 		realEnv.MockPPSTransactionServer.InspectPipelineInTransaction.
-			Use(func(txnctx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
+			Use(func(ctx context.Context, txnctx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 				return nil, col.ErrNotFound{
 					Type: "pipelines",
 					Key:  pipeline.String(),

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -147,7 +147,7 @@ func (t *directTransaction) StartCommit(original *pfs.StartCommitRequest) (*pfs.
 
 func (t *directTransaction) FinishCommit(original *pfs.FinishCommitRequest) error {
 	req := proto.Clone(original).(*pfs.FinishCommitRequest)
-	return errors.EnsureStack(t.txnEnv.serviceEnv.PfsServer().FinishCommitInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.serviceEnv.PfsServer().FinishCommitInTransaction(t.ctx, t.txnCtx, req))
 }
 
 func (t *directTransaction) SquashCommitSet(original *pfs.SquashCommitSetRequest) error {
@@ -167,12 +167,12 @@ func (t *directTransaction) DeleteBranch(original *pfs.DeleteBranchRequest) erro
 
 func (t *directTransaction) StopJob(original *pps.StopJobRequest) error {
 	req := proto.Clone(original).(*pps.StopJobRequest)
-	return errors.EnsureStack(t.txnEnv.serviceEnv.PpsServer().StopJobInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.serviceEnv.PpsServer().StopJobInTransaction(t.ctx, t.txnCtx, req))
 }
 
 func (t *directTransaction) UpdateJobState(original *pps.UpdateJobStateRequest) error {
 	req := proto.Clone(original).(*pps.UpdateJobStateRequest)
-	return errors.EnsureStack(t.txnEnv.serviceEnv.PpsServer().UpdateJobStateInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.serviceEnv.PpsServer().UpdateJobStateInTransaction(t.ctx, t.txnCtx, req))
 }
 
 func (t *directTransaction) ModifyRoleBinding(original *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
@@ -297,7 +297,7 @@ func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *pachsql.Tx, cb 
 		txnCtx.PfsPropagater = env.serviceEnv.PfsServer().NewPropagater(txnCtx)
 	}
 	if env.serviceEnv.PpsServer() != nil {
-		txnCtx.PpsPropagater = env.serviceEnv.PpsServer().NewPropagater(ctx, txnCtx)
+		txnCtx.PpsPropagater = env.serviceEnv.PpsServer().NewPropagater(txnCtx)
 		txnCtx.PpsJobStopper = env.serviceEnv.PpsServer().NewJobStopper(txnCtx)
 		txnCtx.PpsJobFinisher = env.serviceEnv.PpsServer().NewJobFinisher(txnCtx)
 	}
@@ -306,7 +306,7 @@ func (env *TransactionEnv) attemptTx(ctx context.Context, sqlTx *pachsql.Tx, cb 
 	if err != nil {
 		return err
 	}
-	return txnCtx.Finish()
+	return txnCtx.Finish(ctx)
 }
 
 func (env *TransactionEnv) waitReady(ctx context.Context) error {

--- a/src/internal/transactionenv/txncontext/context.go
+++ b/src/internal/transactionenv/txncontext/context.go
@@ -114,24 +114,24 @@ func (t *TransactionContext) DeleteBranch(branch *pfs.Branch) {
 
 // Finish applies the deferred logic in the pfsPropagator and ppsPropagator to
 // the transaction
-func (t *TransactionContext) Finish() error {
+func (t *TransactionContext) Finish(ctx context.Context) error {
 	if t.PfsPropagater != nil {
-		if err := t.PfsPropagater.Run(); err != nil {
+		if err := t.PfsPropagater.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
 	if t.PpsPropagater != nil {
-		if err := t.PpsPropagater.Run(); err != nil {
+		if err := t.PpsPropagater.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
 	if t.PpsJobStopper != nil {
-		if err := t.PpsJobStopper.Run(); err != nil {
+		if err := t.PpsJobStopper.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
 	if t.PpsJobFinisher != nil {
-		if err := t.PpsJobFinisher.Run(); err != nil {
+		if err := t.PpsJobFinisher.Run(ctx); err != nil {
 			return errors.EnsureStack(err)
 		}
 	}
@@ -143,14 +143,14 @@ func (t *TransactionContext) Finish() error {
 type PfsPropagater interface {
 	PropagateBranch(branch *pfs.Branch) error
 	DeleteBranch(branch *pfs.Branch)
-	Run() error
+	Run(context.Context) error
 }
 
 // PpsPropagater is the interface that PPS implements to start jobs at the end
 // of a transaction.  It is defined here to avoid a circular dependency.
 type PpsPropagater interface {
 	PropagateJobs()
-	Run() error
+	Run(context.Context) error
 }
 
 // PpsJobStopper is the interface that PPS implements to stop jobs of deleted
@@ -158,10 +158,10 @@ type PpsPropagater interface {
 // circular dependency.
 type PpsJobStopper interface {
 	StopJobs(commitset *pfs.CommitSet)
-	Run() error
+	Run(context.Context) error
 }
 
 type PpsJobFinisher interface {
 	FinishJob(commitInfo *pfs.CommitInfo)
-	Run() error
+	Run(context.Context) error
 }

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -178,7 +178,7 @@ func (a *apiServer) ActivateAuthEverywhere(ctx context.Context, scopes []Activat
 				}
 			case ActivationScopePPS:
 				log.Debug(ctx, "attempting to activate PPS auth")
-				if _, err := a.env.GetPpsServer().ActivateAuthInTransaction(txCtx, &pps.ActivateAuthRequest{}); err != nil {
+				if _, err := a.env.GetPpsServer().ActivateAuthInTransaction(ctx, txCtx, &pps.ActivateAuthRequest{}); err != nil {
 					return errors.Wrap(err, "activate auth for pps")
 				}
 			}

--- a/src/server/pfs/iface.go
+++ b/src/server/pfs/iface.go
@@ -21,16 +21,16 @@ type APIServer interface {
 	DeleteReposInTransaction(context.Context, *txncontext.TransactionContext, []*pfs_client.Repo, bool) error
 
 	StartCommitInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.StartCommitRequest) (*pfs_client.Commit, error)
-	FinishCommitInTransaction(*txncontext.TransactionContext, *pfs_client.FinishCommitRequest) error
-	InspectCommitInTransaction(*txncontext.TransactionContext, *pfs_client.InspectCommitRequest) (*pfs_client.CommitInfo, error)
+	FinishCommitInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.FinishCommitRequest) error
+	InspectCommitInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.InspectCommitRequest) (*pfs_client.CommitInfo, error)
 
 	InspectCommitSetInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.CommitSet, bool) ([]*pfs_client.CommitInfo, error)
 	SquashCommitSetInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.SquashCommitSetRequest) error
 
 	CreateBranchInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.CreateBranchRequest) error
-	InspectBranchInTransaction(*txncontext.TransactionContext, *pfs_client.InspectBranchRequest) (*pfs_client.BranchInfo, error)
+	InspectBranchInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.InspectBranchRequest) (*pfs_client.BranchInfo, error)
 	DeleteBranchInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.DeleteBranchRequest) error
 
-	AddFileSetInTransaction(*txncontext.TransactionContext, *pfs_client.AddFileSetRequest) error
+	AddFileSetInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.AddFileSetRequest) error
 	ActivateAuthInTransaction(context.Context, *txncontext.TransactionContext, *pfs_client.ActivateAuthRequest) (*pfs_client.ActivateAuthResponse, error)
 }

--- a/src/server/pfs/server/commit_set.go
+++ b/src/server/pfs/server/commit_set.go
@@ -280,7 +280,7 @@ func (d *driver) deleteCommit(ctx context.Context, txnCtx *txncontext.Transactio
 		}
 	}
 	if len(headlessBranches) > 0 {
-		repoCommit, err := d.makeEmptyCommit(txnCtx, headlessBranches[0].Branch, headlessBranches[0].DirectProvenance, nil)
+		repoCommit, err := d.makeEmptyCommit(ctx, txnCtx, headlessBranches[0].Branch, headlessBranches[0].DirectProvenance, nil)
 		if err != nil {
 			return err
 		}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -312,7 +312,7 @@ func (d *driver) listRepoInTransaction(ctx context.Context, txnCtx *txncontext.T
 			}
 			repoPair.RepoInfo.AuthInfo = &pfs.AuthInfo{Permissions: permissions, Roles: roles}
 		}
-		size, err := d.repoSize(txnCtx, repoPair.RepoInfo)
+		size, err := d.repoSize(ctx, txnCtx, repoPair.RepoInfo)
 		if err != nil {
 			return errors.Wrapf(err, "getting repo size for %q", repoPair.RepoInfo.Repo)
 		}
@@ -352,7 +352,7 @@ func (d *driver) deleteReposHelper(ctx context.Context, txnCtx *txncontext.Trans
 	// filter out repos that cannot be deleted
 	var filter []*pfs.RepoInfo
 	for _, ri := range ris {
-		ok, err := d.canDeleteRepo(txnCtx, ri.Repo)
+		ok, err := d.canDeleteRepo(ctx, txnCtx, ri.Repo)
 		if err != nil {
 			return nil, err
 		} else if ok {
@@ -363,7 +363,7 @@ func (d *driver) deleteReposHelper(ctx context.Context, txnCtx *txncontext.Trans
 	var deleted []*pfs.Repo
 	var bis []*pfs.BranchInfo
 	for _, ri := range ris {
-		bs, err := d.listRepoBranches(txnCtx, ri)
+		bs, err := d.listRepoBranches(ctx, txnCtx, ri)
 		if err != nil {
 			return nil, err
 		}
@@ -388,7 +388,7 @@ func (d *driver) deleteRepo(ctx context.Context, txnCtx *txncontext.TransactionC
 		}
 		return false, nil
 	}
-	if ok, err := d.canDeleteRepo(txnCtx, repo); err != nil {
+	if ok, err := d.canDeleteRepo(ctx, txnCtx, repo); err != nil {
 		return false, errors.Wrapf(err, "error checking whether repo %q can be deleted", repo.String())
 	} else if !ok {
 		return false, nil
@@ -399,7 +399,7 @@ func (d *driver) deleteRepo(ctx context.Context, txnCtx *txncontext.TransactionC
 	}
 	var bis []*pfs.BranchInfo
 	for _, ri := range related {
-		bs, err := d.listRepoBranches(txnCtx, ri)
+		bs, err := d.listRepoBranches(ctx, txnCtx, ri)
 		if err != nil {
 			return false, err
 		}
@@ -429,10 +429,10 @@ func (d *driver) deleteBranches(ctx context.Context, txnCtx *txncontext.Transact
 	return nil
 }
 
-func (d *driver) listRepoBranches(txnCtx *txncontext.TransactionContext, repo *pfs.RepoInfo) ([]*pfs.BranchInfo, error) {
+func (d *driver) listRepoBranches(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.RepoInfo) ([]*pfs.BranchInfo, error) {
 	var bis []*pfs.BranchInfo
 	for _, branch := range repo.Branches {
-		bi, err := d.inspectBranchInTransaction(txnCtx, branch)
+		bi, err := d.inspectBranchInTransaction(ctx, txnCtx, branch)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error inspecting branch %s", branch)
 		}
@@ -507,7 +507,7 @@ func (d *driver) relatedRepos(ctx context.Context, txnCtx *txncontext.Transactio
 	return related, nil
 }
 
-func (d *driver) canDeleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.Repo) (bool, error) {
+func (d *driver) canDeleteRepo(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo) (bool, error) {
 	userRepo := proto.Clone(repo).(*pfs.Repo)
 	userRepo.Type = pfs.UserRepoType
 	if err := d.env.AuthServer.CheckRepoIsAuthorizedInTransaction(txnCtx, userRepo, auth.Permission_REPO_DELETE); err != nil {
@@ -516,7 +516,7 @@ func (d *driver) canDeleteRepo(txnCtx *txncontext.TransactionContext, repo *pfs.
 		}
 		return false, errors.Wrapf(err, "check repo %q is authorized for deletion", userRepo.String())
 	}
-	if _, err := d.env.GetPipelineInspector().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(repo)); err == nil {
+	if _, err := d.env.GetPipelineInspector().InspectPipelineInTransaction(ctx, txnCtx, pps.RepoPipeline(repo)); err == nil {
 		return false, errors.Errorf("cannot delete a repo associated with a pipeline - delete the pipeline instead")
 	} else if err != nil && !errutil.IsNotFoundError(err) {
 		return false, errors.Wrapf(err, "inspect pipeline %q", pps.RepoPipeline(repo).String())
@@ -773,14 +773,14 @@ func (d *driver) deleteProject(ctx context.Context, txnCtx *txncontext.Transacti
 }
 
 // Set child.ParentCommit (if 'parent' has been determined) and write child to parent's ChildCommits
-func (d *driver) linkParent(txnCtx *txncontext.TransactionContext, child *pfs.CommitInfo, parent *pfs.Commit, needsFinishedParent bool) error {
+func (d *driver) linkParent(ctx context.Context, txnCtx *txncontext.TransactionContext, child *pfs.CommitInfo, parent *pfs.Commit, needsFinishedParent bool) error {
 	if parent == nil {
 		return nil
 	}
 	// Resolve 'parent' if it's a branch that isn't 'branch' (which can
 	// happen if 'branch' is new and diverges from the existing branch in
 	// 'parent').
-	parentCommitInfo, err := d.resolveCommit(txnCtx.SqlTx, parent)
+	parentCommitInfo, err := d.resolveCommit(ctx, txnCtx.SqlTx, parent)
 	if err != nil {
 		return errors.Wrapf(err, "parent commit not found")
 	}
@@ -799,8 +799,8 @@ func (d *driver) linkParent(txnCtx *txncontext.TransactionContext, child *pfs.Co
 // NOTE: Requiring source commits to have finishing / finished parents ensures that the commits are not compacted
 // in a pathological order (finishing later commits before earlier commits will result with us compacting
 // the earlier commits multiple times).
-func (d *driver) addCommit(txnCtx *txncontext.TransactionContext, newCommitInfo *pfs.CommitInfo, parent *pfs.Commit, directProvenance []*pfs.Branch, needsFinishedParent bool) error {
-	if err := d.linkParent(txnCtx, newCommitInfo, parent, needsFinishedParent); err != nil {
+func (d *driver) addCommit(ctx context.Context, txnCtx *txncontext.TransactionContext, newCommitInfo *pfs.CommitInfo, parent *pfs.Commit, directProvenance []*pfs.Branch, needsFinishedParent bool) error {
+	if err := d.linkParent(ctx, txnCtx, newCommitInfo, parent, needsFinishedParent); err != nil {
 		return err
 	}
 	for _, prov := range directProvenance {
@@ -886,7 +886,7 @@ func (d *driver) startCommit(
 		// Otherwise, we don't allow user code to start commits on output branches
 		return nil, pfsserver.ErrCommitOnOutputBranch{Branch: branch}
 	}
-	if err := d.addCommit(txnCtx, newCommitInfo, parent, branchInfo.DirectProvenance, true); err != nil {
+	if err := d.addCommit(ctx, txnCtx, newCommitInfo, parent, branchInfo.DirectProvenance, true); err != nil {
 		return nil, err
 	}
 	// Defer propagation of the commit until the end of the transaction so we can
@@ -897,8 +897,8 @@ func (d *driver) startCommit(
 	return newCommitInfo.Commit, nil
 }
 
-func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs.Commit, description, commitError string, force bool) error {
-	commitInfo, err := d.resolveCommit(txnCtx.SqlTx, commit)
+func (d *driver) finishCommit(ctx context.Context, txnCtx *txncontext.TransactionContext, commit *pfs.Commit, description, commitError string, force bool) error {
+	commitInfo, err := d.resolveCommit(ctx, txnCtx.SqlTx, commit)
 	if err != nil {
 		return err
 	}
@@ -908,7 +908,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 		}
 	}
 	if !force && len(commitInfo.DirectProvenance) > 0 {
-		if info, err := d.env.GetPipelineInspector().InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
+		if info, err := d.env.GetPipelineInspector().InspectPipelineInTransaction(ctx, txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil && !errutil.IsNotFoundError(err) {
 			return errors.EnsureStack(err)
 		} else if err == nil && info.Type == pps.PipelineInfo_PIPELINE_TYPE_TRANSFORM {
 			return errors.Errorf("cannot finish a pipeline output or meta commit, use 'stop job' instead")
@@ -923,7 +923,7 @@ func (d *driver) finishCommit(txnCtx *txncontext.TransactionContext, commit *pfs
 	return errors.EnsureStack(d.commits.ReadWrite(txnCtx.SqlTx).Put(commitInfo.Commit, commitInfo))
 }
 
-func (d *driver) repoSize(txnCtx *txncontext.TransactionContext, repoInfo *pfs.RepoInfo) (int64, error) {
+func (d *driver) repoSize(ctx context.Context, txnCtx *txncontext.TransactionContext, repoInfo *pfs.RepoInfo) (int64, error) {
 	for _, branch := range repoInfo.Branches {
 		if branch.Name == "master" {
 			branchInfo := &pfs.BranchInfo{}
@@ -932,7 +932,7 @@ func (d *driver) repoSize(txnCtx *txncontext.TransactionContext, repoInfo *pfs.R
 			}
 			commit := branchInfo.Head
 			for commit != nil {
-				commitInfo, err := d.resolveCommit(txnCtx.SqlTx, commit)
+				commitInfo, err := d.resolveCommit(ctx, txnCtx.SqlTx, commit)
 				if err != nil {
 					return 0, err
 				}
@@ -963,7 +963,7 @@ func (d *driver) repoSize(txnCtx *txncontext.TransactionContext, repoInfo *pfs.R
 // starts downstream output commits (which trigger PPS jobs) when new input
 // commits arrive on 'branch', when 'branches's HEAD is deleted, or when
 // 'branches' are newly created (i.e. in CreatePipeline).
-func (d *driver) propagateBranches(txnCtx *txncontext.TransactionContext, branches []*pfs.Branch) error {
+func (d *driver) propagateBranches(ctx context.Context, txnCtx *txncontext.TransactionContext, branches []*pfs.Branch) error {
 	if len(branches) == 0 {
 		return nil
 	}
@@ -1124,7 +1124,7 @@ func (d *driver) resolveCommitWithAuth(ctx context.Context, commit *pfs.Commit) 
 	var commitInfo *pfs.CommitInfo
 	if err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		commitInfo, err = d.resolveCommit(txnCtx.SqlTx, commit)
+		commitInfo, err = d.resolveCommit(ctx, txnCtx.SqlTx, commit)
 		return err
 	}); err != nil {
 		return nil, err
@@ -1136,7 +1136,7 @@ func (d *driver) resolveCommitWithAuth(ctx context.Context, commit *pfs.Commit) 
 // be a commit ID or branch reference, plus '~' and/or '^') to a repo + commit
 // ID. It accepts a postgres transaction so that it can be used in a transaction
 // and avoids an inconsistent call to d.inspectCommit()
-func (d *driver) resolveCommit(sqlTx *pachsql.Tx, userCommit *pfs.Commit) (*pfs.CommitInfo, error) {
+func (d *driver) resolveCommit(ctx context.Context, sqlTx *pachsql.Tx, userCommit *pfs.Commit) (*pfs.CommitInfo, error) {
 	if userCommit == nil {
 		return nil, errors.Errorf("cannot resolve nil commit")
 	}
@@ -1248,7 +1248,7 @@ func (d *driver) getCommit(ctx context.Context, commit *pfs.Commit) (*pfs.Commit
 	var commitInfo *pfs.CommitInfo
 	if err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		commitInfo, err = d.resolveCommit(txnCtx.SqlTx, commit)
+		commitInfo, err = d.resolveCommit(ctx, txnCtx.SqlTx, commit)
 		return err
 	}); err != nil {
 		return nil, err
@@ -1504,7 +1504,7 @@ func (d *driver) clearCommit(ctx context.Context, commit *pfs.Commit) error {
 }
 
 // TODO(provenance): consider removing this functionality
-func (d *driver) fillNewBranches(txnCtx *txncontext.TransactionContext, branch *pfs.Branch, provenance []*pfs.Branch) error {
+func (d *driver) fillNewBranches(ctx context.Context, txnCtx *txncontext.TransactionContext, branch *pfs.Branch, provenance []*pfs.Branch) error {
 	newRepoCommits := make(map[string]*pfs.Commit)
 	for _, p := range provenance {
 		branchInfo := &pfs.BranchInfo{}
@@ -1515,7 +1515,7 @@ func (d *driver) fillNewBranches(txnCtx *txncontext.TransactionContext, branch *
 				var ok bool
 				if head, ok = newRepoCommits[pfsdb.RepoKey(branchInfo.Branch.Repo)]; !ok {
 					var err error
-					head, err = d.makeEmptyCommit(txnCtx, branchInfo.Branch, nil, nil)
+					head, err = d.makeEmptyCommit(ctx, txnCtx, branchInfo.Branch, nil, nil)
 					if err != nil {
 						return err
 					}
@@ -1738,13 +1738,13 @@ func (d *driver) createBranch(ctx context.Context, txnCtx *txncontext.Transactio
 		}
 	}
 	// Create any of the provenance branches that don't exist yet, and give them an empty commit
-	if err := d.fillNewBranches(txnCtx, branch, provenance); err != nil {
+	if err := d.fillNewBranches(ctx, txnCtx, branch, provenance); err != nil {
 		return err
 	}
 	// if the user passed a commit to point this branch at, resolve it
 	var ci *pfs.CommitInfo
 	if commit != nil {
-		ci, err = d.resolveCommit(txnCtx.SqlTx, commit)
+		ci, err = d.resolveCommit(ctx, txnCtx.SqlTx, commit)
 		if err != nil {
 			return errors.Wrapf(err, "unable to inspect %s", commit)
 		}
@@ -1774,7 +1774,7 @@ func (d *driver) createBranch(ctx context.Context, txnCtx *txncontext.Transactio
 		//
 		// TODO(provenance): This sort of hurts Branch Provenance invariant. See if we can re-assess....
 		if branchInfo.Head == nil || (!same(oldProvenance, provenance) && len(provenance) != 0) {
-			c, err := d.makeEmptyCommit(txnCtx, branch, provenance, branchInfo.Head)
+			c, err := d.makeEmptyCommit(ctx, txnCtx, branch, provenance, branchInfo.Head)
 			if err != nil {
 				return err
 			}
@@ -1806,7 +1806,7 @@ func (d *driver) inspectBranch(ctx context.Context, branch *pfs.Branch) (*pfs.Br
 	branchInfo := &pfs.BranchInfo{}
 	if err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		branchInfo, err = d.inspectBranchInTransaction(txnCtx, branch)
+		branchInfo, err = d.inspectBranchInTransaction(ctx, txnCtx, branch)
 		return err
 	}); err != nil {
 		return nil, err
@@ -1814,7 +1814,7 @@ func (d *driver) inspectBranch(ctx context.Context, branch *pfs.Branch) (*pfs.Br
 	return branchInfo, nil
 }
 
-func (d *driver) inspectBranchInTransaction(txnCtx *txncontext.TransactionContext, branch *pfs.Branch) (*pfs.BranchInfo, error) {
+func (d *driver) inspectBranchInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, branch *pfs.Branch) (*pfs.BranchInfo, error) {
 	// Validate arguments
 	if branch == nil {
 		return nil, errors.New("branch cannot be nil")
@@ -1992,7 +1992,7 @@ func (d *driver) deleteAll(ctx context.Context) error {
 }
 
 // only transform source repos and spouts get a closed commit
-func (d *driver) makeEmptyCommit(txnCtx *txncontext.TransactionContext, branch *pfs.Branch, directProvenance []*pfs.Branch, parent *pfs.Commit) (*pfs.Commit, error) {
+func (d *driver) makeEmptyCommit(ctx context.Context, txnCtx *txncontext.TransactionContext, branch *pfs.Branch, directProvenance []*pfs.Branch, parent *pfs.Commit) (*pfs.Commit, error) {
 	// Input repos and spouts want a closed head commit, so decide if we leave
 	// it open by the presence of branch provenance.  If it's only provenant on
 	// a spec repo, we assume it's a spout and close the commit.
@@ -2022,7 +2022,7 @@ func (d *driver) makeEmptyCommit(txnCtx *txncontext.TransactionContext, branch *
 			return nil, errors.EnsureStack(err)
 		}
 	}
-	if err := d.addCommit(txnCtx, commitInfo, parent, directProvenance, false /* needsFinishedParent */); err != nil {
+	if err := d.addCommit(ctx, txnCtx, commitInfo, parent, directProvenance, false /* needsFinishedParent */); err != nil {
 		return nil, err
 	}
 	return commit, nil

--- a/src/server/pfs/server/driver_file.go
+++ b/src/server/pfs/server/driver_file.go
@@ -75,7 +75,7 @@ func (d *driver) oneOffModifyFile(ctx context.Context, renewer *fileset.Renewer,
 		if err := d.commitStore.AddFileSetTx(txnCtx.SqlTx, commit, *id); err != nil {
 			return errors.EnsureStack(err)
 		}
-		return d.finishCommit(txnCtx, commit, "", "", false)
+		return d.finishCommit(ctx, txnCtx, commit, "", "", false)
 	})
 }
 
@@ -619,8 +619,8 @@ func (d *driver) shardFileSet(ctx context.Context, fsid fileset.ID) ([]*pfs.Path
 	return pathRanges, nil
 }
 
-func (d *driver) addFileSet(txnCtx *txncontext.TransactionContext, commit *pfs.Commit, filesetID fileset.ID) error {
-	commitInfo, err := d.resolveCommit(txnCtx.SqlTx, commit)
+func (d *driver) addFileSet(ctx context.Context, txnCtx *txncontext.TransactionContext, commit *pfs.Commit, filesetID fileset.ID) error {
+	commitInfo, err := d.resolveCommit(ctx, txnCtx.SqlTx, commit)
 	if err != nil {
 		return err
 	}

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -20,7 +20,7 @@ import (
 )
 
 type PipelineInspector interface {
-	InspectPipelineInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
+	InspectPipelineInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (*pps.PipelineInfo, error)
 }
 
 // Env is the dependencies needed to run the PFS API server

--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -297,7 +297,7 @@ func (d *driver) runCronTrigger(ctx context.Context, branch *pfs.Branch) error {
 			return errors.EnsureStack(context.Cause(ctx))
 		}
 		if err := d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-			trigBI, err := d.inspectBranchInTransaction(txnCtx, branchInfo.Branch.Repo.NewBranch(branchInfo.Trigger.Branch))
+			trigBI, err := d.inspectBranchInTransaction(ctx, txnCtx, branchInfo.Branch.Repo.NewBranch(branchInfo.Trigger.Branch))
 			if err != nil {
 				return err
 			}
@@ -449,7 +449,7 @@ func (d *driver) finalizeCommit(ctx context.Context, commit *pfs.Commit, validat
 				txnCtx.FinishJob(commitInfo)
 			}
 			if commitInfo.Error == "" {
-				return d.triggerCommit(txnCtx, commitInfo)
+				return d.triggerCommit(ctx, txnCtx, commitInfo)
 			}
 			return nil
 		})

--- a/src/server/pfs/server/transaction_defer.go
+++ b/src/server/pfs/server/transaction_defer.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -44,7 +46,7 @@ func (t *Propagater) DeleteBranch(branch *pfs.Branch) {
 
 // Run performs any final tasks and cleanup tasks in the transaction, such as
 // propagating branches
-func (t *Propagater) Run() error {
+func (t *Propagater) Run(ctx context.Context) error {
 	branches := make([]*pfs.Branch, 0, len(t.branches))
 	for _, branch := range t.branches {
 		branches = append(branches, branch)
@@ -52,5 +54,5 @@ func (t *Propagater) Run() error {
 	if err := t.d.validateDAGStructure(t.txnCtx, branches); err != nil {
 		return errors.Wrap(err, "validate DAG at end of transaction")
 	}
-	return t.d.propagateBranches(t.txnCtx, branches)
+	return t.d.propagateBranches(ctx, t.txnCtx, branches)
 }

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -18,7 +18,7 @@ import (
 
 // triggerCommit is called when a commit is finished, it updates branches in
 // the repo if they trigger on the change
-func (d *driver) triggerCommit(txnCtx *txncontext.TransactionContext, commitInfo *pfs.CommitInfo) error {
+func (d *driver) triggerCommit(ctx context.Context, txnCtx *txncontext.TransactionContext, commitInfo *pfs.CommitInfo) error {
 	branchInfos := make(map[string]*pfs.BranchInfo)
 	branchInfo := &pfs.BranchInfo{}
 	if err := d.branches.ReadWrite(txnCtx.SqlTx).GetByIndex(pfsdb.BranchesRepoIndex, pfsdb.RepoKey(commitInfo.Commit.Repo), branchInfo, col.DefaultOptions(), func(_ string) error {
@@ -60,7 +60,7 @@ func (d *driver) triggerCommit(txnCtx *txncontext.TransactionContext, commitInfo
 		if err := d.commits.ReadWrite(txnCtx.SqlTx).Get(bi.Head, oldHead); err != nil {
 			return nil, errors.EnsureStack(err)
 		}
-		triggered, err := d.isTriggered(txnCtx, bi.Trigger, oldHead, newHead)
+		triggered, err := d.isTriggered(ctx, txnCtx, bi.Trigger, oldHead, newHead)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func (d *driver) triggerCommit(txnCtx *txncontext.TransactionContext, commitInfo
 
 // isTriggered checks to see if a branch should be updated from oldHead to
 // newHead based on a trigger.
-func (d *driver) isTriggered(txnCtx *txncontext.TransactionContext, t *pfs.Trigger, oldHead, newHead *pfs.CommitInfo) (bool, error) {
+func (d *driver) isTriggered(ctx context.Context, txnCtx *txncontext.TransactionContext, t *pfs.Trigger, oldHead, newHead *pfs.CommitInfo) (bool, error) {
 	result := t.All
 	merge := func(cond bool) {
 		if t.All {
@@ -135,7 +135,7 @@ func (d *driver) isTriggered(txnCtx *txncontext.TransactionContext, t *pfs.Trigg
 			commits++
 			if ci.ParentCommit != nil && oldHead.Commit.Id != ci.ParentCommit.Id {
 				var err error
-				ci, err = d.resolveCommit(txnCtx.SqlTx, ci.ParentCommit)
+				ci, err = d.resolveCommit(ctx, txnCtx.SqlTx, ci.ParentCommit)
 				if err != nil {
 					return false, err
 				}

--- a/src/server/pfs/server/val_server.go
+++ b/src/server/pfs/server/val_server.go
@@ -38,7 +38,7 @@ func (a *validatedAPIServer) DeleteRepoInTransaction(ctx context.Context, txnCtx
 
 // FinishCommitInTransaction is identical to FinishCommit except that it can run
 // inside an existing postgres transaction.  This is not an RPC.
-func (a *validatedAPIServer) FinishCommitInTransaction(txnCtx *txncontext.TransactionContext, request *pfs.FinishCommitRequest) error {
+func (a *validatedAPIServer) FinishCommitInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pfs.FinishCommitRequest) error {
 	userCommit := request.Commit
 	// Validate arguments
 	if err := checkCommit(userCommit); err != nil {
@@ -47,7 +47,7 @@ func (a *validatedAPIServer) FinishCommitInTransaction(txnCtx *txncontext.Transa
 	if err := a.auth.CheckRepoIsAuthorizedInTransaction(txnCtx, userCommit.Repo, auth.Permission_REPO_WRITE); err != nil {
 		return errors.EnsureStack(err)
 	}
-	return a.apiServer.FinishCommitInTransaction(txnCtx, request)
+	return a.apiServer.FinishCommitInTransaction(ctx, txnCtx, request)
 }
 
 // InspectFile implements the protobuf pfs.InspectFile RPC

--- a/src/server/pps/iface.go
+++ b/src/server/pps/iface.go
@@ -14,16 +14,16 @@ import (
 type APIServer interface {
 	pps_client.APIServer
 
-	NewPropagater(context.Context, *txncontext.TransactionContext) txncontext.PpsPropagater
+	NewPropagater(*txncontext.TransactionContext) txncontext.PpsPropagater
 	NewJobStopper(*txncontext.TransactionContext) txncontext.PpsJobStopper
 	NewJobFinisher(*txncontext.TransactionContext) txncontext.PpsJobFinisher
 
-	StopJobInTransaction(*txncontext.TransactionContext, *pps_client.StopJobRequest) error
-	UpdateJobStateInTransaction(*txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
+	StopJobInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.StopJobRequest) error
+	UpdateJobStateInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.UpdateJobStateRequest) error
 	CreatePipelineInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.CreatePipelineTransaction) error
 	// InspectPipelineInTransaction returns the pipeline information for a
 	// pipeline.  Note that the pipeline name may include ancestry syntax.
-	InspectPipelineInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (*pps_client.PipelineInfo, error)
-	ActivateAuthInTransaction(*txncontext.TransactionContext, *pps_client.ActivateAuthRequest) (*pps_client.ActivateAuthResponse, error)
+	InspectPipelineInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (*pps_client.PipelineInfo, error)
+	ActivateAuthInTransaction(context.Context, *txncontext.TransactionContext, *pps_client.ActivateAuthRequest) (*pps_client.ActivateAuthResponse, error)
 	CreateDetPipelineSideEffects(context.Context, *pps.Pipeline, []string) error
 }

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -496,7 +496,7 @@ func (a *apiServer) UpdateJobState(ctx context.Context, request *pps.UpdateJobSt
 	return &emptypb.Empty{}, nil
 }
 
-func (a *apiServer) UpdateJobStateInTransaction(txnCtx *txncontext.TransactionContext, request *pps.UpdateJobStateRequest) error {
+func (a *apiServer) UpdateJobStateInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pps.UpdateJobStateRequest) error {
 	jobs := a.jobs.ReadWrite(txnCtx.SqlTx)
 	jobInfo := &pps.JobInfo{}
 	if err := jobs.Get(ppsdb.JobKey(request.Job), jobInfo); err != nil {
@@ -979,7 +979,7 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 	}
 	ensurePipelineProject(request.Job.Pipeline)
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		return a.deleteJobInTransaction(txnCtx, request)
+		return a.deleteJobInTransaction(ctx, txnCtx, request)
 	}); err != nil {
 		return nil, err
 	}
@@ -987,8 +987,8 @@ func (a *apiServer) DeleteJob(ctx context.Context, request *pps.DeleteJobRequest
 	return &emptypb.Empty{}, nil
 }
 
-func (a *apiServer) deleteJobInTransaction(txnCtx *txncontext.TransactionContext, request *pps.DeleteJobRequest) error {
-	if err := a.stopJob(txnCtx, request.Job, "job deleted"); err != nil {
+func (a *apiServer) deleteJobInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pps.DeleteJobRequest) error {
+	if err := a.stopJob(ctx, txnCtx, request.Job, "job deleted"); err != nil {
 		return err
 	}
 	return errors.EnsureStack(a.jobs.ReadWrite(txnCtx.SqlTx).Delete(ppsdb.JobKey(request.Job)))
@@ -1017,15 +1017,15 @@ func clearJobCache(pachClient *client.APIClient, tagPrefix string) {
 
 // StopJobInTransaction is identical to StopJob except that it can run inside an
 // existing postgres transaction.  This is not an RPC.
-func (a *apiServer) StopJobInTransaction(txnCtx *txncontext.TransactionContext, request *pps.StopJobRequest) error {
+func (a *apiServer) StopJobInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pps.StopJobRequest) error {
 	reason := request.Reason
 	if reason == "" {
 		reason = "job stopped"
 	}
-	return a.stopJob(txnCtx, request.Job, reason)
+	return a.stopJob(ctx, txnCtx, request.Job, reason)
 }
 
-func (a *apiServer) stopJob(txnCtx *txncontext.TransactionContext, job *pps.Job, reason string) error {
+func (a *apiServer) stopJob(ctx context.Context, txnCtx *txncontext.TransactionContext, job *pps.Job, reason string) error {
 	jobs := a.jobs.ReadWrite(txnCtx.SqlTx)
 	if job == nil {
 		return errors.New("Job must be specified")
@@ -1036,7 +1036,7 @@ func (a *apiServer) stopJob(txnCtx *txncontext.TransactionContext, job *pps.Job,
 		return errors.EnsureStack(err)
 	}
 
-	commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(txnCtx, &pfs.InspectCommitRequest{
+	commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(ctx, txnCtx, &pfs.InspectCommitRequest{
 		Commit: jobInfo.OutputCommit,
 	})
 	if err != nil && !pfsServer.IsCommitNotFoundErr(err) && !pfsServer.IsCommitDeletedErr(err) {
@@ -1046,14 +1046,14 @@ func (a *apiServer) stopJob(txnCtx *txncontext.TransactionContext, job *pps.Job,
 	// TODO: Leaning on the reason rather than state for commit errors seems a bit sketchy, but we don't
 	// store commit states.
 	if commitInfo != nil {
-		if err := a.env.PFSServer.FinishCommitInTransaction(txnCtx, &pfs.FinishCommitRequest{
+		if err := a.env.PFSServer.FinishCommitInTransaction(ctx, txnCtx, &pfs.FinishCommitRequest{
 			Commit: ppsutil.MetaCommit(commitInfo.Commit),
 			Error:  reason,
 			Force:  true,
 		}); err != nil && !pfsServer.IsCommitNotFoundErr(err) && !pfsServer.IsCommitDeletedErr(err) && !pfsServer.IsCommitFinishedErr(err) {
 			return errors.EnsureStack(err)
 		}
-		if err := a.env.PFSServer.FinishCommitInTransaction(txnCtx, &pfs.FinishCommitRequest{
+		if err := a.env.PFSServer.FinishCommitInTransaction(ctx, txnCtx, &pfs.FinishCommitRequest{
 			Commit: commitInfo.Commit,
 			Error:  reason,
 			Force:  true,
@@ -2362,7 +2362,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 	var (
 		projectName          = request.Pipeline.Project.GetName()
 		pipelineName         = request.Pipeline.Name
-		oldPipelineInfo, err = a.InspectPipelineInTransaction(txnCtx, request.Pipeline)
+		oldPipelineInfo, err = a.InspectPipelineInTransaction(ctx, txnCtx, request.Pipeline)
 	)
 	if err != nil && !errutil.IsNotFoundError(err) {
 		// silently ignore pipeline not found, old info will be nil
@@ -2461,7 +2461,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 			return errors.New("Cannot update a pipeline and provide a spec commit at the same time")
 		}
 		// Check if there is an existing spec commit
-		commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(txnCtx, &pfs.InspectCommitRequest{
+		commitInfo, err := a.env.PFSServer.InspectCommitInTransaction(ctx, txnCtx, &pfs.InspectCommitRequest{
 			Commit: request.SpecCommit,
 		})
 		if err != nil {
@@ -2477,7 +2477,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 		if err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := a.env.PFSServer.FinishCommitInTransaction(txnCtx, &pfs.FinishCommitRequest{
+		if err := a.env.PFSServer.FinishCommitInTransaction(ctx, txnCtx, &pfs.FinishCommitRequest{
 			Commit: newPipelineInfo.SpecCommit,
 		}); err != nil {
 			return errors.EnsureStack(err)
@@ -2511,7 +2511,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 	if update {
 		// Kill all unfinished jobs (as those are for the previous version and will
 		// no longer be completed)
-		if err := a.stopAllJobsInPipeline(txnCtx, request.Pipeline, "all jobs killed because pipeline was updated"); err != nil {
+		if err := a.stopAllJobsInPipeline(ctx, txnCtx, request.Pipeline, "all jobs killed because pipeline was updated"); err != nil {
 			return err
 		}
 
@@ -2547,7 +2547,7 @@ func (a *apiServer) CreatePipelineInTransaction(ctx context.Context, txnCtx *txn
 	if visitErr := pps.VisitInput(request.Input, func(input *pps.Input) error {
 		if input.Pfs != nil && input.Pfs.Trigger != nil {
 			var prevHead *pfs.Commit
-			if branchInfo, err := a.env.PFSServer.InspectBranchInTransaction(txnCtx, &pfs.InspectBranchRequest{
+			if branchInfo, err := a.env.PFSServer.InspectBranchInTransaction(ctx, txnCtx, &pfs.InspectBranchRequest{
 				Branch: client.NewBranch(input.Pfs.Project, input.Pfs.Repo, input.Pfs.Branch),
 			}); err != nil {
 				if !errutil.IsNotFoundError(err) {
@@ -2661,7 +2661,7 @@ func setInputDefaults(pipelineName string, input *pps.Input) {
 	})
 }
 
-func (a *apiServer) stopAllJobsInPipeline(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline, reason string) error {
+func (a *apiServer) stopAllJobsInPipeline(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline, reason string) error {
 	// Using ReadWrite here may load a large number of jobs inline in the
 	// transaction, but doing an inconsistent read outside of the transaction
 	// would be pretty sketchy (and we'd have to worry about trying to get another
@@ -2674,24 +2674,25 @@ func (a *apiServer) stopAllJobsInPipeline(txnCtx *txncontext.TransactionContext,
 	}
 	reason += " for user " + username
 	err := a.jobs.ReadWrite(txnCtx.SqlTx).GetByIndex(ppsdb.JobsTerminalIndex, ppsdb.JobsTerminalKey(pipeline, false), jobInfo, sort, func(string) error {
-		return a.stopJob(txnCtx, jobInfo.Job, reason)
+		return a.stopJob(ctx, txnCtx, jobInfo.Job, reason)
 	})
 	return errors.EnsureStack(err)
 }
 
 func (a *apiServer) updatePipeline(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	pipeline *pps.Pipeline,
 	info *pps.PipelineInfo,
 	cb func() error) error {
 
 	// get most recent pipeline key
-	key, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, pipeline, "")
+	key, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, pipeline, "")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "find pipeline spec commit")
 	}
 
-	return errors.EnsureStack(a.pipelines.ReadWrite(txnCtx.SqlTx).Update(key, info, cb))
+	return errors.Wrapf(a.pipelines.ReadWrite(txnCtx.SqlTx).Update(key, info, cb), "update pipeline %v", key)
 }
 
 // InspectPipeline implements the protobuf pps.InspectPipeline RPC
@@ -2707,7 +2708,7 @@ func (a *apiServer) inspectPipeline(ctx context.Context, pipeline *pps.Pipeline,
 	var info *pps.PipelineInfo
 	if err := a.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		info, err = a.InspectPipelineInTransaction(txnCtx, pipeline)
+		info, err = a.InspectPipelineInTransaction(ctx, txnCtx, pipeline)
 		return err
 	}); err != nil {
 		return nil, err
@@ -2762,7 +2763,7 @@ func (a *apiServer) inspectPipeline(ctx context.Context, pipeline *pps.Pipeline,
 }
 
 // InspectPipelineInTransaction implements the APIServer interface.
-func (a *apiServer) InspectPipelineInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
+func (a *apiServer) InspectPipelineInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (*pps.PipelineInfo, error) {
 	// The pipeline pipelineName arrived in ancestry format; need to turn it into a simple pipelineName.
 	pipelineName, ancestors, err := ancestry.Parse(pipeline.Name)
 	if err != nil {
@@ -2774,7 +2775,7 @@ func (a *apiServer) InspectPipelineInTransaction(txnCtx *txncontext.TransactionC
 	}
 
 	pipeline.Name = pipelineName
-	commit, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, pipeline, "")
+	commit, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, pipeline, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "pipeline was not inspected: couldn't find up to date spec for pipeline %q", pipeline)
 	}
@@ -2848,7 +2849,7 @@ func (a *apiServer) listPipeline(ctx context.Context, request *pps.ListPipelineR
 
 	loadPipelineAtCommit := func(pi *pps.PipelineInfo, commitSetID string) error { // mutates pi
 		return a.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-			key, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, pi.Pipeline, commitSetID)
+			key, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, pi.Pipeline, commitSetID)
 			if err != nil {
 				return errors.Wrapf(err, "couldn't find up to date spec for pipeline %q", pi.Pipeline)
 			}
@@ -2969,7 +2970,7 @@ func (a *apiServer) deletePipelineInTransaction(ctx context.Context, txnCtx *txn
 	pipelineInfo := &pps.PipelineInfo{}
 	// Try to retrieve PipelineInfo for this pipeline. If we see a not found error,
 	// we will still try to delete what we can because we know there is a pipeline
-	if specCommit, err := ppsutil.FindPipelineSpecCommitInTransaction(txnCtx, a.env.PFSServer, request.Pipeline, ""); err == nil {
+	if specCommit, err := ppsutil.FindPipelineSpecCommitInTransaction(ctx, txnCtx, a.env.PFSServer, request.Pipeline, ""); err == nil {
 		if err := a.pipelines.ReadWrite(txnCtx.SqlTx).Get(specCommit, pipelineInfo); err != nil && !col.IsErrNotFound(err) {
 			return nil, errors.EnsureStack(err)
 		}
@@ -3009,7 +3010,7 @@ func (a *apiServer) deletePipelineInTransaction(ctx context.Context, txnCtx *txn
 	jobInfo := &pps.JobInfo{}
 	if err := a.jobs.ReadWrite(txnCtx.SqlTx).GetByIndex(ppsdb.JobsPipelineIndex, ppsdb.JobsPipelineKey(request.Pipeline), jobInfo, col.DefaultOptions(), func(string) error {
 		job := proto.Clone(jobInfo.Job).(*pps.Job)
-		err := a.deleteJobInTransaction(txnCtx, &pps.DeleteJobRequest{Job: job})
+		err := a.deleteJobInTransaction(ctx, txnCtx, &pps.DeleteJobRequest{Job: job})
 		if errutil.IsNotFoundError(err) || auth.IsErrNoRoleBinding(err) {
 			return nil
 		}
@@ -3124,7 +3125,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 	ensurePipelineProject(request.Pipeline)
 
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		pipelineInfo, err := a.InspectPipelineInTransaction(txnCtx, request.Pipeline)
+		pipelineInfo, err := a.InspectPipelineInTransaction(ctx, txnCtx, request.Pipeline)
 		if err != nil {
 			return err
 		}
@@ -3154,7 +3155,7 @@ func (a *apiServer) StartPipeline(ctx context.Context, request *pps.StartPipelin
 		}
 
 		newPipelineInfo := &pps.PipelineInfo{}
-		return a.updatePipeline(txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
+		return a.updatePipeline(ctx, txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
 			newPipelineInfo.Stopped = false
 			return nil
 		})
@@ -3171,7 +3172,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 	}
 	ensurePipelineProject(request.Pipeline)
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-		if pipelineInfo, err := a.InspectPipelineInTransaction(txnCtx, request.Pipeline); err == nil {
+		if pipelineInfo, err := a.InspectPipelineInTransaction(ctx, txnCtx, request.Pipeline); err == nil {
 			// check if the caller is authorized to update this pipeline
 			// don't pass in the input - stopping the pipeline means they won't be read anymore,
 			// so we don't need to check any permissions
@@ -3196,7 +3197,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 			}
 
 			newPipelineInfo := &pps.PipelineInfo{}
-			if err := a.updatePipeline(txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
+			if err := a.updatePipeline(ctx, txnCtx, pipelineInfo.Pipeline, newPipelineInfo, func() error {
 				newPipelineInfo.Stopped = true
 				return nil
 			}); err != nil {
@@ -3209,7 +3210,7 @@ func (a *apiServer) StopPipeline(ctx context.Context, request *pps.StopPipelineR
 		// Kill any remaining jobs
 		// if the pipeline output repo doesn't exist, we technically run this without authorization,
 		// but it's not clear what authorization means in that case, and those jobs are doomed, anyway
-		return a.stopAllJobsInPipeline(txnCtx, request.Pipeline, "all jobs killed because pipeline was stopped")
+		return a.stopAllJobsInPipeline(ctx, txnCtx, request.Pipeline, "all jobs killed because pipeline was stopped")
 	}); err != nil {
 		return nil, err
 	}
@@ -3275,7 +3276,7 @@ func (a *apiServer) propagateJobs(ctx context.Context, txnCtx *txncontext.Transa
 		}
 		// Skip commits from repos that have no associated pipeline
 		var pipelineInfo *pps.PipelineInfo
-		if pipelineInfo, err = a.InspectPipelineInTransaction(txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil {
+		if pipelineInfo, err = a.InspectPipelineInTransaction(ctx, txnCtx, pps.RepoPipeline(commitInfo.Commit.Repo)); err != nil {
 			if col.IsErrNotFound(err) {
 				continue
 			}
@@ -3426,7 +3427,7 @@ func (a *apiServer) ActivateAuth(ctx context.Context, req *pps.ActivateAuthReque
 	var resp *pps.ActivateAuthResponse
 	if err := a.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
 		var err error
-		resp, err = a.ActivateAuthInTransaction(txnCtx, req)
+		resp, err = a.ActivateAuthInTransaction(ctx, txnCtx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -3434,7 +3435,7 @@ func (a *apiServer) ActivateAuth(ctx context.Context, req *pps.ActivateAuthReque
 	return resp, nil
 }
 
-func (a *apiServer) ActivateAuthInTransaction(txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (resp *pps.ActivateAuthResponse, retErr error) {
+func (a *apiServer) ActivateAuthInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *pps.ActivateAuthRequest) (resp *pps.ActivateAuthResponse, retErr error) {
 	// Unauthenticated users can't create new pipelines or repos, and users can't
 	// log in while auth is in an intermediate state, so 'pipelines' is exhaustive
 	pi := &pps.PipelineInfo{}
@@ -3445,7 +3446,7 @@ func (a *apiServer) ActivateAuthInTransaction(txnCtx *txncontext.TransactionCont
 		if err != nil {
 			return errors.Wrapf(grpcutil.ScrubGRPC(err), "could not generate pipeline auth token")
 		}
-		if err := a.updatePipeline(txnCtx, pi.Pipeline, pi, func() error {
+		if err := a.updatePipeline(ctx, txnCtx, pi.Pipeline, pi, func() error {
 			pi.AuthToken = token
 			return nil
 		}); err != nil {

--- a/src/server/pps/server/transaction_defer.go
+++ b/src/server/pps/server/transaction_defer.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -17,15 +18,13 @@ import (
 // and will call the Run function at the end of a transaction.
 type Propagater struct {
 	a        *apiServer
-	ctx      context.Context
 	txnCtx   *txncontext.TransactionContext
 	notified bool
 }
 
-func (a *apiServer) NewPropagater(ctx context.Context, txnCtx *txncontext.TransactionContext) txncontext.PpsPropagater {
+func (a *apiServer) NewPropagater(txnCtx *txncontext.TransactionContext) txncontext.PpsPropagater {
 	return &Propagater{
 		a:      a,
-		ctx:    ctx,
 		txnCtx: txnCtx,
 	}
 }
@@ -38,9 +37,9 @@ func (t *Propagater) PropagateJobs() {
 }
 
 // Run creates any jobs for the modified CommitSets
-func (t *Propagater) Run() error {
+func (t *Propagater) Run(ctx context.Context) error {
 	if t.notified {
-		return t.a.propagateJobs(t.ctx, t.txnCtx)
+		return t.a.propagateJobs(ctx, t.txnCtx)
 	}
 	return nil
 }
@@ -70,12 +69,12 @@ func (t *JobStopper) StopJobs(commitset *pfs.CommitSet) {
 }
 
 // Run stops any jobs for the removed CommitSets
-func (t *JobStopper) Run() error {
+func (t *JobStopper) Run(ctx context.Context) error {
 	if len(t.commitsets) > 0 {
 		for _, commitset := range t.commitsets {
 			jobInfo := &pps.JobInfo{}
 			if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commitset.Id, jobInfo, col.DefaultOptions(), func(string) error {
-				return t.a.stopJob(t.txnCtx, jobInfo.Job, "output commit removed")
+				return t.a.stopJob(ctx, t.txnCtx, jobInfo.Job, "output commit removed")
 			}); err != nil {
 				return errors.EnsureStack(err)
 			}
@@ -101,7 +100,7 @@ func (jf *JobFinisher) FinishJob(commitInfo *pfs.CommitInfo) {
 	jf.commitInfos = append(jf.commitInfos, commitInfo)
 }
 
-func (jf *JobFinisher) Run() error {
+func (jf *JobFinisher) Run(ctx context.Context) error {
 	if len(jf.commitInfos) > 0 {
 		pipelines := jf.a.pipelines.ReadWrite(jf.txnCtx.SqlTx)
 		jobs := jf.a.jobs.ReadWrite(jf.txnCtx.SqlTx)

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -215,7 +215,7 @@ func mockJobFromCommit(t *testing.T, env *testEnv, pi *pps.PipelineInfo, commit 
 			cancel()
 		}
 	}
-	env.MockPPSTransactionServer.UpdateJobStateInTransaction.Use(func(txnCtx *txncontext.TransactionContext, request *pps.UpdateJobStateRequest) error {
+	env.MockPPSTransactionServer.UpdateJobStateInTransaction.Use(func(ctx context.Context, txnCtx *txncontext.TransactionContext, request *pps.UpdateJobStateRequest) error {
 		updateJobState(request)
 		return nil
 	})


### PR DESCRIPTION
This is the promised refactoring that plumbs in a context to all public PFS/PPS APIs (where they call each other).

This is necessary for the database rework; the parts that don't take contexts happen to be parts that aren't moved to the new database yet.  I'm adding it because it allows us to do some input validation that wasn't possible for (in a ... past PR; I'll rebase that one on top  of this once approved).

The most non-mechanical part of this was making constructors of propagators NOT take a context, but instead making the run method take that.  That eliminates a context inside a struct, which is fortunately decreasing in number rapidly in the codebase!

The auth API still doesn't take contexts, even though it's basically the same idea as PFS and PPS in terms of its interface.  That's because auth is last on the list of things to move over to the database, and there is some talk about changing it dramatically in the near future.  If that happens, we might as well not bother with the refactor yet; nothing will need it in this code's lifetime, it seems.

