### PR TITLE
obj: don't clear staging in local fs client

### DIFF
--- a/src/internal/obj/local_client.go
+++ b/src/internal/obj/local_client.go
@@ -54,8 +54,8 @@ func (c *fsClient) Put(ctx context.Context, name string, r io.Reader) (retErr er
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	defer c.closeFile(ctx, &retErr, f)
-	defer c.removeFile(ctx, &retErr, staging)
+	defer c.closeFile(&retErr, f)
+	defer c.removeFile(&retErr, staging)
 	if _, err := io.Copy(f, r); err != nil {
 		return errors.EnsureStack(err)
 	}
@@ -72,7 +72,7 @@ func (c *fsClient) Get(ctx context.Context, name string, w io.Writer) (retErr er
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	defer c.closeFile(ctx, &retErr, f)
+	defer c.closeFile(&retErr, f)
 	_, err = io.Copy(w, f)
 	return errors.EnsureStack(err)
 }
@@ -157,7 +157,7 @@ func (c *fsClient) transformError(err error, name string) error {
 	return err
 }
 
-func (c *fsClient) closeFile(ctx context.Context, retErr *error, f *os.File) {
+func (c *fsClient) closeFile(retErr *error, f *os.File) {
 	if err := f.Close(); err != nil {
 		if !strings.Contains(err.Error(), "already closed") {
 			errors.JoinInto(retErr, errors.Wrap(err, "close"))
@@ -165,7 +165,7 @@ func (c *fsClient) closeFile(ctx context.Context, retErr *error, f *os.File) {
 	}
 }
 
-func (c *fsClient) removeFile(ctx context.Context, retErr *error, p string) {
+func (c *fsClient) removeFile(retErr *error, p string) {
 	err := os.Remove(p)
 	if os.IsNotExist(err) {
 		err = nil

--- a/src/internal/obj/local_client.go
+++ b/src/internal/obj/local_client.go
@@ -47,6 +47,7 @@ func newFSClient(rootDir string) (Client, error) {
 }
 
 func (c *fsClient) Put(ctx context.Context, name string, r io.Reader) (retErr error) {
+	log.Info(ctx, "put", zap.String("key", name))
 	staging := c.stagingPathFor(name)
 	final := c.finalPathFor(name)
 	f, err := os.OpenFile(staging, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0o644)
@@ -65,6 +66,7 @@ func (c *fsClient) Put(ctx context.Context, name string, r io.Reader) (retErr er
 }
 
 func (c *fsClient) Get(ctx context.Context, name string, w io.Writer) (retErr error) {
+	log.Info(ctx, "get", zap.String("key", name))
 	defer func() { retErr = c.transformError(retErr, name) }()
 	f, err := os.Open(c.finalPathFor(name))
 	if err != nil {
@@ -76,6 +78,7 @@ func (c *fsClient) Get(ctx context.Context, name string, w io.Writer) (retErr er
 }
 
 func (c *fsClient) Delete(ctx context.Context, name string) error {
+	log.Info(ctx, "delete", zap.String("key", name))
 	err := os.Remove(c.finalPathFor(name))
 	if os.IsNotExist(err) {
 		err = nil
@@ -155,12 +158,9 @@ func (c *fsClient) transformError(err error, name string) error {
 }
 
 func (c *fsClient) closeFile(ctx context.Context, retErr *error, f *os.File) {
-	err := f.Close()
-	if err != nil && !strings.Contains(err.Error(), "file already closed") {
-		if *retErr == nil {
-			*retErr = err
-		} else {
-			log.Error(ctx, "error closing file", zap.Error(err))
+	if err := f.Close(); err != nil {
+		if !strings.Contains(err.Error(), "already closed") {
+			errors.JoinInto(retErr, errors.Wrap(err, "close"))
 		}
 	}
 }
@@ -171,10 +171,6 @@ func (c *fsClient) removeFile(ctx context.Context, retErr *error, p string) {
 		err = nil
 	}
 	if err != nil {
-		if *retErr == nil {
-			*retErr = err
-		} else {
-			log.Error(ctx, "error deleting file", zap.Error(err))
-		}
+		errors.JoinInto(retErr, errors.Wrap(err, "deleting file"))
 	}
 }

--- a/src/internal/storage/kv/filesystem.go
+++ b/src/internal/storage/kv/filesystem.go
@@ -51,7 +51,7 @@ func (s *FSStore) Put(ctx context.Context, key, value []byte) (retErr error) {
 	}
 	staging := s.stagingPathFor(key)
 	final := s.finalPathFor(key)
-	defer s.cleanupFile(ctx, &retErr, staging)
+	defer s.cleanupFile(&retErr, staging)
 	if err := os.WriteFile(staging, value, 0o644); err != nil {
 		return s.transformError(err, key)
 	}
@@ -63,7 +63,7 @@ func (s *FSStore) Get(ctx context.Context, key, buf []byte) (_ int, retErr error
 	if err != nil {
 		return 0, s.transformError(err, key)
 	}
-	defer s.closeFile(ctx, &retErr, f)
+	defer s.closeFile(&retErr, f)
 	return miscutil.ReadInto(buf, f)
 }
 
@@ -176,7 +176,7 @@ func (s *FSStore) transformError(err error, key []byte) error {
 	return err
 }
 
-func (c *FSStore) closeFile(ctx context.Context, retErr *error, f *os.File) {
+func (c *FSStore) closeFile(retErr *error, f *os.File) {
 	if err := f.Close(); err != nil {
 		if !strings.Contains(err.Error(), "already closed") {
 			errors.JoinInto(retErr, errors.Wrap(err, "close"))
@@ -184,7 +184,7 @@ func (c *FSStore) closeFile(ctx context.Context, retErr *error, f *os.File) {
 	}
 }
 
-func (c *FSStore) cleanupFile(ctx context.Context, retErr *error, p string) {
+func (c *FSStore) cleanupFile(retErr *error, p string) {
 	err := os.Remove(p)
 	if os.IsNotExist(err) {
 		err = nil

--- a/src/internal/storage/kv/filesystem.go
+++ b/src/internal/storage/kv/filesystem.go
@@ -156,9 +156,6 @@ func (s *FSStore) ensureInit(ctx context.Context) (err error) {
 }
 
 func (s *FSStore) init(ctx context.Context) error {
-	if err := os.RemoveAll(filepath.Join(s.dir, "staging")); err != nil {
-		return errors.EnsureStack(err)
-	}
 	if err := os.MkdirAll(filepath.Join(s.dir, "staging"), 0755); err != nil {
 		return errors.EnsureStack(err)
 	}
@@ -182,7 +179,7 @@ func (s *FSStore) transformError(err error, key []byte) error {
 func (c *FSStore) closeFile(ctx context.Context, retErr *error, f *os.File) {
 	err := f.Close()
 	if err != nil && !strings.Contains(err.Error(), "file already closed") {
-		if retErr == nil {
+		if *retErr == nil {
 			*retErr = err
 		} else {
 			log.Error(ctx, "error closing file", zap.Error(err))
@@ -197,7 +194,7 @@ func (c *FSStore) cleanupFile(ctx context.Context, retErr *error, p string) {
 		err = nil
 	}
 	if err != nil {
-		if retErr == nil {
+		if *retErr == nil {
 			*retErr = err
 		} else {
 			log.Error(ctx, "error deleting file", zap.Error(err))


### PR DESCRIPTION
Currently, we clear temporary objects in the local object store during startup.  This could potentially interfere with concurrent uploads.  By removing this step, we allow abandoned uploads to pile up, but we also prevent concurrent instances from clobbering one another on startup.

Also fix the error handling pattern where `retErr *error` is compared directly to nil (useless) instead of `*retErr == nil`.