### PR TITLE
real_env: log server messages to a file in /tmp instead of t.Log

### DIFF
--- a/src/internal/testutil/cmds.go
+++ b/src/internal/testutil/cmds.go
@@ -172,6 +172,12 @@ func PachctlBashCmdCtx(ctx context.Context, t *testing.T, c *client.APIClient, s
 	cmd, err := p.CommandTemplate(ctx, scriptTemplate, data)
 	require.NoError(t, err, "could not create command")
 	cmd.Cmd.Stdout = nil // some existing tests expect Stdout not to be redirected
-	cmd.Cmd.Stderr = log.WriterAt(ctx, log.DebugLevel)
+
+	// If you're wondering why you're not seeing stderr, it's probably because you got here via
+	// PachctlBashCmd (without a context), and thus there is no logger to log to.  Supply
+	// pctx.TestContext(t) as context, and you'll be good to go.
+	stderr := log.WriterAt(ctx, log.DebugLevel)
+	t.Cleanup(func() { stderr.Close() })
+	cmd.Cmd.Stderr = stderr
 	return cmd.Cmd
 }


### PR DESCRIPTION
I really thought these logs would be helpful, but they have never helped me.  They just drown out the actual issue I'm testing 99% of the time.  So into /tmp they go.  Not lost, but forgotten.

Each test gets a uniquely named file, and we don't clean it up after the tests.  That way when you see "FAIL TestFooBar", you can `jlog < /tmp/pachyderm-real-env-TestFooBar.log` and see the results.  (You can also tail -f the file while the tests are running.)