### PR TITLE
[CORE-1972] refresh autoscaling goroutines when pipelines update (#9330)

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -3092,22 +3092,27 @@ func TestUpdatePipelineWithInProgressCommitsAndStats(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	t.Parallel()
+
 	c, _ := minikubetestenv.AcquireCluster(t)
 	dataRepo := tu.UniqueString("TestUpdatePipelineWithInProgressCommitsAndStats_data")
+	c = tu.AuthenticatedPachClient(t, c, "pachtest")
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, dataRepo))
-
 	pipeline := tu.UniqueString("pipeline")
 	createPipeline := func() {
 		_, err := c.PpsAPIClient.CreatePipeline(
-			context.Background(),
+			c.Ctx(),
 			&pps.CreatePipelineRequest{
 				Pipeline: client.NewPipeline(pfs.DefaultProjectName, pipeline),
 				Transform: &pps.Transform{
 					Cmd:   []string{"bash"},
 					Stdin: []string{"sleep 1"},
 				},
-				Input:  client.NewPFSInput(pfs.DefaultProjectName, dataRepo, "/*"),
-				Update: true,
+				ParallelismSpec: &pps.ParallelismSpec{
+					Constant: 1,
+				},
+				Autoscaling: true, // Autoscale for CORE-1972
+				Input:       client.NewPFSInput(pfs.DefaultProjectName, dataRepo, "/*"),
+				Update:      true,
 			})
 		require.NoError(t, err)
 	}
@@ -3126,14 +3131,24 @@ func TestUpdatePipelineWithInProgressCommitsAndStats(t *testing.T) {
 	flushJob(1)
 
 	// Create multiple new commits.
-	numCommits := 5
+	numCommits := 15
 	for i := 1; i < numCommits; i++ {
 		commit, err := c.StartCommit(pfs.DefaultProjectName, dataRepo, "master")
 		require.NoError(t, err)
 		require.NoError(t, c.PutFile(commit, "file"+strconv.Itoa(i), strings.NewReader("foo"), client.WithAppendPutFile()))
 		require.NoError(t, c.FinishCommit(pfs.DefaultProjectName, dataRepo, commit.Branch.Name, commit.Id))
 	}
-
+	// wait for jobs to start before updating
+	require.NoError(t, backoff.Retry(func() error {
+		pipelineInfo, err := c.InspectPipeline(pfs.DefaultProjectName, pipeline, false)
+		if err != nil {
+			return err
+		}
+		if pipelineInfo.State != pps.PipelineState_PIPELINE_RUNNING {
+			return errors.Errorf("pipeline waiting to run, state: %s", pipelineInfo.State.String())
+		}
+		return nil
+	}, backoff.NewConstantBackOff(time.Millisecond*200)))
 	// Force the in progress commits to be finished.
 	createPipeline()
 	// Create a new job that should succeed (should not get blocked on an unfinished stats commit).

--- a/src/server/pps/server/pipeline_controller_test.go
+++ b/src/server/pps/server/pipeline_controller_test.go
@@ -498,8 +498,8 @@ func TestEvaluate(t *testing.T) {
 		pi.State = startState
 		actualState, actualSideEffects, _, err := evaluate(pi, rc)
 		require.NoError(t, err)
-		require.Equal(t, expectedState, actualState)
-		require.Equal(t, len(expectedSideEffects), len(actualSideEffects))
+		require.Equal(t, expectedState, actualState, "for start state %v, expected state was %v but got %v", startState, expectedState, actualState)
+		require.Equal(t, len(expectedSideEffects), len(actualSideEffects), "for start state %v, expected side effects are %v but got %v", startState, expectedSideEffects, actualSideEffects)
 		for i := 0; i < len(expectedSideEffects); i++ {
 			require.True(t, expectedSideEffects[i].equals(actualSideEffects[i]))
 		}
@@ -534,6 +534,7 @@ func TestEvaluate(t *testing.T) {
 			state: pps.PipelineState_PIPELINE_RUNNING,
 			sideEffects: []sideEffect{
 				CrashingMonitorSideEffect(sideEffectToggle_DOWN),
+				PipelineMonitorSideEffect(sideEffectToggle_DOWN),
 			},
 		},
 		pps.PipelineState_PIPELINE_FAILURE: {
@@ -638,6 +639,7 @@ func TestEvaluate(t *testing.T) {
 			sideEffects: []sideEffect{
 				ResourcesSideEffect(sideEffectToggle_UP),
 				CrashingMonitorSideEffect(sideEffectToggle_DOWN),
+				PipelineMonitorSideEffect(sideEffectToggle_DOWN),
 			},
 		},
 		pps.PipelineState_PIPELINE_PAUSED: {


### PR DESCRIPTION
This PR updates a test to show a customer issue. It adds auth and autoscaling to the test and waits for the pipeline to run before updating.

The core issue is that the goroutines used to monitor autoscaling are not restarted with the latest pipeline info / auth creds when the pipeline is updated. This PR fixes that.

---------