### PR TITLE
[Jupyter] Paginated Filebrowser

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1017,7 +1017,8 @@ jobs:
             mkdir pfs
             export PFS_MOUNT_DIR=$(pwd)/pfs
             CI=true CYPRESS_RECORD_KEY=$JUPYTERLAB_PACHYDERM_CYPRESS_RECORD_KEY npm run e2e
-
+      - store_artifacts:
+          path: cypress/
   jupyter-extension-frontend-test:
     resource_class: xlarge
     docker:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1017,13 +1017,6 @@ jobs:
             mkdir pfs
             export PFS_MOUNT_DIR=$(pwd)/pfs
             CI=true CYPRESS_RECORD_KEY=$JUPYTERLAB_PACHYDERM_CYPRESS_RECORD_KEY npm run e2e
-      - when:
-          condition: on_fail
-          steps:
-            - store_artifacts:
-                path: cypress/videos/
-            - store_artifacts:
-                path: cypress/screenshots/
 
   jupyter-extension-frontend-test:
     resource_class: xlarge

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1017,8 +1017,14 @@ jobs:
             mkdir pfs
             export PFS_MOUNT_DIR=$(pwd)/pfs
             CI=true CYPRESS_RECORD_KEY=$JUPYTERLAB_PACHYDERM_CYPRESS_RECORD_KEY npm run e2e
-      - store_artifacts:
-          path: cypress/
+      - when:
+          condition: on_fail
+          steps:
+            - store_artifacts:
+                path: cypress/videos/
+            - store_artifacts:
+                path: cypress/screenshots/
+
   jupyter-extension-frontend-test:
     resource_class: xlarge
     docker:

--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -59,6 +59,6 @@ describe('mount', () => {
     cy.findByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
-    cy.get('ul.jp-DirListing-content').should('have.attr', 'loading');
+    cy.get('ul.jp-DirListing-content[loading]').should('have.length', 1);
   });
 });

--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -54,4 +54,12 @@ describe('mount', () => {
       .next()
       .should('have.text', 'Copy Path');
   });
+
+  it('file browser should have loading attribute', () => {
+    cy.findByText('Mount').first().click();
+    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('default_images').first().click();
+    cy.findAllByText('liberty.png').first().rightclick();
+    cy.get('ul.jp-DirListing-content').should('have.attr', 'loading');
+  });
 });

--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -59,6 +59,6 @@ describe('mount', () => {
     cy.findByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
-    cy.get('ul.jp-DirListing-content').first().should('have.attr', 'loading');
+    cy.get('ul.jp-DirListing-content').should('have.attr', 'loading');
   });
 });

--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -18,7 +18,7 @@ describe('mount', () => {
     cy.findByText('/ pfs').should('have.length', 1);
     cy.findAllByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images').last().click();
+    cy.findAllByText('default_images').first().click();
 
     cy.get('[id="pachyderm-mount"] div.jp-FileBrowser-crumbs')
       .first()
@@ -30,21 +30,21 @@ describe('mount', () => {
     cy.findByTestId('ListItem__select').select('branch');
     cy.findAllByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images_branch').last().click();
+    cy.findAllByText('default_images_branch').first().click();
     cy.findAllByText('branch.png').should('have.length', 1);
   });
 
   it('should open mounted directory in the file browser on click', () => {
     cy.findAllByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images').last().click();
+    cy.findAllByText('default_images').first().click();
     cy.findAllByText('liberty.png').should('have.length', 1);
   });
 
   it('file browser should show correct right click actions', () => {
     cy.findByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images').last().click();
+    cy.findAllByText('default_images').first().click();
     cy.findAllByText('liberty.png').first().rightclick();
     cy.get('ul.lm-Menu-content.p-Menu-content')
       .children()

--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -18,7 +18,7 @@ describe('mount', () => {
     cy.findByText('/ pfs').should('have.length', 1);
     cy.findAllByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images').first().click();
+    cy.findAllByText('default_images').last().click();
 
     cy.get('[id="pachyderm-mount"] div.jp-FileBrowser-crumbs')
       .first()
@@ -30,21 +30,21 @@ describe('mount', () => {
     cy.findByTestId('ListItem__select').select('branch');
     cy.findAllByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images_branch').first().click();
+    cy.findAllByText('default_images_branch').last().click();
     cy.findAllByText('branch.png').should('have.length', 1);
   });
 
   it('should open mounted directory in the file browser on click', () => {
     cy.findAllByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images').first().click();
+    cy.findAllByText('default_images').last().click();
     cy.findAllByText('liberty.png').should('have.length', 1);
   });
 
   it('file browser should show correct right click actions', () => {
     cy.findByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('default_images').first().click();
+    cy.findAllByText('default_images').last().click();
     cy.findAllByText('liberty.png').first().rightclick();
     cy.get('ul.lm-Menu-content.p-Menu-content')
       .children()

--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -59,7 +59,6 @@ describe('mount', () => {
     cy.findByText('Mount').first().click();
     cy.findAllByText('Unmount').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
-    cy.findAllByText('liberty.png').first().rightclick();
-    cy.get('ul.jp-DirListing-content').should('have.attr', 'loading');
+    cy.get('ul.jp-DirListing-content').first().should('have.attr', 'loading');
   });
 });

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -94,6 +94,15 @@ const createCustomFileBrowser = (
         'jp-DirListing-content',
       )[0];
 
+      // Connect the MountDrive loading signal to mark the browser content as loading.
+      drive.loading.connect(async (_, loading) => {
+        if (loading) {
+          browserContent.setAttribute('loading', 'true');
+        } else {
+          browserContent.setAttribute('loading', 'false');
+        }
+      });
+
       browserContent.addEventListener('contextmenu', (event: any) => {
         event.stopPropagation();
         event.preventDefault();

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -51,7 +51,7 @@ const createCustomFileBrowser = (
     if (breadCrumbs) {
       breadCrumbs.node
         .querySelector('svg[data-icon="ui-components:folder"]')
-        ?.replaceWith('/pfs');
+        ?.replaceWith('/ pfs');
       const homeElement = breadCrumbs.node
         .getElementsByClassName('jp-BreadCrumbs-home')
         .item(0);

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -13,6 +13,7 @@ import {each} from '@lumino/algorithm';
 
 import {MountDrive} from './mountDrive';
 import {MOUNT_BROWSER_NAME} from './mount';
+import {Paging} from './paging';
 
 const createCustomFileBrowser = (
   app: JupyterFrontEnd,
@@ -28,24 +29,32 @@ const createCustomFileBrowser = (
     refreshInterval: 10000,
   });
 
+  const filenameSearcher = browser.node
+    .getElementsByClassName('jp-FileBrowser-filterBox')
+    .item(0);
+  if (filenameSearcher) {
+    browser.node.removeChild(filenameSearcher);
+  }
+
+  const toolbar = browser.node
+    .getElementsByClassName('jp-FileBrowser-toolbar')
+    .item(0);
+  if (toolbar) {
+    browser.node.removeChild(toolbar);
+  }
+
   try {
-    const newLauncher = browser.toolbar.node.childNodes[0];
-    const newFolder = browser.toolbar.node.childNodes[1];
-    browser.toolbar.node.removeChild(newLauncher);
-    browser.toolbar.node.removeChild(newFolder);
-
     const widgets = browser.layout.widgets || [];
-
     const breadCrumbs = widgets.find(
       (element) => element instanceof BreadCrumbs,
     );
     if (breadCrumbs) {
       breadCrumbs.node
         .querySelector('svg[data-icon="ui-components:folder"]')
-        ?.replaceWith('/ pfs');
-      const homeElement = breadCrumbs.node.querySelector(
-        'span[title="~/extension-wd"]',
-      );
+        ?.replaceWith('/pfs');
+      const homeElement = breadCrumbs.node
+        .getElementsByClassName('jp-BreadCrumbs-home')
+        .item(0);
       if (homeElement) {
         homeElement.className = 'jp-BreadCrumbs-item';
       }
@@ -96,6 +105,17 @@ const createCustomFileBrowser = (
   } catch (e) {
     console.log('Failed to edit default browser.');
   }
+
+  const paging = new Paging({
+    browser_model: browser.model,
+    page_model: drive.model,
+  });
+  browser.model.pathChanged.connect(async (_, __) => {
+    // If the FileBrowser path has changed, then the MountDrive has reset the pagination model.
+    // Therefore, the pagination widget needs to be re-rendered.
+    paging.update();
+  });
+  browser.layout.addWidget(paging);
 
   return browser;
 };

--- a/jupyter-extension/src/plugins/mount/mount.css
+++ b/jupyter-extension/src/plugins/mount/mount.css
@@ -436,6 +436,11 @@ textarea {
   text-align: center;
 }
 
+.jp-DirListing-content[loading="true"] {
+  opacity: 0.5;
+  cursor: progress;
+}
+
 .jp-DirPagination {
   flex: 0 0 auto;
   display: flex;

--- a/jupyter-extension/src/plugins/mount/mount.css
+++ b/jupyter-extension/src/plugins/mount/mount.css
@@ -435,3 +435,24 @@ textarea {
   padding: 0.25em;
   text-align: center;
 }
+
+.jp-DirPagination {
+  flex: 0 0 auto;
+  display: flex;
+}
+
+.jp-DirPagination * {
+  color: black;
+  flex: 1;
+  text-align: center;
+  padding: 8px 0;
+}
+
+.jp-DirPagination a.active {
+  background-color: var(--jp-icon-contrast-color1);
+  color: white;
+}
+
+.jp-DirPagination a:hover:not(.active) {
+  background-color: var(--jp-layout-color0);
+}

--- a/jupyter-extension/src/plugins/mount/mount.css
+++ b/jupyter-extension/src/plugins/mount/mount.css
@@ -454,7 +454,7 @@ textarea {
 }
 
 .jp-DirPagination a.active {
-  background-color: var(--jp-icon-contrast-color1);
+  background-color: var(--pachyderm-hover-plum);
   color: white;
 }
 

--- a/jupyter-extension/src/plugins/mount/mountDrive.ts
+++ b/jupyter-extension/src/plugins/mount/mountDrive.ts
@@ -1,24 +1,49 @@
 import {ModelDB} from '@jupyterlab/observables';
 import {Contents, ServerConnection} from '@jupyterlab/services';
+import {PartialJSONObject} from '@lumino/coreutils';
 import {Signal, ISignal} from '@lumino/signaling';
 import {DocumentRegistry} from '@jupyterlab/docregistry';
 import {URLExt} from '@jupyterlab/coreutils';
 import {requestAPI} from '../../handler';
+import {Paging} from './paging';
+
+const MAX_NUM_CONTENTS_PAGE = 100;
+const DEFAULT_CONTENT_MODEL: Contents.IModel = {
+  name: '',
+  path: '',
+  last_modified: '',
+  created: '',
+  content: [],
+  format: 'json',
+  mimetype: '',
+  size: undefined,
+  writable: true,
+  type: 'directory',
+};
 
 export class MountDrive implements Contents.IDrive {
   public _registry: DocumentRegistry;
+  readonly _model: Paging.IModel;
   private _fileChanged = new Signal<this, Contents.IChangedArgs>(this);
   private _serverSettings = ServerConnection.makeSettings();
   private _isDisposed = false;
+  private _cache: {key: string | null; contents: any};
   modelDBFactory?: ModelDB.IFactory | undefined;
 
   constructor(registry: DocumentRegistry) {
     this._registry = registry;
+    this._model = {page: 0, max_page: 0};
+    this._cache = {key: null, contents: DEFAULT_CONTENT_MODEL};
   }
 
   get name(): 'mount-browser' {
     return 'mount-browser';
   }
+
+  get model(): Paging.IModel {
+    return this._model;
+  }
+
   get fileChanged(): ISignal<this, Contents.IChangedArgs> {
     return this._fileChanged;
   }
@@ -30,32 +55,61 @@ export class MountDrive implements Contents.IDrive {
     return this._isDisposed;
   }
 
+  async _get(
+    url: string,
+    options: PartialJSONObject,
+  ): Promise<Contents.IModel> {
+    url += URLExt.objectToQueryString(options);
+    return requestAPI<Contents.IModel>(url, 'GET');
+  }
+
+  // We might be able to pass pagination to the ContentsManager backend by including
+  // it in the URI specifier. This would require a custom ContentsManager which
+  // supports pagination.
   async get(
     localPath: string,
     options?: Contents.IFetchOptions,
   ): Promise<Contents.IModel> {
+    const url = URLExt.join('pfs', localPath);
+
+    // Make a no-content request to determine the type of content being requested.
+    // If the content type is not a directory, then we want to preserve our cache
+    //   and not paginate the results.
+    let shallowResponse;
     try {
-      const response = await requestAPI<Contents.IModel>(
-        URLExt.join('pfs', localPath),
-        'GET',
-      );
-      return response;
+      shallowResponse = await this._get(url, {content: '0'});
     } catch (e) {
       console.log('/pfs not found');
-      return {
-        name: '',
-        path: '',
-        last_modified: '2022-04-26T16:28:48.015858Z',
-        created: '2022-04-26T16:28:48.015858Z',
-        content: [],
-        format: 'json',
-        mimetype: '',
-        size: undefined,
-        writable: true,
-        type: 'directory',
-      };
+      return DEFAULT_CONTENT_MODEL;
     }
+    const content = options?.content ? '1' : '0';
+    if (!content) {
+      return shallowResponse;
+    }
+
+    if (shallowResponse.type !== 'directory') {
+      return await this._get(url, {...options, content});
+    }
+
+    // If we don't have contents cached, then we fetch them and cache the results.
+    if (localPath !== this._cache.key || !localPath) {
+      const response = await this._get(url, {...options, content});
+      this._model.page = 1;
+      this._model.max_page = Math.ceil(
+        response.content.length / MAX_NUM_CONTENTS_PAGE,
+      );
+      this._cache = {key: localPath, contents: response.content};
+    }
+
+    return {
+      ...shallowResponse,
+      content: this._cache.contents.slice(
+        (this._model.page - 1) * MAX_NUM_CONTENTS_PAGE,
+        this._model.page * MAX_NUM_CONTENTS_PAGE,
+      ),
+    };
   }
+
   getDownloadUrl(localPath: string): Promise<string> {
     throw new Error('Method not implemented.');
   }

--- a/jupyter-extension/src/plugins/mount/mountDrive.ts
+++ b/jupyter-extension/src/plugins/mount/mountDrive.ts
@@ -94,6 +94,9 @@ export class MountDrive implements Contents.IDrive {
     // If we don't have contents cached, then we fetch them and cache the results.
     if (localPath !== this._cache.key || !localPath) {
       const response = await this._get(url, {...options, content});
+      if (!response.content) {
+        return response;
+      }
       this._model.page = 1;
       this._model.max_page = Math.ceil(
         response.content.length / MAX_NUM_CONTENTS_PAGE,

--- a/jupyter-extension/src/plugins/mount/mountDrive.ts
+++ b/jupyter-extension/src/plugins/mount/mountDrive.ts
@@ -83,7 +83,7 @@ export class MountDrive implements Contents.IDrive {
       return DEFAULT_CONTENT_MODEL;
     }
     const content = options?.content ? '1' : '0';
-    if (!content) {
+    if (content === '0') {
       return shallowResponse;
     }
 
@@ -94,9 +94,6 @@ export class MountDrive implements Contents.IDrive {
     // If we don't have contents cached, then we fetch them and cache the results.
     if (localPath !== this._cache.key || !localPath) {
       const response = await this._get(url, {...options, content});
-      if (!response.content) {
-        return response;
-      }
       this._model.page = 1;
       this._model.max_page = Math.ceil(
         response.content.length / MAX_NUM_CONTENTS_PAGE,

--- a/jupyter-extension/src/plugins/mount/paging.ts
+++ b/jupyter-extension/src/plugins/mount/paging.ts
@@ -1,0 +1,112 @@
+import {Widget} from '@lumino/widgets';
+import {FileBrowserModel} from '@jupyterlab/filebrowser';
+
+export class Paging extends Widget {
+  constructor(options: Paging.IOptions) {
+    super();
+    this._browser_model = options.browser_model;
+    this._page_model = options.page_model;
+    this.addClass('jp-DirPagination');
+    this.update();
+  }
+
+  /**
+   * Update the paging buttons
+   */
+  public update(): void {
+    const max_page = this._page_model.max_page;
+    const page = this._page_model.page;
+
+    // Delete all page buttons.
+    while (this.node.firstChild) {
+      this.node.removeChild(this.node.firstChild);
+    }
+
+    // Don't show the paging widget if paging is not needed
+    if (max_page === 1) {
+      return;
+    }
+
+    /*
+    if max_page <= 7
+      show all items
+    otherwise
+    if page <= 4
+     show 1-5 and the right ellipse
+    if max_page-3 <= page
+     show the left ellipse and max_page-4 to max_page
+    if 4 < page < max_page-3
+     show left ellipse, page-1, page, page+1, right ellipse
+    */
+    if (max_page <= 7) {
+      for (let i = 1; i <= max_page; i++) {
+        this._createButton(i, page);
+      }
+    } else if (page <= 4) {
+      for (let i = 1; i <= 5; i++) {
+        this._createButton(i, page);
+      }
+      this._createEllipse();
+      this._createButton(max_page, page);
+    } else if (page >= max_page - 3) {
+      this._createButton(1, page);
+      this._createEllipse();
+      for (let i = max_page - 4; i <= max_page; i++) {
+        this._createButton(i, page);
+      }
+    } else {
+      this._createButton(1, page);
+      this._createEllipse();
+      this._createButton(page - 1, page);
+      this._createButton(page, page);
+      this._createButton(page + 1, page);
+      this._createEllipse();
+      this._createButton(max_page, page);
+    }
+  }
+
+  private _createButton(i: number, activePage: number) {
+    const button = document.createElement('a');
+    button.textContent = i.toString();
+    button.onclick = async () => {
+      this._page_model.page = i;
+      await this._browser_model.cd();
+      this.update();
+    };
+    if (i === activePage) {
+      button.className = 'active';
+    }
+    this.node.appendChild(button);
+  }
+
+  private _createEllipse() {
+    const ellipse = document.createElement('span');
+    ellipse.textContent = '...';
+    this.node.appendChild(ellipse);
+  }
+
+  private _browser_model: FileBrowserModel;
+  private _page_model: Paging.IModel;
+}
+
+export namespace Paging {
+  /**
+   * An options object for initializing a file browser directory listing.
+   */
+  export interface IOptions {
+    /**
+     * The file browser model instance.
+     */
+    browser_model: FileBrowserModel;
+    /**
+     * The pagination model instance.
+     * This model is shared with the MountDrive class.
+     */
+    page_model: IModel;
+  }
+
+  export interface IModel {
+    page: number;
+    max_page: number;
+  }
+}


### PR DESCRIPTION
Modifies the `CustomFileBrowser` used within the extension's `Explore` view to paginate its contents if too many items are returned. Currently this is set (globally, within the code) to 100 items. This should^[1] prevent the extension from crashing when trying to view a directly containing a large number of files.

## Implementation
This was implemented using the ideas developed [here](https://github.com/cnydw/jupyterlab/commit/6e615c058d9b9e27caeba405b7c3f32446d90214). Unfortunately there doesn't appear to be a straightforward way for our extension to extend the `FileBrowser` class into a `PaginatedFileBrowser`, so the workaround was to place a `Paging` widget below the `FileBrowser` widget and have this `Paging` widget share some state with our implemented `MountDrive`.

This works well enough, but there is a downside. All of the contents of a directory are streamed from the jupyter-server backend to the frontend. This cannot be avoided unless we re-implement their ContentsManager with pagination support. The result is that, when loading a directory, the user must wait for all directory contents to be streamed to the frontend and therefore the directories containing more files take longer to load. However, since we are forced to load the contents into memory we cache the results to allow moving between pages to be instantaneous. 

Other Fixes:
- The `createFileBrowser` method was bugged. The code to remove the `NewLauncher` and `NewFolder` buttons act on the global browser object, and therefore the after a couple load all of the toolbar buttons are removed and the method starts to silently fail. None of the buttons (besides refresh which now with cached paginated won't do anything) are relevant for our explore view so I just removed the toolbar.
- Also removed the `FilenameSearch` since it only works for the current page being displayed. However, I'm tempted to add this back in since without it the filebrowser looks a bit bare and technically when paginated is not activated (<100
 files) the search bar works as intended.
- The MountDrive had a bug where it wasn't sending the options to the backend.

---
![image](https://github.com/pachyderm/pachyderm/assets/28938409/c2f25744-5e7b-46db-9def-378b9bbb5696)

### Screen Recording
For some reason the screen recording has the cursor spinning wheel all glitched but on my screen it displayed fine.
![video](https://github.com/pachyderm/pachyderm/assets/28938409/c64be9d0-ab20-4e2e-bbff-65e2423b370f)

---
[1] The jupyter-server backend still streams all of the contents to the frontend, so technically the user's browser could run out of memory trying to load and cache the directories contents.