### PR TITLE
Remove global logger in log.TestInit, so that tests can be run in any order

### DIFF
--- a/src/internal/log/loggers_test.go
+++ b/src/internal/log/loggers_test.go
@@ -14,6 +14,9 @@ import (
 
 func TestInit(t *testing.T) {
 	buf := new(bytes.Buffer)
+	t.Cleanup(func() {
+		zap.ReplaceGlobals(zap.NewNop())
+	})
 
 	// Create a development logger that logs to buf.
 	developmentLogger = true

--- a/src/internal/log/loggers_test.go
+++ b/src/internal/log/loggers_test.go
@@ -14,9 +14,6 @@ import (
 
 func TestInit(t *testing.T) {
 	buf := new(bytes.Buffer)
-	t.Cleanup(func() {
-		zap.ReplaceGlobals(zap.NewNop())
-	})
 
 	// Create a development logger that logs to buf.
 	developmentLogger = true
@@ -30,6 +27,10 @@ func TestInit(t *testing.T) {
 		true,
 		nil,
 	)
+	t.Cleanup(func() {
+		zap.ReplaceGlobals(zap.NewNop())
+	})
+
 	if got, want := buf.String(), ""; got != want {
 		t.Errorf("unexpected log messages: %s", got)
 	}
@@ -136,6 +137,9 @@ func TestWarnings(t *testing.T) {
 		false,
 		nil,
 	)
+	t.Cleanup(func() {
+		zap.ReplaceGlobals(zap.NewNop())
+	})
 	if got, want := buf.String(), `"this is an init warning"`; !strings.Contains(got, want) {
 		t.Errorf("init:\n  got: %v\n want: /%v/", got, want)
 	}


### PR DESCRIPTION
fixes `go test "./src/internal/log" -v -run="^TestInit$|^TestTestParallel$"`