### PR TITLE
Djanicek/allow upload timeout

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2356,7 +2356,7 @@ commands:
           name: Store test results for overtime reports
           when: always
           shell: /bin/sh # ignore fails without pipefail
-          command: timeout 5m go run -v src/testing/cmds/go-test-results/collector/main.go || true
+          command: timeout 2m go run -v src/testing/cmds/go-test-results/collector/main.go || true
   install-poetry:
     steps:
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2356,7 +2356,7 @@ commands:
           name: Store test results for overtime reports
           when: always
           shell: /bin/sh # ignore fails without pipefail
-          command: go run -v src/testing/cmds/go-test-results/collector/main.go || true
+          command: timeout 7m go run -v src/testing/cmds/go-test-results/collector/main.go || true
   install-poetry:
     steps:
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2356,7 +2356,7 @@ commands:
           name: Store test results for overtime reports
           when: always
           shell: /bin/sh # ignore fails without pipefail
-          command: timeout 7m go run -v src/testing/cmds/go-test-results/collector/main.go || true
+          command: timeout 5m go run -v src/testing/cmds/go-test-results/collector/main.go || true
   install-poetry:
     steps:
       - run:


### PR DESCRIPTION
pachhub is currently upgrading. Because of this, requests are going to pachyderm to store reports for grafana and circle ci is timing out waiting for them to finish. This step was intended to never fail so it wouldn't disrupt CI pipelines if GCP was down. I added a timeout so we never hit the circle-ci timeout and fail.