### PR TITLE
fix propagateCommit comments

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -945,14 +945,14 @@ func (d *driver) repoSize(ctx context.Context, txnCtx *txncontext.TransactionCon
 }
 
 // propagateBranches starts commits downstream of 'branches'
-// in order to restore the invariant that branch provenance matches HEAD commit
+// in order to restore the invariant that branch provenance implies HEAD commit
 // provenance:
 //
-//	B.Head is provenant on A.Head <=>
-//	branch B is provenant on branch A
+//	branch B is provenant on branch A =>
+//	(B.Head is provenant on A.Head) OR (A.Head is nil)
 //
 // The implementation assumes that the invariant already holds for all branches
-// upstream of 'branches', but not necessarily for each 'branch' itself.
+// upstream of 'branches', but not necessarily for each member of 'branches' itself.
 //
 // In other words, propagateBranches scans all branches b_downstream that are
 // equal to or downstream of 'branches', and if the HEAD of b_downstream isn't


### PR DESCRIPTION
An "iff" that should've been an "if" but has been wrong for several years.

Note that the backwards implication is not guaranteed by pachyderm. It's possible to have a branch A and B where B is not provenant on A but B.Head is provenant on A.Head, by doing the following:
- Create branch A and branch B that _is_ provenant on A
- Commit to A, causing a downstream commit to be created in B
- Call `CreateBranch` on B and remove its provenance link with A

This is a valid DAG. Future commits in A will not create downstream commits in B, but right after `CreateBranch` is called, the DAG violates the reverse implication in the comment.