### PR TITLE
[PFS-138] Create Initial Schema Migration for Commits

### DIFF
--- a/src/internal/clusterstate/v2.8.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.8.0/clusterstate.go
@@ -36,7 +36,7 @@ func Migrate(state migrations.State) migrations.State {
 		}).
 		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash).
 		Apply("Migrate collections.commits to pfs.commits", func(ctx context.Context, env migrations.Env) error {
-			if err := migrateCommits(ctx, env.Tx); err != nil {
+			if err := migrateCommits(ctx, env); err != nil {
 				return errors.Wrap(err, "migrating commits")
 			}
 			return nil

--- a/src/internal/clusterstate/v2.8.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.8.0/clusterstate.go
@@ -35,10 +35,5 @@ func Migrate(state migrations.State) migrations.State {
 			return nil
 		}).
 		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash).
-		Apply("Migrate collections.commits to pfs.commits", func(ctx context.Context, env migrations.Env) error {
-			if err := migrateCommits(ctx, env); err != nil {
-				return errors.Wrap(err, "migrating commits")
-			}
-			return nil
-		}, migrations.Squash)
+		Apply("Migrate collections.commits to pfs.commits", migrateCommits, migrations.Squash)
 }

--- a/src/internal/clusterstate/v2.8.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.8.0/clusterstate.go
@@ -34,5 +34,11 @@ func Migrate(state migrations.State) migrations.State {
 			}
 			return nil
 		}).
-		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash)
+		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash).
+		Apply("Migrate collections.commits to pfs.commits", func(ctx context.Context, env migrations.Env) error {
+			if err := migrateCommits(ctx, env.Tx); err != nil {
+				return errors.Wrap(err, "migrating commits")
+			}
+			return nil
+		}, migrations.Squash)
 }

--- a/src/internal/clusterstate/v2.8.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.8.0/clusterstate.go
@@ -27,6 +27,7 @@ func Migrate(state migrations.State) migrations.State {
 			}
 			return nil
 		}, migrations.Squash).
+		Apply("Alter the pfs.commits schema", migrateCommitSchema, migrations.Squash).
 		Apply("Migrate collections.branches to pfs.branches", migrateBranches, migrations.Squash).
 		Apply("Synthesize cluster defaults from environment variables", func(ctx context.Context, env migrations.Env) error {
 			if err := synthesizeClusterDefaults(ctx, env); err != nil {
@@ -34,6 +35,6 @@ func Migrate(state migrations.State) migrations.State {
 			}
 			return nil
 		}).
-		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash).
-		Apply("Migrate collections.commits to pfs.commits", migrateCommits, migrations.Squash)
+		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash)
+
 }

--- a/src/internal/clusterstate/v2.8.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.8.0/clusterstate.go
@@ -27,8 +27,8 @@ func Migrate(state migrations.State) migrations.State {
 			}
 			return nil
 		}, migrations.Squash).
-		Apply("Alter the pfs.commits schema", migrateCommitSchema, migrations.Squash).
 		Apply("Migrate collections.branches to pfs.branches", migrateBranches, migrations.Squash).
+		Apply("Alter the pfs.commits schema", migrateCommitSchema, migrations.Squash).
 		Apply("Synthesize cluster defaults from environment variables", func(ctx context.Context, env migrations.Env) error {
 			if err := synthesizeClusterDefaults(ctx, env); err != nil {
 				return errors.Wrap(err, "could not synthesize cluster defaults")
@@ -36,5 +36,4 @@ func Migrate(state migrations.State) migrations.State {
 			return nil
 		}).
 		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash)
-
 }

--- a/src/internal/clusterstate/v2.8.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb.go
@@ -225,8 +225,6 @@ func alterCommitsTable(ctx context.Context, tx *pachsql.Tx) error {
 	query := `
 	CREATE TYPE pfs.commit_origin AS ENUM ('ORIGIN_KIND_UNKNOWN', 'USER', 'AUTO', 'FSCK');
 
-	DROP INDEX IF EXISTS pfs.commit_provenance_from_id_idx;
-
 	ALTER TABLE pfs.commits
 		ADD COLUMN repo_id bigint REFERENCES pfs.repos(id),
 		ADD COLUMN origin pfs.commit_origin,
@@ -234,8 +232,8 @@ func alterCommitsTable(ctx context.Context, tx *pachsql.Tx) error {
 		ADD COLUMN start_time timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		ADD COLUMN finishing_time timestamptz,
 		ADD COLUMN finished_time timestamptz,
-		ADD COLUMN compacting_time bigint,
-		ADD COLUMN validating_time bigint,
+		ADD COLUMN compacting_time_s bigint,
+		ADD COLUMN validating_time_s bigint,
 		ADD COLUMN error text,
 		ADD COLUMN size bigint,
 		ADD COLUMN updated_at timestamptz DEFAULT CURRENT_TIMESTAMP,

--- a/src/internal/clusterstate/v2.8.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb.go
@@ -239,7 +239,7 @@ func alterCommitsTable(ctx context.Context, tx *pachsql.Tx) error {
 		ADD COLUMN error text,
 		ADD COLUMN size bigint,
 		ADD COLUMN updated_at timestamptz DEFAULT CURRENT_TIMESTAMP,
-		ADD COLUMN branch_id bigint;
+		ADD COLUMN branch_id bigint REFERENCES pfs.branches(id);
 
 	CREATE TRIGGER set_updated_at
 		BEFORE UPDATE ON pfs.commits

--- a/src/internal/clusterstate/v2.8.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb.go
@@ -225,6 +225,8 @@ func alterCommitsTable(ctx context.Context, tx *pachsql.Tx) error {
 	query := `
 	CREATE TYPE pfs.commit_origin AS ENUM ('ORIGIN_KIND_UNKNOWN', 'USER', 'AUTO', 'FSCK');
 
+	DROP INDEX IF EXISTS pfs.commit_provenance_from_id_idx;
+
 	ALTER TABLE pfs.commits
 		ADD COLUMN repo_id bigint REFERENCES pfs.repos(id),
 		ADD COLUMN origin pfs.commit_origin,

--- a/src/internal/clusterstate/v2.8.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb.go
@@ -298,7 +298,7 @@ func createNotifyCommitsTrigger(ctx context.Context, tx *pachsql.Tx) error {
 }
 
 // Migrate commits from collections.commits to pfs.commits
-func migrateCommits(ctx context.Context, env migrations.Env) error {
+func migrateCommitSchema(ctx context.Context, env migrations.Env) error {
 	if err := alterCommitsTable(ctx, env.Tx); err != nil {
 		return err
 	}


### PR DESCRIPTION
The goal of this PR is to merge in the initial schema migration. The overall schema migration has to happen in stages. The second half of the schema migration needs to be called after the data is migrated over. 