### PR TITLE
Set GOMEMLIMIT in the storage container from pipeline sidecar resource requests

### DIFF
--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -59,6 +59,8 @@ const (
 	StorageMaxOpenFileSetsEnvVar               = "STORAGE_FILESETS_MAX_OPEN"
 	StorageDiskCacheSizeEnvVar                 = "STORAGE_DISK_CACHE_SIZE"
 	StorageMemoryCacheSizeEnvVar               = "STORAGE_MEMORY_CACHE_SIZE"
+	SidecarMemoryRequestEnvVar                 = "K8S_MEMORY_REQUEST"
+	SidecarMemoryLimitEnvVar                   = "K8S_MEMORY_LIMIT"
 )
 
 // Parameters used when creating the kubernetes replication controller in charge
@@ -517,7 +519,7 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 	if options.sidecarResourceLimits != nil {
 		if m := options.sidecarResourceLimits.Memory(); m != nil {
 			podSpec.Containers[1].Env = append(podSpec.Containers[1].Env, v1.EnvVar{
-				Name:  "K8S_MEMORY_LIMIT",
+				Name:  SidecarMemoryLimitEnvVar,
 				Value: m.AsDec().String(),
 			})
 		}
@@ -530,7 +532,7 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 	if options.sidecarResourceRequests != nil {
 		if m := options.sidecarResourceRequests.Memory(); m != nil {
 			podSpec.Containers[1].Env = append(podSpec.Containers[1].Env, v1.EnvVar{
-				Name:  "K8S_MEMORY_REQUEST",
+				Name:  SidecarMemoryRequestEnvVar,
 				Value: m.AsDec().String(),
 			})
 		}

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -515,6 +515,12 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 	}
 
 	if options.sidecarResourceLimits != nil {
+		if m := options.sidecarResourceLimits.Memory(); m != nil {
+			podSpec.Containers[1].Env = append(podSpec.Containers[1].Env, v1.EnvVar{
+				Name:  "K8S_MEMORY_LIMIT",
+				Value: m.AsDec().String(),
+			})
+		}
 		podSpec.Containers[1].Resources.Limits = make(v1.ResourceList)
 		for k, v := range *options.sidecarResourceLimits {
 			podSpec.Containers[1].Resources.Limits[k] = v
@@ -522,6 +528,12 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 	}
 
 	if options.sidecarResourceRequests != nil {
+		if m := options.sidecarResourceRequests.Memory(); m != nil {
+			podSpec.Containers[1].Env = append(podSpec.Containers[1].Env, v1.EnvVar{
+				Name:  "K8S_MEMORY_REQUEST",
+				Value: m.AsDec().String(),
+			})
+		}
 		podSpec.Containers[1].Resources.Requests = make(v1.ResourceList)
 		for k, v := range *options.sidecarResourceRequests {
 			podSpec.Containers[1].Resources.Requests[k] = v


### PR DESCRIPTION
This hooks into the same machinery that pachd uses, but we don't use the downward API, we just set the values ourselves.  If we used the downward API, then we'd unexpectedly pick up the post-pod-patch results, which seems surprising to me.

CORE-1985