### PR TITLE
Handle memory requests/limits that are a fraction of a byte

### DIFF
--- a/src/internal/cmdutil/env.go
+++ b/src/internal/cmdutil/env.go
@@ -112,7 +112,7 @@ func populateInternal(reflectValue reflect.Value, decoderMap map[string]string, 
 		}
 		parsedValue, err := parseField(structField, value)
 		if err != nil {
-			errors.JoinInto(&errs, errors.Wrapf(err, "%v (=%v)", structField.Name, value))
+			errors.JoinInto(&errs, errors.Wrapf(err, "%v (%v = %v)", envTag.key, structField.Name, value))
 			continue
 		}
 		reflectValue.Field(i).Set(reflect.ValueOf(parsedValue))

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -78,8 +78,8 @@ type GlobalConfiguration struct {
 	// These are automatically injected into pachd by Kubernetes so that Go's GC can be tuned to
 	// take advantage of the memory made available to the container.  They should not be set by
 	// users manually; use GOMEMLIMIT directly instead.
-	K8sMemoryLimit   int64 `env:"K8S_MEMORY_LIMIT,default=0"`
-	K8sMemoryRequest int64 `env:"K8S_MEMORY_REQUEST,default=0"`
+	K8sMemoryLimit   float64 `env:"K8S_MEMORY_LIMIT,default=0"`
+	K8sMemoryRequest float64 `env:"K8S_MEMORY_REQUEST,default=0"`
 
 	// Users tend to have a bad experience when they request 0 resources from k8s.  These are
 	// the defaults for piplines that don't supply any requests or limits.  (As soon as you


### PR DESCRIPTION
When people set resources like `1.2Gi`, they don't realize that they are actually asking for a fraction of a byte (`1288490188.8` bytes).  We assume k8s is going to give us an integer, but it won't in that case.  This change changes the code to accept the requested memory or memory limit as a floating point number, and then we request the ceiling of 95% of that.  We use the ceiling and not round because k8s also does this (observe 66.4 round up to 67):

```
kubectl describe pod pachd-cb46b8c7c-74lwf
...
Resources:
    Requests:
      cpu:      8                                                                                                                                                                         
      memory:   17287243366400m
...
Environment:
     K8S_MEMORY_REQUEST:                        17287243367 (requests.memory)
```

k8s actually warns about this:

```
$ kubectl edit deployments.apps pachd
Warning: spec.template.spec.containers[0].resources.limits[memory]: fractional byte value "17287243366400m" is invalid, must be an integer
Warning: spec.template.spec.containers[0].resources.requests[memory]: fractional byte value "17287243366400m" is invalid, must be an integer
```

(This is from setting `16.1Gi` as the memory request/limit for pachd.)

***

I also made  `env.Populate` return all errors, instead of just the first error.  Now you can run `K8S_MEMORY_REQUEST=104962457.600000000 go run ../src/server/cmd/pachd` and get the error, even if other required fields parsed before K8S_MEMORY_REQUEST aren't present.

For example, we used to print:

```
$ K8S_MEMORY_REQUEST=104962457.600000000 go run ./../../../src/server/cmd/pachd
{"severity":"info","time":"2023-10-23T18:01:09.20858577-04:00","caller":"pachd/main.go:40","message":"pachd: starting","mode":"full"}
env key not set when required: PG_BOUNCER_HOST pachconfig.PostgresConfiguration
exit status 1
```

but now we print:

```
{"severity":"info","time":"2023-10-23T18:05:45.553415045-04:00","caller":"pachd/main.go:40","message":"pachd: starting","mode":"full"}
populate configuration from environment: GlobalConfiguration: [
PostgresConfiguration: [
env key not set when required: PG_BOUNCER_HOST (field PGBouncerHost of pachconfig.PostgresConfiguration)
env key not set when required: PG_BOUNCER_PORT (field PGBouncerPort of pachconfig.PostgresConfiguration)
]
env key not set when required: ETCD_SERVICE_HOST (field EtcdHost of pachconfig.GlobalConfiguration)
env key not set when required: ETCD_SERVICE_PORT (field EtcdPort of pachconfig.GlobalConfiguration)
K8S_MEMORY_REQUEST (K8sMemoryRequest = 104962457.600000000): cannot parse: strconv.ParseInt: parsing "104962457.600000000": invalid syntax
]
PachdSpecificConfiguration: [
env key not set when required: STORAGE_BACKEND (field StorageBackend of pachconfig.PachdSpecificConfiguration)
env key not set when required: KUBERNETES_PORT_443_TCP_ADDR (field KubeAddress of pachconfig.PachdSpecificConfiguration)
env key not set when required: PACHD_POD_NAME (field PachdPodName of pachconfig.PachdSpecificConfiguration)
]
exit status 1
```
(The braces don't look great, but multierrors print as join("\n"), and this is the only format that makes the recursive nesting clear.  It's also annoying that "cannot parse": appears in the middle of the message whereas "env key not set" appears at the start.  That's because every parser's if condition adds the text "cannot parse:", so it's hard to fix.)