### PR TITLE
Update jupyter_server version to 2.7.0 to match Determined AI

### DIFF
--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 packages = find:
 install_requires =
   pyyaml>=6.0
-  jupyter_server>=1.6,<2
+  jupyter_server==2.7.0
   python-pachyderm>=v7.4.0,<8
 include_package_data = True
 zip_safe = False
@@ -34,4 +34,5 @@ dev=
   pytest
   pytest-asyncio
   pytest-tornasync
+  pytest-jupyter
   python-pachyderm>=v7.4.0,<8


### PR DESCRIPTION
Determined's task environments have jupyter_server==2.7.0, but jupyterlab-pachyderm is locked to  jupyter_server>=1.6,<2 which prevents it from being installed into a Determined task environment. Change the locked version to jupyter_server==2.7.0 to match Determined as of 0.24.0.   jupyter_server recommends that the version be pinned
to avoid plug-in breakage.