### PR TITLE
upgrade envoy

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -867,7 +867,7 @@ jobs:
             find . -maxdepth 10 -name \*.jsonnet | xargs jsonnet-lint
   test-envoy:
     docker:
-      - image: envoyproxy/envoy:v1.27.0
+      - image: envoyproxy/envoy:v1.27.1
         entrypoint: /bin/sh
     steps:
       - run: apt update

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -1218,7 +1218,7 @@ proxy:
   # The envoy image to pull.
   image:
     repository: "envoyproxy/envoy-distroless"
-    tag: "v1.27.0"
+    tag: "v1.27.1"
     pullPolicy: "IfNotPresent"
   # Set up resources.  The proxy is configured to shed traffic before using 500MB of RAM, so that's
   # a resonable memory limit.  It doesn't need much CPU.


### PR DESCRIPTION
This is to mitigate the http2 rapid reset issue, CVE-2023-44487.