### PR TITLE
[CORE-1978] Remove cluster.local domain

### DIFF
--- a/etc/helm/pachyderm/templates/_helpers.tpl
+++ b/etc/helm/pachyderm/templates/_helpers.tpl
@@ -121,7 +121,7 @@ http://localhost:30657/authorization-code/callback
 {{- end }}
 
 {{- define "pachyderm.pachdPeerAddress" -}}
-pachd-peer.{{ .Release.Namespace }}.svc.cluster.local:30653
+pachd-peer.{{ .Release.Namespace }}.svc:30653
 {{- end }}
 
 {{- define "pachyderm.localhostIssuer" -}}

--- a/etc/helm/pachyderm/templates/etcd/statefulset.yaml
+++ b/etc/helm/pachyderm/templates/etcd/statefulset.yaml
@@ -46,8 +46,8 @@ spec:
         - '"/usr/local/bin/etcd" "--listen-client-urls=http://0.0.0.0:2379" "--advertise-client-urls=http://0.0.0.0:2379"
           "--data-dir=/var/data/etcd" "--auto-compaction-retention=1" "--max-txn-ops={{ .Values.etcd.maxTxnOps }}"
           "--max-request-bytes=52428800" "--quota-backend-bytes=8589934592" "--listen-peer-urls=http://0.0.0.0:2380"
-          "--initial-cluster-token=pach-cluster" "--initial-advertise-peer-urls=http://${ETCD_NAME}.etcd-headless.${NAMESPACE}.svc.cluster.local:2380"
-          "--initial-cluster={{ range $i, $e := until (.Values.etcd.dynamicNodes | int) }}etcd-{{$e}}=http://etcd-{{$e}}.etcd-headless.${NAMESPACE}.svc.cluster.local:2380,{{ end }}"'
+          "--initial-cluster-token=pach-cluster" "--initial-advertise-peer-urls=http://${ETCD_NAME}.etcd-headless.${NAMESPACE}.svc:2380"
+          "--initial-cluster={{ range $i, $e := until (.Values.etcd.dynamicNodes | int) }}etcd-{{$e}}=http://etcd-{{$e}}.etcd-headless.${NAMESPACE}.svc:2380,{{ end }}"'
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
allows on-cluster dns to resolve to a particular `svc` endpoint without using cluster.local