### PR TITLE
jupyter extension - create config parent directory if it doesn't exist

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -9,6 +9,7 @@ import grpc.aio
 from jupyter_server.base.handlers import APIHandler, path_regex
 from jupyter_server.services.contents.handlers import ContentsHandler, validate_model
 from jupyter_server.utils import url_path_join
+import os
 from pachyderm_sdk import Client, errors
 from pachyderm_sdk.api.auth import AuthenticateRequest, AuthenticateResponse
 from pachyderm_sdk.config import ConfigFile, Context
@@ -570,6 +571,7 @@ def write_config(
         config.add_context(name, context, overwrite=True)
     else:
         config = ConfigFile.new_with_context(name, context)
+        os.makedirs(PACH_CONFIG.parent, exist_ok=True)
     config.write(PACH_CONFIG)
 
 


### PR DESCRIPTION
if the config file's parent directory does not exist, an exception will be thrown: 
```
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.9/site-packages/tornado/web.py", line 1790, in _execute
        result = await result
      File "/home/jovyan/extension-wd/jupyterlab_pachyderm/handlers.py", line 369, in put
        write_config(self.client.address, self.client.root_certs, None)
      File "/home/jovyan/extension-wd/jupyterlab_pachyderm/handlers.py", line 573, in write_config
        config.write(PACH_CONFIG)
      File "/opt/conda/lib/python3.9/site-packages/pachyderm_sdk/config.py", line 139, in write
        with config_file.open("w") as file_out:
      File "/opt/conda/lib/python3.9/pathlib.py", line 1252, in open
        return io.open(self, mode, buffering, encoding, errors, newline,
      File "/opt/conda/lib/python3.9/pathlib.py", line 1120, in _opener
        return self._accessor.open(self, flags, mode)
    FileNotFoundError: [Errno 2] No such file or directory: '/home/jovyan/.pachyderm/config.json'
```
this change updates the extension to create the parent directory if it does not already exist.
[INT-1173](https://pachyderm.atlassian.net/browse/INT-1173)

[INT-1173]: https://pachyderm.atlassian.net/browse/INT-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ