### PR TITLE
handle race between delete repo and set commit

### DIFF
--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -228,10 +228,8 @@ func setTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.I
 	if err := tr.CreateTx(tx, oid, pointsTo, track.NoTTL); err != nil {
 		return errors.EnsureStack(err)
 	}
-	if exists, err := getRepoExists(tx, commit); err != nil {
+	if err := checkRepo(tx, commit); err != nil {
 		return errors.EnsureStack(err)
-	} else if !exists {
-		return nil // repo has been removed - do not update commit totals
 	}
 	_, err := tx.Exec(`INSERT INTO pfs.commit_totals (commit_id, fileset_id)
 	VALUES ($1, $2)
@@ -248,10 +246,8 @@ func setDiff(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.ID
 	if err := tr.CreateTx(tx, oid, pointsTo, track.NoTTL); err != nil {
 		return errors.EnsureStack(err)
 	}
-	if exists, err := getRepoExists(tx, commit); err != nil {
+	if err := checkRepo(tx, commit); err != nil {
 		return errors.EnsureStack(err)
-	} else if !exists {
-		return nil
 	}
 	_, err := tx.Exec(`INSERT INTO pfs.commit_diffs (commit_id, fileset_id)
 	VALUES ($1, $2)
@@ -259,21 +255,16 @@ func setDiff(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.ID
 	return errors.EnsureStack(err)
 }
 
-func getRepoExists(tx *pachsql.Tx, commit *pfs.Commit) (bool, error) {
+func checkRepo(tx *pachsql.Tx, commit *pfs.Commit) error {
 	var name *string = new(string)
-	if err := tx.QueryRow(`SELECT name FROM pfs.repos AS r
+	err := tx.QueryRow(`SELECT name FROM pfs.repos AS r
 		WHERE r.project_id=(SELECT id FROM core.projects WHERE name=$1) AND r.name=$2 AND r.type =$3
 		FETCH FIRST 1 ROWS ONLY`,
 		commit.GetRepo().GetProject().GetName(),
 		commit.GetRepo().GetName(),
 		commit.GetRepo().GetType(),
-	).Scan(name); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return false, nil
-		}
-		return false, errors.EnsureStack(err)
-	}
-	return true, nil
+	).Scan(name)
+	return errors.EnsureStack(err)
 }
 
 func commitDiffTrackerID(commit *pfs.Commit, fs fileset.ID) string {

--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -229,9 +229,6 @@ func setTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.I
 		return errors.EnsureStack(err)
 	}
 	if err := checkCommitDB(tx, commit); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return errors.EnsureStack(err)
-		}
 		return errors.EnsureStack(err)
 	}
 	_, err := tx.Exec(`INSERT INTO pfs.commit_totals (commit_id, fileset_id)
@@ -250,9 +247,6 @@ func setDiff(tx *pachsql.Tx, tr track.Tracker, commit *pfs.Commit, id fileset.ID
 		return errors.EnsureStack(err)
 	}
 	if err := checkCommitDB(tx, commit); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return errors.EnsureStack(err)
-		}
 		return errors.EnsureStack(err)
 	}
 	_, err := tx.Exec(`INSERT INTO pfs.commit_diffs (commit_id, fileset_id)

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -2012,6 +2012,11 @@ func (d *driver) makeEmptyCommit(ctx context.Context, txnCtx *txncontext.Transac
 		commitInfo.Finishing = txnCtx.Timestamp
 		commitInfo.Finished = txnCtx.Timestamp
 		commitInfo.Details = &pfs.CommitInfo_Details{}
+	}
+	if err := d.addCommit(ctx, txnCtx, commitInfo, parent, directProvenance, false /* needsFinishedParent */); err != nil {
+		return nil, err
+	}
+	if closed {
 		total, err := d.storage.Filesets.ComposeTx(txnCtx.SqlTx, nil, defaultTTL)
 		if err != nil {
 			return nil, err
@@ -2019,9 +2024,6 @@ func (d *driver) makeEmptyCommit(ctx context.Context, txnCtx *txncontext.Transac
 		if err := d.commitStore.SetTotalFileSetTx(txnCtx.SqlTx, commit, *total); err != nil {
 			return nil, errors.EnsureStack(err)
 		}
-	}
-	if err := d.addCommit(ctx, txnCtx, commitInfo, parent, directProvenance, false /* needsFinishedParent */); err != nil {
-		return nil, err
 	}
 	return commit, nil
 }


### PR DESCRIPTION
This change should fix the TestSpoutPachctl fix. The full [design is here](https://www.notion.so/2023-09-01-TestSpoutPachctl-Flake-mini-design-0bfa96b7a8e445889c18722d9c719c34). This fix corresponds to option 3 in the design: verify the repo exists before updating commit totals and diffs.

This should resolve the bug with normal pipeline deletion as well as delete all, but it does not settle on a solution to Option 6.(That is upcoming in a deep dive - to be scheduled)

I've been thinking about where to put this check, and I think this location makes sense, but I'm definitely open to other ideas here. It could go higher up so we only check once for both setDiff and setTotal, but that does open up the possibility of the repo being removed between the two sets.
