### PR TITLE
Bosterbuhr/fix det priorityclass CORE-2047

### DIFF
--- a/etc/helm/pachyderm/templates/determined/priority-classes.yaml
+++ b/etc/helm/pachyderm/templates/determined/priority-classes.yaml
@@ -8,7 +8,7 @@ value: 1000000
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."
-{{ end }}
+{{- end }}
 ---
 {{- if .Values.determined.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1

--- a/etc/helm/pachyderm/templates/determined/priority-classes.yaml
+++ b/etc/helm/pachyderm/templates/determined/priority-classes.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.determined.enabled -}}
-{{- $systemClassExists := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "determined-system-priority" }}
-{{- if not $systemClassExists }}
 {{- if .Values.determined.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -10,11 +8,8 @@ value: 1000000
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."
-{{- end }}
 {{ end }}
 ---
-{{- $mediumClassExists := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "determined-medium-priority" }}
-{{- if not $mediumClassExists }}
 {{- if .Values.determined.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -24,6 +19,5 @@ value: 50
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for medium priority Determined jobs."
-{{- end }}
 {{- end }}
 {{- end }}

--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -31,10 +31,11 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	ns, portOffset := minikubetestenv.ClaimCluster(t)
 	k := testutil.GetKubeClient(t)
 	opts := &minikubetestenv.DeployOpts{
-		AuthUser:   auth.RootUser,
-		Enterprise: true,
-		PortOffset: portOffset,
-		Determined: true,
+		AuthUser:     auth.RootUser,
+		Enterprise:   true,
+		PortOffset:   portOffset,
+		Determined:   true,
+		CleanupAfter: true,
 	}
 	valueOverrides["pachd.replicas"] = "1"
 	opts.ValueOverrides = valueOverrides

--- a/src/testing/deploy/determined_test.go
+++ b/src/testing/deploy/determined_test.go
@@ -55,10 +55,11 @@ func TestDeterminedInstallAndIntegration(t *testing.T) {
 	ns, portOffset := minikubetestenv.ClaimCluster(t)
 	k := testutil.GetKubeClient(t)
 	opts := &minikubetestenv.DeployOpts{
-		AuthUser:   auth.RootUser,
-		Enterprise: true,
-		PortOffset: portOffset,
-		Determined: true,
+		AuthUser:     auth.RootUser,
+		Enterprise:   true,
+		PortOffset:   portOffset,
+		Determined:   true,
+		CleanupAfter: true, // this cluster is likely to not be re-used
 	}
 	valueOverrides["pachd.replicas"] = "1"
 	opts.ValueOverrides = valueOverrides


### PR DESCRIPTION
checking to see if a priority class exists before deploying is causing issue when someone attempts a `helm upgrade`. If the Priority classes do exist, then they get removed from the kubernetes manifest when upgrading, and then deleted in the cluster. This removes our old handling and adds in Determined's newer handling which gives the deployer manual control over the priority classes. 

With this change, the tests also need to be updated to manually handle running determined in two separate namespaces.