### PR TITLE
parameterize the number of threads for collect

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=4 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
+          command: GOMAXPROCS=4 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=12
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=4 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
+          command: GOMAXPROCS=4 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=14
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=12
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=6
+          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=4
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=4
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -218,10 +218,6 @@ jobs:
             - cached-deps/
       - go/install:
           version: << pipeline.parameters.go-version >>
-      - run:
-          name: Collect tests to run
-          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
-          background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -250,6 +246,10 @@ jobs:
           paths:
             - /home/circleci/.gocache
       - run: go mod download
+      - run:
+          name: Collect tests to run
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          background: true
       - run: etc/testing/circle/wait-minikube.sh
       - run:
           name: Collect kube events

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=4 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,10 +83,10 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=4
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
           background: true
       - run: go install gotest.tools/gotestsum@latest
-      - run: CGO_ENABLED=0 go install ./src/server/cmd/pachctl
+      - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
       - run: go install ./src/testing/match
       - run: etc/testing/circle/install.sh
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 go install ./src/server/cmd/pachctl
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -212,16 +212,16 @@ jobs:
             - pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
       - run: etc/testing/circle/install.sh
       - install-go-releaser
-      - run:
-          name: Collect tests to run
-          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
-          background: true
       - save_cache:
           key: pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
           paths:
             - cached-deps/
       - go/install:
           version: << pipeline.parameters.go-version >>
+      - run:
+          name: Collect tests to run
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -224,7 +224,7 @@ jobs:
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest
-      - run: CGO_ENABLED=0 go install ./src/server/cmd/pachctl
+      - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
       - wait-for-docker
       - start-minikube-2xlarge
       # The build cache will grow indefinitely, so we rotate the cache once a week.

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
+          command: GOMAXPROCS=4 GOMEMLIMIT=2GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -218,10 +218,6 @@ jobs:
             - cached-deps/
       - go/install:
           version: << pipeline.parameters.go-version >>
-      - run:
-          name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=4
-          background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -241,6 +237,10 @@ jobs:
           keys:
             - pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
       - run: make install # Install pachctl
+      - run:
+          name: Collect tests to run
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          background: true
       - save_cache:
           key: pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -212,6 +212,10 @@ jobs:
             - pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
       - run: etc/testing/circle/install.sh
       - install-go-releaser
+      - run:
+          name: Collect tests to run
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          background: true
       - save_cache:
           key: pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
           paths:
@@ -237,10 +241,6 @@ jobs:
           keys:
             - pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
       - run: make install # Install pachctl
-      - run:
-          name: Collect tests to run
-          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
-          background: true
       - save_cache:
           key: pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=64
+          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=4 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=12
+          command: GOMAXPROCS=4 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=14
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=64
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=2GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=4 GOMEMLIMIT=2GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          command: GOMAXPROCS=4 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=8
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -83,7 +83,7 @@ jobs:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=4
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 go install ./src/server/cmd/pachctl

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=12
+          command: GOMAXPROCS=2 go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -220,7 +220,7 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=4
+          command: GOMAXPROCS=2 GOMEMLIMIT=6GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=6
           background: true
       - run: mkdir ${TEST_RESULTS}
       - run: go install gotest.tools/gotestsum@latest

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -101,7 +101,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -38,6 +38,9 @@ func main() {
 	pkg := flag.String("pkg", "./...", "Package to run defaults to all packages.")
 	threadPool := flag.Int("procs", 2, "GOMAXPROCS value for the go test -list sbcommand.")
 	flag.Parse()
+	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
+	defer monitorCancel()
+	go proc.MonitorSelf(monitorCtx)
 	err := run(ctx, *tags, *exclusiveTags, *fileName, *pkg, *threadPool)
 	if err != nil {
 		log.Exit(ctx, "Error during tests splitting", zap.Error(err))
@@ -104,9 +107,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}
-	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
-	defer monitorCancel()
-	go proc.MonitorProcessGroup(monitorCtx, cmd.Process.Pid)
+
 	testNames, err := readTests(stdout)
 	if err != nil {
 		return nil, err

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/proc"
 	"go.uber.org/zap"
 	"k8s.io/kubectl/pkg/util/slice"
 )
@@ -37,6 +38,7 @@ func main() {
 	pkg := flag.String("pkg", "./...", "Package to run defaults to all packages.")
 	threadPool := flag.Int("procs", 2, "GOMAXPROCS value for the go test -list sbcommand.")
 	flag.Parse()
+	proc.MonitorSelf(ctx)
 	err := run(ctx, *tags, *exclusiveTags, *fileName, *pkg, *threadPool)
 	if err != nil {
 		log.Exit(ctx, "Error during tests splitting", zap.Error(err))
@@ -103,6 +105,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}
+	proc.MonitorProcessGroup(ctx, cmd.Process.Pid)
 	testNames, err := readTests(stdout)
 	if err != nil {
 		return nil, err

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -100,7 +100,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=16GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "CGO_ENABLED=0", "GOMEMLIMIT=16GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()
 	go proc.MonitorProcessGroup(monitorCtx, -os.Getpid())

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -98,7 +98,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=16GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=6GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	err = cmd.Start()
 	if err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -101,7 +101,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", "GOGC=25", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()
@@ -115,11 +115,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	if err != nil {
 		return nil, err
 	}
-	err = stdout.Close()
-	if err != nil {
-		return nil, errors.EnsureStack(err)
-	}
-	cmd.Wait()
+	err = cmd.Wait()
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -101,7 +101,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=36GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -29,8 +29,11 @@ type testOutput struct {
 	Output  string
 }
 
-func main() {
+func init() {
 	log.InitPachctlLogger()
+}
+
+func main() {
 	ctx := pctx.Background("test-collector")
 	tags := flag.String("tags", "", "Tags to run, for example k8s. Tests without this flag will not be selected.")
 	exclusiveTags := flag.Bool("exclusiveTags", true, "If true, ONLY tests with the specified tags will run. If false, "+
@@ -101,7 +104,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=16GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -98,7 +98,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=16GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	err = cmd.Start()
 	if err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -29,7 +29,7 @@ type testOutput struct {
 }
 
 func main() {
-	log.InitBatchLogger("test-collector.log")
+	log.InitPachctlLogger()
 	ctx := pctx.Background("test-collector")
 	tags := flag.String("tags", "", "Tags to run, for example k8s. Tests without this flag will not be selected.")
 	exclusiveTags := flag.Bool("exclusiveTags", true, "If true, ONLY tests with the specified tags will run. If false, "+

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -29,11 +29,8 @@ type testOutput struct {
 	Output  string
 }
 
-func init() {
-	log.InitPachctlLogger()
-}
-
 func main() {
+	log.InitPachctlLogger()
 	ctx := pctx.Background("test-collector")
 	tags := flag.String("tags", "", "Tags to run, for example k8s. Tests without this flag will not be selected.")
 	exclusiveTags := flag.Bool("exclusiveTags", true, "If true, ONLY tests with the specified tags will run. If false, "+
@@ -118,7 +115,11 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	if err != nil {
 		return nil, err
 	}
-	err = cmd.Wait()
+	err = stdout.Close()
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	cmd.Wait()
 	if err != nil {
 		return nil, errors.EnsureStack(err)
 	}

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -101,7 +101,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", "GOGC=25", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -101,7 +101,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, "GOMEMLIMIT=36GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()

--- a/src/testing/cmds/harness/test-collector/main.go
+++ b/src/testing/cmds/harness/test-collector/main.go
@@ -104,7 +104,7 @@ func testNames(ctx context.Context, pkg string, threadPool int, addtlCmdArgs ...
 	}
 	cmd.Stderr = log.WriterAt(log.ChildLogger(ctx, "stderr"), log.InfoLevel)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOMEMLIMIT=8GiB", fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOMAXPROCS=%d", threadPool)) // This prevents the command from running wild eating up processes in the pipelines
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	monitorCtx, monitorCancel := context.WithCancel(pctx.Child(ctx, "monitor go process"))
 	defer monitorCancel()

--- a/src/testing/cmds/harness/test-runner/main.go
+++ b/src/testing/cmds/harness/test-runner/main.go
@@ -136,7 +136,7 @@ func waitForTestListFile(fileName string) error {
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	timer := time.NewTimer(7 * time.Minute)
+	timer := time.NewTimer(8 * time.Minute)
 	defer timer.Stop()
 	for {
 		select {

--- a/src/testing/cmds/harness/test-runner/main.go
+++ b/src/testing/cmds/harness/test-runner/main.go
@@ -136,7 +136,7 @@ func waitForTestListFile(fileName string) error {
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	timer := time.NewTimer(5 * time.Minute)
+	timer := time.NewTimer(7 * time.Minute)
 	defer timer.Stop()
 	for {
 		select {

--- a/src/testing/cmds/harness/test-runner/main.go
+++ b/src/testing/cmds/harness/test-runner/main.go
@@ -136,7 +136,7 @@ func waitForTestListFile(fileName string) error {
 	if err != nil {
 		return errors.EnsureStack(err)
 	}
-	timer := time.NewTimer(8 * time.Minute)
+	timer := time.NewTimer(9 * time.Minute)
 	defer timer.Stop()
 	for {
 		select {


### PR DESCRIPTION
go test -list sometimes runs and times out without any output. I believe I tracked this down to a CPU issue since dialing the cpus down seems to help. I'm parameterizing this so we can tune it per-job since on master for some reason it seems to fail for the unit tests which use smaller runners.
example: https://app.circleci.com/pipelines/github/pachyderm/pachyderm/25074/workflows/a9d19a0d-0af4-4e16-8082-20f7055c6a64/jobs/444597