### PR TITLE
[2.7.x] Handle memory requests/limits that are fractions of a bytes

### DIFF
--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -78,8 +78,8 @@ type GlobalConfiguration struct {
 	// These are automatically injected into pachd by Kubernetes so that Go's GC can be tuned to
 	// take advantage of the memory made available to the container.  They should not be set by
 	// users manually; use GOMEMLIMIT directly instead.
-	K8sMemoryLimit   int64 `env:"K8S_MEMORY_LIMIT,default=0"`
-	K8sMemoryRequest int64 `env:"K8S_MEMORY_REQUEST,default=0"`
+	K8sMemoryLimit   float64 `env:"K8S_MEMORY_LIMIT,default=0"`
+	K8sMemoryRequest float64 `env:"K8S_MEMORY_REQUEST,default=0"`
 
 	// Users tend to have a bad experience when they request 0 resources from k8s.  These are
 	// the defaults for piplines that don't supply any requests or limits.  (As soon as you

--- a/src/internal/pachd/builder.go
+++ b/src/internal/pachd/builder.go
@@ -427,13 +427,13 @@ func setupMemoryLimit(ctx context.Context, config pachconfig.GlobalConfiguration
 	// > account for memory sources the Go runtime is unaware of.
 	//
 	// We pick 5%, since CGO_ENABLED=0 which reduces "unknown" sources of memory.
-	var target int64
+	var target float64
 	var source string
 	if v := config.K8sMemoryRequest; v > 0 {
-		target = v - int64(0.05*float64(v))
+		target = v - 0.05*v
 		source = "kubernetes request"
 	} else if v := config.K8sMemoryLimit; v > 0 {
-		target = v - int64(0.05*float64(v))
+		target = v - 0.05*v
 		source = "kubernetes limit"
 	}
 	if target <= 0 {
@@ -441,6 +441,7 @@ func setupMemoryLimit(ctx context.Context, config pachconfig.GlobalConfiguration
 		return
 	}
 
-	log.Info(ctx, "memlimit: setting GOMEMLIMIT (95% of the k8s value)", zap.String("limit", humanize.IBytes(uint64(target))), zap.String("setFrom", source))
-	debug.SetMemoryLimit(target)
+	actual := int64(math.Ceil(target))
+	log.Info(ctx, "memlimit: setting GOMEMLIMIT (95% of the k8s value)", zap.String("limit", humanize.IBytes(uint64(actual))), zap.String("setFrom", source))
+	debug.SetMemoryLimit(actual)
 }


### PR DESCRIPTION
This is a backport of #9460, but without changing the environment variable parser (unnecessary risk for the stable version).  