### PR TITLE
[INT-1160] Rename "Mount" to "Load" in Explore and Test views

### DIFF
--- a/jupyter-extension/README.md
+++ b/jupyter-extension/README.md
@@ -13,8 +13,8 @@ for the frontend extension.
 
 - JupyterLab >= 3.0
 
-- Python >=3.7,<4
-    - [pyenv](https://github.com/pyenv/pyenv) is a great way to manage and install different versions of python. You can check which version you are using by running `pyenv versions`. Our Python extension is built to be compatible with Python versions 3.7 to 3.10. Therefore, it is best to run the lowest version (3.7.x) for highest compatibility.
+- Python >=3.8,<4
+    - [pyenv](https://github.com/pyenv/pyenv) is a great way to manage and install different versions of python. You can check which version you are using by running `pyenv versions`. Our Python extension is built to be compatible with Python versions 3.8 to 3.10. Therefore, it is best to run the lowest version (3.8.x) for highest compatibility.
 
 - Node
     - If you are using [nvm](https://github.com/nvm-sh/nvm) first run `nvm install`. This will install and switch the version of node to the one defined in the `.nvmrc`. If you are upgrading the version of node used in the project, please check and make sure that the versions defined in the `.nvmrc`.
@@ -130,7 +130,7 @@ You can watch the source directory and run JupyterLab at the same time in differ
 # Watch the source directory in one terminal, automatically rebuilding when needed
 npm run watch
 # Run JupyterLab in another terminal
-jupyter lab --allow-root
+jupyter lab --allow-root --ip=0.0.0.0
 ```
 
 With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -119,7 +119,7 @@ const Datum: React.FC<DatumProps> = ({
             onClick={callMountDatums}
             style={{padding: '0.5rem'}}
           >
-            Mount Datums
+            Load Datums
           </button>
           {shouldShowDownload && (
             <button

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -114,7 +114,7 @@ const Datum: React.FC<DatumProps> = ({
           style={{display: 'flex'}}
         >
           <button
-            data-testid="Datum__mountDatums"
+            data-testid="Datum__loadDatums"
             className="pachyderm-button-link"
             onClick={callMountDatums}
             style={{padding: '0.5rem'}}

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -27,8 +27,8 @@ describe('datum screen', () => {
     window.IntersectionObserver = mockIntersectionObserver;
   });
 
-  describe('mounting datums', () => {
-    it('successful mount datums call shows cycler and download', async () => {
+  describe('loading datums', () => {
+    it('successful load datums call shows cycler and download', async () => {
       mockRequestAPI.requestAPI.mockImplementation(
         mockedRequestAPI({
           id: 'asdfaew34ri92jafiolwe',
@@ -53,7 +53,7 @@ describe('datum screen', () => {
       expect(queryByTestId('Datum__downloadDatum')).not.toBeInTheDocument();
 
       const input = await findByTestId('Datum__inputSpecInput');
-      const submit = await findByTestId('Datum__mountDatums');
+      const submit = await findByTestId('Datum__loadDatums');
 
       userEvent.type(input, '{"pfs": "a"}'.replace(/[{[]/g, '$&$&'));
       expect(input).toHaveValue('{"pfs": "a"}');
@@ -97,7 +97,7 @@ describe('datum screen', () => {
       );
 
       const input = await findByTestId('Datum__inputSpecInput');
-      const submit = await findByTestId('Datum__mountDatums');
+      const submit = await findByTestId('Datum__loadDatums');
 
       userEvent.type(input, '{"pfs": "a"}'.replace(/[{[]/g, '$&$&'));
       expect(input).toHaveValue('{"pfs": "a"}');
@@ -144,7 +144,7 @@ describe('datum screen', () => {
       expect(getByTestId('Datum__errorMessage')).toHaveTextContent('');
 
       const input = await findByTestId('Datum__inputSpecInput');
-      const submit = await findByTestId('Datum__mountDatums');
+      const submit = await findByTestId('Datum__loadDatums');
 
       userEvent.type(input, '{"pfs": "a"'.replace(/[{[]/g, '$&$&'));
       expect(input).toHaveValue('{"pfs": "a"');
@@ -173,7 +173,7 @@ describe('datum screen', () => {
       expect(getByTestId('Datum__errorMessage')).toHaveTextContent('');
 
       const input = await findByTestId('Datum__inputSpecInput');
-      const submit = await findByTestId('Datum__mountDatums');
+      const submit = await findByTestId('Datum__loadDatums');
 
       userEvent.type(input, '{"pfs": "fake_repo"}'.replace(/[{[]/g, '$&$&'));
       expect(input).toHaveValue('{"pfs": "fake_repo"}');
@@ -200,7 +200,7 @@ describe('datum screen', () => {
       expect(getByTestId('Datum__errorMessage')).toHaveTextContent('');
 
       const input = await findByTestId('Datum__inputSpecInput');
-      const submit = await findByTestId('Datum__mountDatums');
+      const submit = await findByTestId('Datum__loadDatums');
 
       userEvent.type(input, '{"pfs": "repo"}'.replace(/[{[]/g, '$&$&'));
       expect(input).toHaveValue('{"pfs": "repo"}');
@@ -225,7 +225,7 @@ describe('datum screen', () => {
       expect(getByTestId('Datum__errorMessage')).toHaveTextContent('');
 
       const input = await findByTestId('Datum__inputSpecInput');
-      const submit = await findByTestId('Datum__mountDatums');
+      const submit = await findByTestId('Datum__loadDatums');
 
       userEvent.type(input, YAML.stringify({pfs: 'repo'}));
       expect(input).toHaveValue(YAML.stringify({pfs: 'repo'}));

--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListMount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListMount.tsx
@@ -11,7 +11,7 @@ type ListMountProps = {
 const ListMount: React.FC<ListMountProps> = ({item, open, updateData}) => {
   const [disabled, setDisabled] = useState<boolean>(false);
   const branch = item.branch;
-  const buttonText = 'Unmount';
+  const buttonText = 'Unload';
 
   const openFolder = () => {
     open(item.name);

--- a/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/ListUnmount.tsx
@@ -25,7 +25,7 @@ const ListUnmount: React.FC<ListUnmountProps> = ({
   const [disabled, setDisabled] = useState<boolean>(false);
   const [authorized, setAuthorized] = useState<boolean>(false);
   const hasBranches = item?.branches?.length > 0;
-  const buttonText = 'Mount';
+  const buttonText = 'Load';
 
   useEffect(() => {
     setAuthorized(item.authorization !== 'none');

--- a/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/SortableList/__tests__/SortableList.test.tsx
@@ -133,7 +133,7 @@ describe('sortable list components', () => {
       />,
     );
     const listItem = getByTestId('ListItem__repo');
-    const mountButton = getByTestId('ListItem__mount');
+    const mountButton = getByTestId('ListItem__load');
 
     expect(listItem).toHaveTextContent('images');
     expect(mountButton).not.toBeDisabled();
@@ -177,7 +177,7 @@ describe('sortable list components', () => {
       />,
     );
     const listItem = getByTestId('ListItem__repo');
-    const unmountButton = getByTestId('ListItem__unmount');
+    const unmountButton = getByTestId('ListItem__unload');
 
     expect(listItem).toHaveTextContent('images');
     expect(unmountButton).not.toBeDisabled();
@@ -246,7 +246,7 @@ describe('sortable list components', () => {
     expect(select.value).toBe('master');
     fireEvent.change(select, {target: {value: 'develop'}});
 
-    getByText('Mount').click();
+    getByText('Load').click();
     expect(mockRequestAPI.requestAPI).toHaveBeenCalledWith('_mount', 'PUT', {
       mounts: [
         {
@@ -318,7 +318,7 @@ describe('sortable list components', () => {
         projects={[]}
       />,
     );
-    const unmountButtons = getAllByTestId('ListItem__unmount');
+    const unmountButtons = getAllByTestId('ListItem__unload');
     expect(unmountButtons[0]).toBeDisabled();
     expect(unmountButtons[1]).toBeDisabled();
     expect(unmountButtons[2]).toBeDisabled();
@@ -432,10 +432,10 @@ describe('sortable list components', () => {
     fireEvent.change(getByTestId('ListItem__select'), {
       target: {value: 'mounted_branch'},
     });
-    expect(getByTestId('ListItem__mount')).toBeDisabled();
+    expect(getByTestId('ListItem__load')).toBeDisabled();
 
     fireEvent.change(getByTestId('ListItem__select'), {target: {value: 'dev'}});
-    expect(getByTestId('ListItem__mount')).not.toBeDisabled();
+    expect(getByTestId('ListItem__load')).not.toBeDisabled();
   });
 
   it('project filtering', async () => {


### PR DESCRIPTION
https://pachyderm.atlassian.net/browse/INT-1160

Updated the few instances of `Mount` and `Unmount` to be `Load` and `Unload` respectively. Each instance mentioned in the story was updated and I also searched for both strings in the `./jupyter-extension/` directory. Test ids/findByText references for both strings were also updated. There are definitely a lot more references to mount/unmount I noticed in our classes and function names, but those seem out of scope for the story.

I made a few updates to the README.md to note that python 3.8.X should be used and `--ip=0.0.0.0` needs to be specified for the Linux VM development environment. They aren't really related to this story, but they were such small changes that it seemed unnecessary to create another PR.