### PR TITLE
Djanicek/test yml cleanup

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -81,9 +81,10 @@ jobs:
       - restore_cache:
           keys:
             - pach-go-unittest-mod-cache-v1-{{arch}}-{{ checksum "go.sum" }}
+      - run: go mod download
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=8
+          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=16
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -219,10 +220,9 @@ jobs:
       - go/install:
           version: << pipeline.parameters.go-version >>
       - run: mkdir ${TEST_RESULTS}
+      - start-minikube-2xlarge
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
-      - wait-for-docker
-      - start-minikube-2xlarge
       # The build cache will grow indefinitely, so we rotate the cache once a week.
       # This ensures the time to restore the cache isn't longer than the speedup in compilation.
       - run: "echo $(($(date +%s)/604800)) > current_week"
@@ -236,7 +236,7 @@ jobs:
       - restore_cache:
           keys:
             - pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
-      - run: make install # Install pachctl
+      - run: go mod download
       - save_cache:
           key: pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
           paths:
@@ -245,11 +245,11 @@ jobs:
           key: pach-go-build-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "current_week" }}
           paths:
             - /home/circleci/.gocache
-      - run: go mod download
       - run:
           name: Collect tests to run
           command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
           background: true
+      - wait-for-docker
       - run: etc/testing/circle/wait-minikube.sh
       - run:
           name: Collect kube events

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -84,7 +84,7 @@ jobs:
       - run: go mod download
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=16
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -247,7 +247,7 @@ jobs:
             - /home/circleci/.gocache
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=24
           background: true
       - wait-for-docker
       - run: etc/testing/circle/wait-minikube.sh

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -84,7 +84,7 @@ jobs:
       - run: go mod download
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 GOMEMLIMIT=8GiB PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv -procs=16
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -file=tests_to_run_unit.csv
           background: true
       - run: go install gotest.tools/gotestsum@latest
       - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
@@ -247,7 +247,7 @@ jobs:
             - /home/circleci/.gocache
       - run:
           name: Collect tests to run
-          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv -procs=16
+          command: GOMAXPROCS=2 PACHYDERM_LOG_LEVEL="debug" go run ./src/testing/cmds/harness/test-collector/main.go -tags=k8s -file=tests_to_run_k8s.csv
           background: true
       - wait-for-docker
       - run: etc/testing/circle/wait-minikube.sh

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -151,8 +151,6 @@ jobs:
           key: pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
           paths:
             - cached-deps/
-      - go/install:
-          version: << pipeline.parameters.go-version >>
       - run: mkdir ${TEST_RESULTS}
       # The build cache will grow indefinitely, so we rotate the cache once a week.
       # This ensures the time to restore the cache isn't longer than the speedup in compilation.
@@ -166,6 +164,8 @@ jobs:
       - restore_cache:
           keys:
             - pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
+      - go/install:
+          version: << pipeline.parameters.go-version >>
       - save_cache:
           key: pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
           paths:
@@ -217,12 +217,8 @@ jobs:
           key: pach-build-dependencies-v2-{{ arch }}-{{ checksum "etc/testing/circle/install.sh" }}
           paths:
             - cached-deps/
-      - go/install:
-          version: << pipeline.parameters.go-version >>
       - run: mkdir ${TEST_RESULTS}
       - start-minikube-2xlarge
-      - run: go install gotest.tools/gotestsum@latest
-      - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
       # The build cache will grow indefinitely, so we rotate the cache once a week.
       # This ensures the time to restore the cache isn't longer than the speedup in compilation.
       - run: "echo $(($(date +%s)/604800)) > current_week"
@@ -236,6 +232,10 @@ jobs:
       - restore_cache:
           keys:
             - pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}
+      - go/install:
+          version: << pipeline.parameters.go-version >>
+      - run: go install gotest.tools/gotestsum@latest
+      - run: CGO_ENABLED=0 GOMAXPROCS=2 go install ./src/server/cmd/pachctl
       - run: go mod download
       - save_cache:
           key: pach-go-mod-cache-v2-{{ arch }}-{{ checksum "go.sum" }}


### PR DESCRIPTION
For the test bucket change, there was an issue if the test-collector was running at the same time as a cache restore or go mod download, as that could change dependency or go binaries as the collector was using for `go test -list` as it was running. This lead to weird SIGBUS errors.

I put a fix in earlier just to get it working(https://github.com/pachyderm/pachyderm/pull/9585), but while I was doing it I noticed a bunch of weirdness with our caching and how steps were ordered that was slowing down the test jobs. This PR re-orders our dependency installing and caching to speed the integration tests back up to where they were before we hit the dependency race issue.