### PR TITLE
circle: use all available cores for test-go

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -68,7 +68,7 @@ jobs:
   test-go:
     machine:
       image: << pipeline.parameters.machine_image >>
-    resource_class: xlarge
+    resource_class: 2xlarge
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:
@@ -86,7 +86,7 @@ jobs:
       - run:
           no_output_timeout: 20m
           command: |-
-            GOMAXPROCS=8 CGO_ENABLED=0 KUBECONFIG=/dev/null PACH_CONFIG=/dev/null \
+            CGO_ENABLED=0 KUBECONFIG=/dev/null PACH_CONFIG=/dev/null \
             gotestsum \
             --raw-command \
             --junitfile ${TEST_RESULTS}/gotestsum-report.xml \

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -68,7 +68,7 @@ jobs:
   test-go:
     machine:
       image: << pipeline.parameters.machine_image >>
-    resource_class: 2xlarge
+    resource_class: xlarge
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:

--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -145,6 +145,7 @@ func ensureDBEnv(t testing.TB, ctx context.Context) error {
 			30228: 5432,
 		},
 		Image: "postgres:13.0-alpine",
+		Cmd:   []string{"postgres", "-c", "max_connections=500"},
 	}); err != nil {
 		return errors.EnsureStack(err)
 	}

--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -163,7 +163,7 @@ func ensureDBEnv(t testing.TB, ctx context.Context) error {
 			"POSTGRESQL_PASSWORD":                 "password",
 			"POSTGRESQL_HOST":                     postgresIP,
 			"POSTGRESQL_PORT":                     "5432",
-			"PGBOUNCER_MAX_CLIENT_CONN":           "1000",
+			"PGBOUNCER_MAX_CLIENT_CONN":           "100000",
 			"PGBOUNCER_POOL_MODE":                 "transaction",
 			"PGBOUNCER_IGNORE_STARTUP_PARAMETERS": "extra_float_digits",
 		},


### PR DESCRIPTION
I think GOMAXPROCS=8 predated having pgbouncer in the tests.  Let's see if this speeds things up.

This also lets me run the tests locally without setting GOMAXPROCS (which is 32 on my machine).

I tested bumping up the instance size to 2xl; that makes the tests about a minute faster, so probably not worth it.  On my local machine with 32 cores, it's not much faster, docker-proxy is using all the CPU, and postgres and pgbouncer are also quite busy.  So I think this is fine.