### PR TITLE
Fix HPC nonpriv containers + mount-server --sock-path

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -137,7 +137,7 @@ def test_list_mounts(pachyderm_resources, dev_server):
             "branch",
             "project",
             "commit",
-            "files",
+            "path",
             "mode",
             "state",
             "status",


### PR DESCRIPTION
The support for mount-server unix domain sockets was not tested
with NONPRIV_CONTAINER=1, add support to enable both to work.

Singularity/Apptainer/Enroot container runtime platforms provide
much less isolation than docker.   The pgrep command inside the
container may find the pid of mount-server instances running inside
other containers on the same node -- even by a different user.
This change limits the search for mount-server processes that are in
the same session as the command we launched.   We get the pid
of the command we launch, but it is wrappered by a bash and an
unshare command before the mount-server we are trying to find.

Fix a failure in the jupyterlab_pachyderm/tests/test_integrations.py
introduced by some other change.