### PR TITLE
FE-253: Remove stack trace on console by disabling nbclassic

### DIFF
--- a/jupyter-extension/Dockerfile
+++ b/jupyter-extension/Dockerfile
@@ -34,3 +34,4 @@ COPY dist dist
 WORKDIR /home/jovyan
 RUN pip install `find /app/dist/ -name \*.whl` nbgitpuller
 RUN pip install determined==0.23.3
+RUN /opt/conda/bin/jupyter lab extension disable nbclassic


### PR DESCRIPTION
The following stack trace is is seen on the console when running jupyter lab.
Note:- only stack trace posted here.
```
[I 2023-10-11 23:35:02.964 ServerApp] jupyter_server_terminals
extension was successfully linked.
[I 2023-10-11 23:35:02.973 ServerApp] jupyterlab | extension was successfully linked
[I 2023-10-11 23:35:02.973 ServerApp] jupyterlab_pachyderm
extension was successfully linked
[W 2023-10-11 23:35:02.973 ServerApp] nbclassic | error linking extension: module 'notebook' has no attribute 'base
Traceback (most recent
call last):
File "/opt/conda/lib/python3.9/site-packages/jupyter_server/extension/manager.py", line 342, in link_extension
extension.link_all_points(self.serverapp)
File
"/opt/conda/lib/python3.9/site-packages/jupyter_server/extension/manager.py",line 224, in link_all_points
self.link_point (point_name,
serverapp)
File
"/opt/conda/lib/python3.9/site-packages/jupyter_server/extension/manager.py",line 214, in link_point
point.link(serverapp)
File
"/opt/conda/lib/python3.9/site-packages/jupyter_server/extension/manager.py",
, line 136, in link
linker(serverapp)
File "/opt/conda/lib/python3.9/site-packages/nbclassic/notebookapp.py",line197,in_link_jupyter_server_extension
notebook.base.handlers. IPythonHandler.get_template = get_template
AttributeError: module
'notebook'
has no attribute
"base
```
By disabling nbclassic, the stack traces are no longer there. 

Testing: 
Tested by creating a Docker image as per instructions in the README.md and Connecting with Pachyderm Cluster successfully.
<img width="1467" alt="console-logs" src="https://github.com/pachyderm/pachyderm/assets/5267730/9deda332-36d4-4f11-a272-e97b1719bf38">
<img width="1040" alt="jupyterlabclient-docker" src="https://github.com/pachyderm/pachyderm/assets/5267730/915a787a-5848-4090-a7fd-c2d160f5c068">

