### PR TITLE
Testing jupyter_server version update.

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/dev_server.py
+++ b/jupyter-extension/jupyterlab_pachyderm/dev_server.py
@@ -1,11 +1,31 @@
 # Quickly spin up a local service for testing purposes
 import tornado.ioloop
 import tornado.web
+from jupyter_server.auth.identity import IdentityProvider, User
+from jupyter_server.base.handlers import JupyterHandler
 
 from . import setup_handlers
+
+
+class TestIdentityProvider(IdentityProvider):
+    """An identity provider for the tests, disable auth checks made."""
+
+    def get_user(self, handler: JupyterHandler) -> User:
+        """Get the user."""
+        return User("testuser")
+
 
 if __name__ == "__main__":
     app = tornado.web.Application(base_url="/")
     setup_handlers(app)
+
+    # Disable authorization checks between test API and dev-server
+    app.settings["identity_provider"] = TestIdentityProvider()
+    app.settings["disable_check_xsrf"] = True
+
+    # Increase the timeout on the MountServerClient
+    app.settings["pachyderm_mount_client"].client.configure(
+        None,defaults=dict(connect_timeout=20, request_timeout=60))
+
     app.listen(8888)
     tornado.ioloop.IOLoop.current().start()

--- a/jupyter-extension/package-lock.json
+++ b/jupyter-extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jupyterlab/application": "^3.1.0",
+        "@jupyterlab/application": "^3.5.3",
         "@jupyterlab/coreutils": "^5.1.0",
         "@jupyterlab/filebrowser": "^3.2.4",
         "@jupyterlab/launcher": "^3.2.3",
@@ -3184,59 +3184,73 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/@jupyter/ydoc": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-0.2.5.tgz",
+      "integrity": "sha512-XsAAkq55k6UCIv2kAFKbWahiuCsSxLQaRuWfULUuAhKVnA/QD2gqVMYx2yvnB0+AR7PKpKdf65uUxGxnSTBKqA==",
+      "dependencies": {
+        "@jupyterlab/nbformat": "^3.0.0 || ^4.0.0-alpha.15",
+        "@lumino/coreutils": "^1.11.0 || ^2.0.0-alpha.6",
+        "@lumino/disposable": "^1.10.0 || ^2.0.0-alpha.6",
+        "@lumino/signaling": "^1.10.0 || ^2.0.0-alpha.6",
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.5.40"
+      }
+    },
     "node_modules/@jupyterlab/application": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-3.2.4.tgz",
-      "integrity": "sha512-/2RwT5UC6asT5YiCqIIXDk4bffrOP1NK1RInMuK/dvuGkiTX8EWw2+5VYM2hRG46lEqco/0IdS71WNvnN5SsIw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-3.6.5.tgz",
+      "integrity": "sha512-T9pjZbIB26HBkssG1bLVZqwUXjSMCobYGRwNvit0GiJ4BF1I2GxuVF4Hd2tNIqqFreRVEyvobN+w+DGZWFLxfw==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.12.0",
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/docregistry": "^3.2.4",
-        "@jupyterlab/rendermime": "^3.2.4",
-        "@jupyterlab/rendermime-interfaces": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/application": "^1.16.0",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0"
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/docregistry": "^3.6.5",
+        "@jupyterlab/rendermime": "^3.6.5",
+        "@jupyterlab/rendermime-interfaces": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/application": "^1.31.4",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "node_modules/@jupyterlab/apputils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-3.2.4.tgz",
-      "integrity": "sha512-x+lWYhmwR4nLHSiODtMidr//AoYhr7G/qSK16aV/shn5mgp7FWFViPpTGcCT//TQkuj+82N+azbMOIysZ2wOEw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-3.6.5.tgz",
+      "integrity": "sha512-cJ4FnsnEMwhcrh/27Z7q04hYRPYWgFRrBylw10SBHWzOryiFc9chg8LqzUOL0CNjmBRui6hS6w5R/Z7YmINpTg==",
       "dependencies": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/settingregistry": "^3.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/domutils": "^1.2.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.8.0",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/settingregistry": "^3.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/domutils": "^1.8.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/virtualdom": "^1.14.0",
+        "@lumino/widgets": "^1.37.2",
         "@types/react": "^17.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "sanitize-html": "~2.3.3",
+        "sanitize-html": "~2.7.3",
         "url": "^0.11.0"
       }
     },
@@ -3388,57 +3402,57 @@
       }
     },
     "node_modules/@jupyterlab/codeeditor": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-3.2.4.tgz",
-      "integrity": "sha512-h0PLQEuuth+y0Hz5jdj/aQSg3a4AFMnirTXIzbrP+YVLjLj7NzY12WKDukWayDd+SMQA+kHlbscO3lnWE7v89Q==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-3.6.5.tgz",
+      "integrity": "sha512-Wp81WZaUg3cJh/cKhoB/RemDOxE6hyEx0kvNu8BRTTYobKMqMQWahKTEWRoHxTCoeQzb/tJUSEJQV8u7d0vr1Q==",
       "dependencies": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/dragdrop": "^1.7.1",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0"
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/dragdrop": "^1.13.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "node_modules/@jupyterlab/codemirror": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-3.2.4.tgz",
-      "integrity": "sha512-6ocnfoQtFO70KfnJhneOVCcxqTZrO+9vBF+MdoISEPKK03MPwM/9tRs0rPEvzHUE4xEN+1KjFEb/3pcHB6WZiQ==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-3.6.5.tgz",
+      "integrity": "sha512-BonbNpBxOn4CDPuyl2JtkruwgiA8ANsIAuzrZMoTnglOScHLGxmddnF5BhsjuvatG2cDM/PZtY+KaQqcaJQBQQ==",
       "dependencies": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codeeditor": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@jupyterlab/statusbar": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codeeditor": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/statusbar": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2",
         "codemirror": "~5.61.0",
         "react": "^17.0.1",
         "y-codemirror": "^3.0.1"
       }
     },
     "node_modules/@jupyterlab/coreutils": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.2.4.tgz",
-      "integrity": "sha512-0QXhg8R0bkb5LILhfphE/K5k4zJI8N+fNsmy/Nr4mDo8l8mB7km6OUcbSSNuJg1mYikOhEA+UxhqE0954UgxkQ==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.6.5.tgz",
+      "integrity": "sha512-nQ0eY9rv8bj0KoFHAwR4dDJY033XZsSDH5EV/E5m5/0f/oyLxWmKI3L/C1alXrltgdivh3nudbDX7VzQRoZPHA==",
       "dependencies": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
         "minimist": "~1.2.0",
         "moment": "^2.24.0",
         "path-browserify": "^1.0.0",
@@ -3468,41 +3482,45 @@
       }
     },
     "node_modules/@jupyterlab/docprovider": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docprovider/-/docprovider-3.2.4.tgz",
-      "integrity": "sha512-7yh9lJslZb9/kgKD4Jta8XWhBrdZXN+/g2XKbRtgpESWboJ0/YAgglhxk2O+7pLVzs9vMdZmqAMCHbwui9+ltA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docprovider/-/docprovider-3.6.5.tgz",
+      "integrity": "sha512-jPFI2hKt1D/9ZpDH7iB9XDoKj8HYSNAFFENWOlRaEXCHL3S3lZA9b2G+T1XunQRefYxdyDZlY2JUSXojdgV2mA==",
       "dependencies": {
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "lib0": "^0.2.42",
-        "y-websocket": "^1.3.15",
-        "yjs": "^13.5.17"
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "y-protocols": "^1.0.5",
+        "y-websocket": "^1.4.6"
       }
     },
     "node_modules/@jupyterlab/docregistry": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-3.2.4.tgz",
-      "integrity": "sha512-3RVZrRgudrUqebz6FIgF8vD0nQsn7zzgy72XwB5YkYa7FBdLTf875ehUFXX4MdxqJC/uM/1th+0RPnnl8OwvaA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-3.6.5.tgz",
+      "integrity": "sha512-/QYkpDyqmDFeB12fjr0ANbSuJ2CRGk3O4yVft58pUsQHcWTZLXMG23XMMt9SaFjlr5LcYjhAbIfPzR8NYwGU9Q==",
       "dependencies": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codeeditor": "^3.2.4",
-        "@jupyterlab/codemirror": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/docprovider": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/rendermime": "^3.2.4",
-        "@jupyterlab/rendermime-interfaces": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
-        "yjs": "^13.5.17"
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codeeditor": "^3.6.5",
+        "@jupyterlab/codemirror": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/docprovider": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/rendermime": "^3.6.5",
+        "@jupyterlab/rendermime-interfaces": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "node_modules/@jupyterlab/filebrowser": {
@@ -3565,11 +3583,11 @@
       }
     },
     "node_modules/@jupyterlab/nbformat": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.2.4.tgz",
-      "integrity": "sha512-tEwt+vKAQEqj2smC8B5Myg693/5md3T9Nm3BM3Ix2NYqioCLlnGJ+aYQaOx1bsjyYWGLH/liW26O0NAUB3oEWg==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.6.5.tgz",
+      "integrity": "sha512-yyyNniuzxycsF+kHvjpAIjZ+qrt3G/HEViZN+FJA3vFpg6e2n/nqa7BgzlxINS5SH4FnBG6rM/u45bwih38VkA==",
       "dependencies": {
-        "@lumino/coreutils": "^1.5.3"
+        "@lumino/coreutils": "^1.11.0"
       }
     },
     "node_modules/@jupyterlab/notebook": {
@@ -3603,15 +3621,15 @@
       }
     },
     "node_modules/@jupyterlab/observables": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.2.4.tgz",
-      "integrity": "sha512-9b1a2+Tmda/Jr8oLMpMhQJAEpMRgILo8unjTnpMCb9RZgOZAwMRs+vItNqrjrapa4OO1vhIFVRWWqmxa5vz/6Q==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.6.5.tgz",
+      "integrity": "sha512-k6x7kLou+1EPtVlrQ6OFoujFj1jlvsKMcnap83Omjqj1DIkzSBGat3Y7Yf5OS7lrdyERJGYbtV9vfeSkwdjkjA==",
       "dependencies": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "node_modules/@jupyterlab/outputarea": {
@@ -3636,111 +3654,117 @@
       }
     },
     "node_modules/@jupyterlab/rendermime": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-3.2.4.tgz",
-      "integrity": "sha512-G/CS2rMLM+rp5xrQ09Aq2Q2w+c3WN2XvLnEM091ELrfl7WGNytu9ms1bGSaM/ZCXw1o7FDRo1t4Yj066XtkB8A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-3.6.5.tgz",
+      "integrity": "sha512-ln0UgKJo+2qS4FehCQUR5W/SDbnwiUHX+zdKEViNI6NHK2oAeXtD4BbuxfS3ZfJyEKZcB6hMj+OVqO7opL/fvw==",
       "dependencies": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codemirror": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/rendermime-interfaces": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codemirror": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/rendermime-interfaces": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2",
         "lodash.escape": "^4.0.1",
-        "marked": "^2.0.0"
+        "marked": "^4.0.17"
       }
     },
     "node_modules/@jupyterlab/rendermime-interfaces": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.2.4.tgz",
-      "integrity": "sha512-/zVDeW2ZaRMzQW0EFj5v/hjpJNSDfhJfbx96rprYZC8d0qEvm3Bxyyda4CvsRhmaJKMTAQLW+oOEBn1kNbFTmg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.8.6.tgz",
+      "integrity": "sha512-GPtyTwIiQH3jh9rT0LnjcPay6MQmUvMAbEHv42TksZ6dX98038ohuHt7cP1SZqHhQ8YdPcw0s8K7MjxEl2y/Ig==",
       "dependencies": {
-        "@jupyterlab/translation": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/widgets": "^1.19.0"
+        "@lumino/coreutils": "^1.11.0 || ^2.1.2",
+        "@lumino/widgets": "^1.37.2 || ^2.3.0"
+      }
+    },
+    "node_modules/@jupyterlab/rendermime/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@jupyterlab/services": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.2.4.tgz",
-      "integrity": "sha512-WpcKLDkwpq9jUQXUWJJn1cybxwwe8YMC8fdkVnI7RmCg5n0tGSV8+urfUv5Q8DdMdkAJnzSHEC6kIRbGoFpceQ==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.6.5.tgz",
+      "integrity": "sha512-ReTi7r8nAzop1u65Jc4HDlyERcyV8ebjTGmXUohRWEqMbgjrFH8rz4rV8iQnobg5GZ2Kyf2RBdSTKwEttj2Ghg==",
       "dependencies": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/settingregistry": "^3.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/signaling": "^1.4.3",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/settingregistry": "^3.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/signaling": "^1.10.0",
         "node-fetch": "^2.6.0",
         "ws": "^7.4.6"
       }
     },
     "node_modules/@jupyterlab/settingregistry": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.2.4.tgz",
-      "integrity": "sha512-kyr6y32YTD4S2XGthy17yRa6BdEQyuXqIl2hIKrn9oPdfM0OF3TDkAByB8W79KLQojsKcmGka19LvQov/N4+6A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.6.5.tgz",
+      "integrity": "sha512-PLg6E7j9x5otTnsTntFHwhbd+SacSsjiTP5krVq1WwTV6FrqrfT29ttxTCgV5+y7j91YmnEaHhZD+TXx5bQqIQ==",
       "dependencies": {
-        "@jupyterlab/statedb": "^3.2.4",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
         "ajv": "^6.12.3",
         "json5": "^2.1.1"
       }
     },
     "node_modules/@jupyterlab/shared-models": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/shared-models/-/shared-models-3.2.4.tgz",
-      "integrity": "sha512-Jr2Yz5L0GneKhrFpomm3LW5eGDfRaxWt0c+MT/eFXWmqvVkOKW4N3qPEfP1HNIMqagcC1OoN2pvZAWkE3qQYjA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/shared-models/-/shared-models-3.6.5.tgz",
+      "integrity": "sha512-5ZsX5Kt9n3tVvTSNDnV8vKKpQFDZ/zdUifwClx1gy5ZLMc0rtjXyIC10UKk0l8fIFSFGj7EN2ZR6pIAF0TRDZg==",
       "dependencies": {
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "y-protocols": "^1.0.5",
-        "yjs": "^13.5.17"
+        "@jupyter/ydoc": "~0.2.4",
+        "@jupyterlab/nbformat": "^3.6.5"
       }
     },
     "node_modules/@jupyterlab/statedb": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.2.4.tgz",
-      "integrity": "sha512-md9AlnrW1pzZTQiVUIJrZgijB3CsSs2J05V5cywo4/sgjwBTO1YGKQDEi6qtMAeO03gxfomGK7xLpoP+2Uaa2A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.6.5.tgz",
+      "integrity": "sha512-Ah6pwJiU0XDI41iH+Ihw1lONBNDUrM4h58HwXD5qMvEPIWw5IxQn7QKt5XuaQWpTagXfUeuHrNpbekgdEImMog==",
       "dependencies": {
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "node_modules/@jupyterlab/statusbar": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-3.2.4.tgz",
-      "integrity": "sha512-1oxNr926SJkxJ0b+hoHEWaFOnv+LVY6MWmv0wQvVzwCVDaQ3IjLXtOYheSXx7WtP4G3NjH2G/wM4mzqMs1JDbQ==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-3.6.5.tgz",
+      "integrity": "sha512-+kSW6ZgpXOfbfH9727JBYtx+lmgPiJCfFDKqlZfTbxYfvFx9j0C7eWfHZm6sL1WFYv5lB0iCUEY3GfL7X4LjHQ==",
       "dependencies": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codeeditor": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codeeditor": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2",
         "csstype": "~3.0.3",
         "react": "^17.0.1",
         "typestyle": "^2.0.4"
@@ -3763,31 +3787,33 @@
       }
     },
     "node_modules/@jupyterlab/translation": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/translation/-/translation-3.2.4.tgz",
-      "integrity": "sha512-FTXhNw/KRmGGR/stWWyaeyyha3Y7k1jh/dVJIXMO5xlT+zzFHvquGCiMeMZR20P+xBDstrgX8Ei/LhG+gkx0yw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/translation/-/translation-3.6.5.tgz",
+      "integrity": "sha512-avk96gOFuWqZWywCezeXvvjNnib4xQv5VY4rvvhTrz0unAeo8CtQ3L3ZBdLtWLq+aA470WfdhneLwtv3n6JYdw==",
       "dependencies": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3"
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@lumino/coreutils": "^1.11.0"
       }
     },
     "node_modules/@jupyterlab/ui-components": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-3.2.4.tgz",
-      "integrity": "sha512-uKxv8U/6TdAMbs0kBm142oAx9R4FcPk+CK5pbsBTInq+nvCmUlSYSAFEnuTbfNLeKQlWHdj8N2Q7upLFgfEs2w==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-3.6.5.tgz",
+      "integrity": "sha512-yEkC/MLxalEJ9PvZs7AQo/IJDxqAToBBWvqC57t8lGEEkwNBG4hNDv8bmQMtfVv9BMvooQzhac5wJiaEj0T6sg==",
       "dependencies": {
         "@blueprintjs/core": "^3.36.0",
         "@blueprintjs/select": "^3.15.0",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.8.0",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/virtualdom": "^1.14.0",
+        "@lumino/widgets": "^1.37.2",
+        "@rjsf/core": "^3.1.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "typestyle": "^2.0.4"
@@ -3797,85 +3823,85 @@
       }
     },
     "node_modules/@lumino/algorithm": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.9.1.tgz",
-      "integrity": "sha512-d0rj7IYRzYj6WbWSrbJbKvrfO4H0NUnXT2yjSWS/sCklpTpSp0IGmndK/X4r6gG+ev5lb5+wBg9ofUDBvoAlAw=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.9.2.tgz",
+      "integrity": "sha512-Z06lp/yuhz8CtIir3PNTGnuk7909eXt4ukJsCzChsGuot2l5Fbs96RJ/FOHgwCedaX74CtxPjXHXoszFbUA+4A=="
     },
     "node_modules/@lumino/application": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.29.0.tgz",
-      "integrity": "sha512-Ld2eWUjZMUn/y9tMMTfuBB1kZxIoVQtlZy8B7q53NiAfOdZ1cthfu2C7MUIeDMKLU7gZBSJqPSeuOxRFzv4wFA==",
+      "version": "1.31.4",
+      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.31.4.tgz",
+      "integrity": "sha512-dOSsDJ1tXOxC3fnSHvtDQK5RcICLEVPtO19HeCGwurb5W2ZZ55SZT2b5jZu6V/v8lGdtkNbr1RJltRpJRSRb/A==",
       "dependencies": {
-        "@lumino/commands": "^1.20.0",
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/widgets": "^1.32.0"
+        "@lumino/commands": "^1.21.1",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "node_modules/@lumino/collections": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.9.1.tgz",
-      "integrity": "sha512-5RaRGUY7BJ/1j173sc9DCfiVf70Z0hopRnBV8/AeAaK9bJJRAYjDhlZ9O8xTyouegh6krkOfiDyjl3pwogLrQw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.9.3.tgz",
+      "integrity": "sha512-2i2Wf1xnfTgEgdyKEpqM16bcYRIhUOGCDzaVCEZACVG9R1CgYwOe3zfn71slBQOVSjjRgwYrgLXu4MBpt6YK+g==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "node_modules/@lumino/commands": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.20.0.tgz",
-      "integrity": "sha512-xyrzDIJ9QEbcbRAwmXrjb7A7/E5MDNbnLANKwqmFVNF+4LSnF62obdvY4On3Rify3HmfX0u16Xr9gfoWPX9wLQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.21.1.tgz",
+      "integrity": "sha512-d1zJmwz5bHU0BM/Rl3tRdZ7/WgXnFB0bM7x7Bf0XDlmX++jnU9k0j3mh6/5JqCGLmIApKCRwVqSaV7jPmSJlcQ==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/disposable": "^1.10.1",
-        "@lumino/domutils": "^1.8.1",
-        "@lumino/keyboard": "^1.8.1",
-        "@lumino/signaling": "^1.10.1",
-        "@lumino/virtualdom": "^1.14.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/signaling": "^1.11.1",
+        "@lumino/virtualdom": "^1.14.3"
       }
     },
     "node_modules/@lumino/coreutils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.0.tgz",
-      "integrity": "sha512-DSglh4ylmLi820CNx9soJmDJCpUgymckdWeGWuN0Ash5g60oQvrQDfosVxEhzmNvtvXv45WZEqSBzDP6E5SEmQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.1.tgz",
+      "integrity": "sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==",
       "peerDependencies": {
         "crypto": "1.0.1"
       }
     },
     "node_modules/@lumino/disposable": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.1.tgz",
-      "integrity": "sha512-mZQILc8sVGZC7mJNOGVmehDRO9/u3sIRdjZ+pCYjDgXKcINLd6HoPhZDquKCWiRBfHTL1B3tOHjnBhahBc2N/Q==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.4.tgz",
+      "integrity": "sha512-4ZxyYcyzUS+ZeB2KAH9oAH3w0DUUceiVr+FIZHZ2TAYGWZI/85WlqJtfm0xjwEpCwLLW1TDqJrISuZu3iMmVMA==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/signaling": "^1.10.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/signaling": "^1.11.1"
       }
     },
     "node_modules/@lumino/domutils": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.8.1.tgz",
-      "integrity": "sha512-QUVXwmDMIfcHC3yslhmyGK4HYBKaJ3xX5MTwDrjsSX7J7AZ4jwL4zfsxyF9ntdqEKraoJhLQ6BaUBY+Ur1cnYw=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.8.2.tgz",
+      "integrity": "sha512-QIpMfkPJrs4GrWBuJf2Sn1fpyVPmvqUUAeD8xAQo8+4V5JAT0vUDLxZ9HijefMgNCi3+Bs8Z3lQwRCrz+cFP1A=="
     },
     "node_modules/@lumino/dragdrop": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.14.0.tgz",
-      "integrity": "sha512-hO8sgF0BkpihKIP6UZgVJgiOEhz89i7Oxtp9FR9Jqw5alGocxSXt7q3cteMvqpcL6o2/s3CafZNRkVLRXmepNw==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.14.5.tgz",
+      "integrity": "sha512-LC5xB82+xGF8hFyl716TMpV32OIMIMl+s3RU1PaqDkD6B7PkgiVk6NkJ4X9/GcEvl2igkvlGQt/3L7qxDAJNxw==",
       "dependencies": {
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/disposable": "^1.10.1"
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4"
       }
     },
     "node_modules/@lumino/keyboard": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.1.tgz",
-      "integrity": "sha512-8x0y2ZQtEvOsblpI2gfTgf+gboftusP+5aukKEsgNQtzFl28RezQXEOSVd8iD3K6+Q1MaPQF0OALYP0ASqBjBg=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.2.tgz",
+      "integrity": "sha512-Dy+XqQ1wXbcnuYtjys5A0pAqf4SpAFl9NY6owyIhXAo0Va7w3LYp3jgiP1xAaBAwMuUppiUAfrbjrysZuZ625g=="
     },
     "node_modules/@lumino/messaging": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.10.1.tgz",
-      "integrity": "sha512-XZSdt9ih94rdeeLL0cryUw6HHD51D7TP8c+MFf+YRF6VKwOFB9RoajfQWadeqpmH+schTs3EsrFfA9KHduzC7w==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.10.3.tgz",
+      "integrity": "sha512-F/KOwMCdqvdEG8CYAJcBSadzp6aI7a47Fr60zAKGqZATSRRRV41q53iXU7HjFPqQqQIvdn9Z7J32rBEAyQAzww==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/collections": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/collections": "^1.9.3"
       }
     },
     "node_modules/@lumino/polling": {
@@ -3889,42 +3915,43 @@
       }
     },
     "node_modules/@lumino/properties": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.8.1.tgz",
-      "integrity": "sha512-O+CCcAqP64Di32DUZ4Jqq0DtUyE5RJREN5vbkgGZGu+WauJ/RYoiLDe1ubbAeSaHk71OrS60ZBV7QyC8ZaBVsA=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.8.2.tgz",
+      "integrity": "sha512-EkjI9Cw8R0U+xC9HxdFSu7X1tz1H1vKu20cGvJ2gU+CXlMB1DvoYJCYxCThByHZ+kURTAap4SE5x8HvKwNPbig=="
     },
     "node_modules/@lumino/signaling": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.10.1.tgz",
-      "integrity": "sha512-GZVbX4cfk/ZqLwkemPD/NwqToaTL/6q7qdLpEhgkiPlaH1S5/V7fDpP7N1uFy4n3BDITId8cpYgH/Ds32Mdp3A==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.11.1.tgz",
+      "integrity": "sha512-YCUmgw08VoyMN5KxzqPO3KMx+cwdPv28tAN06C0K7Q/dQf+oufb1XocuhZb5selTrTmmuXeizaYxgLIQGdS1fA==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/properties": "^1.8.2"
       }
     },
     "node_modules/@lumino/virtualdom": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.1.tgz",
-      "integrity": "sha512-imIJd/wtRkoR1onEiG5nxPEaIrf70nn4PgD/56ri3/Lo6AJEX2CusF6iIA27GVB8yl/7CxgTHUnzzCwTFPypcA==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.3.tgz",
+      "integrity": "sha512-5joUC1yuxeXbpfbSBm/OR8Mu9HoTo6PDX0RKqzlJ9o97iml7zayFN/ynzcxScKGQAo9iaXOY8uVIvGUT8FnsGw==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "node_modules/@lumino/widgets": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.32.0.tgz",
-      "integrity": "sha512-f2wHtr20ZEGHt+FZo9yjMQijGVI+2zzvVyiMkeIdjeuxYpKTfsZl1OVb1dcAFqr5VbsqfQ3TEdq816Nfjf5Mvw==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.37.2.tgz",
+      "integrity": "sha512-NHKu1NBDo6ETBDoNrqSkornfUCwc8EFFzw6+LWBfYVxn2PIwciq2SdiJGEyNqL+0h/A9eVKb5ui5z4cwpRekmQ==",
       "dependencies": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/commands": "^1.20.0",
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/disposable": "^1.10.1",
-        "@lumino/domutils": "^1.8.1",
-        "@lumino/dragdrop": "^1.14.0",
-        "@lumino/keyboard": "^1.8.1",
-        "@lumino/messaging": "^1.10.1",
-        "@lumino/properties": "^1.8.1",
-        "@lumino/signaling": "^1.10.1",
-        "@lumino/virtualdom": "^1.14.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/commands": "^1.21.1",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/dragdrop": "^1.14.5",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/messaging": "^1.10.3",
+        "@lumino/properties": "^1.8.2",
+        "@lumino/signaling": "^1.11.1",
+        "@lumino/virtualdom": "^1.14.3"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -6975,6 +7002,28 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@rjsf/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^6.7.0",
+        "core-js-pure": "^3.6.5",
+        "json-schema-merge-allof": "^0.6.0",
+        "jsonpointer": "^5.0.0",
+        "lodash": "^4.17.15",
+        "nanoid": "^3.1.23",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/@sideway/address": {
@@ -11272,6 +11321,27 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -20576,6 +20646,24 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
+      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
+      "dependencies": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -20631,6 +20719,14 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -20768,14 +20864,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/known-css-properties": {
@@ -20976,14 +21064,18 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.43",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.43.tgz",
-      "integrity": "sha512-MJ1KLoz5p3gljIUBfdjjNuL/wlWHHK6+DrcIRhzSRLvtAu1XNdRtRGATYM51KSTI0P2nxJZFQM8rwCH6ga9KUw==",
+      "version": "0.2.85",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.85.tgz",
+      "integrity": "sha512-vtAhVttLXCu3ps2OIsTz8CdKYKdcMo7ds1MNBIcSXz6vrY8sxASqpTi4vmsAIn7xjWvyT7haKcWW6woP6jebjQ==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -21412,7 +21504,7 @@
     "node_modules/ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "optional": true
     },
     "node_modules/lunr": {
@@ -23373,7 +23465,7 @@
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "node_modules/parse5": {
       "version": "5.1.0",
@@ -28293,17 +28385,16 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.3.3.tgz",
-      "integrity": "sha512-DCFXPt7Di0c6JUnlT90eIgrjs6TsJl/8HYU3KLdmrVclFN4O0heTcVbJiMa23OKVr6aR051XYtsgd8EWwEBwUA==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^6.0.0",
         "is-plain-object": "^5.0.0",
-        "klona": "^2.0.3",
         "parse-srcset": "^1.0.2",
-        "postcss": "^8.0.2"
+        "postcss": "^8.3.11"
       }
     },
     "node_modules/sanitize-html/node_modules/escape-string-regexp": {
@@ -31403,6 +31494,38 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
+    },
     "node_modules/validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -32974,9 +33097,9 @@
       }
     },
     "node_modules/y-leveldb": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/y-leveldb/-/y-leveldb-0.1.0.tgz",
-      "integrity": "sha512-sMuitVrsAUNh+0b66I42nAuW3lCmez171uP4k0ePcTAJ+c+Iw9w4Yq3wwiyrDMFXBEyQSjSF86Inc23wEvWnxw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/y-leveldb/-/y-leveldb-0.1.2.tgz",
+      "integrity": "sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg==",
       "optional": true,
       "dependencies": {
         "level": "^6.0.1",
@@ -33003,15 +33126,16 @@
       }
     },
     "node_modules/y-websocket": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-1.3.18.tgz",
-      "integrity": "sha512-xdQhvq/iQ6lyrmQ0GhLWXVcpXXjyj7E+PEcC3d2IAShLbz0I8rAOKbq/tGrAQPy6g1oilRz6eb8M7EbqsJj6tg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-1.5.0.tgz",
+      "integrity": "sha512-A8AO6XtnQlYwWFytWdkDCeXg4l8ghRTIw5h2YUgUYDmEC9ugWGIwYNW80yadhSFAF7CvuWTEkQNEpevnH6EiZw==",
       "dependencies": {
-        "lib0": "^0.2.42",
+        "lib0": "^0.2.52",
         "lodash.debounce": "^4.0.8",
         "y-protocols": "^1.0.5"
       },
       "bin": {
+        "y-websocket": "bin/server.js",
         "y-websocket-server": "bin/server.js"
       },
       "funding": {
@@ -33099,12 +33223,15 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.5.22",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.22.tgz",
-      "integrity": "sha512-qxsVlu/E2dLUUtJyhDbwkhrw1gWbdE+UWzVI2VEeY6G1M8TYI51VvXSoPC/4QQMNIyEdsCOW2cWxPUyoCH43gw==",
-      "hasInstallScript": true,
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
       "dependencies": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -35415,59 +35542,73 @@
         }
       }
     },
+    "@jupyter/ydoc": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-0.2.5.tgz",
+      "integrity": "sha512-XsAAkq55k6UCIv2kAFKbWahiuCsSxLQaRuWfULUuAhKVnA/QD2gqVMYx2yvnB0+AR7PKpKdf65uUxGxnSTBKqA==",
+      "requires": {
+        "@jupyterlab/nbformat": "^3.0.0 || ^4.0.0-alpha.15",
+        "@lumino/coreutils": "^1.11.0 || ^2.0.0-alpha.6",
+        "@lumino/disposable": "^1.10.0 || ^2.0.0-alpha.6",
+        "@lumino/signaling": "^1.10.0 || ^2.0.0-alpha.6",
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.5.40"
+      }
+    },
     "@jupyterlab/application": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-3.2.4.tgz",
-      "integrity": "sha512-/2RwT5UC6asT5YiCqIIXDk4bffrOP1NK1RInMuK/dvuGkiTX8EWw2+5VYM2hRG46lEqco/0IdS71WNvnN5SsIw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-3.6.5.tgz",
+      "integrity": "sha512-T9pjZbIB26HBkssG1bLVZqwUXjSMCobYGRwNvit0GiJ4BF1I2GxuVF4Hd2tNIqqFreRVEyvobN+w+DGZWFLxfw==",
       "requires": {
         "@fortawesome/fontawesome-free": "^5.12.0",
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/docregistry": "^3.2.4",
-        "@jupyterlab/rendermime": "^3.2.4",
-        "@jupyterlab/rendermime-interfaces": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/application": "^1.16.0",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0"
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/docregistry": "^3.6.5",
+        "@jupyterlab/rendermime": "^3.6.5",
+        "@jupyterlab/rendermime-interfaces": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/application": "^1.31.4",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "@jupyterlab/apputils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-3.2.4.tgz",
-      "integrity": "sha512-x+lWYhmwR4nLHSiODtMidr//AoYhr7G/qSK16aV/shn5mgp7FWFViPpTGcCT//TQkuj+82N+azbMOIysZ2wOEw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-3.6.5.tgz",
+      "integrity": "sha512-cJ4FnsnEMwhcrh/27Z7q04hYRPYWgFRrBylw10SBHWzOryiFc9chg8LqzUOL0CNjmBRui6hS6w5R/Z7YmINpTg==",
       "requires": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/settingregistry": "^3.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/domutils": "^1.2.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.8.0",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/settingregistry": "^3.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/domutils": "^1.8.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/virtualdom": "^1.14.0",
+        "@lumino/widgets": "^1.37.2",
         "@types/react": "^17.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "sanitize-html": "~2.3.3",
+        "sanitize-html": "~2.7.3",
         "url": "^0.11.0"
       }
     },
@@ -35604,57 +35745,57 @@
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-3.2.4.tgz",
-      "integrity": "sha512-h0PLQEuuth+y0Hz5jdj/aQSg3a4AFMnirTXIzbrP+YVLjLj7NzY12WKDukWayDd+SMQA+kHlbscO3lnWE7v89Q==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-3.6.5.tgz",
+      "integrity": "sha512-Wp81WZaUg3cJh/cKhoB/RemDOxE6hyEx0kvNu8BRTTYobKMqMQWahKTEWRoHxTCoeQzb/tJUSEJQV8u7d0vr1Q==",
       "requires": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/dragdrop": "^1.7.1",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0"
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/dragdrop": "^1.13.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-3.2.4.tgz",
-      "integrity": "sha512-6ocnfoQtFO70KfnJhneOVCcxqTZrO+9vBF+MdoISEPKK03MPwM/9tRs0rPEvzHUE4xEN+1KjFEb/3pcHB6WZiQ==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-3.6.5.tgz",
+      "integrity": "sha512-BonbNpBxOn4CDPuyl2JtkruwgiA8ANsIAuzrZMoTnglOScHLGxmddnF5BhsjuvatG2cDM/PZtY+KaQqcaJQBQQ==",
       "requires": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codeeditor": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@jupyterlab/statusbar": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codeeditor": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/statusbar": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2",
         "codemirror": "~5.61.0",
         "react": "^17.0.1",
         "y-codemirror": "^3.0.1"
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.2.4.tgz",
-      "integrity": "sha512-0QXhg8R0bkb5LILhfphE/K5k4zJI8N+fNsmy/Nr4mDo8l8mB7km6OUcbSSNuJg1mYikOhEA+UxhqE0954UgxkQ==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.6.5.tgz",
+      "integrity": "sha512-nQ0eY9rv8bj0KoFHAwR4dDJY033XZsSDH5EV/E5m5/0f/oyLxWmKI3L/C1alXrltgdivh3nudbDX7VzQRoZPHA==",
       "requires": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
         "minimist": "~1.2.0",
         "moment": "^2.24.0",
         "path-browserify": "^1.0.0",
@@ -35684,41 +35825,45 @@
       }
     },
     "@jupyterlab/docprovider": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docprovider/-/docprovider-3.2.4.tgz",
-      "integrity": "sha512-7yh9lJslZb9/kgKD4Jta8XWhBrdZXN+/g2XKbRtgpESWboJ0/YAgglhxk2O+7pLVzs9vMdZmqAMCHbwui9+ltA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docprovider/-/docprovider-3.6.5.tgz",
+      "integrity": "sha512-jPFI2hKt1D/9ZpDH7iB9XDoKj8HYSNAFFENWOlRaEXCHL3S3lZA9b2G+T1XunQRefYxdyDZlY2JUSXojdgV2mA==",
       "requires": {
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "lib0": "^0.2.42",
-        "y-websocket": "^1.3.15",
-        "yjs": "^13.5.17"
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "y-protocols": "^1.0.5",
+        "y-websocket": "^1.4.6"
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-3.2.4.tgz",
-      "integrity": "sha512-3RVZrRgudrUqebz6FIgF8vD0nQsn7zzgy72XwB5YkYa7FBdLTf875ehUFXX4MdxqJC/uM/1th+0RPnnl8OwvaA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-3.6.5.tgz",
+      "integrity": "sha512-/QYkpDyqmDFeB12fjr0ANbSuJ2CRGk3O4yVft58pUsQHcWTZLXMG23XMMt9SaFjlr5LcYjhAbIfPzR8NYwGU9Q==",
       "requires": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codeeditor": "^3.2.4",
-        "@jupyterlab/codemirror": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/docprovider": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/rendermime": "^3.2.4",
-        "@jupyterlab/rendermime-interfaces": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/shared-models": "^3.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
-        "yjs": "^13.5.17"
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codeeditor": "^3.6.5",
+        "@jupyterlab/codemirror": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/docprovider": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/rendermime": "^3.6.5",
+        "@jupyterlab/rendermime-interfaces": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/shared-models": "^3.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "@jupyterlab/filebrowser": {
@@ -35781,11 +35926,11 @@
       }
     },
     "@jupyterlab/nbformat": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.2.4.tgz",
-      "integrity": "sha512-tEwt+vKAQEqj2smC8B5Myg693/5md3T9Nm3BM3Ix2NYqioCLlnGJ+aYQaOx1bsjyYWGLH/liW26O0NAUB3oEWg==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.6.5.tgz",
+      "integrity": "sha512-yyyNniuzxycsF+kHvjpAIjZ+qrt3G/HEViZN+FJA3vFpg6e2n/nqa7BgzlxINS5SH4FnBG6rM/u45bwih38VkA==",
       "requires": {
-        "@lumino/coreutils": "^1.5.3"
+        "@lumino/coreutils": "^1.11.0"
       }
     },
     "@jupyterlab/notebook": {
@@ -35819,15 +35964,15 @@
       }
     },
     "@jupyterlab/observables": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.2.4.tgz",
-      "integrity": "sha512-9b1a2+Tmda/Jr8oLMpMhQJAEpMRgILo8unjTnpMCb9RZgOZAwMRs+vItNqrjrapa4OO1vhIFVRWWqmxa5vz/6Q==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.6.5.tgz",
+      "integrity": "sha512-k6x7kLou+1EPtVlrQ6OFoujFj1jlvsKMcnap83Omjqj1DIkzSBGat3Y7Yf5OS7lrdyERJGYbtV9vfeSkwdjkjA==",
       "requires": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "@jupyterlab/outputarea": {
@@ -35852,111 +35997,113 @@
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-3.2.4.tgz",
-      "integrity": "sha512-G/CS2rMLM+rp5xrQ09Aq2Q2w+c3WN2XvLnEM091ELrfl7WGNytu9ms1bGSaM/ZCXw1o7FDRo1t4Yj066XtkB8A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-3.6.5.tgz",
+      "integrity": "sha512-ln0UgKJo+2qS4FehCQUR5W/SDbnwiUHX+zdKEViNI6NHK2oAeXtD4BbuxfS3ZfJyEKZcB6hMj+OVqO7opL/fvw==",
       "requires": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codemirror": "^3.2.4",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/rendermime-interfaces": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codemirror": "^3.6.5",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/rendermime-interfaces": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2",
         "lodash.escape": "^4.0.1",
-        "marked": "^2.0.0"
+        "marked": "^4.0.17"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+          "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+        }
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.2.4.tgz",
-      "integrity": "sha512-/zVDeW2ZaRMzQW0EFj5v/hjpJNSDfhJfbx96rprYZC8d0qEvm3Bxyyda4CvsRhmaJKMTAQLW+oOEBn1kNbFTmg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.8.6.tgz",
+      "integrity": "sha512-GPtyTwIiQH3jh9rT0LnjcPay6MQmUvMAbEHv42TksZ6dX98038ohuHt7cP1SZqHhQ8YdPcw0s8K7MjxEl2y/Ig==",
       "requires": {
-        "@jupyterlab/translation": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/widgets": "^1.19.0"
+        "@lumino/coreutils": "^1.11.0 || ^2.1.2",
+        "@lumino/widgets": "^1.37.2 || ^2.3.0"
       }
     },
     "@jupyterlab/services": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.2.4.tgz",
-      "integrity": "sha512-WpcKLDkwpq9jUQXUWJJn1cybxwwe8YMC8fdkVnI7RmCg5n0tGSV8+urfUv5Q8DdMdkAJnzSHEC6kIRbGoFpceQ==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.6.5.tgz",
+      "integrity": "sha512-ReTi7r8nAzop1u65Jc4HDlyERcyV8ebjTGmXUohRWEqMbgjrFH8rz4rV8iQnobg5GZ2Kyf2RBdSTKwEttj2Ghg==",
       "requires": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@jupyterlab/observables": "^4.2.4",
-        "@jupyterlab/settingregistry": "^3.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/signaling": "^1.4.3",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/nbformat": "^3.6.5",
+        "@jupyterlab/observables": "^4.6.5",
+        "@jupyterlab/settingregistry": "^3.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/signaling": "^1.10.0",
         "node-fetch": "^2.6.0",
         "ws": "^7.4.6"
       }
     },
     "@jupyterlab/settingregistry": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.2.4.tgz",
-      "integrity": "sha512-kyr6y32YTD4S2XGthy17yRa6BdEQyuXqIl2hIKrn9oPdfM0OF3TDkAByB8W79KLQojsKcmGka19LvQov/N4+6A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.6.5.tgz",
+      "integrity": "sha512-PLg6E7j9x5otTnsTntFHwhbd+SacSsjiTP5krVq1WwTV6FrqrfT29ttxTCgV5+y7j91YmnEaHhZD+TXx5bQqIQ==",
       "requires": {
-        "@jupyterlab/statedb": "^3.2.4",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
         "ajv": "^6.12.3",
         "json5": "^2.1.1"
       }
     },
     "@jupyterlab/shared-models": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/shared-models/-/shared-models-3.2.4.tgz",
-      "integrity": "sha512-Jr2Yz5L0GneKhrFpomm3LW5eGDfRaxWt0c+MT/eFXWmqvVkOKW4N3qPEfP1HNIMqagcC1OoN2pvZAWkE3qQYjA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/shared-models/-/shared-models-3.6.5.tgz",
+      "integrity": "sha512-5ZsX5Kt9n3tVvTSNDnV8vKKpQFDZ/zdUifwClx1gy5ZLMc0rtjXyIC10UKk0l8fIFSFGj7EN2ZR6pIAF0TRDZg==",
       "requires": {
-        "@jupyterlab/nbformat": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "y-protocols": "^1.0.5",
-        "yjs": "^13.5.17"
+        "@jupyter/ydoc": "~0.2.4",
+        "@jupyterlab/nbformat": "^3.6.5"
       }
     },
     "@jupyterlab/statedb": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.2.4.tgz",
-      "integrity": "sha512-md9AlnrW1pzZTQiVUIJrZgijB3CsSs2J05V5cywo4/sgjwBTO1YGKQDEi6qtMAeO03gxfomGK7xLpoP+2Uaa2A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.6.5.tgz",
+      "integrity": "sha512-Ah6pwJiU0XDI41iH+Ihw1lONBNDUrM4h58HwXD5qMvEPIWw5IxQn7QKt5XuaQWpTagXfUeuHrNpbekgdEImMog==",
       "requires": {
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "@jupyterlab/statusbar": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-3.2.4.tgz",
-      "integrity": "sha512-1oxNr926SJkxJ0b+hoHEWaFOnv+LVY6MWmv0wQvVzwCVDaQ3IjLXtOYheSXx7WtP4G3NjH2G/wM4mzqMs1JDbQ==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-3.6.5.tgz",
+      "integrity": "sha512-+kSW6ZgpXOfbfH9727JBYtx+lmgPiJCfFDKqlZfTbxYfvFx9j0C7eWfHZm6sL1WFYv5lB0iCUEY3GfL7X4LjHQ==",
       "requires": {
-        "@jupyterlab/apputils": "^3.2.4",
-        "@jupyterlab/codeeditor": "^3.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/translation": "^3.2.4",
-        "@jupyterlab/ui-components": "^3.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/apputils": "^3.6.5",
+        "@jupyterlab/codeeditor": "^3.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@jupyterlab/ui-components": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/widgets": "^1.37.2",
         "csstype": "~3.0.3",
         "react": "^17.0.1",
         "typestyle": "^2.0.4"
@@ -35979,114 +36126,116 @@
       }
     },
     "@jupyterlab/translation": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/translation/-/translation-3.2.4.tgz",
-      "integrity": "sha512-FTXhNw/KRmGGR/stWWyaeyyha3Y7k1jh/dVJIXMO5xlT+zzFHvquGCiMeMZR20P+xBDstrgX8Ei/LhG+gkx0yw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/translation/-/translation-3.6.5.tgz",
+      "integrity": "sha512-avk96gOFuWqZWywCezeXvvjNnib4xQv5VY4rvvhTrz0unAeo8CtQ3L3ZBdLtWLq+aA470WfdhneLwtv3n6JYdw==",
       "requires": {
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@jupyterlab/services": "^6.2.4",
-        "@jupyterlab/statedb": "^3.2.4",
-        "@lumino/coreutils": "^1.5.3"
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/services": "^6.6.5",
+        "@jupyterlab/statedb": "^3.6.5",
+        "@lumino/coreutils": "^1.11.0"
       }
     },
     "@jupyterlab/ui-components": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-3.2.4.tgz",
-      "integrity": "sha512-uKxv8U/6TdAMbs0kBm142oAx9R4FcPk+CK5pbsBTInq+nvCmUlSYSAFEnuTbfNLeKQlWHdj8N2Q7upLFgfEs2w==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-3.6.5.tgz",
+      "integrity": "sha512-yEkC/MLxalEJ9PvZs7AQo/IJDxqAToBBWvqC57t8lGEEkwNBG4hNDv8bmQMtfVv9BMvooQzhac5wJiaEj0T6sg==",
       "requires": {
         "@blueprintjs/core": "^3.36.0",
         "@blueprintjs/select": "^3.15.0",
-        "@jupyterlab/coreutils": "^5.2.4",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.8.0",
-        "@lumino/widgets": "^1.19.0",
+        "@jupyterlab/coreutils": "^5.6.5",
+        "@jupyterlab/translation": "^3.6.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "@lumino/virtualdom": "^1.14.0",
+        "@lumino/widgets": "^1.37.2",
+        "@rjsf/core": "^3.1.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "typestyle": "^2.0.4"
       }
     },
     "@lumino/algorithm": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.9.1.tgz",
-      "integrity": "sha512-d0rj7IYRzYj6WbWSrbJbKvrfO4H0NUnXT2yjSWS/sCklpTpSp0IGmndK/X4r6gG+ev5lb5+wBg9ofUDBvoAlAw=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.9.2.tgz",
+      "integrity": "sha512-Z06lp/yuhz8CtIir3PNTGnuk7909eXt4ukJsCzChsGuot2l5Fbs96RJ/FOHgwCedaX74CtxPjXHXoszFbUA+4A=="
     },
     "@lumino/application": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.29.0.tgz",
-      "integrity": "sha512-Ld2eWUjZMUn/y9tMMTfuBB1kZxIoVQtlZy8B7q53NiAfOdZ1cthfu2C7MUIeDMKLU7gZBSJqPSeuOxRFzv4wFA==",
+      "version": "1.31.4",
+      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.31.4.tgz",
+      "integrity": "sha512-dOSsDJ1tXOxC3fnSHvtDQK5RcICLEVPtO19HeCGwurb5W2ZZ55SZT2b5jZu6V/v8lGdtkNbr1RJltRpJRSRb/A==",
       "requires": {
-        "@lumino/commands": "^1.20.0",
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/widgets": "^1.32.0"
+        "@lumino/commands": "^1.21.1",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/widgets": "^1.37.2"
       }
     },
     "@lumino/collections": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.9.1.tgz",
-      "integrity": "sha512-5RaRGUY7BJ/1j173sc9DCfiVf70Z0hopRnBV8/AeAaK9bJJRAYjDhlZ9O8xTyouegh6krkOfiDyjl3pwogLrQw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.9.3.tgz",
+      "integrity": "sha512-2i2Wf1xnfTgEgdyKEpqM16bcYRIhUOGCDzaVCEZACVG9R1CgYwOe3zfn71slBQOVSjjRgwYrgLXu4MBpt6YK+g==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "@lumino/commands": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.20.0.tgz",
-      "integrity": "sha512-xyrzDIJ9QEbcbRAwmXrjb7A7/E5MDNbnLANKwqmFVNF+4LSnF62obdvY4On3Rify3HmfX0u16Xr9gfoWPX9wLQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.21.1.tgz",
+      "integrity": "sha512-d1zJmwz5bHU0BM/Rl3tRdZ7/WgXnFB0bM7x7Bf0XDlmX++jnU9k0j3mh6/5JqCGLmIApKCRwVqSaV7jPmSJlcQ==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/disposable": "^1.10.1",
-        "@lumino/domutils": "^1.8.1",
-        "@lumino/keyboard": "^1.8.1",
-        "@lumino/signaling": "^1.10.1",
-        "@lumino/virtualdom": "^1.14.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/signaling": "^1.11.1",
+        "@lumino/virtualdom": "^1.14.3"
       }
     },
     "@lumino/coreutils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.0.tgz",
-      "integrity": "sha512-DSglh4ylmLi820CNx9soJmDJCpUgymckdWeGWuN0Ash5g60oQvrQDfosVxEhzmNvtvXv45WZEqSBzDP6E5SEmQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.1.tgz",
+      "integrity": "sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==",
       "requires": {}
     },
     "@lumino/disposable": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.1.tgz",
-      "integrity": "sha512-mZQILc8sVGZC7mJNOGVmehDRO9/u3sIRdjZ+pCYjDgXKcINLd6HoPhZDquKCWiRBfHTL1B3tOHjnBhahBc2N/Q==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.4.tgz",
+      "integrity": "sha512-4ZxyYcyzUS+ZeB2KAH9oAH3w0DUUceiVr+FIZHZ2TAYGWZI/85WlqJtfm0xjwEpCwLLW1TDqJrISuZu3iMmVMA==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/signaling": "^1.10.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/signaling": "^1.11.1"
       }
     },
     "@lumino/domutils": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.8.1.tgz",
-      "integrity": "sha512-QUVXwmDMIfcHC3yslhmyGK4HYBKaJ3xX5MTwDrjsSX7J7AZ4jwL4zfsxyF9ntdqEKraoJhLQ6BaUBY+Ur1cnYw=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.8.2.tgz",
+      "integrity": "sha512-QIpMfkPJrs4GrWBuJf2Sn1fpyVPmvqUUAeD8xAQo8+4V5JAT0vUDLxZ9HijefMgNCi3+Bs8Z3lQwRCrz+cFP1A=="
     },
     "@lumino/dragdrop": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.14.0.tgz",
-      "integrity": "sha512-hO8sgF0BkpihKIP6UZgVJgiOEhz89i7Oxtp9FR9Jqw5alGocxSXt7q3cteMvqpcL6o2/s3CafZNRkVLRXmepNw==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.14.5.tgz",
+      "integrity": "sha512-LC5xB82+xGF8hFyl716TMpV32OIMIMl+s3RU1PaqDkD6B7PkgiVk6NkJ4X9/GcEvl2igkvlGQt/3L7qxDAJNxw==",
       "requires": {
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/disposable": "^1.10.1"
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4"
       }
     },
     "@lumino/keyboard": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.1.tgz",
-      "integrity": "sha512-8x0y2ZQtEvOsblpI2gfTgf+gboftusP+5aukKEsgNQtzFl28RezQXEOSVd8iD3K6+Q1MaPQF0OALYP0ASqBjBg=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.2.tgz",
+      "integrity": "sha512-Dy+XqQ1wXbcnuYtjys5A0pAqf4SpAFl9NY6owyIhXAo0Va7w3LYp3jgiP1xAaBAwMuUppiUAfrbjrysZuZ625g=="
     },
     "@lumino/messaging": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.10.1.tgz",
-      "integrity": "sha512-XZSdt9ih94rdeeLL0cryUw6HHD51D7TP8c+MFf+YRF6VKwOFB9RoajfQWadeqpmH+schTs3EsrFfA9KHduzC7w==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.10.3.tgz",
+      "integrity": "sha512-F/KOwMCdqvdEG8CYAJcBSadzp6aI7a47Fr60zAKGqZATSRRRV41q53iXU7HjFPqQqQIvdn9Z7J32rBEAyQAzww==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/collections": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/collections": "^1.9.3"
       }
     },
     "@lumino/polling": {
@@ -36100,42 +36249,43 @@
       }
     },
     "@lumino/properties": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.8.1.tgz",
-      "integrity": "sha512-O+CCcAqP64Di32DUZ4Jqq0DtUyE5RJREN5vbkgGZGu+WauJ/RYoiLDe1ubbAeSaHk71OrS60ZBV7QyC8ZaBVsA=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.8.2.tgz",
+      "integrity": "sha512-EkjI9Cw8R0U+xC9HxdFSu7X1tz1H1vKu20cGvJ2gU+CXlMB1DvoYJCYxCThByHZ+kURTAap4SE5x8HvKwNPbig=="
     },
     "@lumino/signaling": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.10.1.tgz",
-      "integrity": "sha512-GZVbX4cfk/ZqLwkemPD/NwqToaTL/6q7qdLpEhgkiPlaH1S5/V7fDpP7N1uFy4n3BDITId8cpYgH/Ds32Mdp3A==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.11.1.tgz",
+      "integrity": "sha512-YCUmgw08VoyMN5KxzqPO3KMx+cwdPv28tAN06C0K7Q/dQf+oufb1XocuhZb5selTrTmmuXeizaYxgLIQGdS1fA==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/properties": "^1.8.2"
       }
     },
     "@lumino/virtualdom": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.1.tgz",
-      "integrity": "sha512-imIJd/wtRkoR1onEiG5nxPEaIrf70nn4PgD/56ri3/Lo6AJEX2CusF6iIA27GVB8yl/7CxgTHUnzzCwTFPypcA==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.3.tgz",
+      "integrity": "sha512-5joUC1yuxeXbpfbSBm/OR8Mu9HoTo6PDX0RKqzlJ9o97iml7zayFN/ynzcxScKGQAo9iaXOY8uVIvGUT8FnsGw==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "@lumino/widgets": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.32.0.tgz",
-      "integrity": "sha512-f2wHtr20ZEGHt+FZo9yjMQijGVI+2zzvVyiMkeIdjeuxYpKTfsZl1OVb1dcAFqr5VbsqfQ3TEdq816Nfjf5Mvw==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.37.2.tgz",
+      "integrity": "sha512-NHKu1NBDo6ETBDoNrqSkornfUCwc8EFFzw6+LWBfYVxn2PIwciq2SdiJGEyNqL+0h/A9eVKb5ui5z4cwpRekmQ==",
       "requires": {
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/commands": "^1.20.0",
-        "@lumino/coreutils": "^1.12.0",
-        "@lumino/disposable": "^1.10.1",
-        "@lumino/domutils": "^1.8.1",
-        "@lumino/dragdrop": "^1.14.0",
-        "@lumino/keyboard": "^1.8.1",
-        "@lumino/messaging": "^1.10.1",
-        "@lumino/properties": "^1.8.1",
-        "@lumino/signaling": "^1.10.1",
-        "@lumino/virtualdom": "^1.14.1"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/commands": "^1.21.1",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/dragdrop": "^1.14.5",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/messaging": "^1.10.3",
+        "@lumino/properties": "^1.8.2",
+        "@lumino/signaling": "^1.11.1",
+        "@lumino/virtualdom": "^1.14.3"
       }
     },
     "@mapbox/node-pre-gyp": {
@@ -38509,6 +38659,22 @@
             }
           }
         }
+      }
+    },
+    "@rjsf/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==",
+      "requires": {
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^6.7.0",
+        "core-js-pure": "^3.6.5",
+        "json-schema-merge-allof": "^0.6.0",
+        "jsonpointer": "^5.0.0",
+        "lodash": "^4.17.15",
+        "nanoid": "^3.1.23",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
       }
     },
     "@sideway/address": {
@@ -41813,6 +41979,27 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "requires": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
       }
     },
     "concat-map": {
@@ -49024,6 +49211,24 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
+      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -49068,6 +49273,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -49180,11 +49390,6 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "dev": true
-    },
-    "klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
     },
     "known-css-properties": {
       "version": "0.21.0",
@@ -49340,9 +49545,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.43",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.43.tgz",
-      "integrity": "sha512-MJ1KLoz5p3gljIUBfdjjNuL/wlWHHK6+DrcIRhzSRLvtAu1XNdRtRGATYM51KSTI0P2nxJZFQM8rwCH6ga9KUw==",
+      "version": "0.2.85",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.85.tgz",
+      "integrity": "sha512-vtAhVttLXCu3ps2OIsTz8CdKYKdcMo7ds1MNBIcSXz6vrY8sxASqpTi4vmsAIn7xjWvyT7haKcWW6woP6jebjQ==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -49687,7 +49892,7 @@
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "optional": true
     },
     "lunr": {
@@ -51214,7 +51419,7 @@
     "parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "parse5": {
       "version": "5.1.0",
@@ -55021,17 +55226,16 @@
       }
     },
     "sanitize-html": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.3.3.tgz",
-      "integrity": "sha512-DCFXPt7Di0c6JUnlT90eIgrjs6TsJl/8HYU3KLdmrVclFN4O0heTcVbJiMa23OKVr6aR051XYtsgd8EWwEBwUA==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^6.0.0",
         "is-plain-object": "^5.0.0",
-        "klona": "^2.0.3",
         "parse-srcset": "^1.0.2",
-        "postcss": "^8.0.2"
+        "postcss": "^8.3.11"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -57499,6 +57703,38 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
+    },
     "validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -58698,9 +58934,9 @@
       }
     },
     "y-leveldb": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/y-leveldb/-/y-leveldb-0.1.0.tgz",
-      "integrity": "sha512-sMuitVrsAUNh+0b66I42nAuW3lCmez171uP4k0ePcTAJ+c+Iw9w4Yq3wwiyrDMFXBEyQSjSF86Inc23wEvWnxw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/y-leveldb/-/y-leveldb-0.1.2.tgz",
+      "integrity": "sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg==",
       "optional": true,
       "requires": {
         "level": "^6.0.1",
@@ -58716,11 +58952,11 @@
       }
     },
     "y-websocket": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-1.3.18.tgz",
-      "integrity": "sha512-xdQhvq/iQ6lyrmQ0GhLWXVcpXXjyj7E+PEcC3d2IAShLbz0I8rAOKbq/tGrAQPy6g1oilRz6eb8M7EbqsJj6tg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-1.5.0.tgz",
+      "integrity": "sha512-A8AO6XtnQlYwWFytWdkDCeXg4l8ghRTIw5h2YUgUYDmEC9ugWGIwYNW80yadhSFAF7CvuWTEkQNEpevnH6EiZw==",
       "requires": {
-        "lib0": "^0.2.42",
+        "lib0": "^0.2.52",
         "lodash.debounce": "^4.0.8",
         "ws": "^6.2.1",
         "y-leveldb": "^0.1.0",
@@ -58792,11 +59028,11 @@
       }
     },
     "yjs": {
-      "version": "13.5.22",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.22.tgz",
-      "integrity": "sha512-qxsVlu/E2dLUUtJyhDbwkhrw1gWbdE+UWzVI2VEeY6G1M8TYI51VvXSoPC/4QQMNIyEdsCOW2cWxPUyoCH43gw==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
       "requires": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.74"
       }
     },
     "yocto-queue": {

--- a/jupyter-extension/package.json
+++ b/jupyter-extension/package.json
@@ -52,7 +52,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyterlab/application": "^3.1.0",
+    "@jupyterlab/application": "^3.5.3",
     "@jupyterlab/coreutils": "^5.1.0",
     "@jupyterlab/filebrowser": "^3.2.4",
     "@jupyterlab/launcher": "^3.2.3",
@@ -128,7 +128,7 @@
   "jupyter-releaser": {
     "hooks": {
       "before-build-npm": [
-        "python -m pip install jupyterlab~=3.1",
+        "python -m pip install jupyterlab~=3.5",
         "npm"
       ]
     }

--- a/jupyter-extension/pyproject.toml
+++ b/jupyter-extension/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.5"]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.options]

--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 packages = find:
 install_requires =
   pyyaml>=6.0
-  jupyter_server>=1.6,<2
+  jupyter_server>=2.7.0,<2.8
   python-pachyderm>=v7.4.0,<8
 include_package_data = True
 zip_safe = False
@@ -34,4 +34,5 @@ dev=
   pytest
   pytest-asyncio
   pytest-tornasync
+  pytest-jupyter
   python-pachyderm>=v7.4.0,<8


### PR DESCRIPTION
Determineds task environments have jupyter_server==2.7.0, but jupyterlab-pachyderm is locked to  jupyter_server>=1.6,<2 which prevents it from being installed into a Determined task environment. Change the locked version to jupyter_server>=2.7.0,<2.8  to match Determined as of 0.24.0, yet allow for fixes.  jupyter_server recommends that the version be pinned to avoid plug-in breakage, so this locks major and minor.

The integration tests use an unauthenticated interface between the
tests and the dev_server.   Add an jupyter_server identity provider
that disables authentication to enable this to continue working with
jupyter_server >= 2.0.