### PR TITLE
internal/client: add functions for file methods

### DIFF
--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -897,6 +897,24 @@ func (c *APIClient) AddMetadata(ctx context.Context) context.Context {
 	return metadata.NewOutgoingContext(ctx, finalMD)
 }
 
+func SetAuthToken(ctx context.Context, token string) context.Context {
+	// Rescue any metadata pairs already in 'ctx' (otherwise
+	// metadata.NewOutgoingContext() would drop them). Note that this is similar
+	// to metadata.Join(), but distinct because it discards conflicting k/v pairs
+	// instead of merging them)
+	incomingMD, _ := metadata.FromIncomingContext(ctx)
+	outgoingMD, _ := metadata.FromOutgoingContext(ctx)
+	finalMD := make(metadata.MD) // Collect k/v pairs
+	for _, md := range []metadata.MD{incomingMD, outgoingMD} {
+		for k, v := range md {
+			finalMD[k] = v
+		}
+	}
+	finalMD[auth.ContextTokenKey] = []string{token}
+
+	return metadata.NewOutgoingContext(ctx, finalMD)
+}
+
 // Ctx is a convenience function that returns adds Pachyderm authn metadata
 // to context.Background().
 func (c *APIClient) Ctx() context.Context {


### PR DESCRIPTION
There are many file utility methods on the pach client, and they are pretty widely used.  But in order to take advantage of them, you have to pay the cost of the pach client abstraction, which means a dependency on all the services.

These changes create functions for each of these methods and change the methods to call into the functions, so they are useful anywhere a pfs.APIClient is available.