### PR TITLE
pachd: add PreflightEnv for preflight mode dependencies

### DIFF
--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -27,7 +28,7 @@ func Populate(object interface{}, decoders ...Decoder) error {
 // Main runs the common functionality needed in a go main function.
 // appEnv will be populated and passed to do, defaultEnv can be nil
 // if there is an error, os.Exit(1) will be called.
-func Main[T any](ctx context.Context, do func(context.Context, T) error, appEnv T, decoders ...Decoder) {
+func Main[T pachconfig.AnyConfig](ctx context.Context, do func(context.Context, T) error, appEnv T, decoders ...Decoder) {
 	if err := Populate(appEnv, decoders...); err != nil {
 		mainError(err)
 	}

--- a/src/internal/errors/errors.go
+++ b/src/internal/errors/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -12,10 +13,6 @@ var (
 	// New returns an error with the supplied message.
 	// New also records the stack trace at the point it was called.
 	New = errors.New
-	// Errorf formats according to a format specifier and returns the string
-	// as a value that satisfies error.
-	// Errorf also records the stack trace at the point it was called.
-	Errorf = errors.Errorf
 	// Unwrap returns the underlying wrapped error if it exists, or nil otherwise.
 	Unwrap = errors.Unwrap
 	// Is reports whether any error in err's chain matches target. An error is
@@ -34,6 +31,13 @@ var (
 	// If err is nil, WithStack returns nil.
 	WithStack = errors.WithStack
 )
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(fmtStr string, args ...any) error {
+	return EnsureStack(fmt.Errorf(fmtStr, args...))
+}
 
 // EnsureStack will add a stack onto the given error only if it does not already
 // have a stack. If err is nil, EnsureStack returns nil.

--- a/src/internal/errors/errors.go
+++ b/src/internal/errors/errors.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -13,6 +12,10 @@ var (
 	// New returns an error with the supplied message.
 	// New also records the stack trace at the point it was called.
 	New = errors.New
+	// Errorf formats according to a format specifier and returns the string
+	// as a value that satisfies error.
+	// Errorf also records the stack trace at the point it was called.
+	Errorf = errors.Errorf
 	// Unwrap returns the underlying wrapped error if it exists, or nil otherwise.
 	Unwrap = errors.Unwrap
 	// Is reports whether any error in err's chain matches target. An error is
@@ -31,13 +34,6 @@ var (
 	// If err is nil, WithStack returns nil.
 	WithStack = errors.WithStack
 )
-
-// Errorf formats according to a format specifier and returns the string
-// as a value that satisfies error.
-// Errorf also records the stack trace at the point it was called.
-func Errorf(fmtStr string, args ...any) error {
-	return EnsureStack(fmt.Errorf(fmtStr, args...))
-}
 
 // EnsureStack will add a stack onto the given error only if it does not already
 // have a stack. If err is nil, EnsureStack returns nil.

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -93,6 +93,8 @@ type GlobalConfiguration struct {
 	SidecarDefaultStorageRequest resource.Quantity `env:"SIDECAR_DEFAULT_STORAGE_REQUEST,default=1Gi"`
 }
 
+func (GlobalConfiguration) isPachConfig() {}
+
 // PostgresConfiguration configures postgres and pg-bouncer.
 type PostgresConfiguration struct {
 	PostgresSSL                    string `env:"POSTGRES_SSL,default=disable"`
@@ -119,6 +121,8 @@ type PachdFullConfiguration struct {
 	PachdSpecificConfiguration
 	EnterpriseSpecificConfiguration
 }
+
+func (PachdFullConfiguration) isPachConfig() {}
 
 // PachdSpecificConfiguration contains the pachd specific configuration.
 type PachdSpecificConfiguration struct {
@@ -230,6 +234,8 @@ type PachdPreflightConfiguration struct {
 	PostgresConfiguration
 }
 
+func (PachdPreflightConfiguration) isPachConfig() {}
+
 // NewConfiguration creates a generic configuration from a specific type of configuration.
 func NewConfiguration(config any) *Configuration {
 	configuration := &Configuration{}
@@ -258,4 +264,14 @@ func NewConfiguration(config any) *Configuration {
 	default:
 		return nil
 	}
+}
+
+// TODO: remove
+// At the time of writing EmptyConfig is only used in pachctl-doc
+type EmptyConfig struct{}
+
+func (EmptyConfig) isPachConfig() {}
+
+type AnyConfig interface {
+	isPachConfig()
 }

--- a/src/internal/pachd/base.go
+++ b/src/internal/pachd/base.go
@@ -1,0 +1,90 @@
+package pachd
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/version"
+	"go.uber.org/automaxprocs/maxprocs"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+type setupStep struct {
+	Name string
+	Fn   func(context.Context) error
+}
+
+// base structures the setup and run phases of pachds
+type base struct {
+	setup      []setupStep
+	background map[string]func(context.Context) error
+	done       bool
+
+	config pachconfig.Configuration
+}
+
+func (b *base) setConfig(config pachconfig.Configuration) {
+	b.config = config
+}
+
+func (b *base) addSetup(name string, fn func(context.Context) error) {
+	b.setup = append(b.setup, setupStep{
+		Name: name,
+		Fn:   fn,
+	})
+}
+
+func (b *base) addBackground(name string, fn func(context.Context) error) {
+	if _, exists := b.background[name]; exists {
+		panic(fmt.Sprintf("2 background functions with same name %q", name))
+	}
+	b.background[name] = fn
+}
+
+func (b *base) Run(ctx context.Context) error {
+	if b.done {
+		panic("pachd has already been run")
+	}
+	defer func() { b.done = true }()
+
+	log.Info(ctx, "pachd begin setup")
+	for _, step := range b.setup {
+		endf := log.Span(ctx, step.Name)
+		if err := step.Fn(ctx); err != nil {
+			return errors.Errorf("during setup step %s: %w", step.Name, err)
+		}
+		endf()
+	}
+	log.Info(ctx, "pachd setup complete")
+
+	log.Info(ctx, "pachd running services")
+	eg, ctx := errgroup.WithContext(ctx)
+	for name, fn := range b.background {
+		ctx := pctx.Child(ctx, name)
+		eg.Go(func() error {
+			return fn(ctx)
+		})
+	}
+	return eg.Wait()
+}
+
+func (b *base) printVersion(ctx context.Context) error {
+	log.Info(ctx, "version info", log.Proto("versionInfo", version.Version))
+	return nil
+}
+
+// TODO: move this into caller of internal/pachd package
+func (b *base) tweakResources(ctx context.Context) error {
+	// set GOMAXPROCS to the container limit & log outcome to stdout
+	maxprocs.Set(maxprocs.Logger(zap.S().Named("maxprocs").Infof)) //nolint:errcheck
+	debug.SetGCPercent(b.config.GCPercent)
+	log.Info(ctx, "gc: set gc percent", zap.Int("value", b.config.GCPercent))
+	setupMemoryLimit(ctx, *b.config.GlobalConfiguration)
+	return nil
+}

--- a/src/internal/pachd/base.go
+++ b/src/internal/pachd/base.go
@@ -66,6 +66,8 @@ func (b *base) Run(ctx context.Context) error {
 	log.Info(ctx, "pachd running services")
 	eg, ctx := errgroup.WithContext(ctx)
 	for name, fn := range b.background {
+		name := name
+		fn := fn
 		ctx := pctx.Child(ctx, name)
 		eg.Go(func() error {
 			return fn(ctx)

--- a/src/internal/pachd/preflight.go
+++ b/src/internal/pachd/preflight.go
@@ -28,7 +28,9 @@ func NewPreflight(env PreFlightEnv, config pachconfig.PachdPreflightConfiguratio
 	pf.addSetup("print version", pf.printVersion)
 	pf.addSetup("await DB", pf.awaitDB)
 	pf.addSetup("test migrations", pf.testMigrations)
-	pf.addSetup("", pf.everythingOK)
+	pf.addSetup("OK", pf.everythingOK)
+	// TODO: remove
+	pf.addBackground("", func(context.Context) error { return nil })
 	return pf
 }
 

--- a/src/internal/pachd/preflight.go
+++ b/src/internal/pachd/preflight.go
@@ -19,14 +19,13 @@ type PreFlightEnv struct {
 // PreFlight is a minimal pachd for running preflight checks.
 type PreFlight struct {
 	base
-	env PreFlightEnv
+	env    PreFlightEnv
+	config pachconfig.PachdPreflightConfiguration
 }
 
-func NewPreflight(env PreFlightEnv, config pachconfig.Configuration) *PreFlight {
-	pf := &PreFlight{env: env}
-	pf.setConfig(config)
+func NewPreflight(env PreFlightEnv, config pachconfig.PachdPreflightConfiguration) *PreFlight {
+	pf := &PreFlight{env: env, config: config}
 	pf.addSetup("print version", pf.printVersion)
-	pf.addSetup("tweak resources", pf.tweakResources)
 	pf.addSetup("await DB", pf.awaitDB)
 	pf.addSetup("test migrations", pf.testMigrations)
 	pf.addSetup("", pf.everythingOK)

--- a/src/internal/setupenv/db.go
+++ b/src/internal/setupenv/db.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func openDirectDB(config pachconfig.Configuration) (*pachsql.DB, error) {
+func openDirectDB(config pachconfig.PostgresConfiguration) (*pachsql.DB, error) {
 	db, err := dbutil.NewDB(
 		dbutil.WithHostPort(config.PostgresHost, config.PostgresPort),
 		dbutil.WithDBName(config.PostgresDBName),

--- a/src/internal/setupenv/db.go
+++ b/src/internal/setupenv/db.go
@@ -1,11 +1,11 @@
 package setupenv
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/dlmiddlecote/sqlstats"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +27,7 @@ func openDirectDB(config pachconfig.PostgresConfiguration) (*pachsql.DB, error) 
 		return nil, err
 	}
 	if err := prometheus.Register(sqlstats.NewStatsCollector("direct", db)); err != nil {
-		return nil, fmt.Errorf("problem registering stats collector for direct db client: %w", err)
+		return nil, errors.Errorf("problem registering stats collector for direct db client: %w", err)
 	}
 	return db, nil
 }

--- a/src/internal/setupenv/db.go
+++ b/src/internal/setupenv/db.go
@@ -1,0 +1,33 @@
+package setupenv
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dlmiddlecote/sqlstats"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func openDirectDB(config pachconfig.Configuration) (*pachsql.DB, error) {
+	db, err := dbutil.NewDB(
+		dbutil.WithHostPort(config.PostgresHost, config.PostgresPort),
+		dbutil.WithDBName(config.PostgresDBName),
+		dbutil.WithUserPassword(config.PostgresUser, config.PostgresPassword),
+		dbutil.WithMaxOpenConns(config.PostgresMaxOpenConns),
+		dbutil.WithMaxIdleConns(config.PostgresMaxIdleConns),
+		dbutil.WithConnMaxLifetime(time.Duration(config.PostgresConnMaxLifetimeSeconds)*time.Second),
+		dbutil.WithConnMaxIdleTime(time.Duration(config.PostgresConnMaxIdleSeconds)*time.Second),
+		dbutil.WithSSLMode(config.PostgresSSL),
+		dbutil.WithQueryLog(config.PostgresQueryLogging, "pgx.direct"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := prometheus.Register(sqlstats.NewStatsCollector("direct", db)); err != nil {
+		return nil, fmt.Errorf("problem registering stats collector for direct db client: %w", err)
+	}
+	return db, nil
+}

--- a/src/internal/setupenv/setupenv.go
+++ b/src/internal/setupenv/setupenv.go
@@ -1,0 +1,15 @@
+// Package setupenv manages creating pachd.*Envs from pachconfig objects.
+package setupenv
+
+import (
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
+)
+
+func NewPreflightEnv(config pachconfig.Configuration) (*pachd.PreFlightEnv, error) {
+	db, err := openDirectDB(config)
+	if err != nil {
+		return nil, err
+	}
+	return &pachd.PreFlightEnv{DB: db}, nil
+}

--- a/src/internal/setupenv/setupenv.go
+++ b/src/internal/setupenv/setupenv.go
@@ -6,8 +6,8 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
 )
 
-func NewPreflightEnv(config pachconfig.Configuration) (*pachd.PreFlightEnv, error) {
-	db, err := openDirectDB(config)
+func NewPreflightEnv(config pachconfig.PachdPreflightConfiguration) (*pachd.PreFlightEnv, error) {
+	db, err := openDirectDB(config.PostgresConfiguration)
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/cmd/pachctl-doc/main.go
+++ b/src/server/cmd/pachctl-doc/main.go
@@ -13,19 +13,18 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/server/cmd/pachctl/cmd"
 
 	"github.com/spf13/cobra/doc"
 )
 
-type appEnv struct{}
-
 func main() {
 	log.InitPachctlLogger()
-	cmdutil.Main(context.Background(), do, &appEnv{})
+	cmdutil.Main(context.Background(), do, &pachconfig.EmptyConfig{})
 }
 
-func do(ctx context.Context, appEnvObj *appEnv) error {
+func do(ctx context.Context, _ *pachconfig.EmptyConfig) error {
 	path := "./docs/"
 
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -65,14 +65,14 @@ func main() {
 		cmdutil.Main(ctx, pachd.PausedMode, &pachconfig.PachdFullConfiguration{})
 	case mode == "preflight":
 		logMode("preflight")
-		cmdutil.Main(ctx, func(ctx context.Context, config *pachconfig.Configuration) error {
+		cmdutil.Main(ctx, func(ctx context.Context, config *pachconfig.PachdPreflightConfiguration) error {
 			env, err := setupenv.NewPreflightEnv(*config)
 			if err != nil {
 				return err
 			}
 			pd := pachd.NewPreflight(*env, *config)
 			return pd.Run(ctx)
-		}, &pachconfig.Configuration{})
+		}, &pachconfig.PachdPreflightConfiguration{})
 	default:
 		log.Error(ctx, "pachd: unrecognized mode", zap.String("mode", mode))
 		fmt.Printf("unrecognized mode: %s\n", mode)

--- a/src/server/cmd/pachd/main.go
+++ b/src/server/cmd/pachd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/proc"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serviceenv"
+	"github.com/pachyderm/pachyderm/v2/src/internal/setupenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
 	_ "github.com/pachyderm/pachyderm/v2/src/internal/task/taskprotos"
 )
@@ -64,7 +65,14 @@ func main() {
 		cmdutil.Main(ctx, pachd.PausedMode, &pachconfig.PachdFullConfiguration{})
 	case mode == "preflight":
 		logMode("preflight")
-		cmdutil.Main(ctx, pachd.PreflightMode, &pachconfig.PachdPreflightConfiguration{})
+		cmdutil.Main(ctx, func(ctx context.Context, config *pachconfig.Configuration) error {
+			env, err := setupenv.NewPreflightEnv(*config)
+			if err != nil {
+				return err
+			}
+			pd := pachd.NewPreflight(*env, *config)
+			return pd.Run(ctx)
+		}, &pachconfig.Configuration{})
 	default:
 		log.Error(ctx, "pachd: unrecognized mode", zap.String("mode", mode))
 		fmt.Printf("unrecognized mode: %s\n", mode)


### PR DESCRIPTION
The Preflight mode of pachd now has it's own dependency struct `PreflightEnv`, which currently only contains a database client.  A lightweight scaffolding `base` is introduced to run setup tasks.