### PR TITLE
[2.8.x] Backport generic watcher for commits

### DIFF
--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -7,14 +7,18 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+	"github.com/pachyderm/pachyderm/v2/src/internal/watch/postgres"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -92,6 +96,7 @@ const (
 		JOIN pfs.commit_ancestry ancestry ON ancestry.parent = commit.int_id`
 	getChildCommit = getCommit + `
 		JOIN pfs.commit_ancestry ancestry ON ancestry.child = commit.int_id`
+	commitsPageSize = 1000
 )
 
 // CommitNotFoundError is returned by GetCommit() when a commit is not found in postgres.
@@ -752,6 +757,7 @@ type commitColumn string
 var (
 	CommitColumnID        = commitColumn("commit.int_id")
 	CommitColumnSetID     = commitColumn("commit.commit_set_id")
+	CommitColumnRepoID    = commitColumn("commit.repo_id")
 	CommitColumnOrigin    = commitColumn("commit.origin")
 	CommitColumnCreatedAt = commitColumn("commit.created_at")
 	CommitColumnUpdatedAt = commitColumn("commit.updated_at")
@@ -843,7 +849,7 @@ func ForEachCommitTxByFilter(ctx context.Context, tx *pachsql.Tx, filter *pfs.Co
 	if filter == nil {
 		return errors.Errorf("filter cannot be empty")
 	}
-	iter, err := NewCommitsIterator(ctx, tx, 0, 100, filter, orderBys...)
+	iter, err := NewCommitsIterator(ctx, tx, 0, commitsPageSize, filter, orderBys...)
 	if err != nil {
 		return errors.Wrap(err, "for each commit tx by filter")
 	}
@@ -864,4 +870,105 @@ func ListCommitTxByFilter(ctx context.Context, tx *pachsql.Tx, filter *pfs.Commi
 		return nil, errors.Wrap(err, "list commits tx by filter")
 	}
 	return commits, nil
+}
+
+// Helper functions for watching commits.
+type commitUpsertHandler func(id CommitID, commitInfo *pfs.CommitInfo) error
+type commitDeleteHandler func(id CommitID) error
+
+// WatchCommits creates a watcher and watches the pfs.commits table for changes.
+func WatchCommits(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString("watch-commits-"), CommitsChannelName)
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	snapshot, err := NewCommitsIterator(ctx, db, 0, commitsPageSize, nil, OrderByCommitColumn{Column: CommitColumnID, Order: SortOrderAsc})
+	if err != nil {
+		return err
+	}
+	return watchCommits(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+// WatchCommitsInRepo creates a watcher and watches for commits in a repo.
+func WatchCommitsInRepo(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, repoID RepoID, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString(fmt.Sprintf("watch-commits-in-repo-%d", repoID)), CommitsInRepoChannel(repoID))
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	// Optimized query for getting commits in a repo.
+	query := getCommit + fmt.Sprintf(" WHERE %s = ?  ORDER BY %s ASC", CommitColumnRepoID, CommitColumnID)
+	query = db.Rebind(query)
+	snapshot := &CommitIterator{paginator: newPageIterator[Commit](ctx, query, []any{repoID}, 0, commitsPageSize), extCtx: db}
+	return watchCommits(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+// WatchCommit creates a watcher and watches for changes to a single commit.
+func WatchCommit(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, commitID CommitID, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString(fmt.Sprintf("watch-commit-%d-", commitID)), fmt.Sprintf("%s%d", CommitChannelName, commitID))
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	var commitWithID CommitWithID
+	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
+		commitInfo, err := GetCommit(ctx, tx, commitID)
+		if err != nil {
+			return errors.Wrap(err, "watch commit")
+		}
+		commitWithID = CommitWithID{ID: commitID, CommitInfo: commitInfo}
+		return nil
+	}); err != nil {
+		return err
+	}
+	snapshot := stream.NewSlice([]CommitWithID{commitWithID})
+	return watchCommits(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+func watchCommits(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator[CommitWithID], events <-chan *postgres.Event, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	// Handle snapshot
+	if err := stream.ForEach[CommitWithID](ctx, snapshot, func(commitWith CommitWithID) error {
+		return onUpsert(commitWith.ID, commitWith.CommitInfo)
+	}); err != nil {
+		return err
+	}
+	// Handle delta
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return errors.Errorf("watcher closed")
+			}
+			if event.Err != nil {
+				return event.Err
+			}
+			id := CommitID(event.Id)
+			switch event.Type {
+			case postgres.EventDelete:
+				if err := onDelete(id); err != nil {
+					return err
+				}
+			case postgres.EventInsert, postgres.EventUpdate:
+				var commitInfo *pfs.CommitInfo
+				if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
+					var err error
+					commitInfo, err = GetCommit(ctx, tx, id)
+					if err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := onUpsert(id, commitInfo); err != nil {
+					return err
+				}
+			default:
+				return errors.Errorf("unknown event type: %v", event.Type)
+			}
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "watcher cancelled")
+		}
+	}
 }

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path"
 	"sort"
 	"strings"
 	"time"
@@ -31,14 +30,12 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
-	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset/index"
 	txnenv "github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
-	"github.com/pachyderm/pachyderm/v2/src/internal/watch/postgres"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
 	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
@@ -1091,97 +1088,48 @@ func (d *driver) inspectCommit(ctx context.Context, commit *pfs.Commit, wait pfs
 	return commitInfo, nil
 }
 
-func (d *driver) watchCommit(ctx context.Context, commitInfo *pfs.CommitInfo, cb func(commitInfo *pfs.CommitInfo) error) error {
-	var err error
-	var commitWithID *pfsdb.CommitWithID
-	if err := dbutil.WithTx(ctx, d.env.DB, func(cbCtx context.Context, tx *pachsql.Tx) error {
-		commitWithID, err = pfsdb.GetCommitWithIDByKey(ctx, tx, commitInfo.Commit)
-		if err != nil {
-			if pfsdb.IsNotFoundError(err) {
-				return errors.Join(err, pfsserver.ErrCommitDeleted{Commit: commitInfo.Commit})
-			}
-			return errors.Wrap(err, "watch commit")
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	watcherID := fmt.Sprintf("%s%d", pfsdb.CommitChannelName, commitWithID.ID)
-	watcher, err := postgres.NewWatcher(d.env.DB, d.env.Listener, path.Join(randutil.UniqueString(d.prefix), pfsdb.CommitKey(commitInfo.Commit)), watcherID)
-	if err != nil {
-		return errors.Wrap(err, "new watcher")
-	}
-	defer watcher.Close()
-	// get resource again after setting up the watcher to catch the state of the commit between the watcher being created.
-	if err := dbutil.WithTx(ctx, d.env.DB, func(cbCtx context.Context, tx *pachsql.Tx) error {
-		commitWithID, err = pfsdb.GetCommitWithIDByKey(ctx, tx, commitInfo.Commit)
-		if err != nil {
-			if pfsdb.IsNotFoundError(err) {
-				return errors.Join(err, pfsserver.ErrCommitDeleted{Commit: commitInfo.Commit})
-			}
-			return errors.Wrap(err, "watch commit")
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	// check if the code in cb() already would succeed, in which case the watcher doesn't need to be instantiated.
-	if err := cb(commitWithID.CommitInfo); err != nil {
-		if errors.Is(err, errutil.ErrBreak) {
-			return nil
-		}
-		return errors.Wrap(err, "watch commit")
-	}
-	var newCommitInfo *pfs.CommitInfo
-	for {
-		event, ok := <-watcher.Watch()
-		if !ok {
-			return errors.Errorf("watcher for inspect commit %v closed channel")
-		}
-		if event.Type == postgres.EventDelete {
-			return pfsserver.ErrCommitDeleted{Commit: commitInfo.Commit}
-		}
-		if event.Err != nil {
-			return event.Err
-		}
-		if err := dbutil.WithTx(ctx, d.env.DB, func(ctx context.Context, tx *pachsql.Tx) error {
-			newCommitInfo, err = pfsdb.GetCommit(ctx, tx, pfsdb.CommitID(event.Id))
-			if err != nil && pfsdb.IsNotFoundError(err) {
-				return errors.Join(err, pfsserver.ErrCommitDeleted{Commit: commitInfo.Commit})
-			}
-			return err
-		}); err != nil {
-			return errors.Wrap(err, "getting commit from event")
-		}
-		if err := cb(newCommitInfo); err != nil {
-			if errors.Is(err, errutil.ErrBreak) {
-				return nil
-			}
-			return errors.Wrap(err, "watch commit")
-		}
-	}
-}
-
+// inspectProcessingCommits waits for the commit to be FINISHING or FINISHED.
 func (d *driver) inspectProcessingCommits(ctx context.Context, commitInfo *pfs.CommitInfo, wait pfs.CommitState) (*pfs.CommitInfo, error) {
-	var commit *pfs.CommitInfo
-	if err := d.watchCommit(ctx, commitInfo, func(commitInfo *pfs.CommitInfo) error {
-		switch wait {
-		case pfs.CommitState_FINISHING:
-			if commitInfo.Finishing != nil {
-				commit = commitInfo
-				return errutil.ErrBreak
-			}
-		case pfs.CommitState_FINISHED:
-			if commitInfo.Finished != nil {
-				commit = commitInfo
-				return errutil.ErrBreak
-			}
+	var commitID pfsdb.CommitID
+	if err := d.txnEnv.WithReadContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
+		var err error
+		commitID, err = pfsdb.GetCommitID(ctx, txnCtx.SqlTx, commitInfo.Commit)
+		if err != nil {
+			return err
 		}
 		return nil
 	}); err != nil {
+		return nil, err
+	}
+	// We only cancel the watcher if we detect the commit is the right state.
+	expectedErr := errors.New("commit is in the right state")
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	if err := pfsdb.WatchCommit(ctx, d.env.DB, d.env.Listener, commitID,
+		func(id pfsdb.CommitID, ci *pfs.CommitInfo) error {
+			switch wait {
+			case pfs.CommitState_FINISHING:
+				if ci.Finishing != nil {
+					commitInfo = ci
+					cancel(expectedErr)
+					return nil
+				}
+			case pfs.CommitState_FINISHED:
+				if ci.Finished != nil {
+					commitInfo = ci
+					cancel(expectedErr)
+					return nil
+				}
+			}
+			return nil
+		},
+		func(id pfsdb.CommitID) error {
+			return pfsserver.ErrCommitDeleted{Commit: commitInfo.Commit}
+		},
+	); err != nil && !errors.Is(context.Cause(ctx), expectedErr) {
 		return nil, errors.Wrap(err, "inspect finishing or finished commit")
 	}
-	return commit, nil
+	return commitInfo, nil
 }
 
 // resolveCommitWithAuth is like resolveCommit, but it does some pre-resolution checks like repo authorization.
@@ -1555,85 +1503,42 @@ func (d *driver) subscribeCommit(
 	}
 	// keep track of the commits that have been sent
 	seen := make(map[string]bool)
-	var ID pfsdb.RepoID
+	var repoID pfsdb.RepoID
 	var err error
 	if err := dbutil.WithTx(ctx, d.env.DB, func(ctx context.Context, tx *pachsql.Tx) error {
-		ID, err = pfsdb.GetRepoID(ctx, tx, repo.Project.Name, repo.Name, repo.Type)
+		repoID, err = pfsdb.GetRepoID(ctx, tx, repo.Project.Name, repo.Name, repo.Type)
 		return errors.Wrap(err, "get repo ID")
 	}); err != nil {
 		return err
 	}
-	// Note that this watch may leave events unread for a long amount of time
-	// while waiting for the commit state - if the watch channel fills up, it will
-	// error out.
-	watcher, err := postgres.NewWatcher(d.env.DB, d.env.Listener,
-		path.Join(randutil.UniqueString(d.prefix), "subscribeCommit", pfsdb.RepoKey(repo)), fmt.Sprintf("%s%d", pfsdb.CommitsRepoChannelName, ID))
-	if err != nil {
-		return errors.Wrap(err, "new watcher")
-	}
-	defer watcher.Close()
-	// Get existing entries.
-	if err := pfsdb.ForEachCommit(ctx, d.env.DB, &pfs.Commit{Repo: repo}, func(commitWithID pfsdb.CommitWithID) error {
-		return d.subscribeCommitHelper(ctx, branch, from, state, commitWithID.CommitInfo, all, originKind, seen, cb)
-	}); err != nil {
-		return errors.Wrap(err, "list commits")
-	}
-	for {
-		event, ok := <-watcher.Watch()
-		if !ok {
-			return errors.Errorf("watcher for repo %v closed channel", pfsdb.RepoKey(repo))
-		}
-		if event.Type == postgres.EventDelete {
-			continue
-		}
-		if event.Err != nil {
-			return event.Err
-		}
-		var commitInfo *pfs.CommitInfo
-		if err := dbutil.WithTx(ctx, d.env.DB, func(cbCtx context.Context, tx *pachsql.Tx) error {
-			commitInfo, err = pfsdb.GetCommit(ctx, tx, pfsdb.CommitID(event.Id))
-			return err
-		}); err != nil {
-			return errors.Wrap(err, "getting commit from event")
-		}
-		if err := d.subscribeCommitHelper(ctx, branch, from, state, commitInfo, all, originKind, seen, cb); err != nil {
-			return errors.Wrap(err, "subscribe commit")
-		}
-	}
-}
-
-func (d *driver) subscribeCommitHelper(
-	ctx context.Context,
-	branch string,
-	from *pfs.Commit,
-	state pfs.CommitState,
-	commitInfo *pfs.CommitInfo,
-	all bool,
-	originKind pfs.OriginKind,
-	seen map[string]bool,
-	cb func(*pfs.CommitInfo) error,
-) error {
-	// if branch is provided, make sure the commit was created on that branch
-	if branch != "" && commitInfo.Commit.Branch.Name != branch {
-		return nil
-	}
-	// If the origin of the commit doesn't match what we're interested in, skip it
-	if !passesCommitOriginFilter(commitInfo, all, originKind) {
-		return nil
-	}
-	// We don't want to include the `from` commit itself
-	if !(seen[commitInfo.Commit.Id] || (from != nil && from.Id == commitInfo.Commit.Id)) {
-		// Wait for the commit to enter the right state
-		commitInfo, err := d.inspectCommit(ctx, proto.Clone(commitInfo.Commit).(*pfs.Commit), state)
-		if err != nil {
-			return err
-		}
-		if err := cb(commitInfo); err != nil {
-			return err
-		}
-		seen[commitInfo.Commit.Id] = true
-	}
-	return nil
+	return pfsdb.WatchCommitsInRepo(ctx, d.env.DB, d.env.Listener, repoID,
+		func(id pfsdb.CommitID, commitInfo *pfs.CommitInfo) error { // onUpsert
+			// if branch is provided, make sure the commit was created on that branch
+			if branch != "" && commitInfo.Commit.Branch.Name != branch {
+				return nil
+			}
+			// If the origin of the commit doesn't match what we're interested in, skip it
+			if !passesCommitOriginFilter(commitInfo, all, originKind) {
+				return nil
+			}
+			// We don't want to include the `from` commit itself
+			if !(seen[commitInfo.Commit.Id] || (from != nil && from.Id == commitInfo.Commit.Id)) {
+				// Wait for the commit to enter the right state
+				commitInfo, err := d.inspectCommit(ctx, proto.Clone(commitInfo.Commit).(*pfs.Commit), state)
+				if err != nil {
+					return err
+				}
+				if err := cb(commitInfo); err != nil {
+					return err
+				}
+				seen[commitInfo.Commit.Id] = true
+			}
+			return nil
+		},
+		func(id pfsdb.CommitID) error { // onDelete
+			return nil
+		},
+	)
 }
 
 func (d *driver) clearCommit(ctx context.Context, commit *pfs.Commit) error {


### PR DESCRIPTION
This CL is mostly just a refactor of our existing approach to watching for events related to Commits. There are no new ideas here. I simply abstracted away the common patterns into a re-usable set of functions, deleted the repeated code, and used the new stuff instead.

Maybe one new idea here is having separate explicit handlers for Put/Update events versus Delete events. This is because fundamentally, delete events don't have commit infos. This is to improve safety, since without distinguishing the two, the client might accidentally try to retrieve a non-existent commit info.

TODO: We also need this for projects, repos, and branches. Can we think of a way to genericize the code further?