### PR TITLE
[PFS-94] Handle Potentially Nil Branches

### DIFF
--- a/src/server/pfs/fuse/fuse.go
+++ b/src/server/pfs/fuse/fuse.go
@@ -76,7 +76,7 @@ func Mount(c *client.APIClient, project, target string, opts *Options) (retErr e
 				}
 				branch := ""
 				for _, ci := range cis {
-					if ci.Commit.Branch.Repo.Name == repo {
+					if ci.Commit.Branch != nil && ci.Commit.Branch.Repo.Name == repo {
 						if branch != "" {
 							return errors.Errorf("multiple branches (%s and %s) have commit %s, specify a branch", branch, ci.Commit.Branch.Name, ropts.File.Commit.Id)
 						}

--- a/src/server/pfs/fuse/server.go
+++ b/src/server/pfs/fuse/server.go
@@ -1120,7 +1120,9 @@ func (mi *MountInfo) verifyProjectRepoBranchCommitExist(client *client.APIClient
 	if err != nil {
 		return false, err
 	}
-	mi.Branch = commitInfo.Commit.Branch.Name
+	if commitInfo.Commit.Branch != nil {
+		mi.Branch = commitInfo.Commit.Branch.Name
+	}
 	mi.Commit = commitInfo.Commit.Id
 	return true, nil
 }


### PR DESCRIPTION
As part of the commits and branches postgres migration, a commit can have a potentially nil branch field (this can happen if the branch was deleted, but the commit is still around). This PR just updates the fuse mount server to handle that.