### PR TITLE
Djanicek - PFS-175 - debug rollback err (#9537)

### DIFF
--- a/src/internal/pfsdb/branches.go
+++ b/src/internal/pfsdb/branches.go
@@ -213,6 +213,9 @@ func GetBranchInfoWithID(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*B
 	if err := tx.GetContext(ctx, row, getBranchByNameQuery, project, repo, repoType, branch); err != nil {
 		if err == sql.ErrNoRows {
 			if _, err := GetRepoByName(ctx, tx, project, repo, repoType); err != nil {
+				if errors.As(err, new(*RepoNotFoundError)) {
+					return nil, errors.Join(err, &BranchNotFoundError{BranchKey: b.Key()})
+				}
 				return nil, errors.Wrapf(err, "get repo for branch info %v", b.Key())
 			}
 			return nil, &BranchNotFoundError{BranchKey: b.Key()}

--- a/src/internal/pfsdb/branches.go
+++ b/src/internal/pfsdb/branches.go
@@ -213,7 +213,7 @@ func GetBranchInfoWithID(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*B
 	if err := tx.GetContext(ctx, row, getBranchByNameQuery, project, repo, repoType, branch); err != nil {
 		if err == sql.ErrNoRows {
 			if _, err := GetRepoByName(ctx, tx, project, repo, repoType); err != nil {
-				return nil, errors.Join(err, &BranchNotFoundError{BranchKey: b.Key()})
+				return nil, errors.Wrapf(err, "get repo for branch info %v", b.Key())
 			}
 			return nil, &BranchNotFoundError{BranchKey: b.Key()}
 		}

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -562,7 +562,7 @@ func UpdateCommit(ctx context.Context, tx *pachsql.Tx, id CommitID, commitInfo *
 	if rowsAffected == 0 {
 		_, err := GetRepoByName(ctx, tx, commitInfo.Commit.Repo.Project.Name, commitInfo.Commit.Repo.Name, commitInfo.Commit.Repo.Type)
 		if err != nil {
-			return errors.Join(err, &CommitNotFoundError{RowID: id})
+			return errors.Wrapf(err, "get repo for update commit with row id %v", id)
 		}
 		return &CommitNotFoundError{RowID: id}
 	}
@@ -702,7 +702,7 @@ func getCommitRowByCommitKey(ctx context.Context, tx *pachsql.Tx, commit *pfs.Co
 		if err == sql.ErrNoRows {
 			_, err := GetRepoByName(ctx, tx, commit.Repo.Project.Name, commit.Repo.Name, commit.Repo.Type)
 			if err != nil {
-				return nil, errors.Join(err, &CommitNotFoundError{CommitID: id})
+				return nil, errors.Wrapf(err, "get repo for scan commit row with commit id %v", id)
 			}
 			return nil, &CommitNotFoundError{CommitID: id}
 		}

--- a/src/internal/pfsdb/repos.go
+++ b/src/internal/pfsdb/repos.go
@@ -91,6 +91,9 @@ func DeleteRepo(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repo
 	}
 	if rowsAffected == 0 {
 		if _, err := GetProjectByName(ctx, tx, repoProject); err != nil {
+			if errors.As(err, new(*ProjectNotFoundError)) {
+				return errors.Join(err, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType})
+			}
 			return errors.Wrapf(err, "could not get project %v for delete repo", repoProject)
 		}
 		return &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType}
@@ -144,6 +147,9 @@ func getRepoByName(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, r
 	); err != nil {
 		if err == sql.ErrNoRows {
 			if _, err := GetProjectByName(ctx, tx, repoProject); err != nil {
+				if errors.As(err, new(*ProjectNotFoundError)) {
+					return nil, errors.Join(err, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType})
+				}
 				return nil, errors.Wrapf(err, "could not get project for get repo", repoProject)
 			}
 			return nil, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType}

--- a/src/internal/pfsdb/repos.go
+++ b/src/internal/pfsdb/repos.go
@@ -91,7 +91,7 @@ func DeleteRepo(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repo
 	}
 	if rowsAffected == 0 {
 		if _, err := GetProjectByName(ctx, tx, repoProject); err != nil {
-			return errors.Join(err, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType})
+			return errors.Wrapf(err, "could not get project %v for delete repo", repoProject)
 		}
 		return &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType}
 	}
@@ -144,7 +144,7 @@ func getRepoByName(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, r
 	); err != nil {
 		if err == sql.ErrNoRows {
 			if _, err := GetProjectByName(ctx, tx, repoProject); err != nil {
-				return nil, errors.Join(err, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType})
+				return nil, errors.Wrapf(err, "could not get project for get repo", repoProject)
 			}
 			return nil, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType}
 		}


### PR DESCRIPTION
TestDatabaseStats became flaky recently. This seems to be because `could not serialize access` errors in SQL were being treated as `NotFound` errors in some cases. This PR removes the error joins with not found errors so those errors can't be "casted" into NotFound errors.