### PR TITLE
Use `gazelle -mode=diff` instead of `gazelle --mode=fix; git diff` in CI

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1546,9 +1546,7 @@ jobs:
       - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto
       - run: git checkout MODULE.bazel.lock # For OSX-only changes.
       - run: git diff --exit-code
-      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle
-      - run: git checkout MODULE.bazel.lock # For OSX-only changes.
-      - run: git diff --exit-code
+      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle --  -mode=diff
       - run: bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test
       - run:
           command: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1545,9 +1545,21 @@ jobs:
       - checkout
       - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto
       - run: git checkout MODULE.bazel.lock # For OSX-only changes.
-      - run: git diff --exit-code
-      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle --  -mode=diff
-      - run: bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test
+      - run:
+          name: Check that you ran make proto
+          command: |
+            echo "If you see diffs here, it means that you forgot to run `bazel run //:make_proto`"
+            git diff --exit-code
+      - run:
+          name: Check that you ran gazelle
+          command: |
+            echo "If you see an error here, it means you forgot to `bazel run //:gazelle`"
+            bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle --  -mode=diff
+      - run:
+          name: Check that you ran buildifier
+          command: |
+            echo "If you see an error here, it means you forgot to `bazel run //:buildifier`"
+            bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test
       - run:
           command: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
           when: always


### PR DESCRIPTION
This might make failures clearer.  The first push of this PR contains an example of such a failure: https://app.circleci.com/pipelines/github/pachyderm/pachyderm/25697/workflows/b88aaa2c-9e3c-4626-a6a8-335c9d04ad4a/jobs/457814