### PR TITLE
[jupyter extension] add download file/dir functionality

### DIFF
--- a/jupyter-extension/cypress/integration/mount.ts
+++ b/jupyter-extension/cypress/integration/mount.ts
@@ -48,11 +48,13 @@ describe('mount', () => {
     cy.findAllByText('liberty.png').first().rightclick();
     cy.get('ul.lm-Menu-content.p-Menu-content')
       .children()
-      .should('have.length', 2)
+      .should('have.length', 3)
       .first()
       .should('have.text', 'Open')
       .next()
-      .should('have.text', 'Copy Path');
+      .should('have.text', 'Copy Path')
+      .next()
+      .should('have.text', 'Download');
   });
 
   it('file browser should have loading attribute', () => {

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -11,7 +11,6 @@ import {FileBrowser, IFileBrowserFactory} from '@jupyterlab/filebrowser';
 import {INotebookModel, NotebookPanel} from '@jupyterlab/notebook';
 import {Contents} from '@jupyterlab/services';
 import {settingsIcon} from '@jupyterlab/ui-components';
-import {JSONObject} from '@lumino/coreutils';
 import {Signal} from '@lumino/signaling';
 import {SplitPanel, Widget} from '@lumino/widgets';
 
@@ -274,6 +273,7 @@ export class MountPlugin implements IMountPlugin {
       manager,
       factory,
       'pfs',
+      'explore',
       'pfs',
     );
     this._datumBrowser = createCustomFileBrowser(
@@ -281,6 +281,7 @@ export class MountPlugin implements IMountPlugin {
       manager,
       factory,
       'view_datum',
+      'test',
       'datum',
     );
     this._poller.mountedSignal.connect(this.verifyBrowserPath);


### PR DESCRIPTION
Adds functionality to download individual files and directories from the file browser view. Downloads will go to the CWD where the extension is running.

![Screen Shot 2024-01-18 at 2 35 41 PM](https://github.com/pachyderm/pachyderm/assets/2468631/2b20cb5a-579a-44ba-87c4-f72553b3aa6a)
![Screen Shot 2024-01-18 at 2 36 11 PM](https://github.com/pachyderm/pachyderm/assets/2468631/01cb2f0c-f10f-4dfd-89b9-8457be9aafba)


[INT-1148](https://pachyderm.atlassian.net/browse/INT-1148)

[INT-1148]: https://pachyderm.atlassian.net/browse/INT-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ