### PR TITLE
Bosterbuhr/fix det priorityclass CORE-2047 (#9640)

### DIFF
--- a/etc/helm/pachyderm/templates/determined/priority-classes.yaml
+++ b/etc/helm/pachyderm/templates/determined/priority-classes.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.determined.enabled -}}
-{{- $systemClassExists := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "determined-system-priority" }}
-{{- if not $systemClassExists }}
 {{- if .Values.determined.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -11,10 +9,7 @@ preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."
 {{- end }}
-{{ end }}
 ---
-{{- $mediumClassExists := lookup "scheduling.k8s.io/v1" "PriorityClass" "" "determined-medium-priority" }}
-{{- if not $mediumClassExists }}
 {{- if .Values.determined.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -24,6 +19,5 @@ value: 50
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for medium priority Determined jobs."
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
checking to see if a priority class exists before deploying is causing issue when someone attempts a `helm upgrade`. If the Priority classes do exist, then they get removed from the kubernetes manifest when upgrading, and then deleted in the cluster. This removes our old handling and adds in Determined's newer handling which gives the deployer manual control over the priority classes.

With this change, the tests also need to be updated to manually handle running determined in two separate namespaces.

---------
Backporting without some of the test changes since the test harness overhaul is not in 2.8