### PR TITLE
Update jupyter_server version to 2.7.0 to match Determined AI

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/dev_server.py
+++ b/jupyter-extension/jupyterlab_pachyderm/dev_server.py
@@ -1,11 +1,31 @@
 # Quickly spin up a local service for testing purposes
 import tornado.ioloop
 import tornado.web
+from jupyter_server.auth.identity import IdentityProvider, User
+from jupyter_server.base.handlers import JupyterHandler
 
 from . import setup_handlers
+
+
+class TestIdentityProvider(IdentityProvider):
+    """An identity provider for the tests, disable auth checks made."""
+
+    def get_user(self, handler: JupyterHandler) -> User:
+        """Get the user."""
+        return User("testuser")
+
 
 if __name__ == "__main__":
     app = tornado.web.Application(base_url="/")
     setup_handlers(app)
+
+    # Disable authorization checks between test API and dev-server
+    app.settings["identity_provider"] = TestIdentityProvider()
+    app.settings["disable_check_xsrf"] = True
+
+    # Increase the timeout on the MountServerClient
+    app.settings["pachyderm_mount_client"].client.configure(
+        None,defaults=dict(connect_timeout=20, request_timeout=60))
+
     app.listen(8888)
     tornado.ioloop.IOLoop.current().start()

--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 packages = find:
 install_requires =
   pyyaml>=6.0
-  jupyter_server>=1.6,<2
+  jupyter_server>=2.7.0,<2.8
   python-pachyderm>=v7.4.0,<8
 include_package_data = True
 zip_safe = False
@@ -34,4 +34,5 @@ dev=
   pytest
   pytest-asyncio
   pytest-tornasync
+  pytest-jupyter
   python-pachyderm>=v7.4.0,<8


### PR DESCRIPTION
# Summary

Determined's task environments have jupyter_server==2.7.0, but jupyterlab-pachyderm is locked to  jupyter_server>=1.6,<2 which prevents it from being installed into a Determined task environment.  Change the locked version to jupyter_server==2.7.0 to match Determined as of 0.24.0.   jupyter_server recommends that the version be pinned
to avoid plug-in breakage.

The integration tests use an unauthenticated interface between the tests and the dev_server.   Add an jupyter_server identity provider that disables authentication to enable this to continue working with jupyter_server >= 2.0.


# Testing

Verified the plug-in mount capability with this configuration.
Are there other specific areas that we need to verify?

`docker run -it -p 8888:8888 --cap-add SYS_ADMIN --device /dev/fuse   pachyderm/notebooks-user:dev`

![image](https://github.com/pachyderm/pachyderm/assets/84593277/aecfb5d8-31bc-485c-ae5f-2a5c5b0c6830)