### PR TITLE
cmputil: add WantErr, to handle tests that want to check errors 

### DIFF
--- a/src/internal/cmputil/cmputil.go
+++ b/src/internal/cmputil/cmputil.go
@@ -4,6 +4,7 @@ package cmputil
 import (
 	"regexp"
 	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -21,4 +22,41 @@ func RegexpStrings() cmp.Option {
 		}
 		return a == b
 	})
+}
+
+// WantErr is an assertion helper that checks err against wantErr.  wantErr can be a boolean,
+// string, or /string/ which acts like a regular expression against the error message.  WantErr
+// returns true if tests should continue to test the non-error case, or false if the test should end
+// immediately.
+func WantErr[T ~bool | ~string](t *testing.T, err error, wantErr T) (cont bool) {
+	t.Helper()
+	var want any = wantErr
+	switch w := want.(type) {
+	case bool:
+		switch {
+		case err == nil && w:
+			t.Errorf("expected error, but got success")
+			return false
+		case err != nil && !w:
+			t.Errorf("unexpected error: %v", err)
+		case err != nil:
+		case err == nil && !w:
+		}
+	case string:
+		switch {
+		case err == nil && w != "":
+			t.Errorf("expected error, but got success")
+			return false
+		case err != nil && w == "":
+			t.Errorf("unexpected error: %v", err)
+		case err != nil:
+			if diff := cmp.Diff(w, err.Error(), RegexpStrings()); diff != "" {
+				t.Errorf("err: (-want +got)\n%s", diff)
+			}
+		case err == nil && w == "":
+		}
+	default:
+		panic("impossible type passed to WantErr")
+	}
+	return err == nil
 }

--- a/src/internal/cmputil/cmputil_test.go
+++ b/src/internal/cmputil/cmputil_test.go
@@ -1,6 +1,7 @@
 package cmputil
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,5 +51,20 @@ func TestRegexpStrings(t *testing.T) {
 				t.Error("diff empty, but wanted one")
 			}
 		})
+	}
+}
+
+func TestWantErr(t *testing.T) {
+	if got, want := WantErr(t, nil, false), true; got != want {
+		t.Errorf("WantErr(nil, false).continue:\n  got: %v\n want: %v", got, want)
+	}
+	if got, want := WantErr(t, nil, ""), true; got != want {
+		t.Errorf("WantErr(nil, \"\").continue:\n  got: %v\n want: %v", got, want)
+	}
+	if got, want := WantErr(t, errors.New("blah"), true), false; got != want {
+		t.Errorf("WantErr(error(\"blah\"), true).continue:\n  got: %v\n want: %v", got, want)
+	}
+	if got, want := WantErr(t, errors.New("some text then blah and more text"), "/blah/"), false; got != want {
+		t.Errorf("WantErr(error(\"some text...\"), \"/blah/\")).continue:\n  got: %v\n want: %v", got, want)
 	}
 }


### PR DESCRIPTION
This is borrowed from a PR I haven't submitted yet, but I need it now.

Use like:

```go
test := testCase{
    input: ...,
    want: ...,
    wantErr: ...,
}
got, err := foo()
if cont := cmputil.WantErr(t, err, test.wantErr); !cont {
   return
}
if diff := cmp.Diff(test.want, got); diff != "" {
   t.Errorf("foo (-want +got):\n%s", diff)
}
```

wantErr can be a boolean, exact string, or string for `cmputil.RegexpStrings`.

Normally this test requires writing a block for 4 cases; `err != nil && test.wantErr`, `err == nil && !test.wantErr`, `err != nil && !test.wantErr`, `err == nil && test.wantErr`, which are easy to get wrong.  This simplifies that common check. 