### PR TITLE
Dynamic k8s API for starlark scripts

### DIFF
--- a/src/internal/pachd/env.go
+++ b/src/internal/pachd/env.go
@@ -156,13 +156,14 @@ func PPSEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, reporter 
 
 func DebugEnv(env serviceenv.ServiceEnv) debug_server.Env {
 	return debug_server.Env{
-		Config:        *env.Config(),
-		Name:          env.Config().PachdPodName,
-		DB:            env.GetDBClient(),
-		SidecarClient: nil,
-		GetKubeClient: env.GetKubeClient,
-		GetLokiClient: env.GetLokiClient,
-		GetPachClient: env.GetPachClient,
-		TaskService:   env.GetTaskService(env.Config().EtcdPrefix),
+		Config:               *env.Config(),
+		Name:                 env.Config().PachdPodName,
+		DB:                   env.GetDBClient(),
+		SidecarClient:        nil,
+		GetKubeClient:        env.GetKubeClient,
+		GetDynamicKubeClient: env.GetDynamicKubeClient,
+		GetLokiClient:        env.GetLokiClient,
+		GetPachClient:        env.GetPachClient,
+		TaskService:          env.GetTaskService(env.Config().EtcdPrefix),
 	}
 }

--- a/src/internal/serviceenv/testing.go
+++ b/src/internal/serviceenv/testing.go
@@ -19,6 +19,7 @@ import (
 	loki "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
 	etcd "go.etcd.io/etcd/client/v3"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/dynamic"
 	kube "k8s.io/client-go/kubernetes"
 )
 
@@ -29,6 +30,7 @@ type TestServiceEnv struct {
 	PachClient               *client.APIClient
 	EtcdClient               *etcd.Client
 	KubeClient               kube.Interface
+	DynamicKubeClient        dynamic.Interface
 	LokiClient               *loki.Client
 	DBClient, DirectDBClient *pachsql.DB
 	PostgresListener         col.PostgresListener
@@ -72,6 +74,9 @@ func (s *TestServiceEnv) GetTaskService(prefix string) task.Service {
 }
 func (s *TestServiceEnv) GetKubeClient() kube.Interface {
 	return s.KubeClient
+}
+func (s *TestServiceEnv) GetDynamicKubeClient() dynamic.Interface {
+	return s.DynamicKubeClient
 }
 func (s *TestServiceEnv) GetLokiClient() (*loki.Client, error) {
 	return s.LokiClient, nil
@@ -171,6 +176,11 @@ func (env *TestServiceEnv) SetEnterpriseServer(s enterprise_server.APIServer) {
 // SetKubeClient can be used to override the kubeclient in testing.
 func (env *TestServiceEnv) SetKubeClient(s kube.Interface) {
 	env.KubeClient = s
+}
+
+// SetDynamicKubeClient can be used to override the dynamic kubeclient in testing.
+func (env *TestServiceEnv) SetDynamicKubeClient(s dynamic.Interface) {
+	env.DynamicKubeClient = s
 }
 
 // InitDexDB implements the ServiceEnv interface.

--- a/src/internal/starlark/lib/k8s/doc.star
+++ b/src/internal/starlark/lib/k8s/doc.star
@@ -1,0 +1,99 @@
+"""
+The k8s module allows access to the Kubernetes API.
+
+In personalities where Kubernetes is available, a k8s object will be available to code.  The k8s
+object contains an attribute for each resource discovered on the server, like "pods", "services",
+etc.  Each of these attributes contains a client for accessing that resource.  No access outside the
+configured namespace is available, except for namespace-less resources (like "nodes").
+
+The k8s module is built by talking to the server to see what resources it has.  You must test for
+existence of a resource before using it:
+
+    if "pods" in dir(k8s):
+        k8s.pods.list()
+
+"""
+
+def Unstructured():
+    """Unstructured is a Kubernetes object without compile-time Go type information.
+
+    Unstructured is not a function; this is a placeholder for documentation.
+
+    An Unstructured object is logically a dict; use like:
+    k8s.pods.get("some-pod")["metadata"]["name"] to get the name of a pod.
+
+    k8s.pods.get("some-pod") is an Unstructured, but k8s.pods.get("some-pod")["metadata"] is
+    an ordinary dict.
+
+    type(Unstructured) is the runtime type of the object, like /v1/Pod.
+    str(Unstructured) is the Go representation of the object, not the JSON representation of the object.
+    json.encode(Unstructured) formats the JSON as kubectl would.
+    A non-error Unstructured object is non-False (if pod.get("foo") is true, you have the pod.)
+
+    If writing were implemented, this would work:
+        pachd = k8s.deployments.get("pachd")
+        pachd["replias"] = 42
+        k8s.deployments.put(pachd)
+    """
+
+def resource(object: str | dict) -> Unstructured:
+    """Resource returns a runtime object based on the provided JSON or dictionary.
+
+    This is mostly intended for testing, to create literals to cmp.diff() against.
+
+    Args:
+        object: A Kubernetes object, as JSON or a dict.
+    Returns:
+        An Unstructured object.
+    """
+
+def logs(podName: str, container: str, previous: bool = False) -> bytes:
+    """Logs returns up to 10MB of logs for the named container.
+
+    Logs may return an error message instead of the actual logs, like get and list below.
+
+    Args:
+        container: The container to return logs from.  We don't attempt to guess the container
+            because customer installs may have sidecars, so we can't assume that there is only
+            one container and that randomly selecting one of the Pod's containers will be useful.
+            Get the pod first and iterate over its containers.
+        previous: If true, return logs from the previous instance of the container.
+
+    Returns:
+        A bytestring containing the logs.
+    """
+
+def get(name: str, resourceVersion: None | str = None) -> Unstructured:
+    """Get returns the named resource at the provided version.
+
+    Get can return an error instead of an object; the error has the same API as the Unstructured
+    object, but returns itself for every operation.  The error value is treated specially during
+    JSON marshaling or debug dumping.  For example, k8s.pods.get("foo")["metadata"]["name"] will
+    work whether "foo" is found or not, but if you json.encode(that thing), it will encode as
+    `{"error": "pod foo not found"}` instead of an actual pod.
+
+    Args:
+        name: The name of the resource.
+        resourceVersion: The resource version to fetch.
+
+    Returns:
+        An Unstructured object.
+    """
+
+def list(labels: None | dict | str = None, fields: None | dict | str = None) -> Iterable[Unstructured]:
+    """List returns an Iterable of all resrouces of the client type.
+
+    The returned collection may be an error, as with get() above.  An error has the same API as a
+    non-error, but again with special treatment during marshaling or debug dumping.
+
+    Args:
+        labels: A label selector specifying which objects to match.  Strings are parsed as `kubectl -l`,
+            while dicts are parsed as the Go client would treat a labels.Selector{} object.
+            `{"suite": "pachyderm"}` (dict) equals `-l suite=pachyderm`.
+        fields: A field selector specifying which objects to match.  The syntax is the same as a label
+            selector.
+
+    Returns:
+        A collection of Unstructured objects.  The collection is indexable by name (result["some-pod"])
+        and is iterable (`for pod in k8s.pods.list()`).
+    """

--- a/src/internal/starlark/lib/k8s/k8s.go
+++ b/src/internal/starlark/lib/k8s/k8s.go
@@ -2,8 +2,8 @@
 package k8s
 
 import (
+	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -12,12 +12,262 @@ import (
 	"github.com/zeebo/xxh3"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
+	"go.starlark.net/syntax"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
+// resource is a starlark.Value wrapper around unstructured.Unstructured.  It is used over
+// ourstar.Value(Unstructured) to preserve MarshalJSON when calling json.encode(obj) from Starlark.
+type resource struct {
+	*unstructured.Unstructured
+}
+
+var _ json.Marshaler = (*resource)(nil)
+var _ ourstar.ToGoer = (*resourceList)(nil)
+var _ starlark.Value = (*resource)(nil)
+var _ starlark.Mapping = (*resource)(nil)
+var _ starlark.Unpacker = (*resource)(nil)
+
+func (r *resource) MarshalJSON() ([]byte, error) {
+	if r.Unstructured == nil {
+		return nil, nil
+	}
+	return r.Unstructured.MarshalJSON()
+}
+func (r *resource) ToGo() any {
+	return r.Unstructured
+}
+func (r *resource) String() string {
+	result, err := r.MarshalJSON()
+	if err != nil {
+		return fmt.Sprintf("%#v", r.Unstructured)
+	}
+	return string(result)
+}
+func (r *resource) Type() string {
+	return "<" + r.Unstructured.GetObjectKind().GroupVersionKind().String() + ">"
+}
+func (r *resource) Freeze() {}
+func (r *resource) Truth() starlark.Bool {
+	return r.Unstructured != nil && len(r.Unstructured.Object) > 0
+}
+func (r *resource) Hash() (uint32, error) { return 0, errors.New("unhashable") }
+func (r *resource) Get(x starlark.Value) (starlark.Value, bool, error) {
+	k, ok := starlark.AsString(x)
+	if !ok {
+		return nil, false, errors.Errorf("value %v cannot be used as a string key", x)
+	}
+	if r.Unstructured == nil {
+		return starlark.None, false, nil
+	}
+	v, ok := r.Unstructured.Object[k]
+	if !ok {
+		return starlark.None, false, nil
+	}
+	return ourstar.Value(v), true, nil
+}
+func (r *resource) Unpack(v starlark.Value) error {
+	switch x := v.(type) {
+	case starlark.String:
+		us := unstructured.Unstructured{}
+		return us.UnmarshalJSON([]byte(x))
+	case starlark.Bytes:
+		us := unstructured.Unstructured{}
+		return us.UnmarshalJSON([]byte(x))
+	case *starlark.Dict:
+		obj := make(map[string]any)
+		for _, item := range x.Items() {
+			if len(item) != 2 {
+				return errors.New("invalid tuple in dict item")
+			}
+			k, v := item[0], item[1]
+			key, ok := starlark.AsString(k)
+			if !ok {
+				return errors.Errorf("convert %v to string", key)
+			}
+			obj[key] = ourstar.FromStarlark(v)
+		}
+		r.Unstructured = &unstructured.Unstructured{
+			Object: obj,
+		}
+		return nil
+	}
+	return errors.Errorf("invalid type %#v for resource", v)
+}
+
+// resource is a starlark.Value wrapper around unstructured.UnstructuredList, where the unstructured
+// list is actually a single object.  It is used over
+// starlark.List(ourstar.Value(UnstructuredList.Item[0]), ...) to preserve MarshalJSON when calling
+// json.encode(obj) from Starlark.
+type resourceList struct {
+	*unstructured.UnstructuredList
+}
+
+var _ json.Marshaler = (*resourceList)(nil)
+var _ ourstar.ToGoer = (*resourceList)(nil)
+var _ starlark.Value = (*resourceList)(nil)
+var _ starlark.Mapping = (*resourceList)(nil)
+var _ starlark.Iterable = (*resourceList)(nil)
+
+func (r *resourceList) MarshalJSON() ([]byte, error) {
+	if r == nil || r.UnstructuredList == nil {
+		return nil, nil
+	}
+	return r.UnstructuredList.MarshalJSON()
+}
+func (r *resourceList) ToGo() any {
+	return r.UnstructuredList
+}
+func (r *resourceList) String() string {
+	result, err := r.MarshalJSON()
+	if err != nil {
+		return fmt.Sprintf("%#v", r.UnstructuredList)
+	}
+	return string(result)
+}
+func (r *resourceList) Type() string {
+	return "<" + r.UnstructuredList.GetObjectKind().GroupVersionKind().String() + ">"
+}
+func (r *resourceList) Freeze() {}
+func (r *resourceList) Truth() starlark.Bool {
+	return r.UnstructuredList != nil && len(r.UnstructuredList.Items) > 0
+}
+func (r *resourceList) Hash() (uint32, error) { return 0, errors.New("unhashable") }
+
+// Get treats the list of items as a map from name to value.
+func (r *resourceList) Get(x starlark.Value) (starlark.Value, bool, error) {
+	if r.UnstructuredList == nil {
+		return starlark.None, false, nil
+	}
+	for _, v := range r.UnstructuredList.Items {
+		rawmd, ok := v.Object["metadata"]
+		if !ok {
+			continue
+		}
+		md, ok := rawmd.(map[string]any)
+		if !ok {
+			continue
+		}
+		n, ok := md["name"]
+		if !ok {
+			continue
+		}
+		found, err := starlark.Compare(syntax.EQL, x, ourstar.Value(n))
+		if err != nil {
+			return starlark.None, false, errors.Wrapf(err, "compare %v to %v", x, n)
+		}
+		if !found {
+			continue
+		}
+		return &resource{
+			Unstructured: &unstructured.Unstructured{
+				Object: v.Object,
+			},
+		}, true, nil
+	}
+	return starlark.None, false, nil
+}
+func (r *resourceList) Iterate() starlark.Iterator {
+	var values []starlark.Value
+	if r.UnstructuredList != nil {
+		for _, x := range r.Items {
+			x := x
+			values = append(values, &resource{Unstructured: &x})
+		}
+	}
+	return starlark.NewList(values).Iterate()
+}
+
+// wrappedError is an error pretending to be a k8s object.  Since scripts cannot handle errors, this
+// lets them treat an error like it's an object.  The debug dump machinery, for example, knows how
+// to write an error object, so if you're just doing something like:
+//
+//	pods = k8s.pods.list()
+//	for pod in pods:
+//	    dump(pod["metadata"]["name"]+".json", json.encode(pod))
+//
+// and list returns an error, the script will still complete, but you'll get a file named "error"
+// instead of a JSON file for each pod.
+type wrappedError struct {
+	err error
+}
+
+var _ error = (*wrappedError)(nil)
+var _ json.Marshaler = (*wrappedError)(nil)
+var _ starlark.Value = (*wrappedError)(nil)
+var _ starlark.Mapping = (*wrappedError)(nil)
+var _ starlark.IterableMapping = (*wrappedError)(nil)
+var _ starlark.Iterable = (*wrappedError)(nil)
+
+func (e *wrappedError) Error() string         { return e.err.Error() }
+func (e *wrappedError) String() string        { return fmt.Sprintf("Error: %v", e.err) }
+func (e *wrappedError) Type() string          { return "error" }
+func (e *wrappedError) Freeze()               {}
+func (e *wrappedError) Truth() starlark.Bool  { return false }
+func (e *wrappedError) Hash() (uint32, error) { return uint32(xxh3.HashString(e.err.Error())), nil }
+func (e *wrappedError) Get(x starlark.Value) (starlark.Value, bool, error) {
+	return e, true, nil
+}
+func (e *wrappedError) Iterate() starlark.Iterator { return &emptyIterator{} }
+func (e *wrappedError) Items() []starlark.Tuple    { return nil }
+func (e *wrappedError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{"error": e.Error()})
+}
+
+type emptyIterator struct{}
+
+var _ starlark.Iterator = emptyIterator{}
+
+func (i emptyIterator) Next(p *starlark.Value) bool { return false }
+func (i emptyIterator) Done()                       {}
+
+// selector is a labels.Selector, from a Starlark string or dict.
+type selector struct{ labels.Selector }
+
+func (s *selector) String() string {
+	if s == nil || s.Selector == nil {
+		return ""
+	}
+	return s.Selector.String()
+}
+func (s *selector) Unpack(v starlark.Value) error {
+	switch x := v.(type) {
+	case starlark.String:
+		l, err := labels.Parse(string(x))
+		if err != nil {
+			return errors.Wrap(err, "parse selector as string")
+		}
+		s.Selector = l
+		return nil
+	case *starlark.Dict:
+		set := make(labels.Set)
+		for _, item := range x.Items() {
+			if len(item) != 2 {
+				return errors.New("invalid item tuple in selector dict")
+			}
+			k, ok := starlark.AsString(item[0])
+			if !ok {
+				return errors.Errorf("invalid selector key %v", item[0])
+			}
+			v, ok := starlark.AsString(item[1])
+			if !ok {
+				return errors.Errorf("invalid selector value %v", item[1])
+			}
+			set[k] = v
+		}
+		s.Selector = set.AsSelector()
+		return nil
+	}
+	return errors.Errorf("invalid selector %#v", v)
+}
+
+// resourceClient is a k8s client for a particular resource (or subresource) available to Starlark.
+// Each client has attributes like client.get(name), client.list(), and .<subresource>.
 type resourceClient struct {
 	resource    metav1.APIResource
 	subresource string
@@ -44,10 +294,11 @@ func (c *resourceClient) verbs() []string {
 }
 func (c *resourceClient) String() string {
 	b := new(strings.Builder)
+	b.WriteRune('<')
 	if c.subresource == "" {
-		fmt.Fprintf(b, "<%v_client", c.resource.Name)
+		fmt.Fprintf(b, "%v_client", c.resource.Name)
 	} else {
-		fmt.Fprintf(b, "<%v.%v_client", c.resource.Name, c.subresource)
+		fmt.Fprintf(b, "%v.%v_client", c.resource.Name, c.subresource)
 	}
 	if c.resource.Namespaced {
 		fmt.Fprintf(b, " namespace=%q", c.namespace)
@@ -138,52 +389,26 @@ func (c *resourceClient) makeGet() *starlark.Builtin {
 		if err != nil {
 			return &wrappedError{err: err}, nil
 		}
-		return ourstar.Value(got.Object), nil
+		return &resource{Unstructured: got}, nil
 	})
 }
 
 func (c *resourceClient) makeList() *starlark.Builtin {
-	return nil
-}
-
-type wrappedError struct {
-	err error
-}
-
-var _ error = (*wrappedError)(nil)
-var _ starlark.Value = (*wrappedError)(nil)
-
-func (e *wrappedError) String() string        { return fmt.Sprintf("Error: %v", e.err) }
-func (e *wrappedError) Type() string          { return "error" }
-func (e *wrappedError) Freeze()               {}
-func (e *wrappedError) Truth() starlark.Bool  { return true }
-func (e *wrappedError) Hash() (uint32, error) { return uint32(xxh3.HashString(e.err.Error())), nil }
-func (e *wrappedError) Error() string         { return e.err.Error() }
-
-var camelCase = regexp.MustCompile(`[^A-Z][A-Z]`)
-
-func set(dest map[string]map[string]map[string]*starlarkstruct.Module, gvk schema.GroupVersionKind, m *starlarkstruct.Module) {
-	group, version, kind := gvk.Group, gvk.Version, gvk.Kind
-	group = strings.ReplaceAll(group, ".", "_")
-	version = strings.ReplaceAll(version, ".", "_")
-	kind = strings.ReplaceAll(kind, "API", "api")
-	kind = camelCase.ReplaceAllStringFunc(kind, func(s string) string {
-		if len(s) == 2 {
-			return strings.ToLower(string([]byte{s[0], '_', s[1]}))
+	return starlark.NewBuiltin(fmt.Sprintf("%v.%v", c.resource.Name, "list"), func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var labels, fields selector
+		if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "labels?", &labels, "fields?", &fields); err != nil {
+			return nil, errors.Wrap(err, "unpack args")
 		}
-		return strings.ToLower(s)
+		ctx := ourstar.GetContext(t)
+		got, err := c.getClient().List(ctx, metav1.ListOptions{
+			LabelSelector: labels.String(),
+			FieldSelector: fields.String(),
+		})
+		if err != nil {
+			return starlark.NewList([]starlark.Value{&wrappedError{err: err}}), nil
+		}
+		return &resourceList{UnstructuredList: got}, nil
 	})
-	kind = strings.ToLower(kind)
-	if gvk.Group == "" { // Core objects.
-		group, version, kind = version, kind, ""
-	}
-	if dest[group] == nil {
-		dest[group] = make(map[string]map[string]*starlarkstruct.Module)
-	}
-	if dest[group][version] == nil {
-		dest[group][version] = make(map[string]*starlarkstruct.Module)
-	}
-	dest[group][version][kind] = m
 }
 
 func NewClientset(namespace string, sc kubernetes.Interface, dc dynamic.Interface) (*starlarkstruct.Module, error) {
@@ -192,10 +417,17 @@ func NewClientset(namespace string, sc kubernetes.Interface, dc dynamic.Interfac
 		return nil, errors.Wrap(err, "discover server resources")
 	}
 	result := &starlarkstruct.Module{
-		Name:    "k8s",
-		Members: starlark.StringDict{},
+		Name: "k8s",
+		Members: starlark.StringDict{
+			"resource": starlark.NewBuiltin("resource", func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+				var object resource
+				if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "object", &object); err != nil {
+					return nil, errors.Wrap(err, "unpack args")
+				}
+				return &object, nil
+			}),
+		},
 	}
-
 	for _, rl := range rls {
 		gv, err := schema.ParseGroupVersion(rl.GroupVersion)
 		if err != nil {

--- a/src/internal/starlark/lib/k8s/k8s.go
+++ b/src/internal/starlark/lib/k8s/k8s.go
@@ -1,0 +1,236 @@
+// Package k8s is a Kubernetes API binding for Starlark.
+package k8s
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+	"github.com/zeebo/xxh3"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+type resourceClient struct {
+	resource    metav1.APIResource
+	subresource string
+	extra       []metav1.APIResource
+	namespace   string
+	client      dynamic.Interface
+}
+
+var _ starlark.Value = (*resourceClient)(nil)
+var _ starlark.HasAttrs = (*resourceClient)(nil)
+
+func (c *resourceClient) shorten(r metav1.APIResource) string {
+	return strings.TrimPrefix(r.Name, c.resource.Name+"/")
+}
+func (c *resourceClient) verbs() []string {
+	var verbs []string
+	for _, v := range c.resource.Verbs {
+		if v == "list" || v == "get" {
+			verbs = append(verbs, v)
+		}
+	}
+	sort.Strings(verbs)
+	return verbs
+}
+func (c *resourceClient) String() string {
+	b := new(strings.Builder)
+	if c.subresource == "" {
+		fmt.Fprintf(b, "<%v_client", c.resource.Name)
+	} else {
+		fmt.Fprintf(b, "<%v.%v_client", c.resource.Name, c.subresource)
+	}
+	if c.resource.Namespaced {
+		fmt.Fprintf(b, " namespace=%q", c.namespace)
+	}
+	if len(c.extra) > 0 {
+		var extras []string
+		for _, e := range c.extra {
+			extras = append(extras, c.shorten(e))
+		}
+		sort.Strings(extras)
+		fmt.Fprintf(b, " subresources=%v", extras)
+	}
+	if len(c.resource.Verbs) > 0 {
+		fmt.Fprintf(b, " verbs=%v", c.verbs())
+	}
+	b.WriteRune('>')
+	return b.String()
+}
+func (c *resourceClient) Type() string         { return fmt.Sprintf("%v_client", c.resource.Name) }
+func (c *resourceClient) Freeze()              {}
+func (c *resourceClient) Truth() starlark.Bool { return true }
+func (c *resourceClient) Hash() (uint32, error) {
+	return uint32(xxh3.HashString(c.resource.Name)), nil
+}
+
+func (c *resourceClient) AttrNames() []string {
+	result := c.verbs()
+	for _, e := range c.extra {
+		result = append(result, c.shorten(e))
+	}
+	return result
+}
+
+func (c *resourceClient) Attr(attr string) (starlark.Value, error) {
+	for _, e := range c.extra {
+		if c.shorten(e) == attr {
+			return &resourceClient{
+				client:      c.client,
+				namespace:   c.namespace,
+				subresource: c.shorten(e),
+				resource:    c.resource,
+			}, nil
+		}
+	}
+	if attr == "get" && c.can("get") {
+		return c.makeGet(), nil
+	}
+	if attr == "list" && c.can("list") {
+		return c.makeList(), nil
+	}
+	return nil, nil
+}
+
+func (c *resourceClient) can(x string) bool {
+	for _, v := range c.resource.Verbs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *resourceClient) getClient() dynamic.ResourceInterface {
+	gvr := schema.GroupVersionResource{
+		Group:    c.resource.Group,
+		Version:  c.resource.Version,
+		Resource: c.resource.Name,
+	}
+	cl := c.client.Resource(gvr)
+	if c.resource.Namespaced {
+		return cl.Namespace(c.namespace)
+	}
+	return cl
+}
+
+func (c *resourceClient) makeGet() *starlark.Builtin {
+	return starlark.NewBuiltin(fmt.Sprintf("%v.%v", c.resource.Name, "get"), func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var name, resourceVersion string
+		if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "name", &name, "resourceVersion?", &resourceVersion); err != nil {
+			return nil, errors.Wrap(err, "unpack args")
+		}
+		ctx := ourstar.GetContext(t)
+		var sr []string
+		if c.subresource != "" {
+			sr = append(sr, c.subresource)
+		}
+		got, err := c.getClient().Get(ctx, name, metav1.GetOptions{ResourceVersion: resourceVersion}, sr...)
+		if err != nil {
+			return &wrappedError{err: err}, nil
+		}
+		return ourstar.Value(got.Object), nil
+	})
+}
+
+func (c *resourceClient) makeList() *starlark.Builtin {
+	return nil
+}
+
+type wrappedError struct {
+	err error
+}
+
+var _ error = (*wrappedError)(nil)
+var _ starlark.Value = (*wrappedError)(nil)
+
+func (e *wrappedError) String() string        { return fmt.Sprintf("Error: %v", e.err) }
+func (e *wrappedError) Type() string          { return "error" }
+func (e *wrappedError) Freeze()               {}
+func (e *wrappedError) Truth() starlark.Bool  { return true }
+func (e *wrappedError) Hash() (uint32, error) { return uint32(xxh3.HashString(e.err.Error())), nil }
+func (e *wrappedError) Error() string         { return e.err.Error() }
+
+var camelCase = regexp.MustCompile(`[^A-Z][A-Z]`)
+
+func set(dest map[string]map[string]map[string]*starlarkstruct.Module, gvk schema.GroupVersionKind, m *starlarkstruct.Module) {
+	group, version, kind := gvk.Group, gvk.Version, gvk.Kind
+	group = strings.ReplaceAll(group, ".", "_")
+	version = strings.ReplaceAll(version, ".", "_")
+	kind = strings.ReplaceAll(kind, "API", "api")
+	kind = camelCase.ReplaceAllStringFunc(kind, func(s string) string {
+		if len(s) == 2 {
+			return strings.ToLower(string([]byte{s[0], '_', s[1]}))
+		}
+		return strings.ToLower(s)
+	})
+	kind = strings.ToLower(kind)
+	if gvk.Group == "" { // Core objects.
+		group, version, kind = version, kind, ""
+	}
+	if dest[group] == nil {
+		dest[group] = make(map[string]map[string]*starlarkstruct.Module)
+	}
+	if dest[group][version] == nil {
+		dest[group][version] = make(map[string]*starlarkstruct.Module)
+	}
+	dest[group][version][kind] = m
+}
+
+func NewClientset(namespace string, sc kubernetes.Interface, dc dynamic.Interface) (*starlarkstruct.Module, error) {
+	_, rls, err := sc.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		return nil, errors.Wrap(err, "discover server resources")
+	}
+	result := &starlarkstruct.Module{
+		Name:    "k8s",
+		Members: starlark.StringDict{},
+	}
+
+	for _, rl := range rls {
+		gv, err := schema.ParseGroupVersion(rl.GroupVersion)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse GroupVersion received from the server")
+		}
+		for _, r := range rl.APIResources {
+			// NOTE(jrockway): metrics.k8s.io seems broken on my machine; that's what
+			// this tries to skip.
+			if r.SingularName == "" {
+				continue
+			}
+
+			var name string
+			if parts := strings.SplitN(r.Name, "/", 2); len(parts) == 2 {
+				name = parts[0]
+			} else {
+				name = r.Name
+			}
+			val, ok := result.Members[name]
+			if !ok {
+				val = &resourceClient{
+					client:    dc,
+					namespace: namespace,
+				}
+				result.Members[name] = val
+			}
+			client := val.(*resourceClient)
+			if name == r.Name {
+				r.Group = gv.Group
+				r.Version = gv.Version
+				client.resource = r
+			} else {
+				client.extra = append(client.extra, r)
+			}
+		}
+	}
+	return result, nil
+}

--- a/src/internal/starlark/lib/k8s/k8s.go
+++ b/src/internal/starlark/lib/k8s/k8s.go
@@ -298,9 +298,6 @@ type resourceClient struct {
 var _ starlark.Value = (*resourceClient)(nil)
 var _ starlark.HasAttrs = (*resourceClient)(nil)
 
-func (c *resourceClient) shorten(r metav1.APIResource) string {
-	return strings.TrimPrefix(r.Name, c.resource.Name+"/")
-}
 func (c *resourceClient) verbs() []string {
 	var verbs []string
 	for _, v := range c.resource.Verbs {

--- a/src/internal/starlark/lib/k8s/k8s_test.go
+++ b/src/internal/starlark/lib/k8s/k8s_test.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	"testing"
+
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+	"github.com/pachyderm/pachyderm/v2/src/internal/starlark/startest"
+	"go.starlark.net/starlark"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dfake "k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+func TestClient(t *testing.T) {
+	objects := []runtime.Object{
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-pod-abc123",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "test",
+					},
+				},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-test-pod",
+				Namespace: "default",
+				Labels: map[string]string{
+					"suite": "test",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "test",
+					},
+				},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+	}
+	sc := kfake.NewSimpleClientset(objects...)
+	sc.Fake.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:         "pods",
+					SingularName: "pod",
+					Namespaced:   true,
+					Kind:         "Pod",
+					Verbs:        metav1.Verbs{"get", "list", "watch"},
+				},
+			},
+		},
+	}
+	dc := dfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
+	module, err := NewClientset("default", sc, dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startest.RunTest(t, "k8s_test.star", ourstar.Options{
+		Predefined: starlark.StringDict{
+			"k8s": module,
+		},
+	})
+}

--- a/src/internal/starlark/lib/k8s/k8s_test.star
+++ b/src/internal/starlark/lib/k8s/k8s_test.star
@@ -1,0 +1,77 @@
+load("cmp", "diff")
+
+def test_get_pod(t):
+    name = "some-pod-abc123"
+    got = k8s.pods.get(name)
+    if not (got):
+        t.Errorf("pod object is unexpectedly false")
+    want = k8s.resource({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "some-pod-abc123",
+            "namespace": "default",
+            "creationTimestamp": None,
+        },
+        "spec": {"containers": [
+            {
+                "name": "test",
+                "resources": {},
+            },
+        ]},
+        "status": {
+            "phase": "Running",
+        },
+    })
+    d = diff(want, got)
+    if d != "":
+        t.Errorf("pod %v (-want +got):\n%s", name, d)
+
+def test_get_pod_field(t):
+    name = "some-pod-abc123"
+    got = k8s.pods.get(name)["spec"]["containers"][0]["name"]
+    want = "test"
+    if got != want:
+        t.Errorf("get pod %v spec.containers[0].name:\n  got: %v\n want: %v", name, got, want)
+
+def test_list_pods(t):
+    list = k8s.pods.list(labels = {"suite": "test"})
+    if not list:
+        t.Errorf("list is unexpectedly false")
+    got = [x["metadata"]["name"] for x in list]
+    want = ["some-test-pod"]
+    if got != want:
+        t.Errorf("list pods:\n  got: %v, want: %v", got, want)
+
+def test_errors_work_like_objects(t):
+    # Ensure single objects can be used as multi-level dicts.
+    for x in [k8s.pods.get("some-test-pod"), k8s.pods.get("does-not-exist")]:
+        # Should be able to get keys.
+        x["metadata"]["namespace"]
+
+        # Should be able to JSON encode.
+        json.encode(x)
+
+    # Ensure lists can be used as objects.
+    for x in [k8s.pods.list(), k8s.pods.list(labels = "label=does-not-exist")]:
+        # Should be able to JSON encode.
+        json.encode(x)
+
+        # Should be able to iterate as list.
+        for value in x:
+            value["metadata"]["namespace"]
+
+    # Should be able to index a pod.
+    x = k8s.pods.list()
+    x["some-pod-abc123"]["metadata"]["name"]
+
+def test_errors_are_false(t):
+    got = k8s.pods.get("does-not-exist")
+    if got:
+        t.Error("error is unexpectedly true")
+
+def test_string(t):
+    str(k8s.pods)
+    str(k8s.pods.get("some-pod-abc123"))
+    str(k8s.pods.get("does-not-exist"))
+    str(k8s.pods.list())

--- a/src/internal/starlark/reflect.go
+++ b/src/internal/starlark/reflect.go
@@ -140,6 +140,14 @@ func Value(in any) starlark.Value {
 		return starlark.Float(float64(x))
 	case float64:
 		return starlark.Float(x)
+	case map[string]any:
+		dict := starlark.NewDict(len(x))
+		for k, v := range x {
+			if err := dict.SetKey(starlark.String(k), Value(v)); err != nil {
+				break
+			}
+		}
+		return dict
 	}
 	return value(reflect.ValueOf(in))
 }

--- a/src/internal/starlark/repl.go
+++ b/src/internal/starlark/repl.go
@@ -27,7 +27,9 @@ func RunShell(ctx context.Context, path string, opts Options) error {
 			if err != nil {
 				return nil, errors.Wrapf(err, "run %v", module)
 			}
-			globals = result
+			for k, v := range result {
+				globals[k] = v
+			}
 		}
 		for k, v := range opts.REPLPredefined {
 			globals[k] = v

--- a/src/internal/starlark/starlark.go
+++ b/src/internal/starlark/starlark.go
@@ -112,7 +112,7 @@ func Run(rctx context.Context, in string, opts Options, f RunFunc) (starlark.Str
 		Set:               true,
 		While:             true,
 		TopLevelControl:   true,
-		GlobalReassign:    false,
+		GlobalReassign:    true,
 		LoadBindsGlobally: false,
 		Recursion:         false,
 	}

--- a/src/internal/testpachd/realenv/real_env.go
+++ b/src/internal/testpachd/realenv/real_env.go
@@ -16,7 +16,9 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
+	testdynamic "k8s.io/client-go/dynamic/fake"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/pachyderm/pachyderm/v2/src/debug"
 	"github.com/pachyderm/pachyderm/v2/src/identity"
@@ -270,6 +272,7 @@ func newRealEnv(ctx context.Context, t testing.TB, mockPPSTransactionServer bool
 		reporter := metrics.NewReporter(realEnv.ServiceEnv)
 		clientset := testclient.NewSimpleClientset()
 		realEnv.ServiceEnv.SetKubeClient(clientset)
+		realEnv.ServiceEnv.SetDynamicKubeClient(testdynamic.NewSimpleDynamicClient(scheme.Scheme))
 		ppsEnv := pachd.PPSEnv(realEnv.ServiceEnv, txnEnv, reporter)
 		realEnv.PPSServer, err = ppsserver.NewAPIServer(ppsEnv)
 		realEnv.ServiceEnv.SetPpsServer(realEnv.PPSServer)

--- a/src/server/cmd/worker/main.go
+++ b/src/server/cmd/worker/main.go
@@ -93,14 +93,15 @@ func do(ctx context.Context, config *pachconfig.WorkerFullConfiguration) error {
 	workerapi.RegisterWorkerServer(server.Server, workerInstance.APIServer)
 	versionpb.RegisterAPIServer(server.Server, version.NewAPIServer(version.Version, version.APIServerOptions{}))
 	debugSrv := debugserver.NewDebugServer(debugserver.Env{
-		DB:            env.GetDBClient(),
-		SidecarClient: pachClient,
-		GetLokiClient: env.GetLokiClient,
-		Name:          env.Config().PodName,
-		GetPachClient: pachClient.WithCtx,
-		GetKubeClient: env.GetKubeClient,
-		Config:        *env.Config(),
-		TaskService:   env.GetTaskService("debug"),
+		DB:                   env.GetDBClient(),
+		SidecarClient:        pachClient,
+		GetLokiClient:        env.GetLokiClient,
+		Name:                 env.Config().PodName,
+		GetPachClient:        pachClient.WithCtx,
+		GetKubeClient:        env.GetKubeClient,
+		GetDynamicKubeClient: env.GetDynamicKubeClient,
+		Config:               *env.Config(),
+		TaskService:          env.GetTaskService("debug"),
 	})
 	debugclient.RegisterDebugServer(server.Server, debugSrv)
 

--- a/src/server/debug/server/debugstar/debugstar.go
+++ b/src/server/debug/server/debugstar/debugstar.go
@@ -18,11 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/log"
-	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
-	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
-	"github.com/pachyderm/pachyderm/v2/src/internal/starlark/lib/k8s"
 	"go.starlark.net/starlark"
 	"k8s.io/client-go/dynamic"
 	dfake "k8s.io/client-go/dynamic/fake"
@@ -30,6 +25,12 @@ import (
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/promutil"
+	ourstar "github.com/pachyderm/pachyderm/v2/src/internal/starlark"
+	"github.com/pachyderm/pachyderm/v2/src/internal/starlark/lib/k8s"
 )
 
 // BuiltinScripts are the scripts loaded from starlark/.

--- a/src/server/debug/server/debugstar/debugstar_k8s_test.go
+++ b/src/server/debug/server/debugstar/debugstar_k8s_test.go
@@ -1,0 +1,27 @@
+//go:build k8s
+
+package debugstar
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+)
+
+func TestBuiltinScripts(t *testing.T) {
+	var ran bool
+	for name, script := range BuiltinScripts {
+		t.Run(name, func(t *testing.T) {
+			ctx := pctx.TestContext(t)
+			env := &Env{FS: testDumpFS(fstest.MapFS{})}
+			if err := env.RunStarlark(ctx, script, string(script)); err != nil {
+				t.Errorf("run script: %v", err)
+			}
+			ran = true
+		})
+	}
+	if !ran {
+		t.Fatal("expected to run at least 1 built-in script")
+	}
+}

--- a/src/server/debug/server/debugstar/debugstar_test.go
+++ b/src/server/debug/server/debugstar/debugstar_test.go
@@ -74,23 +74,6 @@ func TestStarlark(t *testing.T) {
 	}
 }
 
-func TestBuiltinScripts(t *testing.T) {
-	var ran bool
-	for name, script := range BuiltinScripts {
-		t.Run(name, func(t *testing.T) {
-			ctx := pctx.TestContext(t)
-			env := &Env{FS: testDumpFS(fstest.MapFS{})}
-			if err := env.RunStarlark(ctx, script, string(script)); err != nil {
-				t.Errorf("run script: %v", err)
-			}
-			ran = true
-		})
-	}
-	if !ran {
-		t.Fatal("expected to run at least 1 built-in script")
-	}
-}
-
 func TestInteractiveDumpFS(t *testing.T) {
 	base := t.TempDir()
 	fs := &InteractiveDumpFS{Base: base}

--- a/src/server/debug/server/debugstar/starlark/list_rcs.star
+++ b/src/server/debug/server/debugstar/starlark/list_rcs.star
@@ -1,0 +1,12 @@
+def dump_rcs():
+    rcs = k8s.replicationcontrollers.list(labels = {"suite": "pachyderm", "app": "pipeline"})
+    for rc in rcs:
+        name = rc["metadata"]["name"]
+        dump("%s/rc.json" % name, json.encode(rc))
+        pods = k8s.pods.list(labels = rc["spec"]["selector"])
+        for pod in pods:
+            podname = pod["metadata"]["name"]
+            dump("%s/pod-%s.json" % (name, podname), json.encode(pod))
+
+if "replicationcontrollers" in dir(k8s) and "pods" in dir(k8s):
+    dump_rcs()

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -1551,7 +1551,10 @@ func (s *debugServer) makeStarlarkScriptTask(st *debug.Starlark, rp incProgressF
 		ctx, c := context.WithTimeout(rctx, timeout)
 		defer c()
 
-		env := debugstar.Env{FS: dfs.WithPrefix(name)}
+		env := debugstar.Env{
+			FS:         dfs.WithPrefix(name),
+			Kubernetes: s.env.GetKubeClient(),
+		}
 		if err := env.RunStarlark(ctx, name, script); err != nil {
 			return errors.Wrapf(err, "starlark script %q", name)
 		}

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -36,6 +36,7 @@ import (
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	describe "k8s.io/kubectl/pkg/describe"
 
@@ -66,13 +67,14 @@ const (
 )
 
 type Env struct {
-	DB            *pachsql.DB
-	SidecarClient *client.APIClient
-	Name          string
-	GetLokiClient func() (*loki.Client, error)
-	GetKubeClient func() kubernetes.Interface
-	Config        pachconfig.Configuration
-	TaskService   task.Service
+	DB                   *pachsql.DB
+	SidecarClient        *client.APIClient
+	Name                 string
+	GetLokiClient        func() (*loki.Client, error)
+	GetKubeClient        func() kubernetes.Interface
+	GetDynamicKubeClient func() dynamic.Interface
+	Config               pachconfig.Configuration
+	TaskService          task.Service
 
 	GetPachClient func(context.Context) *client.APIClient
 }
@@ -1552,8 +1554,10 @@ func (s *debugServer) makeStarlarkScriptTask(st *debug.Starlark, rp incProgressF
 		defer c()
 
 		env := debugstar.Env{
-			FS:         dfs.WithPrefix(name),
-			Kubernetes: s.env.GetKubeClient(),
+			FS:                  dfs.WithPrefix(name),
+			Kubernetes:          s.env.GetKubeClient(),
+			KubernetesDynamic:   s.env.GetDynamicKubeClient(),
+			KubernetesNamespace: s.env.Config.Namespace,
 		}
 		if err := env.RunStarlark(ctx, name, script); err != nil {
 			return errors.Wrapf(err, "starlark script %q", name)


### PR DESCRIPTION
This adds a Kubernetes library for starlark scripts.  It uses the dynamic k8s client, which is the least horrible option.  (The other options were to use reflection against the static client, or generate a starlark client from the OpenAPI specs.)  I didn't use reflection because the static client can't access dynamic resources; say we want to dump Istio configs, you can't do that with the static client.  I didn't do the codegen because I thought it would take too long, but in the end not doing it took too long.  (We'd have to ship the compiler, though, for the same Istio reason above.)  Dynamic is the least bad, but it's not great.

It's actually amazing how bad the Kubernetes API is.  I used to think they had a good reason for not using protos + grpc, but nope, they did not.  Instead they just made a pretty bad implementation of grpc (oh but with versions!)  Looking forward to version 2.0.

The dynamic client is horrible in many regards.  We have to figure out that Kubernetes has a thing called "pods" by querying the server.  That's literally not compiled into the client anywhere!!!  These methods do not take contexts (and the bug for this is closed with "who cares why would that need a context?"), so creating a k8s starlark client can take unbounded time.  Unfortunate, but actually very difficult to fix.

Kubernetes also has the concept of "subresources", which pod logs are one of.  The dynamic client has no clue how to handle these; it has code to handle them, but it gets it totally wrong. 

The library is designed to keep charging along in case of errors; error objects have the same API surface as the result objects, and when the debug dumper sees them it writes an error file instead of the requested file.  This is necessary because starlark errors are fatal; the script cannot continue when there's an error.

To get a taste of the API, here's a script that dumps pipeline RCs as JSON, and all associated pods:

```python
def dump_rcs():
    rcs = k8s.replicationcontrollers.list(labels = {"suite": "pachyderm", "app": "pipeline"})
    for rc in rcs:
        name = rc["metadata"]["name"]
        dump("%s/rc.json" % name, json.encode(rc))
        pods = k8s.pods.list(labels = rc["spec"]["selector"])
        for pod in pods:
            podname = pod["metadata"]["name"]
            dump("%s/pod-%s.json" % (name, podname), json.encode(pod))

if "replicationcontrollers" in dir(k8s) and "pods" in dir(k8s):
    dump_rcs()
```

You can also open up a shell and write something like `pods = k8s.pods` and `print(pods)` or `dir(pods)` to see the functions available.

Finally, if you are wondering about the starlark.go change that sets `ReassignGlobals` to true... it turns out no code reads the other fields in that struct; if it's false, then you can't have top-level for loops or if statements 😂.  We are totally OK with those things, so we enable them here.