### PR TITLE
FE-243: Auto-detect if non-priv mode should be used

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -8,7 +8,7 @@ PFS_SOCK_PATH = os.environ.get("PFS_SOCK_PATH", "/tmp/pfs.sock")
 DEFAULT_SCHEMA = os.environ.get("DEFAULT_SCHEMA", HTTP_UNIX_SOCKET_SCHEMA)
 SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
 MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
-NONPRIV_CONTAINER = strtobool(os.environ.get("NONPRIV_CONTAINER").lower()) # Unset assume --privileged container
+NONPRIV_CONTAINER = strtobool(os.environ.get("NONPRIV_CONTAINER", "False").lower()) # Unset assume --privileged container
 DET_RESOURCES_TYPE = os.environ.get("DET_RESOURCES_TYPE") # Assume MLDE if set
 SLURM_JOB="slurm-job" # For launcher HPC this is set in DispatcherRM
 

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -9,7 +9,8 @@ DEFAULT_SCHEMA = os.environ.get("DEFAULT_SCHEMA", HTTP_UNIX_SOCKET_SCHEMA)
 SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
 MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
 NONPRIV_CONTAINER = os.environ.get("NONPRIV_CONTAINER") # Unset assume --privileged container
-
+DET_RESOURCES_TYPE = os.environ.get("DET_RESOURCES_TYPE") # Assume MLDE if set
+SLURM_JOB="slurm-job" # For launcher HPC this is set in DispatcherRM
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -8,7 +8,7 @@ PFS_SOCK_PATH = os.environ.get("PFS_SOCK_PATH", "/tmp/pfs.sock")
 DEFAULT_SCHEMA = os.environ.get("DEFAULT_SCHEMA", HTTP_UNIX_SOCKET_SCHEMA)
 SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
 MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
-NONPRIV_CONTAINER = os.environ.get("NONPRIV_CONTAINER") # Unset assume --privileged container
+NONPRIV_CONTAINER = strtobool(os.environ.get("NONPRIV_CONTAINER").lower()) # Unset assume --privileged container
 DET_RESOURCES_TYPE = os.environ.get("DET_RESOURCES_TYPE") # Assume MLDE if set
 SLURM_JOB="slurm-job" # For launcher HPC this is set in DispatcherRM
 

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -10,7 +10,7 @@ SIDECAR_MODE = strtobool(os.environ.get("SIDECAR_MODE", "False").lower())
 MOUNT_SERVER_LOG_DIR = os.environ.get("MOUNT_SERVER_LOG_DIR") # defaults to stdout/stderr
 NONPRIV_CONTAINER = strtobool(os.environ.get("NONPRIV_CONTAINER", "False").lower()) # Unset assume --privileged container
 DET_RESOURCES_TYPE = os.environ.get("DET_RESOURCES_TYPE") # Assume MLDE if set
-SLURM_JOB="slurm-job" # For launcher HPC this is set in DispatcherRM
+SLURM_JOB="slurm-job" # For launcher this is set in DispatcherRM
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -12,7 +12,16 @@ from tornado import locks
 
 from .pachyderm import MountInterface
 from .log import get_logger
-from .env import SIDECAR_MODE, MOUNT_SERVER_LOG_DIR, NONPRIV_CONTAINER, HTTP_UNIX_SOCKET_SCHEMA, HTTP_SCHEMA, DEFAULT_SCHEMA
+from .env import (
+    SIDECAR_MODE,
+    MOUNT_SERVER_LOG_DIR,
+    NONPRIV_CONTAINER,
+    HTTP_UNIX_SOCKET_SCHEMA,
+    HTTP_SCHEMA,
+    DEFAULT_SCHEMA,
+    DET_RESOURCES_TYPE,
+    SLURM_JOB
+    )
 
 lock = locks.Lock()
 MOUNT_SERVER_PORT = 9002
@@ -37,8 +46,11 @@ class MountServerClient(MountInterface):
             self.sock_path = ""
         self.client = AsyncHTTPClient()
         # non-prived container flag (set via -e NONPRIV_CONTAINER=1)
-        # TODO: Would be preferable to auto-detect this, but unclear how
+        # or use DET_RESOURCES_TYPE environment variable to auto-detect this.
         self.nopriv = NONPRIV_CONTAINER
+        self.determined_resources_type = DET_RESOURCES_TYPE
+        if self.determined_resources_type == SLURM_JOB:
+            self.nopriv = 1
 
     async def _is_mount_server_running(self):
         get_logger().debug("Checking if mount server running...")

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -48,8 +48,7 @@ class MountServerClient(MountInterface):
         # non-prived container flag (set via -e NONPRIV_CONTAINER=1)
         # or use DET_RESOURCES_TYPE environment variable to auto-detect this.
         self.nopriv = NONPRIV_CONTAINER
-        self.determined_resources_type = DET_RESOURCES_TYPE
-        if self.determined_resources_type == SLURM_JOB:
+        if DET_RESOURCES_TYPE == SLURM_JOB:
             self.nopriv = 1
 
     async def _is_mount_server_running(self):

--- a/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/mount_server_client.py
@@ -49,6 +49,7 @@ class MountServerClient(MountInterface):
         # or use DET_RESOURCES_TYPE environment variable to auto-detect this.
         self.nopriv = NONPRIV_CONTAINER
         if DET_RESOURCES_TYPE == SLURM_JOB:
+            get_logger().debug("Inferring non privileged container for launcher/MLDE...")
             self.nopriv = 1
 
     async def _is_mount_server_running(self):


### PR DESCRIPTION
When the jupyter_pachyderm plugin is used in an Determined AI root-less/daemon-less HPC container runtime (Singularity/Enroot/Apptatiner/Podman), automatically assume NONPRIV_CONTAINER=1 to enable /pfs to work.
This is accomplished by checking the environment variable DET_RESOURCES_TYPE for the value "slurm-job" which is set by Determined when launching such containers on an HPC cluster.

The following tests were done and found to be successful

setup
Built a docker image locally on my laptop which includes changes in this PR
Tagged it and pushed it to docker hub
Success criteria: Connect to pachyderm cluster (cluster 1) in Houston lab
Testing
Tested the docker image by running it locally. This was done without setting nonpriv option. Test was successful
Build Singularity and Podman images on casablanca and tested both of them without nonpriv option set. Test was successful.
Note:- The singularity and podman tests above was done as described in FE-80
Used the above built singularity image to run it in non-privileged mode

singularity run --no-mount=tmp --writable-tmpfs  --env NONPRIV_CONTAINER=1 notebooks-user-dev.sif
This test was successful

Tested by setting
export DET_RESOURCES_TYPE="slurm-job"
and running the command
singularity run --no-mount=tmp --writable-tmpfs notebooks-user-dev.sif
this test was successful too.
<img width="1055" alt="singularity-nonpriv-autodetect-mode" src="https://github.com/pachyderm/pachyderm/assets/5267730/d9fde43f-3239-4bad-8e99-5b8d806bcff9">

