### PR TITLE
FE-243: Auto-detect if non-priv mode should be used

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -10,7 +10,7 @@ SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
 MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
 NONPRIV_CONTAINER = os.environ.get("NONPRIV_CONTAINER") # Unset assume --privileged container
 DET_RESOURCES_TYPE = os.environ.get("DET_RESOURCES_TYPE") # Assume MLDE if set
-SLURM_JOB="slurm-job" # For launcher HPC this is set in Determined RM
+SLURM_JOB="slurm-job" # For launcher HPC this is set in DispatcherRM
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -9,7 +9,8 @@ DEFAULT_SCHEMA = os.environ.get("DEFAULT_SCHEMA", HTTP_UNIX_SOCKET_SCHEMA)
 SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
 MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
 NONPRIV_CONTAINER = os.environ.get("NONPRIV_CONTAINER") # Unset assume --privileged container
-
+DET_RESOURCES_TYPE = os.environ.get("DET_RESOURCES_TYPE") # Assume MLDE if set
+SLURM_JOB="slurm-job" # For launcher HPC this is set in Determined RM
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -80,7 +80,7 @@ class MountServerClient(MountInterface):
         bound, it will exit straight away. If it's not, it might start up
         successfully with the updated config.
         """
-        # TODO: add --socket and --log-file stdout args
+        # TODO: add --log-file stdout args
         # TODO: add better error handling
         if await self._is_mount_server_running():
             return True


### PR DESCRIPTION
When the jupyter_pachyderm plugin is used in an Determined AI root-less/daemon-less HPC container runtime (Singularity/Enroot/Apptatiner/Podman), automatically assume NONPRIV_CONTAINER=1 to enable /pfs to work.
This is accomplished by checking the environment variable DET_RESOURCES_TYPE for the value "slurm-job" which is set by Determined when launching such containers on an HPC cluster.