### PR TITLE
csrf: delete cookies instead of categorically denying

### DIFF
--- a/src/server/http/http.go
+++ b/src/server/http/http.go
@@ -106,9 +106,8 @@ func CSRFWrapper(h http.Handler) http.HandlerFunc {
 			return
 		}
 		if origin != r.Host {
-			log.Info(r.Context(), "csrf: origin/host mismatch; deny", zap.String("resolved_origin", origin), zap.Strings("origin", r.Header.Values("origin")), zap.Strings("referer", r.Header.Values("referer")), zap.String("host", r.Host))
-			http.Error(w, "csrf: origin/host mismatch", http.StatusForbidden)
-			return
+			log.Info(r.Context(), "csrf: origin/host mismatch; delete cookies", zap.String("resolved_origin", origin), zap.Strings("origin", r.Header.Values("origin")), zap.Strings("referer", r.Header.Values("referer")), zap.String("host", r.Host))
+			r.Header.Del("cookie")
 		}
 		// Origin and Host match; allow.
 		h.ServeHTTP(w, r)

--- a/src/server/http/http_test.go
+++ b/src/server/http/http_test.go
@@ -10,73 +10,83 @@ import (
 
 func TestCSRFWrapper(t *testing.T) {
 	testData := []struct {
-		name     string
-		request  func(req *http.Request)
-		wantCode int
+		name        string
+		request     func(req *http.Request)
+		wantAllowed bool
 	}{
 		{
-			name:     "empty",
-			request:  func(req *http.Request) {},
-			wantCode: http.StatusOK,
+			name:        "empty",
+			request:     func(req *http.Request) {},
+			wantAllowed: true,
 		},
 		{
-			name:     "origin mismatch",
-			request:  func(req *http.Request) { req.Header.Add("origin", "http://example.com:1234") },
-			wantCode: http.StatusForbidden,
+			name:        "origin mismatch",
+			request:     func(req *http.Request) { req.Header.Add("origin", "http://example.com:1234") },
+			wantAllowed: false,
 		},
 		{
-			name:     "referer mismatch",
-			request:  func(req *http.Request) { req.Header.Add("referer", "http://example.com:1234/index.html") },
-			wantCode: http.StatusForbidden,
+			name:        "referer mismatch",
+			request:     func(req *http.Request) { req.Header.Add("referer", "http://example.com:1234/index.html") },
+			wantAllowed: false,
 		},
 		{
-			name:     "no host in origin",
-			request:  func(req *http.Request) { req.Header.Add("origin", "foo:bar") },
-			wantCode: http.StatusForbidden,
+			name:        "no host in origin",
+			request:     func(req *http.Request) { req.Header.Add("origin", "foo:bar") },
+			wantAllowed: false,
 		},
 		{
-			name:     "no host in referer",
-			request:  func(req *http.Request) { req.Header.Add("referer", "foo:bar") },
-			wantCode: http.StatusForbidden,
+			name:        "no host in referer",
+			request:     func(req *http.Request) { req.Header.Add("referer", "foo:bar") },
+			wantAllowed: false,
 		},
 		{
-			name:     "unparseable origin",
-			request:  func(req *http.Request) { req.Header.Add("origin", string([]byte{0x7f})) },
-			wantCode: http.StatusForbidden,
+			name:        "unparseable origin",
+			request:     func(req *http.Request) { req.Header.Add("origin", string([]byte{0x7f})) },
+			wantAllowed: false,
 		},
 		{
-			name:     "unparseable referer",
-			request:  func(req *http.Request) { req.Header.Add("referer", string([]byte{0x7f})) },
-			wantCode: http.StatusForbidden,
+			name:        "unparseable referer",
+			request:     func(req *http.Request) { req.Header.Add("referer", string([]byte{0x7f})) },
+			wantAllowed: false,
 		},
 		{
-			name:     "valid origin",
-			request:  func(req *http.Request) { req.Header.Add("origin", "http://example.com") },
-			wantCode: http.StatusOK,
+			name:        "valid origin",
+			request:     func(req *http.Request) { req.Header.Add("origin", "http://example.com") },
+			wantAllowed: true,
 		},
 		{
-			name:     "valid referer",
-			request:  func(req *http.Request) { req.Header.Add("referer", "http://example.com/index.html") },
-			wantCode: http.StatusOK,
+			name:        "valid referer",
+			request:     func(req *http.Request) { req.Header.Add("referer", "http://example.com/index.html") },
+			wantAllowed: true,
 		},
 	}
 
-	f := CSRFWrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok")) //nolint:errcheck
-	}))
 	for _, test := range testData {
 		t.Run(test.name, func(t *testing.T) {
+			var gotCookies []*http.Cookie
+			wantCookie := &http.Cookie{
+				Name:  "cookie",
+				Value: "cookie",
+			}
+			f := CSRFWrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotCookies = r.Cookies()
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("ok")) //nolint:errcheck
+			}))
+
 			ctx := pctx.TestContext(t)
 			req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 			req = req.WithContext(ctx)
+			req.AddCookie(wantCookie)
 			test.request(req)
 			w := httptest.NewRecorder()
 			f(w, req)
-			if got, want := w.Code, test.wantCode; got != want {
-				t.Errorf("code:\n  got: %v\n want: %v", got, want)
+			if !test.wantAllowed && len(gotCookies) > 0 {
+				t.Errorf("did not want cookies, but got %#v", gotCookies)
+			}
+			if test.wantAllowed && len(gotCookies) == 0 {
+				t.Error("wanted cookies, but got none")
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
We mostly only care about CSRF in the presence of cookies.  Instead of denying all cross-site requests, this deletes the cookies on cross-site requests.