### PR TITLE
[INT-843] Support packaging external files

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -420,7 +420,7 @@ class PPSCreateHandler(BaseHandler):
         except Exception as e:
             if isinstance(e, tornado.web.HTTPError):
                 # Common case: only way to print the "reason" field of HTTPError
-                get_logger().error(f"couldn't create pipeline: {e.reason}")
+                get_logger().error(f"Couldn't create pipeline: {e.reason}")
             get_logger().error(
                 "\n".join(traceback.format_exception(type(e), value=e, tb=None))
             )
@@ -437,7 +437,7 @@ class PPSCreateHandler(BaseHandler):
         except Exception as e:
             if isinstance(e, tornado.web.HTTPError):
                 # Common case: only way to print the "reason" field of HTTPError
-                get_logger().error(f"couldn't create pipeline: {e.reason}")
+                get_logger().error(f"Couldn't create pipeline: {e.reason}")
             get_logger().error(
                 "\n".join(traceback.format_exception(type(e), value=e, tb=None))
             )

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -72,7 +72,7 @@ class PpsConfig:
 
         external_files = []
         external_files_str = config.get("external_files")
-        if isinstance(external_files_str, str):
+        if external_files_str:
             for external_file in external_files_str.strip().split(','):
                 external_files.append(os.path.join(notebook_directory, external_file.strip()))
 

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -206,7 +206,7 @@ def upload_environment(
                 commit.put_file_from_file(path="/requirements.txt", file=reqs_file)
         for external_file in config.external_files:
             with open(external_file, "rb") as external_file_data:
-                commit.put_file_from_file(path=f'/{external_file}', file=external_file_data)
+                commit.put_file_from_file(path=f'/{os.path.basename(external_file)}', file=external_file_data)
         commit.put_file_from_bytes(
             path="/entrypoint.py", data=entrypoint_script.encode("utf-8")
         )
@@ -281,7 +281,7 @@ class PPSClient:
         
         for external_file in config.external_files:
             if not os.path.exists(external_file):
-                raise HTTPError(status_code=400, reason=f'external file {external_file} could not be found in the directory of the Jupyter notebook')
+                raise HTTPError(status_code=400, reason=f'external file {os.path.basename(external_file)} could not be found in the directory of the Jupyter notebook')
 
         script, _resources = self.nbconvert.from_filename(str(path))
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -475,13 +475,13 @@ def simple_pachyderm_env(request):
     pipeline = pps.Pipeline(project=project, name=f"test_pipeline_{suffix}")
     companion_repo = pfs.Repo(name=f"{pipeline.name}__context", project=project)
     client.pfs.create_repo(repo=repo)
-    yield client, repo, pipeline
+    yield client, repo, companion_repo, pipeline
     client.pps.delete_pipeline(pipeline=pipeline, force=True)
     client.pfs.delete_repo(repo=companion_repo, force=True)
     client.pfs.delete_repo(repo=repo, force=True)
 
 
-def _update_metadata(notebook: Path, repo: pfs.Repo, pipeline: pps.Pipeline) -> str:
+def _update_metadata(notebook: Path, repo: pfs.Repo, pipeline: pps.Pipeline, external_files: str = '') -> str:
     """Updates the metadata of the specified notebook file with the specified
     project/repo/pipeline information.
 
@@ -496,6 +496,7 @@ def _update_metadata(notebook: Path, repo: pfs.Repo, pipeline: pps.Pipeline) -> 
     config.requirements = str(
         notebook.with_name(config.requirements).relative_to(os.getcwd())
     )
+    config.external_files = external_files
     notebook_data["metadata"][METADATA_KEY]["config"] = config.to_dict()
     return json.dumps(notebook_data)
 
@@ -508,7 +509,7 @@ def notebook_path(simple_pachyderm_env) -> Path:
       with the expected pipeline and repo names provided by the
       simple_pachyderm_env fixture.
     """
-    _client, repo, pipeline = simple_pachyderm_env
+    _client, repo, _companion_repo, pipeline = simple_pachyderm_env
 
     # Do a considerable amount of data munging.
     notebook_data = _update_metadata(TEST_NOTEBOOK, repo, pipeline)
@@ -521,7 +522,7 @@ def notebook_path(simple_pachyderm_env) -> Path:
 
 
 def test_pps(dev_server, simple_pachyderm_env, notebook_path):
-    client, repo, pipeline = simple_pachyderm_env
+    client, repo, _companion_repo, pipeline = simple_pachyderm_env
     with client.pfs.commit(branch=pfs.Branch(repo=repo, name="master")) as commit:
         client.pfs.put_file_from_bytes(commit=commit, path="/data", data=b"data")
     last_modified = datetime.utcfromtimestamp(os.path.getmtime(notebook_path))
@@ -542,16 +543,62 @@ def test_pps_last_modified_time_not_specified_validation(dev_server, notebook_pa
     assert r.status_code == 400, r.text
     assert r.json()["reason"] == f"Bad Request: last_modified_time not specified"
 
-def test_pps_external_files_do_not_exist_validation(dev_server, notebook_path):
-    client, repo, pipeline = simple_pachyderm_env   
-    with client.pfs.commit(branch=pfs.Branch(repo=repo, name="master")) as commit:
-        client.pfs.put_file_from_bytes(commit=commit, path="/data", data=b"data")
+@pytest.mark.parametrize("simple_pachyderm_env", [True], indirect=True)
+def test_pps_external_files_do_not_exist_validation(
+    dev_server, simple_pachyderm_env, notebook_path
+):
+    _client, repo, _companion_repo, pipeline = simple_pachyderm_env
+
+    # Specifying 'fakefile.py' when no such file exists is what forces the error asserted at the end of this test
+    new_notebook_data = _update_metadata(TEST_NOTEBOOK, repo, pipeline, 'fakefile.py')
+
+    notebook_path.write_text(new_notebook_data)
     last_modified = datetime.utcfromtimestamp(os.path.getmtime(notebook_path))
     data = dict(last_modified_time=f"{datetime.isoformat(last_modified)}Z")
-    r = requests.put(f"{BASE_URL}/pps/_create/{notebook_path}", data=json.dumps(data))
-    assert r.status_code == 400, r.text
-    assert r.json()["reason"] == f"Bad Request: last_modified_time not specified"
+    r = requests.put(
+        f"{BASE_URL}/pps/_create/{notebook_path}", data=json.dumps(data)
+    )
+    
+    assert r.status_code == 400
+    assert r.json()["message"] == 'Bad Request'
+    assert r.json()["reason"] == 'external file fakefile.py could not be found in the directory of the Jupyter notebook'
 
+@pytest.mark.parametrize("simple_pachyderm_env", [True], indirect=True)
+def test_pps_uploads_external_files(
+    dev_server, simple_pachyderm_env, notebook_path
+):
+    client, repo, companion_repo, pipeline = simple_pachyderm_env
+    new_notebook_data = _update_metadata(TEST_NOTEBOOK, repo, pipeline, 'hello.py,world.py')
+    notebook_path.write_text(new_notebook_data)
+    last_modified = datetime.utcfromtimestamp(os.path.getmtime(notebook_path))
+    data = dict(last_modified_time=f"{datetime.isoformat(last_modified)}Z")
+    try:
+        TEST_NOTEBOOK.with_name("hello.py").write_text("print('hello')")
+        TEST_NOTEBOOK.with_name("world.py").write_text("print('world')")
+
+        r = requests.put(
+            f"{BASE_URL}/pps/_create/{notebook_path}", data=json.dumps(data)
+        )
+
+        assert r.status_code == 200, r.text
+        job_info = next(client.pps.list_job(pipeline=pipeline))
+        job_info = client.pps.inspect_job(job=job_info.job, wait=True)
+        assert job_info.state == pps.JobState.JOB_SUCCESS
+        assert r.json()["message"] == (
+            "Create pipeline request sent. You may monitor its "
+            'status by running "pachctl list pipelines" in a terminal.'
+        )
+        commits = [info.commit.id for info in client.pfs.list_commit(repo=companion_repo)]
+        assert len(commits) == 1
+        file_uri = f'{companion_repo.project.name}/{companion_repo.name}@{commits[0]}:'
+        print(file_uri)
+        with client.pfs.pfs_file(file=pfs.File.from_uri(f'{file_uri}/hello.py')) as pfs_file:
+            assert pfs_file.read().decode() == "print('hello')"
+        with client.pfs.pfs_file(file=pfs.File.from_uri(f'{file_uri}/world.py')) as pfs_file:
+            assert pfs_file.read().decode() == "print('world')"
+    finally:
+        os.remove(TEST_NOTEBOOK.with_name("hello.py"))
+        os.remove(TEST_NOTEBOOK.with_name("world.py"))
 
 @pytest.mark.parametrize("simple_pachyderm_env", [True], indirect=True)
 def test_pps_reuse_pipeline_name_different_project(
@@ -560,7 +607,7 @@ def test_pps_reuse_pipeline_name_different_project(
     """This tests creating a pipeline from a notebook within a project, and then creating a new
     pipeline with the same name inside the default project. A bug existed where reusing the pipeline
     name caused an error."""
-    client, repo, pipeline = simple_pachyderm_env
+    client, repo, _companion_repo, pipeline = simple_pachyderm_env
     test_pps(dev_server, simple_pachyderm_env, notebook_path)
 
     default_project = pfs.Project(name="default")
@@ -597,7 +644,7 @@ def test_pps_update_default_project_pipeline(
     """This tests creating and then updating a pipeline within the default project,
     but doing so using an empty string. A bug existed where we would incorrectly try to
     recreate the existing context repo."""
-    _client, repo, pipeline = simple_pachyderm_env
+    _client, repo, _companion_repo, pipeline = simple_pachyderm_env
     repo: pfs.Repo
     pipeline: pps.Pipeline
     empty_project = pfs.Project(name="")

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -549,9 +549,7 @@ def test_pps_external_files_do_not_exist_validation(
 ):
     _client, repo, _companion_repo, pipeline = simple_pachyderm_env
 
-    # Specifying 'fakefile.py' when no such file exists is what forces the error asserted at the end of this test
-    new_notebook_data = _update_metadata(TEST_NOTEBOOK, repo, pipeline, 'fakefile.py')
-
+    new_notebook_data = _update_metadata(TEST_NOTEBOOK, repo, pipeline, 'does_not_exist.py')
     notebook_path.write_text(new_notebook_data)
     last_modified = datetime.utcfromtimestamp(os.path.getmtime(notebook_path))
     data = dict(last_modified_time=f"{datetime.isoformat(last_modified)}Z")
@@ -561,7 +559,7 @@ def test_pps_external_files_do_not_exist_validation(
     
     assert r.status_code == 400
     assert r.json()["message"] == 'Bad Request'
-    assert r.json()["reason"] == 'external file fakefile.py could not be found in the directory of the Jupyter notebook'
+    assert r.json()["reason"] == 'external file does_not_exist.py could not be found in the directory of the Jupyter notebook'
 
 @pytest.mark.parametrize("simple_pachyderm_env", [True], indirect=True)
 def test_pps_uploads_external_files(

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -27,6 +27,7 @@ pfs:
   glob: /*
 `;
 const placeholderRequirements = './requirements.txt';
+const placeholderExternalFiles = 'library1.py,library2.py'
 const placeholderProject = 'default';
 
 const Pipeline: React.FC<PipelineProps> = ({
@@ -54,6 +55,8 @@ const Pipeline: React.FC<PipelineProps> = ({
     setResourceSpec,
     requirements,
     setRequirements,
+    externalFiles,
+    setExternalFiles,
     callCreatePipeline,
     currentNotebook,
     errorMessage,
@@ -170,6 +173,25 @@ const Pipeline: React.FC<PipelineProps> = ({
           }}
           disabled={loading}
           placeholder={placeholderRequirements}
+        ></input>
+      </div>
+      <div className="pachyderm-pipeline-input-wrapper">
+        <label
+          className="pachyderm-pipeline-input-label"
+          htmlFor="external-files"
+        >
+          External Files:{'  '}
+        </label>
+        <input
+          className="pachyderm-pipeline-input"
+          data-testid="Pipeline__inputExternalFiles"
+          name="externalFiles"
+          value={externalFiles}
+          onChange={(e: any) => {
+            setExternalFiles(e.target.value);
+          }}
+          disabled={loading}
+          placeholder={placeholderExternalFiles}
         ></input>
       </div>
       <div className="pachyderm-pipeline-input-wrapper">
@@ -307,4 +329,7 @@ ${
   );
 };
 
+// TODO errors:
+// {"Couldn't create pipeline: External file library1.py could not be found in the directory of the Jupyter notebook."}
+// {"Couldn't create pipeline: 'library1.py|library2.py' is not a comma separated list of files which is expected for External Files."}
 export default Pipeline;

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -27,7 +27,7 @@ pfs:
   glob: /*
 `;
 const placeholderRequirements = './requirements.txt';
-const placeholderExternalFiles = 'library1.py,library2.py'
+const placeholderExternalFiles = 'library1.py,library2.py';
 const placeholderProject = 'default';
 
 const Pipeline: React.FC<PipelineProps> = ({

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/Pipeline.tsx
@@ -329,7 +329,4 @@ ${
   );
 };
 
-// TODO errors:
-// {"Couldn't create pipeline: External file library1.py could not be found in the directory of the Jupyter notebook."}
-// {"Couldn't create pipeline: 'library1.py|library2.py' is not a comma separated list of files which is expected for External Files."}
 export default Pipeline;

--- a/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Pipeline/hooks/usePipeline.tsx
@@ -30,6 +30,8 @@ export type usePipelineResponse = {
   setResourceSpec: (input: string) => void;
   requirements: string;
   setRequirements: (input: string) => void;
+  externalFiles: string;
+  setExternalFiles: (input: string) => void;
   callCreatePipeline: () => Promise<void>;
   currentNotebook: string;
   errorMessage: string;
@@ -51,6 +53,7 @@ export const usePipeline = (
   const [gpuMode, setGpuMode] = useState(GpuMode.None);
   const [resourceSpec, setResourceSpec] = useState('');
   const [requirements, setRequirements] = useState('');
+  const [externalFiles, setExternalFiles] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [responseMessage, setResponseMessage] = useState('');
   const [currentNotebook, setCurrentNotebook] = useState('None');
@@ -64,6 +67,7 @@ export const usePipeline = (
       ppsContext?.metadata?.config.pipeline.project?.name ?? '',
     );
     setRequirements(ppsContext?.metadata?.config.requirements ?? '');
+    setExternalFiles(ppsContext?.metadata?.config.external_files ?? '');
     setResponseMessage('');
     if (ppsContext?.metadata?.config.input_spec) {
       setInputSpec(ppsContext.metadata.config.input_spec);
@@ -137,6 +141,7 @@ export const usePipeline = (
         pipeline: {name: pipelineName, project: {name: pipelineProject}},
         image: imageName,
         requirements: requirements,
+        external_files: externalFiles,
         input_spec: inputSpec,
         port: pipelinePort,
         gpu_mode: gpuMode,
@@ -163,6 +168,8 @@ export const usePipeline = (
     setResourceSpec,
     requirements,
     setRequirements,
+    externalFiles,
+    setExternalFiles,
     callCreatePipeline,
     currentNotebook,
     errorMessage,

--- a/jupyter-extension/src/plugins/mount/mount.css
+++ b/jupyter-extension/src/plugins/mount/mount.css
@@ -461,3 +461,7 @@ textarea {
 .jp-DirPagination a:hover:not(.active) {
   background-color: var(--jp-layout-color0);
 }
+
+.pachyderm-pipeline-error {
+  color: red;
+}

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -132,6 +132,7 @@ export type PpsConfig = {
   pipeline: Pipeline;
   image: string;
   requirements: string | null;
+  external_files: string | null;
   input_spec: string;
   port: string;
   gpu_mode: GpuMode;


### PR DESCRIPTION
Allow external files to be uploaded to the root of the companion repo with a new "External Files:" optional input that accepts a comma separated list of files. Those files must be in the same directory as the notebook. An error should be shown if any of the files do not exist.

![image](https://github.com/pachyderm/pachyderm/assets/401518/3b65b0e5-7425-49e5-b0af-048715bf0937)

I wrote two new integration tests for both the existing external files case and the non existing external files case. The frontend code seemed light enough to not require any unit tests. A few things I manually tested besides the integration test scenarios.
* Adding unnecessary spaces around each external file name were stripped away.
* External files not being defined does not throw any sort of required warning.
* External files are deleted if they are removed from the config on a second run after being added.

Successful Test
<img width="598" alt="Screenshot 2024-01-09 at 9 27 10 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/46774986-7aa9-4d4a-93e8-905a895132da">
<img width="1074" alt="Screenshot 2024-01-09 at 9 27 21 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/b7b5874a-51cc-449d-86ee-be1e8804de58">
<img width="495" alt="Screenshot 2024-01-09 at 9 27 25 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/0ba94840-fce7-441f-af8b-6f652e1cacbe">
<img width="429" alt="Screenshot 2024-01-09 at 9 27 31 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/c6b6737a-2274-4f8a-a784-6716d0e1a0d1">

Missing External File Test
<img width="583" alt="Screenshot 2024-01-09 at 9 32 32 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/9a9e3138-1f1c-4be4-ac44-ee2f35986fb5">