### PR TITLE
[Jupyter] Better handling of PFSConentManager errors

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/filemanager.py
+++ b/jupyter-extension/jupyterlab_pachyderm/filemanager.py
@@ -1,4 +1,7 @@
+import os
+
 from jupyter_server.services.contents.filemanager import FileContentsManager
+from tornado.web import HTTPError
 
 
 class PFSContentsManager(FileContentsManager):
@@ -10,3 +13,17 @@ class PFSContentsManager(FileContentsManager):
         """Avoid validating the root_dir and potentially crashing the server
         extension because we want to allow the user to create it."""
         pass
+
+    def get(self, path, content=True, type=None, format=None):
+        """Wrapper method that overwrites the error message for a 404 error."""
+        try:
+            return super().get(path, content, type, format)
+        except HTTPError as error:
+            if error.status_code == 404:
+                # Include the full path to the content as the all PFS content is
+                #   locally mounted and the mount point is only accessible by the
+                #   backend. The frontend is able to then provide a more helpful
+                #   error message.
+                full_path = os.path.join(self.root_dir, path.lstrip("/"))
+                error.log_message = f"file or directory does not exist: {full_path}"
+            raise error

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -217,7 +217,7 @@ class PFSHandler(ContentsHandler):
         content = self.get_query_argument("content", default="1")
         if content not in {"0", "1"}:
             raise tornado.web.HTTPError(400, "Content %r is invalid" % content)
-        content = int(content)
+        content = bool(int(content))
 
         model = await ensure_async(
             self.pfs_contents_manager.get(

--- a/jupyter-extension/src/plugins/mount/mountDrive.ts
+++ b/jupyter-extension/src/plugins/mount/mountDrive.ts
@@ -85,8 +85,14 @@ export class MountDrive implements Contents.IDrive {
     try {
       shallowResponse = await this._get(url, {content: '0'});
     } catch (e) {
-      console.log('/pfs not found');
-      return DEFAULT_CONTENT_MODEL;
+      if (e instanceof ServerConnection.ResponseError) {
+        if (!localPath) {
+          console.warn('mount point does not exist:', e.message);
+          return DEFAULT_CONTENT_MODEL;
+        }
+        console.warn(e.message);
+      }
+      throw e;
     }
     const content = options?.content ? '1' : '0';
     if (content === '0') {


### PR DESCRIPTION
Wraps the `PFSContentManager.get` call to return the full path to the content and propagate errors through the MountDrive. Using the full path to the content allows the frontend to display a more useful error message. Propagating the errors is more correct and allows a modal to pop up to display the error message like below:

![image](https://github.com/pachyderm/pachyderm/assets/28938409/7290b6d7-0dde-4c1c-9016-dfd730cc4fa8)

[INT-1128]

[INT-1128]: https://pachyderm.atlassian.net/browse/INT-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ