### PR TITLE
[CORE-1972] refresh autoscaling goroutines when pipelines update

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3092,22 +3092,27 @@ func TestUpdatePipelineWithInProgressCommitsAndStats(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
+
 	c, _ := minikubetestenv.AcquireCluster(t)
 	dataRepo := tu.UniqueString("TestUpdatePipelineWithInProgressCommitsAndStats_data")
+	c = tu.AuthenticatedPachClient(t, c, "pachtest")
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, dataRepo))
-
 	pipeline := tu.UniqueString("pipeline")
 	createPipeline := func() {
 		_, err := c.PpsAPIClient.CreatePipeline(
-			context.Background(),
+			c.Ctx(),
 			&pps.CreatePipelineRequest{
 				Pipeline: client.NewPipeline(pfs.DefaultProjectName, pipeline),
 				Transform: &pps.Transform{
 					Cmd:   []string{"bash"},
 					Stdin: []string{"sleep 1"},
 				},
-				Input:  client.NewPFSInput(pfs.DefaultProjectName, dataRepo, "/*"),
-				Update: true,
+				ParallelismSpec: &pps.ParallelismSpec{
+					Constant: 1,
+				},
+				Autoscaling: true, // Autoscale for CORE-1972
+				Input:       client.NewPFSInput(pfs.DefaultProjectName, dataRepo, "/*"),
+				Update:      true,
 			})
 		require.NoError(t, err)
 	}
@@ -3126,14 +3131,24 @@ func TestUpdatePipelineWithInProgressCommitsAndStats(t *testing.T) {
 	flushJob(1)
 
 	// Create multiple new commits.
-	numCommits := 5
+	numCommits := 15
 	for i := 1; i < numCommits; i++ {
 		commit, err := c.StartCommit(pfs.DefaultProjectName, dataRepo, "master")
 		require.NoError(t, err)
 		require.NoError(t, c.PutFile(commit, "file"+strconv.Itoa(i), strings.NewReader("foo"), client.WithAppendPutFile()))
 		require.NoError(t, c.FinishCommit(pfs.DefaultProjectName, dataRepo, commit.Branch.Name, commit.Id))
 	}
-
+	// wait for jobs to start before updating
+	require.NoError(t, backoff.Retry(func() error {
+		pipelineInfo, err := c.InspectPipeline(pfs.DefaultProjectName, pipeline, false)
+		if err != nil {
+			return err
+		}
+		if pipelineInfo.State != pps.PipelineState_PIPELINE_RUNNING {
+			return errors.Errorf("pipeline waiting to run, state: %s", pipelineInfo.State.String())
+		}
+		return nil
+	}, backoff.NewConstantBackOff(time.Millisecond*200)))
 	// Force the in progress commits to be finished.
 	createPipeline()
 	// Create a new job that should succeed (should not get blocked on an unfinished stats commit).

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/cronutil"
@@ -39,11 +38,7 @@ func (pc *pipelineController) startMonitor(ctx context.Context, pipelineInfo *pp
 		pctx.Child(ctx, fmt.Sprintf("monitorPipeline(%s)", pipelineInfo.Pipeline),
 			pctx.WithFields(zap.Stringer("pipeline", pipelineInfo.Pipeline))),
 		func(ctx context.Context) {
-			// monitorPipeline needs auth privileges to call subscribeCommit and
-			// inspectCommit
-			pachClient := pc.env.GetPachClient(ctx)
-			pachClient.SetAuthToken(pipelineInfo.AuthToken)
-			pc.monitorPipeline(pachClient.Ctx(), pipelineInfo)
+			pc.monitorPipeline(ctx, pipelineInfo)
 		})
 }
 
@@ -113,7 +108,10 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 			return backoff.RetryUntilCancel(ctx, func() error {
 				pachClient := pc.env.GetPachClient(ctx)
 				return pachClient.SubscribeCommit(client.NewRepo(pipelineInfo.Pipeline.Project.GetName(), pipelineName), "", "", pfs.CommitState_READY, func(ci *pfs.CommitInfo) error {
-					ciChan <- ci
+					select {
+					case ciChan <- ci:
+					case <-ctx.Done():
+					}
 					return nil
 				})
 			}, backoff.NewInfiniteBackOff(),
@@ -193,12 +191,9 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 						// Stay running while commits are available and there's still job-related compaction to do
 					running:
 						for {
-							pachClient := pc.env.GetPachClient(ctx)
-							pachClient.SetAuthToken(pipelineInfo.GetAuthToken())                                                // set auth token so we are certain we have the up to date token
-							if err := pc.blockStandby(pachClient, ci.Commit); err != nil && !errors.Is(err, auth.ErrBadToken) { // we just set token to pipeline token, but pipeline could be deleted during the block, causing a bad auth token error
+							if err := pc.blockStandby(pc.env.GetPachClient(ctx), ci.Commit); err != nil {
 								return err
 							}
-
 							tracing.FinishAnySpan(childSpan)
 							childSpan = nil
 							select {
@@ -337,7 +332,6 @@ func makeCronCommits(ctx context.Context, env Env, in *pps.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "getLatestCronTime")
 	}
-
 	for {
 		// get the time of the next time from the latest time using the cron schedule
 		next := schedule.Next(latestTime)

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -405,7 +405,9 @@ func evaluate(pi *pps.PipelineInfo, rc *v1.ReplicationController) (pps.PipelineS
 		if pi.Details.Autoscaling && pi.State == pps.PipelineState_PIPELINE_STARTING {
 			return pps.PipelineState_PIPELINE_STANDBY, sideEffects, "", nil
 		}
-		sideEffects = append(sideEffects, PipelineMonitorSideEffect(sideEffectToggle_DOWN))
+		if pi.State == pps.PipelineState_PIPELINE_RESTARTING { // the conditional isn't necessary but provides clearer semantics
+			sideEffects = append(sideEffects, PipelineMonitorSideEffect(sideEffectToggle_DOWN))
+		}
 		return pps.PipelineState_PIPELINE_RUNNING, sideEffects, "", nil
 	}
 	if rc == nil {

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -188,7 +188,7 @@ func PipelineMonitorSideEffect(toggle sideEffectToggle) sideEffect {
 		toggle: toggle,
 		apply: func(ctx context.Context, pc *pipelineController, pi *pps.PipelineInfo, rc *v1.ReplicationController) error {
 			if toggle == sideEffectToggle_UP {
-				pc.startPipelineMonitor(pi)
+				pc.startPipelineMonitor(ctx, pi)
 			} else {
 				pc.stopPipelineMonitor()
 			}
@@ -405,6 +405,7 @@ func evaluate(pi *pps.PipelineInfo, rc *v1.ReplicationController) (pps.PipelineS
 		if pi.Details.Autoscaling && pi.State == pps.PipelineState_PIPELINE_STARTING {
 			return pps.PipelineState_PIPELINE_STANDBY, sideEffects, "", nil
 		}
+		sideEffects = append(sideEffects, PipelineMonitorSideEffect(sideEffectToggle_DOWN))
 		return pps.PipelineState_PIPELINE_RUNNING, sideEffects, "", nil
 	}
 	if rc == nil {
@@ -520,9 +521,9 @@ func rcIsFresh(ctx context.Context, pi *pps.PipelineInfo, rc *v1.ReplicationCont
 // one doesn't exist already), which manages standby and cron inputs, and
 // updates the the pipeline state.
 // Note: this is called by every run through step(), so must be idempotent
-func (pc *pipelineController) startPipelineMonitor(pi *pps.PipelineInfo) {
+func (pc *pipelineController) startPipelineMonitor(ctx context.Context, pi *pps.PipelineInfo) {
 	if pc.monitorCancel == nil {
-		pc.monitorCancel = pc.startMonitor(pc.ctx, pi)
+		pc.monitorCancel = pc.startMonitor(ctx, pi)
 	}
 }
 

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -534,6 +534,7 @@ func TestEvaluate(t *testing.T) {
 			state: pps.PipelineState_PIPELINE_RUNNING,
 			sideEffects: []sideEffect{
 				CrashingMonitorSideEffect(sideEffectToggle_DOWN),
+				PipelineMonitorSideEffect(sideEffectToggle_DOWN),
 			},
 		},
 		pps.PipelineState_PIPELINE_FAILURE: {

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -498,8 +498,8 @@ func TestEvaluate(t *testing.T) {
 		pi.State = startState
 		actualState, actualSideEffects, _, err := evaluate(pi, rc)
 		require.NoError(t, err)
-		require.Equal(t, expectedState, actualState)
-		require.Equal(t, len(expectedSideEffects), len(actualSideEffects))
+		require.Equal(t, expectedState, actualState, "for start state %v, expected state was %v but got %v", startState, expectedState, actualState)
+		require.Equal(t, len(expectedSideEffects), len(actualSideEffects), "for start state %v, expected side effects are %v but got %v", startState, expectedSideEffects, actualSideEffects)
 		for i := 0; i < len(expectedSideEffects); i++ {
 			require.True(t, expectedSideEffects[i].equals(actualSideEffects[i]))
 		}
@@ -639,6 +639,7 @@ func TestEvaluate(t *testing.T) {
 			sideEffects: []sideEffect{
 				ResourcesSideEffect(sideEffectToggle_UP),
 				CrashingMonitorSideEffect(sideEffectToggle_DOWN),
+				PipelineMonitorSideEffect(sideEffectToggle_DOWN),
 			},
 		},
 		pps.PipelineState_PIPELINE_PAUSED: {


### PR DESCRIPTION
This PR updates a test to show a customer issue. It adds auth and autoscaling to the test and waits for the pipeline to run before updating. 

The core issue is that the goroutines used to monitor autoscaling are not restarted with the latest pipeline info / auth creds when the pipeline is updated. This PR fixes that.
