### PR TITLE
[INT-1151] Add config file write support

### DIFF
--- a/python-sdk/pachyderm_sdk/client.py
+++ b/python-sdk/pachyderm_sdk/client.py
@@ -236,7 +236,7 @@ class Client:
         Client
             A properly configured Client.
         """
-        config = ConfigFile.from_file(config_file)
+        config = ConfigFile.from_path(config_file)
         active_context = config.active_context
         client = cls.from_pachd_address(
             active_context.active_pachd_address,

--- a/python-sdk/pachyderm_sdk/client.py
+++ b/python-sdk/pachyderm_sdk/client.py
@@ -236,7 +236,7 @@ class Client:
         Client
             A properly configured Client.
         """
-        config = ConfigFile(config_file)
+        config = ConfigFile.from_file(config_file)
         active_context = config.active_context
         client = cls.from_pachd_address(
             active_context.active_pachd_address,

--- a/python-sdk/pachyderm_sdk/config.py
+++ b/python-sdk/pachyderm_sdk/config.py
@@ -1,6 +1,7 @@
 """Functionality for parsing Pachyderm config files."""
 import json
 import os
+import uuid
 from base64 import b64decode
 from copy import deepcopy
 from dataclasses import dataclass, asdict
@@ -59,10 +60,11 @@ class ConfigFile:
             The context object.
         """
         data = dict(
+            user_id=str(uuid.uuid4()).replace("-", ""),
             v2=dict(
                 active_context=name,
                 contexts={name: asdict(context)},
-                metrics=False,  # TODO: Reconsider after understanding user_id.
+                metrics=True,
             ),
         )
         return cls(data)

--- a/python-sdk/pachyderm_sdk/config.py
+++ b/python-sdk/pachyderm_sdk/config.py
@@ -3,7 +3,6 @@ import json
 import os
 import uuid
 from base64 import b64decode
-from copy import deepcopy
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, Optional, Union
@@ -31,13 +30,13 @@ class ConfigFile:
             "active_context" in v2 and "contexts" in v2
         ):
             raise ValueError(
-                'Expected format: {"v2": {"active_context": ..., "contexts": {...}}'
+                'Missing required fields v2.active_context and/or v2.contexts.'
             )
         self._config_file_data = data
 
     @classmethod
-    def from_file(cls, config_file: Union[Path, str]) -> "ConfigFile":
-        """Parse a Pachyderm config file.
+    def from_path(cls, config_file: Union[Path, str]) -> "ConfigFile":
+        """Parse a Pachyderm config file from a local file.
 
         Parameters
         ----------
@@ -137,9 +136,8 @@ class ConfigFile:
             The path to the config file.
         """
         config_file = Path(os.path.expanduser(config_file)).resolve()
-        data = deepcopy(self._config_file_data)
         with config_file.open("w") as file_out:
-            file_out.write(json.dumps(data, indent=2))
+            file_out.write(json.dumps(self._config_file_data, indent=2))
             file_out.write("\n")
 
 

--- a/python-sdk/pachyderm_sdk/config.py
+++ b/python-sdk/pachyderm_sdk/config.py
@@ -30,7 +30,7 @@ class ConfigFile:
             "active_context" in v2 and "contexts" in v2
         ):
             raise ValueError(
-                'Missing required fields v2.active_context and/or v2.contexts.'
+                "Missing required fields v2.active_context and/or v2.contexts."
             )
         self._config_file_data = data
 

--- a/python-sdk/tests/test_config.py
+++ b/python-sdk/tests/test_config.py
@@ -105,7 +105,8 @@ class TestConfig:
 
         # Assert
         assert config.active_context == context
-        assert config.user_id is None
+        assert config.user_id is not None
+        assert len(config.user_id) == 32
 
     @staticmethod
     def test_set_active_context():

--- a/python-sdk/tests/test_config.py
+++ b/python-sdk/tests/test_config.py
@@ -1,24 +1,27 @@
+import json
+from filecmp import cmp
+from pathlib import Path
+
 import pytest
 
-from pachyderm_sdk.config import ConfigFile
+from pachyderm_sdk.config import ConfigFile, Context
 from pachyderm_sdk.errors import ConfigError
 
-TEST_CONFIG = """
-{
+TEST_CONFIG = """{
   "user_id": "some_user",
   "v2": {
     "active_context": "default",
     "contexts": {
       "default": {
-        "session_token": "token",
         "cluster_deployment_id": "id",
-        "project": "default"
+        "project": "default",
+        "session_token": "token"
       },
       "other_context": {
-        "pachd_address": "grpc://localhost:12345",
-        "session_token": "other_token",
         "cluster_deployment_id": "other_id",
-        "project": "other_project"
+        "pachd_address": "grpc://localhost:12345",
+        "project": "other_project",
+        "session_token": "other_token"
       }
     },
     "metrics": true
@@ -56,21 +59,64 @@ class TestConfig:
         config_path = tmp_path / "config.json"
         with open(config_path, "w") as config_file:
             config_file.write(TEST_CONFIG)
-            config_file.flush()
-            c = ConfigFile(config_file.name)
-            context = c.active_context
-            assert c.user_id == "some_user"
-            assert context.session_token == "token"
-            assert context.cluster_deployment_id == "id"
-            assert context.project == "default"
+
+        config = ConfigFile.from_file(config_path)
+        context = config.active_context
+        assert config.user_id == "some_user"
+        assert context.session_token == "token"
+        assert context.cluster_deployment_id == "id"
+        assert context.project == "default"
 
     @staticmethod
     def test_invalid_context(tmp_path):
-        config_path = tmp_path / "config.json"
-        with open(config_path, "w") as config_file:
-            config_file.write(TEST_CONFIG_INVALID_CONTEXT)
-            config_file.flush()
-            with pytest.raises(ConfigError) as e:
-                c = ConfigFile(config_file=config_file.name)
-                context = c.active_context
-            assert "active context not found: invalid_context" in str(e.value)
+        config = ConfigFile(json.loads(TEST_CONFIG_INVALID_CONTEXT))
+        with pytest.raises(ConfigError) as error:
+            _ = config.active_context
+        assert "active context not found: invalid_context" in str(error.value)
+
+    @staticmethod
+    def test_to_from_file(tmp_path: Path):
+        """Test that reading from and writing to a file compatibly implemented"""
+        # Arrange
+        original_path = tmp_path / "config.json"
+        with open(original_path, "w") as config_file:
+            config_file.write(TEST_CONFIG)
+        original_config = ConfigFile.from_file(original_path)
+
+        # Act
+        new_path = tmp_path / "new_config.json"
+        original_config.write(new_path)
+
+        assert original_path.read_text() == new_path.read_text()
+        assert cmp(original_path, new_path, shallow=False)
+
+    @staticmethod
+    def test_new_with_context():
+        """Test that a new config file object can be created from a single context."""
+        # Arrange
+        context = Context(
+            cluster_deployment_id="abc123",
+            pachd_address="grpc://localhost:12345",
+            project="default",
+        )
+
+        # Act
+        config = ConfigFile.new_with_context(name="my-new-context", context=context)
+
+        # Assert
+        assert config.active_context == context
+        assert config.user_id is None
+
+    @staticmethod
+    def test_set_active_context():
+        """Test that set_active_context updates the active context as expected."""
+        # Arrange
+        config = ConfigFile(data=json.loads(TEST_CONFIG))
+
+        # Act & Assert
+        assert config.active_context.cluster_deployment_id == "id"
+        config.set_active_context("other_context")
+        assert config.active_context.cluster_deployment_id == "other_id"
+
+        with pytest.raises(ValueError):
+            config.set_active_context("fake-context")

--- a/python-sdk/tests/test_config.py
+++ b/python-sdk/tests/test_config.py
@@ -60,7 +60,7 @@ class TestConfig:
         with open(config_path, "w") as config_file:
             config_file.write(TEST_CONFIG)
 
-        config = ConfigFile.from_file(config_path)
+        config = ConfigFile.from_path(config_path)
         context = config.active_context
         assert config.user_id == "some_user"
         assert context.session_token == "token"
@@ -81,7 +81,7 @@ class TestConfig:
         original_path = tmp_path / "config.json"
         with open(original_path, "w") as config_file:
             config_file.write(TEST_CONFIG)
-        original_config = ConfigFile.from_file(original_path)
+        original_config = ConfigFile.from_path(original_path)
 
         # Act
         new_path = tmp_path / "new_config.json"


### PR DESCRIPTION
Adds the ability to write out config files. This is intended to be an internal feature.

In order to make this work, I had to do some non-backwards compatible changes to the `ConfigFile.\_\_init\_\_` method. User's really have no reason to be touching this code, so I feel comfortable with this change. Additionally I refreshed the config tests a bit.