### PR TITLE
Djanicek/test ouput change

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -99,7 +99,7 @@ jobs:
               -shard=$CIRCLE_NODE_INDEX \
               -total-shards=$CIRCLE_NODE_TOTAL \
               -threads=2 \
-              -gotestsum-args="--format=testdox"
+              -gotestsum-args="--format=testdox" \
               -gotest-args="-parallel=6 -timeout=20m -cover -test.gocoverdir=\"$TEST_RESULTS\" -coverprofile=${TEST_RESULTS}/coverage.txt -covermode=atomic -coverpkg=./..."
       - run:
           name: Format code coverage
@@ -298,7 +298,7 @@ jobs:
               -shard=$CIRCLE_NODE_INDEX \
               -total-shards=$CIRCLE_NODE_TOTAL \
               -threads=7 \
-              -gotestsum-args="--format=testdox"
+              -gotestsum-args="--format=testdox" \
               -gotest-args="-parallel=4 -timeout=30m -cover -test.gocoverdir=\"$TEST_RESULTS\" -covermode=atomic -coverpkg=./..."
       - run:
           name: Format code coverage

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -99,6 +99,7 @@ jobs:
               -shard=$CIRCLE_NODE_INDEX \
               -total-shards=$CIRCLE_NODE_TOTAL \
               -threads=2 \
+              -gotestsum-args="--format=testdox"
               -gotest-args="-parallel=6 -timeout=20m -cover -test.gocoverdir=\"$TEST_RESULTS\" -coverprofile=${TEST_RESULTS}/coverage.txt -covermode=atomic -coverpkg=./..."
       - run:
           name: Format code coverage
@@ -297,6 +298,7 @@ jobs:
               -shard=$CIRCLE_NODE_INDEX \
               -total-shards=$CIRCLE_NODE_TOTAL \
               -threads=7 \
+              -gotestsum-args="--format=testdox"
               -gotest-args="-parallel=4 -timeout=30m -cover -test.gocoverdir=\"$TEST_RESULTS\" -covermode=atomic -coverpkg=./..."
       - run:
           name: Format code coverage

--- a/src/testing/cmds/harness/test-runner/main.go
+++ b/src/testing/cmds/harness/test-runner/main.go
@@ -170,7 +170,6 @@ func runTest(pkg string, testNames []string, tags string, gotestsumArgs []string
 		fmt.Sprintf("--packages=%s", pkg),
 		"--rerun-fails",
 		"--rerun-fails-max-failures=1",
-		"--format=standard-verbose",
 		"--debug",
 		fmt.Sprintf("--junitfile=%s/circle/gotestsum-report-%s.xml", resultsFolder, pkgShort),
 		fmt.Sprintf("--jsonfile=%s/%s-go-test-results.jsonl", resultsFolder, pkgShort),


### PR DESCRIPTION
Change the tests to use the testdox format that his nice check marks and x's for pass and fail and is less cluttered than the verbose output. This should make it easier to find and debug errors in the CI pipeline. It still outputs verbose output for failing tests.

![image](https://github.com/pachyderm/pachyderm/assets/116583733/bbd249f2-f8c3-4e97-97d2-a394910a271f)
