### PR TITLE
Djanicek/2.7 resource lower static checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ parameters:
     default: ""
   go-version:
     type: string
-    default: "1.20.7"
+    default: "1.21.1"
 # our defined job, and its steps
 jobs:
   setup:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -235,6 +235,67 @@ jobs:
       - codecov/upload:
           file: /tmp/test-results/coverage.txt
       - collect-test-results
+  static-checks:
+    resource_class: 2xlarge
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    environment:
+      GOPROXY: https://proxy.golang.org
+      TEST_RESULTS: /tmp/test-results
+    steps:
+      - checkout
+      - run:
+          name: Collect node stats
+          command: sar 10 -BbdHwzS -I SUM -n DEV -q -r ALL -u ALL -h
+          background: true
+      - run:
+          name: setup env vars
+          command: |
+            echo 'export GOCACHE=/home/circleci/.gocache' >> $BASH_ENV
+            echo 'export GOPATH=/home/circleci/.go_workspace' >> $BASH_ENV
+
+            echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
+            echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*) ]]
+            then
+              echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
+            else
+              echo 'export TEST_IMAGE_SHA=cover-$CIRCLE_SHA1' >> $BASH_ENV
+            fi
+      - restore_cache:
+          keys:
+            - pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
+      - run: etc/testing/circle/install.sh
+      - save_cache:
+          key: pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
+          paths:
+            - cached-deps/
+      - go/install:
+          version: << pipeline.parameters.go-version >>
+      - run: mkdir ${TEST_RESULTS}
+      # The build cache will grow indefinitely, so we rotate the cache once a week.
+      # This ensures the time to restore the cache isn't longer than the speedup in compilation.
+      - run: "echo $(($(date +%s)/604800)) > current_week"
+      - restore_cache:
+          keys:
+            - pach-go-build-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "current_week" }}
+            - pach-go-build-cache-v1-master-{{ arch }}-{{ checksum "current_week" }}
+      # Only restore the module cache based on an exact match for go.sum.
+      # This also avoids accumulating old versions of modules over time.
+      - restore_cache:
+          keys:
+            - pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
+      - save_cache:
+          key: pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
+          paths:
+            - /home/circleci/.go_workspace/pkg/mod
+      - save_cache:
+          key: pach-go-build-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "current_week" }}
+          paths:
+            - /home/circleci/.gocache
+      - run:
+          no_output_timeout: 20m
+          command: etc/testing/circle/run_ci_linters.sh | ts '%Y-%m-%dT%H:%M:%S'
   integration-tests:
     parameters:
       bucket:
@@ -1535,6 +1596,7 @@ workflows:
       - jsonnet-lint
       - test-go
       - govulncheck
+      - static-checks
       - test-envoy
       - test-pps
       - integration-tests:
@@ -1747,6 +1809,8 @@ workflows:
           filters: *only-release-tags
       - test-pps:
           filters: *only-release-tags
+      - static-checks:
+          filters: *only-release-tags
       - integration-tests:
           matrix:
             parameters:
@@ -1770,6 +1834,7 @@ workflows:
           filters: *only-release-tags
           requires:
             - helm-tests
+            - static-checks
             - integration-tests
       - helm-publish:
           name: publish-chart-preview
@@ -1971,6 +2036,8 @@ workflows:
           filters: *only-nightly-tags
       - test-pps:
           filters: *only-nightly-tags
+      - static-checks:
+          filters: *only-nightly-tags
       - integration-tests:
           matrix:
             parameters:
@@ -1985,6 +2052,7 @@ workflows:
           filters: *only-nightly-tags
           requires:
             - helm-tests
+            - static-checks
             - integration-tests
       - build-docker-images:
           appVersion: ${CIRCLE_TAG:1}
@@ -1994,6 +2062,7 @@ workflows:
           filters: *only-nightly-tags
           requires:
             - helm-tests
+            - static-checks
             - integration-tests
       - helm-publish:
           name: publish-chart-preview

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -119,7 +119,7 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
       GOPROXY: https://proxy.golang.org
-    parallelism: 10
+    parallelism: 8
     steps:
       - checkout
       - run:
@@ -236,7 +236,7 @@ jobs:
           file: /tmp/test-results/coverage.txt
       - collect-test-results
   static-checks:
-    resource_class: 2xlarge
+    resource_class: xlarge
     machine:
       image: << pipeline.parameters.machine_image >>
     environment:
@@ -623,10 +623,10 @@ jobs:
     parameters:
       num_executors:
         type: integer
-        default: 4
+        default: 2
       resource_class:
         type: string
-        default: 2xlarge
+        default: large
       arch:
         type: string
         default: amd64
@@ -1750,14 +1750,14 @@ workflows:
     jobs:
       - deploy-tests:
           name: amd64 deploy tests
-          resource_class: 2xlarge # amd64
+          resource_class: xlarge # amd64
           arch: amd64
-          num_executors: 6
+          num_executors: 4
       - deploy-tests:
           name: arm64 deploy tests
-          resource_class: arm.2xlarge # arm64
+          resource_class: arm.xlarge # arm64
           arch: arm64
-          num_executors: 4
+          num_executors: 2
   jupyter-extension:
     when: << pipeline.parameters.run-jupyter-jobs >>
     jobs:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -36,7 +36,7 @@ parameters:
     default: ubuntu-2204:2023.04.2
   go-version:
     type: string
-    default: "1.20.7"
+    default: "1.21.1"
   go-releaser-version:
     type: string
     default: "1.17.1"

--- a/etc/proto/Dockerfile
+++ b/etc/proto/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.7
+ARG GOVERSION=golang:1.21.1
 FROM $GOVERSION
 
 LABEL maintainer="msteffen@pachyderm.io"

--- a/etc/testing/circle/run_ci_linters.sh
+++ b/etc/testing/circle/run_ci_linters.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -exo pipefail
+
+make lint
+make enterprise-code-checkin-test
+make test-proto-static

--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -26,11 +26,8 @@ go clean -testcache
 
 case "${BUCKET}" in
  MISC)
-    make lint
-    make enterprise-code-checkin-test
     go install -v ./src/testing/match
     make test-cmds
-    make test-proto-static
     make test-transaction
     make test-s3gateway-unit
     make test-worker

--- a/etc/testing/kafka/Dockerfile
+++ b/etc/testing/kafka/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.7
+ARG GOVERSION=golang:1.21.1
 FROM $GOVERSION
 WORKDIR /app
 ADD . /app/

--- a/etc/testing/spout/Dockerfile
+++ b/etc/testing/spout/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=golang:1.20.7
+ARG GOVERSION=golang:1.21.1
 FROM $GOVERSION
 RUN mkdir /app
 ADD . /app/

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pachyderm/pachyderm/v2
 
 go 1.20
 
+toolchain go1.21.1
+
 require (
 	cloud.google.com/go/profiler v0.3.0
 	cloud.google.com/go/storage v1.30.1

--- a/src/integrations/connectors/snowflake/Dockerfile
+++ b/src/integrations/connectors/snowflake/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.20 AS build
+FROM golang:1.21 AS build
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/src/testing/cmds/go-test-results/Dockerfile
+++ b/src/testing/cmds/go-test-results/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7-alpine
+FROM golang:1.21.1-alpine
 
 RUN go install github.com/jackc/tern/v2@latest
 

--- a/src/testing/deploy/upgrade_test.go
+++ b/src/testing/deploy/upgrade_test.go
@@ -173,9 +173,8 @@ func TestUpgradeOpenCVWithAuth(t *testing.T) {
 		t.Skip("Skipping upgrade test")
 	}
 	fromVersions := []string{
-		"2.3.9",
-		"2.4.6",
 		"2.5.0",
+		"2.6.3",
 	}
 	montage := func(fromVersion string) string {
 		repo := montageRepo


### PR DESCRIPTION
merges 3 changes from master
- split static-checks out of integration-MISC for cherry-picking future CI changes
- lower resources in 2.7
- update go version for govulncheck