### PR TITLE
Moves EnvFromServiceEnv functions into internal/pachd.

### DIFF
--- a/src/internal/pachd/builder.go
+++ b/src/internal/pachd/builder.go
@@ -73,8 +73,8 @@ type builder struct {
 	env                serviceenv.ServiceEnv
 	daemon             daemon
 	txnEnv             *transactionenv.TransactionEnv
-	licenseEnv         licenseserver.Env
-	enterpriseEnv      eprsserver.Env
+	licenseEnv         *licenseserver.Env
+	enterpriseEnv      *eprsserver.Env
 	reporter           *metrics.Reporter
 	authInterceptor    *authmw.Interceptor
 	loggingInterceptor *loggingmw.LoggingInterceptor

--- a/src/internal/pachd/builder.go
+++ b/src/internal/pachd/builder.go
@@ -73,8 +73,8 @@ type builder struct {
 	env                serviceenv.ServiceEnv
 	daemon             daemon
 	txnEnv             *transactionenv.TransactionEnv
-	licenseEnv         *licenseserver.Env
-	enterpriseEnv      *eprsserver.Env
+	licenseEnv         licenseserver.Env
+	enterpriseEnv      eprsserver.Env
 	reporter           *metrics.Reporter
 	authInterceptor    *authmw.Interceptor
 	loggingInterceptor *loggingmw.LoggingInterceptor
@@ -229,7 +229,7 @@ func (b builder) forGRPCServer(f func(*grpc.Server)) {
 }
 
 func (b *builder) registerLicenseServer(ctx context.Context) error {
-	b.licenseEnv = licenseserver.EnvFromServiceEnv(b.env)
+	b.licenseEnv = LicenseEnv(b.env)
 	apiServer, err := licenseserver.New(b.licenseEnv)
 	if err != nil {
 		return err
@@ -253,7 +253,7 @@ func (b *builder) registerIdentityServer(ctx context.Context) error {
 
 func (b *builder) registerAuthServer(ctx context.Context) error {
 	apiServer, err := authserver.NewAuthServer(
-		authserver.EnvFromServiceEnv(b.env, b.txnEnv),
+		AuthEnv(b.env, b.txnEnv),
 		true, !b.daemon.criticalServersOnly, true,
 	)
 	if err != nil {
@@ -269,7 +269,7 @@ func (b *builder) registerAuthServer(ctx context.Context) error {
 }
 
 func (b *builder) registerPFSServer(ctx context.Context) error {
-	env, err := pfs_server.EnvFromServiceEnv(b.env, b.txnEnv)
+	env, err := PFSEnv(b.env, b.txnEnv)
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (b *builder) registerPFSServer(ctx context.Context) error {
 }
 
 func (b *builder) registerPPSServer(ctx context.Context) error {
-	apiServer, err := pps_server.NewAPIServer(pps_server.EnvFromServiceEnv(b.env, b.txnEnv, b.reporter))
+	apiServer, err := pps_server.NewAPIServer(PPSEnv(b.env, b.txnEnv, b.reporter))
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ func (b *builder) registerTransactionServer(ctx context.Context) error {
 }
 
 func (b *builder) registerAdminServer(ctx context.Context) error {
-	apiServer := adminserver.NewAPIServer(adminserver.EnvFromServiceEnv(b.env, false))
+	apiServer := adminserver.NewAPIServer(AdminEnv(b.env, false))
 	b.forGRPCServer(func(s *grpc.Server) { admin.RegisterAPIServer(s, apiServer) })
 	return nil
 }
@@ -395,7 +395,7 @@ func (b *builder) maybeInitDexDB(ctx context.Context) error {
 }
 
 func (b *builder) initPachwController(ctx context.Context) error {
-	env, err := pachw.EnvFromServiceEnv(b.env)
+	env, err := PachwEnv(b.env)
 	if err != nil {
 		return err
 	}
@@ -441,13 +441,5 @@ func setupMemoryLimit(ctx context.Context, config pachconfig.GlobalConfiguration
 }
 
 func (b *builder) newDebugServer() debugclient.DebugServer {
-	return debugserver.NewDebugServer(debugserver.Env{
-		Config:        *b.env.Config(),
-		Name:          b.env.Config().PachdPodName,
-		DB:            b.env.GetDBClient(),
-		SidecarClient: nil,
-		KubeClient:    b.env.GetKubeClient(),
-		GetLokiClient: b.env.GetLokiClient,
-		GetPachClient: b.env.GetPachClient,
-	})
+	return debugserver.NewDebugServer(DebugEnv(b.env))
 }

--- a/src/internal/pachd/enterprise.go
+++ b/src/internal/pachd/enterprise.go
@@ -26,14 +26,16 @@ type enterpriseBuilder struct {
 // TODO: refactor the four modes to have a cleaner license/enterprise server
 // abstraction.
 func (eb *enterpriseBuilder) registerEnterpriseServer(ctx context.Context) error {
-	eb.enterpriseEnv = eprsserver.EnvFromServiceEnv(
+	eb.enterpriseEnv = EnterpriseEnv(
 		eb.env,
 		path.Join(eb.env.Config().EtcdPrefix, eb.env.Config().EnterpriseEtcdPrefix),
 		eb.txnEnv,
 	)
 	apiServer, err := eprsserver.NewEnterpriseServer(
 		eb.enterpriseEnv,
-		true,
+		eprsserver.Config{
+			Heartbeat: true,
+		},
 	)
 	if err != nil {
 		return err

--- a/src/internal/pachd/env.go
+++ b/src/internal/pachd/env.go
@@ -44,8 +44,8 @@ func AuthEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) auth_ser
 	}
 }
 
-func EnterpriseEnv(senv serviceenv.ServiceEnv, etcdPrefix string, txEnv *txnenv.TransactionEnv) enterprise_server.Env {
-	e := enterprise_server.Env{
+func EnterpriseEnv(senv serviceenv.ServiceEnv, etcdPrefix string, txEnv *txnenv.TransactionEnv) *enterprise_server.Env {
+	e := &enterprise_server.Env{
 		DB:       senv.GetDBClient(),
 		Listener: senv.GetPostgresListener(),
 		TxnEnv:   txEnv,
@@ -64,8 +64,8 @@ func EnterpriseEnv(senv serviceenv.ServiceEnv, etcdPrefix string, txEnv *txnenv.
 	return e
 }
 
-func LicenseEnv(senv serviceenv.ServiceEnv) license_server.Env {
-	return license_server.Env{
+func LicenseEnv(senv serviceenv.ServiceEnv) *license_server.Env {
+	return &license_server.Env{
 		DB:               senv.GetDBClient(),
 		Listener:         senv.GetPostgresListener(),
 		Config:           senv.Config(),

--- a/src/internal/pachd/env.go
+++ b/src/internal/pachd/env.go
@@ -1,0 +1,155 @@
+package pachd
+
+import (
+	"path"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/metrics"
+	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
+	admin_server "github.com/pachyderm/pachyderm/v2/src/server/admin/server"
+	auth_server "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
+	debug_server "github.com/pachyderm/pachyderm/v2/src/server/debug/server"
+	enterprise_server "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
+	license_server "github.com/pachyderm/pachyderm/v2/src/server/license/server"
+	pachw_server "github.com/pachyderm/pachyderm/v2/src/server/pachw/server"
+	pfs_server "github.com/pachyderm/pachyderm/v2/src/server/pfs/server"
+	pps_server "github.com/pachyderm/pachyderm/v2/src/server/pps/server"
+)
+
+func AdminEnv(senv serviceenv.ServiceEnv, paused bool) admin_server.Env {
+	return admin_server.Env{
+		ClusterID: senv.ClusterID(),
+		Config:    senv.Config(),
+		PFSServer: senv.PfsServer(),
+		Paused:    paused,
+	}
+}
+
+func AuthEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) auth_server.Env {
+	return auth_server.Env{
+		DB:         senv.GetDBClient(),
+		EtcdClient: senv.GetEtcdClient(),
+		Listener:   senv.GetPostgresListener(),
+		TxnEnv:     txnEnv,
+
+		GetEnterpriseServer: senv.EnterpriseServer,
+		GetIdentityServer:   senv.IdentityServer,
+		GetPfsServer:        senv.PfsServer,
+		GetPpsServer:        senv.PpsServer,
+
+		BackgroundContext: pctx.Child(senv.Context(), "auth"),
+		Config:            *senv.Config(),
+	}
+}
+
+func EnterpriseEnv(senv serviceenv.ServiceEnv, etcdPrefix string, txEnv *txnenv.TransactionEnv) enterprise_server.Env {
+	e := enterprise_server.Env{
+		DB:       senv.GetDBClient(),
+		Listener: senv.GetPostgresListener(),
+		TxnEnv:   txEnv,
+
+		EtcdClient: senv.GetEtcdClient(),
+		EtcdPrefix: etcdPrefix,
+
+		AuthServer:    senv.AuthServer(),
+		GetPachClient: senv.GetPachClient,
+		GetKubeClient: senv.GetKubeClient,
+
+		BackgroundContext: senv.Context(),
+		Namespace:         senv.Config().Namespace,
+		Config:            *senv.Config(),
+	}
+	return e
+}
+
+func LicenseEnv(senv serviceenv.ServiceEnv) license_server.Env {
+	return license_server.Env{
+		DB:               senv.GetDBClient(),
+		Listener:         senv.GetPostgresListener(),
+		Config:           senv.Config(),
+		EnterpriseServer: senv.EnterpriseServer(),
+	}
+}
+
+func PachwEnv(env serviceenv.ServiceEnv) (*pachw_server.Env, error) {
+	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PFSEtcdPrefix)
+	if env.AuthServer() == nil {
+		panic("auth server cannot be nil")
+	}
+	return &pachw_server.Env{
+		EtcdPrefix:        etcdPrefix,
+		EtcdClient:        env.GetEtcdClient(),
+		TaskService:       env.GetTaskService(etcdPrefix),
+		KubeClient:        env.GetKubeClient(),
+		Namespace:         env.Config().Namespace,
+		MinReplicas:       env.Config().PachwMinReplicas,
+		MaxReplicas:       env.Config().PachwMaxReplicas,
+		BackgroundContext: env.Context(),
+	}, nil
+}
+
+func PFSEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) (*pfs_server.Env, error) {
+	// Setup etcd, object storage, and database clients.
+	objClient, err := obj.NewClient(env.Context(), env.Config().StorageBackend, env.Config().StorageRoot)
+	if err != nil {
+		return nil, err
+	}
+	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PFSEtcdPrefix)
+	if env.AuthServer() == nil {
+		panic("auth server cannot be nil")
+	}
+	return &pfs_server.Env{
+		ObjectClient: objClient,
+		DB:           env.GetDBClient(),
+		TxnEnv:       txnEnv,
+		Listener:     env.GetPostgresListener(),
+		EtcdPrefix:   etcdPrefix,
+		EtcdClient:   env.GetEtcdClient(),
+		TaskService:  env.GetTaskService(etcdPrefix),
+
+		AuthServer:           env.AuthServer(),
+		GetPipelineInspector: func() pfs_server.PipelineInspector { return env.PpsServer() },
+		GetPachClient:        env.GetPachClient,
+
+		BackgroundContext: pctx.Child(env.Context(), "PFS"),
+		StorageConfig:     env.Config().StorageConfiguration,
+		PachwInSidecar:    env.Config().PachwInSidecars,
+	}, nil
+}
+
+func PPSEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, reporter *metrics.Reporter) pps_server.Env {
+	etcdPrefix := path.Join(senv.Config().EtcdPrefix, senv.Config().PPSEtcdPrefix)
+	return pps_server.Env{
+		DB:            senv.GetDBClient(),
+		TxnEnv:        txnEnv,
+		Listener:      senv.GetPostgresListener(),
+		KubeClient:    senv.GetKubeClient(),
+		EtcdClient:    senv.GetEtcdClient(),
+		EtcdPrefix:    etcdPrefix,
+		TaskService:   senv.GetTaskService(etcdPrefix),
+		GetLokiClient: senv.GetLokiClient,
+
+		PFSServer:     senv.PfsServer(),
+		AuthServer:    senv.AuthServer(),
+		GetPachClient: senv.GetPachClient,
+
+		Reporter:          reporter,
+		BackgroundContext: pctx.Child(senv.Context(), "PPS"),
+		Config:            *senv.Config(),
+		PachwInSidecar:    senv.Config().PachwInSidecars,
+	}
+}
+
+func DebugEnv(env serviceenv.ServiceEnv) debug_server.Env {
+	return debug_server.Env{
+		Config:        *env.Config(),
+		Name:          env.Config().PachdPodName,
+		DB:            env.GetDBClient(),
+		SidecarClient: nil,
+		KubeClient:    env.GetKubeClient(),
+		GetLokiClient: env.GetLokiClient,
+		GetPachClient: env.GetPachClient,
+	}
+}

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -34,16 +34,18 @@ func (fb *fullBuilder) maybeRegisterIdentityServer(ctx context.Context) error {
 // TODO: refactor the four modes to have a cleaner license/enterprise server
 // abstraction.
 func (fb *fullBuilder) registerEnterpriseServer(ctx context.Context) error {
-	fb.enterpriseEnv = eprsserver.EnvFromServiceEnv(
+	fb.enterpriseEnv = EnterpriseEnv(
 		fb.env,
 		path.Join(fb.env.Config().EtcdPrefix, fb.env.Config().EnterpriseEtcdPrefix),
 		fb.txnEnv,
-		eprsserver.WithMode(eprsserver.FullMode),
-		eprsserver.WithUnpausedMode(os.Getenv("UNPAUSED_MODE")),
 	)
 	apiServer, err := eprsserver.NewEnterpriseServer(
 		fb.enterpriseEnv,
-		true,
+		eprsserver.Config{
+			Heartbeat:    true,
+			Mode:         eprsserver.FullMode,
+			UnpausedMode: os.Getenv("UNPAUSED_MODE"),
+		},
 	)
 	if err != nil {
 		return err

--- a/src/internal/pachd/pachw.go
+++ b/src/internal/pachd/pachw.go
@@ -27,7 +27,7 @@ func newPachwBuilder(config any) *pachwBuilder {
 }
 
 func (pachwb *pachwBuilder) registerPFSServer(ctx context.Context) error {
-	env, err := pfs_server.EnvFromServiceEnv(pachwb.env, pachwb.txnEnv)
+	env, err := PFSEnv(pachwb.env, pachwb.txnEnv)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (pachwb *pachwBuilder) registerPFSServer(ctx context.Context) error {
 
 func (pachwb *pachwBuilder) registerAuthServer(ctx context.Context) error {
 	apiServer, err := authserver.NewAuthServer(
-		authserver.EnvFromServiceEnv(pachwb.env, pachwb.txnEnv),
+		AuthEnv(pachwb.env, pachwb.txnEnv),
 		false, !pachwb.daemon.criticalServersOnly, false,
 	)
 	if err != nil {
@@ -57,14 +57,16 @@ func (pachwb *pachwBuilder) registerAuthServer(ctx context.Context) error {
 }
 
 func (pachwb *pachwBuilder) registerEnterpriseServer(ctx context.Context) error {
-	pachwb.enterpriseEnv = eprsserver.EnvFromServiceEnv(
+	pachwb.enterpriseEnv = EnterpriseEnv(
 		pachwb.env,
 		path.Join(pachwb.env.Config().EtcdPrefix, pachwb.env.Config().EnterpriseEtcdPrefix),
 		pachwb.txnEnv,
 	)
 	apiServer, err := eprsserver.NewEnterpriseServer(
 		pachwb.enterpriseEnv,
-		false,
+		eprsserver.Config{
+			Heartbeat: false,
+		},
 	)
 	if err != nil {
 		return err

--- a/src/internal/pachd/paused.go
+++ b/src/internal/pachd/paused.go
@@ -47,8 +47,8 @@ func (pb *pausedBuilder) registerEnterpriseServer(ctx context.Context) error {
 	apiServer, err := eprsserver.NewEnterpriseServer(
 		pb.enterpriseEnv,
 		eprsserver.Config{
-			Heartbeat: true,
-			Mode: eprsserver.PausedMode,
+			Heartbeat:    true,
+			Mode:         eprsserver.PausedMode,
 			UnpausedMode: os.Getenv("UNPAUSED_MODE"),
 		},
 	)

--- a/src/internal/pachd/paused.go
+++ b/src/internal/pachd/paused.go
@@ -64,7 +64,7 @@ func (pb *pausedBuilder) registerEnterpriseServer(ctx context.Context) error {
 
 	// Stop workers because unpaused pachds in the process
 	// of rolling may have started them back up.
-	if err := eprsserver.StopWorkers(ctx, pb.enterpriseEnv); err != nil {
+	if err := eprsserver.StopWorkers(ctx, pb.enterpriseEnv.GetKubeClient(), pb.enterpriseEnv.Namespace); err != nil {
 		return err
 	}
 	return nil

--- a/src/internal/pachd/sidecar.go
+++ b/src/internal/pachd/sidecar.go
@@ -28,7 +28,7 @@ func newSidecarBuilder(config any) *sidecarBuilder {
 }
 
 func (sb *sidecarBuilder) registerAuthServer(ctx context.Context) error {
-	apiServer, err := authserver.NewAuthServer(authserver.EnvFromServiceEnv(sb.env, sb.txnEnv), false, false, false)
+	apiServer, err := authserver.NewAuthServer(AuthEnv(sb.env, sb.txnEnv), false, false, false)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func (sb *sidecarBuilder) registerAuthServer(ctx context.Context) error {
 }
 
 func (sb *sidecarBuilder) registerPFSServer(ctx context.Context) error {
-	env, err := pfs_server.EnvFromServiceEnv(sb.env, sb.txnEnv)
+	env, err := PFSEnv(sb.env, sb.txnEnv)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (sb *sidecarBuilder) registerPFSServer(ctx context.Context) error {
 }
 
 func (sb *sidecarBuilder) registerPPSServer(ctx context.Context) error {
-	apiServer, err := pps_server.NewSidecarAPIServer(pps_server.EnvFromServiceEnv(sb.env, sb.txnEnv, nil),
+	apiServer, err := pps_server.NewSidecarAPIServer(PPSEnv(sb.env, sb.txnEnv, nil),
 		sb.env.Config().Namespace,
 		sb.env.Config().PPSWorkerPort,
 		sb.env.Config().PeerPort)
@@ -74,13 +74,15 @@ func (sb *sidecarBuilder) registerPPSServer(ctx context.Context) error {
 // TODO: refactor the four modes to have a cleaner license/enterprise server
 // abstraction.
 func (sb *sidecarBuilder) registerEnterpriseServer(ctx context.Context) error {
-	sb.enterpriseEnv = eprsserver.EnvFromServiceEnv(
+	sb.enterpriseEnv = EnterpriseEnv(
 		sb.env,
 		path.Join(sb.env.Config().EtcdPrefix, sb.env.Config().EnterpriseEtcdPrefix),
 		sb.txnEnv)
 	apiServer, err := eprsserver.NewEnterpriseServer(
 		sb.enterpriseEnv,
-		false,
+		eprsserver.Config{
+			Heartbeat: false,
+		},
 	)
 	if err != nil {
 		return err

--- a/src/server/admin/server/api_server.go
+++ b/src/server/admin/server/api_server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/weblinker"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/version"
@@ -24,15 +23,6 @@ type Env struct {
 	Config    *pachconfig.Configuration
 	PFSServer pfs.APIServer
 	Paused    bool
-}
-
-func EnvFromServiceEnv(senv serviceenv.ServiceEnv, paused bool) Env {
-	return Env{
-		ClusterID: senv.ClusterID(),
-		Config:    senv.Config(),
-		PFSServer: senv.PfsServer(),
-		Paused:    paused,
-	}
 }
 
 // APIServer represents an APIServer

--- a/src/server/auth/server/env.go
+++ b/src/server/auth/server/env.go
@@ -7,8 +7,6 @@ import (
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/server/enterprise"
 	"github.com/pachyderm/pachyderm/v2/src/server/pfs"
@@ -31,21 +29,4 @@ type Env struct {
 
 	BackgroundContext context.Context
 	Config            pachconfig.Configuration
-}
-
-func EnvFromServiceEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) Env {
-	return Env{
-		DB:         senv.GetDBClient(),
-		EtcdClient: senv.GetEtcdClient(),
-		Listener:   senv.GetPostgresListener(),
-		TxnEnv:     txnEnv,
-
-		GetEnterpriseServer: senv.EnterpriseServer,
-		GetIdentityServer:   senv.IdentityServer,
-		GetPfsServer:        senv.PfsServer,
-		GetPpsServer:        senv.PpsServer,
-
-		BackgroundContext: pctx.Child(senv.Context(), "auth"),
-		Config:            *senv.Config(),
-	}
 }

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -49,20 +49,17 @@ const (
 
 type apiServer struct {
 	enterprise.UnimplementedAPIServer
-
-	env *Env
-
+	env                  Env
+	config               Config
 	enterpriseTokenCache *keycache.Cache
-
 	// enterpriseTokenCol is a collection containing the enterprise license state
 	enterpriseTokenCol col.EtcdCollection
-
 	// configCol is a collection containing the license server configuration
 	configCol col.PostgresCollection
 }
 
 // NewEnterpriseServer returns an implementation of ec.APIServer.
-func NewEnterpriseServer(env *Env, heartbeat bool) (*apiServer, error) {
+func NewEnterpriseServer(env Env, config Config) (*apiServer, error) {
 	defaultEnterpriseRecord := &ec.EnterpriseRecord{}
 	enterpriseTokenCol := col.NewEtcdCollection(
 		env.EtcdClient,
@@ -75,13 +72,14 @@ func NewEnterpriseServer(env *Env, heartbeat bool) (*apiServer, error) {
 
 	s := &apiServer{
 		env:                  env,
+		config:               config,
 		enterpriseTokenCache: keycache.NewCache(env.BackgroundContext, enterpriseTokenCol.ReadOnly(env.BackgroundContext), enterpriseTokenKey, defaultEnterpriseRecord),
 		enterpriseTokenCol:   enterpriseTokenCol,
 		configCol:            EnterpriseConfigCollection(env.DB, env.Listener),
 	}
 	go s.enterpriseTokenCache.Watch()
 
-	if heartbeat {
+	if config.Heartbeat {
 		go s.heartbeatRoutine(env.BackgroundContext)
 	}
 	return s, nil
@@ -244,7 +242,7 @@ func (a *apiServer) Heartbeat(ctx context.Context, req *ec.HeartbeatRequest) (re
 // Activate implements the Activate RPC
 func (a *apiServer) Activate(ctx context.Context, req *ec.ActivateRequest) (resp *ec.ActivateResponse, retErr error) {
 	// must not activate while paused
-	if a.env.mode == PausedMode {
+	if a.config.Mode == PausedMode {
 		return nil, errors.New("cannot activate paused cluster; unpause first")
 	}
 	// Try to heartbeat before persisting the configuration
@@ -364,7 +362,7 @@ func (a *apiServer) getEnterpriseRecord() (*ec.GetActivationCodeResponse, error)
 // cluster in the "NONE" enterprise state.
 func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (resp *ec.DeactivateResponse, retErr error) {
 	// must not deactivate while paused
-	if a.env.mode == PausedMode {
+	if a.config.Mode == PausedMode {
 		return nil, errors.New("cannot deactivate paused cluster; unpause first")
 	}
 	if _, err := col.NewSTM(ctx, a.env.EtcdClient, func(stm col.STM) error {
@@ -407,7 +405,7 @@ func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (
 // Pause sets the cluster to paused mode, restarting all pachds in a paused
 // status.  If they are already paused, it is a no-op.
 func (a *apiServer) Pause(ctx context.Context, req *ec.PauseRequest) (resp *ec.PauseResponse, retErr error) {
-	if a.env.mode == UnpausableMode {
+	if a.config.Mode == UnpausableMode {
 		return nil, errors.Errorf("this pachd instance is not in a pausable mode")
 	}
 	if err := a.rollPachd(ctx, true); err != nil {
@@ -433,8 +431,8 @@ func (a *apiServer) Pause(ctx context.Context, req *ec.PauseRequest) (resp *ec.P
 // ConfigMap and the '$(MODE)' reference is verbatim.
 func (a *apiServer) rollPachd(ctx context.Context, paused bool) error {
 	var (
-		kc        = a.env.getKubeClient()
-		namespace = a.env.namespace
+		kc        = a.env.GetKubeClient()
+		namespace = a.env.Namespace
 	)
 	cc := kc.CoreV1().ConfigMaps(namespace)
 	c, err := cc.Get(ctx, "pachd-config", metav1.GetOptions{})
@@ -444,7 +442,7 @@ func (a *apiServer) rollPachd(ctx context.Context, paused bool) error {
 			return nil
 		}
 		// Since pachd-config is not managed by Helm, it may not exist.
-		c = newPachdConfigMap(namespace, a.env.unpausedMode)
+		c = newPachdConfigMap(namespace, a.config.UnpausedMode)
 		c.Annotations[updatedAtFieldName] = time.Now().Format(time.RFC3339Nano)
 		c.Data["MODE"] = "paused"
 		if _, err := cc.Create(ctx, c, metav1.CreateOptions{}); err != nil {
@@ -456,7 +454,7 @@ func (a *apiServer) rollPachd(ctx context.Context, paused bool) error {
 		// Curiously, Get can return no error and an empty configmap!
 		// If this happens, need to set the name and namespace.
 		if c.ObjectMeta.Name == "" {
-			c = newPachdConfigMap(namespace, a.env.unpausedMode)
+			c = newPachdConfigMap(namespace, a.config.UnpausedMode)
 		}
 		if c.Data == nil {
 			c.Data = make(map[string]string)
@@ -477,7 +475,7 @@ func (a *apiServer) rollPachd(ctx context.Context, paused bool) error {
 		if paused {
 			c.Data["MODE"] = "paused"
 		} else {
-			c.Data["MODE"] = a.env.unpausedMode
+			c.Data["MODE"] = a.config.UnpausedMode
 		}
 		if c.Annotations == nil {
 			c.Annotations = make(map[string]string)
@@ -544,7 +542,7 @@ func scaleDownWorkers(ctx context.Context, kc kubernetes.Interface, namespace st
 }
 
 func (a *apiServer) Unpause(ctx context.Context, req *ec.UnpauseRequest) (resp *ec.UnpauseResponse, retErr error) {
-	if a.env.mode == UnpausableMode {
+	if a.config.Mode == UnpausableMode {
 		return nil, errors.Errorf("this pachd instance is not in an unpausable mode")
 	}
 	if err := a.rollPachd(ctx, false); err != nil {
@@ -568,8 +566,8 @@ func (a *apiServer) Unpause(ctx context.Context, req *ec.UnpauseRequest) (resp *
 // after the ConfigMap was updated then it has taken effect and the cluster is
 // in the indicated state.
 func (a *apiServer) PauseStatus(ctx context.Context, req *ec.PauseStatusRequest) (resp *ec.PauseStatusResponse, retErr error) {
-	kc := a.env.getKubeClient()
-	cc := kc.CoreV1().ConfigMaps(a.env.namespace)
+	kc := a.env.GetKubeClient()
+	cc := kc.CoreV1().ConfigMaps(a.env.Namespace)
 	c, err := cc.Get(ctx, "pachd-config", metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		// If there is no configmap, then the pachd pods must be
@@ -592,7 +590,7 @@ func (a *apiServer) PauseStatus(ctx context.Context, req *ec.PauseStatusRequest)
 		return nil, errors.Errorf("could not parse update time %v: %v", c.Annotations[updatedAtFieldName], err)
 	}
 
-	pods := kc.CoreV1().Pods(a.env.namespace)
+	pods := kc.CoreV1().Pods(a.env.Namespace)
 	pp, err := pods.List(ctx, metav1.ListOptions{
 		LabelSelector: "app=pachd",
 	})

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -49,7 +49,7 @@ const (
 
 type apiServer struct {
 	enterprise.UnimplementedAPIServer
-	env                  Env
+	env                  *Env
 	config               Config
 	enterpriseTokenCache *keycache.Cache
 	// enterpriseTokenCol is a collection containing the enterprise license state
@@ -59,7 +59,8 @@ type apiServer struct {
 }
 
 // NewEnterpriseServer returns an implementation of ec.APIServer.
-func NewEnterpriseServer(env Env, config Config) (*apiServer, error) {
+// TODO: Envs should not be passed by pointer
+func NewEnterpriseServer(env *Env, config Config) (*apiServer, error) {
 	defaultEnterpriseRecord := &ec.EnterpriseRecord{}
 	enterpriseTokenCol := col.NewEtcdCollection(
 		env.EtcdClient,

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/server/auth"
 )
@@ -27,12 +26,10 @@ type Env struct {
 
 	AuthServer    auth.APIServer
 	GetPachClient func(context.Context) *client.APIClient
-	getKubeClient func() kube.Interface
+	GetKubeClient func() kube.Interface
+	Namespace     string
 
 	BackgroundContext context.Context
-	namespace         string
-	mode              PauseMode
-	unpausedMode      string
 	Config            pachconfig.Configuration
 }
 
@@ -45,43 +42,10 @@ const (
 	PausedMode
 )
 
-type Option func(Env) Env
-
-func WithUnpausedMode(mode string) Option {
-	return func(e Env) Env {
-		e.unpausedMode = mode
-		return e
-	}
-}
-
-func WithMode(mode PauseMode) Option {
-	return func(e Env) Env {
-		e.mode = mode
-		return e
-	}
-}
-
-func EnvFromServiceEnv(senv serviceenv.ServiceEnv, etcdPrefix string, txEnv *txnenv.TransactionEnv, options ...Option) *Env {
-	e := Env{
-		DB:       senv.GetDBClient(),
-		Listener: senv.GetPostgresListener(),
-		TxnEnv:   txEnv,
-
-		EtcdClient: senv.GetEtcdClient(),
-		EtcdPrefix: etcdPrefix,
-
-		AuthServer:    senv.AuthServer(),
-		GetPachClient: senv.GetPachClient,
-		getKubeClient: senv.GetKubeClient,
-
-		BackgroundContext: senv.Context(),
-		namespace:         senv.Config().Namespace,
-		Config:            *senv.Config(),
-	}
-	for _, o := range options {
-		e = o(e)
-	}
-	return &e
+type Config struct {
+	Heartbeat    bool
+	Mode         PauseMode
+	UnpausedMode string
 }
 
 func EnterpriseConfigCollection(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
@@ -137,6 +101,6 @@ func DeleteEnterpriseConfigFromEtcd(ctx context.Context, etcd *clientv3.Client) 
 }
 
 // StopWorkers stops all workers
-func (env Env) StopWorkers(ctx context.Context) error {
-	return scaleDownWorkers(ctx, env.getKubeClient(), env.namespace)
+func StopWorkers(ctx context.Context, env Env) error {
+	return scaleDownWorkers(ctx, env.GetKubeClient(), env.Namespace)
 }

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -101,6 +101,6 @@ func DeleteEnterpriseConfigFromEtcd(ctx context.Context, etcd *clientv3.Client) 
 }
 
 // StopWorkers stops all workers
-func StopWorkers(ctx context.Context, env Env) error {
-	return scaleDownWorkers(ctx, env.GetKubeClient(), env.Namespace)
+func StopWorkers(ctx context.Context, kc kube.Interface, namespace string) error {
+	return scaleDownWorkers(ctx, kc, namespace)
 }

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -28,13 +28,13 @@ const (
 type apiServer struct {
 	lc.UnimplementedAPIServer
 
-	env *Env
+	env Env
 	// license is the database record where we store the active enterprise license
 	license col.PostgresCollection
 }
 
 // New returns an implementation of license.APIServer, and a function that bootstraps the license server via environment.
-func New(env *Env) (*apiServer, error) {
+func New(env Env) (*apiServer, error) {
 	s := &apiServer{
 		env:     env,
 		license: licenseCollection(env.DB, env.Listener),

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -28,13 +28,13 @@ const (
 type apiServer struct {
 	lc.UnimplementedAPIServer
 
-	env Env
+	env *Env
 	// license is the database record where we store the active enterprise license
 	license col.PostgresCollection
 }
 
 // New returns an implementation of license.APIServer, and a function that bootstraps the license server via environment.
-func New(env Env) (*apiServer, error) {
+func New(env *Env) (*apiServer, error) {
 	s := &apiServer{
 		env:     env,
 		license: licenseCollection(env.DB, env.Listener),

--- a/src/server/license/server/env.go
+++ b/src/server/license/server/env.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/server/enterprise"
 )
 
@@ -14,13 +13,4 @@ type Env struct {
 	Listener         collection.PostgresListener
 	Config           *pachconfig.Configuration
 	EnterpriseServer enterprise.APIServer
-}
-
-func EnvFromServiceEnv(senv serviceenv.ServiceEnv) *Env {
-	return &Env{
-		DB:               senv.GetDBClient(),
-		Listener:         senv.GetPostgresListener(),
-		Config:           senv.Config(),
-		EnterpriseServer: senv.EnterpriseServer(),
-	}
 }

--- a/src/server/pachw/server/env.go
+++ b/src/server/pachw/server/env.go
@@ -2,12 +2,10 @@ package server
 
 import (
 	"context"
-	"path"
 
 	etcd "go.etcd.io/etcd/client/v3"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 )
 
@@ -21,21 +19,4 @@ type Env struct {
 	MaxReplicas       int
 	MinReplicas       int
 	BackgroundContext context.Context
-}
-
-func EnvFromServiceEnv(env serviceenv.ServiceEnv) (*Env, error) {
-	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PFSEtcdPrefix)
-	if env.AuthServer() == nil {
-		panic("auth server cannot be nil")
-	}
-	return &Env{
-		EtcdPrefix:        etcdPrefix,
-		EtcdClient:        env.GetEtcdClient(),
-		TaskService:       env.GetTaskService(etcdPrefix),
-		KubeClient:        env.GetKubeClient(),
-		Namespace:         env.Config().Namespace,
-		MinReplicas:       env.Config().PachwMinReplicas,
-		MaxReplicas:       env.Config().PachwMaxReplicas,
-		BackgroundContext: env.Context(),
-	}, nil
 }

--- a/src/server/pfs/server/env.go
+++ b/src/server/pfs/server/env.go
@@ -2,15 +2,12 @@ package server
 
 import (
 	"context"
-	"path"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -41,34 +38,4 @@ type Env struct {
 	BackgroundContext context.Context
 	StorageConfig     pachconfig.StorageConfiguration
 	PachwInSidecar    bool
-}
-
-// TODO: move this to serviceenv
-func EnvFromServiceEnv(env serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv) (*Env, error) {
-	// Setup etcd, object storage, and database clients.
-	objClient, err := obj.NewClient(env.Context(), env.Config().StorageBackend, env.Config().StorageRoot)
-	if err != nil {
-		return nil, err
-	}
-	etcdPrefix := path.Join(env.Config().EtcdPrefix, env.Config().PFSEtcdPrefix)
-	if env.AuthServer() == nil {
-		panic("auth server cannot be nil")
-	}
-	return &Env{
-		ObjectClient: objClient,
-		DB:           env.GetDBClient(),
-		TxnEnv:       txnEnv,
-		Listener:     env.GetPostgresListener(),
-		EtcdPrefix:   etcdPrefix,
-		EtcdClient:   env.GetEtcdClient(),
-		TaskService:  env.GetTaskService(etcdPrefix),
-
-		AuthServer:           env.AuthServer(),
-		GetPipelineInspector: func() PipelineInspector { return env.PpsServer() },
-		GetPachClient:        env.GetPachClient,
-
-		BackgroundContext: pctx.Child(env.Context(), "PFS"),
-		StorageConfig:     env.Config().StorageConfiguration,
-		PachwInSidecar:    env.Config().PachwInSidecars,
-	}, nil
 }

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"path"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
@@ -13,7 +12,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/ppsdb"
-	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	authserver "github.com/pachyderm/pachyderm/v2/src/server/auth"
@@ -46,29 +44,6 @@ type Env struct {
 	BackgroundContext context.Context
 	Config            pachconfig.Configuration
 	PachwInSidecar    bool
-}
-
-func EnvFromServiceEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, reporter *metrics.Reporter) Env {
-	etcdPrefix := path.Join(senv.Config().EtcdPrefix, senv.Config().PPSEtcdPrefix)
-	return Env{
-		DB:            senv.GetDBClient(),
-		TxnEnv:        txnEnv,
-		Listener:      senv.GetPostgresListener(),
-		KubeClient:    senv.GetKubeClient(),
-		EtcdClient:    senv.GetEtcdClient(),
-		EtcdPrefix:    etcdPrefix,
-		TaskService:   senv.GetTaskService(etcdPrefix),
-		GetLokiClient: senv.GetLokiClient,
-
-		PFSServer:     senv.PfsServer(),
-		AuthServer:    senv.AuthServer(),
-		GetPachClient: senv.GetPachClient,
-
-		Reporter:          reporter,
-		BackgroundContext: pctx.Child(senv.Context(), "PPS"),
-		Config:            *senv.Config(),
-		PachwInSidecar:    senv.Config().PachwInSidecars,
-	}
 }
 
 // NewAPIServer creates an APIServer and runs the master loop in the background


### PR DESCRIPTION
These functions belong in the code that sets up the subsystem. It also removes another reference to serviceenv from all of the subsystems.