### PR TITLE
Remove PFS from proto owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,11 @@
 # All
-/src/*/*.proto           @pachyderm/CORE @pachyderm/INT @pachyderm/PFS
+/src/*/*.proto           @pachyderm/CORE @pachyderm/INT
 
 # PFS
 /src/pfs/                @pachyderm/PFS
 /src/server/pfs/         @pachyderm/PFS
+/src/internal/pfsdb/     @pachyderm/PFS
+/src/internal/storage/   @pachyderm/PFS
 
 # Integrations
 /src/server/pfs/s3       @pachyderm/INT


### PR DESCRIPTION
- Remove PFS as an owner of all protos, we didn't have any skin in the game for a lot of the PRs we were assigned.
- Add PFS as owner of storage and pfsdb.