### PR TITLE
[Notebooks] Utilize ListDatum pagination

### DIFF
--- a/jupyter-extension/README.md
+++ b/jupyter-extension/README.md
@@ -223,8 +223,10 @@ PUT /_mount # mounts a single repo
 PUT /_unmount # unmounts a single repo
 PUT /_commit # commits any changes to the repo
 PUT /_unmount_all # unmounts all repos
-PUT /_mount_datums # mounts first datum of given input spec
-PUT /_show_datum # cycles through mounted datums
+PUT /datums/_mount # mounts first datum of given input spec
+PUT /datums/_next # mounts next datum
+PUT /datums/_prev # mounts prev datum
+GET /datums # returns info on mounted datum
 ```
 
 The servers-side extension extends jupyter server, so it automatically starts as part of `jupyter lab`.

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -142,27 +142,42 @@ class MountDatumsHandler(BaseHandler):
             get_logger().debug(f"Mount datums: {response}")
             self.finish(response)
         except Exception as e:
-            get_logger().error(f"Error mounting datums with input {body}", exc_info=True)
+            get_logger().error(
+                f"Error mounting datums with input {body}", exc_info=True
+            )
             raise tornado.web.HTTPError(
-                status_code=getattr(e, "code", 500), reason=f"Error mounting datums with input {body}: {e}."
+                status_code=getattr(e, "code", 500),
+                reason=f"Error mounting datums with input {body}: {e}.",
             )
 
 
-class ShowDatumHandler(BaseHandler):
+class DatumNextHandler(BaseHandler):
     @tornado.web.authenticated
     async def put(self):
         try:
-            slug = {
-                "idx": self.get_argument("idx", None),
-                "id": self.get_argument("id", None)
-            }
-            response = await self.mount_client.show_datum(slug)
-            get_logger().debug(f"Show datum: {response}")
+            response = await self.mount_client.next_datum()
+            get_logger().debug(f"Next datum: {response}")
             self.finish(response)
         except Exception as e:
-            get_logger().error(f"Error showing datum {slug}", exc_info=True)
+            get_logger().error(f"Error mounting next datum", exc_info=True)
             raise tornado.web.HTTPError(
-                status_code=getattr(e, "code", 500), reason=f"Error showing datum {slug}: {e}."
+                status_code=getattr(e, "code", 500),
+                reason=f"Error mounting next datum: {e}.",
+            )
+
+
+class DatumPrevHandler(BaseHandler):
+    @tornado.web.authenticated
+    async def put(self):
+        try:
+            response = await self.mount_client.prev_datum()
+            get_logger().debug(f"Prev datum: {response}")
+            self.finish(response)
+        except Exception as e:
+            get_logger().error(f"Error mounting prev datum", exc_info=True)
+            raise tornado.web.HTTPError(
+                status_code=getattr(e, "code", 500),
+                reason=f"Error mounting prev datum: {e}.",
             )
 
 
@@ -332,10 +347,11 @@ def setup_handlers(web_app):
         ("/_unmount", UnmountHandler),
         ("/_commit", CommitHandler),
         ("/_unmount_all", UnmountAllHandler),
-        ("/_mount_datums", MountDatumsHandler),
-        (r"/_show_datum", ShowDatumHandler),
-        (r"/pfs%s" % path_regex, PFSHandler),
+        ("/datums/_mount", MountDatumsHandler),
+        ("/datums/_next", DatumNextHandler),
+        ("/datums/_prev", DatumPrevHandler),
         ("/datums", DatumsHandler),
+        (r"/pfs%s" % path_regex, PFSHandler),
         ("/config", ConfigHandler),
         ("/auth/_login", AuthLoginHandler),
         ("/auth/_logout", AuthLogoutHandler),

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -179,17 +179,25 @@ class MountServerClient(MountInterface):
     async def mount_datums(self, body):
         await self._ensure_mount_server()
         response = await self.client.fetch(
-            f"{self.address}/_mount_datums",
+            f"{self.address}/datums/_mount",
             method="PUT",
             body=json.dumps(body),
         )
         return response.body
 
-    async def show_datum(self, slug):
+    async def next_datum(self):
         await self._ensure_mount_server()
-        slug = '&'.join(f"{k}={v}" for k,v in slug.items() if v is not None)
         response = await self.client.fetch(
-            f"{self.address}/_show_datum?{slug}",
+            f"{self.address}/datums/_next",
+            method="PUT",
+            body="{}",
+        )
+        return response.body
+
+    async def prev_datum(self):
+        await self._ensure_mount_server()
+        response = await self.client.fetch(
+            f"{self.address}/datums/_prev",
             method="PUT",
             body="{}",
         )

--- a/jupyter-extension/jupyterlab_pachyderm/pachyderm.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pachyderm.py
@@ -23,7 +23,10 @@ class MountInterface:
     async def mount_datums(self, body):
         pass
 
-    async def show_datum(self, slug):
+    async def next_datum(self):
+        pass
+
+    async def prev_datum(self):
         pass
 
     async def get_datums(self):

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_handlers.py
@@ -393,27 +393,22 @@ async def test_unmount_all(mock_client, jp_fetch):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
-@patch("jupyterlab_pachyderm.handlers.MountDatumsHandler.mount_client", spec=MountInterface)
+@patch(
+    "jupyterlab_pachyderm.handlers.MountDatumsHandler.mount_client", spec=MountInterface
+)
 async def test_mount_datums(mock_client, jp_fetch):
-    body = {
-        "input": {
-            "pfs": {
-                "repo": "images",
-                "branch": "dev", 
-                "glob": "/*"
-            }
+    body = {"input": {"pfs": {"repo": "images", "branch": "dev", "glob": "/*"}}}
+    mock_client.mount_datums.return_value = json.dumps(
+        {
+            "id": "ad9329d",
+            "idx": 0,
+            "num_datums": 3,
+            "all_datums_received": True,
         }
-    }
-    mock_client.mount_datums.return_value = json.dumps({
-        "id": "ad9329d",
-        "idx": 0,
-        "num_datums": 3,
-    })
+    )
 
     r = await jp_fetch(
-        f"/{NAMESPACE}/{VERSION}/_mount_datums",
-        method="PUT",
-        body=json.dumps(body)
+        f"/{NAMESPACE}/{VERSION}/datums/_mount", method="PUT", body=json.dumps(body)
     )
     mock_client.mount_datums.assert_called_with(body)
 
@@ -421,46 +416,83 @@ async def test_mount_datums(mock_client, jp_fetch):
         "id": "ad9329d",
         "idx": 0,
         "num_datums": 3,
+        "all_datums_received": True,
     }
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
-@patch("jupyterlab_pachyderm.handlers.ShowDatumHandler.mount_client", spec=MountInterface)
-async def test_show_datum(mock_client, jp_fetch):
-    mock_client.show_datum.return_value = json.dumps({
-        "id": "jdkw9j23",
-        "idx": 2,
-        "num_datums": 3,
-    })
+@patch(
+    "jupyterlab_pachyderm.handlers.DatumNextHandler.mount_client", spec=MountInterface
+)
+async def test_next_datum(mock_client, jp_fetch):
+    mock_client.next_datum.return_value = json.dumps(
+        {
+            "id": "jdkw9j23",
+            "idx": 1,
+            "num_datums": 3,
+            "all_datums_received": True,
+        }
+    )
 
     r = await jp_fetch(
-        f"/{NAMESPACE}/{VERSION}/_show_datum",
+        f"/{NAMESPACE}/{VERSION}/datums/_next",
         method="PUT",
-        body=json.dumps({"idx": "2"})
     )
 
     assert json.loads(r.body) == {
         "id": "jdkw9j23",
-        "idx": 2,
+        "idx": 1,
         "num_datums": 3,
+        "all_datums_received": True,
+    }
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
+@patch(
+    "jupyterlab_pachyderm.handlers.DatumPrevHandler.mount_client", spec=MountInterface
+)
+async def test_prev_datum(mock_client, jp_fetch):
+    mock_client.prev_datum.return_value = json.dumps(
+        {
+            "id": "jdkw9j23",
+            "idx": 0,
+            "num_datums": 3,
+            "all_datums_received": True,
+        }
+    )
+
+    r = await jp_fetch(
+        f"/{NAMESPACE}/{VERSION}/datums/_prev",
+        method="PUT",
+    )
+
+    assert json.loads(r.body) == {
+        "id": "jdkw9j23",
+        "idx": 0,
+        "num_datums": 3,
+        "all_datums_received": True,
     }
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 @patch("jupyterlab_pachyderm.handlers.DatumsHandler.mount_client", spec=MountInterface)
 async def test_get_datums(mock_client, jp_fetch):
-    mock_client.get_datums.return_value = json.dumps({
-        "input": {"pfs": {"repo": "repo", "branch": "dev", "glob": "/*"}},
-        "num_datums": 3,
-        "curr_idx": 2,
-    })
+    mock_client.get_datums.return_value = json.dumps(
+        {
+            "input": {"pfs": {"repo": "repo", "branch": "dev", "glob": "/*"}},
+            "num_datums": 3,
+            "idx": 2,
+            "all_datums_received": True,
+        }
+    )
 
     r = await jp_fetch(f"/{NAMESPACE}/{VERSION}/datums")
 
     assert json.loads(r.body) == {
         "input": {"pfs": {"repo": "repo", "branch": "dev", "glob": "/*"}},
         "num_datums": 3,
-        "curr_idx": 2,
+        "idx": 2,
+        "all_datums_received": True,
     }
 
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_handlers.py
@@ -437,6 +437,7 @@ async def test_next_datum(mock_client, jp_fetch):
     r = await jp_fetch(
         f"/{NAMESPACE}/{VERSION}/datums/_next",
         method="PUT",
+        body="{}"
     )
 
     assert json.loads(r.body) == {
@@ -464,6 +465,7 @@ async def test_prev_datum(mock_client, jp_fetch):
     r = await jp_fetch(
         f"/{NAMESPACE}/{VERSION}/datums/_prev",
         method="PUT",
+        body="{}"
     )
 
     assert json.loads(r.body) == {

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -289,6 +289,7 @@ def test_mount_datums(pachyderm_resources, dev_server):
     assert r.status_code == 200
     assert r.json()["idx"] == 0
     assert r.json()["num_datums"] == 4
+    assert r.json()["all_datums_received"] == True
     list(os.walk(os.path.join(PFS_MOUNT_DIR, "out")))  # makes "out" dir appear
     assert len(list(os.walk(PFS_MOUNT_DIR))[0][1]) == 4
     datum0_id = r.json()["id"]
@@ -304,12 +305,14 @@ def test_mount_datums(pachyderm_resources, dev_server):
     assert r.json()["idx"] == 1
     assert r.json()["num_datums"] == 4
     assert r.json()["id"] != datum0_id
+    assert r.json()["all_datums_received"] == True
 
     r = requests.put(f"{BASE_URL}/datums/_prev")
     assert r.status_code == 200
     assert r.json()["idx"] == 0
     assert r.json()["num_datums"] == 4
     assert r.json()["id"] == datum0_id
+    assert r.json()["all_datums_received"] == True
 
     r = requests.get(f"{BASE_URL}/datums")
     assert r.status_code == 200
@@ -345,7 +348,8 @@ def test_mount_datums(pachyderm_resources, dev_server):
         ]
     }
     assert r.json()["num_datums"] == 4
-    assert r.json()["curr_idx"] == 0
+    assert r.json()["idx"] == 0
+    assert r.json()["all_datums_received"] == True
 
     r = requests.put(f"{BASE_URL}/_unmount_all")
     assert r.status_code == 200

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -285,7 +285,7 @@ def test_mount_datums(pachyderm_resources, dev_server):
         }
     }
 
-    r = requests.put(f"{BASE_URL}/_mount_datums", data=json.dumps(input_spec))
+    r = requests.put(f"{BASE_URL}/datums/_mount", data=json.dumps(input_spec))
     assert r.status_code == 200
     assert r.json()["idx"] == 0
     assert r.json()["num_datums"] == 4
@@ -299,19 +299,13 @@ def test_mount_datums(pachyderm_resources, dev_server):
     assert "".join([DEFAULT_PROJECT, "_", repos[1], "_dev"]) in list(os.walk(PFS_MOUNT_DIR))[0][1]
     assert len(list(os.walk(os.path.join(PFS_MOUNT_DIR, "".join([DEFAULT_PROJECT, "_", repos[2]]))))[0][2]) == 1
 
-    r = requests.put(f"{BASE_URL}/_show_datum", params={"idx": "2"})
+    r = requests.put(f"{BASE_URL}/datums/_next")
     assert r.status_code == 200
-    assert r.json()["idx"] == 2
+    assert r.json()["idx"] == 1
     assert r.json()["num_datums"] == 4
     assert r.json()["id"] != datum0_id
 
-    r = requests.put(
-        f"{BASE_URL}/_show_datum",
-        params={
-            "idx": "2",
-            "id": datum0_id,
-        },
-    )
+    r = requests.put(f"{BASE_URL}/datums/_prev")
     assert r.status_code == 200
     assert r.json()["idx"] == 0
     assert r.json()["num_datums"] == 4

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -40,11 +40,11 @@ const Datum: React.FC<DatumProps> = ({
     loading,
     shouldShowCycler,
     currDatum,
-    currIdx,
-    setCurrIdx,
     inputSpec,
     setInputSpec,
     callMountDatums,
+    callNextDatum,
+    callPrevDatum,
     callUnmountAll,
     errorMessage,
     saveInputSpec,
@@ -135,28 +135,28 @@ const Datum: React.FC<DatumProps> = ({
               <button
                 className="pachyderm-button-link"
                 data-testid="Datum__cyclerLeft"
-                disabled={currIdx <= 0}
-                onClick={() => {
-                  if (currIdx >= 1) {
-                    setCurrIdx(currIdx - 1);
-                  }
-                }}
+                disabled={currDatum.idx <= 0}
+                onClick={callPrevDatum}
               >
                 <caretLeftIcon.react
                   tag="span"
                   className="pachyderm-mount-datum-left"
                 />
               </button>
-              {'(' + (currIdx + 1) + '/' + currDatum.num_datums + ')'}
+              {'(' +
+                (currDatum.idx + 1) +
+                '/' +
+                currDatum.num_datums +
+                (currDatum.all_datums_received ? '' : '+') +
+                ')'}
               <button
                 className="pachyderm-button-link"
                 data-testid="Datum__cyclerRight"
-                disabled={currIdx >= currDatum.num_datums - 1}
-                onClick={() => {
-                  if (currIdx < currDatum.num_datums - 1) {
-                    setCurrIdx(currIdx + 1);
-                  }
-                }}
+                disabled={
+                  currDatum.idx >= currDatum.num_datums - 1 &&
+                  currDatum.all_datums_received
+                }
+                onClick={callNextDatum}
               >
                 <caretRightIcon.react
                   tag="span"

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -36,6 +36,7 @@ describe('datum screen', () => {
           id: 'asdfaew34ri92jafiolwe',
           idx: 0,
           num_datums: 6,
+          all_datums_received: true,
         }),
       );
 
@@ -64,7 +65,7 @@ describe('datum screen', () => {
       await waitFor(() => {
         expect(mockRequestAPI.requestAPI).toHaveBeenNthCalledWith(
           2,
-          '_mount_datums',
+          'datums/_mount',
           'PUT',
           {input: {pfs: 'a'}},
         );
@@ -77,12 +78,13 @@ describe('datum screen', () => {
   });
 
   describe('cycle through datums', () => {
-    it('hitting datum cycler makes show datum call', async () => {
+    it('hitting datum cycler makes next datum call', async () => {
       mockRequestAPI.requestAPI.mockImplementation(
         mockedRequestAPI({
           id: 'asdfaew34ri92jafiolwe',
           idx: 0,
           num_datums: 6,
+          all_datums_received: false,
         }),
       );
 
@@ -110,6 +112,7 @@ describe('datum screen', () => {
           id: 'ilwe9nme9902ja039jf20snv',
           idx: 1,
           num_datums: 6,
+          all_datums_received: false,
         }),
       );
 
@@ -118,15 +121,15 @@ describe('datum screen', () => {
 
       await waitFor(() => {
         expect(mockRequestAPI.requestAPI).toHaveBeenNthCalledWith(
-          4,
-          '_show_datum?idx=1',
+          3,
+          'datums/_next',
           'PUT',
         );
       });
 
       getByTestId('Datum__cyclerLeft');
       getByTestId('Datum__cyclerRight');
-      expect(getByTestId('Datum__cycler')).toHaveTextContent('(2/6)');
+      expect(getByTestId('Datum__cycler')).toHaveTextContent('(2/6+)');
     });
   });
 

--- a/jupyter-extension/src/plugins/mount/components/Datum/hooks/useDatum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/hooks/useDatum.tsx
@@ -17,11 +17,11 @@ export type useDatumResponse = {
   loading: boolean;
   shouldShowCycler: boolean;
   currDatum: MountDatumResponse;
-  currIdx: number;
-  setCurrIdx: (idx: number) => void;
   inputSpec: string;
   setInputSpec: (input: string) => void;
   callMountDatums: () => Promise<void>;
+  callNextDatum: () => Promise<void>;
+  callPrevDatum: () => Promise<void>;
   callUnmountAll: () => Promise<void>;
   errorMessage: string;
   saveInputSpec: () => void;
@@ -39,11 +39,11 @@ export const useDatum = (
 ): useDatumResponse => {
   const [loading, setLoading] = useState(false);
   const [shouldShowCycler, setShouldShowCycler] = useState(false);
-  const [currIdx, setCurrIdx] = useState(-1);
   const [currDatum, setCurrDatum] = useState<MountDatumResponse>({
     id: '',
     idx: -1,
     num_datums: 0,
+    all_datums_received: false,
   });
   const [inputSpec, setInputSpec] = useState('');
   const [initialInputSpec, setInitialInputSpec] = useState({});
@@ -51,12 +51,6 @@ export const useDatum = (
   const [datumViewInputSpec, setDatumViewInputSpec] = useState<
     string | JSONObject
   >({});
-
-  useEffect(() => {
-    if (showDatum && currIdx !== -1) {
-      callShowDatum();
-    }
-  }, [currIdx, showDatum]);
 
   useEffect(() => {
     if (showDatum) {
@@ -67,11 +61,11 @@ export const useDatum = (
       // Executes when browser reloaded; resume at currently mounted datum
       if (keepMounted && currentDatumInfo) {
         setShouldShowCycler(true);
-        setCurrIdx(currentDatumInfo.curr_idx);
         setCurrDatum({
           id: '',
-          idx: currentDatumInfo.curr_idx,
+          idx: currentDatumInfo.idx,
           num_datums: currentDatumInfo.num_datums,
+          all_datums_received: currentDatumInfo.all_datums_received,
         });
         setInputSpec(inputSpecObjToText(currentDatumInfo.input));
         setKeepMounted(false);
@@ -144,11 +138,10 @@ export const useDatum = (
 
     try {
       const spec = inputSpecTextToObj();
-      const res = await requestAPI<MountDatumResponse>('_mount_datums', 'PUT', {
+      const res = await requestAPI<MountDatumResponse>('datums/_mount', 'PUT', {
         input: spec,
       });
       open('');
-      setCurrIdx(0);
       setCurrDatum(res);
       setShouldShowCycler(true);
       setInputSpec(inputSpecObjToText(spec));
@@ -168,14 +161,35 @@ export const useDatum = (
     setLoading(false);
   };
 
-  const callShowDatum = async () => {
+  const callNextDatum = async () => {
     setLoading(true);
+    setErrorMessage('');
 
     try {
-      const res = await requestAPI<MountDatumResponse>(
-        `_show_datum?idx=${currIdx}`,
-        'PUT',
-      );
+      const res = await requestAPI<MountDatumResponse>('datums/_next', 'PUT');
+      open('');
+      setCurrDatum(res);
+    } catch (e) {
+      if (e instanceof ServerConnection.ResponseError) {
+        setCurrDatum({
+          id: currDatum.id,
+          idx: currDatum.idx,
+          num_datums: currDatum.num_datums,
+          all_datums_received: true,
+        });
+        setErrorMessage('Reached final datum');
+      }
+    }
+
+    setLoading(false);
+  };
+
+  const callPrevDatum = async () => {
+    setLoading(true);
+    setErrorMessage('');
+
+    try {
+      const res = await requestAPI<MountDatumResponse>('datums/_prev', 'PUT');
       open('');
       setCurrDatum(res);
     } catch (e) {
@@ -193,8 +207,12 @@ export const useDatum = (
       await requestAPI<ListMountsResponse>('_unmount_all', 'PUT');
       open('');
       await pollRefresh();
-      setCurrIdx(-1);
-      setCurrDatum({id: '', idx: -1, num_datums: 0});
+      setCurrDatum({
+        id: '',
+        idx: -1,
+        num_datums: 0,
+        all_datums_received: false,
+      });
       setShouldShowCycler(false);
     } catch (e) {
       console.log(e);
@@ -208,11 +226,11 @@ export const useDatum = (
     loading,
     shouldShowCycler,
     currDatum,
-    currIdx,
-    setCurrIdx,
     inputSpec,
     setInputSpec,
     callMountDatums,
+    callNextDatum,
+    callPrevDatum,
     callUnmountAll,
     errorMessage,
     saveInputSpec,

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -338,7 +338,12 @@ export class MountPlugin implements IMountPlugin {
     if (this.isCurrentWidgetNotebook(widget.newValue)) {
       await this.handleNotebookChanged(widget.newValue);
     }
-    this.setShowPipeline(this._showPipeline);
+    // Only make this call if the user is currently in the "Publish" tab.
+    // Otherwise it can mess with the "Test" tab, where it switches off the "Test"
+    // tab to the "Explore" tab on a browser refresh.
+    if (this._showPipeline) {
+      this.setShowPipeline(this._showPipeline);
+    }
     await Promise.resolve();
   };
 

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -63,13 +63,15 @@ export type CrossInputSpec = {
 export type CurrentDatumResponse = {
   num_datums: number;
   input: {[key: string]: any};
-  curr_idx: number;
+  idx: number;
+  all_datums_received: boolean;
 };
 
 export type MountDatumResponse = {
   id: string;
   idx: number;
   num_datums: number;
+  all_datums_received: boolean;
 };
 
 export type ListMountsResponse = {

--- a/src/internal/ppsutil/decoder.go
+++ b/src/internal/ppsutil/decoder.go
@@ -30,7 +30,7 @@ func NewPipelineManifestReader(r io.Reader) (result *PipelineManifestReader, ret
 
 // DisableValidation disables pipeline validation.
 //
-// TODO(INT-1006): this exists only because the implementation of the /_mount_datums
+// TODO(INT-1006): this exists only because the implementation of the /datums/_mount
 // endpoint in the FUSE server parses its PUT body as a full pipeline spec.
 func (r *PipelineManifestReader) DisableValidation() *PipelineManifestReader {
 	r.specReader = r.specReader.DisableValidation()
@@ -66,7 +66,7 @@ func NewSpecReader(r io.Reader) *SpecReader {
 
 // DisableValidation disables pipeline validation.
 //
-// TODO(INT-1006): this exists only because the implementation of the /_mount_datums
+// TODO(INT-1006): this exists only because the implementation of the /datums/_mount
 // endpoint in the FUSE server parses its PUT body as a full pipeline spec.
 func (r *SpecReader) DisableValidation() *SpecReader {
 	r.noValidate = true

--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -630,19 +630,6 @@ func (n *loopbackNode) download(ctx context.Context, origPath string, state file
 		if !strings.HasPrefix(fi.File.Path, ro.File.Path) && !strings.HasPrefix(ro.File.Path, fi.File.Path) {
 			return nil
 		}
-		if skip := func() bool {
-			if len(ro.Subpaths) == 0 {
-				return false
-			}
-			for _, sp := range ro.Subpaths {
-				if strings.HasPrefix(fi.File.Path, sp) || strings.HasPrefix(sp, fi.File.Path) {
-					return false
-				}
-			}
-			return true
-		}(); skip {
-			return nil
-		}
 		if fi.FileType == pfs.FileType_DIR {
 			return errors.EnsureStack(os.MkdirAll(n.filePath(name, fi), 0777))
 		}
@@ -679,12 +666,22 @@ func (n *loopbackNode) download(ctx context.Context, origPath string, state file
 		}
 		return nil
 	}
-	filePath := pathpkg.Join(parts[1:]...)
 	projectName := ro.File.Commit.Branch.Repo.Project.GetName()
 	repoName := ro.File.Commit.Branch.Repo.Name
-	if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), filePath, createFile); err != nil && !errutil.IsNotFoundError(err) &&
-		!pfsserver.IsOutputCommitNotFinishedErr(err) {
-		return err
+	// If mounting just a subset of files in a repo, mount just those files
+	if len(ro.Subpaths) != 0 {
+		for _, path := range ro.Subpaths {
+			if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), path, createFile); err != nil && !errutil.IsNotFoundError(err) &&
+				!pfsserver.IsOutputCommitNotFinishedErr(err) {
+				return err
+			}
+		}
+	} else {
+		filePath := pathpkg.Join(parts[1:]...)
+		if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), filePath, createFile); err != nil && !errutil.IsNotFoundError(err) &&
+			!pfsserver.IsOutputCommitNotFinishedErr(err) {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -40,7 +40,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
-const NumDatumsPerPage = 1000 // The number of datums requested per ListDatum call
+const NumDatumsPerPage = 500 // The number of datums requested per ListDatum call
 
 type ServerOptions struct {
 	MountDir string

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -472,7 +472,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, errMsg, webCode)
 			return
 		}
-		if len(mm.Datums) != 0 {
+		if len(mm.Datums) > 0 {
 			http.Error(w, "can't mount repos while in mounted datum mode", http.StatusBadRequest)
 			return
 		}
@@ -514,7 +514,7 @@ func Server(sopts *ServerOptions, existingClient *client.APIClient) error {
 			http.Error(w, errMsg, webCode)
 			return
 		}
-		if len(mm.Datums) != 0 {
+		if len(mm.Datums) > 0 {
 			http.Error(w, "can't unmount repos while in mounted datum mode", http.StatusBadRequest)
 			return
 		}

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -40,7 +40,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 )
 
-const NumDatumsPerPage = 500 // The number of datums requested per ListDatum call
+const NumDatumsPerPage = 1000 // The number of datums requested per ListDatum call
 
 type ServerOptions struct {
 	MountDir string

--- a/src/server/pfs/fuse/server_integration_test.go
+++ b/src/server/pfs/fuse/server_integration_test.go
@@ -706,7 +706,7 @@ func TestMountDatumsPagination(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, numDatumsPerPage, mdr.NumDatums)
-		require.Equal(t, false, mdr.AllDatumsReceived)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		// Cycle to last datum in page
 		for i := 0; i < numDatumsPerPage-1; i++ {
@@ -725,7 +725,7 @@ func TestMountDatumsPagination(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(dr))
 		require.Equal(t, numDatumsPerPage, dr.NumDatums)
 		require.Equal(t, numDatumsPerPage-1, dr.Idx)
-		require.Equal(t, true, dr.AllDatumsReceived)
+		require.Equal(t, false, dr.AllDatumsReceived)
 
 		input = []byte(fmt.Sprintf(
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': '%d'}}}`,

--- a/src/server/pfs/fuse/server_integration_test.go
+++ b/src/server/pfs/fuse/server_integration_test.go
@@ -706,7 +706,7 @@ func TestMountDatumsPagination(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, numDatumsPerPage, mdr.NumDatums)
-		require.Equal(t, true, mdr.AllDatumsReceived)
+		require.Equal(t, false, mdr.AllDatumsReceived)
 
 		// Cycle to last datum in page
 		for i := 0; i < numDatumsPerPage-1; i++ {
@@ -725,7 +725,7 @@ func TestMountDatumsPagination(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(dr))
 		require.Equal(t, numDatumsPerPage, dr.NumDatums)
 		require.Equal(t, numDatumsPerPage-1, dr.Idx)
-		require.Equal(t, false, dr.AllDatumsReceived)
+		require.Equal(t, true, dr.AllDatumsReceived)
 
 		input = []byte(fmt.Sprintf(
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': '%d'}}}`,

--- a/src/server/pfs/fuse/server_integration_test.go
+++ b/src/server/pfs/fuse/server_integration_test.go
@@ -95,7 +95,7 @@ func TestMountDatum(t *testing.T) {
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/'}}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -104,6 +104,7 @@ func TestMountDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 1, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err := os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo"))
 		require.NoError(t, err)
@@ -120,7 +121,7 @@ func TestMountDatum(t *testing.T) {
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*'}}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err = put("_mount_datums", bytes.NewReader(input))
+		resp, err = put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -129,6 +130,7 @@ func TestMountDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err = os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo"))
 		require.NoError(t, err)
@@ -167,7 +169,7 @@ func TestCrossDatum(t *testing.T) {
 			{'pfs': {'glob': '/*', 'repo': 'repo2', 'branch': 'dev'}}]}}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -176,6 +178,7 @@ func TestCrossDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err := os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo1"))
 		require.NoError(t, err)
@@ -217,7 +220,7 @@ func TestUnionDatum(t *testing.T) {
 			{'pfs': {'glob': '/*', 'project': '%s', 'repo': 'repo2', 'branch': 'dev'}}]}}}`,
 			pfs.DefaultProjectName, pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -226,6 +229,7 @@ func TestUnionDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 3, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 	})
 }
 
@@ -257,7 +261,7 @@ func TestRepeatedBranchesDatum(t *testing.T) {
 			{'pfs': {'glob': '/*', 'project': '%s', 'repo': 'repo1'}}]}}`,
 			pfs.DefaultProjectName, pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -266,6 +270,7 @@ func TestRepeatedBranchesDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 4, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err := os.ReadDir(filepath.Join(mountPoint))
 		require.NoError(t, err)
@@ -284,7 +289,7 @@ func TestRepeatedBranchesDatum(t *testing.T) {
 			{'pfs': {'glob': '/*', 'project': '%s', 'repo': 'repo1', 'branch': 'dev'}}]}}`,
 			pfs.DefaultProjectName, pfs.DefaultProjectName, pfs.DefaultProjectName),
 		)
-		resp, err = put("_mount_datums", bytes.NewReader(input))
+		resp, err = put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -293,6 +298,7 @@ func TestRepeatedBranchesDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 8, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		_, err = os.ReadDir(filepath.Join(mountPoint, "out")) // Loads "out" folder
 		require.NoError(t, err)
@@ -323,7 +329,7 @@ func TestShowDatum(t *testing.T) {
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': 'dev'}}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -333,12 +339,13 @@ func TestShowDatum(t *testing.T) {
 		require.NotEqual(t, "", mdr.Id)
 		datum1Id := mdr.Id
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err := os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo_dev"))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(files))
 
-		resp, err = put("_show_datum?idx=1", nil)
+		resp, err = put("datums/_next", nil)
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -346,8 +353,13 @@ func TestShowDatum(t *testing.T) {
 		require.Equal(t, 1, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
-		resp, err = put(fmt.Sprintf("_show_datum?idx=1&id=%s", datum1Id), nil)
+		resp, err = put("datums/_next", nil)
+		require.NoError(t, err)
+		require.Equal(t, 400, resp.StatusCode)
+
+		resp, err = put("datums/_prev", nil)
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -355,6 +367,11 @@ func TestShowDatum(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.Equal(t, datum1Id, mdr.Id)
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
+
+		resp, err = put("datums/_prev", nil)
+		require.NoError(t, err)
+		require.Equal(t, 400, resp.StatusCode)
 	})
 }
 
@@ -379,12 +396,13 @@ func TestGetDatums(t *testing.T) {
 		dr := &DatumsResponse{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(dr))
 		require.Equal(t, 0, dr.NumDatums)
+		require.Equal(t, true, dr.AllDatumsReceived)
 
 		input := []byte(fmt.Sprintf(
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': 'dev'}}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err = put("_mount_datums", bytes.NewReader(input))
+		resp, err = put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -394,6 +412,7 @@ func TestGetDatums(t *testing.T) {
 		require.NotEqual(t, "", mdr.Id)
 		datum1Id := mdr.Id
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err := os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo_dev"))
 		require.NoError(t, err)
@@ -409,9 +428,10 @@ func TestGetDatums(t *testing.T) {
 		require.Equal(t, "repo", dr.Input.Pfs.Repo)
 		require.Equal(t, "dev", dr.Input.Pfs.Branch)
 		require.Equal(t, "/*", dr.Input.Pfs.Glob)
-		require.Equal(t, 0, dr.CurrIdx)
+		require.Equal(t, 0, dr.Idx)
+		require.Equal(t, true, dr.AllDatumsReceived)
 
-		resp, err = put("_show_datum?idx=1", nil)
+		resp, err = put("datums/_next", nil)
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -419,6 +439,7 @@ func TestGetDatums(t *testing.T) {
 		require.Equal(t, 1, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		resp, err = get("datums")
 		require.NoError(t, err)
@@ -426,9 +447,10 @@ func TestGetDatums(t *testing.T) {
 
 		dr = &DatumsResponse{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(dr))
-		require.Equal(t, 1, dr.CurrIdx)
+		require.Equal(t, 1, dr.Idx)
+		require.Equal(t, true, dr.AllDatumsReceived)
 
-		resp, err = put(fmt.Sprintf("_show_datum?idx=1&id=%s", datum1Id), nil)
+		resp, err = put("datums/_prev", nil)
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -436,6 +458,7 @@ func TestGetDatums(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.Equal(t, datum1Id, mdr.Id)
 		require.Equal(t, 2, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 	})
 }
 
@@ -488,7 +511,7 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 			{'pfs': {'glob': '/*', 'project': '%s', 'repo': 'repo1', 'branch': 'dev'}}]}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -497,6 +520,7 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 4, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err := os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo1"))
 		require.NoError(t, err)
@@ -510,7 +534,7 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 			{'pfs': {'glob': '/*', 'project': '%s', 'repo': 'repo1', 'branch': 'dev'}}]}}`,
 			projectName, projectName),
 		)
-		resp, err = put("_mount_datums", bytes.NewReader(input))
+		resp, err = put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -519,6 +543,7 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 		require.Equal(t, 0, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 8, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		files, err = os.ReadDir(filepath.Join(mountPoint, pfs.DefaultProjectName+"_repo1"))
 		require.NoError(t, err)
@@ -530,7 +555,7 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(files))
 
-		resp, err = put("_show_datum?idx=1", nil)
+		resp, err = put("datums/_next", nil)
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -538,9 +563,10 @@ func TestMountShowDatumsCrossProject(t *testing.T) {
 		require.Equal(t, 1, mdr.Idx)
 		require.NotEqual(t, "", mdr.Id)
 		require.Equal(t, 8, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 
 		input = []byte("{'input': {'pfs': {'project': 'invalid', 'repo': 'repo1', 'glob': '/*'}}}")
-		resp, err = put("_mount_datums", bytes.NewReader(input))
+		resp, err = put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 400, resp.StatusCode)
 	})
@@ -571,7 +597,7 @@ func TestMountDatumsBranchHeadFromOtherBranch(t *testing.T) {
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo1', 'glob': '/*', 'branch': 'copy'}}}`,
 			pfs.DefaultProjectName),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 
@@ -608,7 +634,7 @@ func TestMountDatumsSpecifyingCommit(t *testing.T) {
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'commit': '%s'}}}`,
 			pfs.DefaultProjectName, commitInfo.Commit.Id),
 		)
-		resp, err := put("_mount_datums", bytes.NewReader(input))
+		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 400, resp.StatusCode)
 	})

--- a/src/server/pfs/fuse/server_integration_test.go
+++ b/src/server/pfs/fuse/server_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -637,5 +638,123 @@ func TestMountDatumsSpecifyingCommit(t *testing.T) {
 		resp, err := put("datums/_mount", bytes.NewReader(input))
 		require.NoError(t, err)
 		require.Equal(t, 400, resp.StatusCode)
+	})
+}
+
+func TestMountDatumsPagination(t *testing.T) {
+	c, _ := minikubetestenv.AcquireCluster(t)
+	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "repo"))
+
+	// Arbitrary number of files less than fuse.NumDatumsPerPage
+	lessThanNumDatumsPerPage := 200
+	commit := client.NewCommit(pfs.DefaultProjectName, "repo", strconv.Itoa(lessThanNumDatumsPerPage), "")
+	for i := 0; i < lessThanNumDatumsPerPage; i++ {
+		err := c.PutFile(commit, fmt.Sprintf("file%d", i), strings.NewReader("foo"))
+		require.NoError(t, err)
+	}
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, "repo", strconv.Itoa(lessThanNumDatumsPerPage), "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
+
+	numDatumsPerPage := NumDatumsPerPage
+	commit = client.NewCommit(pfs.DefaultProjectName, "repo", strconv.Itoa(numDatumsPerPage), "")
+	for i := 0; i < numDatumsPerPage; i++ {
+		err := c.PutFile(commit, fmt.Sprintf("file%d", i), strings.NewReader("foo"))
+		require.NoError(t, err)
+	}
+	commitInfo, err = c.InspectCommit(pfs.DefaultProjectName, "repo", strconv.Itoa(numDatumsPerPage), "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
+
+	numDatumsPerPagePlusOne := numDatumsPerPage + 1
+	commit = client.NewCommit(pfs.DefaultProjectName, "repo", strconv.Itoa(numDatumsPerPagePlusOne), "")
+	for i := 0; i < numDatumsPerPagePlusOne; i++ {
+		err := c.PutFile(commit, fmt.Sprintf("file%d", i), strings.NewReader("foo"))
+		require.NoError(t, err)
+	}
+	commitInfo, err = c.InspectCommit(pfs.DefaultProjectName, "repo", strconv.Itoa(numDatumsPerPagePlusOne), "")
+	require.NoError(t, err)
+	_, err = c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err)
+
+	withServerMount(t, c, nil, func(mountPoint string) {
+		input := []byte(fmt.Sprintf(
+			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': '%d'}}}`,
+			pfs.DefaultProjectName, lessThanNumDatumsPerPage),
+		)
+		resp, err := put("datums/_mount", bytes.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		mdr := &MountDatumResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(mdr))
+		require.Equal(t, 0, mdr.Idx)
+		require.NotEqual(t, "", mdr.Id)
+		require.Equal(t, lessThanNumDatumsPerPage, mdr.NumDatums)
+		require.Equal(t, true, mdr.AllDatumsReceived)
+
+		input = []byte(fmt.Sprintf(
+			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': '%d'}}}`,
+			pfs.DefaultProjectName, numDatumsPerPage),
+		)
+		resp, err = put("datums/_mount", bytes.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		mdr = &MountDatumResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(mdr))
+		require.Equal(t, 0, mdr.Idx)
+		require.NotEqual(t, "", mdr.Id)
+		require.Equal(t, numDatumsPerPage, mdr.NumDatums)
+		require.Equal(t, false, mdr.AllDatumsReceived)
+
+		// Cycle to last datum in page
+		for i := 0; i < numDatumsPerPage-1; i++ {
+			resp, err = put("datums/_next", nil)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.StatusCode)
+		}
+		resp, err = put("datums/_next", bytes.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, 400, resp.StatusCode)
+
+		resp, err = get("datums")
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		dr := &DatumsResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(dr))
+		require.Equal(t, numDatumsPerPage, dr.NumDatums)
+		require.Equal(t, numDatumsPerPage-1, dr.Idx)
+		require.Equal(t, true, dr.AllDatumsReceived)
+
+		input = []byte(fmt.Sprintf(
+			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': '%d'}}}`,
+			pfs.DefaultProjectName, numDatumsPerPagePlusOne),
+		)
+		resp, err = put("datums/_mount", bytes.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		mdr = &MountDatumResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(mdr))
+		require.Equal(t, 0, mdr.Idx)
+		require.NotEqual(t, "", mdr.Id)
+		require.Equal(t, numDatumsPerPage, mdr.NumDatums)
+		require.Equal(t, false, mdr.AllDatumsReceived)
+
+		// Cycle to last datum in page
+		for i := 0; i < numDatumsPerPage-1; i++ {
+			resp, err = put("datums/_next", nil)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.StatusCode)
+		}
+		resp, err = put("datums/_next", bytes.NewReader(input))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		mdr = &MountDatumResponse{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(mdr))
+		require.Equal(t, numDatumsPerPagePlusOne, mdr.NumDatums)
+		require.Equal(t, numDatumsPerPagePlusOne-1, mdr.Idx)
+		require.Equal(t, true, mdr.AllDatumsReceived)
 	})
 }

--- a/src/server/pfs/fuse/server_integration_test.go
+++ b/src/server/pfs/fuse/server_integration_test.go
@@ -397,7 +397,7 @@ func TestGetDatums(t *testing.T) {
 		dr := &DatumsResponse{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(dr))
 		require.Equal(t, 0, dr.NumDatums)
-		require.Equal(t, true, dr.AllDatumsReceived)
+		require.Equal(t, false, dr.AllDatumsReceived)
 
 		input := []byte(fmt.Sprintf(
 			`{'input': {'pfs': {'project': '%s', 'repo': 'repo', 'glob': '/*', 'branch': 'dev'}}}`,


### PR DESCRIPTION
This PR utilizes ListDatum pagination when mounting datums in the Jupyter extension. As of now, this doesn't yield a performance improvement because ListDatum still collects ALL the datums, even if it returns `number` datums. When the ListDatum implementation is updated to only collect `number` of datums, then the mounting datums speedup will be visible via this PR.

Details:
- Datums page size of 500 used
- UI datum cycler will look something like `1/500+` or `892/1000+` or `729/1000`, depending on how far the user has cycled ahead and how many total datums there are
- Mount server endpoint URLs standardized
    - `/_mount_datum` -> `/datums/_mount`
    - `/_show_datum?idx={i}` -> `/datums/_next/`, `/datums/_prev`
    - `/datums` URL remains same
- Tests at all layers (mount server, Python, TypeScript) updated

Jira: [INT-824]

[INT-824]: https://pachyderm.atlassian.net/browse/INT-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ