### PR TITLE
[jupyter extension] show error dialog when there is an error downloading files

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -445,7 +445,6 @@ class PPSCreateHandler(BaseHandler):
 class ExploreDownloadHandler(BaseHandler):
     @tornado.web.authenticated
     async def put(self, path):
-        print(f"PUT for /download/explore{path} called")
         try:
             self.pfs_manager.download_file(path=path)
         except FileExistsError:
@@ -463,7 +462,6 @@ class ExploreDownloadHandler(BaseHandler):
 class TestDownloadHandler(BaseHandler):
     @tornado.web.authenticated
     async def put(self, path):
-        print(f"PUT for /download/test{path} called")
         try:
             self.datum_manager.download_file(path=path)
         except FileExistsError:

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -112,7 +112,7 @@ const createCustomFileBrowser = (
               'download/' + downloadPath + '/' + itemPath,
               'PUT',
             ).catch((e) => {
-              showErrorMessage('Error downloading file', e.response.statusText);
+              showErrorMessage('Download Error', e.response.statusText);
             });
           });
         },

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -7,7 +7,7 @@ import {
   DirListing,
   FileBrowser,
 } from '@jupyterlab/filebrowser';
-import {Clipboard} from '@jupyterlab/apputils';
+import {Clipboard, showErrorMessage} from '@jupyterlab/apputils';
 import {CommandRegistry} from '@lumino/commands';
 import {each} from '@lumino/algorithm';
 
@@ -108,10 +108,12 @@ const createCustomFileBrowser = (
               MOUNT_BROWSER_PREFIX + nameSuffix + ':',
               '',
             );
-            const res = requestAPI(
+            requestAPI(
               'download/' + downloadPath + '/' + itemPath,
               'PUT',
-            );
+            ).catch((e) => {
+              showErrorMessage('Error downloading file', e.response.statusText);
+            });
           });
         },
       });


### PR DESCRIPTION
instead of silently swallowing errors, show a dialog box that reports them when there is an issue downloading.

![Screen Shot 2024-01-19 at 4 34 43 PM](https://github.com/pachyderm/pachyderm/assets/2468631/55cf506a-6035-4055-bb8d-be9c3109e1d6)
