### PR TITLE
make name unique

### DIFF
--- a/src/internal/obj/testsuite.go
+++ b/src/internal/obj/testsuite.go
@@ -55,7 +55,7 @@ func TestSuite(t *testing.T, newClient func(t testing.TB) Client) {
 	t.Run("TestIntegrity", func(t *testing.T) {
 		t.Parallel()
 		client := newClient(t)
-		name := "prefix/test-object"
+		name := randutil.UniqueString("prefix/test-object")
 		expectedData, err := io.ReadAll(io.LimitReader(rand.Reader, 1<<20))
 		require.NoError(t, err)
 		expectedHash := pachhash.Sum(expectedData)


### PR DESCRIPTION
One of the flaky test alerts is TestMinioClient/**/TestIntegrity. I'm pretty sure it's just because the tests run in parallel but don't use a thread-unique name.