### PR TITLE
[Mount Server] Fixes mounting datum bug in loopback.go

### DIFF
--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -630,19 +630,6 @@ func (n *loopbackNode) download(ctx context.Context, origPath string, state file
 		if !strings.HasPrefix(fi.File.Path, ro.File.Path) && !strings.HasPrefix(ro.File.Path, fi.File.Path) {
 			return nil
 		}
-		if skip := func() bool {
-			if len(ro.Subpaths) == 0 {
-				return false
-			}
-			for _, sp := range ro.Subpaths {
-				if strings.HasPrefix(fi.File.Path, sp) || strings.HasPrefix(sp, fi.File.Path) {
-					return false
-				}
-			}
-			return true
-		}(); skip {
-			return nil
-		}
 		if fi.FileType == pfs.FileType_DIR {
 			return errors.EnsureStack(os.MkdirAll(n.filePath(name, fi), 0777))
 		}
@@ -679,12 +666,22 @@ func (n *loopbackNode) download(ctx context.Context, origPath string, state file
 		}
 		return nil
 	}
-	filePath := pathpkg.Join(parts[1:]...)
 	projectName := ro.File.Commit.Branch.Repo.Project.GetName()
 	repoName := ro.File.Commit.Branch.Repo.Name
-	if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), filePath, createFile); err != nil && !errutil.IsNotFoundError(err) &&
-		!pfsserver.IsOutputCommitNotFinishedErr(err) {
-		return err
+	// If mounting just a subset of files in a repo, mount just those files
+	if len(ro.Subpaths) != 0 {
+		for _, path := range ro.Subpaths {
+			if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), path, createFile); err != nil && !errutil.IsNotFoundError(err) &&
+				!pfsserver.IsOutputCommitNotFinishedErr(err) {
+				return err
+			}
+		}
+	} else {
+		filePath := pathpkg.Join(parts[1:]...)
+		if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), filePath, createFile); err != nil && !errutil.IsNotFoundError(err) &&
+			!pfsserver.IsOutputCommitNotFinishedErr(err) {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/server/pfs/fuse/loopback.go
+++ b/src/server/pfs/fuse/loopback.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -668,22 +667,45 @@ func (n *loopbackNode) download(ctx context.Context, origPath string, state file
 	}
 	projectName := ro.File.Commit.Branch.Repo.Project.GetName()
 	repoName := ro.File.Commit.Branch.Repo.Name
-	// If mounting just a subset of files in a repo, mount just those files
-	if len(ro.Subpaths) != 0 {
-		for _, path := range ro.Subpaths {
-			if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), path, createFile); err != nil && !errutil.IsNotFoundError(err) &&
-				!pfsserver.IsOutputCommitNotFinishedErr(err) {
-				return err
-			}
-		}
-	} else {
-		filePath := pathpkg.Join(parts[1:]...)
-		if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), filePath, createFile); err != nil && !errutil.IsNotFoundError(err) &&
+	subpaths := subpathsToMount(ro.Subpaths, filepath.Join(parts[1:]...))
+	log.Info(pctx.TODO(), "subpathsToMount", zap.Any("ro.Subpaths", ro.Subpaths), zap.String("filePath", filepath.Join(parts[1:]...)), zap.String("subpaths", fmt.Sprintf("%v", subpaths)))
+	for _, subpath := range subpaths {
+		log.Info(pctx.TODO(), "Calling ListFile", zap.String("path", subpath))
+		if err := n.c().ListFile(client.NewCommit(projectName, repoName, branch, commit), subpath, createFile); err != nil && !errutil.IsNotFoundError(err) &&
 			!pfsserver.IsOutputCommitNotFinishedErr(err) {
 			return err
 		}
 	}
 	return nil
+}
+
+// If we're only mounting a subset of the repo, we need to determine what needs to be mounted
+// given that the user is trying to access the filesystem at filePath
+func subpathsToMount(subpaths []string, filePath string) []string {
+	filePath = filepath.Join("/", filePath)
+	// Whole repo is being mounted so no need to filter
+	if len(subpaths) == 0 {
+		return []string{filePath}
+	}
+	var paths []string
+	for _, path := range subpaths {
+		if path == "" || path == "/" {
+			// One of the subpaths is full repo so no need to filter
+			return []string{filePath}
+		}
+		if strings.HasPrefix(filePath, path) { 
+			// filePath is a descendant of path
+			paths = append(paths, filePath)
+		} else if strings.HasPrefix(path, filePath) { 
+			// filePath is an ancestor of path
+			// Mount the portion of path that is an immediate child of filePath
+			childPath := strings.TrimPrefix(path, filePath)
+			childPath = strings.TrimPrefix(childPath, "/")
+			childPathParts := strings.Split(childPath, "/")
+			paths = append(paths, filepath.Join(filePath, childPathParts[0]))
+		}
+	}
+	return paths
 }
 
 func (n *loopbackNode) trimPath(path string) string {

--- a/src/server/pfs/fuse/options.go
+++ b/src/server/pfs/fuse/options.go
@@ -35,8 +35,7 @@ type RepoOptions struct {
 	// of the same repo at the same time.
 	Name string
 
-	File     *pfs.File
-	Subpaths []string
+	File *pfs.File
 	// Repo is the name of the repo to mount
 	// Repo string
 	// Branch is the branch of the repo to mount

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -80,13 +80,13 @@ type DatumsResponse struct {
 }
 
 type MountInfo struct {
-	Name    string   `json:"name"`
-	Project string   `json:"project"`
-	Repo    string   `json:"repo"`
-	Branch  string   `json:"branch"`
-	Commit  string   `json:"commit"` // "" for no commit (commit as noun)
-	Files   []string `json:"files"`
-	Mode    string   `json:"mode"` // "ro", "rw"
+	Name    string `json:"name"`
+	Project string `json:"project"`
+	Repo    string `json:"repo"`
+	Branch  string `json:"branch"`
+	Commit  string `json:"commit"` // "" for no commit (commit as noun)
+	Path    string `json:"path"`
+	Mode    string `json:"mode"` // "ro", "rw"
 }
 
 type Request struct {
@@ -112,7 +112,7 @@ type MountManager struct {
 
 	Datums              []*pps.DatumInfo
 	DatumInput          *pps.Input
-	DatumInputsToMounts map[string]string
+	DatumInputsToMounts map[string][]string
 	CurrDatumIdx        int
 
 	// map from mount name onto mfc for that mount
@@ -199,7 +199,6 @@ func (mm *MountManager) ListByMounts() (ListMountResponse, error) {
 				return mr, err
 			}
 			ms := msm.MountState
-			ms.Files = nil
 			mr.Mounted = append(mr.Mounted, ms)
 		}
 	}
@@ -1144,12 +1143,12 @@ func (mm *MountManager) verifyMountRequest(mis []*MountInfo) error {
 }
 
 // Visit each entry in the Input spec and set default values if unassigned
-func sanitizeInputAndGetAlias(datumInput *pps.Input, c *client.APIClient) (map[string]string, error) {
+func sanitizeInputAndGetAlias(datumInput *pps.Input, c *client.APIClient) (map[string][]string, error) {
 	if datumInput == nil {
 		return nil, errors.New("datum input is not specified")
 	}
 
-	datumInputsToMounts := map[string]string{} // Maps input to mount name
+	datumInputsToMounts := map[string][]string{} // Maps input to mount name(s)
 	if err := pps.VisitInput(datumInput, func(input *pps.Input) error {
 		if input.Pfs == nil {
 			return nil
@@ -1177,7 +1176,13 @@ func sanitizeInputAndGetAlias(datumInput *pps.Input, c *client.APIClient) (map[s
 			return err
 		}
 		pfsInput := client.NewBranch(input.Pfs.Project, input.Pfs.Repo, bi.Head.Branch.Name).String()
-		datumInputsToMounts[pfsInput] = input.Pfs.Name
+		// In the case where a cross is done on the same repo, we will need to map FileInfo's from
+		// the same repo to different user-specified mount names.
+		if mountNames, ok := datumInputsToMounts[pfsInput]; ok {
+			datumInputsToMounts[pfsInput] = append(mountNames, input.Pfs.Name)
+		} else {
+			datumInputsToMounts[pfsInput] = []string{input.Pfs.Name}
+		}
 
 		return nil
 	}); err != nil {
@@ -1187,40 +1192,37 @@ func sanitizeInputAndGetAlias(datumInput *pps.Input, c *client.APIClient) (map[s
 	return datumInputsToMounts, nil
 }
 
+func getCopyOfMapping(datumInputsToMounts map[string][]string) map[string][]string {
+	datumInputsToMountsCopy := map[string][]string{}
+	for k, v := range datumInputsToMounts {
+		datumInputsToMountsCopy[k] = v
+	}
+	return datumInputsToMountsCopy
+}
+
 func (mm *MountManager) datumToMounts(d *pps.DatumInfo) []*MountInfo {
-	mounts := map[string]*MountInfo{}
-	files := map[string]map[string]bool{}
+	log.Info(pctx.TODO(), "HERE")
+	datumInputsToMounts := getCopyOfMapping(mm.DatumInputsToMounts)
+	mis := []*MountInfo{}
 	for _, fi := range d.Data {
 		project := fi.File.Commit.Branch.Repo.GetProject().GetName()
 		repo := fi.File.Commit.Branch.Repo.Name
 		branch := fi.File.Commit.Branch.Name
 		commit := fi.File.Commit.Id
-		name := mm.DatumInputsToMounts[client.NewBranch(project, repo, branch).String()]
 
-		if _, ok := files[name]; !ok {
-			files[name] = map[string]bool{}
-		}
-		var mi *MountInfo
-		var ok bool
-		if mi, ok = mounts[name]; !ok {
-			mi = &MountInfo{
-				Name:    name,
-				Project: project,
-				Repo:    repo,
-				Branch:  branch,
-				Commit:  commit,
-				Files:   []string{fi.File.Path},
-				Mode:    "ro",
-			}
-		} else if _, ok = files[name][fi.File.Path]; !ok {
-			mi.Files = append(mi.Files, fi.File.Path)
-		}
-		mounts[name] = mi
-		files[name][fi.File.Path] = true
-	}
+		mountsForRepo := datumInputsToMounts[client.NewBranch(project, repo, branch).String()]
+		name := mountsForRepo[0]
+		datumInputsToMounts[client.NewBranch(project, repo, branch).String()] = mountsForRepo[1:]
 
-	mis := []*MountInfo{}
-	for _, mi := range mounts {
+		mi := &MountInfo{
+			Name:    name,
+			Project: project,
+			Repo:    repo,
+			Branch:  branch,
+			Commit:  commit,
+			Path:    fi.File.Path,
+			Mode:    "ro",
+		}
 		mis = append(mis, mi)
 	}
 	return mis
@@ -1465,7 +1467,7 @@ func unmountedState(m *MountStateMachine) StateFn {
 			m.Repo = req.Repo
 			m.Branch = req.Branch
 			m.Commit = req.Commit
-			m.Files = req.Files
+			m.Path = req.Path
 			m.Mode = req.Mode
 			return mountingState
 		case "commit":
@@ -1500,10 +1502,9 @@ func mountingState(m *MountStateMachine) StateFn {
 		m.manager.mu.Lock()
 		defer m.manager.mu.Unlock()
 		m.manager.root.repoOpts[m.Name] = &RepoOptions{
-			Name:     m.Name,
-			File:     client.NewFile(m.Project, m.Repo, m.Branch, m.Commit, ""),
-			Subpaths: m.Files,
-			Write:    m.Mode == "rw",
+			Name:  m.Name,
+			File:  client.NewFile(m.Project, m.Repo, m.Branch, m.Commit, m.Path),
+			Write: m.Mode == "rw",
 		}
 		m.manager.root.branches[m.Name] = m.Branch
 		if m.Commit != "" {

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -1201,7 +1201,6 @@ func getCopyOfMapping(datumInputsToMounts map[string][]string) map[string][]stri
 }
 
 func (mm *MountManager) datumToMounts(d *pps.DatumInfo) []*MountInfo {
-	log.Info(pctx.TODO(), "HERE")
 	datumInputsToMounts := getCopyOfMapping(mm.DatumInputsToMounts)
 	mis := []*MountInfo{}
 	for _, fi := range d.Data {


### PR DESCRIPTION
Fixes bug in [INT-1117]. The filtering logic in the createFile callback in loopback.go::download() that checks file prefix against `ro.Subpaths` allowed false positives. The screenshots in the ticket show an example that exposed the bug.

[INT-1117]: https://pachyderm.atlassian.net/browse/INT-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ