### PR TITLE
pps: add Worker and WorkerEnv

### DIFF
--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -101,6 +101,7 @@ func (fb *fullBuilder) buildAndRun(ctx context.Context) error {
 		fb.resumeHealth,
 		fb.startPFSWorker,
 		fb.startPFSMaster,
+		fb.startPPSWorker,
 		fb.startDebugWorker,
 		fb.daemon.serve,
 	)

--- a/src/internal/pachd/pachw.go
+++ b/src/internal/pachd/pachw.go
@@ -105,6 +105,7 @@ func (pachwb *pachwBuilder) buildAndRun(ctx context.Context) error {
 		pachwb.internallyListen,
 		pachwb.resumeHealth,
 		pachwb.startPFSWorker,
+		pachwb.startPPSWorker,
 		pachwb.startDebugWorker,
 		pachwb.daemon.serve,
 	)

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -59,7 +59,6 @@ func NewAPIServer(env Env) (ppsiface.APIServer, error) {
 		log.Error(env.BackgroundContext, "Preflight checks are disabled. This is not recommended.")
 	}
 	go apiServer.master(env.BackgroundContext)
-	go apiServer.worker(env.BackgroundContext)
 	return apiServer, nil
 }
 

--- a/src/server/pps/server/worker.go
+++ b/src/server/pps/server/worker.go
@@ -5,21 +5,36 @@ import (
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/backoff"
+	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/datum"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-func (a *apiServer) worker(ctx context.Context) {
-	taskSource := a.env.TaskService.NewSource(ppsTaskNamespace)
-	backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
+type WorkerEnv struct {
+	TaskService   task.Service
+	GetPachClient func(context.Context) *client.APIClient
+}
+
+type Worker struct {
+	env WorkerEnv
+}
+
+func NewWorker(env WorkerEnv) *Worker {
+	return &Worker{env: env}
+}
+
+func (w *Worker) Run(ctx context.Context) error {
+	taskSource := w.env.TaskService.NewSource(ppsTaskNamespace)
+	return backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
 		err := taskSource.Iterate(ctx, func(ctx context.Context, input *anypb.Any) (_ *anypb.Any, retErr error) {
 			defer log.Span(ctx, "pps task", log.Proto("input", input))(log.Errorp(&retErr))
 			switch {
 			case datum.IsTask(input):
-				pachClient := a.env.GetPachClient(ctx)
+				pachClient := w.env.GetPachClient(ctx)
 				return datum.ProcessTask(pachClient, input)
 			default:
 				return nil, errors.Errorf("unrecognized any type (%v) in pps worker", input.TypeUrl)

--- a/src/server/pps/server/worker.go
+++ b/src/server/pps/server/worker.go
@@ -29,7 +29,7 @@ func NewWorker(env WorkerEnv) *Worker {
 
 func (w *Worker) Run(ctx context.Context) error {
 	taskSource := w.env.TaskService.NewSource(ppsTaskNamespace)
-	return backoff.RetryUntilCancel(ctx, func() error { //nolint:errcheck
+	return backoff.RetryUntilCancel(ctx, func() error {
 		err := taskSource.Iterate(ctx, func(ctx context.Context, input *anypb.Any) (_ *anypb.Any, retErr error) {
 			defer log.Span(ctx, "pps task", log.Proto("input", input))(log.Errorp(&retErr))
 			switch {


### PR DESCRIPTION
- Separate PPS worker from API server
- Run PPS worker in pachw

The intention is to add more PPS tasks to the PPS worker in later PRs.  First it has to be running in pachw.