### PR TITLE
Djanicek/core 861/delete loki pvc in test

### DIFF
--- a/etc/testing/circle/run_tests.sh
+++ b/etc/testing/circle/run_tests.sh
@@ -44,7 +44,7 @@ case "${BUCKET}" in
     ;;
   S3_AUTH)
     export PACH_TEST_WITH_AUTH=1
-    bash -ceo pipefail "go test -count=1 -tags=k8s ./src/server/pps/server/s3g_sidecar_test.go -timeout 420s ${TESTFLAGS}"
+    bash -ceo pipefail "go test -count=1 -tags=k8s ./src/server/pps/server/s3g_sidecar_test.go -timeout 600s ${TESTFLAGS}"
     ;;
   AUTH)
     make test-auth


### PR DESCRIPTION
While working through issues to remove test buckets and `unit_tests` I found that loki is not getting the `suite=pachyderm` label, so when the test removes the release we manually delete pvcs(pvcs are not deleted by helm) by selector. I suspect this is the issue with some of our flaky tests around logs, so I'd like to get the fix in sooner than the full test bucket redo.

We now manually delete loki when minikubetestenv restarts. I looked into adding `suite=pachyderm` to loki, but loki references the logs it's scraping through that label, so that seems like it could be self referential. Initial testing adding the label hasn't been promising.

I additionally increased auth test timeout to 10 minutes like all the other tests. This will be removed once CORE-861 is complete(the who `run_test.sh` file is being deleted), but for now it should decrease required test reruns.