### PR TITLE
Add support for branch triggers in pfsdb

### DIFF
--- a/src/internal/clusterstate/v2.8.0/pfsdb.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/jmoiron/sqlx"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
-	"google.golang.org/protobuf/proto"
 	"strings"
 	"time"
+
+	"github.com/jmoiron/sqlx"
+	"google.golang.org/protobuf/proto"
 
 	v2_7_0 "github.com/pachyderm/pachyderm/v2/src/internal/clusterstate/v2.7.0"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
@@ -532,15 +533,15 @@ func migrateBranches(ctx context.Context, env migrations.Env) error {
 	}
 	if _, err := tx.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS pfs.branch_triggers (
-			from_branch_id bigint REFERENCES pfs.branches(id) NOT NULL,
+			from_branch_id bigint REFERENCES pfs.branches(id) PRIMARY KEY,
 			to_branch_id bigint REFERENCES pfs.branches(id) NOT NULL,
 			cron_spec text,
 			rate_limit_spec text,
 			size text,
 			num_commits bigint,
-			all_conditions bool,
-			PRIMARY KEY (from_branch_id, to_branch_id)
+			all_conditions bool
 		);
+		CREATE INDEX ON pfs.branch_triggers (to_branch_id);
 	`); err != nil {
 		return errors.Wrap(err, "creating branch triggers table")
 	}

--- a/src/internal/pfsdb/branches.go
+++ b/src/internal/pfsdb/branches.go
@@ -410,7 +410,8 @@ func UpsertBranchTrigger(ctx context.Context, tx *pachsql.Tx, from BranchID, to 
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO pfs.branch_triggers(from_branch_id, to_branch_id, cron_spec, rate_limit_spec, size, num_commits, all_conditions)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		ON CONFLICT (from_branch_id, to_branch_id) DO UPDATE SET
+		ON CONFLICT (from_branch_id) DO UPDATE SET
+			to_branch_id = EXCLUDED.to_branch_id,
 			cron_spec = EXCLUDED.cron_spec,
 			rate_limit_spec = EXCLUDED.rate_limit_spec,
 			size = EXCLUDED.size,

--- a/src/internal/pfsdb/branches.go
+++ b/src/internal/pfsdb/branches.go
@@ -387,6 +387,7 @@ func GetBranchTrigger(ctx context.Context, tx *pachsql.Tx, from BranchID) (*pfs.
 		WHERE trigger.from_branch_id = $1
 	`, from).Scan(&branchName, &cronSpec, &rateLimitSpec, &size, &numCommits, &all); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			// Branches don't need to have triggers
 			return nil, nil
 		}
 		return nil, errors.Wrap(err, "could not get branch trigger")

--- a/src/internal/pfsdb/branches_test.go
+++ b/src/internal/pfsdb/branches_test.go
@@ -316,11 +316,11 @@ func TestBranchDelete(t *testing.T) {
 func TestBranchTrigger(t *testing.T) {
 	t.Parallel()
 	withDB(t, func(ctx context.Context, t *testing.T, db *pachsql.DB) {
-		repoInfo := newRepoInfo(&pfs.Project{Name: "project1"}, "repo1", pfs.UserRepoType)
 		var masterBranchID, stagingBranchID pfsdb.BranchID
-		// Create two branches
+		// Create two branches, master and staging in the same repo.
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 			var err error
+			repoInfo := newRepoInfo(&pfs.Project{Name: "project1"}, "repo1", pfs.UserRepoType)
 			commit1 := createCommitPair(t, ctx, tx, newCommitInfo(repoInfo.Repo, random.String(32), nil)).CommitInfo.Commit
 			masterBranchInfo := &pfs.BranchInfo{Branch: &pfs.Branch{Repo: repoInfo.Repo, Name: "master"}, Head: commit1}
 			masterBranchID, err = pfsdb.UpsertBranch(ctx, tx, masterBranchInfo)
@@ -330,12 +330,11 @@ func TestBranchTrigger(t *testing.T) {
 			stagingBranchID, err = pfsdb.UpsertBranch(ctx, tx, stagingBranchInfo)
 			require.NoError(t, err)
 		})
-		// Create the branch trigger that re-points master to staging
+		// Create the branch trigger that re-points master to staging.
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
-			// Create a second branch staging, and add a trigger to the main branch to re-point to this branch.
 			trigger := &pfs.Trigger{
 				Branch:        "staging",
-				CronSpec:      "* * * * *", // Every minute
+				CronSpec:      "* * * * *",
 				RateLimitSpec: "",
 				Size:          "100M",
 				Commits:       10,

--- a/src/internal/pfsdb/model.go
+++ b/src/internal/pfsdb/model.go
@@ -127,3 +127,24 @@ func (branch *Branch) Pb() *pfs.Branch {
 		Repo: branch.Repo.Pb(),
 	}
 }
+
+type BranchTrigger struct {
+	FromBranch    Branch `db:"from_branch"`
+	ToBranch      Branch `db:"to_branch"`
+	CronSpec      string `db:"cron_spec"`
+	RateLimitSpec string `db:"rate_limit_spec"`
+	Size          string `db:"size"`
+	NumCommits    int64  `db:"num_commits"`
+	AllConditions bool   `db:"all_conditions"`
+}
+
+func (trigger *BranchTrigger) Pb() *pfs.Trigger {
+	return &pfs.Trigger{
+		Branch:        trigger.ToBranch.Name,
+		CronSpec:      trigger.CronSpec,
+		RateLimitSpec: trigger.RateLimitSpec,
+		Size:          trigger.Size,
+		Commits:       trigger.NumCommits,
+		All:           trigger.AllConditions,
+	}
+}


### PR DESCRIPTION
Changed the schema of branch triggers to be unique on the "from branch" because a branch can only have one other branch to re-point to at a given time.
Also added cascade deletes in `DeleteBranch`.