### PR TITLE
[Backport - 2.8] [PFS-188] Improve put file UX and fix trailing slash bug

### DIFF
--- a/src/server/pfs/cmds/cmds_test.go
+++ b/src/server/pfs/cmds/cmds_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -110,6 +111,162 @@ func TestCommit(t *testing.T) {
 		"repo", tu.UniqueString("TestCommit-repo"),
 		"project", tu.UniqueString("project"),
 	).Run())
+}
+
+func TestPutFileFullPathNoFilePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
+	mockInspectCluster(env)
+	c := env.PachClient
+
+	// Create a temporary directory and file with nested structure
+	tmpDir, err := os.MkdirTemp("", "pachyderm_test_put_file_full_path")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	nestedDir := filepath.Join(tmpDir, "nested/dir")
+	require.NoError(t, os.MkdirAll(nestedDir, 0755))
+
+	filePath := filepath.Join(nestedDir, "testfile.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("test data"), 0644))
+
+	repoName := tu.UniqueString("TestPutFileFullPathNoFilePath")
+
+	// Create repo and put file with fullPath flag, and verify
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
+        pachctl create repo {{.repo}}
+        pachctl put file {{.repo}}@master -f {{.filePath}} --full-path
+        pachctl get file "{{.repo}}@master:{{.filePath}}" \
+          | match "test data"
+    `, "repo", repoName, "filePath", filePath).Run())
+}
+
+func TestPutFileFullPathWithFilePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
+	mockInspectCluster(env)
+	c := env.PachClient
+
+	// Create a temporary file in a nested directory
+	tmpDir, err := os.MkdirTemp("", "pachyderm_test_full_path_with_file_path")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	nestedDir := filepath.Join(tmpDir, "nested/dir")
+	require.NoError(t, os.MkdirAll(nestedDir, 0755))
+
+	filePath := filepath.Join(nestedDir, "testfile.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("test data"), 0644))
+
+	repoName := tu.UniqueString("TestPutFileFullPathWithFilePath")
+	targetFilePath := "specific/target/file.txt"
+
+	// Create repo, put file with file.Path and fullPath flag, and verify
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
+        pachctl create repo {{.repo}}
+        pachctl put file {{.repo}}@master:{{.targetFilePath}} -f {{.filePath}} --full-path
+        pachctl get file "{{.repo}}@master:{{.targetFilePath}}" \
+          | match "test data"
+    `, "repo", repoName, "targetFilePath", targetFilePath, "filePath", filePath).Run())
+}
+
+func TestPutFileFullPathWithFilePathEndingSlash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
+	mockInspectCluster(env)
+	c := env.PachClient
+
+	// Create a temporary file in a nested directory
+	tmpDir, err := os.MkdirTemp("", "pachyderm_test_full_path_with_file_path_ending_slash")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	nestedDir := filepath.Join(tmpDir, "nested/dir")
+	require.NoError(t, os.MkdirAll(nestedDir, 0755))
+
+	filePath := filepath.Join(nestedDir, "testfile.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("test data"), 0644))
+
+	repoName := tu.UniqueString("TestPutFileFullPathWithFilePathEndingSlash")
+	targetPrefix := "nested/dir/"
+
+	// Create repo, put file with file.Path ending with '/' and fullPath flag, and verify
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
+        pachctl create repo {{.repo}}
+        pachctl put file {{.repo}}@master:{{.targetPrefix}} -f {{.filePath}} --full-path
+        pachctl get file "{{.repo}}@master:{{.targetPrefix}}{{.filePath}}" \
+          | match "test data"
+    `, "repo", repoName, "targetPrefix", targetPrefix, "filePath", filePath).Run())
+}
+
+func TestPutFileFilePathEndsWithSlashSingleSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
+	mockInspectCluster(env)
+	c := env.PachClient
+
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "pachyderm_test_put_file_single_source")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	require.NoError(t, os.WriteFile(tmpFile.Name(), []byte("test data"), 0644))
+
+	repoName := tu.UniqueString("TestPutFileFilePathEndsWithSlashSingleSource")
+	targetPrefix := "dir/"
+
+	// Create repo, put file with file.Path ending with '/', and verify
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
+        pachctl create repo {{.repo}}
+        pachctl put file {{.repo}}@master:{{.targetPrefix}} -f {{.fileName}}
+        pachctl get file "{{.repo}}@master:{{.targetPrefix}}{{.baseFileName}}" \
+          | match "test data"
+    `, "repo", repoName, "targetPrefix", targetPrefix, "fileName", tmpFile.Name(), "baseFileName", filepath.Base(tmpFile.Name())).Run())
+}
+
+func TestPutFileFilePathWithoutSlashSingleSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	ctx := pctx.TestContext(t)
+	env := realenv.NewRealEnv(ctx, t, dockertestenv.NewTestDBConfig(t).PachConfigOption)
+	mockInspectCluster(env)
+	c := env.PachClient
+
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "pachyderm_test_put_file_single_source_no_slash")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	require.NoError(t, os.WriteFile(tmpFile.Name(), []byte("test data"), 0644))
+
+	repoName := tu.UniqueString("TestPutFileFilePathWithoutSlashSingleSource")
+	targetFilePath := "specific/target/path/file.txt"
+
+	// Create repo, put file with file.Path without ending '/', and verify
+	require.NoError(t, tu.PachctlBashCmd(t, c, `
+        pachctl create repo {{.repo}}
+        pachctl put file {{.repo}}@master:{{.targetFilePath}} -f {{.fileName}}
+        pachctl get file "{{.repo}}@master:{{.targetFilePath}}" \
+          | match "test data"
+    `, "repo", repoName, "targetFilePath", targetFilePath, "fileName", tmpFile.Name()).Run())
 }
 
 func TestPutFileTAR(t *testing.T) {


### PR DESCRIPTION
This PR is meant to address issues related to `pachctl put file`

Behavior before PR:

- `pachctl put file repo@branch:/ -f file.txt` will currently break everything until you delete the corresponding commit
- `pachctl put file repo@branch:/dir -f file.txt` creates `/dir` as expected, but `pachctl put file repo@branch:/dir/ -f file.txt` also creates `/dir`
- `pachctl put file put-test@master:/dir/ -f dir2/file.txt --full-path` creates `/dir`

Behavior after PR:

- `pachctl put file repo@branch:/ -f file.txt` creates `/file.txt`
- `pachctl put file repo@branch:/dir/ -f file.txt` creates `/dir/file.txt`
- `pachctl put file put-test@master:/dir/ -f dir2/file.txt --full-path` creates `/dir/dir2/file.txt`