### PR TITLE
jupyter extension - allow configuration via env var

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -8,6 +8,8 @@ PACH_CONFIG = Path(
     os.path.expanduser(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
 ).resolve()
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
+PACHD_ADDRESS = os.environ.get("PACHD_ADDRESS", None)
+DEX_TOKEN = os.environ.get("DEX_TOKEN", None)
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -9,7 +9,7 @@ PACH_CONFIG = Path(
 ).resolve()
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 PACHD_ADDRESS = os.environ.get("PACHD_ADDRESS", None)
-DEX_TOKEN = os.environ.get("DEX_TOKEN", None)
+DEX_TOKEN = os.environ.get("DEX_TOKEN", None)  # If specified, this is the ID_TOKEN used in auth
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -9,7 +9,8 @@ PACH_CONFIG = Path(
 ).resolve()
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 PACHD_ADDRESS = os.environ.get("PACHD_ADDRESS", None)
-DEX_TOKEN = os.environ.get("DEX_TOKEN", None)  # If specified, this is the ID_TOKEN used in auth
+# If specified, this is the ID_TOKEN used in auth
+DEX_TOKEN = os.environ.get("DEX_TOKEN", None)
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -665,7 +665,9 @@ def setup_handlers(web_app, config_file: Path):
         )
     except FileNotFoundError:
         if PACHD_ADDRESS:
-            client = Client().from_pachd_address(pachd_address=PACHD_ADDRESS, auth_token=DEX_TOKEN)
+            client = Client().from_pachd_address(pachd_address=PACHD_ADDRESS)
+            if DEX_TOKEN:
+                client.auth_token = client.auth.authenticate(id_token=DEX_TOKEN).pach_token
             get_logger().debug(
                 f"Created Pachyderm client for {client.address} from env var"
             )

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -667,7 +667,9 @@ def setup_handlers(web_app, config_file: Path):
         if PACHD_ADDRESS:
             client = Client().from_pachd_address(pachd_address=PACHD_ADDRESS)
             if DEX_TOKEN:
-                client.auth_token = client.auth.authenticate(id_token=DEX_TOKEN).pach_token
+                client.auth_token = client.auth.authenticate(
+                    id_token=DEX_TOKEN
+                ).pach_token
             get_logger().debug(
                 f"Created Pachyderm client for {client.address} from env var"
             )

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -19,6 +19,7 @@ import tornado
 import tornado.concurrent
 import tornado.web
 
+from .env import PACHD_ADDRESS, DEX_TOKEN
 from .log import get_logger
 from .pfs_manager import PFSManager, DatumManager
 from .pps_client import PPSClient
@@ -648,16 +649,32 @@ def write_config(
 
 
 def setup_handlers(web_app, config_file: Path):
+    """
+    Sets up the Pachyderm client and the HTTP request handler.
+
+    Config for the Pachyderm client will first be attempted by reading
+    the local config file. This falls back to the PACHD_ADDRESS and
+    DEX_TOKEN env vars, and finally defaulting to a localhost client
+    on the default port 30650 failing that.
+    """
+    client = None
     try:
         client = Client().from_config(config_file)
         get_logger().debug(
             f"Created Pachyderm client for {client.address} from local config"
         )
     except FileNotFoundError:
-        get_logger().debug(
-            "Could not find config file -- no pachyderm client instantiated"
-        )
-    else:
+        if PACHD_ADDRESS:
+            client = Client().from_pachd_address(pachd_address=PACHD_ADDRESS, auth_token=DEX_TOKEN)
+            get_logger().debug(
+                f"Created Pachyderm client for {client.address} from env var"
+            )
+        else:
+            get_logger().debug(
+                "Could not find config file -- no pachyderm client instantiated"
+            )
+
+    if client:
         web_app.settings["pachyderm_client"] = client
         web_app.settings["pachyderm_pps_client"] = PPSClient(client=client)
         web_app.settings["pfs_contents_manager"] = PFSManager(client=client)


### PR DESCRIPTION
Allow the Pachyderm Jupyter extension address and token to be configured via env var for compatibility with the Determined launcher.

[INT-1149](https://pachyderm.atlassian.net/browse/INT-1149)

[INT-1149]: https://pachyderm.atlassian.net/browse/INT-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ