### PR TITLE
Add Starlark-running infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cheggaaa/pb v1.0.27 // indirect
@@ -137,7 +138,9 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
+	github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448 // indirect
 	github.com/xanzy/ssh-agent v0.3.2 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
@@ -327,7 +330,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.7.0 // indirect
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.16.0 // indirect
-	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	go.starlark.net v0.0.0-20230912135651-745481cf39ed // indirect
 	golang.org/x/image v0.0.0-20210216034530-4410531fe030 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/adrg/xdg v0.4.0
 	github.com/aws/aws-lambda-go v1.17.0
 	github.com/aws/aws-sdk-go v1.44.68
 	github.com/breml/rootcerts v0.2.4
@@ -77,7 +78,9 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/uber/jaeger-client-go v2.28.0+incompatible
 	github.com/vbauerster/mpb/v6 v6.0.2
+	github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448
 	github.com/wcharczuk/go-chart v2.0.1+incompatible
+	github.com/zeebo/xxh3 v1.0.2
 	go.etcd.io/etcd/api/v3 v3.5.9
 	go.etcd.io/etcd/client/v3 v3.5.8
 	go.etcd.io/etcd/server/v3 v3.5.8
@@ -112,7 +115,6 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
-	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cheggaaa/pb v1.0.27 // indirect
@@ -138,9 +140,7 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
-	github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448 // indirect
 	github.com/xanzy/ssh-agent v0.3.2 // indirect
-	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
@@ -330,7 +330,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.7.0 // indirect
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.16.0 // indirect
-	go.starlark.net v0.0.0-20230912135651-745481cf39ed // indirect
+	go.starlark.net v0.0.0-20230912135651-745481cf39ed
 	golang.org/x/image v0.0.0-20210216034530-4410531fe030 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
@@ -347,7 +347,7 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
+	sigs.k8s.io/yaml v1.3.0
 )
 
 // until the changes in github.com/pachyderm/dex are upstreamed to github.com/dexidp/dex, we swap in our repo

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -1918,6 +1920,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
+github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448 h1:AzpBtmgdXa3uznrb3esNeEoaLqtNEwckRmaUH0qWD6w=
+github.com/wader/readline v0.0.0-20230307172220-bcb7158e7448/go.mod h1:Zgz8IJWvJoe7NK23CCPpC109XMCqJCpUhpHcnnA4XaM=
 github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLVLBCWz1STcD3doU0A=
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
@@ -1957,6 +1961,8 @@ github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -2057,6 +2063,8 @@ go.opentelemetry.io/proto/otlp v0.16.0 h1:WHzDWdXUvbc5bG2ObdrGfaNpQz7ft7QN9HHmJl
 go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 h1:+FNtrFTmVw0YZGpBGX56XDee331t6JAXeK2bcyhLOOc=
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
+go.starlark.net v0.0.0-20230912135651-745481cf39ed h1:kNt8RXSIU6IRBO9MP3m+6q3WpyBHQQXqSktcyVKDPOQ=
+go.starlark.net v0.0.0-20230912135651-745481cf39ed/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -2495,6 +2503,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/go.sum
+++ b/go.sum
@@ -1961,6 +1961,8 @@ github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -2061,8 +2063,6 @@ go.opentelemetry.io/proto/otlp v0.12.1/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.16.0 h1:WHzDWdXUvbc5bG2ObdrGfaNpQz7ft7QN9HHmJlbiB1E=
 go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 h1:+FNtrFTmVw0YZGpBGX56XDee331t6JAXeK2bcyhLOOc=
-go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
 go.starlark.net v0.0.0-20230912135651-745481cf39ed h1:kNt8RXSIU6IRBO9MP3m+6q3WpyBHQQXqSktcyVKDPOQ=
 go.starlark.net v0.0.0-20230912135651-745481cf39ed/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -2376,7 +2376,6 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/src/cmd/starpach/main.go
+++ b/src/cmd/starpach/main.go
@@ -1,0 +1,161 @@
+// Command starpach is a tool for developers of Pachyderm.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"sort"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/cmdutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+	"github.com/spf13/cobra"
+	"go.starlark.net/starlark"
+	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
+)
+
+var (
+	verbose    bool
+	profile    bool
+	gofh, stfh *os.File
+	logFile    string
+	endLogging func(error)
+	timeout    time.Duration
+	root       = &cobra.Command{
+		Use:           os.Args[0],
+		Short:         "Invoke various tools that make working on Pachyderm easier.",
+		SilenceUsage:  true, // This avoids usage on errors.
+		SilenceErrors: true, // We print our own errors.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if verbose {
+				log.SetLevel(log.DebugLevel)
+			}
+			endLogging = log.InitBatchLogger(logFile)
+
+			ctx, stopSignals := signal.NotifyContext(pctx.Background(""), os.Interrupt)
+			stop := func() { stopSignals() }
+			go func() {
+				<-ctx.Done()
+				stop()
+			}()
+			if timeout > 0 {
+				var c func()
+				ctx, c = context.WithTimeout(ctx, timeout)
+				stop = func() { stopSignals(); c() }
+			}
+			cmd.SetContext(ctx)
+			if profile {
+				var err error
+				gofh, err = os.Create(fmt.Sprintf("/tmp/pprof.%v.go.out", os.Getpid()))
+				if err != nil {
+					return errors.Wrap(err, "create file for cpu profile")
+				}
+				if err := pprof.StartCPUProfile(gofh); err != nil {
+					log.Info(ctx, "failed to start go profiler", zap.Error(err))
+				}
+				stfh, err = os.Create(fmt.Sprintf("/tmp/pprof.%v.starlark.out", os.Getpid()))
+				if err != nil {
+					return errors.Wrap(err, "create file for cpu profile")
+				}
+				if err := starlark.StartProfile(stfh); err != nil {
+					log.Info(ctx, "failed to start starlark profiler", zap.Error(err))
+				}
+			}
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) (retErr error) {
+			if profile {
+				defer errors.Close(&retErr, gofh, "close go profile")
+				defer errors.Close(&retErr, stfh, "close starlark profile")
+				pprof.StopCPUProfile()
+				if err := starlark.StopProfile(); err != nil {
+					return errors.Wrap(err, "stop starlark profiler")
+				}
+			}
+			return nil
+		},
+	}
+
+	run = &cobra.Command{
+		Use:   "run <workflow.star>",
+		Short: "Build the referenced artifacts using the provided workflow.",
+		Args:  cobra.MatchAll(cobra.MinimumNArgs(1), cmdutil.FileMustExist(0)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			got, err := ourstar.RunProgram(cmd.Context(), args[0], ourstar.Personality.Options)
+			if err != nil {
+				return err
+			}
+			keys := maps.Keys(got)
+			sort.Strings(keys)
+			for _, k := range keys {
+				v := got[k]
+				if verbose {
+					fmt.Fprintf(os.Stdout, "%v: %#v\n", k, v)
+				} else {
+					fmt.Fprintf(os.Stdout, "%v: %v\n", k, v)
+				}
+			}
+			return nil
+		},
+	}
+
+	shell = &cobra.Command{
+		Use:   "shell [<workflow.star>]",
+		Short: "Run the named Starlark program, then drop into a debugging shell.",
+		Args:  cobra.MatchAll(cobra.RangeArgs(0, 1), cmdutil.FileMustExist(0)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var in string
+			if len(args) == 1 {
+				in = args[0]
+			}
+			return ourstar.RunShell(cmd.Context(), in, ourstar.Personality.Options)
+		},
+	}
+)
+
+func init() {
+	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "If true, show all log messages.")
+	root.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 0, "If non-zero, stop all work after this interval.")
+	root.PersistentFlags().BoolVar(&profile, "profile", false, "If true, write a CPU profile to /tmp/pprof.*.out.")
+	root.PersistentFlags().StringVar(&logFile, "log", "", "If set, also log to a file.")
+
+	ourstar.UsePersonalityFlag(run.Flags())
+
+	ourstar.UsePersonalityFlag(shell.Flags())
+
+	root.AddCommand(run, shell)
+}
+
+func main() {
+	err := root.ExecuteContext(pctx.Background(""))
+	if err != nil {
+		starErr := new(starlark.EvalError)
+		if errors.As(err, &starErr) {
+			fmt.Fprintf(os.Stderr, "%v\n", starErr.Backtrace())
+			if goErr := starErr.Unwrap(); verbose && goErr != nil {
+				v := fmt.Sprintf("%+v", goErr)
+				if v != err.Error() {
+					fmt.Fprintf(os.Stderr, "%v\n", v)
+				}
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "%v\n", err.Error())
+			if verbose {
+				v := fmt.Sprintf("%+v", err)
+				if v != err.Error() {
+					fmt.Fprintf(os.Stderr, "%v\n", v)
+				}
+			}
+		}
+	}
+	if endLogging != nil {
+		endLogging(err)
+	}
+}

--- a/src/cmd/starpach/main.go
+++ b/src/cmd/starpach/main.go
@@ -27,7 +27,7 @@ var (
 	profile                bool        // If true, collect profiles.
 	goProfile, starProfile io.Closer   // Closers for profilers, if profiling.
 	logFile                string      // Log to a custom file.
-	endLogging             func(error) //
+	endLogging             func(error) // Callback to clean up the logs after run.
 	timeout                time.Duration
 	root                   = &cobra.Command{
 		Use:           os.Args[0],

--- a/src/internal/cmdutil/util.go
+++ b/src/internal/cmdutil/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/serde"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -88,5 +89,19 @@ func InteractiveConfirm() (bool, error) {
 func PrintStdinReminder() {
 	if fd := os.Stdin.Fd(); isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd) {
 		fmt.Fprintln(os.Stderr, "Reading from stdin.")
+	}
+}
+
+// FileMustExist is an argument that can be passed to cobra.Command.Args to ensure that the argument
+// at index i is a file that exists.
+func FileMustExist(i int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if i >= len(args) {
+			return nil
+		}
+		if _, err := os.Stat(args[i]); err != nil {
+			return err
+		}
+		return nil
 	}
 }

--- a/src/internal/cmdutil/util.go
+++ b/src/internal/cmdutil/util.go
@@ -100,7 +100,7 @@ func FileMustExist(i int) cobra.PositionalArgs {
 			return nil
 		}
 		if _, err := os.Stat(args[i]); err != nil {
-			return err
+			return errors.Wrap(err, "stat")
 		}
 		return nil
 	}

--- a/src/internal/log/encoders.go
+++ b/src/internal/log/encoders.go
@@ -59,4 +59,20 @@ var (
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 	}
+
+	// This is a less chatty console encoder.
+	minimalConsoleEncoder = zapcore.EncoderConfig{
+		TimeKey:          zapcore.OmitKey,
+		LevelKey:         "L",
+		NameKey:          "N",
+		CallerKey:        "C",
+		FunctionKey:      zapcore.OmitKey,
+		MessageKey:       "M",
+		StacktraceKey:    "S",
+		LineEnding:       zapcore.DefaultLineEnding,
+		EncodeLevel:      zapcore.CapitalLevelEncoder,
+		EncodeDuration:   zapcore.StringDurationEncoder,
+		EncodeCaller:     zapcore.ShortCallerEncoder,
+		ConsoleSeparator: " ",
+	}
 )

--- a/src/internal/log/loggers.go
+++ b/src/internal/log/loggers.go
@@ -254,7 +254,7 @@ func InitBatchLogger(logFile string) func(err error) {
 				zap.S().Infof("logfile retained at %v", logFile)
 			}
 			close()
-			if !keepLog {
+			if !keepLog && logFile != "" {
 				if err := os.Remove(logFile); err != nil {
 					// The logger is gone at this point, so... we can't log the error.
 					fmt.Fprintf(os.Stderr, "unable to delete unwanted logfile at %v: %v", logFile, err)

--- a/src/internal/log/loggers.go
+++ b/src/internal/log/loggers.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/fatih/color"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -188,6 +190,88 @@ func InitPachctlLogger() {
 	}
 	enc := zapcore.NewConsoleEncoder(cfg)
 	makeLoggerOnce(enc, os.Stderr, false, []zap.Option{zap.AddCaller()})
+}
+
+// InitBatchLogger creates a new logger for command-line tools that need to retain their logs on
+// error.  If the returned callback is called with no error, then the log file is deleted.  If it's
+// called with an error, the path to the log is printed, the log file is retained, and log.Exit is
+// called to log the error (and ensure everything is flushed).  If logFile is non-empty, then the
+// log file is always retained.
+func InitBatchLogger(logFile string) func(err error) {
+	cfg := minimalConsoleEncoder
+	if !color.NoColor { // Enable color if it's not disabled via flags.
+		cfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	}
+	enc := zapcore.NewConsoleEncoder(cfg)
+	keepLog := logFile != ""
+	close := func() {}
+	makeLoggerOnce(enc, os.Stderr, false, []zap.Option{zap.AddCaller(), zap.WrapCore(
+		func(c zapcore.Core) zapcore.Core {
+			name := "batch"
+			if len(os.Args) > 0 {
+				name = filepath.Base(os.Args[0])
+			}
+			if logFile == "" {
+				var err error
+				// On error, out is set to "" again.
+				logFile, err = xdg.CacheFile(fmt.Sprintf("pachyderm/log/%s.%s.log", name, time.Now().In(time.UTC).Format("20060102T150405Z")))
+				if err != nil {
+					addInitWarningf("problem creating log file in xdg cache dir: %v", err)
+					logFile = ""
+					keepLog = false
+					return c
+				}
+			} else {
+				if stat, err := os.Stat(logFile); err == nil {
+					// Any errors here will be handled by Open.
+					if stat.IsDir() {
+						addInitWarningf("log file %v is a directory; not logging to file", logFile)
+						logFile = ""
+						keepLog = false
+						return c
+					}
+				}
+			}
+			ws, closeLog, err := zap.Open(logFile)
+			if err != nil {
+				addInitWarningf("problem opening log file %v: %v", logFile, err)
+				logFile = ""
+				keepLog = false
+				return c
+			}
+			close = closeLog
+			enc := zapcore.NewJSONEncoder(pachdEncoder)
+			fileCore := zapcore.NewCore(enc, ws, zap.DebugLevel)
+			return zapcore.NewTee(c, fileCore)
+		},
+	)})
+	if logFile != "" {
+		zap.S().Debugf("logging to file %v", logFile)
+	}
+	return func(err error) {
+		if err == nil {
+			if keepLog {
+				zap.S().Infof("logfile retained at %v", logFile)
+			}
+			close()
+			if !keepLog {
+				if err := os.Remove(logFile); err != nil {
+					// The logger is gone at this point, so... we can't log the error.
+					fmt.Fprintf(os.Stderr, "unable to delete unwanted logfile at %v: %v", logFile, err)
+				}
+			}
+			return
+		}
+		// If we're exiting because of a context being canceled, give those goroutines a
+		// little time to do IO and notice that the context is dead.  That way, their final
+		// errors go to the log file and don't print an error about trying to write to the
+		// closed log file.  (Needed 800us in testing.)
+		time.Sleep(5 * time.Millisecond)
+		if logFile != "" {
+			zap.L().Info(fmt.Sprintf("logfile retained at %v", logFile))
+		}
+		close()
+	}
 }
 
 // makeLoggerOnce sets up the global logger once.

--- a/src/internal/starlark/fields.go
+++ b/src/internal/starlark/fields.go
@@ -1,0 +1,51 @@
+package starlark
+
+import (
+	"fmt"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"go.starlark.net/starlark"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func marshalStack(stack starlark.CallStack) func(zapcore.ArrayEncoder) error {
+	return func(ae zapcore.ArrayEncoder) error {
+		if len(stack) == 0 {
+			return nil
+		}
+		ae.AppendString("Traceback (most recent call last):")
+		for _, fr := range stack {
+			ae.AppendString(fmt.Sprintf("  %s: in %s", fr.Pos, fr.Name))
+		}
+		return nil
+	}
+}
+
+func Stack(name string, stack starlark.CallStack) zap.Field {
+	if len(stack) == 0 {
+		return zap.Skip()
+	}
+	return zap.Array(name, zapcore.ArrayMarshalerFunc(marshalStack(stack)))
+}
+
+func Error(name string, err error) []zap.Field {
+	result := []zap.Field{zap.Error(err)}
+	eErr := new(starlark.EvalError)
+	if errors.As(err, &eErr) {
+		result = append(result, zap.Object("starlarkError", zapcore.ObjectMarshalerFunc(func(oe zapcore.ObjectEncoder) (retErr error) {
+			if eErr.Msg != err.Error() {
+				oe.AddString("msg", eErr.Msg)
+			}
+			errors.JoinInto(&retErr,
+				oe.AddArray("traceback", zapcore.ArrayMarshalerFunc(marshalStack(eErr.CallStack))))
+			if ue := errors.Unwrap(eErr); err != nil {
+				if ue.Error() != err.Error() {
+					oe.AddString("cause", ue.Error())
+				}
+			}
+			return
+		})))
+	}
+	return result
+}

--- a/src/internal/starlark/personality.go
+++ b/src/internal/starlark/personality.go
@@ -1,0 +1,68 @@
+package starlark
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/spf13/pflag"
+	"golang.org/x/exp/maps"
+)
+
+var (
+	// Personalities are modes of running Starpach scripts, like "debug", "build", "test", etc.
+	// Scripts of a certain personality may have predefined bindings for that personality; debug
+	// has "dump()" predefined, for example.
+	personalities = map[string]Options{}
+)
+
+// personality is a type that holds a personality set from the command line.
+type personality struct {
+	Name    string
+	Options Options
+}
+
+var _ pflag.Value = (*personality)(nil)
+
+func (f *personality) Set(x string) error {
+	p, ok := personalities[x]
+	if !ok {
+		ps := maps.Keys(personalities)
+		sort.Strings(ps)
+		return errors.Errorf("no personality %v; try one of %v", x, ps)
+	}
+	f.Name = x
+	f.Options = p
+	return nil
+}
+
+func (f *personality) String() string {
+	return f.Name
+}
+
+func (f *personality) Type() string {
+	return "personality"
+}
+
+// Personality is the personality selected from the command line.
+var Personality = personality{
+	Name:    "",
+	Options: Options{},
+}
+
+// RegisterPersonality registers a personality; intended to be called from the init() section of
+// modules that provide starlark bindings.
+func RegisterPersonality(name string, opts Options) {
+	if _, ok := personalities[name]; ok {
+		panic(fmt.Sprintf("personality %q already registered", name))
+	}
+	personalities[name] = opts
+}
+
+// UsePersonalityFlag registers DefaultPersonality with the provided flagset.
+func UsePersonalityFlag(flagset *pflag.FlagSet) {
+	ps := maps.Keys(personalities)
+	sort.Strings(ps)
+	flagset.VarP(&Personality, "personality", "p",
+		fmt.Sprintf("Invoke the shell with the personality of a certain type of script; one of %v", ps))
+}

--- a/src/internal/starlark/reflect.go
+++ b/src/internal/starlark/reflect.go
@@ -32,7 +32,10 @@ func (r *Reflect) String() string {
 	return fmt.Sprintf("%#v", r.Any)
 }
 func (r *Reflect) Type() string {
-	return reflect.TypeOf(r.Any).String()
+	if t := reflect.TypeOf(r.Any); t != nil {
+		return t.String()
+	}
+	return "<nil>"
 }
 func (r *Reflect) Freeze() {}
 func (r *Reflect) Hash() (uint32, error) {
@@ -41,7 +44,7 @@ func (r *Reflect) Hash() (uint32, error) {
 	}
 	return uint32(xxh3.HashString(r.String())), nil
 }
-func (r *Reflect) Truth() starlark.Bool { return r.Any == nil }
+func (r *Reflect) Truth() starlark.Bool { return r.Any != nil }
 func (r *Reflect) Get(v starlark.Value) (starlark.Value, bool, error) {
 	name, ok := starlark.AsString(v)
 	if !ok {

--- a/src/internal/starlark/reflect.go
+++ b/src/internal/starlark/reflect.go
@@ -157,9 +157,12 @@ func value(v reflect.Value) starlark.Value {
 		d := starlark.NewDict(v.Len())
 		iter := v.MapRange()
 		for iter.Next() {
-			k := Value(iter.Key().Interface())
-			v := Value(iter.Value().Interface())
-			d.SetKey(k, v)
+			kk := Value(iter.Key().Interface())
+			vv := Value(iter.Value().Interface())
+			if err := d.SetKey(kk, vv); err != nil {
+				// Unexpected; we can't handle it, so just do nothing.
+				return &Reflect{Any: v.Interface}
+			}
 		}
 		return d
 	}

--- a/src/internal/starlark/reflect.go
+++ b/src/internal/starlark/reflect.go
@@ -1,0 +1,237 @@
+package starlark
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/zeebo/xxh3"
+	"go.starlark.net/starlark"
+)
+
+// Reflect is a starlark.Value that exposes the fields of struct types.  For example, `package foo;
+// struct Test { Foo string }` would be of type "foo.Test" and have one attribute, "Foo", in
+// starlark, used like value.Foo.
+type Reflect struct {
+	Any any
+}
+
+var _ starlark.Value = (*Reflect)(nil)
+var _ starlark.Mapping = (*Reflect)(nil)
+var _ starlark.HasAttrs = (*Reflect)(nil)
+var _ starlark.TotallyOrdered = (*Reflect)(nil)
+
+func (r *Reflect) String() string {
+	if r.Any == nil {
+		return "<nil reflect>"
+	}
+	if s, ok := r.Any.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%#v", r.Any)
+}
+func (r *Reflect) Type() string {
+	return reflect.TypeOf(r.Any).String()
+}
+func (r *Reflect) Freeze() {}
+func (r *Reflect) Hash() (uint32, error) {
+	if r.Any == nil {
+		return 0, errors.New("nil object in Reflect{}")
+	}
+	return uint32(xxh3.HashString(r.String())), nil
+}
+func (r *Reflect) Truth() starlark.Bool { return r.Any == nil }
+func (r *Reflect) Get(v starlark.Value) (starlark.Value, bool, error) {
+	name, ok := starlark.AsString(v)
+	if !ok {
+		return nil, false, errors.Errorf("%v cannot be converted to string for key lookup", v)
+	}
+	v, err := r.Attr(name)
+	if err != nil {
+		return nil, false, err
+	}
+	return v, true, nil
+
+}
+func (r *Reflect) Attr(name string) (starlark.Value, error) {
+	if r.Any == nil {
+		return nil, errors.New("nil object in Reflect{}")
+	}
+	rv := reflect.ValueOf(r.Any)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() == reflect.Struct {
+		fv := rv.FieldByName(name)
+		if fv.Kind() == reflect.Invalid {
+			return nil, errors.Errorf("no field %q", name)
+		}
+		return Value(fv.Interface()), nil
+	}
+	return nil, errors.Errorf("cannot index into type %v (%v)", rv.Type(), rv.Kind())
+}
+func (r *Reflect) AttrNames() []string {
+	if r.Any == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(r.Any)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() == reflect.Struct {
+		var result []string
+		n := rv.NumField()
+		for i := 0; i < n; i++ {
+			result = append(result, rv.Type().Field(i).Name)
+		}
+		return result
+	}
+	return nil
+}
+func (r *Reflect) Cmp(y starlark.Value, _ int) (int, error) {
+	sr := FromStarlark(r)
+	sy := FromStarlark(y)
+	if reflect.DeepEqual(sr, sy) {
+		return 0, nil
+	}
+	return 0, errors.Errorf("cannot compare a %T (%v) to a %T (%v)", r, r, sy, sy)
+}
+
+// Value makes any Go value available to Starlark.
+func Value(in any) starlark.Value {
+	switch x := in.(type) {
+	case starlark.Value:
+		return x
+	case []starlark.Value:
+		return ReflectList(x)
+	case []byte:
+		return starlark.Bytes(string(x))
+	case string:
+		return starlark.String(x)
+	case bool:
+		return starlark.Bool(x)
+	case int:
+		return starlark.MakeInt(x)
+	case int8:
+		return starlark.MakeInt64(int64(x))
+	case int16:
+		return starlark.MakeInt64(int64(x))
+	case int32:
+		return starlark.MakeInt64(int64(x))
+	case int64:
+		return starlark.MakeInt64(x)
+	case uint:
+		return starlark.MakeUint(x)
+	case uint8:
+		return starlark.MakeUint64(uint64(x))
+	case uint16:
+		return starlark.MakeUint64(uint64(x))
+	case uint32:
+		return starlark.MakeUint64(uint64(x))
+	case uint64:
+		return starlark.MakeUint64(x)
+	case *big.Int:
+		return starlark.MakeBigInt(x)
+	case float32:
+		return starlark.Float(float64(x))
+	case float64:
+		return starlark.Float(x)
+	}
+	return value(reflect.ValueOf(in))
+}
+
+func value(v reflect.Value) starlark.Value {
+	if v.Kind() == reflect.Invalid {
+		return starlark.None
+	}
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		n := v.Len()
+		var anys []any
+		for i := 0; i < n; i++ {
+			anys = append(anys, v.Index(i).Interface())
+		}
+		return ReflectList(anys)
+	case reflect.Map:
+		d := starlark.NewDict(v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			k := Value(iter.Key().Interface())
+			v := Value(iter.Value().Interface())
+			d.SetKey(k, v)
+		}
+		return d
+	}
+	return &Reflect{Any: v.Interface()}
+}
+
+// ReflectList returns a starlark.List from any Go slice.
+func ReflectList[T any](xs []T) *starlark.List {
+	var values []starlark.Value
+	for _, x := range xs {
+		values = append(values, Value(x))
+	}
+	return starlark.NewList(values)
+}
+
+// FromStarlark returns a Go value for a Starlark value.
+func FromStarlark(v starlark.Value) any {
+	switch x := v.(type) {
+	case *Reflect:
+		return x.Any
+	case starlark.NoneType:
+		return nil
+	case starlark.Bool:
+		return bool(x)
+	case starlark.Bytes:
+		return []byte(x)
+	case starlark.String:
+		return string(x)
+	case starlark.Int:
+		i := x.BigInt()
+		if i.IsInt64() {
+			return i.Int64()
+		} else if i.IsUint64() {
+			return i.Uint64()
+		}
+		return i
+	case starlark.Float:
+		return float64(x)
+	case starlark.Tuple:
+		var result []any
+		n := x.Len()
+		for i := 0; i < n; i++ {
+			v := x.Index(i)
+			result = append(result, FromStarlark(v))
+		}
+		return result
+	case *starlark.List:
+		n := x.Len()
+		var result []any
+		for i := 0; i < n; i++ {
+			v := x.Index(i)
+			result = append(result, FromStarlark(v))
+		}
+		return result
+	case *starlark.Dict:
+		result := make(map[string]any)
+		for _, item := range x.Items() {
+			if len(item) != 2 {
+				// Something is weird; bail out.
+				return x
+			}
+			var key string
+			switch x := item[0].(type) {
+			case starlark.String:
+				key = string(x)
+			default:
+				key = x.String()
+			}
+			result[key] = FromStarlark(item[1])
+		}
+		return result
+	default:
+		return v.String()
+	}
+}

--- a/src/internal/starlark/reflect_test.go
+++ b/src/internal/starlark/reflect_test.go
@@ -48,7 +48,7 @@ func TestRoundTrip(t *testing.T) {
 	want := map[string]any{
 		"nil":        nil,
 		"struct":     SimpleStruct{Field: "simple"},
-		"struct_ptr": SimpleStruct{Field: "pointer"},
+		"struct_ptr": &SimpleStruct{Field: "pointer"},
 		"string":     "string",
 		"byte":       []byte("bytes"),
 		"int64":      int64(math.MinInt64),

--- a/src/internal/starlark/reflect_test.go
+++ b/src/internal/starlark/reflect_test.go
@@ -1,0 +1,78 @@
+package starlark_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+	"github.com/pachyderm/pachyderm/v2/src/internal/starlark/startest"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+type SimpleStruct struct {
+	Field string
+	Me    *SimpleStruct
+}
+
+func (s *SimpleStruct) String() string {
+	return "simple struct" // test fmt.Stringer passthru
+}
+
+func TestValue(t *testing.T) {
+	simple := SimpleStruct{
+		Field: "simple",
+	}
+	simple.Me = &simple
+
+	predefined := starlark.StringDict{
+		"wrappednil": ourstar.Value(&ourstar.Reflect{}),
+		"struct":     ourstar.Value(simple),
+		"struct_ptr": ourstar.Value(&simple),
+		"string":     ourstar.Value("string"),
+		"bool":       ourstar.Value(bool(true)),
+		"byte":       ourstar.Value([]byte("bytes")),
+		"int":        ourstar.Value(42),
+		"float":      ourstar.Value(123.45),
+		"stringlist": ourstar.Value([]starlark.Value{starlark.String("string"), starlark.String("string")}),
+		"map":        ourstar.Value(map[string]int{"one": 1, "two": 2}),
+		"array":      ourstar.Value([10]int{5: 5}),
+		"int8":       ourstar.Value(int8(-128)),
+		"uint8":      ourstar.Value(uint8(255)),
+	}
+	startest.RunTest(t, "tests/reflect_test.star", ourstar.Options{Predefined: predefined})
+}
+
+func TestRoundTrip(t *testing.T) {
+	want := map[string]any{
+		"nil":        nil,
+		"struct":     SimpleStruct{Field: "simple"},
+		"struct_ptr": SimpleStruct{Field: "pointer"},
+		"string":     "string",
+		"byte":       []byte("bytes"),
+		"int64":      int64(math.MinInt64),
+		"unt64":      uint64(math.MaxInt64 + 1),
+		"float":      float64(123.45),
+		"list":       []any{"string", "string"},
+		"complex":    complex(2, 1),
+		"dict":       map[string]any{"one": int64(1), "two": int64(2)},
+	}
+	th := new(starlark.Thread)
+	result, err := starlark.EvalOptions(&syntax.FileOptions{}, th, "<test>", "lambda x: x", starlark.StringDict{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := result.(*starlark.Function)
+	got := map[string]any{}
+	for k, v := range want {
+		out, err := starlark.Call(th, f, starlark.Tuple([]starlark.Value{ourstar.Value(v)}), nil)
+		if err != nil {
+			t.Fatalf("Call(%v): %v", k, err)
+		}
+		got[k] = ourstar.FromStarlark(out)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("round trip (-want +got):\n%s", diff)
+	}
+}

--- a/src/internal/starlark/repl.go
+++ b/src/internal/starlark/repl.go
@@ -1,0 +1,235 @@
+package starlark
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/wader/readline"
+
+	"github.com/adrg/xdg"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func RunShell(ctx context.Context, path string, opts Options) error {
+	_, err := Run(ctx, path, opts, func(fileOpts *syntax.FileOptions, thread *starlark.Thread, in string, module string, globals starlark.StringDict) (starlark.StringDict, error) {
+		if in != "" {
+			fmt.Printf("Running %v...", module)
+			result, err := starlark.ExecFileOptions(fileOpts, thread, module, nil, globals)
+			fmt.Println("done.")
+			if err != nil {
+				return nil, errors.Wrapf(err, "run %v", module)
+			}
+			globals = result
+		}
+		for k, v := range opts.REPLPredefined {
+			globals[k] = v
+		}
+		rlcfg := &readline.Config{
+			Prompt:       ">>> ",
+			HistoryFile:  filepath.Join(xdg.StateHome, "starpach.history"),
+			HistoryLimit: 10000,
+			AutoComplete: &completer{t: thread, globals: globals},
+		}
+		rl, err := readline.NewEx(rlcfg)
+		if err != nil {
+			printError(err)
+			return nil, errors.Wrap(err, "readline.NewEx")
+		}
+		defer rl.Close()
+		for {
+			signal.Reset(os.Interrupt) // This is rude, but oh well.
+			oneCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+			thread.Uncancel()
+			thread.SetLocal(goContextKey, oneCtx)
+			go func() {
+				<-oneCtx.Done()
+				if err := context.Cause(oneCtx); err != nil {
+					thread.Cancel(err.Error())
+				} else {
+					thread.Cancel("no context error, but context is done")
+				}
+			}()
+			if err := rep(fileOpts, rl, thread, globals); err != nil {
+				if err == readline.ErrInterrupt {
+					fmt.Println(err)
+					stop()
+					<-oneCtx.Done()
+					continue
+				}
+				stop()
+				<-oneCtx.Done()
+				break
+			}
+			stop()
+			<-oneCtx.Done()
+		}
+		return nil, nil
+	})
+	return err
+}
+
+type completer struct {
+	t       *starlark.Thread
+	globals starlark.StringDict
+}
+
+func (c *completer) Do(line []rune, pos int) ([][]rune, int) {
+	if len(line) != pos {
+		// Completing mid-line is difficult, so we opt out here.
+		return nil, 0
+	}
+	var trim int
+	for i, r := range line {
+		if !unicode.IsSpace(r) {
+			break
+		} else {
+			trim = i + 1
+			pos--
+		}
+	}
+	line = line[trim:]
+
+	var results [][]rune
+	// If a Universe function completes the entire line, include it.
+	for k := range starlark.Universe {
+		if strings.HasPrefix(k, string(line)) {
+			results = append(results, []rune(k[pos:]))
+		}
+	}
+
+	// If a global completes the entire line, include it.
+	for k := range c.globals {
+		if strings.HasPrefix(k, string(line)) {
+			results = append(results, []rune(k[pos:]))
+		}
+	}
+
+	// If there is an opening paren, treat it like the start of a new expression.
+	lastParen := -1
+	for i := len(line) - 1; i >= 0; i-- {
+		if line[i] == '(' || line[i] == ',' || line[i] == '[' || line[i] == '=' {
+			lastParen = i
+			break
+		}
+	}
+	if lastParen > 0 {
+		newLine := line[lastParen+1:]
+		results, _ = c.Do(newLine, len(newLine))
+		return results, pos
+	}
+
+	// If there is a single period, assume it's <some global>.<want an attr>, and complete the
+	// attr.
+	lastDot := -1
+	for i := len(line) - 1; i >= 0; i-- {
+		// Search backwards for a .
+		if line[i] == '.' {
+			switch {
+			case lastDot == -1:
+				// Found one.
+				lastDot = i
+			case lastDot != -2:
+				// Found another one, which invalidates this method of completion.
+				// It's an expression like foo.bar.something, and we'd have to eval
+				// foo.bar to figure out how to complete "something".
+				lastDot = -2
+			}
+		}
+	}
+	if lastDot > 0 {
+		sym := string(line[:lastDot])
+		part := string(line[lastDot+1:])
+		if sym, ok := c.globals[sym]; ok {
+			if ha, ok := sym.(starlark.HasAttrs); ok {
+				for _, attr := range ha.AttrNames() {
+					if strings.HasPrefix(attr, part) {
+						results = append(results, []rune(attr[len(part):]))
+					}
+				}
+			}
+		}
+	}
+	return results, pos
+}
+
+// printError prints the error to stderr,
+// or its backtrace if it is a Starlark evaluation error.
+func printError(err error) {
+	if evalErr, ok := err.(*starlark.EvalError); ok {
+		fmt.Fprintln(os.Stderr, evalErr.Backtrace())
+	} else {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+// rep is copied from go.starlark.net/repl.
+func rep(opts *syntax.FileOptions, rl *readline.Instance, thread *starlark.Thread, globals starlark.StringDict) error {
+	eof := false
+
+	// readline returns EOF, ErrInterrupted, or a line including "\n".
+	rl.SetPrompt(">>> ")
+	readline := func() ([]byte, error) {
+		line, err := rl.Readline()
+		rl.SetPrompt("... ")
+		if err != nil {
+			if err == io.EOF {
+				eof = true
+			}
+			return nil, err //nolint:errcheck
+		}
+		return []byte(line + "\n"), nil
+	}
+
+	// Treat load bindings as global (like they used to be) in the REPL.
+	// Fixes github.com/google/starlark-go/issues/224.
+	opts2 := *opts
+	opts2.LoadBindsGlobally = true
+	opts = &opts2
+
+	// parse
+	f, err := opts.ParseCompoundStmt("<stdin>", readline)
+	if err != nil {
+		if eof {
+			return io.EOF
+		}
+		printError(err)
+		return nil
+	}
+
+	if expr := soleExpr(f); expr != nil {
+		// eval
+		v, err := starlark.EvalExprOptions(f.Options, thread, expr, globals)
+		if err != nil {
+			printError(err)
+			return nil
+		}
+		globals["_"] = v // Python does this.
+
+		// print
+		if v != starlark.None {
+			fmt.Println(v)
+		}
+	} else if err := starlark.ExecREPLChunk(f, thread, globals); err != nil {
+		printError(err)
+		return nil
+	}
+
+	return nil
+}
+
+func soleExpr(f *syntax.File) syntax.Expr {
+	if len(f.Stmts) == 1 {
+		if stmt, ok := f.Stmts[0].(*syntax.ExprStmt); ok {
+			return stmt.X
+		}
+	}
+	return nil
+}

--- a/src/internal/starlark/repl.go
+++ b/src/internal/starlark/repl.go
@@ -183,7 +183,7 @@ func rep(opts *syntax.FileOptions, rl *readline.Instance, thread *starlark.Threa
 			if err == io.EOF {
 				eof = true
 			}
-			return nil, err //nolint:errcheck
+			return nil, err //nolint:wrapcheck
 		}
 		return []byte(line + "\n"), nil
 	}

--- a/src/internal/starlark/repl_test.go
+++ b/src/internal/starlark/repl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
@@ -107,7 +108,7 @@ func TestCompletion(t *testing.T) {
 				for k, v := range r {
 					g[k] = v
 				}
-				return r, err
+				return r, errors.Wrap(err, "ExecFileOptions")
 			}); err != nil {
 				t.Fatalf("compile example file: %v", err)
 			}

--- a/src/internal/starlark/repl_test.go
+++ b/src/internal/starlark/repl_test.go
@@ -1,0 +1,129 @@
+package starlark
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func TestCompletion(t *testing.T) {
+	testData := []struct {
+		line string
+		want []string
+		skip bool
+	}{
+		{
+			line: "Fal",
+			want: []string{"se"},
+		},
+		{
+			line: "som",
+			want: []string{"e_dict", "efoo", "e123"},
+		},
+		{
+			line: "somef",
+			want: []string{"oo"},
+		},
+		{
+			line: "\tsomef",
+			want: []string{"oo"},
+		},
+		{
+			line: "    somef",
+			want: []string{"oo"},
+		},
+		{
+			line: "    some f",
+		},
+		{
+			line: ".",
+		},
+		{
+			line: ".some",
+		},
+		{
+			line: "some_dict.",
+			want: []string{"clear", "get", "items", "keys", "pop", "popitem", "setdefault", "update", "values"},
+		},
+		{
+			line: "some_dict.cl",
+			want: []string{"ear"},
+		},
+		{
+			line: "some_dict.some_dict.",
+		},
+		{
+			line: "some_dict.Fal",
+		},
+		{
+			line: "exciting_function(Fal",
+			want: []string{"se"},
+		},
+		{
+			line: "exciting_function( Fal",
+			want: []string{"se"},
+		},
+		{
+			line: "exciting_function(some_dict.cl",
+			want: []string{"ear"},
+		},
+		{
+			line: "exciting_function(arg=Fal",
+			want: []string{"se"},
+		},
+		{
+			line: "exciting_function(arg=some_dict.cl",
+			want: []string{"ear"},
+		},
+		{
+			line: "[None, True, Fal",
+			want: []string{"se"},
+		},
+		{
+			line: "nested[0].cl",
+			want: []string{"ear"},
+			// To complete .clear here, we'd need to eval "nested[0]".  It would be a
+			// nice feature, though.
+			skip: true,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.line, func(t *testing.T) {
+			if test.skip {
+				t.Skip("skipped")
+			}
+			ctx := pctx.TestContext(t)
+			var th *starlark.Thread
+			var g starlark.StringDict
+			if _, err := Run(ctx, "testdata/completion.star", Options{}, func(fileOpts *syntax.FileOptions, thread *starlark.Thread, path string, module string, globals starlark.StringDict) (starlark.StringDict, error) {
+				th = thread
+				g = globals
+				r, err := starlark.ExecFileOptions(fileOpts, thread, module, nil, globals)
+				for k, v := range r {
+					g[k] = v
+				}
+				return r, err
+			}); err != nil {
+				t.Fatalf("compile example file: %v", err)
+			}
+			c := &completer{t: th, globals: g}
+			rs := []rune(test.line)
+			result, _ := c.Do(rs, len(rs))
+			var got []string
+			for _, x := range result {
+				got = append(got, string(x))
+			}
+			sort := func(x, y string) bool {
+				return x < y
+			}
+			if diff := cmp.Diff(test.want, got, cmpopts.EquateEmpty(), cmpopts.SortSlices(sort)); diff != "" {
+				t.Errorf("complete(%v) (-want +got):\n%s", test.line, diff)
+			}
+		})
+	}
+}

--- a/src/internal/starlark/starcmp/starcmp.go
+++ b/src/internal/starlark/starcmp/starcmp.go
@@ -1,0 +1,21 @@
+// Package starcmp provides utilities for running cmp.Diff on Starlark values.  It's not in the
+// startest package because startest depends on internal/starlark, but the internal/starlark tests
+// want to compare things.
+package starcmp
+
+import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+// Compare is a cmp.Option that compares Starlark values with Starlark's `==` operator.
+var Compare = cmp.Option(cmp.Comparer(func(a, b starlark.Value) bool {
+	x, err := starlark.Compare(syntax.EQL, a, b)
+	if err != nil {
+		panic(fmt.Sprintf("compare failed: %v", err))
+	}
+	return x
+}))

--- a/src/internal/starlark/starcmp/starcmp_test.go
+++ b/src/internal/starlark/starcmp/starcmp_test.go
@@ -1,0 +1,54 @@
+package starcmp
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.starlark.net/starlark"
+)
+
+func TestCompare(t *testing.T) {
+	testData := []struct {
+		name      string
+		a, b      starlark.Value
+		wantEqual bool
+	}{
+		{
+			name:      "not equal strings",
+			a:         starlark.String("a"),
+			b:         starlark.String("b"),
+			wantEqual: false,
+		},
+		{
+			name:      "equal strings",
+			a:         starlark.String("a"),
+			b:         starlark.String("a"),
+			wantEqual: true,
+		},
+		{
+			name:      "not equal numbers",
+			a:         starlark.MakeInt(42),
+			b:         starlark.MakeInt(43),
+			wantEqual: false,
+		},
+		{
+			name:      "equal numbers",
+			a:         starlark.MakeInt(42),
+			b:         starlark.MakeInt(42),
+			wantEqual: true,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			diff := cmp.Diff(test.a, test.b, Compare)
+			if got, want := (diff == ""), test.wantEqual; got != want {
+				if diff != "" {
+					t.Errorf("values differ, but want same:\n%s", diff)
+				} else {
+					t.Error("values unexpectedly equal")
+				}
+			}
+		})
+	}
+}

--- a/src/internal/starlark/starlark.go
+++ b/src/internal/starlark/starlark.go
@@ -1,0 +1,223 @@
+// Package starlark runs Pachyderm-specific starlark programs.  It's recommended to import this as
+// "ourstar" when also using go.starlark.net/starlark in the same package.
+package starlark
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	starjson "go.starlark.net/lib/json"
+	starmath "go.starlark.net/lib/math"
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+	"go.uber.org/zap"
+)
+
+const (
+	goContextKey       = "goContext"
+	scriptDirectoryKey = "scriptDirectory"
+)
+
+func init() {
+	starlark.Universe["json"] = starjson.Module
+	starlark.Universe["time"] = startime.Module
+	starlark.Universe["math"] = starmath.Module
+}
+
+// GetContext returns a context.Context that applies to in the provided Starlark thread.
+func GetContext(t *starlark.Thread) context.Context {
+	x := t.Local(goContextKey)
+	if ctx, ok := x.(context.Context); ok {
+		return ctx
+	}
+	return pctx.TODO()
+}
+
+func scriptDirectory(t *starlark.Thread) string {
+	x := t.Local(scriptDirectoryKey)
+	if s, ok := x.(string); ok {
+		return s
+	}
+	return "/dev/null"
+}
+
+func nameScript(t *starlark.Thread, abs string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return abs
+	}
+	rel, err := filepath.Rel(wd, abs)
+	if err != nil {
+		return abs
+	}
+	return rel
+}
+
+type loadResult struct {
+	globals starlark.StringDict
+	err     error
+}
+
+func newThread(name string) *starlark.Thread {
+	return &starlark.Thread{
+		Name: name,
+		Print: func(t *starlark.Thread, msg string) {
+			log.Info(GetContext(t), msg)
+		},
+	}
+}
+
+// Options controls the Starlark execution environment.
+type Options struct {
+	// Modules are built-in modules that are available for programs to load with "load".
+	// "*.star" is always resolve to a disk path; everything else can be a key in this map.  The
+	// StringDict map value should be a map from function names to starlark.Builtin objects.
+	Modules map[string]starlark.StringDict
+	// Predefined is a dictionary of predefined values that don't need to be loaded.
+	Predefined starlark.StringDict
+	// REPLPredefined are values that are only predefined in an interactive shell.
+	REPLPredefined starlark.StringDict
+	// ThreadLocalVars are additional thread-local variables to set.  Go code can get at these
+	// environment variables with thread.Local(key).  See GetContext() for an example.
+	ThreadLocalVars map[string]any
+}
+
+// RunFn is a function that can run a Starlark program in a thread.  in is the string passed to Run,
+// module is the canonical module name for that code, if applicable.
+type RunFn func(fileOpts *syntax.FileOptions, thread *starlark.Thread, in string, module string, globals starlark.StringDict) (starlark.StringDict, error)
+
+// Run runs the provided RunFn.  The input "in" is not run here, and only serves as a base path for
+// resolving module loads.
+func Run(rctx context.Context, in string, opts Options, f RunFn) (starlark.StringDict, error) {
+	ctx, c := pctx.WithCancel(rctx)
+	defer c()
+	path := filepath.Clean(in)
+	dir := filepath.Dir(path)
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "find absolute location of starlark file %v", path)
+	}
+
+	thread := newThread(filepath.Base(path))
+	thread.SetLocal(goContextKey, ctx)
+	thread.SetLocal(scriptDirectoryKey, abs)
+
+	fileOpts := &syntax.FileOptions{
+		Set:               true,
+		While:             true,
+		TopLevelControl:   true,
+		GlobalReassign:    false,
+		LoadBindsGlobally: false,
+		Recursion:         false,
+	}
+	vars := opts.Predefined
+	if vars == nil {
+		vars = make(starlark.StringDict)
+	}
+	if opts.Modules == nil {
+		opts.Modules = make(map[string]starlark.StringDict)
+	}
+
+	modules := make(map[string]*loadResult)
+	var load func(*starlark.Thread, string) (starlark.StringDict, error)
+	load = func(t *starlark.Thread, module string) (starlark.StringDict, error) {
+		// If this is a built-in module, just return it.
+		if !strings.HasSuffix(module, ".star") {
+			if data, ok := opts.Modules[module]; ok {
+				return data, nil
+			} else {
+				return nil, errors.Errorf("no built-in module %q", module)
+			}
+		}
+		script := filepath.Clean(filepath.Join(scriptDirectory(t), module))
+		dir, err := filepath.Abs(filepath.Dir(script))
+		if err != nil {
+			return nil, errors.Wrapf(err, "setup location of module %v", module)
+		}
+		module = script
+
+		// Check to see if we've already loaded the module.
+		result, ok := modules[module]
+		if ok {
+			// result=nil is a placeholder indicating that we are already attempting to
+			// load this module.
+			if result == nil {
+				return nil, errors.New("cycle in load graph")
+			}
+			// Otherwise, load from the cache.
+			return result.globals, result.err
+		}
+		// Mark this module as attempting to load.  This will signal an import cycle.
+		modules[module] = nil
+
+		// Since we're here, we want to read a file from disk and interpret it.
+		name := nameScript(thread, module)
+		ctx, done := log.SpanContext(GetContext(t), "load("+name+")")
+		localThread := newThread(name)
+		localThread.Load = load
+		localThread.SetLocal(goContextKey, ctx)
+		localThread.SetLocal(scriptDirectoryKey, dir)
+		for k, v := range opts.ThreadLocalVars {
+			localThread.SetLocal(k, v)
+		}
+
+		log.Debug(ctx, "attempting to load module from disk")
+		data, err := os.ReadFile(module)
+		if err != nil {
+			err = errors.Wrap(err, "read module")
+			done(zap.Error(err))
+			return nil, err
+		}
+		threadVars := make(starlark.StringDict)
+		for k, v := range vars {
+			threadVars[k] = v
+		}
+		globals, err := starlark.ExecFileOptions(fileOpts, localThread, name, data, threadVars)
+		modules[module] = &loadResult{
+			globals: globals,
+			err:     err,
+		}
+		err = errors.Wrap(err, "compile module")
+		done(Error("error", err)...)
+		if err != nil {
+			return nil, err
+		}
+		return globals, nil
+	}
+	thread.Load = load
+	for k, v := range opts.ThreadLocalVars {
+		thread.SetLocal(k, v)
+	}
+	go func() {
+		<-ctx.Done()
+		if err := context.Cause(ctx); err != nil {
+			thread.Cancel(err.Error())
+		} else {
+			thread.Cancel("no context error, but context is done")
+		}
+
+	}()
+	return f(fileOpts, thread, in, path, vars)
+}
+
+// RunProgram runs an on-disk Starlark script located at path.
+func RunProgram(ctx context.Context, path string, opts Options) (starlark.StringDict, error) {
+	return Run(ctx, path, opts, func(fileOpts *syntax.FileOptions, thread *starlark.Thread, _ string, module string, globals starlark.StringDict) (starlark.StringDict, error) {
+		return starlark.ExecFileOptions(fileOpts, thread, module, nil, globals)
+	})
+}
+
+// RunScript runs a script named "name" from the program text in "script".
+func RunScript(ctx context.Context, name string, script string, opts Options) (starlark.StringDict, error) {
+	return Run(ctx, name, opts, func(fileOpts *syntax.FileOptions, thread *starlark.Thread, in, module string, globals starlark.StringDict) (starlark.StringDict, error) {
+		// If the implementation looks confusing, ExecFileOptions is "generic" in that the
+		// "src" argument can be a string or []byte with program text.
+		return starlark.ExecFileOptions(fileOpts, thread, name, script, globals)
+	})
+}

--- a/src/internal/starlark/starlark.go
+++ b/src/internal/starlark/starlark.go
@@ -209,7 +209,11 @@ func Run(rctx context.Context, in string, opts Options, f RunFn) (starlark.Strin
 // RunProgram runs an on-disk Starlark script located at path.
 func RunProgram(ctx context.Context, path string, opts Options) (starlark.StringDict, error) {
 	return Run(ctx, path, opts, func(fileOpts *syntax.FileOptions, thread *starlark.Thread, _ string, module string, globals starlark.StringDict) (starlark.StringDict, error) {
-		return starlark.ExecFileOptions(fileOpts, thread, module, nil, globals)
+		result, err := starlark.ExecFileOptions(fileOpts, thread, module, nil, globals)
+		if err != nil {
+			return result, errors.Wrapf(err, "exec starlark file %v", module)
+		}
+		return result, nil
 	})
 }
 
@@ -218,6 +222,11 @@ func RunScript(ctx context.Context, name string, script string, opts Options) (s
 	return Run(ctx, name, opts, func(fileOpts *syntax.FileOptions, thread *starlark.Thread, in, module string, globals starlark.StringDict) (starlark.StringDict, error) {
 		// If the implementation looks confusing, ExecFileOptions is "generic" in that the
 		// "src" argument can be a string or []byte with program text.
-		return starlark.ExecFileOptions(fileOpts, thread, name, script, globals)
+		result, err := starlark.ExecFileOptions(fileOpts, thread, name, script, globals)
+		if err != nil {
+			return result, errors.Wrap(err, "exec starlark script")
+		}
+		return result, nil
+
 	})
 }

--- a/src/internal/starlark/starlark.go
+++ b/src/internal/starlark/starlark.go
@@ -88,13 +88,13 @@ type Options struct {
 	ThreadLocalVars map[string]any
 }
 
-// RunFn is a function that can run a Starlark program in a thread.  in is the string passed to Run,
+// RunFunc is a function that can run a Starlark program in a thread.  in is the string passed to Run,
 // module is the canonical module name for that code, if applicable.
-type RunFn func(fileOpts *syntax.FileOptions, thread *starlark.Thread, in string, module string, globals starlark.StringDict) (starlark.StringDict, error)
+type RunFunc func(fileOpts *syntax.FileOptions, thread *starlark.Thread, in string, module string, globals starlark.StringDict) (starlark.StringDict, error)
 
-// Run runs the provided RunFn.  The input "in" is not run here, and only serves as a base path for
-// resolving module loads.
-func Run(rctx context.Context, in string, opts Options, f RunFn) (starlark.StringDict, error) {
+// Run runs the provided RunFunc.  The input "in" is not run here, and only serves as a base path
+// for resolving module loads.
+func Run(rctx context.Context, in string, opts Options, f RunFunc) (starlark.StringDict, error) {
 	ctx, c := pctx.WithCancel(rctx)
 	defer c()
 	path := filepath.Clean(in)

--- a/src/internal/starlark/starlark_test.go
+++ b/src/internal/starlark/starlark_test.go
@@ -1,0 +1,66 @@
+package starlark
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/starlark/starcmp"
+	"go.starlark.net/starlark"
+)
+
+func TestRunProgram(t *testing.T) {
+	testData := []struct {
+		file    string
+		wantErr bool
+	}{
+		{file: "good.star"},
+		{file: "nested/good.star"},
+		{file: "cycle.star", wantErr: true},
+	}
+
+	for _, test := range testData {
+		t.Run(test.file, func(t *testing.T) {
+			var testOK bool
+			opts := Options{
+				Modules: map[string]starlark.StringDict{
+					"test": {
+						"test_ok": starlark.NewBuiltin("test_ok", func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+							t.Log("test.test_ok called")
+							testOK = true
+							return starlark.None, nil
+						}),
+					},
+				},
+			}
+			ctx := pctx.TestContext(t)
+			_, err := RunProgram(ctx, "testdata/"+test.file, opts)
+			if err != nil {
+				t.Log(err)
+				if test.wantErr {
+					return
+				}
+				t.Fatal(err)
+			}
+			if test.wantErr {
+				t.Error("want error, but got success")
+			}
+			if !testOK {
+				t.Errorf("test never called test_ok()")
+			}
+		})
+	}
+}
+
+func TestRunScript(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	list := ReflectList([]int{42: 1234})
+	got, err := RunScript(ctx, "test", "y = x[42] + 1", Options{Predefined: starlark.StringDict{"x": list}})
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	want := starlark.StringDict{"y": starlark.MakeInt(1235)}
+	if diff := cmp.Diff(want, got, starcmp.Compare); diff != "" {
+		t.Errorf("RunScript (-want +got):\n%s", diff)
+	}
+}

--- a/src/internal/starlark/startest/startest.go
+++ b/src/internal/starlark/startest/startest.go
@@ -1,0 +1,210 @@
+package startest
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"go.starlark.net/syntax"
+	"golang.org/x/exp/maps"
+)
+
+const testingTKey = "testingT"
+
+// T is a subset of testing.TB for Starlark tests.  We don't attempt to implement testing.TB because
+// it contains a private field to prevent people from implementing it.  We also have Run.  We are
+// playing these games so that the "failing tests" test suite can run against either a testing.T (to
+// see that the fail while developing), or a recorder (to see that they continue to "fail" according
+// to the spec; i.e. all the Go tests will pass, when the Go tests are running intentionally-failing
+// Starlark tests).
+type T interface {
+	Run(string, func(T)) bool
+	Helper()
+	Log(...any)
+	Logf(string, ...any)
+	Error(...any)
+	Errorf(string, ...any)
+	Fatal(...any)
+	Fatalf(string, ...any)
+}
+
+type testingTWrapper struct {
+	*testing.T
+}
+
+var _ T = (*testingTWrapper)(nil)
+
+func (w *testingTWrapper) Run(name string, f func(T)) bool {
+	return w.T.Run(name, func(t *testing.T) {
+		f(&testingTWrapper{T: t})
+	})
+}
+
+// testingT is the testing.T API exposed to Starlark tests.
+var testingT = starlark.StringDict{
+	// print() is preferred over Log().
+	"Logf":   makeStarlarkTestFunction("Logf", func(t T, c string, args []any) { call(t.Log, c, args) }),
+	"Error":  makeStarlarkTestFunction("Error", func(t T, c string, args []any) { call(t.Error, c, args) }),
+	"Errorf": makeStarlarkTestFunction("Errorf", func(t T, c string, args []any) { callf(t.Errorf, c, args) }),
+	"Fatal":  makeStarlarkTestFunction("Fatal", func(t T, c string, args []any) { call(t.Fatal, c, args) }),
+	"Fatalf": makeStarlarkTestFunction("Fatal", func(t T, c string, args []any) { callf(t.Fatalf, c, args) }),
+}
+
+func call(f func(args ...any), caller string, args []any) {
+	if len(args) > 0 {
+		args[0] = fmt.Sprintf("%v: %v", caller, args[0])
+	} else {
+		args = append(args, fmt.Sprintf("%v: %v", caller, "empty call"))
+	}
+	f(args...)
+}
+
+func callf(f func(message string, args ...any), caller string, originalArgs []any) {
+	msg := "%v: empty call"
+	args := []any{caller}
+	if len(originalArgs) > 0 {
+		if _, ok := originalArgs[0].(string); ok {
+			// TODO: if the filename contains a %, we break the format string.
+			msg = fmt.Sprintf("%v: %v", "%v", originalArgs[0])
+			args = append(args, originalArgs[1:]...)
+		} else {
+			msg = "%v: invalid format string: "
+			args = append(args, originalArgs...)
+		}
+	}
+	f(msg, args...)
+}
+
+func caller(th *starlark.Thread) string {
+	stack := th.CallStack()
+	caller := strings.ReplaceAll(stack.String(), "\n", "/") // emergency backup
+	if len(stack) > 1 {
+		i := len(stack) - 2
+		caller = fmt.Sprintf("%v:%v:%v", stack[i].Pos.Filename(), stack[i].Pos.Line, stack[i].Pos.Col)
+	}
+	return caller
+}
+
+func makeStarlarkTestFunction(name string, f func(t T, caller string, args []any)) *starlark.Builtin {
+	return starlark.NewBuiltin(name, func(th *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		t := getTestingT(th)
+		caller := caller(th)
+		if len(kwargs) != 0 {
+			t.Errorf("%v: unexpected kwargs in %v", caller, fn.Name())
+			return starlark.None, nil
+		}
+		var goArgs []any
+		for _, arg := range args {
+			v := ourstar.FromStarlark(arg)
+			goArgs = append(goArgs, v)
+		}
+		f(t, caller, goArgs)
+		return starlark.None, nil
+	})
+}
+
+func getTestingT(th *starlark.Thread) T {
+	return th.Local(testingTKey).(T)
+}
+
+func setTestingT(th *starlark.Thread, t T) {
+	th.SetLocal(testingTKey, t)
+}
+
+func setupPrint(th *starlark.Thread, t T) {
+	// Redirect print() to t.Log.
+	th.Print = func(th *starlark.Thread, msg string) {
+		t.Logf("%v: %v", caller(th), msg)
+	}
+}
+
+// RunTest runs an on-disk Starlark test.  Tests are scripts that produce functions that start with
+// the name "test_", and take a *testing.T object as their first argument.  The tests work like Go
+// tests; t.Error fails the test and continues, t.Fatal aborts the test.  Each Starlark test
+// function is run as a subtest of a "starlark" test created by this command.  Starlark tests cannot
+// call t.Parallel, since we use the same Starlark thread for each test, but there is no reason why
+// this stipulation cannot be removed.
+func RunTest(t *testing.T, script string, opts ourstar.Options) {
+	ctx := pctx.TestContext(t)
+	runTest(ctx, &testingTWrapper{T: t}, script, opts)
+}
+
+func runTest(ctx context.Context, t T, script string, opts ourstar.Options) {
+	t.Helper()
+	t.Run("starlark", func(t T) {
+		if _, err := ourstar.Run(ctx, script, opts, func(fileOpts *syntax.FileOptions, th *starlark.Thread, in, module string, globals starlark.StringDict) (starlark.StringDict, error) {
+			setupPrint(th, t)
+			result, err := starlark.ExecFileOptions(fileOpts, th, module, nil, globals)
+			if err != nil {
+				return nil, errors.Wrap(err, "compile test")
+			}
+
+			// We can't easily investigate the top-level identifiers in source code
+			// order; too much information from the parser fails to make it here.  So,
+			// we look for valid tests in alphabetical order, and then run those tests
+			// in source code order.
+			identifiers := maps.Keys(result)
+			sort.Strings(identifiers)
+			var tests []*starlark.Function
+			var skipped []string
+			for _, k := range identifiers {
+				v := result[k]
+				if !strings.HasPrefix(k, "test_") {
+					skipped = append(skipped, k)
+					continue
+				}
+				if v.Type() != "function" {
+					skipped = append(skipped, k)
+					continue
+				}
+				f, ok := v.(*starlark.Function)
+				if !ok {
+					skipped = append(skipped, v.String())
+					continue
+				}
+				if got, want := f.NumParams(), 1; got != want {
+					t.Errorf("%v@%v: unexpected params: got %v, want %v", f.Name(), f.Position().String(), got, want)
+					skipped = append(skipped, f.Name())
+					continue
+				}
+				tests = append(tests, f)
+			}
+			if len(skipped) != 0 {
+				t.Errorf("invalid top-level identifiers found in test file: %v", skipped)
+			}
+			if len(tests) == 0 {
+				t.Fatal("no tests to run")
+			}
+			// Run the tests, in order.
+			sort.Slice(tests, func(i, j int) bool {
+				a, b := tests[i].Position(), tests[j].Position()
+				if a.Line == b.Line {
+					return a.Col < b.Col
+				}
+				return a.Line < b.Line
+			})
+			for _, f := range tests {
+				t.Run(f.Name(), func(t T) {
+					setupPrint(th, t)
+					setTestingT(th, t)
+					args := starlark.Tuple([]starlark.Value{
+						&starlarkstruct.Module{Name: "testing.T", Members: testingT},
+					})
+					if _, err := starlark.Call(th, f, args, nil); err != nil {
+						t.Fatalf("%v@%v: cannot run test: %v", f.Name(), f.Position().String(), err)
+					}
+				})
+			}
+			return nil, nil
+		}); err != nil {
+			t.Fatalf("run starlark: %v", err)
+		}
+	})
+}

--- a/src/internal/starlark/startest/startest_test.go
+++ b/src/internal/starlark/startest/startest_test.go
@@ -1,0 +1,174 @@
+package startest
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+)
+
+func TestRunTest(t *testing.T) {
+	RunTest(t, "testdata/good_test.star", ourstar.Options{})
+}
+
+type op struct {
+	Name string
+	Args string
+}
+
+type fakeTestingT struct {
+	*testing.T
+	Name string
+	Ops  []*op
+}
+
+func (t *fakeTestingT) Run(name string, f func(t T)) bool {
+	sub := &fakeTestingT{T: t.T, Name: t.Name + "/" + name}
+	defer func() {
+		if err := recover(); err != nil && err != "fakeTestingT.Fatal" {
+			panic(err)
+		}
+		t.Ops = append(t.Ops, sub.Ops...)
+	}()
+	f(sub)
+	return false
+}
+
+func (t *fakeTestingT) Log(args ...any) {
+	t.Ops = append(t.Ops, &op{Name: t.Name + ".Log", Args: fmt.Sprint(args...)})
+}
+
+func (t *fakeTestingT) Error(args ...any) {
+	t.Ops = append(t.Ops, &op{Name: t.Name + ".Error", Args: fmt.Sprint(args...)})
+}
+
+func (t *fakeTestingT) Fatal(args ...any) {
+	t.Ops = append(t.Ops, &op{Name: t.Name + ".Fatal", Args: fmt.Sprint(args...)})
+	panic("fakeTestingT.Fatal")
+}
+
+func (t *fakeTestingT) Logf(msg string, args ...any) {
+	t.Ops = append(t.Ops, &op{Name: t.Name + ".Logf", Args: fmt.Sprintf(msg, args...)})
+}
+
+func (t *fakeTestingT) Errorf(msg string, args ...any) {
+	t.Ops = append(t.Ops, &op{Name: t.Name + ".Errorf", Args: fmt.Sprintf(msg, args...)})
+}
+
+func (t *fakeTestingT) Fatalf(msg string, args ...any) {
+	t.Ops = append(t.Ops, &op{Name: t.Name + ".Fatalf", Args: fmt.Sprintf(msg, args...)})
+	panic("fakeTestingT.Fatal")
+}
+
+var runFailingTests = flag.Bool("run-failing-tests", false, "If true, run the tests that are supposed to fail.")
+
+func TestRunFailingTests(t *testing.T) {
+	var ourT T
+	var got *fakeTestingT
+	if *runFailingTests {
+		ourT = &testingTWrapper{T: t}
+	} else {
+		got = &fakeTestingT{T: t}
+		ourT = got
+	}
+	ctx := pctx.TestContext(t)
+	runTest(ctx, ourT, "testdata/failing_test.star", ourstar.Options{})
+
+	if !*runFailingTests {
+		got.T = nil
+		want := &fakeTestingT{
+			Ops: []*op{
+				{
+					Name: "/starlark.Logf",
+					Args: "testdata/failing_test.star:25:6: this is logged at the top level",
+				},
+				{
+					Name: "/starlark.Errorf",
+					Args: "test_extra_parameters@testdata/failing_test.star:17:1: unexpected params: got 3, want 1",
+				},
+				{
+					Name: "/starlark.Errorf",
+					Args: "test_invalid_parameters@testdata/failing_test.star:14:1: unexpected params: got 0, want 1",
+				},
+				{
+					Name: "/starlark.Errorf",
+					Args: "invalid top-level identifiers found in test file: [test_extra_parameters test_invalid_parameters test_variable this_is_not_a_test]",
+				},
+				{
+					Name: "/starlark/test_error.Error",
+					Args: "testdata/failing_test.star:2:12: this is an errorthis too",
+				},
+				{
+					Name: "/starlark/test_error.Errorf",
+					Args: "testdata/failing_test.star:3:13: this is also an error",
+				},
+				{
+					Name: "/starlark/test_fatal.Logf",
+					Args: "testdata/failing_test.star:6:10: start",
+				},
+				{
+					Name: "/starlark/test_fatal.Fatal",
+					Args: "testdata/failing_test.star:7:12: this has failedseverely",
+				},
+				{
+					Name: "/starlark/test_unexpected_kwargs.Errorf",
+					Args: "testdata/failing_test.star:12:13: unexpected kwargs in Errorf",
+				},
+				{
+					Name: "/starlark/test_bad_calls.Logf",
+					Args: "testdata/failing_test.star:28:10: ",
+				},
+				{
+					Name: "/starlark/test_bad_calls.Error",
+					Args: "testdata/failing_test.star:29:12: empty call",
+				},
+				{
+					Name: "/starlark/test_bad_calls.Log",
+					Args: "testdata/failing_test.star:30:11: empty call",
+				},
+				{
+					Name: "/starlark/test_bad_calls.Errorf",
+					Args: "testdata/failing_test.star:31:13: invalid format string: %!(EXTRA int64=42, int64=43)",
+				},
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("test log (-want +got):\n%s", diff)
+		}
+	}
+}
+
+func TestRunEmptyTest(t *testing.T) {
+	var ourT T
+	var got *fakeTestingT
+	if *runFailingTests {
+		ourT = &testingTWrapper{T: t}
+	} else {
+		got = &fakeTestingT{T: t}
+		ourT = got
+	}
+	ctx := pctx.TestContext(t)
+	runTest(ctx, ourT, "testdata/empty_test.star", ourstar.Options{})
+
+	if !*runFailingTests {
+		got.T = nil
+		want := &fakeTestingT{
+			Ops: []*op{
+				{
+					Name: "/starlark.Logf",
+					Args: "testdata/empty_test.star:1:6: This is an empty test!",
+				},
+				{
+					Name: "/starlark.Fatal",
+					Args: "no tests to run",
+				},
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("test log (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/src/internal/starlark/startest/testdata/empty_test.star
+++ b/src/internal/starlark/startest/testdata/empty_test.star
@@ -1,0 +1,1 @@
+print("This is an empty test!")

--- a/src/internal/starlark/startest/testdata/failing_test.star
+++ b/src/internal/starlark/startest/testdata/failing_test.star
@@ -1,0 +1,31 @@
+def test_error(t):
+    t.Error("this is an error", "this too")
+    t.Errorf("%v", "this is also an error")
+
+def test_fatal(t):
+    print("start")
+    t.Fatal("this has failed", "severely")
+    t.Error("you should not see this")
+    print("you should also not see this")
+
+def test_unexpected_kwargs(t):
+    t.Errorf(message = "foo")
+
+def test_invalid_parameters():
+    pass
+
+def test_extra_parameters(foo, bar, baz = "quux"):
+    pass
+
+test_variable = "this is not a test"
+
+def this_is_not_a_test(t):
+    t.Fatal("this should not have run")
+
+print("this is logged at the top level")
+
+def test_bad_calls(t):
+    print()
+    t.Error()
+    t.Logf()
+    t.Errorf(42, 43)

--- a/src/internal/starlark/startest/testdata/good_test.star
+++ b/src/internal/starlark/startest/testdata/good_test.star
@@ -1,0 +1,5 @@
+def test_two_plus_two(t):
+    got, want = 2 + 2, 4
+    print("got, want = %d, %d" % (got, want))
+    if got != want:
+        t.Errorf("2 + 2 is not equal to 4:\n  got: %v\n want: %v", got, want)

--- a/src/internal/starlark/testdata/a.star
+++ b/src/internal/starlark/testdata/a.star
@@ -1,0 +1,4 @@
+load("test", orig = "test_ok")
+
+def test_ok():
+    orig()

--- a/src/internal/starlark/testdata/b.star
+++ b/src/internal/starlark/testdata/b.star
@@ -1,0 +1,3 @@
+load("cycle.star", "test_fail")
+
+test_fail()  # Never reached

--- a/src/internal/starlark/testdata/completion.star
+++ b/src/internal/starlark/testdata/completion.star
@@ -1,0 +1,8 @@
+somefoo = "foo"
+some123 = 123
+some_dict = {}
+
+def exciting_function(*args):
+    pass
+
+nested = [dict()]

--- a/src/internal/starlark/testdata/cycle.star
+++ b/src/internal/starlark/testdata/cycle.star
@@ -1,0 +1,3 @@
+load("b.star", "test_fail")
+
+test_fail()  # Never reached.

--- a/src/internal/starlark/testdata/good.star
+++ b/src/internal/starlark/testdata/good.star
@@ -1,0 +1,3 @@
+load("a.star", "test_ok")
+
+test_ok()

--- a/src/internal/starlark/testdata/nested/good.star
+++ b/src/internal/starlark/testdata/nested/good.star
@@ -1,0 +1,3 @@
+load("../a.star", "test_ok")
+
+test_ok()

--- a/src/internal/starlark/tests/reflect_test.star
+++ b/src/internal/starlark/tests/reflect_test.star
@@ -1,0 +1,69 @@
+def test_struct(t):
+    if struct.Field != "simple":
+        t.Errorf("struct.Field: got %v, want %v", struct.Field, "simple")
+    if struct["Field"] != "simple":
+        t.Errorf("struct.Field: got %v, want %v", struct["Field"], "simple")
+    if struct_ptr != struct.Me:
+        t.Errorf("struct.Me: got %v, want %v", struct.Me, struct_ptr)
+    if type(struct) != "starlark_test.SimpleStruct":
+        t.Errorf("type(struct): got %v, want %v", type(struct), "starlark_test.SimpleStruct")
+
+    want_fields = ["Field", "Me"]
+    if dir(struct) != want_fields:
+        t.Errorf("dir(struct): got %v, want %v", dir(struct), want_fields)
+
+def test_struct_pointer(t):
+    if struct_ptr.Field != "simple":
+        t.Errorf("struct_ptr.Field: got %v, want %v", struct_ptr.Field, "simple")
+    if struct_ptr["Field"] != "simple":
+        t.Errorf("struct_ptr.Field: got %v, want %v", struct_ptr["Field"], "simple")
+    if struct_ptr != struct_ptr.Me:
+        t.Errorf("struct_ptr.Me: got %v, want %v", struct_ptr.Me, struct_ptr)
+    if str(struct_ptr) != "simple struct":
+        t.Errorf("str(struct_ptr): got %v, want %v", string(struct_ptr), "simple struct")
+    if type(struct_ptr) != "*starlark_test.SimpleStruct":
+        t.Errorf("type(struct_ptr): got %v, want %v", type(struct_ptr), "*starlark_test.SimpleStruct")
+
+    want_fields = ["Field", "Me"]
+    if dir(struct_ptr) != want_fields:
+        t.Errorf("dir(struct_ptr): got %v, want %v", dir(struct_ptr), want_fields)
+
+def test_basic_types(t):
+    gotdata = {
+        "string": string,
+        "bool": bool,
+        "bytes": byte,
+        "int": int,
+        "float": float,
+        "stringlist": stringlist,
+        "array": array,
+        "int8": int8,
+        "uint8": uint8,
+    }
+    wantdata = {
+        "string": "string",
+        "bool": True,
+        "bytes": bytes("bytes"),
+        "int": 42,
+        "float": 123.45,
+        "stringlist": ["string", "string"],
+        "array": [0, 0, 0, 0, 0, 5, 0, 0, 0, 0],
+        "int8": -128,
+        "uint8": 255,
+    }
+    for k, want in wantdata.items():
+        got = gotdata[k]
+        if got != want:
+            t.Errorf("item %v:\n  got: %v\n want: %v", k, got, want)
+
+    wantdata = {"one": 1, "two": 2}
+    for k, want in wantdata.items():
+        got = map[k]
+        if got != want:
+            t.Errorf("item %v:\n  got: %v\n want: %v", k, got, want)
+
+def test_wrapped_nil(t):
+    print(str(wrappednil))
+
+def test_putting_structs_into_a_map(t):
+    x = {struct: 42, struct_ptr: 43}

--- a/src/internal/starlark/util.go
+++ b/src/internal/starlark/util.go
@@ -1,0 +1,13 @@
+package starlark
+
+import "go.starlark.net/starlark"
+
+func Union(dicts ...starlark.StringDict) starlark.StringDict {
+	result := make(starlark.StringDict)
+	for _, d := range dicts {
+		for k, v := range d {
+			result[k] = v
+		}
+	}
+	return result
+}


### PR DESCRIPTION
To run Starlark during debug dumps, we need some tools.  This adds `src/cmd/starpach` which lets developers use a REPL and CLI to develop the scripts.  (It's in `src/cmd` instead of `src/server/cmd` because Bob asked me to not put it in `src/server` 😂.)  Right now this is fairly useless, but it will be useful in the next PR.  I guess you can open up the shell and type `json.encode({"now": time.now().format("2006-01-02T15:04:05Z07:00")})` or something.  That's fun.  It also supports taking CPU profiles of both Go and Starlark code, verbose logging, etc.  Everything we'll need when we start adding stuff.

The `internal/starlark` package adds some utility functions for future Starlark work; reflection to expose Go values to Starlark (and get them back), the REPL to actually make the shell possible to use (tab completion!!), `internal/starlark/starcmp` for tests that want to `cmp.Diff` Starlark values, `internal/starlark/startest` for unit testing your Starlark scripts, a module loader, a way to pass Go contexts to Starlark functions, etc.

The `internal/log` package adds a new CLI logger, which is less verbose than pachctl, but logs everything at level debug to a file (in $XDG_STATE_HOME, which is where the XDG spec says logs should go).  If the command you ran succeeds, the logfile is deleted.  If it errors, then we keep the log file and print the name at the very end.  This should make the tool quite possible to debug.

The next PR will allow the debug server to run Starlark and send the results back, and some pachctl changes to run these Starlark scripts locally.  After that, will be a Starlark k8s library that supports running both server-side and client-side.