### PR TITLE
Adds redirect_uri to allow for login via det cli

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/identity-config.yaml
+++ b/etc/helm/pachyderm/templates/pachd/identity-config.yaml
@@ -35,6 +35,7 @@ data:
       name: {{ default "determined" .Values.determined.oidc.clientId }}
       redirect_uris:
       - {{ required "A valid recipient url is required!" (printf "%s/oidc/callback" .Values.determined.oidc.idpRecipientUrl) }}
+      - {{ required "A valid recipient url is required!" (printf "%s/oidc/callback?relayState=cli" .Values.determined.oidc.idpRecipientUrl) | quote }}
     {{- end }}
   trusted-peers: |
 {{ toYaml .Values.pachd.additionalTrustedPeers | indent 4 }}

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -451,6 +451,14 @@
                 "customCaCerts": {
                     "type": "boolean"
                 },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "imagePullSecrets": {
                     "type": "array"
                 },


### PR DESCRIPTION
- To be able to log into the determined cli when using unified authentication the determined client needs to have two `redirect_uris` one for the UI and one for the cli
- Also updated the values schema to include the image registry change