### PR TITLE
Build a docker image as the base for CI runs

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -37,7 +37,7 @@ parameters:
     default: ubuntu-2204:2023.04.2
   ci_runner_image:
     type: string
-    default: docker.io/pachyderm/ci-runner:20240111-e924f02d931ce45599850b00505b1b5fa480c309@sha256:7d72ac4678249d21b7eec6545f7d89b00d0be17e0880469dc9632e2cd93ad12a
+    default: docker.io/pachyderm/ci-runner:20240111-2e591973e71abd68d57d906c60df38c422ed44b8@sha256:db90415c9db3d93f86767754b4ca679737f57cfb7a6c45248f07fed3ee7c9991
   go-version:
     type: string
     default: "1.21.5"

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1588,51 +1588,27 @@ jobs:
   bazel-style-tests:
     resource_class: xlarge
     docker:
-      - image: debian:stable
-        entrypoint: /bin/bash
-    working_directory: /code
+      - image: docker.io/pachyderm/ci-runner:20240111-77dd2fb4d97eb96ea0180c76ff9194c2ac402e5f
     steps:
-      - run: apt update
-      - run: DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt install -y wget git build-essential python3
       - checkout
-      - run: |
-          pushd /tmp
-          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
-          chmod a+x bazelisk-linux-amd64
-          ln -s $PWD/bazelisk-linux-amd64 /usr/bin/bazel
-          useradd bazel -m
-          chown bazel -R /code
-          popd
-      - run: su bazel -c 'bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto'
-      - run: su bazel -c 'git checkout MODULE.bazel.lock' # For OSX-only changes.
-      - run: su bazel -c 'git diff --exit-code'
-      - run: su bazel -c 'bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle'
-      - run: su bazel -c 'git checkout MODULE.bazel.lock' # For OSX-only changes.
-      - run: su bazel -c 'git diff --exit-code'
-      - run: su bazel -c 'bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test'
+      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto
+      - run: git checkout MODULE.bazel.lock # For OSX-only changes.
+      - run: git diff --exit-code
+      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle
+      - run: git checkout MODULE.bazel.lock # For OSX-only changes.
+      - run: git diff --exit-code
+      - run: bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test
       - run: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
       - store_test_results:
           path: /tmp/bazel-testlogs/
   bazel-tests:
     resource_class: xlarge
     docker:
-      - image: debian:stable
-        entrypoint: /bin/bash
-    working_directory: /code
+      - image: docker.io/pachyderm/ci-runner:20240111-77dd2fb4d97eb96ea0180c76ff9194c2ac402e5f
     steps:
-      - run: apt update
-      - run: DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt install -y wget git build-essential python3
       - checkout
-      - run: |
-          pushd /tmp
-          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
-          chmod a+x bazelisk-linux-amd64
-          ln -s $PWD/bazelisk-linux-amd64 /usr/bin/bazel
-          useradd bazel -m
-          chown bazel -R /code
-          popd
       - setup_remote_docker
-      - run: su bazel -c 'bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //oci:all'
+      - run: bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //oci:all
       - run: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
       - store_test_results:
           path: /tmp/bazel-testlogs/

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -37,7 +37,7 @@ parameters:
     default: ubuntu-2204:2023.04.2
   ci_runner_image:
     type: string
-    default: docker.io/pachyderm/ci-runner:20240111-2e591973e71abd68d57d906c60df38c422ed44b8@sha256:db90415c9db3d93f86767754b4ca679737f57cfb7a6c45248f07fed3ee7c9991
+    default: docker.io/pachyderm/ci-runner:20240112-905276c17a17d57de108eab3d53d3322fd27650a@sha256:7968439e70f08b411510f0a2b42d77ffde0d51ac971e3106a65902440b648882
   go-version:
     type: string
     default: "1.21.5"

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -35,6 +35,9 @@ parameters:
   machine_image:
     type: string
     default: ubuntu-2204:2023.04.2
+  ci_runner_image:
+    type: string
+    default: docker.io/pachyderm/ci-runner:20240111-8785e910198c73c384125822774df1e5cf200866
   go-version:
     type: string
     default: "1.21.5"
@@ -1588,7 +1591,7 @@ jobs:
   bazel-style-tests:
     resource_class: xlarge
     docker:
-      - image: docker.io/pachyderm/ci-runner:20240111-77dd2fb4d97eb96ea0180c76ff9194c2ac402e5f
+      - image: << pipeline.parameters.ci_runner_image >>
     steps:
       - checkout
       - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto
@@ -1604,7 +1607,7 @@ jobs:
   bazel-tests:
     resource_class: xlarge
     docker:
-      - image: docker.io/pachyderm/ci-runner:20240111-77dd2fb4d97eb96ea0180c76ff9194c2ac402e5f
+      - image: << pipeline.parameters.ci_runner_image >>
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -37,7 +37,7 @@ parameters:
     default: ubuntu-2204:2023.04.2
   ci_runner_image:
     type: string
-    default: docker.io/pachyderm/ci-runner:20240111-8785e910198c73c384125822774df1e5cf200866
+    default: docker.io/pachyderm/ci-runner:20240111-e924f02d931ce45599850b00505b1b5fa480c309@sha256:7d72ac4678249d21b7eec6545f7d89b00d0be17e0880469dc9632e2cd93ad12a
   go-version:
     type: string
     default: "1.21.5"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 licenses(["notice"])
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    ".bazelversion",
+])
 
 # Conifigure supported architectures.  Note that some architectures are only supported for tooling
 # reasons; you can run protoc Windows, but you can't run Pachyderm or pachctl on Windows.  Which

--- a/etc/ci-image/BUILD.bazel
+++ b/etc/ci-image/BUILD.bazel
@@ -1,0 +1,26 @@
+genrule(
+    name = "dockerfile_with_bazelversion",
+    srcs = [
+        "Dockerfile.tmpl",
+        "//:.bazelversion",
+    ],
+    outs = ["Dockerfile"],
+    cmd = "sed -e s/{BAZEL_VERSION}/$$(cat .bazelversion)/ ./etc/ci-image/Dockerfile.tmpl > $@",
+)
+
+genrule(
+    name = "version",
+    outs = ["version"],
+    cmd = "grep STABLE_CI_RUNNER_IMAGE_VERSION bazel-out/stable-status.txt | cut -d ' ' -f 2 > $@",
+    stamp = 1,
+)
+
+sh_binary(
+    name = "push",
+    srcs = ["push.sh"],
+    data = [
+        ":Dockerfile",
+        ":version",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/etc/ci-image/BUILD.bazel
+++ b/etc/ci-image/BUILD.bazel
@@ -24,3 +24,13 @@ sh_binary(
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
+
+sh_binary(
+    name = "run",
+    srcs = ["run.sh"],
+    data = [
+        ":Dockerfile",
+        ":version",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/etc/ci-image/Dockerfile.tmpl
+++ b/etc/ci-image/Dockerfile.tmpl
@@ -21,6 +21,7 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     curl \
     gnupg \
     wget \
+    openssh-client \
     git \
     && \
     rm -rf /var/lib/apt/lists/* && \

--- a/etc/ci-image/Dockerfile.tmpl
+++ b/etc/ci-image/Dockerfile.tmpl
@@ -16,6 +16,7 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     ca-certificates \
     ca-certificates-java \
     curl \
+    fuse3 \
     git \
     gnupg \
     lcov \

--- a/etc/ci-image/Dockerfile.tmpl
+++ b/etc/ci-image/Dockerfile.tmpl
@@ -11,18 +11,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Core deps
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    build-essential \
     ca-certificates \
     ca-certificates-java \
-    python3 \
-    build-essential \
-    locales \
-    sudo \
-    apt-transport-https \
     curl \
-    gnupg \
-    wget \
-    openssh-client \
     git \
+    gnupg \
+    lcov \
+    locales \
+    openssh-client \
+    python3 \
+    sudo \
+    wget \
     && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd --gid=1002 circleci && \

--- a/etc/ci-image/Dockerfile.tmpl
+++ b/etc/ci-image/Dockerfile.tmpl
@@ -9,7 +9,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PAGER=cat
 
 # Core deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     ca-certificates-java \
     python3 \
@@ -20,8 +21,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg \
     wget \
+    git \
     && \
-    locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd --gid=1002 circleci && \
     useradd --uid=1001 --gid=circleci --create-home circleci && \
@@ -29,7 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
     sudo -u circleci mkdir /home/circleci/project && \
     sudo -u circleci mkdir /home/circleci/bin && \
-    sudo -u circleci mkdir -p /home/circleci/.local/bin
+    sudo -u circleci mkdir -p /home/circleci/.local/bin && \
+    sudo -u circleci git config --global --add safe.directory /home/circleci/project
 
 # Docker (but just the client, for remote execution)
 RUN install -m 0755 -d /etc/apt/keyrings && \
@@ -49,12 +51,13 @@ RUN wget "https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazel
     mv "bazelisk-linux-$(dpkg --print-architecture)" /usr/bin/bazel && \
     chmod a+x /usr/bin/bazel
 
-# Install the Bazel version that the workspace needs at the current time.
-RUN USE_BAZEL_VERSION={BAZEL_VERSION} bazel version
-
+# Environment that CI jobs will run in.
 ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \
 	LANG=en_US.UTF-8 \
 	LANGUAGE=en_US:en \
-	LC_ALL=en_US.UTF-8
+        LC_ALL=en_US.UTF-8
 USER circleci
 WORKDIR /home/circleci/project
+
+# Install the Bazel version that the workspace needs at the current time.
+RUN USE_BAZEL_VERSION={BAZEL_VERSION} bazel version

--- a/etc/ci-image/Dockerfile.tmpl
+++ b/etc/ci-image/Dockerfile.tmpl
@@ -1,0 +1,60 @@
+FROM debian:12-slim@sha256:f4a83aa865a2b4a064ff142aa91c713180df9fcb86ce676b5de2981029379c37
+# based on https://github.com/CircleCI-Public/cimg-base/blob/main/22.04/Dockerfile
+
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBIAN_NONINTERACTIVE_SEEN=true \
+    TERM=dumb \
+    PAGER=cat
+
+# Core deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    ca-certificates-java \
+    python3 \
+    build-essential \
+    locales \
+    sudo \
+    apt-transport-https \
+    curl \
+    gnupg \
+    wget \
+    && \
+    locale-gen en_US.UTF-8 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid=1002 circleci && \
+    useradd --uid=1001 --gid=circleci --create-home circleci && \
+    echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
+    echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
+    sudo -u circleci mkdir /home/circleci/project && \
+    sudo -u circleci mkdir /home/circleci/bin && \
+    sudo -u circleci mkdir -p /home/circleci/.local/bin
+
+# Docker (but just the client, for remote execution)
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    docker-ce-cli \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bazelisk
+RUN wget "https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-$(dpkg --print-architecture)" && \
+    mv "bazelisk-linux-$(dpkg --print-architecture)" /usr/bin/bazel && \
+    chmod a+x /usr/bin/bazel
+
+# Install the Bazel version that the workspace needs at the current time.
+RUN USE_BAZEL_VERSION={BAZEL_VERSION} bazel version
+
+ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \
+	LANG=en_US.UTF-8 \
+	LANGUAGE=en_US:en \
+	LC_ALL=en_US.UTF-8
+USER circleci
+WORKDIR /home/circleci/project

--- a/etc/ci-image/push.sh
+++ b/etc/ci-image/push.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck source=/dev/null.
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+docker buildx build - --platform=linux/amd64,linux/arm64 --push --tag=pachyderm/ci-runner:"$(cat "$(rlocation _main/etc/ci-image/version)")" < "$(rlocation _main/etc/ci-image/Dockerfile)"

--- a/etc/ci-image/run.sh
+++ b/etc/ci-image/run.sh
@@ -13,5 +13,5 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 # --- end runfiles.bash initialization v3 ---
 
 docker buildx build - --load --tag=pachyderm/ci-runner:"$(cat "$(rlocation _main/etc/ci-image/version)")" < "$(rlocation _main/etc/ci-image/Dockerfile)" --tag=pachyderm/ci-runner:latest
-exec docker run -it -v $BUILD_WORKSPACE_DIRECTORY:/home/circleci/project:ro \
+exec docker run -it -v "$BUILD_WORKSPACE_DIRECTORY":/home/circleci/project:ro \
      pachyderm/ci-runner:latest

--- a/etc/ci-image/run.sh
+++ b/etc/ci-image/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck source=/dev/null.
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+docker buildx build - --load --tag=pachyderm/ci-runner:"$(cat "$(rlocation _main/etc/ci-image/version)")" < "$(rlocation _main/etc/ci-image/Dockerfile)" --tag=pachyderm/ci-runner:latest
+exec docker run -it -v $BUILD_WORKSPACE_DIRECTORY:/home/circleci/project:ro \
+     pachyderm/ci-runner:latest

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -19,3 +19,6 @@ echo "STABLE_APP_VERSION 2.9.0"
 
 additional_version=$(git diff-index --quiet HEAD -- && echo "-${commit_sha}" || echo "-${commit_sha}+dirty")
 echo "STABLE_ADDITIONAL_VERSION $additional_version"
+
+ci_runner_image_version="$(date +%Y%m%d)-${commit_sha}"
+echo "STABLE_CI_RUNNER_IMAGE_VERSION ${ci_runner_image_version}"


### PR DESCRIPTION
This builds an image for CircleCI tests.  It already has all the dependencies needed to run bazel installed, so CI runs don't have to do that every time anymore.

The image includes bazel, but if .bazelversion in the repository changes, it will fetch that version and not use its cached copy.  That way if nobody feels like rebuilding the container, it's not a big deal, it will just take a few seconds to download a newer version of bazel.

It's sort of built with bazel; `bazel run //etc/ci-image:push` will build and push a new version after you edit the Dockerfile.  This is how we bake in the version of bazel mentioned in `.bazelversion`.

A bunch of people asked me to use Nix for this.  I tried, but I ended up with an image that was about 1.5GB and didn't work with circle.  (For those following along at home, I used nixpkgs.dockerTools.[buildImage|buildNixShellImage], but neither were particularly great.  I also tried `rules_nixpkgs` and added nixpkgs directly to a Debian base image; that doesn't work because nxpkgs dynamically links everything, including go binaries like bazelisk, with a libc in /nix/store/<some hash that depends on the exact version of the package you get>, and the binaries can't be run on other linuxes.)