### PR TITLE
re-enable jupyter extension e2e tests

### DIFF
--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -4,21 +4,20 @@ describe('mount', () => {
     cy.isAppReady();
     cy.unmountAllRepos();
     cy.openMountPlugin();
-    cy.findAllByText('Mount');
+    cy.findAllByText('Load');
     cy.wait(3000);
   });
 
-  /* TODO: tests must be updated for the new FUSE-less impl
   it('should mount and unmount pachyderm repos', () => {
-    cy.findAllByText('Mount').first().click();
-    cy.findAllByText('Unmount').first().click();
-    cy.findAllByText('Mount').should('have.length', 1);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').first().click();
+    cy.findAllByText('Load').should('have.length', 1);
   });
 
   it('file browser should show correct breadcrumbs', () => {
-    cy.findByText('/ pfs').should('have.length', 2);
-    cy.findAllByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('/ pfs').should('have.length', 2);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
 
     cy.get('[id="pachyderm-mount"] div.jp-FileBrowser-crumbs')
@@ -29,22 +28,22 @@ describe('mount', () => {
 
   it("should correctly mount a repo's branch", () => {
     cy.findByTestId('ListItem__select').select('branch');
-    cy.findAllByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
     cy.findAllByText('default_images_branch').first().click();
     cy.findAllByText('branch.png').should('have.length', 1);
   });
 
   it('should open mounted directory in the file browser on click', () => {
-    cy.findAllByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
     cy.findAllByText('liberty.png').should('have.length', 1);
   });
 
   it('file browser should show correct right click actions', () => {
-    cy.findByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
     cy.findAllByText('liberty.png').first().rightclick();
     cy.get('ul.lm-Menu-content.p-Menu-content')
@@ -57,9 +56,9 @@ describe('mount', () => {
   });
 
   it('file browser should have loading attribute', () => {
-    cy.findByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
     cy.findAllByText('default_images').first().click();
-    cy.get('ul.jp-DirListing-content[loading]').should('have.length', 1);
-  });*/
+    cy.get('ul.jp-DirListing-content[loading]').should('have.length', 2);
+  });
 });

--- a/jupyter-extension/cypress/integration/repo-datum-mode-switch.ts
+++ b/jupyter-extension/cypress/integration/repo-datum-mode-switch.ts
@@ -4,11 +4,10 @@ describe('switching between repo and datum mode', () => {
     cy.isAppReady();
     cy.unmountAllRepos();
     cy.openMountPlugin();
-    cy.findAllByText('Mount');
+    cy.findAllByText('Load');
     cy.wait(3000);
   });
 
-  /* TODO: tests must be updated for the new FUSE-less impl
   it('should open datum mode', () => {
     cy.findByTestId('Datum__mode').click();
     cy.findAllByText('Test Datums').should('have.length', 1);
@@ -18,10 +17,10 @@ describe('switching between repo and datum mode', () => {
   });
 
   it('mounted repos appear in datum input spec and again when switching back', () => {
-    cy.findAllByText('Mount').first().click();
+    cy.findAllByText('Load').first().click();
     cy.findByTestId('ListItem__select').select('branch');
-    cy.findAllByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 2);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 2);
 
     cy.findByTestId('Datum__mode').click();
     cy.findByTestId('Datum__inputSpecInput')
@@ -29,7 +28,7 @@ describe('switching between repo and datum mode', () => {
       .should('contain', 'cross:');
     cy.findByTestId('Datum__back').click();
 
-    cy.findAllByText('Unmount').should('have.length', 2);
+    cy.findAllByText('Unload').should('have.length', 2);
     cy.wait(3000);
     cy.findAllByText('default_images').first().click();
     cy.findAllByText('liberty.png').should('have.length', 1);
@@ -37,10 +36,10 @@ describe('switching between repo and datum mode', () => {
     cy.findAllByText('branch.png').should('have.length', 1);
   });
 
-  it.skip('modifying input spec saves and restores it when back in datum mode', () => {
+  it('modifying input spec saves and restores it when back in datum mode', () => {
     cy.findByTestId('ListItem__select').select('branch');
-    cy.findAllByText('Mount').first().click();
-    cy.findAllByText('Unmount').should('have.length', 1);
+    cy.findAllByText('Load').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
 
     cy.findByTestId('Datum__mode').click();
     cy.findByTestId('Datum__inputSpecInput')
@@ -52,12 +51,11 @@ describe('switching between repo and datum mode', () => {
       .should('contain', 'a');
     cy.findByTestId('Datum__back').click();
 
-    cy.findAllByText('Unmount').should('have.length', 1);
-    cy.findAllByText('Unmount').first().click();
+    cy.findAllByText('Unload').should('have.length', 1);
+    cy.findAllByText('Unload').first().click();
     cy.findByTestId('Datum__mode').click();
     cy.findByTestId('Datum__inputSpecInput')
       .invoke('prop', 'value')
       .should('contain', 'a');
   });
-*/
 });

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -509,47 +509,6 @@ export class MountPlugin implements IMountPlugin {
     this._saveInputSpecSignal.emit(this._repoViewInputSpec);
   };
 
-  restoreMountedReposList = async (): Promise<void> => {
-    const mounts: JSONObject[] = [];
-    // Restoring from cross of multiple mounts
-    if (
-      Object.prototype.hasOwnProperty.call(this._repoViewInputSpec, 'cross') &&
-      Array.isArray(this._repoViewInputSpec.cross)
-    ) {
-      for (let i = 0; i < this._repoViewInputSpec.cross.length; i++) {
-        const pfsInput = (this._repoViewInputSpec.cross[i] as PfsInput).pfs;
-        mounts.push({
-          name: pfsInput.name ? pfsInput.name : pfsInput.repo,
-          repo: pfsInput.repo,
-          project: pfsInput.project ? pfsInput.project : 'default',
-          branch: pfsInput.branch ? pfsInput.branch : 'master',
-          mode: 'ro',
-        });
-      }
-    }
-    // Restoring from single mount
-    else if (
-      Object.prototype.hasOwnProperty.call(this._repoViewInputSpec, 'pfs')
-    ) {
-      const pfsInput = (this._repoViewInputSpec as PfsInput).pfs;
-      mounts.push({
-        name: pfsInput.name ? pfsInput.name : pfsInput.repo,
-        repo: pfsInput.repo,
-        project: pfsInput.project ? pfsInput.project : 'default',
-        branch: pfsInput.branch ? pfsInput.branch : 'master',
-        mode: 'ro',
-      });
-    }
-
-    if (mounts.length > 0) {
-      const res = await requestAPI<ListMountsResponse>('_mount', 'PUT', {
-        mounts: mounts,
-      });
-      this._poller.updateData(res);
-    }
-    this.openPFS('');
-  };
-
   setShowDatum = async (shouldShow: boolean): Promise<void> => {
     if (shouldShow) {
       this._datum.setHidden(false);
@@ -562,7 +521,6 @@ export class MountPlugin implements IMountPlugin {
       this._datum.setHidden(true);
       this._mountedList.setHidden(false);
       this._unmountedList.setHidden(false);
-      await this.restoreMountedReposList();
       this._pfsBrowser.setHidden(false);
       this._datumBrowser.setHidden(true);
     }


### PR DESCRIPTION
update the end-to-end tests for the fuse-less implementation and re-enables them
[INT-1166](https://pachyderm.atlassian.net/browse/INT-1166)

[INT-1166]: https://pachyderm.atlassian.net/browse/INT-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ