### PR TITLE
Refactor clusterstate v2.8.0

### DIFF
--- a/src/internal/clusterstate/v2.8.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.8.0/clusterstate.go
@@ -1,39 +1,15 @@
 package v2_8_0
 
 import (
-	"context"
-
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 )
 
 func Migrate(state migrations.State) migrations.State {
 	return state.
-		Apply("Create pfs schema", func(ctx context.Context, env migrations.Env) error {
-			if err := createPFSSchema(ctx, env.Tx); err != nil {
-				return errors.Wrap(err, "creating pfs schema")
-			}
-			return nil
-		}).
-		Apply("Create pfs.repos table", func(ctx context.Context, env migrations.Env) error {
-			if err := createReposTable(ctx, env.Tx); err != nil {
-				return errors.Wrap(err, "creating pfs.repos table")
-			}
-			return nil
-		}, migrations.Squash).
-		Apply("Migrate collections.repos to pfs.repos", func(ctx context.Context, env migrations.Env) error {
-			if err := migrateRepos(ctx, env.Tx); err != nil {
-				return errors.Wrap(err, "migrating repos")
-			}
-			return nil
-		}, migrations.Squash).
+		Apply("Create pfs schema", createPFSSchema).
+		Apply("Migrate collections.repos to pfs.repos", migrateRepos, migrations.Squash).
 		Apply("Migrate collections.branches to pfs.branches", migrateBranches, migrations.Squash).
 		Apply("Alter the pfs.commits schema", migrateCommitSchema, migrations.Squash).
-		Apply("Synthesize cluster defaults from environment variables", func(ctx context.Context, env migrations.Env) error {
-			if err := synthesizeClusterDefaults(ctx, env); err != nil {
-				return errors.Wrap(err, "could not synthesize cluster defaults")
-			}
-			return nil
-		}).
+		Apply("Synthesize cluster defaults from environment variables", synthesizeClusterDefaults).
 		Apply("Synthesize user and effective specs from their pipeline details", synthesizeSpecs, migrations.Squash)
 }


### PR DESCRIPTION
I very much prefer this style of implementing migration functions, with the signature `func(ctx context.Context, env Env) error`, allowing each migration step to be just one line in `clusterstate.go`.