### PR TITLE
Fix error handling in pipeline controller

### DIFF
--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -459,6 +459,7 @@ func FindPipelineSpecCommitInTransaction(ctx context.Context, txnCtx *txncontext
 	commitInfo, err := pfsServer.InspectCommitInTransaction(ctx, txnCtx, &pfs.InspectCommitRequest{Commit: curr})
 	if err != nil {
 		if errors.As(err, &pfsserver.ErrCommitNotFound{}) || errors.As(err, &pfsserver.ErrRepoNotFound{}) || errors.As(err, &pfsserver.ErrBranchNotFound{}) {
+			// Propagate a PPS error so that callers who don't know about PFS domain can handle it explicitly.
 			return nil, errors.Join(err, ppsserver.ErrPipelineNotFound{Pipeline: pipeline})
 		}
 		return nil, errors.EnsureStack(err)

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -43,8 +43,8 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
-	pfsServer "github.com/pachyderm/pachyderm/v2/src/server/pfs"
-	ppsServer "github.com/pachyderm/pachyderm/v2/src/server/pps"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
+	ppsserver "github.com/pachyderm/pachyderm/v2/src/server/pps"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/common"
 )
 
@@ -294,7 +294,7 @@ func UpdateJobState(pipelines col.PostgresReadWriteCollection, jobs col.ReadWrit
 	// Check if this is a new job
 	if jobInfo.State != pps.JobState_JOB_STATE_UNKNOWN {
 		if pps.IsTerminal(jobInfo.State) {
-			return ppsServer.ErrJobFinished{Job: jobInfo.Job}
+			return ppsserver.ErrJobFinished{Job: jobInfo.Job}
 		}
 	}
 
@@ -437,7 +437,7 @@ func GetWorkerPipelineInfo(pachClient *client.APIClient, db *pachsql.DB, l col.P
 	return pipelineInfo, nil
 }
 
-func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, txnEnv transactionenv.TransactionEnv, pipeline *pps.Pipeline) (*pfs.Commit, error) {
+func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsserver.APIServer, txnEnv transactionenv.TransactionEnv, pipeline *pps.Pipeline) (*pfs.Commit, error) {
 	var commit *pfs.Commit
 	if err := txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) (err error) {
 		commit, err = FindPipelineSpecCommitInTransaction(ctx, txnCtx, pfsServer, pipeline, "")
@@ -450,15 +450,17 @@ func FindPipelineSpecCommit(ctx context.Context, pfsServer pfsServer.APIServer, 
 
 // FindPipelineSpecCommitInTransaction finds the spec commit corresponding to the pipeline version present in the commit given
 // by startID. If startID is blank, find the current pipeline version
-func FindPipelineSpecCommitInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pfsServer pfsServer.APIServer, pipeline *pps.Pipeline, startID string) (*pfs.Commit, error) {
+func FindPipelineSpecCommitInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pfsServer pfsserver.APIServer, pipeline *pps.Pipeline, startID string) (*pfs.Commit, error) {
 	curr := (&pfs.Repo{
 		Project: pipeline.Project,
 		Name:    pipeline.Name,
 		Type:    pfs.SpecRepoType,
 	}).NewCommit("master", startID)
-	commitInfo, err := pfsServer.InspectCommitInTransaction(ctx, txnCtx,
-		&pfs.InspectCommitRequest{Commit: curr})
+	commitInfo, err := pfsServer.InspectCommitInTransaction(ctx, txnCtx, &pfs.InspectCommitRequest{Commit: curr})
 	if err != nil {
+		if errors.As(err, &pfsserver.ErrCommitNotFound{}) || errors.As(err, &pfsserver.ErrRepoNotFound{}) || errors.As(err, &pfsserver.ErrBranchNotFound{}) {
+			return nil, errors.Join(err, ppsserver.ErrPipelineNotFound{Pipeline: pipeline})
+		}
 		return nil, errors.EnsureStack(err)
 	}
 	return commitInfo.Commit, nil
@@ -507,7 +509,7 @@ func ListPipelineInfo(ctx context.Context,
 		}
 		if len(versionMap) == 0 {
 			// pipeline didn't exist after all
-			return ppsServer.ErrPipelineNotFound{Pipeline: filter}
+			return ppsserver.ErrPipelineNotFound{Pipeline: filter}
 		}
 		return nil
 	}

--- a/src/server/pps/server/pipeline_controller.go
+++ b/src/server/pps/server/pipeline_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/tracing/extended"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+	ppsserver "github.com/pachyderm/pachyderm/v2/src/server/pps"
 	"github.com/pachyderm/pachyderm/v2/src/server/worker/driver"
 	"github.com/pachyderm/pachyderm/v2/src/task"
 	"github.com/pachyderm/pachyderm/v2/src/version"
@@ -329,16 +330,17 @@ func (pc *pipelineController) step(timestamp time.Time) (isDelete bool, retErr e
 	// derive the latest pipelineInfo with a corresponding auth'd context
 	pi, ctx, err := pc.psDriver.FetchState(pc.ctx, pc.pipeline)
 	if err != nil {
+		if errors.As(err, &ppsserver.ErrPipelineNotFound{}) {
+			// pipeline was deleted, so we can clean up k8s resources
+			if err := pc.deletePipelineResources(); err != nil {
+				log.Error(pc.ctx, "error deleting pipelineController resources for pipeline", zap.Error(err))
+				return true, errors.Wrapf(err, "error deleting pipelineController resources for pipeline '%s'", pc.pipeline)
+			}
+			return true, nil
+		}
 		// if we fail to create a new step, there was an error querying the pipeline info, and there's nothing we can do
 		log.Error(pc.ctx, "failed to set up step data to handle event for pipeline", zap.Error(err))
 		return false, errors.Wrapf(err, "failing pipeline %q", pc.pipeline)
-	}
-	if pi == nil {
-		if err := pc.deletePipelineResources(); err != nil {
-			log.Error(pc.ctx, "error deleting pipelineController resources for pipeline", zap.Error(err))
-			return true, errors.Wrapf(err, "error deleting pipelineController resources for pipeline '%s'", pc.pipeline)
-		}
-		return true, nil
 	}
 	var stepErr stepError
 	// TODO(msteffen) should this fail the pipeline? (currently getRC will restart

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -67,13 +67,9 @@ func newPipelineStateDriver(
 // takes pc.ctx
 func (sd *stateDriver) FetchState(ctx context.Context, pipeline *pps.Pipeline) (*pps.PipelineInfo, context.Context, error) {
 	// query pipelineInfo
-	var pi *pps.PipelineInfo
-	var err error
-	if pi, err = sd.tryLoadLatestPipelineInfo(ctx, pipeline); err != nil && collection.IsErrNotFound(err) {
-		// if the pipeline info is not found, interpret the operation as a delete
-		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
+	pi, err := sd.tryLoadLatestPipelineInfo(ctx, pipeline)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "fetch pipeline state")
 	}
 	tracing.TagAnySpan(ctx,
 		"current-state", pi.State.String(),

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/server/pfs/pretty"
+	ppsserver "github.com/pachyderm/pachyderm/v2/src/server/pps"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
@@ -69,6 +70,9 @@ func (sd *stateDriver) FetchState(ctx context.Context, pipeline *pps.Pipeline) (
 	// query pipelineInfo
 	pi, err := sd.tryLoadLatestPipelineInfo(ctx, pipeline)
 	if err != nil {
+		if errors.As(err, &ppsserver.ErrPipelineNotFound{}) {
+			return nil, nil, nil
+		}
 		return nil, nil, errors.Wrap(err, "fetch pipeline state")
 	}
 	tracing.TagAnySpan(ctx,

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -70,9 +70,6 @@ func (sd *stateDriver) FetchState(ctx context.Context, pipeline *pps.Pipeline) (
 	// query pipelineInfo
 	pi, err := sd.tryLoadLatestPipelineInfo(ctx, pipeline)
 	if err != nil {
-		if errors.As(err, &ppsserver.ErrPipelineNotFound{}) {
-			return nil, nil, nil
-		}
 		return nil, nil, errors.Wrap(err, "fetch pipeline state")
 	}
 	tracing.TagAnySpan(ctx,
@@ -224,7 +221,7 @@ func (d *mockStateDriver) FetchState(ctx context.Context, pipeline *pps.Pipeline
 			return pi, ctx, nil
 		}
 	}
-	return nil, nil, nil
+	return nil, nil, ppsserver.ErrPipelineNotFound{Pipeline: pipeline}
 }
 
 func (d *mockStateDriver) Watch(ctx context.Context) (<-chan *watch.Event, func(), error) {


### PR DESCRIPTION
This change fixes the issue where deleting a pipeline doesn't delete the replication controller in K8s.

For some context:
- The Pachyderm pipeline controller is a control loop that talks to both Pachyderm and K8s, and syncs Pachyderm pipeline state with K8s state.
- The root cause of this issue though is that the pipeline controller is calling into code that is checking for a specific type of error that is no longer relevant due to some recent changes in our database layer, where we are returning new error types.

The fix is to make the pipeline controller aware of the new error types.