### PR TITLE
[2.7.x] upgrade envoy

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -861,7 +861,7 @@ jobs:
             find . -maxdepth 10 -name \*.jsonnet | xargs jsonnet-lint
   test-envoy:
     docker:
-      - image: envoyproxy/envoy:v1.25.5
+      - image: envoyproxy/envoy:v1.25.10
         entrypoint: /bin/sh
     steps:
       - run: apt update

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1216,7 +1216,7 @@ proxy:
   # The envoy image to pull.
   image:
     repository: "envoyproxy/envoy-distroless"
-    tag: "v1.25.5"
+    tag: "v1.25.10"
     pullPolicy: "IfNotPresent"
   # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's
   # a resonable memory limit.  It doesn't need much CPU.


### PR DESCRIPTION
This is to mitigate the http2 rapid reset issue, CVE-2023-44487.