### PR TITLE
remove underscores from description frontmatter

### DIFF
--- a/src/server/cmd/pachctl/doc-gen/pachctl/main.go
+++ b/src/server/cmd/pachctl/doc-gen/pachctl/main.go
@@ -49,7 +49,9 @@ description: "Learn about the %s command"
 		now := time.Now().Format(time.RFC3339)
 		name := filepath.Base(filename)
 		base := strings.TrimSuffix(name, filepath.Ext(name))
-		return fmt.Sprintf(fmTemplate, now, strings.Replace(base, "_", " ", -1), base)
+		title := strings.Replace(base, "_", " ", -1)
+		description := strings.Replace(base, "_", " ", -1)
+		return fmt.Sprintf(fmTemplate, now, title, description)
 	}
 
 	linkHandler := func(name string) string {


### PR DESCRIPTION
minor change to cli docs generator that removes the underscores from the description filename printout.