### PR TITLE
Djanicek/infraeng 342/OIDC logic

### DIFF
--- a/etc/helm/examples/local-dev-values-with-det.yaml
+++ b/etc/helm/examples/local-dev-values-with-det.yaml
@@ -54,7 +54,7 @@ console:
   image:
     tag: 49648661011fa26986a6f71ffabe77d1f286eef3 
   config:
-    oauthRedirectURI: http://localhost:8283/oauth/callback/?inline=true #http://localhost:8283/dex/auth 
+    oauthRedirectURI: http://localhost:8283/oauth/callback/?inline=true 
     disableTelemetry: true
 
 oidc:
@@ -80,12 +80,12 @@ determined:
   enterpriseEdition: true
   useNodePortForMaster: false
   useNodePortForDB: false
-  detVersion: 0.26.2
+  detVersion: 0.26.7 # set to latest in tests
   masterPort: 8282
   masterCpuRequest: 250m
   masterMemRequest: 256M
   oidc:
     enabled: true 
     idpRecipientUrl: http://localhost:8282
-    idpSsoUrl: http://pachd.default.svc.cluster.local:30658/dex #"http://localhost:8283" 
+    idpSsoUrl: http://pachd.default.svc.cluster.local:30658/dex 
     clientSecret: "123"

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -82,7 +82,7 @@ stringData:
     {{- if .Values.determined.enterpriseEdition }}
     {{- if .Values.determined.oidc }}
     oidc:
-      enabled: {{ .Values.determined.oidc.enabled | default true }}
+      enabled: {{ .Values.determined.oidc.enabled | default false }}
       provider: {{ default .Values.determined.oidc.provider "dex"}}
       idp_recipient_url: {{ required "A valid recipient url is required!" .Values.determined.oidc.idpRecipientUrl }}
       idp_sso_url: {{ default .Values.determined.oidc.idpSsoUrl (include "pachyderm.issuerURI" . | quote) }}
@@ -97,7 +97,7 @@ stringData:
 
     {{- if .Values.determined.scim }}
     scim:
-      enabled: {{ .Values.determined.scim.enabled | default true }}
+      enabled: {{ .Values.determined.scim.enabled | default false }}
       auth:
         type: {{ required "A valid authentication type is required!" .Values.determined.scim.auth.type }}
         {{- if eq .Values.determined.scim.auth.type "basic" }}

--- a/etc/helm/pachyderm/templates/determined/master-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         image: {{ .Values.determined.imageRegistry }}/{{ $image }}:{{ $tag }}
         imagePullPolicy: "Always"
         {{- if .Values.determined.enterpriseEdition }}
-        {{- if .Values.determined.oidc }}
+        {{- if and .Values.determined.oidc .Values.determined.oidc.enabled }}
         env:
           - name: DET_OIDC_CLIENT_SECRET
             valueFrom:

--- a/etc/helm/pachyderm/templates/determined/secret.yaml
+++ b/etc/helm/pachyderm/templates/determined/secret.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: Pachyderm, Inc. <info@pachyderm.com>
 SPDX-License-Identifier: Apache-2.0
 */ -}}
-{{- if and .Values.determined.enabled .Values.determined.enterpriseEdition   (not .Values.determined.oidc.clientSecretName) -}}
+{{- if and .Values.determined.oidc .Values.determined.oidc.enabled (not .Values.determined.oidc.clientSecretName) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -313,7 +313,7 @@ spec:
               name: {{ default ("pachyderm-console-secret") .Values.console.config.oauthClientSecretSecretName  }}
               key: OAUTH_CLIENT_SECRET
         {{- end }}
-        {{- if and .Values.determined.enabled .Values.determined.enterpriseEdition }}
+        {{- if and .Values.determined.oidc .Values.determined.oidc.enabled }}
         - name: DETERMINED_OAUTH_ID
           value: {{ default "determined" .Values.determined.oidc.clientId }}
         - name: DETERMINED_OAUTH_SECRET

--- a/etc/helm/pachyderm/templates/pachd/identity-config.yaml
+++ b/etc/helm/pachyderm/templates/pachd/identity-config.yaml
@@ -21,7 +21,7 @@ data:
       {{- if .Values.console.enabled}}
       - {{ .Values.console.config.oauthClientID | quote }}
       {{- end }}
-      {{- if .Values.determined.enabled}}
+      {{- if and .Values.determined.oidc .Values.determined.oidc.enabled}}
       - {{ default "determined" .Values.determined.oidc.clientId }}
       {{- end }}
     {{- if .Values.console.enabled }}
@@ -30,7 +30,7 @@ data:
       redirect_uris:
       - {{ include "pachyderm.consoleRedirectURI" . | quote }}
     {{- end }}
-    {{- if .Values.determined.enabled }}
+    {{- if and .Values.determined.enabled .Values.determined.oidc .Values.determined.oidc.enabled}}
     - id: {{ default "determined" .Values.determined.oidc.clientId }}
       name: {{ default "determined" .Values.determined.oidc.clientId }}
       redirect_uris:


### PR DESCRIPTION
I'm definitely open to discussion on this if we want to remove any of these changes. I personally haven't seen agood reason to keep things the way they are but there could definitely be a reason that I am unaware of.

Teams may occasionally want to deploy pachyderm+determined as enterprise without enabling authentication. This is a little odd, but it seems like a reasonable ask for a new enterprise customer to want to try out enterprise without authentication as they get up and running or do some initial testing/evaluation. 

The determined helm chart allows this configuration, but not the unified chart. The pachyderm side often just checks that determined is enabled, and then assumes oidc is enabled. This PR does 3 things to resolve this:

1. Change the pachyderm chart to check `oidc` and `oidc.enabled` instead of `determined.enabled` for oidc related items like client secret.
2. Change the determined chart in the pachyderm repo to match the determined chart in the determined repo for the scim and odic defaults. As they were set(default=true), it was impossible to turn off `oidc.enabled` if `oidc` was set because helm's templating assumes that any false-y value (like `false`) is unset, even when manually set. So, setting `oidc.enabled` to false is read as unset, and so `oidc.enabled` is always true. This cuts down on maintenance too because we no longer deviate from the original determined helm chart here.
3. Smoke test was removed because the test was changed. I'll add a backlog item to re-add a better e2e test for this.