### PR TITLE
[PFS-191] Fix FindCommits API by only logging the branch if the branch exists

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -607,6 +607,14 @@ func (d *driver) findCommits(ctx context.Context, request *pfs.FindCommitsReques
 		if searchDone {
 			return errors.EnsureStack(cb(makeResp(nil, commitsSearched, commit)))
 		}
+		logFields := []zap.Field{
+			zap.String("commit", commit.Id),
+			zap.String("repo", commit.Repo.String()),
+			zap.String("target", request.FilePath),
+		}
+		if commit.Branch != nil {
+			logFields = append(logFields, zap.String("branch", commit.Branch.String()))
+		}
 		if err := log.LogStep(ctx, "searchingCommit", func(ctx context.Context) error {
 			inspectCommitResp, err := d.resolveCommitWithAuth(ctx, commit)
 			if err != nil {
@@ -635,7 +643,7 @@ func (d *driver) findCommits(ctx context.Context, request *pfs.FindCommitsReques
 			}
 			commit = inspectCommitResp.ParentCommit
 			return nil
-		}, zap.String("commit", commit.Id), zap.String("branch", commit.GetBranch().String()), zap.String("repo", commit.Repo.String()), zap.String("target", request.FilePath)); err != nil {
+		}, logFields...); err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return errors.EnsureStack(cb(makeResp(nil, commitsSearched, commit)))
 			}

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -4500,6 +4500,19 @@ func TestFindCommits(t *testing.T) {
 	require.Equal(t, []*pfs.Commit{commit4, commit3, commit1}, resp.FoundCommits)
 	require.Equal(t, uint32(4), resp.CommitsSearched)
 	require.Equal(t, commit1, resp.LastSearchedCommit)
+
+	require.NoError(t, env.PachClient.DeleteBranch(pfs.DefaultProjectName, repo, "master", true))
+	commit4.Branch = nil
+	commit3.Branch = nil
+	commit2.Branch = nil
+	commit1.Branch = nil
+
+	resp, err = env.PachClient.FindCommits(&pfs.FindCommitsRequest{FilePath: "/files/b", Start: commit4, Limit: 0})
+	require.NoError(t, err)
+
+	require.Equal(t, []*pfs.Commit{commit4, commit3, commit1}, resp.FoundCommits)
+	require.Equal(t, uint32(4), resp.CommitsSearched)
+	require.Equal(t, commit1, resp.LastSearchedCommit)
 }
 
 func TestFindCommitsLimit(t *testing.T) {


### PR DESCRIPTION
… is not nil.