### PR TITLE
use unique names and clear DB for test

### DIFF
--- a/src/server/pps/server/api_server_test.go
+++ b/src/server/pps/server/api_server_test.go
@@ -401,8 +401,8 @@ func TestSetClusterDefaults(t *testing.T) {
 		err = json.Unmarshal([]byte(getResp.GetClusterDefaultsJson()), &originalDefaults)
 		require.NoError(t, err, "unmarshal retrieved cluster defaults")
 
-		repo := "input"
-		pipeline := "pipeline"
+		repo := tu.UniqueString("input")
+		pipeline := tu.UniqueString("pipeline")
 		require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 		var pipelineTemplate = `{
 		"pipeline": {
@@ -462,8 +462,10 @@ func TestSetClusterDefaults(t *testing.T) {
 	})
 
 	t.Run("ValidDetails", func(t *testing.T) {
-		repo := "input"
-		pipeline := "pipeline"
+		err := env.PachClient.DeleteAll()
+		require.NoError(t, err)
+		repo := tu.UniqueString("input")
+		pipeline := tu.UniqueString("pipeline")
 		require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 		var pipelineTemplate = `{
 		"pipeline": {


### PR DESCRIPTION
In a funny twist this test fails exactly 50% of the time. It always fails on the first run, then passes when gotestsum runs it `ValidDetails` on it's own.
There are 2 flakes:
* Using the same name for a pipeline gives an error that it exists already
* Not removing the old pipeline causes the affected pipeline length check to get 2 pipelines instead of 1

The delete all should solve both of these, but I it's just good practice to use unique names per test, both to avoid false positives/negatives and to help anyone who might add tests in the future.