### PR TITLE
Refactor pfsdb branches API

### DIFF
--- a/src/internal/pfsdb/branches_test.go
+++ b/src/internal/pfsdb/branches_test.go
@@ -119,9 +119,9 @@ func TestBranchUpsert(t *testing.T) {
 			gotBranchInfo, err := pfsdb.GetBranchInfo(ctx, tx, id)
 			require.NoError(t, err)
 			require.True(t, cmp.Equal(branchInfo, gotBranchInfo, compareBranchOpts()...))
-			gotBranchByName, err := pfsdb.GetBranchInfoByName(ctx, tx, branchInfo.Branch.Repo.Project.Name, branchInfo.Branch.Repo.Name, branchInfo.Branch.Repo.Type, branchInfo.Branch.Name)
+			gotBranchInfoWithID, err := pfsdb.GetBranchInfoWithIDByName(ctx, tx, branchInfo.Branch.Repo.Project.Name, branchInfo.Branch.Repo.Name, branchInfo.Branch.Repo.Type, branchInfo.Branch.Name)
 			require.NoError(t, err)
-			require.True(t, cmp.Equal(branchInfo, gotBranchByName, compareBranchOpts()...))
+			require.True(t, cmp.Equal(branchInfo, gotBranchInfoWithID.BranchInfo, compareBranchOpts()...))
 
 			// Update branch to point to second commit
 			commitInfoWithID2 := createCreateInfoWithID(t, ctx, tx, newCommitInfo(repoInfo.Repo, random.String(32), commitInfoWithID1.CommitInfo.Commit))
@@ -429,7 +429,7 @@ func TestBranchTrigger(t *testing.T) {
 			// Attempt to create trigger with nonexistent branch via UpsertBranch
 			gotMasterBranchInfo.Trigger = &pfs.Trigger{Branch: "nonexistent"}
 			_, err = pfsdb.UpsertBranch(ctx, tx, gotMasterBranchInfo)
-			require.True(t, errors.Is(err, pfsdb.ErrBranchNotFound{BranchKey: "project1/repo1.user@nonexistent"}))
+			require.ErrorIs(t, err, pfsdb.ErrBranchNotFound{Project: gotMasterBranchInfo.Branch.Repo.Project.Name, Repo: gotMasterBranchInfo.Branch.Repo.Name, RepoType: gotMasterBranchInfo.Branch.Repo.Type, Branch: gotMasterBranchInfo.Trigger.Branch})
 		})
 	})
 }

--- a/src/server/pfs/server/commit_set.go
+++ b/src/server/pfs/server/commit_set.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
 
 	"google.golang.org/protobuf/proto"
@@ -265,10 +266,11 @@ func (d *driver) deleteCommit(ctx context.Context, txnCtx *txncontext.Transactio
 	}
 	branchInfo := &pfs.BranchInfo{}
 	for _, b := range repoInfo.Branches {
-		branchInfo, err = pfsdb.GetBranchInfoByName(ctx, txnCtx.SqlTx, b.Repo.Project.Name, b.Repo.Name, b.Repo.Type, b.Name)
+		branchInfoWithID, err := pfsdb.GetBranchInfoWithIDByName(ctx, txnCtx.SqlTx, b.Repo.Project.Name, b.Repo.Name, b.Repo.Type, b.Name)
 		if err != nil {
 			return errors.Wrapf(err, "delete commit: getting branch %s", b)
 		}
+		branchInfo = branchInfoWithID.BranchInfo
 		if pfsdb.CommitKey(branchInfo.Head) == pfsdb.CommitKey(ci.Commit) {
 			if ci.ParentCommit == nil {
 				headlessBranches = append(headlessBranches, proto.Clone(branchInfo).(*pfs.BranchInfo))

--- a/src/server/pfs/server/trigger.go
+++ b/src/server/pfs/server/trigger.go
@@ -75,11 +75,11 @@ func (d *driver) triggerCommit(ctx context.Context, txnCtx *txncontext.Transacti
 			return nil, nil
 		}
 		// Fire the trigger.
-		trigBI, err := pfsdb.GetBranchInfoByName(ctx, txnCtx.SqlTx, bi.Branch.Repo.Project.Name, bi.Branch.Repo.Name,
-			bi.Branch.Repo.Type, bi.Branch.Name)
+		trigBIWithID, err := pfsdb.GetBranchInfoWithIDByName(ctx, txnCtx.SqlTx, bi.Branch.Repo.Project.Name, bi.Branch.Repo.Name, bi.Branch.Repo.Type, bi.Branch.Name)
 		if err != nil {
 			return nil, errors.Wrap(err, "trigger commit")
 		}
+		trigBI := trigBIWithID.BranchInfo
 		trigBI.Head = newHead.Commit
 		_, err = pfsdb.UpsertBranch(ctx, txnCtx.SqlTx, trigBI)
 		if err != nil {


### PR DESCRIPTION
`GetBranchInfoByName` is now `GetBranchInfoWithIDByName`, because the ID could be passed by the caller in downstream operations.