### PR TITLE
Disable remote cache by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,17 +1,27 @@
 try-import %workspace%/.bazelrc.local
 
-build --bes_results_url=https://app.buildbuddy.io/invocation/
-build --bes_backend=grpcs://remote.buildbuddy.io
-build --build_metadata=REPO_URL=https://github.com/pachyderm/pachyderm
-build --workspace_status_command=$(pwd)/workspace_status.sh
-build --remote_cache=grpcs://pachyderm.buildbuddy.io
-build --remote_timeout=3600
-build --experimental_remote_cache_compression
-build --remote_build_event_upload=minimal
-build --noslim_profile --experimental_profile_include_target_label --experimental_profile_include_primary_output
-build --nolegacy_important_outputs
-build --stamp
-build --modify_execution_info=PackageTar=+no-remote,GoLink=+no-remote,OCIImage=+no-remote
+# For developers with working HTTP/2, allow use of a remote cache.  (CI uses the remote cache.)
+build:remotecache --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remotecache --bes_backend=grpcs://remote.buildbuddy.io
+build:remotecache --build_metadata=REPO_URL=https://github.com/pachyderm/pachyderm
+build:remotecache --remote_cache=grpcs://pachyderm.buildbuddy.io
+build:remotecache --remote_timeout=3600
+build:remotecache --experimental_remote_cache_compression
+build:remotecache --remote_build_event_upload=minimal
+build:remotecache --noslim_profile --experimental_profile_include_target_label --experimental_profile_include_primary_output
+build:remotecache --nolegacy_important_outputs
 
+# This is only relevant for remote caching, but using the same value of modify_execution_info allows
+# sharing the analysis cache between local and remotecache builds, saving time when you switch the
+# flag.
+build --modify_execution_info=PackageTar=+no-remote,GoLink=+no-remote-cache,OCIImage=+no-remote-cache
+
+# Common build options.
+build --workspace_status_command=$(pwd)/workspace_status.sh
+build --stamp
+
+# Common options.
 common --test_env=ENT_ACT_CODE
+
+# --config=race for running tests with the race detector.
 test:race --@rules_go//go/config:race

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1604,10 +1604,10 @@ jobs:
           chown bazel -R /code
           popd
       - run: su bazel -c 'bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto'
-      - run: su bazel -c 'git checkout BAZEL.module.lock' # For OSX-only changes.
+      - run: su bazel -c 'git checkout MODULE.bazel.lock' # For OSX-only changes.
       - run: su bazel -c 'git diff --exit-code'
       - run: su bazel -c 'bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle'
-      - run: su bazel -c 'git checkout BAZEL.module.lock' # For OSX-only changes.
+      - run: su bazel -c 'git checkout MODULE.bazel.lock' # For OSX-only changes.
       - run: su bazel -c 'git diff --exit-code'
       - run: su bazel -c 'bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test'
       - run: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1603,11 +1603,13 @@ jobs:
           useradd bazel -m
           chown bazel -R /code
           popd
-      - run: su bazel -c 'bazel run --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto'
+      - run: su bazel -c 'bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto'
+      - run: su bazel -c 'git checkout BAZEL.module.lock' # For OSX-only changes.
       - run: su bazel -c 'git diff --exit-code'
-      - run: su bazel -c 'bazel run --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle'
+      - run: su bazel -c 'bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle'
+      - run: su bazel -c 'git checkout BAZEL.module.lock' # For OSX-only changes.
       - run: su bazel -c 'git diff --exit-code'
-      - run: su bazel -c 'bazel test --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test'
+      - run: su bazel -c 'bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test'
       - run: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
       - store_test_results:
           path: /tmp/bazel-testlogs/
@@ -1630,7 +1632,7 @@ jobs:
           chown bazel -R /code
           popd
       - setup_remote_docker
-      - run: su bazel -c 'bazel test --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //oci:all'
+      - run: su bazel -c 'bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //oci:all'
       - run: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
       - store_test_results:
           path: /tmp/bazel-testlogs/


### PR DESCRIPTION
People that work in the office or use the VPN can't use the remote cache because our proxy blocks HTTP/2.  Fun!  This moves the remote cache configuration to a `--config=remotecache` option, which can be set up in `.bazelrc.local`.

I also added documentation for how to get Bazel to trust our custom TLS MITM certs.  Secure!