### PR TITLE
[Jupyter] Make pycurl optional and sockets non-default.

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -5,10 +5,10 @@ HTTP_UNIX_SOCKET_SCHEMA="http_unix"
 HTTP_SCHEMA="http"
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 PFS_SOCK_PATH = os.environ.get("PFS_SOCK_PATH", "/tmp/pfs.sock")
-DEFAULT_SCHEMA = os.environ.get("DEFAULT_SCHEMA", HTTP_UNIX_SOCKET_SCHEMA)
+DEFAULT_SCHEMA = os.environ.get("DEFAULT_SCHEMA", HTTP_SCHEMA)
 SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
-MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
-NONPRIV_CONTAINER = os.environ.get("NONPRIV_CONTAINER") # Unset assume --privileged container
+MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR")  # defaults to stdout/stderr
+NONPRIV_CONTAINER = os.environ.get("NONPRIV_CONTAINER")  # Unset assume --privileged container
 
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())

--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -21,7 +21,6 @@ install_requires =
   pyyaml>=6.0
   jupyter_server>=2.7.0,<2.8
   python-pachyderm>=v7.4.0,<8
-  pycurl>=7.45.1,<8
 include_package_data = True
 zip_safe = False
 python_requires = >=3.8,<4
@@ -37,3 +36,6 @@ dev=
   pytest-tornasync
   pytest-jupyter
   python-pachyderm>=v7.4.0,<8
+
+socket=
+  pycurl>=7.45.1,<8


### PR DESCRIPTION
Adds a new install option for the jupyter-extension `pip install -e '.[socket]'` that enables the the extension to network using sockets.