### PR TITLE
[Jupyter] Writing config files and Auth bugfixes

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -2,7 +2,9 @@ import os
 from pathlib import Path
 from distutils.util import strtobool
 
-PACH_CONFIG = os.environ.get("PACH_CONFIG", Path.home() / ".pachyderm/config.json")
+from pachyderm_sdk.constants import CONFIG_PATH_LOCAL
+
+PACH_CONFIG = Path(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -4,7 +4,9 @@ from distutils.util import strtobool
 
 from pachyderm_sdk.constants import CONFIG_PATH_LOCAL
 
-PACH_CONFIG = Path(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
+PACH_CONFIG = Path(
+    os.path.expanduser(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
+).resolve()
 PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -352,7 +352,7 @@ class ConfigHandler(BaseHandler):
         try:
             self.client = Client.from_pachd_address(address, root_certs=cas)
             cluster_status = self.cluster_status
-            get_logger().debug(f" ClusterStatus: {cluster_status}")
+            get_logger().info(f"({address}) cluster status: {cluster_status}")
         except Exception as e:
             get_logger().error(
                 f"Error updating config with endpoint {body['pachd_address']}.",
@@ -369,7 +369,6 @@ class ConfigHandler(BaseHandler):
                 write_config(self.client.address, self.client.root_certs, None)
             except RuntimeError as e:
                 get_logger().error(f"Error writing local config: {e}.", exc_info=True)
-                raise tornado.web.HTTPError(500, f"Error writing local config: {e}.")
 
         payload = {"cluster_status": cluster_status, "pachd_address": self.client.address}
         await self.finish(json.dumps(payload))

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -554,10 +554,13 @@ def write_config(
     ------
     RuntimeError: If unable to parse an already existing config file.
     """
+    if server_cas is not None:
+        # server_cas are base64 encoded strings in the config file.
+        server_cas = b64encode(server_cas).decode("utf-8")
     context = Context(
         pachd_address=pachd_address,
         session_token=session_token,
-        server_cas=server_cas and b64encode(server_cas).decode("utf-8"),
+        server_cas=server_cas,
     )
     name = f"jupyter-{pachd_address}"
     if PACH_CONFIG.exists():

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -1,14 +1,22 @@
+from base64 import b64encode
+from pathlib import Path
+import json
+import traceback
+from typing import Optional
+
+import grpc
+import grpc.aio
 from jupyter_server.base.handlers import APIHandler, path_regex
 from jupyter_server.services.contents.handlers import ContentsHandler, validate_model
 from jupyter_server.utils import url_path_join
-import asyncio
-import grpc
-import json
 from pachyderm_sdk import Client, errors
-from pathlib import Path
+from pachyderm_sdk.api.auth import AuthenticateRequest, AuthenticateResponse
+from pachyderm_sdk.config import ConfigFile, Context
 import tornado
-import traceback
+import tornado.concurrent
+import tornado.web
 
+from .env import PACH_CONFIG
 from .log import get_logger
 from .pfs_manager import PFSManager, DatumManager
 from .pps_client import PPSClient
@@ -23,6 +31,13 @@ class BaseHandler(APIHandler):
     @property
     def client(self) -> Client:
         return self.settings["pachyderm_client"]
+
+    @client.setter
+    def client(self, new_client: Client) -> None:
+        self.settings["pachyderm_client"] = new_client
+        self.settings["pfs_contents_manager"] = PFSManager(client=new_client)
+        self.settings["datum_contents_manager"] = DatumManager(client=new_client)
+        self.settings["pachyderm_pps_client"] = PPSClient(client=new_client)
 
     @property
     def pfs_manager(self) -> PFSManager:
@@ -293,53 +308,44 @@ class ViewDatumHandler(ContentsHandler):
         self._finish_model(model, location=False)
 
 
-# TODO: see about writing to/from config file
 class ConfigHandler(BaseHandler):
-    CLUSTER_AUTH_ENABLED = "AUTH_ENABLED"
-    CLUSTER_AUTH_DISABLED = "AUTH_DISABLED"
     CLUSTER_INVALID = "INVALID"
+    CLUSTER_VALID_NO_AUTH = "VALID_NO_AUTH"
+    CLUSTER_VALID_LOGGED_IN = "VALID_LOGGED_IN"
+    CLUSTER_VALID_LOGGED_OUT = "VALID_LOGGED_OUT"
 
-    def config_response(self) -> bytes:
+    @property
+    def cluster_status(self) -> str:
         if not self.client:
-            return json.dumps({"cluster_status": self.CLUSTER_INVALID})
-
+            return self.CLUSTER_INVALID
         try:
             self.client.auth.who_am_i()
-            cluster_status = self.CLUSTER_AUTH_ENABLED
         except grpc.RpcError as err:
+            err: grpc.Call
             if err.code() == grpc.StatusCode.UNAUTHENTICATED:
-                cluster_status = self.CLUSTER_AUTH_ENABLED
+                return self.CLUSTER_VALID_LOGGED_OUT
             elif (
                 err.code() == grpc.StatusCode.UNIMPLEMENTED
                 and "the auth service is not activated" in err.details()
             ):
-                cluster_status = self.CLUSTER_AUTH_DISABLED
+                return self.CLUSTER_VALID_NO_AUTH
             else:
-                cluster_status = self.CLUSTER_INVALID
+                return self.CLUSTER_INVALID
         except errors.AuthServiceNotActivated:
-            cluster_status = self.CLUSTER_AUTH_DISABLED
+            return self.CLUSTER_VALID_NO_AUTH
         except ConnectionError:
-            cluster_status = self.CLUSTER_INVALID
-
-        return json.dumps(
-            {"cluster_status": cluster_status, "pachd_address": self.client.address}
-        )
+            return self.CLUSTER_INVALID
+        else:
+            return self.CLUSTER_VALID_LOGGED_IN
 
     @tornado.web.authenticated
     async def put(self):
+        body = self.get_json_body()
         try:
-            body = self.get_json_body()
             address = body["pachd_address"]
             cas = bytes(body["server_cas"], "utf-8") if "server_cas" in body else None
-
-            client = Client().from_pachd_address(pachd_address=address, root_certs=cas)
-            self.settings["pachyderm_client"] = client
-            self.settings["pfs_contents_manager"] = PFSManager(client=client)
-            self.settings["datum_contents_manager"] = DatumManager(client=client)
-            self.settings["pachyderm_pps_client"] = PPSClient(client=client)
-
-            response = self.config_response()
-            self.finish(response)
+            client = Client.from_pachd_address(address, root_certs=cas)
+            self.client = client
         except Exception as e:
             get_logger().error(
                 f"Error updating config with endpoint {body['pachd_address']}.",
@@ -350,11 +356,29 @@ class ConfigHandler(BaseHandler):
                 reason=f"Error updating config with endpoint {body['pachd_address']}: {e}.",
             )
 
+        # Test client connection to cluster.
+        cluster_status = self.cluster_status
+        get_logger().debug(f" ClusterStatus: {cluster_status}")
+
+        if cluster_status != self.CLUSTER_INVALID:
+            # Attempt to write new pachyderm context to config.
+            try:
+                write_config(client.address, client.root_certs, None)
+            except RuntimeError as e:
+                get_logger().error(f"Error writing local config: {e}.", exc_info=True)
+                raise tornado.web.HTTPError(500, f"Error writing local config: {e}.")
+
+        payload = {"cluster_status": cluster_status, "pachd_address": client.address}
+        await self.finish(json.dumps(payload))
+
     @tornado.web.authenticated
     async def get(self):
         try:
-            response = self.config_response()
-            self.finish(response)
+            payload = {
+                "cluster_status": self.cluster_status,
+                "pachd_address": self.client.address,
+            }
+            await self.finish(json.dumps(payload))
         except Exception as e:
             get_logger().error("Error getting config.", exc_info=True)
             raise tornado.web.HTTPError(
@@ -363,20 +387,52 @@ class ConfigHandler(BaseHandler):
 
 
 class AuthLoginHandler(BaseHandler):
-    async def get_token(self, oidc_state: str):
-        token = self.client.auth.authenticate(oidc_state=oidc_state).pach_token
-        self.settings["pachyderm_client"].auth_token = token
-        self.settings["pfs_contents_manager"] = PFSManager(client=self.client)
-        self.settings["datum_contents_manager"] = DatumManager(client=self.client)
-        self.settings["pachyderm_pps_client"] = PPSClient(client=self.client)
 
     @tornado.web.authenticated
     async def put(self):
         try:
+            # Note: The auth workflow is for the backend to initiate the process by
+            # calling auth.get_oidc_login() which returns a url for the user to login
+            # with, and a state token that the backend can use to complete the workflow.
+            # Therefore, we send the url to the frontend for the user to login with and
+            # wait until the server has created a new session token, which we then retrieve.
             oidc_response = self.client.auth.get_oidc_login()
-            asyncio.create_task(self.get_token(oidc_response.state))
             response = oidc_response.to_json()
-            self.finish(response)
+            await self.finish(response)
+
+            # Unfortunately, there doesn't seem to be a way for us to use the synchronous
+            # version of client.auth.authenticate because it is blocking -- using it blocks
+            # the entire server until either the user successfully logs in or the OIDC login
+            # attempt times out. So, we need to manually do this Authenticate asynchronously.
+            async with grpc.aio.insecure_channel(self.client.address) as channel:
+                async_authenticate = channel.unary_unary(
+                    "/auth_v2.API/Authenticate",
+                    request_serializer=AuthenticateRequest.SerializeToString,
+                    response_deserializer=AuthenticateResponse.FromString,
+                )
+                try:
+                    response = await async_authenticate(
+                        AuthenticateRequest(oidc_state=oidc_response.state),
+                    )
+                except grpc.RpcError as err:
+                    # If the user opens several login attempts, we don't have a clear
+                    # mechanism to cull them after they have successfully logged in.
+                    # When the call inevitably times out, we don't raise and log a warning.
+                    details = err.details()
+                    if "OIDC state token expired" in details:
+                        get_logger().warning(details)
+                        return
+                    raise err
+                token = response.pach_token
+            self.client.auth_token = token
+
+            # Attempt to write new pachyderm context to config.
+            try:
+                write_config(self.client.address, self.client.root_certs, token)
+            except RuntimeError as e:
+                get_logger().error(f"Error updating local config: {e}.", exc_info=True)
+                raise tornado.web.HTTPError(500, f"Error updating local config: {e}.")
+
         except Exception as e:
             get_logger().error("Error logging in to auth.", exc_info=True)
             raise tornado.web.HTTPError(
@@ -476,9 +532,45 @@ class TestDownloadHandler(BaseHandler):
         await self.finish()
 
 
+def write_config(
+    pachd_address: str, server_cas: Optional[bytes], session_token: Optional[str],
+) -> None:
+    """Writes the pachd_address/server_cas context to the local config file.
+    This will create a new config file if one does not exist.
+
+    Parameters
+    ----------
+    pachd_address : str
+        The address to the pachd instance.
+    server_cas : bytes, optional
+        The certs used to establish TLS connections to the pachd instance.
+    session_token : str, optional
+        The pachyderm token used to authenticate your user session.
+
+    Raises
+    ------
+    RuntimeError: If unable to parse an already existing config file.
+    """
+    context = Context(
+        pachd_address=pachd_address,
+        session_token=session_token,
+        server_cas=server_cas and b64encode(server_cas).decode("utf-8"),
+    )
+    name = f"jupyter-{pachd_address}"
+    if PACH_CONFIG.exists():
+        try:
+            config = ConfigFile.from_path(PACH_CONFIG)
+        except Exception:
+            raise RuntimeError(f"failed to load config file: {PACH_CONFIG}")
+        config.add_context(name, context, overwrite=True)
+    else:
+        config = ConfigFile.new_with_context(name, context)
+    config.write(PACH_CONFIG)
+
+
 def setup_handlers(web_app):
     try:
-        client = Client().from_config()
+        client = Client().from_config(PACH_CONFIG)
         get_logger().debug(
             f"Created Pachyderm client for {client.address} from local config"
         )

--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 install_requires =
   pyyaml>=6.0
   jupyter_server>=2.7.0,<2.8
-  pachyderm_sdk>=2.8.0a5
+  pachyderm_sdk>=2.9.0a2
 include_package_data = True
 zip_safe = False
 python_requires = >=3.8,<4

--- a/jupyter-extension/src/plugins/mount/components/Config/Config.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/Config.tsx
@@ -10,7 +10,6 @@ import {KubernetesElephant} from '../../../../utils/components/Svgs';
 type ConfigProps = {
   showConfig: boolean;
   setShowConfig: (shouldShow: boolean) => void;
-  reposStatus?: number;
   updateConfig: (shouldShow: AuthConfig) => void;
   authConfig: AuthConfig;
   refresh: () => Promise<void>;
@@ -19,7 +18,6 @@ type ConfigProps = {
 const Config: React.FC<ConfigProps> = ({
   showConfig,
   setShowConfig,
-  reposStatus,
   updateConfig,
   authConfig,
   refresh,
@@ -34,25 +32,21 @@ const Config: React.FC<ConfigProps> = ({
     updatePachdAddress,
     callLogin,
     callLogout,
-    shouldShowLogin,
+    clusterStatus,
     loading,
     showAdvancedOptions,
     setShowAdvancedOptions,
     serverCa,
     setServerCa,
-  } = useConfig(
-    showConfig,
-    setShowConfig,
-    updateConfig,
-    authConfig,
-    refresh,
-    reposStatus,
-  );
-
+  } = useConfig(showConfig, setShowConfig, updateConfig, authConfig, refresh);
+  const authEnabled =
+    clusterStatus === 'VALID_LOGGED_IN' || clusterStatus === 'VALID_LOGGED_OUT';
+  const connectedToCluster =
+    clusterStatus === 'VALID_NO_AUTH' || clusterStatus === 'VALID_LOGGED_IN';
   return (
     <>
       <div className="pachyderm-mount-config-form-base">
-        {reposStatus === 200 && (
+        {connectedToCluster && (
           <div className="pachyderm-mount-config-back">
             <button
               data-testid="Config__back"
@@ -230,9 +224,9 @@ const Config: React.FC<ConfigProps> = ({
             </div>
           )}
         </div>
-        {shouldShowLogin && !shouldShowAddressInput && (
+        {authEnabled && !shouldShowAddressInput && (
           <div className="pachyderm-mount-login-container">
-            {reposStatus === 200 ? (
+            {clusterStatus === 'VALID_LOGGED_IN' ? (
               <button
                 data-testid="Config__logout"
                 className="pachyderm-button"

--- a/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
@@ -48,7 +48,7 @@ describe('config screen', () => {
   describe('AUTH_ENABLED config', () => {
     it('should show authenticated view', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_ENABLED',
+        cluster_status: 'VALID_LOGGED_OUT',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
@@ -74,7 +74,7 @@ describe('config screen', () => {
 
     it('should show unauthenticated view', () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_ENABLED',
+        cluster_status: 'VALID_LOGGED_OUT',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
@@ -100,7 +100,7 @@ describe('config screen', () => {
 
     it('should allow user to login', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_ENABLED',
+        cluster_status: 'VALID_LOGGED_OUT',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
@@ -171,7 +171,7 @@ describe('config screen', () => {
   describe('AUTH_DISABLED config', () => {
     it('should display default view', () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_DISABLED',
+        cluster_status: 'VALID_NO_AUTH',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
@@ -198,7 +198,7 @@ describe('config screen', () => {
 
   it('should allow user to navigate back to mount screen if get repos is sucessful', () => {
     const authConfig: AuthConfig = {
-      cluster_status: 'AUTH_ENABLED',
+      cluster_status: 'VALID_LOGGED_IN',
       pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
     };
 
@@ -284,13 +284,13 @@ describe('config screen', () => {
 
     it('should allow user to update config', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_ENABLED',
+        cluster_status: 'VALID_LOGGED_IN',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
       mockRequestAPI.requestAPI.mockImplementation(
         mockedRequestAPI({
-          cluster_status: 'AUTH_ENABLED',
+          cluster_status: 'VALID_LOGGED_IN',
           pachd_address:
             'grpcs://hub-123-123123123.clusters.pachyderm.io:31400',
         }),
@@ -332,13 +332,13 @@ describe('config screen', () => {
 
     it('should allow user to set advanced config options', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_ENABLED',
+        cluster_status: 'VALID_LOGGED_IN',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
       mockRequestAPI.requestAPI.mockImplementation(
         mockedRequestAPI({
-          cluster_status: 'AUTH_ENABLED',
+          cluster_status: 'VALID_LOGGED_IN',
           pachd_address:
             'grpcs://hub-123-123123123.clusters.pachyderm.io:31400',
         }),

--- a/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
@@ -47,7 +47,7 @@ describe('config screen', () => {
   describe('AUTH_ENABLED config', () => {
     it('should show authenticated view', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'VALID_LOGGED_OUT',
+        cluster_status: 'VALID_LOGGED_IN',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
@@ -95,9 +95,9 @@ describe('config screen', () => {
       expect(queryByTestId('Config__logout')).not.toBeInTheDocument();
     });
 
-    it('should allow user to login', async () => {
+    it('should allow user to logout', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'VALID_LOGGED_OUT',
+        cluster_status: 'VALID_LOGGED_IN',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
@@ -120,27 +120,24 @@ describe('config screen', () => {
         );
       });
     });
-    /* TODO: tests must be updated for the new FUSE-less impl
-    it('should allow user to logout', async () => {
+
+    it('should allow user to login', async () => {
       const authConfig: AuthConfig = {
-        cluster_status: 'AUTH_ENABLED',
+        cluster_status: 'VALID_LOGGED_OUT',
         pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
       };
 
       window.open = jest.fn();
-
+      const loginUrl =
+        'https://hub-c0-jwn7iwcca9.clusters.pachyderm.io/dex/auth?client_id=pachd';
       mockRequestAPI.requestAPI.mockImplementation(
-        mockedRequestAPI({
-          auth_url:
-            'https://hub-c0-jwn7iwcca9.clusters.pachyderm.io/dex/auth?client_id=pachd',
-        }),
+        mockedRequestAPI({loginUrl: loginUrl}),
       );
 
       const {findByTestId} = render(
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={401}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -156,12 +153,8 @@ describe('config screen', () => {
         );
       });
 
-      expect(window.open).toHaveBeenCalledWith(
-        'https://hub-c0-jwn7iwcca9.clusters.pachyderm.io/dex/auth?client_id=pachd',
-        '',
-        'width=500,height=500,left=262,top=107.2',
-      );
-    });*/
+      expect(window.open).toHaveBeenCalledWith(loginUrl, '', expect.anything());
+    });
   });
 
   describe('AUTH_DISABLED config', () => {
@@ -191,7 +184,7 @@ describe('config screen', () => {
     });
   });
 
-  it('should allow user to navigate back to mount screen if get repos is sucessful', () => {
+  it('shows back button when successfully connected to cluster', () => {
     const authConfig: AuthConfig = {
       cluster_status: 'VALID_LOGGED_IN',
       pachd_address: 'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
@@ -207,7 +200,6 @@ describe('config screen', () => {
       />,
     );
 
-    expect(setShowConfig).not.toHaveBeenCalled();
     getByTestId('Config__back').click();
     expect(setShowConfig).toHaveBeenCalledWith(false);
   });

--- a/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
@@ -28,7 +28,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={401}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -56,7 +55,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={200}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -82,7 +80,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={401}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -108,7 +105,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={200}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -179,7 +175,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={200}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -206,7 +201,6 @@ describe('config screen', () => {
       <Config
         showConfig={true}
         setShowConfig={setShowConfig}
-        reposStatus={200}
         updateConfig={updateConfig}
         authConfig={authConfig}
         refresh={jest.fn()}
@@ -234,7 +228,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={200}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -300,7 +293,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={200}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}
@@ -348,7 +340,6 @@ describe('config screen', () => {
         <Config
           showConfig={true}
           setShowConfig={setShowConfig}
-          reposStatus={200}
           updateConfig={updateConfig}
           authConfig={authConfig}
           refresh={jest.fn()}

--- a/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
@@ -39,7 +39,7 @@ export const useConfig = (
 
   useEffect(() => {
     if (showConfig) {
-      setShouldShowLogin(authConfig.cluster_status === 'AUTH_ENABLED');
+      setShouldShowLogin(authConfig.cluster_status === 'VALID_LOGGED_OUT');
       setShouldShowAddressInput(authConfig.cluster_status === 'INVALID');
     }
     setErrorMessage('');
@@ -83,7 +83,7 @@ export const useConfig = (
           setErrorMessage('Invalid address.');
         } else {
           updateConfig(response);
-          setShouldShowLogin(response.cluster_status === 'AUTH_ENABLED');
+          setShouldShowLogin(response.cluster_status === 'VALID_LOGGED_OUT');
         }
       } else {
         setErrorMessage(

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -120,9 +120,6 @@ export class MountPlugin implements IMountPlugin {
                   <Config
                     showConfig={showConfig ? showConfig : this._showConfig}
                     setShowConfig={this.setShowConfig}
-                    reposStatus={
-                      status ? status.code : this._poller.status.code
-                    }
                     updateConfig={this.updateConfig}
                     authConfig={authConfig ? authConfig : this._poller.config}
                     refresh={this._poller.refresh}

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -160,6 +160,7 @@ export class MountPlugin implements IMountPlugin {
               </button>
               <button
                 className="pachyderm-button-link"
+                data-testid="Config__mode"
                 onClick={() => this.setShowConfig(true)}
               >
                 <settingsIcon.react

--- a/jupyter-extension/src/plugins/mount/pollMounts.ts
+++ b/jupyter-extension/src/plugins/mount/pollMounts.ts
@@ -167,7 +167,10 @@ export class PollMounts {
     try {
       const config = await requestAPI<AuthConfig>('config', 'GET');
       this.config = config;
-      if (config.cluster_status !== 'INVALID') {
+      if (
+        config.cluster_status !== 'INVALID' &&
+        config.cluster_status !== 'VALID_LOGGED_OUT'
+      ) {
         const data = await requestAPI<ListMountsResponse>('mounts', 'GET');
         this.status = {code: 200};
         this.updateData(data);

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -13,6 +13,7 @@ export type mountState =
   | '';
 
 export type clusterStatus =
+  | 'NONE'
   | 'INVALID'
   | 'VALID_NO_AUTH'
   | 'VALID_LOGGED_IN'

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -12,7 +12,11 @@ export type mountState =
   | 'unmounted'
   | '';
 
-export type clusterStatus = 'INVALID' | 'AUTH_DISABLED' | 'AUTH_ENABLED';
+export type clusterStatus =
+  | 'INVALID'
+  | 'VALID_NO_AUTH'
+  | 'VALID_LOGGED_IN'
+  | 'VALID_LOGGED_OUT';
 
 export type authorization = 'off' | 'none' | 'read' | 'write';
 


### PR DESCRIPTION
Adds support for writing/updating the config file local to the backend server. This also updates the config file when the user logs in, meaning they will be logged in across sessions.

### Bugfixes.
Two main ones:
1. [INT-1161] If the active context of the pachyderm config file connected to an auth-enabled cluster but the user was not logged into that cluster, the extension was inaccessible. The config file being present bypassed the config screen within the extension, but the user wasn't able to access the cluster which crashed the extension.

We needed to expand the possible cluster states to
```ts
export type clusterStatus = 'INVALID' | 'VALID_NO_AUTH' | 'VALID_LOGGED_IN' | 'VALID_LOGGED_OUT'
```

2. Login failure made extension non-responsive. The cause of this was that the `client.auth.authenticate` call in the backed is blocking and completes only if the user successfully logs in, or the OIDC event times out. Experimented with several different ways to fix this, but ended up implemented the asynchronous `authenticate` call by hand so that the code no longer blocks. We should probably discuss this code.

### Tests
These bugs have gone unnoticed partially because we don't test this code at all. How do we fix this?

[INT-1161]: https://pachyderm.atlassian.net/browse/INT-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ