### PR TITLE
[Jupyter] relative path for notebook requirements file

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -7,7 +7,7 @@ from pachyderm_sdk.constants import CONFIG_PATH_LOCAL
 PACH_CONFIG = Path(
     os.path.expanduser(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
 ).resolve()
-PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/Users/bonenfab/test_dir")
+PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -7,7 +7,7 @@ from pachyderm_sdk.constants import CONFIG_PATH_LOCAL
 PACH_CONFIG = Path(
     os.path.expanduser(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
 ).resolve()
-PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/pfs")
+PFS_MOUNT_DIR = os.environ.get("PFS_MOUNT_DIR", "/Users/bonenfab/test_dir")
 
 PACHYDERM_EXT_DEBUG = strtobool(os.environ.get("PACHYDERM_EXT_DEBUG", "False").lower())
 if PACHYDERM_EXT_DEBUG:

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -25,10 +25,10 @@ class PpsConfig:
     pipeline: pps.Pipeline
     image: str
     requirements: Optional[str]
-    external_files: List[str]
+    external_files: List[Path]
     port: str
     gpu_mode: str
-    resource_spec: dict
+    resource_spec: Optional[pps.ResourceSpec]
     input_spec: pps.Input
 
     @classmethod
@@ -68,6 +68,8 @@ class PpsConfig:
             raise ValueError("field image not set")
 
         requirements = config.get("requirements")
+        if requirements is not None:
+            requirements = notebook_path.parent.joinpath(requirements).resolve()
 
         external_files = []
         external_files_str = config.get("external_files", "").strip()

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -107,6 +107,8 @@ class PpsConfig:
     def to_dict(self):
         data = asdict(self)
         del data["notebook_path"]
+        if data['requirements'] is not None:
+            data['requirements'] = str(data['requirements'])
         return data
 
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -87,8 +87,13 @@ def dev_server(pach_config: Path):
         p.wait()
         time.sleep(1)
 
+@pytest.fixture
+def dev_server_with_unmount(dev_server):
+    yield
+    requests.put(f"{BASE_URL}/_unmount_all")
 
-def test_list_mounts(pachyderm_resources, dev_server):
+
+def test_list_mounts(pachyderm_resources, dev_server_with_unmount):
     repos, branches, _ = pachyderm_resources
 
     r = requests.put(
@@ -115,7 +120,7 @@ def test_list_mounts(pachyderm_resources, dev_server):
     assert len(resp["unmounted"]) == len(repos)
 
 
-def test_mount(pachyderm_resources, dev_server):
+def test_mount(pachyderm_resources, dev_server_with_unmount):
     repos, _, files = pachyderm_resources
 
     to_mount = {
@@ -171,7 +176,7 @@ def test_mount(pachyderm_resources, dev_server):
     assert len(r.json()["content"]) == 0
 
 
-def test_unmount(pachyderm_resources, dev_server):
+def test_unmount(pachyderm_resources, dev_server_with_unmount):
     repos, branches, files = pachyderm_resources
 
     to_mount = {
@@ -232,7 +237,7 @@ def test_unmount(pachyderm_resources, dev_server):
     assert r.status_code == 400, r.text
 
 
-def test_download_file(pachyderm_resources, dev_server):
+def test_download_file(pachyderm_resources, dev_server_with_unmount):
     repos, _, files = pachyderm_resources
 
     to_mount = {
@@ -283,7 +288,7 @@ def test_download_file(pachyderm_resources, dev_server):
 @pytest.mark.skip(
     reason="test flakes due to 'missing chunk' error that hasn't been diagnosed"
 )
-def test_mount_datums(pachyderm_resources, dev_server):
+def test_mount_datums(pachyderm_resources, dev_server_with_unmount):
     repos, branches, files = pachyderm_resources
     input_spec = {
         "input": {
@@ -386,7 +391,7 @@ def test_mount_datums(pachyderm_resources, dev_server):
 @pytest.mark.skip(
     reason="test flakes due to 'missing chunk' error that hasn't been diagnosed"
 )
-def test_download_datum(pachyderm_resources, dev_server):
+def test_download_datum(pachyderm_resources, dev_server_with_unmount):
     repos, branches, files = pachyderm_resources
     input_spec = {
         "input": {

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from random import randint
+from shutil import copyfile
 
 import pytest
 import requests
@@ -15,9 +16,9 @@ from jupyterlab_pachyderm.env import PACH_CONFIG, PFS_MOUNT_DIR
 from jupyterlab_pachyderm.pps_client import METADATA_KEY, PpsConfig
 from pachyderm_sdk import Client
 from pachyderm_sdk.api import pfs, pps
-from pachyderm_sdk.config import ConfigFile, Context
+from pachyderm_sdk.config import ConfigFile
 
-from . import TEST_NOTEBOOK, TEST_REQUIREMENTS
+from . import TEST_NOTEBOOK
 
 ADDRESS = "http://localhost:8888"
 BASE_URL = f"{ADDRESS}/{NAMESPACE}/{VERSION}"
@@ -48,53 +49,43 @@ def pachyderm_resources():
     yield repos, branches, files
 
 
-@pytest.fixture()
-def pach_config(tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def pach_config(tmpdir_factory) -> Path:
     """Temporary path used to write the pach config for tests."""
-    yield tmp_path / "config.json"
+    config_path = tmpdir_factory.mktemp('pachyderm').join("config.json")
+    copyfile(PACH_CONFIG, config_path)
+    yield config_path
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def dev_server(pach_config: Path):
     print("starting development server...")
     p = subprocess.Popen(
         [sys.executable, "-m", "jupyterlab_pachyderm.dev_server"],
-        # preserve specifically:
-        # PATH, PACH_CONFIG, PFS_MOUNT_DIR and MOUNT_SERVER_LOG_FILE
-        # The args after os.environ should be no-ops, but they're here in case
-        # env.py changes (mount-server should use jupyterlab-pach's defaults).
         env=dict(
             os.environ,
             PACH_CONFIG=str(pach_config),
         ),
         stdout=subprocess.PIPE,
     )
-    # Give time for python test server to start
-    time.sleep(3)
-
-    # Give time for mount server to start
-    running = False
-    for _ in range(15):
-        try:
-            r = requests.get(f"{BASE_URL}/config", timeout=1)
-            if r.status_code == 200 and r.json()["cluster_status"] != "INVALID":
-                running = True
-                break
-        except Exception:
-            pass
+    try:
+        # Give time for python test server to start
+        for _ in range(15):
+            try:
+                r = requests.get(f"{BASE_URL}/config", timeout=1)
+                if r.status_code == 200 and r.json()["cluster_status"] != "INVALID":
+                    yield
+                    break
+            except Exception:
+                pass
+            time.sleep(1)
+        else:
+            raise RuntimeError("could not start development server")
+    finally:
+        print("killing development server...")
+        p.terminate()
+        p.wait()
         time.sleep(1)
-
-    if running:
-        yield
-
-    print("killing development server...")
-
-    p.terminate()
-    p.wait()
-    time.sleep(1)
-
-    if not running:
-        raise RuntimeError("mount server is having issues starting up")
 
 
 def test_list_mounts(pachyderm_resources, dev_server):
@@ -517,7 +508,7 @@ def test_config(dev_server, pach_config):
 
 @pytest.fixture(params=[True, False])
 def simple_pachyderm_env(request):
-    client = Client().from_config()
+    client = Client.from_config()
     suffix = str(randint(100000, 999999))
 
     if request.param:
@@ -550,9 +541,6 @@ def _update_metadata(notebook: Path, repo: pfs.Repo, pipeline: pps.Pipeline, ext
     config.input_spec = f'pfs:\n  repo: {repo.name}\n  glob: "/*"'
     # this is currently not being tested so it is set to the empty string
     config.resource_spec = ""
-    config.requirements = str(
-        notebook.with_name(config.requirements).relative_to(os.getcwd())
-    )
     config.external_files = external_files
     notebook_data["metadata"][METADATA_KEY]["config"] = config.to_dict()
     return json.dumps(notebook_data)


### PR DESCRIPTION
The requirements file is now relative to the notebook file it's paired with, not the working directory of the jupyter server.

Also this cleans up the `test_integrations.py` file a bit. Specifically:
* The tests now copy your local pachctl config file and use it for the tests.
* dev server is setup once and reused (should speed up tests considerably)
* removed references to mount-server