### PR TITLE
dockertestenv: expose configuration for direct and pgbouncer connections

### DIFF
--- a/src/internal/clusterstate/v2.5.0/collection_test.go
+++ b/src/internal/clusterstate/v2.5.0/collection_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func newTestDB(t testing.TB) (*pachsql.DB, string) {
-	options := dockertestenv.NewTestDBOptions(t)
+	options := dockertestenv.NewTestDBConfig(t).Direct.DBOptions()
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)

--- a/src/internal/clusterstate/v2.7.0_test.go
+++ b/src/internal/clusterstate/v2.7.0_test.go
@@ -3,10 +3,11 @@ package clusterstate
 import (
 	"context"
 	"database/sql"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jmoiron/sqlx"
@@ -200,8 +201,7 @@ func setupTestData(t *testing.T, ctx context.Context, db *sqlx.DB) {
 
 func Test_v2_7_0_ClusterState(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	db, _ := dockertestenv.NewEphemeralPostgresDB(ctx, t)
-	defer db.Close()
+	db := dockertestenv.NewTestDirectDB(t)
 	migrationEnv := migrations.Env{EtcdClient: testetcd.NewEnv(ctx, t).EtcdClient}
 
 	// Pre-migration

--- a/src/internal/clusterstate/v2.8.0/collection_test.go
+++ b/src/internal/clusterstate/v2.8.0/collection_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func newTestDB(t testing.TB) (*pachsql.DB, string) {
-	options := dockertestenv.NewTestDBOptions(t)
+	options := dockertestenv.NewTestDBConfig(t).Direct.DBOptions()
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)

--- a/src/internal/clusterstate/v2.8.0_test.go
+++ b/src/internal/clusterstate/v2.8.0_test.go
@@ -1,12 +1,13 @@
 package clusterstate
 
 import (
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
-	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -20,8 +21,7 @@ import (
 
 func Test_v2_8_0_ClusterState(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	db, _ := dockertestenv.NewEphemeralPostgresDB(ctx, t)
-	defer db.Close()
+	db := dockertestenv.NewTestDirectDB(t)
 	migrationEnv := migrations.Env{EtcdClient: testetcd.NewEnv(ctx, t).EtcdClient}
 
 	// Pre-migration

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -54,7 +54,7 @@ func TestPostgresCollections(suite *testing.T) {
 func TestPostgresCollectionsProxy(suite *testing.T) {
 	ctx := pctx.TestContext(suite)
 	watchTests(ctx, suite, newCollectionFunc(func(_ context.Context, t *testing.T) (*pachsql.DB, col.PostgresListener) {
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 		listener := client.NewProxyPostgresListener(func() (proxy.APIClient, error) { return env.PachClient.ProxyClient, nil })
 		t.Cleanup(func() {
 			require.NoError(t, listener.Close())
@@ -211,7 +211,7 @@ func PostgresCollectionWatchTests(suite *testing.T, newCollection func(context.C
 }
 
 func newTestDB(t testing.TB) (*pachsql.DB, string) {
-	options := dockertestenv.NewTestDBOptions(t)
+	options := dockertestenv.NewTestDBConfig(t).PGBouncer.DBOptions()
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func newTestDB(t testing.TB) (*pachsql.DB, string) {
 }
 
 func newTestDirectDB(t testing.TB) (*pachsql.DB, string) {
-	options := dockertestenv.NewTestDirectDBOptions(t)
+	options := dockertestenv.NewTestDBConfig(t).PGBouncer.DBOptions()
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -222,7 +222,7 @@ func newTestDB(t testing.TB) (*pachsql.DB, string) {
 }
 
 func newTestDirectDB(t testing.TB) (*pachsql.DB, string) {
-	options := dockertestenv.NewTestDBConfig(t).PGBouncer.DBOptions()
+	options := dockertestenv.NewTestDBConfig(t).Direct.DBOptions()
 	dsn := dbutil.GetDSN(options...)
 	db, err := dbutil.NewDB(options...)
 	require.NoError(t, err)

--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -113,25 +113,6 @@ func GetDSN(opts ...Option) string {
 	return getDSN(dbc)
 }
 
-// GetDSN2 extracts the DSN from a sqlx.DB
-func GetDSN2(db *sqlx.DB) (string, error) {
-	ctx, cf := context.WithCancel(pctx.TODO())
-	defer cf()
-	c, err := db.Conn(ctx)
-	if err != nil {
-		return "", err
-	}
-	var ret string
-	if err := c.Raw(func(driverConn any) error {
-		c2 := driverConn.(pgx.Conn)
-		ret = c2.Config().ConnString()
-		return nil
-	}); err != nil {
-		return "", err
-	}
-	return ret, nil
-}
-
 // NewDB creates a new DB.
 func NewDB(opts ...Option) (*pachsql.DB, error) {
 	dbc := newConfig(opts...)

--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -113,6 +113,25 @@ func GetDSN(opts ...Option) string {
 	return getDSN(dbc)
 }
 
+// GetDSN2 extracts the DSN from a sqlx.DB
+func GetDSN2(db *sqlx.DB) (string, error) {
+	ctx, cf := context.WithCancel(pctx.TODO())
+	defer cf()
+	c, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	if err := c.Raw(func(driverConn any) error {
+		c2 := driverConn.(pgx.Conn)
+		ret = c2.Config().ConnString()
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return ret, nil
+}
+
 // NewDB creates a new DB.
 func NewDB(opts ...Option) (*pachsql.DB, error) {
 	dbc := newConfig(opts...)

--- a/src/internal/dbutil/tx.go
+++ b/src/internal/dbutil/tx.go
@@ -203,23 +203,3 @@ func isTransactionError(err error) bool {
 	pgxErr := &pgconn.PgError{}
 	return errors.As(err, &pgxErr) && strings.HasPrefix(pgxErr.Code, "40")
 }
-
-// DoTx is a shorter alias for WithTx
-func DoTx(ctx context.Context, db *pachsql.DB, fn func(ctx context.Context, tx *pachsql.Tx) error, opts ...WithTxOption) error {
-	return WithTx(ctx, db, fn, opts...)
-}
-
-// DoTx1 performs a transaction which returns 1 value or an error
-func DoTx1[T any](ctx context.Context, db *pachsql.DB, fn func(ctx context.Context, tx *pachsql.Tx) (T, error), opts ...WithTxOption) (T, error) {
-	var ret T
-	err := DoTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
-		var err error
-		ret, err = fn(ctx, tx)
-		return err
-	})
-	if err != nil {
-		var zero T
-		return zero, err
-	}
-	return ret, nil
-}

--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -110,7 +110,11 @@ func NewTestDBConfig(t testing.TB) DBConfig {
 			DBName:   dbName,
 		},
 		Identity: PostgresConfig{
-			DBName: dexName,
+			Host:     PGBouncerHost(),
+			Port:     PGBouncerPort,
+			User:     DefaultPostgresUser,
+			Password: DefaultPostgresPassword,
+			DBName:   dexName,
 		},
 	}
 }

--- a/src/internal/dockertestenv/postgres.go
+++ b/src/internal/dockertestenv/postgres.go
@@ -45,7 +45,7 @@ type PostgresConfig struct {
 
 func (pgc PostgresConfig) DBOptions() []dbutil.Option {
 	return []dbutil.Option{
-		dbutil.WithMaxOpenConns(1),
+		dbutil.WithMaxOpenConns(10),
 		dbutil.WithUserPassword(pgc.User, pgc.Password),
 		dbutil.WithHostPort(pgc.Host, int(pgc.Port)),
 		dbutil.WithDBName(pgc.DBName),

--- a/src/internal/fileserver/fileserver_test.go
+++ b/src/internal/fileserver/fileserver_test.go
@@ -28,7 +28,7 @@ import (
 func TestDownload(t *testing.T) {
 	// Setup a PFS server.
 	rctx := pctx.TestContext(t)
-	e := realenv.NewRealEnvWithIdentity(rctx, t, dockertestenv.NewTestDBConfig(t))
+	e := realenv.NewRealEnvWithIdentity(rctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	// Fileserver for testing.
 	s := &fileserver.Server{
 		ClientFactory: func(ctx context.Context) *client.APIClient {

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
-	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	auth_interceptor "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
@@ -154,7 +153,6 @@ type Full struct {
 	selfGRPC        *grpc.ClientConn
 	authInterceptor *auth_interceptor.Interceptor
 	txnEnv          *transactionenv.TransactionEnv
-	pgLis           collection.PostgresListener
 
 	healthSrv grpc_health_v1.HealthServer
 	version   version.APIServer
@@ -197,7 +195,7 @@ func NewFull(env Env, config pachconfig.PachdFullConfiguration) *Full {
 		initJaeger(),
 
 		awaitDB(env.DB),
-		runMigrations(env.DB, env.EtcdClient),
+		runMigrations(env.DirectDB, env.EtcdClient),
 		awaitMigrations(env.DB),
 
 		// API Servers

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/enterprise"
+	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	auth_interceptor "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
@@ -153,6 +154,7 @@ type Full struct {
 	selfGRPC        *grpc.ClientConn
 	authInterceptor *auth_interceptor.Interceptor
 	txnEnv          *transactionenv.TransactionEnv
+	pgLis           collection.PostgresListener
 
 	healthSrv grpc_health_v1.HealthServer
 	version   version.APIServer

--- a/src/internal/pachd/testpachd.go
+++ b/src/internal/pachd/testpachd.go
@@ -30,12 +30,12 @@ func NewTestPachd(t testing.TB) *client.APIClient {
 		return logger.Core()
 	})))
 
-	db := dockertestenv.NewTestDB(t)
+	dbcfg := dockertestenv.NewTestDBConfig(t)
 	objC := dockertestenv.NewTestObjClient(ctx, t)
 	lis := testutil.Listen(t)
 	env := Env{
-		DB:         db,
-		DirectDB:   nil, // TODO
+		DB:         testutil.OpenDB(t, dbcfg.PGBouncer.DBOptions()...),
+		DirectDB:   testutil.OpenDB(t, dbcfg.Direct.DBOptions()...), // TODO
 		ObjClient:  objC,
 		EtcdClient: testetcd.NewEnv(ctx, t).EtcdClient,
 		Listener:   lis,

--- a/src/internal/pachd/testpachd.go
+++ b/src/internal/pachd/testpachd.go
@@ -35,7 +35,7 @@ func NewTestPachd(t testing.TB) *client.APIClient {
 	lis := testutil.Listen(t)
 	env := Env{
 		DB:         testutil.OpenDB(t, dbcfg.PGBouncer.DBOptions()...),
-		DirectDB:   testutil.OpenDB(t, dbcfg.Direct.DBOptions()...), // TODO
+		DirectDB:   testutil.OpenDB(t, dbcfg.Direct.DBOptions()...),
 		ObjClient:  objC,
 		EtcdClient: testetcd.NewEnv(ctx, t).EtcdClient,
 		Listener:   lis,

--- a/src/internal/pachsql/table_info_test.go
+++ b/src/internal/pachsql/table_info_test.go
@@ -6,11 +6,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/testsnowflake"
+	"github.com/pachyderm/pachyderm/v2/src/internal/testutil"
 )
 
 func TestGetTableInfo(suite *testing.T) {
@@ -22,7 +24,7 @@ func TestGetTableInfo(suite *testing.T) {
 	tcs := []testCase{
 		{
 			Name:  "Postgres",
-			NewDB: dockertestenv.NewEphemeralPostgresDB,
+			NewDB: newEphemeralPostgresDB,
 			Expected: &pachsql.TableInfo{
 				"pgx",
 				"test_table",
@@ -119,4 +121,9 @@ func TestGetTableInfo(suite *testing.T) {
 			require.Equal(t, tc.Expected, info)
 		})
 	}
+}
+
+func newEphemeralPostgresDB(ctx context.Context, t testing.TB) (*sqlx.DB, string) {
+	c := dockertestenv.NewTestDBConfig(t)
+	return testutil.OpenDB(t, c.Direct.DBOptions()...), c.Direct.DBName
 }

--- a/src/internal/pfssync/sync_test.go
+++ b/src/internal/pfssync/sync_test.go
@@ -21,7 +21,7 @@ import (
 
 func BenchmarkDownload(b *testing.B) {
 	ctx := pctx.TestContext(b)
-	env := realenv.NewRealEnv(ctx, b, dockertestenv.NewTestDBConfig(b))
+	env := realenv.NewRealEnv(ctx, b, dockertestenv.NewTestDBConfig(b).PachConfigOption)
 	repo := "repo"
 	require.NoError(b, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 	commit, err := env.PachClient.StartCommit(pfs.DefaultProjectName, repo, "master")

--- a/src/internal/preflight/preflight_test.go
+++ b/src/internal/preflight/preflight_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestTestMigrations(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	opts := dockertestenv.NewTestDBOptions(t)
+	dbc := dockertestenv.NewTestDBConfig(t)
+	opts := dbc.Direct.DBOptions()
 	opts = append(opts, dbutil.WithQueryLog(true, "migrations"))
 	db := testutil.OpenDB(t, opts...)
 	if err := TestMigrations(ctx, db); err != nil {

--- a/src/internal/testutil/cmds.go
+++ b/src/internal/testutil/cmds.go
@@ -151,7 +151,7 @@ func subsToTemplateData(subs ...string) (map[string]string, error) {
 
 func PachctlBashCmd(t *testing.T, c *client.APIClient, scriptTemplate string, subs ...string) *exec.Cmd {
 	t.Helper()
-	ctx := pctx.Background("")
+	ctx := pctx.TestContext(t)
 	return PachctlBashCmdCtx(ctx, t, c, scriptTemplate, subs...)
 }
 

--- a/src/internal/testutil/db.go
+++ b/src/internal/testutil/db.go
@@ -11,13 +11,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 )
 
-const (
-	DefaultPostgresHost     = "127.0.0.1"
-	DefaultPostgresUser     = "pachyderm"
-	DefaultPostgresPassword = "correcthorsebatterystaple"
-	DefaultPostgresDatabase = "pachyderm"
-)
-
 // set this to false if you want to keep the database around
 var cleanup = true
 

--- a/src/internal/watch/postgres/impl_test.go
+++ b/src/internal/watch/postgres/impl_test.go
@@ -3,9 +3,10 @@ package postgres_test
 import (
 	"context"
 	"fmt"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 	"testing"
 	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
 	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
@@ -22,7 +23,7 @@ import (
 func TestWatchRepos(t *testing.T) {
 	ctx, cancel := context.WithCancel(pctx.TestContext(t))
 	defer cancel()
-	dbOpts := dockertestenv.NewTestDirectDBOptions(t)
+	dbOpts := dockertestenv.NewTestDBConfig(t).Direct.DBOptions()
 	db := testutil.OpenDB(t, dbOpts...)
 
 	// Apply migrations

--- a/src/server/auth/server/testing/auth_test.go
+++ b/src/server/auth/server/testing/auth_test.go
@@ -43,7 +43,7 @@ import (
 func envWithAuth(t *testing.T) *realenv.RealEnv {
 	t.Helper()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateLicense(t, env.PachClient, peerPort)
 	_, err := env.PachClient.Enterprise.Activate(env.PachClient.Ctx(),
@@ -2192,7 +2192,7 @@ func TestGetFileURL(t *testing.T) {
 func TestGetPermissions(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2235,7 +2235,7 @@ func TestGetPermissions(t *testing.T) {
 func TestGetPermissions_Project(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2268,7 +2268,7 @@ func TestGetPermissions_Project(t *testing.T) {
 func TestDeactivateFSAdmin(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2293,7 +2293,7 @@ func TestDeactivateFSAdmin(t *testing.T) {
 func TestExtractAuthToken(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2342,7 +2342,7 @@ func TestExtractAuthToken(t *testing.T) {
 func TestRestoreAuthToken(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2416,7 +2416,7 @@ func TestRestoreAuthToken(t *testing.T) {
 func TestPipelineFailingWithOpenCommit(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2467,7 +2467,7 @@ func TestPipelineFailingWithOpenCommit(t *testing.T) {
 func TestGetRobotTokenErrorNonAdminUser(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2485,7 +2485,7 @@ func TestGetRobotTokenErrorNonAdminUser(t *testing.T) {
 func TestDeleteAll(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -2596,7 +2596,7 @@ func TestListRepoAfterAuthActivation(t *testing.T) {
 	// This test ensures that CORE-1548 doesn't come back.
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient.WithCtx(ctx)
 	ctx = c.Ctx()
 
@@ -2651,7 +2651,7 @@ func TestListRepoAfterAuthActivation(t *testing.T) {
 func TestPreAuthProjects(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	project := tu.UniqueString("project")
 	require.NoError(t, c.CreateProject(project))

--- a/src/server/auth/server/testing/config_test.go
+++ b/src/server/auth/server/testing/config_test.go
@@ -25,7 +25,7 @@ import (
 func TestSetGetConfigBasic(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -58,7 +58,7 @@ func TestSetGetConfigBasic(t *testing.T) {
 func TestIssuerNotLocalhost(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -101,7 +101,7 @@ func TestIssuerNotLocalhost(t *testing.T) {
 func TestGetSetConfigAdminOnly(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -171,7 +171,7 @@ func TestGetSetConfigAdminOnly(t *testing.T) {
 func TestConfigRestartAuth(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -259,7 +259,7 @@ func TestConfigRestartAuth(t *testing.T) {
 func TestSetGetNilConfig(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)

--- a/src/server/auth/server/testing/oidc_test.go
+++ b/src/server/auth/server/testing/oidc_test.go
@@ -23,7 +23,7 @@ import (
 func TestOIDCAuthCodeFlow(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -50,7 +50,7 @@ func TestOIDCAuthCodeFlow(t *testing.T) {
 func TestOIDCTrustedApp(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -77,7 +77,7 @@ func TestOIDCTrustedApp(t *testing.T) {
 func TestCannotAuthenticateWithExpiredLicense(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -30,7 +30,7 @@ import (
 const year = 365 * 24 * time.Hour
 
 func realEnvWithLicense(ctx context.Context, t *testing.T, expireTime ...time.Time) (*realenv.RealEnv, string) {
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	testutil.ActivateLicense(t, env.PachClient, peerPort, expireTime...)
 	_, err := env.PachClient.Enterprise.Activate(ctx,
@@ -184,7 +184,7 @@ func TestDoubleDeactivate(t *testing.T) {
 func TestGetActivationCodeNotAdmin(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	aliceClient := testutil.AuthenticatedPachClient(t, c, "robot:alice", peerPort)

--- a/src/server/identity/server/api_server_test.go
+++ b/src/server/identity/server/api_server_test.go
@@ -26,7 +26,7 @@ import (
 // TestAuthNotActivated checks that no RPCs can be made when the auth service is disabled
 func TestAuthNotActivated(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	_, err := client.SetIdentityServerConfig(client.Ctx(), &identity.SetIdentityServerConfigRequest{Config: &identity.IdentityServerConfig{}})
 	require.YesError(t, err)
@@ -85,7 +85,7 @@ func TestAuthNotActivated(t *testing.T) {
 func TestUserNotAdmin(t *testing.T) {
 	alice := tu.UniqueString("robot:alice")
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	aliceClient := tu.AuthenticatedPachClient(t, c, alice, peerPort)
@@ -145,7 +145,7 @@ func TestUserNotAdmin(t *testing.T) {
 // TestSetConfiguration tests that the web server configuration reloads when the etcd config value is updated
 func TestSetConfiguration(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	adminClient := tu.AuthenticatedPachClient(t, c, auth.RootUser, peerPort)
@@ -187,7 +187,7 @@ func TestSetConfiguration(t *testing.T) {
 
 func TestOIDCClientCRUD(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	adminClient := tu.AuthenticatedPachClient(t, c, auth.RootUser, peerPort)
@@ -232,7 +232,7 @@ func TestOIDCClientCRUD(t *testing.T) {
 
 func TestIDPConnectorCRUD(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	adminClient := tu.AuthenticatedPachClient(t, c, auth.RootUser, peerPort)
@@ -283,7 +283,7 @@ func TestIDPConnectorCRUD(t *testing.T) {
 // expiration shorter than the default of 6 hours
 func TestShortenIDTokenExpiry(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)

--- a/src/server/license/server/license_test.go
+++ b/src/server/license/server/license_test.go
@@ -27,7 +27,7 @@ import (
 func TestActivate(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 
@@ -46,7 +46,7 @@ func TestActivate(t *testing.T) {
 func TestExpired(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateEnterprise(t, client, peerPort)
@@ -74,7 +74,7 @@ func TestExpired(t *testing.T) {
 func TestGetActivationCodeNotAdmin(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateAuthClient(t, client, peerPort)
@@ -89,7 +89,7 @@ func TestGetActivationCodeNotAdmin(t *testing.T) {
 func TestDeleteAll(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateEnterprise(t, client, peerPort)
@@ -125,7 +125,7 @@ func TestDeleteAll(t *testing.T) {
 func TestDeleteAllNotAdmin(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -139,7 +139,7 @@ func TestDeleteAllNotAdmin(t *testing.T) {
 func TestClusterCRUD(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateAuthClient(t, client, peerPort)
@@ -255,7 +255,7 @@ func TestClusterCRUD(t *testing.T) {
 func TestAddClusterAddressValidation(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateEnterprise(t, client, peerPort)
@@ -273,7 +273,7 @@ func TestAddClusterAddressValidation(t *testing.T) {
 func TestUpdateClusterAddressValidation(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateEnterprise(t, client, peerPort)
@@ -291,7 +291,7 @@ func TestUpdateClusterAddressValidation(t *testing.T) {
 func TestAddClusterNoLicense(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	_, err := client.License.AddCluster(client.Ctx(), &license.AddClusterRequest{
@@ -307,7 +307,7 @@ func TestAddClusterNoLicense(t *testing.T) {
 func TestClusterCRUDNotAdmin(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	client := env.PachClient
 	tu.ActivateAuthClient(t, client, peerPort)
@@ -341,7 +341,7 @@ func TestClusterCRUDNotAdmin(t *testing.T) {
 func TestHeartbeat(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -377,7 +377,7 @@ func TestHeartbeat(t *testing.T) {
 func TestHeartbeatWrongSecret(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	pachClient := env.PachClient
 	_, err := pachClient.License.Heartbeat(pachClient.Ctx(), &license.HeartbeatRequest{
 		Id:          "localhost",
@@ -391,7 +391,7 @@ func TestHeartbeatWrongSecret(t *testing.T) {
 func TestListUserClusters(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	client := env.PachClient
 	tu.ActivateAuthClient(t, client, peerPort)

--- a/src/server/pachd_restgateway_test.go
+++ b/src/server/pachd_restgateway_test.go
@@ -57,7 +57,7 @@ func TestRouting(t *testing.T) {
 			ctx := pctx.TestContext(t)
 
 			s, err := pachdhttp.New(ctx, 0, func(ctx context.Context) *client.APIClient {
-				env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+				env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 				client := env.PachClient
 				return client
 			})

--- a/src/server/pachyderm_validation_test.go
+++ b/src/server/pachyderm_validation_test.go
@@ -22,7 +22,7 @@ import (
 func TestInvalidCreatePipeline(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 
 	projectName := tu.UniqueString("prj-")
@@ -96,7 +96,7 @@ func TestInvalidCreatePipeline(t *testing.T) {
 func TestPipelineThatUseNonexistentInputs(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	pipelineName := tu.UniqueString("pipeline")
 	require.YesError(t, c.CreatePipeline(pfs.DefaultProjectName,
@@ -117,7 +117,7 @@ func TestPipelineThatUseNonexistentInputs(t *testing.T) {
 func TestPipelineNamesThatContainUnderscoresAndHyphens(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 
 	projectName := tu.UniqueString("prj-")

--- a/src/server/pfs/cmds/cmds_test.go
+++ b/src/server/pfs/cmds/cmds_test.go
@@ -64,7 +64,7 @@ func TestCommit(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 
@@ -117,7 +117,7 @@ func TestPutFileTAR(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 
@@ -175,7 +175,7 @@ func TestPutFileNonexistentRepo(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	repoName := tu.UniqueString("TestPutFileNonexistentRepo-repo")
@@ -226,7 +226,7 @@ func TestDiffFile(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
@@ -259,7 +259,7 @@ func TestGetFileError(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 
@@ -353,11 +353,11 @@ func TestProject(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 
-	// env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	// env := realenv.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	// c := env.PachClient
 	// using xargs to trim newlines
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
@@ -414,7 +414,7 @@ func TestDeleteAllRepos(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
@@ -434,7 +434,7 @@ func TestDeleteNonExistRepo(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	require.YesError(t, tu.PachctlBashCmd(t, c, `
@@ -451,7 +451,7 @@ func TestDeleteRepo(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
@@ -469,7 +469,7 @@ func TestDeleteAllReposAllProjects(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
@@ -492,7 +492,7 @@ func TestCmdListRepo(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 
@@ -517,7 +517,7 @@ func TestBranchNotFound(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 
@@ -539,7 +539,7 @@ func TestCopyFile(t *testing.T) {
 	}
 
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 
 	// copy within default project
@@ -591,7 +591,7 @@ func TestDeleteProject(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	mockInspectCluster(env)
 	c := env.PachClient
 	project := tu.UniqueString("project")

--- a/src/server/pfs/fuse/fuse_test.go
+++ b/src/server/pfs/fuse/fuse_test.go
@@ -33,7 +33,7 @@ const (
 
 func TestBasic(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
 	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
@@ -65,7 +65,7 @@ func TestBasic(t *testing.T) {
 
 func TestChunkSize(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	err := env.PachClient.PutFile(client.NewCommit(pfs.DefaultProjectName, "repo", "master", ""), "file", strings.NewReader(strings.Repeat("p", int(pfs.ChunkSize))))
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestChunkSize(t *testing.T) {
 
 func TestLargeFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	random.SeedRand(123)
 	src := random.String(GB + 17)
@@ -93,7 +93,7 @@ func TestLargeFile(t *testing.T) {
 
 func BenchmarkLargeFile(b *testing.B) {
 	ctx := pctx.TestContext(b)
-	env := realenv.NewRealEnv(ctx, b, dockertestenv.NewTestDBConfig(b))
+	env := realenv.NewRealEnv(ctx, b, dockertestenv.NewTestDBConfig(b).PachConfigOption)
 	require.NoError(b, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	random.SeedRand(123)
 	src := random.String(GB)
@@ -112,7 +112,7 @@ func BenchmarkLargeFile(b *testing.B) {
 
 func TestSeek(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	data := strings.Repeat("foo", MB)
 	err := env.PachClient.PutFile(client.NewCommit(pfs.DefaultProjectName, "repo", "master", ""), "file", strings.NewReader(data))
@@ -141,7 +141,7 @@ func TestSeek(t *testing.T) {
 
 func TestHeadlessBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	require.NoError(t, env.PachClient.CreateBranch(pfs.DefaultProjectName, "repo", "master", "", "", nil))
 	withMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -154,7 +154,7 @@ func TestHeadlessBranch(t *testing.T) {
 
 func TestReadOnly(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	withMount(t, env.PachClient, &Options{
 		Fuse: &fs.Options{
@@ -169,7 +169,7 @@ func TestReadOnly(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
 	// First, create a file
@@ -280,7 +280,7 @@ func TestWrite(t *testing.T) {
 
 func TestRepoOpts(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo1"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo2"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo3"))
@@ -355,7 +355,7 @@ func TestRepoOpts(t *testing.T) {
 
 func TestOpenCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "in"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "out"))
 	require.NoError(t, env.PachClient.CreateBranch(pfs.DefaultProjectName, "out", "master", "", "", []*pfs.Branch{client.NewBranch(pfs.DefaultProjectName, "in", "master")}))
@@ -398,7 +398,7 @@ func finishProjectCommit(pachClient *client.APIClient, project, repo, branch, id
 
 func TestMountCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	c1, err := env.PachClient.StartCommit(pfs.DefaultProjectName, "repo", "master")
 	require.NoError(t, err)
@@ -458,7 +458,7 @@ func TestMountCommit(t *testing.T) {
 
 func TestMountFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	require.NoError(t, env.PachClient.PutFile(client.NewCommit(pfs.DefaultProjectName, "repo", "master", ""), "foo", strings.NewReader("foo")))
 	require.NoError(t, env.PachClient.PutFile(client.NewCommit(pfs.DefaultProjectName, "repo", "master", ""), "bar", strings.NewReader("bar")))
@@ -512,7 +512,7 @@ func TestMountFile(t *testing.T) {
 
 func TestMountDir(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	err := env.PachClient.WithModifyFileClient(client.NewCommit(pfs.DefaultProjectName, "repo", "master", ""), func(mf client.ModifyFile) error {
 		if err := mf.PutFile("dir/foo", strings.NewReader("foo")); err != nil {

--- a/src/server/pfs/fuse/server_test.go
+++ b/src/server/pfs/fuse/server_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestBasicServerSameNames(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
 	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
@@ -77,7 +77,7 @@ func TestBasicServerSameNames(t *testing.T) {
 
 func TestBasicServerNonMasterBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "dev", "")
 	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
@@ -124,7 +124,7 @@ func TestBasicServerNonMasterBranch(t *testing.T) {
 
 func TestBasicServerDifferingNames(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
 	err := env.PachClient.PutFile(commit, "dir/file1", strings.NewReader("foo"))
@@ -171,7 +171,7 @@ func TestBasicServerDifferingNames(t *testing.T) {
 
 func TestUnmountAll(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo1"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo1", "master", "")
@@ -225,7 +225,7 @@ func TestUnmountAll(t *testing.T) {
 
 func TestMultipleMount(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
 	err := env.PachClient.PutFile(commit, "dir/file", strings.NewReader("foo"))
@@ -305,7 +305,7 @@ func TestMultipleMount(t *testing.T) {
 
 func TestMountNonexistentRepo(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
 		mr := MountRequest{
@@ -327,7 +327,7 @@ func TestMountNonexistentRepo(t *testing.T) {
 func TestRwMountNonexistentBranch(t *testing.T) {
 	// Mounting a nonexistent branch fails for read-only mounts and succeeds for read-write mounts
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -369,7 +369,7 @@ func TestRwUnmountCreatesCommit(t *testing.T) {
 	// Unmounting a mounted read-write filesystem which has had some data
 	// written to it results in a new commit with that data in it.
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -426,7 +426,7 @@ func TestRwUnmountCreatesCommit(t *testing.T) {
 func TestRwCommitCreatesCommit(t *testing.T) {
 	// Commit operation creates a commit.
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -485,7 +485,7 @@ func TestRwCommitTwiceCreatesTwoCommits(t *testing.T) {
 	// Two sequential commit operations create two commits (and they contain the
 	// correct files).
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -565,7 +565,7 @@ func TestRwCommitUnmountCreatesTwoCommits(t *testing.T) {
 	// Commit and then unmount results in two commits, since unmounting creates
 	// one too.
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	withServerMount(t, env.PachClient, nil, func(mountPoint string) {
@@ -645,7 +645,7 @@ func TestRwCommitUnmountCreatesTwoCommits(t *testing.T) {
 
 func TestHealth(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	_, err := get("health")
 	require.YesError(t, err)
 
@@ -659,7 +659,7 @@ func TestHealth(t *testing.T) {
 // Requires 'use_allow_other' to be enabled in /etc/fuse.conf
 func TestAuthLoginLogout(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -702,7 +702,7 @@ func TestAuthLoginLogout(t *testing.T) {
 
 func TestRepoAccess(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -751,7 +751,7 @@ func TestRepoAccess(t *testing.T) {
 
 func TestUnauthenticatedCode(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnvWithIdentity(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	c := env.PachClient
 	tu.ActivateAuthClient(t, c, peerPort)
@@ -775,7 +775,7 @@ func TestUnauthenticatedCode(t *testing.T) {
 
 func TestDeletingMountedRepo(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "b1", "")
@@ -838,7 +838,7 @@ func TestDeletingMountedRepo(t *testing.T) {
 
 func TestMountWithProjects(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "b1", "")
@@ -961,7 +961,7 @@ func TestMountWithProjects(t *testing.T) {
 
 func TestProjects(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "b1", "")
@@ -1015,7 +1015,7 @@ func TestProjects(t *testing.T) {
 
 func TestMountingCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
@@ -1069,7 +1069,7 @@ func TestMountingCommit(t *testing.T) {
 
 func TestMountingCommitRWMode(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")
@@ -1117,7 +1117,7 @@ func TestMountingCommitRWMode(t *testing.T) {
 
 func TestMountingMultipleFiles(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
 	commit := client.NewCommit(pfs.DefaultProjectName, "repo", "master", "")

--- a/src/server/pfs/s3/master_test.go
+++ b/src/server/pfs/s3/master_test.go
@@ -508,7 +508,7 @@ func TestMasterDriver(t *testing.T) {
 	}
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	testRunner(env.Context, t, env.PachClient, "master", s3.NewMasterDriver(), func(t *testing.T, pachClient *client.APIClient, minioClient *minio.Client) {
 		t.Run("ListBuckets", func(t *testing.T) {
 			masterListBuckets(t, pachClient, minioClient)

--- a/src/server/pfs/s3/project_master_test.go
+++ b/src/server/pfs/s3/project_master_test.go
@@ -486,7 +486,7 @@ func TestProjectMasterDriver(t *testing.T) {
 	}
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	projectTestRunner(env.Context, t, env.PachClient, "master", s3.NewMasterDriver(), func(t *testing.T, pachClient *client.APIClient, minioClient *minio.Client) {
 		t.Run("ListBuckets", func(t *testing.T) {
 			projectMasterListBuckets(t, pachClient, minioClient)

--- a/src/server/pfs/s3/worker_test.go
+++ b/src/server/pfs/s3/worker_test.go
@@ -234,7 +234,7 @@ func TestWorkerDriver(t *testing.T) {
 	}
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	pachClient := env.PachClient
 
 	inputRepo := tu.UniqueString("testworkerdriverinput")

--- a/src/server/pfs/server/testing/load_test.go
+++ b/src/server/pfs/server/testing/load_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLoad(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	resp, err := c.DebugClient.RunPFSLoadTestDefault(c.Ctx(), &emptypb.Empty{})
 	require.NoError(t, err)

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -150,7 +150,7 @@ func newEnv(ctx context.Context, t testing.TB) TestEnv {
 
 func TestWalkFileTest(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := newEnv(ctx, t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -150,7 +150,7 @@ func newEnv(ctx context.Context, t testing.TB) TestEnv {
 
 func TestWalkFileTest(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := newEnv(ctx, t)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -216,7 +216,7 @@ func TestWalkFileTest(t *testing.T) {
 
 func TestListFileTest(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -295,7 +295,7 @@ func TestListFileTest(t *testing.T) {
 
 func TestListCommitStartedTime(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	err := env.PachClient.CreateRepo(pfs.DefaultProjectName, "foo")
 	require.NoError(t, err)
 	// create three sequential commits
@@ -344,7 +344,7 @@ func TestListCommitStartedTime(t *testing.T) {
 
 func TestInvalidProject(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	c := env.PachClient
 	badFormatErr := "only alphanumeric characters"
@@ -482,7 +482,7 @@ func TestCreateSameRepoInParallel(t *testing.T) {
 
 func TestCreateDifferentRepoInParallel(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	numGoros := 1000
 	errCh := make(chan error)
@@ -528,7 +528,7 @@ func TestCreateRepoNonExistentProject(t *testing.T) {
 func TestCreateRepoDeleteRepoRace(t *testing.T) {
 	t.Skip()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	for i := 0; i < 100; i++ {
 		require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "foo"))
 		require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "bar"))
@@ -552,7 +552,7 @@ func TestCreateRepoDeleteRepoRace(t *testing.T) {
 
 func TestCreateRepoWithSameNameAndAuthInDifferentProjects(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	// activate auth
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateLicense(t, env.PachClient, peerPort)
@@ -597,7 +597,7 @@ func TestCreateRepoWithSameNameAndAuthInDifferentProjects(t *testing.T) {
 
 func TestBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -618,7 +618,7 @@ func TestBranch(t *testing.T) {
 
 func TestToggleBranchProvenance(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "in"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "out"))
@@ -687,7 +687,7 @@ func TestToggleBranchProvenance(t *testing.T) {
 
 func TestRecreateBranchProvenance(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "in"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "out"))
 	require.NoError(t, env.PachClient.CreateBranch(pfs.DefaultProjectName, "out", "master", "", "", []*pfs.Branch{client.NewBranch(pfs.DefaultProjectName, "in", "master")}))
@@ -718,7 +718,7 @@ func TestRecreateBranchProvenance(t *testing.T) {
 // that branch ID to match the assigned ID, and for commit with a new Global ID to propagate to all downstream branches.
 func TestRewindBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	// for provenance DAG: { a.master <- b.master <- c.master }
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "a"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "b"))
@@ -799,7 +799,7 @@ func TestRewindBranch(t *testing.T) {
 
 func TestRewindInput(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -867,7 +867,7 @@ func TestRewindInput(t *testing.T) {
 
 func TestRewindProvenanceChange(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -999,7 +999,7 @@ func TestListRepo(t *testing.T) {
 // Make sure that artifacts of deleted repos do not resurface
 func TestCreateDeletedRepo(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1049,7 +1049,7 @@ func TestCreateDeletedRepo(t *testing.T) {
 // Make sure that commits of deleted repos do not resurface
 func TestListCommitLimit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	commit := client.NewCommit(pfs.DefaultProjectName, repo, "master", "")
@@ -1081,7 +1081,7 @@ func TestListCommitLimit(t *testing.T) {
 // d1      d2
 func TestUpdateProvenance(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	prov1 := "prov1"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, prov1))
@@ -1124,7 +1124,7 @@ func TestUpdateProvenance(t *testing.T) {
 
 func TestPutFileIntoOpenCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1146,7 +1146,7 @@ func TestPutFileIntoOpenCommit(t *testing.T) {
 
 func TestPutFileDirectoryTraversal(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 
@@ -1180,7 +1180,7 @@ func TestPutFileDirectoryTraversal(t *testing.T) {
 
 func TestCreateInvalidBranchName(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1192,7 +1192,7 @@ func TestCreateInvalidBranchName(t *testing.T) {
 
 func TestCreateBranchHeadOnOtherRepo(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	// create two repos, and create a branch on one that tries to point on another's existing branch
 	repo := "test"
@@ -1231,7 +1231,7 @@ func TestCreateBranchHeadOnOtherRepo(t *testing.T) {
 
 func TestDeleteProject(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PachClient.PfsAPIClient.CreateProject(ctx, &pfs.CreateProjectRequest{Project: &pfs.Project{Name: "test"}})
 	require.NoError(t, err)
@@ -1241,7 +1241,7 @@ func TestDeleteProject(t *testing.T) {
 
 func TestDeleteProjectWithRepos(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PachClient.PfsAPIClient.CreateProject(ctx, &pfs.CreateProjectRequest{Project: &pfs.Project{Name: "test"}})
 	require.NoError(t, err)
@@ -1292,7 +1292,7 @@ func TestDeleteProjectWithRepos(t *testing.T) {
 
 func TestDeleteRepo2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	numRepos := 10
 	repoNames := make(map[string]bool)
@@ -1324,7 +1324,7 @@ func TestDeleteRepo2(t *testing.T) {
 
 func TestDeleteRepoProvenance(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	// Create two repos, one as another's provenance
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
@@ -1369,7 +1369,7 @@ func TestDeleteRepoProvenance(t *testing.T) {
 func TestDeleteRepos(t *testing.T) {
 	var (
 		ctx                  = pctx.TestContext(t)
-		env                  = realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env                  = realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 		projectName          = tu.UniqueString("project")
 		untouchedProjectName = tu.UniqueString("project")
 		reposToDelete        = make(map[string]bool)
@@ -1466,7 +1466,7 @@ func TestDeleteRepos(t *testing.T) {
 
 func TestInspectCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1503,7 +1503,7 @@ func TestInspectCommit(t *testing.T) {
 
 func TestInspectCommitWait(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1525,7 +1525,7 @@ func TestInspectCommitWait(t *testing.T) {
 
 func TestDropCommitSet(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	project := tu.UniqueString("prj")
 	require.NoError(t, env.PachClient.CreateProject(project))
@@ -1566,7 +1566,7 @@ func TestDropCommitSet(t *testing.T) {
 
 func TestDropCommitSetOnlyCommitInBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1604,7 +1604,7 @@ func TestDropCommitSetOnlyCommitInBranch(t *testing.T) {
 
 func TestDropCommitSetFinished(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1641,7 +1641,7 @@ func TestDropCommitSetFinished(t *testing.T) {
 
 func TestBasicFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1662,7 +1662,7 @@ func TestBasicFile(t *testing.T) {
 
 func TestSimpleFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1692,7 +1692,7 @@ func TestSimpleFile(t *testing.T) {
 
 func TestStartCommitWithUnfinishedParent(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1710,7 +1710,7 @@ func TestStartCommitWithUnfinishedParent(t *testing.T) {
 
 func TestProvenanceWithinSingleRepoDisallowed(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1722,7 +1722,7 @@ func TestProvenanceWithinSingleRepoDisallowed(t *testing.T) {
 
 func TestAncestrySyntax(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -1847,7 +1847,7 @@ func TestAncestrySyntax(t *testing.T) {
 
 func TestProvenance(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "C"))
@@ -1908,7 +1908,7 @@ func TestProvenance(t *testing.T) {
 
 func TestCommitBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "input"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "output1"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "output2"))
@@ -1931,7 +1931,7 @@ func TestCommitBranch(t *testing.T) {
 
 func TestCommitBranchProvenanceMovement(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "input"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "output"))
 	// create two commits on input@master
@@ -1988,7 +1988,7 @@ func TestCommitBranchProvenanceMovement(t *testing.T) {
 // When commit x propagates from A to C, verify that queries to B@x resolve to the B commit
 // that was used in C@x.
 func TestResolveAlias(t *testing.T) {
-	env := realenv.NewRealEnv(pctx.TestContext(t), t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(pctx.TestContext(t), t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -2039,7 +2039,7 @@ func TestResolveAlias(t *testing.T) {
 // todo(fahad): fix
 func TestSquashComplex(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	var benches []string
 	start := time.Now()
@@ -2142,7 +2142,7 @@ func TestSquashComplex(t *testing.T) {
 
 func TestBranch1(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2198,7 +2198,7 @@ func TestBranch1(t *testing.T) {
 
 func TestPinBranchCommitsDAG(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	input, pinInput, output := "input", "pinInput", "output"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, input))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, pinInput))
@@ -2223,7 +2223,7 @@ func TestPinBranchCommitsDAG(t *testing.T) {
 
 func TestPutFileBig(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2249,7 +2249,7 @@ func TestPutFileBig(t *testing.T) {
 
 func TestPutFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2271,7 +2271,7 @@ func TestPutFile(t *testing.T) {
 
 func TestPutFile2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2329,7 +2329,7 @@ func TestPutFile2(t *testing.T) {
 
 func TestPutFileBranchCommitID(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2340,7 +2340,7 @@ func TestPutFileBranchCommitID(t *testing.T) {
 
 func TestPutSameFileInParallel(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2363,7 +2363,7 @@ func TestPutSameFileInParallel(t *testing.T) {
 
 func TestInspectFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2414,7 +2414,7 @@ func TestInspectFile(t *testing.T) {
 
 func TestInspectFile2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2457,7 +2457,7 @@ func TestInspectFile2(t *testing.T) {
 
 func TestInspectFile3(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2503,7 +2503,7 @@ func TestInspectFile3(t *testing.T) {
 
 func TestInspectDir(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2534,7 +2534,7 @@ func TestInspectDir(t *testing.T) {
 
 func TestInspectDir2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2575,7 +2575,7 @@ func TestInspectDir2(t *testing.T) {
 
 func TestListFileTwoCommits(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2619,7 +2619,7 @@ func TestListFileTwoCommits(t *testing.T) {
 
 func TestListFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2648,7 +2648,7 @@ func TestListFile(t *testing.T) {
 
 func TestListFile2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2690,7 +2690,7 @@ func TestListFile2(t *testing.T) {
 
 func TestListFile3(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2742,7 +2742,7 @@ func TestListFile3(t *testing.T) {
 
 func TestListFile4(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2774,7 +2774,7 @@ func TestListFile4(t *testing.T) {
 
 func TestRootDirectory(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2794,7 +2794,7 @@ func TestRootDirectory(t *testing.T) {
 
 func TestDeleteFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	project := tu.UniqueString("project")
 	require.NoError(t, env.PachClient.CreateProject(project))
 	repo := "test"
@@ -2859,7 +2859,7 @@ func TestDeleteFile(t *testing.T) {
 
 func TestDeleteFile2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2897,7 +2897,7 @@ func TestDeleteFile2(t *testing.T) {
 
 func TestDeleteFile3(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -2950,7 +2950,7 @@ func TestDeleteFile3(t *testing.T) {
 
 func TestDeleteDir(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3023,7 +3023,7 @@ func TestDeleteDir(t *testing.T) {
 
 func TestListCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3097,7 +3097,7 @@ func TestListCommit(t *testing.T) {
 func TestOffsetRead(t *testing.T) {
 	// TODO(2.0 optional): Decide on how to expose offset read.
 	t.Skip("Offset read exists (inefficient), just need to decide on how to expose it in V2")
-	// 	// env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	// 	// env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	// repo := "test"
 	// require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName,repo))
@@ -3120,7 +3120,7 @@ func TestOffsetRead(t *testing.T) {
 
 func TestBranch2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	project := tu.UniqueString("project")
 	require.NoError(t, env.PachClient.CreateProject(project))
 	repo := "test"
@@ -3181,7 +3181,7 @@ func TestBranch2(t *testing.T) {
 
 func TestDeleteNonexistentBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3190,7 +3190,7 @@ func TestDeleteNonexistentBranch(t *testing.T) {
 
 func TestSubscribeCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	project := tu.UniqueString("project")
 	require.NoError(t, env.PachClient.CreateProject(project))
@@ -3240,7 +3240,7 @@ func TestSubscribeCommit(t *testing.T) {
 
 func TestInspectRepoSimple(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3265,7 +3265,7 @@ func TestInspectRepoSimple(t *testing.T) {
 
 func TestInspectRepoComplex(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3303,7 +3303,7 @@ func TestInspectRepoComplex(t *testing.T) {
 func TestCreate(t *testing.T) {
 	// TODO: Implement put file split writer in V2?
 	t.Skip("Put file split writer not implemented in V2")
-	// 	// env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	// 	// env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	// repo := "test"
 	// require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName,repo))
@@ -3319,7 +3319,7 @@ func TestCreate(t *testing.T) {
 
 func TestGetFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := tu.UniqueString("test")
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3371,7 +3371,7 @@ func TestGetFile(t *testing.T) {
 
 func TestManyPutsSingleFileSingleCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	if testing.Short() {
 		t.Skip("Skipping long tests in short mode")
@@ -3417,7 +3417,7 @@ func TestManyPutsSingleFileSingleCommit(t *testing.T) {
 
 func TestPutFileValidCharacters(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3445,7 +3445,7 @@ func TestPutFileValidCharacters(t *testing.T) {
 
 func TestPutFileValidPaths(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 	// Duplicate paths, different tags.
@@ -3472,7 +3472,7 @@ func TestPutFileValidPaths(t *testing.T) {
 
 func TestBigListFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 	commit, err := env.PachClient.StartCommit(pfs.DefaultProjectName, repo, "master")
@@ -3498,7 +3498,7 @@ func TestBigListFile(t *testing.T) {
 
 func TestStartCommitLatestOnBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3523,7 +3523,7 @@ func TestStartCommitLatestOnBranch(t *testing.T) {
 
 func TestCreateBranchTwice(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3551,7 +3551,7 @@ func TestCreateBranchTwice(t *testing.T) {
 
 func TestWaitCommitSet(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -3575,7 +3575,7 @@ func TestWaitCommitSet(t *testing.T) {
 // A ─▶ B ─▶ C ─▶ D
 func TestWaitCommitSet2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -3628,7 +3628,7 @@ func TestWaitCommitSet2(t *testing.T) {
 // B
 func TestWaitCommitSet3(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -3664,7 +3664,7 @@ func TestWaitCommitSet3(t *testing.T) {
 
 func TestWaitCommitSetWithNoDownstreamRepos(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -3679,7 +3679,7 @@ func TestWaitCommitSetWithNoDownstreamRepos(t *testing.T) {
 
 func TestWaitOpenCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -3712,7 +3712,7 @@ func TestWaitOpenCommit(t *testing.T) {
 
 func TestWaitUninvolvedBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -3727,7 +3727,7 @@ func TestWaitUninvolvedBranch(t *testing.T) {
 
 func TestWaitNonExistentBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	_, err := env.PachClient.StartCommit(pfs.DefaultProjectName, "A", "master")
 	require.NoError(t, err)
@@ -3737,14 +3737,14 @@ func TestWaitNonExistentBranch(t *testing.T) {
 
 func TestEmptyWait(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	_, err := env.PachClient.WaitCommitSetAll("")
 	require.YesError(t, err)
 }
 
 func TestWaitNonExistentCommitSet(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	_, err := env.PachClient.WaitCommitSetAll("fake-commitset")
 	require.YesError(t, err)
 	require.True(t, pfsserver.IsCommitSetNotFoundErr(err))
@@ -3753,7 +3753,7 @@ func TestWaitNonExistentCommitSet(t *testing.T) {
 func TestPutFileSplit(t *testing.T) {
 	// TODO(2.0 optional): Implement put file split.
 	t.Skip("Put file split not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	if testing.Short() {
 	//		t.Skip("Skipping integration tests in short mode")
@@ -3861,7 +3861,7 @@ func TestPutFileSplit(t *testing.T) {
 func TestPutFileSplitBig(t *testing.T) {
 	// TODO(2.0 optional): Implement put file split.
 	t.Skip("Put file split not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	if testing.Short() {
 	//		t.Skip("Skipping integration tests in short mode")
@@ -3891,7 +3891,7 @@ func TestPutFileSplitBig(t *testing.T) {
 func TestPutFileSplitCSV(t *testing.T) {
 	// TODO(2.0 optional): Implement put file split.
 	t.Skip("Put file split not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	// create repos
 	//	repo := "test"
@@ -3915,7 +3915,7 @@ func TestPutFileSplitCSV(t *testing.T) {
 func TestPutFileSplitSQL(t *testing.T) {
 	// TODO(2.0 optional): Implement put file split.
 	t.Skip("Put file split not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	// create repos
 	//	repo := "test"
@@ -3979,7 +3979,7 @@ func TestPutFileSplitSQL(t *testing.T) {
 
 func TestDiffFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4080,7 +4080,7 @@ func TestDiffFile(t *testing.T) {
 
 func TestGlobFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -4200,7 +4200,7 @@ func TestGlobFile(t *testing.T) {
 
 func TestGlobFile2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -4236,7 +4236,7 @@ func TestGlobFile2(t *testing.T) {
 
 func TestGlobFile3(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4267,7 +4267,7 @@ func TestGlobFile3(t *testing.T) {
 // file matching 'glob', file2 is the next lowest, etc.
 func TestGetFileTARGlobOrder(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4293,7 +4293,7 @@ func TestGetFileTARGlobOrder(t *testing.T) {
 
 func TestPathRange(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4345,7 +4345,7 @@ func TestPathRange(t *testing.T) {
 
 func TestApplyWriteOrder(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -4371,7 +4371,7 @@ func TestApplyWriteOrder(t *testing.T) {
 func TestOverwrite(t *testing.T) {
 	// TODO(2.0 optional): Implement put file split.
 	t.Skip("Put file split not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	if testing.Short() {
 	//		t.Skip("Skipping integration tests in short mode")
@@ -4418,7 +4418,7 @@ func TestOverwrite(t *testing.T) {
 func TestFindCommits(t *testing.T) {
 	ctx, cf := context.WithTimeout(pctx.TestContext(t), time.Minute)
 	defer cf()
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4455,7 +4455,7 @@ func TestFindCommits(t *testing.T) {
 func TestFindCommitsLimit(t *testing.T) {
 	ctx, cf := context.WithTimeout(pctx.TestContext(t), time.Minute)
 	defer cf()
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4482,7 +4482,7 @@ func TestFindCommitsLimit(t *testing.T) {
 func TestFindCommitsOpenCommit(t *testing.T) {
 	ctx, cf := context.WithTimeout(pctx.TestContext(t), time.Minute)
 	defer cf()
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4509,7 +4509,7 @@ func TestFindCommitsOpenCommit(t *testing.T) {
 
 func TestCopyFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -4548,7 +4548,7 @@ func TestCopyFile(t *testing.T) {
 
 func TestPropagateBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo1 := "test1"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo1))
@@ -4576,7 +4576,7 @@ func TestPropagateBranch(t *testing.T) {
 // B ──▶ D
 func TestBackfillBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -4616,7 +4616,7 @@ func TestBackfillBranch(t *testing.T) {
 // D ───╯
 func TestUpdateBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -4719,7 +4719,7 @@ func TestBranchProvenance(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 			ctx := pctx.TestContext(t)
-			env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+			env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 			for _, repo := range []string{"A", "B", "C", "D", "E"} {
 				require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 			}
@@ -4813,7 +4813,7 @@ func TestBranchProvenance(t *testing.T) {
 
 func TestChildCommits(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateBranch(pfs.DefaultProjectName, "A", "master", "", "", nil))
@@ -4899,7 +4899,7 @@ func TestChildCommits(t *testing.T) {
 
 func TestStartCommitFork(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	commit, err := env.PachClient.StartCommit(pfs.DefaultProjectName, "A", "master")
@@ -4934,7 +4934,7 @@ func TestStartCommitFork(t *testing.T) {
 // C should create a new output commit to process its unprocessed inputs in B
 func TestUpdateBranchNewOutputCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -4980,7 +4980,7 @@ func TestUpdateBranchNewOutputCommit(t *testing.T) {
 //	 a
 func TestSquashCommitSetMultipleChildrenSingleCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo"))
 	require.NoError(t, env.PachClient.CreateBranch(pfs.DefaultProjectName, "repo", "master", "", "", nil))
@@ -5078,7 +5078,7 @@ func TestSquashCommitSetMultipleChildrenSingleCommit(t *testing.T) {
 // if appropriate
 func TestSquashCommitSetMultiLevelChildrenSimple(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	project := tu.UniqueString("prj-")
 	require.NoError(t, env.PachClient.CreateProject(project))
 	// Create main repo (will have the commit graphs above)
@@ -5218,7 +5218,7 @@ func TestSquashCommitSetMultiLevelChildrenSimple(t *testing.T) {
 // This makes sure that multiple live children are re-pointed at a live parent
 // if appropriate
 func TestSquashCommitSetMultiLevelChildrenComplex(t *testing.T) {
-	env := realenv.NewRealEnv(pctx.TestContext(t), t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(pctx.TestContext(t), t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "upstream1"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "upstream2"))
 	// commit to both inputs
@@ -5368,7 +5368,7 @@ func TestSquashCommitSetMultiLevelChildrenComplex(t *testing.T) {
 
 func TestCommitState(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	// two input repos, one with many commits (logs), and one with few (schema)
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
@@ -5414,7 +5414,7 @@ func TestCommitState(t *testing.T) {
 
 func TestSubscribeStates(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -5465,7 +5465,7 @@ func TestSubscribeStates(t *testing.T) {
 
 func TestPutFileCommit(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	numFiles := 25
 	repo := "repo"
@@ -5521,7 +5521,7 @@ func TestPutFileCommit(t *testing.T) {
 
 func TestPutFileCommitNilBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -5533,7 +5533,7 @@ func TestPutFileCommitNilBranch(t *testing.T) {
 
 func TestPutFileCommitOverwrite(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	numFiles := 5
 	repo := "repo"
@@ -5551,7 +5551,7 @@ func TestPutFileCommitOverwrite(t *testing.T) {
 
 func TestWalkFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -5578,7 +5578,7 @@ func TestWalkFile(t *testing.T) {
 
 func TestWalkFile2(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "WalkFile2"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -5604,7 +5604,7 @@ func TestWalkFile2(t *testing.T) {
 
 func TestWalkFileEmpty(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	latestCommit := client.NewCommit(pfs.DefaultProjectName, repo, "master", "")
@@ -5644,7 +5644,7 @@ func TestWalkFileEmpty(t *testing.T) {
 func TestReadSizeLimited(t *testing.T) {
 	// TODO(2.0 optional): Decide on how to expose offset read.
 	t.Skip("Offset read exists (inefficient), just need to decide on how to expose it in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName,"test"))
 	//	require.NoError(t, env.PachClient.PutFile("test", "master", "", "file", strings.NewReader(strings.Repeat("a", 100*units.MB))))
@@ -5660,7 +5660,7 @@ func TestReadSizeLimited(t *testing.T) {
 
 func TestPutFileURL(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -5683,7 +5683,7 @@ func TestPutFileURL(t *testing.T) {
 
 func TestPutFilesURL(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	repoProto := client.NewRepo(pfs.DefaultProjectName, repo)
@@ -5713,7 +5713,7 @@ func TestPutFilesURL(t *testing.T) {
 
 func TestPutFilesObjURL(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -5751,7 +5751,7 @@ func TestPutFilesObjURL(t *testing.T) {
 
 func TestGetFilesObjURL(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -5794,7 +5794,7 @@ func TestGetFilesObjURL(t *testing.T) {
 
 func TestPutFileOutputRepo(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	inputRepo, outputRepo := "input", "output"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, inputRepo))
@@ -5818,7 +5818,7 @@ func TestFileHistory(t *testing.T) {
 	// TODO: There is no notion of file history in V2. We could potentially implement this, but
 	// we would need to spend some time thinking about the performance characteristics.
 	t.Skip("File history is not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	var err error
 	//
@@ -5859,7 +5859,7 @@ func TestFileHistory(t *testing.T) {
 
 func TestUpdateRepo(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	var err error
 	repo := "test"
@@ -5893,7 +5893,7 @@ func TestUpdateRepo(t *testing.T) {
 
 func TestDeferredProcessing(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "input"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "output1"))
@@ -5940,7 +5940,7 @@ func TestDeferredProcessing(t *testing.T) {
 
 func TestSquashCommitEmptyChild(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "repo"
 	file := "foo"
@@ -5974,7 +5974,7 @@ func TestSquashCommitEmptyChild(t *testing.T) {
 
 func TestListAll(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo1"))
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "repo2"))
@@ -5998,7 +5998,7 @@ func TestMonkeyObjectStorage(t *testing.T) {
 	// This test cannot be done in parallel because the monkey object client
 	// modifies global state.
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	seedStr := func(seed int64) string {
 		return fmt.Sprint("seed: ", strconv.FormatInt(seed, 10))
 	}
@@ -6072,7 +6072,7 @@ func TestFsckFix(t *testing.T) {
 	// TODO(optional 2.0): force-deleting the repo no longer creates dangling references
 	t.Skip("this test no longer creates invalid metadata")
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	input := "input"
 	output1 := "output1"
@@ -6103,7 +6103,7 @@ func TestFsckFix(t *testing.T) {
 
 func TestPutFileAtomic(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	c := env.PachClient
 	test := "test"
@@ -6221,7 +6221,7 @@ const (
 
 func TestFuzzProvenance(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	seed := time.Now().UnixNano()
 	t.Log("Random seed is", seed)
@@ -6397,7 +6397,7 @@ func TestAtomicHistory(t *testing.T) {
 	// TODO: There is no notion of file history in V2. We could potentially implement this, but
 	// we would need to spend some time thinking about the performance characteristics.
 	t.Skip("File history is not implemented in V2")
-	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t))
+	//		//  env := testpachd.NewRealEnv(t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	//
 	//	repo := "test"
 	//	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName,repo))
@@ -6454,7 +6454,7 @@ func TestAtomicHistory(t *testing.T) {
 func TestTrigger(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 
 	t.Run("Simple", func(t *testing.T) {
@@ -7077,7 +7077,7 @@ func TestTrigger(t *testing.T) {
 // TriggerValidation tests branch trigger validation
 func TestTriggerValidation(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	c := env.PachClient
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, "repo"))
@@ -7134,7 +7134,7 @@ func TestTriggerValidation(t *testing.T) {
 
 func TestRegressionOrphanedFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	fsclient, err := env.PachClient.NewCreateFileSetClient()
 	require.NoError(t, err)
@@ -7157,7 +7157,7 @@ func TestCompaction(t *testing.T) {
 	ctx := pctx.TestContext(t)
 	env := realenv.NewRealEnv(ctx, t, func(config *pachconfig.Configuration) {
 		config.StorageCompactionMaxFanIn = 10
-	}, dockertestenv.NewTestDBConfig(t))
+	}, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -7188,7 +7188,7 @@ func TestCompaction(t *testing.T) {
 
 func TestModifyFileGRPCEmptyFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 	c, err := env.PachClient.PfsAPIClient.ModifyFile(context.Background())
@@ -7221,7 +7221,7 @@ func TestModifyFileGRPCEmptyFile(t *testing.T) {
 
 func TestSingleMessageFile(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 	filePath := "file"
@@ -7250,7 +7250,7 @@ func TestSingleMessageFile(t *testing.T) {
 
 func TestTestPanicOnNilArgs(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	requireNoPanic := func(err error) {
 		t.Helper()
@@ -7310,7 +7310,7 @@ func TestTestPanicOnNilArgs(t *testing.T) {
 
 func TestErroredCommits(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	repo := "test"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
 	checks := func(t *testing.T, branch string) {
@@ -7381,7 +7381,7 @@ func TestErroredCommits(t *testing.T) {
 
 func TestSystemRepoDependence(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	sysRepo := client.NewSystemRepo(pfs.DefaultProjectName, "test", pfs.MetaRepoType)
 
@@ -7410,7 +7410,7 @@ func TestSystemRepoDependence(t *testing.T) {
 
 func TestErrorMessages(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	// don't show user .user suffix
 	_, err := env.PachClient.InspectRepo(pfs.DefaultProjectName, "test")
 	require.YesError(t, err)
@@ -7436,7 +7436,7 @@ func TestErrorMessages(t *testing.T) {
 }
 
 func TestEgressToPostgres(_suite *testing.T) {
-	os.Setenv("PACHYDERM_SQL_PASSWORD", tu.DefaultPostgresPassword)
+	os.Setenv("PACHYDERM_SQL_PASSWORD", dockertestenv.DefaultPostgresPassword)
 
 	type Schema struct {
 		Id    int    `column:"ID" dtype:"INT"`
@@ -7529,13 +7529,13 @@ func TestEgressToPostgres(_suite *testing.T) {
 	for _, test := range tests {
 		_suite.Run(test.name, func(t *testing.T) {
 			ctx := pctx.TestContext(t)
-			env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+			env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 			// setup target database
 			dbName := tu.GenerateEphemeralDBName(t)
 			tu.CreateEphemeralDB(t, sqlx.NewDb(env.ServiceEnv.GetDBClient().DB, "postgres"), dbName)
 			db := tu.OpenDB(t,
 				dbutil.WithMaxOpenConns(1),
-				dbutil.WithUserPassword(tu.DefaultPostgresUser, tu.DefaultPostgresPassword),
+				dbutil.WithUserPassword(dockertestenv.DefaultPostgresUser, dockertestenv.DefaultPostgresPassword),
 				dbutil.WithHostPort(dockertestenv.PGBouncerHost(), dockertestenv.PGBouncerPort),
 				dbutil.WithDBName(dbName),
 			)
@@ -7555,7 +7555,7 @@ func TestEgressToPostgres(_suite *testing.T) {
 
 			// run Egress to copy data from source commit to target database
 			test.options.Secret = &pfs.SQLDatabaseEgress_Secret{Name: "does not matter", Key: "does not matter"}
-			test.options.Url = fmt.Sprintf("postgres://%s@%s:%d/%s", tu.DefaultPostgresUser, dockertestenv.PGBouncerHost(), dockertestenv.PGBouncerPort, dbName)
+			test.options.Url = fmt.Sprintf("postgres://%s@%s:%d/%s", dockertestenv.DefaultPostgresUser, dockertestenv.PGBouncerHost(), dockertestenv.PGBouncerPort, dbName)
 			resp, err := env.PachClient.Egress(env.PachClient.Ctx(),
 				&pfs.EgressRequest{
 					Commit: commit,
@@ -7613,7 +7613,7 @@ func TestDeleteRepo(t *testing.T) {
 		t.Skip("Skipping integration tests in short mode")
 	}
 
-	env := realenv.NewRealEnv(context.Background(), t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(context.Background(), t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	c := env.PachClient
 	dataRepo := tu.UniqueString("TestDeleteSpecRepo_data")
 	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, dataRepo))

--- a/src/server/pfs/server/testing/storage_test.go
+++ b/src/server/pfs/server/testing/storage_test.go
@@ -28,6 +28,6 @@ func TestCheckStorage(t *testing.T) {
 }
 
 func newClient(ctx context.Context, t testing.TB) pfs.APIClient {
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	return env.PachClient.PfsAPIClient
 }

--- a/src/server/pps/cmds/cmds_realenv_test.go
+++ b/src/server/pps/cmds/cmds_realenv_test.go
@@ -118,7 +118,7 @@ func TestListDatumFromFile(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	env.MockPachd.Admin.InspectCluster.Use(func(context.Context, *admin.InspectClusterRequest) (*admin.ClusterInfo, error) {
 		return &admin.ClusterInfo{
 			Id:           "dev",
@@ -171,7 +171,7 @@ func TestListDatumFromFile(t *testing.T) {
 
 func TestInspectClusterDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	env.MockPachd.Admin.InspectCluster.Use(func(context.Context, *admin.InspectClusterRequest) (*admin.ClusterInfo, error) {
 		return &admin.ClusterInfo{
 			Id:           "dev",
@@ -187,7 +187,7 @@ func TestInspectClusterDefaults(t *testing.T) {
 
 func TestCreateClusterDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	env.MockPachd.Admin.InspectCluster.Use(func(context.Context, *admin.InspectClusterRequest) (*admin.ClusterInfo, error) {
 		return &admin.ClusterInfo{
 			Id:           "dev",
@@ -205,7 +205,7 @@ func TestCreateClusterDefaults(t *testing.T) {
 
 func TestDeleteClusterDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	env.MockPachd.Admin.InspectCluster.Use(func(context.Context, *admin.InspectClusterRequest) (*admin.ClusterInfo, error) {
 		return &admin.ClusterInfo{
 			Id:           "dev",
@@ -225,7 +225,7 @@ func TestDeleteClusterDefaults(t *testing.T) {
 
 func TestUpdateClusterDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	env.MockPachd.Admin.InspectCluster.Use(func(context.Context, *admin.InspectClusterRequest) (*admin.ClusterInfo, error) {
 		return &admin.ClusterInfo{
 			Id:           "dev",

--- a/src/server/pps/server/api_server_test.go
+++ b/src/server/pps/server/api_server_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestListDatum(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	ctx = env.Context
 	repo := "TestListDatum"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -124,7 +124,7 @@ func TestListDatum(t *testing.T) {
 
 func TestRenderTemplate(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	client := env.PachClient.PpsAPIClient
 	res, err := client.RenderTemplate(ctx, &pps.RenderTemplateRequest{
 		Args: map[string]string{
@@ -278,7 +278,7 @@ func TestParseLokiLine(t *testing.T) {
 
 func TestDeletePipelines(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	inputRepo := tu.UniqueString("repo")
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, inputRepo))
 	// pipeline1 is in default project and takes inputRepo as input
@@ -330,7 +330,7 @@ func TestDeletePipelines(t *testing.T) {
 
 func TestUpdatePipelineInputBranch(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	repo := "input"
 	pipeline := "pipeline"
 	require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, repo))
@@ -365,7 +365,7 @@ func TestUpdatePipelineInputBranch(t *testing.T) {
 
 func TestGetClusterDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	resp, err := env.PPSServer.GetClusterDefaults(ctx, &pps.GetClusterDefaultsRequest{})
 	require.NoError(t, err, "GetClusterDefaults failed")
 	require.NotEqual(t, "", resp.ClusterDefaultsJson)
@@ -375,7 +375,7 @@ func TestGetClusterDefaults(t *testing.T) {
 
 func TestSetClusterDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	t.Run("BadJSON", func(t *testing.T) {
 		_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
@@ -654,7 +654,7 @@ func TestRerunPipeline(t *testing.T) {
 // to the same thing.
 func TestCreatePipelineMultipleNames(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: `{"create_pipeline_request": {"datum_tries": 17, "autoscaling": true, "salt": "mysalt"}}`,
@@ -724,7 +724,7 @@ func TestCreatePipelineMultipleNames(t *testing.T) {
 // TestDefaultPropagation tests that changed defaults propagate to a pipeline.
 func TestDefaultPropagation(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: `{"create_pipeline_request": {"datum_tries": 17, "autoscaling": true, "metadata": {"annotations": {"foo": "bar"}}}}`})
@@ -861,7 +861,7 @@ func unmarshalJSON(s string, v any) error {
 // true does not create a pipeline, but does return a correct effective spec.
 func TestCreatePipelineDryRun(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: `{"create_pipeline_request": {"datum_tries": 17, "autoscaling": true}}`,

--- a/src/server/pps/server/defaults_test.go
+++ b/src/server/pps/server/defaults_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAPIServer_CreatePipelineV2_noDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	dr, err := env.PPSServer.GetClusterDefaults(ctx, &pps.GetClusterDefaultsRequest{})
 	require.NoError(t, err, "GetClusterDefaults must succeed")
@@ -76,7 +76,7 @@ func TestAPIServer_CreatePipelineV2_noDefaults(t *testing.T) {
 
 func TestAPIServer_CreatePipelineV2_defaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: `{"create_pipeline_request": {"datum_tries": 17, "autoscaling": true}}`,
@@ -127,7 +127,7 @@ func TestAPIServer_CreatePipelineV2_defaults(t *testing.T) {
 
 func TestAPIServer_CreatePipelineV2_regenerate(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: `{"create_pipeline_request": {"datum_tries": 17, "autoscaling": true}}`,
@@ -187,7 +187,7 @@ func TestAPIServer_CreatePipelineV2_regenerate(t *testing.T) {
 
 func TestAPIServer_CreatePipelineV2_delete(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: "{}",
@@ -246,7 +246,7 @@ func TestAPIServer_CreatePipelineV2_delete(t *testing.T) {
 
 func TestAPIServer_CreatePipelineV2_zero_value(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	_, err := env.PPSServer.SetClusterDefaults(ctx, &pps.SetClusterDefaultsRequest{
 		ClusterDefaultsJson: `{"create_pipeline_request": {"datum_tries": 17, "autoscaling": true, "resource_requests": {"memory": "200Mi", "cpu": 0}}}`,
@@ -306,7 +306,7 @@ func TestAPIServer_CreatePipelineV2_reprocessSpec(t *testing.T) {
 		"bad reprocess spec":      {defaults: `{"create_pipeline_request": {"reprocessSpec": "#<not a reprocess spec>"}}`, wantErr: true},
 	}
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -328,7 +328,7 @@ func TestAPIServer_CreatePipelineV2_reprocessSpec(t *testing.T) {
 
 func TestAPIServer_GetProjectDefaults(t *testing.T) {
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	_, err := env.PPSServer.GetProjectDefaults(ctx, &pps.GetProjectDefaultsRequest{})
 	require.YesError(t, err, "empty request must be an error")
 	_, err = env.PPSServer.GetProjectDefaults(ctx, &pps.GetProjectDefaultsRequest{Project: &pfs.Project{}})

--- a/src/server/rpc_fuzz_test.go
+++ b/src/server/rpc_fuzz_test.go
@@ -119,7 +119,7 @@ func FuzzRPCs(f *testing.F) {
 		},
 	}))
 	ctx := pctx.Background("")
-	env := realenv.NewRealEnvWithIdentity(ctx, f, dockertestenv.NewTestDBConfig(f))
+	env := realenv.NewRealEnvWithIdentity(ctx, f, dockertestenv.NewTestDBConfig(f).PachConfigOption)
 	peerPort := strconv.Itoa(int(env.ServiceEnv.Config().PeerPort))
 	tu.ActivateAuthClient(f, env.PachClient, peerPort)
 

--- a/src/server/transaction/server/testing/server_test.go
+++ b/src/server/transaction/server/testing/server_test.go
@@ -27,7 +27,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestEmptyTransaction", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestInvalidatedTransaction", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestFailedAppend", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestDependency", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 		project := testutil.UniqueString("p-")
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestCreateBranch", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -235,7 +235,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestDeleteAllTransactions", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		_, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -258,7 +258,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestMultiCommit", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		project := testutil.UniqueString("prj_")
 		err := env.PachClient.CreateProject(project)
@@ -303,7 +303,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestPropagateCommit", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "A"))
 		require.NoError(t, env.PachClient.CreateRepo(pfs.DefaultProjectName, "B"))
@@ -389,7 +389,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestPropagateCommitRedux", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		txn, err := env.PachClient.StartTransaction()
 		require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestBatchTransaction", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 
 		var branchInfos []*pfs.BranchInfo
 		var info *transaction.TransactionInfo
@@ -518,7 +518,7 @@ func TestTransactions(suite *testing.T) {
 	suite.Run("TestProjectlessBatch", func(t *testing.T) {
 		t.Parallel()
 		ctx := pctx.TestContext(t)
-		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+		env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 		_, err := env.PachClient.RunBatchInTransaction(func(builder *client.TransactionBuilder) error {
 			_, err := builder.PfsAPIClient.CreateRepo(builder.Ctx(), &pfs.CreateRepoRequest{
 				Repo: &pfs.Repo{

--- a/src/server/worker/datum/iterator_test.go
+++ b/src/server/worker/datum/iterator_test.go
@@ -27,7 +27,7 @@ import (
 func TestIterators(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	taskDoer := createTaskDoer(t, env)
 	c := env.PachClient
 	pfsC := c.PfsAPIClient
@@ -323,7 +323,7 @@ func createTaskDoer(t *testing.T, env *realenv.RealEnv) task.Doer {
 func TestJoinTrailingSlash(t *testing.T) {
 	t.Parallel()
 	ctx := pctx.TestContext(t)
-	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t))
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
 	pfsC := env.PachClient.PfsAPIClient
 	taskDoer := createTaskDoer(t, env)
 

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -298,7 +298,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobSuccess", func(t *testing.T) {
 		pi := defaultPipelineInfo()
 		ctx := pctx.TestContext(t)
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 		testJobSuccess(t, env, pi, []tarutil.File{
 			tarutil.NewMemFile("/file", []byte("foobar")),
 		})
@@ -309,7 +309,7 @@ func TestTransformPipeline(suite *testing.T) {
 		bucket, url := dockertestenv.NewTestBucket(ctx, t)
 		pi := defaultPipelineInfo()
 		pi.Details.Egress = &pps.Egress{URL: url}
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 
 		files := []tarutil.File{
 			tarutil.NewMemFile("/file1", []byte("foo")),
@@ -336,7 +336,7 @@ func TestTransformPipeline(suite *testing.T) {
 		pi := defaultPipelineInfo()
 		pi.Details.Input.Pfs.Glob = "/"
 		pi.Details.Egress = &pps.Egress{URL: url}
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 
 		testJobSuccess(t, env, pi, nil)
 	})
@@ -344,7 +344,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobFailedDatum", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
 		pi := defaultPipelineInfo()
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 
 		pi.Details.Transform.Cmd = []string{"bash", "-c", "(exit 1)"}
 		tarFiles := []tarutil.File{
@@ -361,7 +361,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobMultiDatum", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
 		pi := defaultPipelineInfo()
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 
 		tarFiles := []tarutil.File{
 			tarutil.NewMemFile("/a", []byte("foobar")),
@@ -373,7 +373,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobSerial", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
 		pi := defaultPipelineInfo()
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 
 		tarFiles := []tarutil.File{
 			tarutil.NewMemFile("/a", []byte("foobar")),
@@ -416,7 +416,7 @@ func TestTransformPipeline(suite *testing.T) {
 	suite.Run("TestJobSerialDelete", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
 		pi := defaultPipelineInfo()
-		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t), pi)
+		env := setupPachAndWorker(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption, pi)
 
 		tarFiles := []tarutil.File{
 			tarutil.NewMemFile("/a", []byte("foobar")),


### PR DESCRIPTION
Trying to setup postgres listeners in NewTestPachd.  I need access to a direct and indirect connection for the same database.  There was a bunch of duplicated code in dockertestenv, so I restructured it around setting up multi-db environments (direct and PGBouncer), with helper functions for getting one DB vs. the other, or converting the configuration to the various option formats used through the codebase.