### PR TITLE
Build a container with pachd built in coverage mode

### DIFF
--- a/oci/BUILD.bazel
+++ b/oci/BUILD.bazel
@@ -46,9 +46,28 @@ pkg_tar(
     ownername = NONROOT_USERNAME,
 )
 
+pkg_tar(
+    name = "pachd_host_coverage_tar",
+    srcs = ["//src/server/cmd/pachd:pachd_coverage"],
+    owner = NONROOT,
+    ownername = NONROOT_USERNAME,
+    remap_paths = {
+        "/pachd_coverage": "/pachd",
+    },
+)
+
 platform_transition_filegroup(
     name = "pachd_linux_tar",
     srcs = [":pachd_host_tar"],
+    target_platform = select({
+        "@platforms//cpu:arm64": "@rules_go//go/toolchain:linux_arm64",
+        "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
+    }),
+)
+
+platform_transition_filegroup(
+    name = "pachd_linux_coverage_tar",
+    srcs = [":pachd_host_coverage_tar"],
     target_platform = select({
         "@platforms//cpu:arm64": "@rules_go//go/toolchain:linux_arm64",
         "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
@@ -67,11 +86,30 @@ oci_image(
     visibility = ["//visibility:public"],
 )
 
+oci_image(
+    name = "pachd_coverage_image",
+    base = "@distroless",
+    entrypoint = ["/pachd"],
+    tars = [
+        ":licenses_tar",
+        ":dex_assets_tar",
+        ":pachd_linux_coverage_tar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 container_structure_test(
     name = "pachd_image_test",
     size = "small",
     configs = ["pachd_image_test.yaml"],
     image = ":pachd_image",
+)
+
+container_structure_test(
+    name = "pachd_coverage_image_test",
+    size = "small",
+    configs = ["pachd_image_test.yaml"],
+    image = ":pachd_coverage_image",
 )
 
 pkg_tar(

--- a/src/cmd/compile-with-coverage/BUILD.bazel
+++ b/src/cmd/compile-with-coverage/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "compile-with-coverage_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/cmd/compile-with-coverage",
+    visibility = ["//visibility:private"],
+    deps = ["//src/internal/errors"],
+)
+
+go_binary(
+    name = "compile-with-coverage",
+    embed = [":compile-with-coverage_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/src/cmd/compile-with-coverage/BUILD.bazel
+++ b/src/cmd/compile-with-coverage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "compile-with-coverage_lib",
@@ -12,4 +12,10 @@ go_binary(
     name = "compile-with-coverage",
     embed = [":compile-with-coverage_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "compile-with-coverage_test",
+    srcs = ["main_test.go"],
+    embed = [":compile-with-coverage_lib"],
 )

--- a/src/cmd/compile-with-coverage/main.go
+++ b/src/cmd/compile-with-coverage/main.go
@@ -1,0 +1,103 @@
+// Binary compile-with-coverage takes a GOPATH created by the Bazel go_path rule, resolves all
+// symlinks inside it by copying, and invokes the Go compiler.  This is because when the GOPATH is
+// used as a runfile, it contains symlinks back into the original repository, but //go:embed can't
+// resolve symlinks.
+package main
+
+import (
+	"flag"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+)
+
+var (
+	gopath = flag.String("gopath", "", "the gopath to build in")
+	target = flag.String("target", "", "the target to build")
+	out    = flag.String("out", "", "where to put the output")
+	gobin  = flag.String("go", "", "the path to the go (compiler) binary")
+)
+
+func resolve(dir string, out string) error {
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) (retErr error) {
+		if err != nil {
+			return errors.Wrapf(err, "%v called with error", path)
+		}
+		newpath := filepath.Join(out, path)
+		if d.IsDir() {
+			if err := os.MkdirAll(newpath, 0o755); err != nil {
+				return errors.Wrap(err, "create directory in output")
+			}
+			return nil
+		}
+		src, err := os.OpenFile(path, os.O_RDONLY, 0)
+		if err != nil {
+			return errors.Wrap(err, "open source")
+		}
+		defer errors.Close(&retErr, src, "close src")
+		dst, err := os.OpenFile(newpath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "open destination")
+		}
+		defer errors.Close(&retErr, dst, "close dst")
+		if _, err := io.Copy(dst, src); err != nil {
+			return errors.Wrapf(err, "copy %v to %v", target, path)
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "walk")
+	}
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if *gopath == "" {
+		log.Fatal("gopath must be set")
+	}
+	if *target == "" {
+		log.Fatal("target must be set")
+	}
+	if *out == "" {
+		log.Fatal("out must be set")
+	}
+	if *gobin == "" {
+		log.Fatal("go must be set")
+	}
+
+	resolvedGopath, err := os.MkdirTemp("", "pachyderm-resolved-gopath-")
+	if err != nil {
+		log.Fatalf("MkdirTemp for resolved $GOPATH: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(resolvedGopath); err != nil {
+			log.Printf("failed to clean up resolved $GOPATH: %v", err)
+		}
+	}()
+	if err := resolve(*gopath, resolvedGopath); err != nil {
+		log.Fatalf("resolve symlinks in %v: %v", *gopath, err)
+	}
+
+	gocache, err := os.MkdirTemp("", "pachyderm-compile-with-coverage-")
+	if err != nil {
+		log.Fatalf("MkdirTemp for $GOCACHE: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(gocache); err != nil {
+			log.Printf("failed to clean up $GOCACHE: %v", err)
+		}
+	}()
+
+	cmd := exec.Command(*gobin, "build", "-o", *out, "-cover", *target)
+	cmd.Env = []string{"GOPATH=" + filepath.Join(resolvedGopath, *gopath), "GO111MODULE=off", "GOCACHE=" + gocache}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("running go: %v", err)
+	}
+}

--- a/src/cmd/compile-with-coverage/main.go
+++ b/src/cmd/compile-with-coverage/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"io/fs"
 	"log"
@@ -17,10 +18,12 @@ import (
 )
 
 var (
-	gopath = flag.String("gopath", "", "the gopath to build in")
-	target = flag.String("target", "", "the target to build")
-	out    = flag.String("out", "", "where to put the output")
-	gobin  = flag.String("go", "", "the path to the go (compiler) binary")
+	gopath            = flag.String("gopath", "", "the gopath to build in")
+	target            = flag.String("target", "", "the target to build")
+	out               = flag.String("out", "", "where to put the output")
+	gobin             = flag.String("go", "", "the path to the go (compiler) binary")
+	appVersion        = flag.String("app_version", "", "the app version of the build")
+	additionalVersion = flag.String("additional_version", "", "the additional version of the build")
 )
 
 func resolve(dir string, out string) error {
@@ -92,8 +95,8 @@ func main() {
 			log.Printf("failed to clean up $GOCACHE: %v", err)
 		}
 	}()
-
-	cmd := exec.Command(*gobin, "build", "-o", *out, "-cover", *target)
+	ldflags := fmt.Sprintf("-X %s=%s -X %s=%s", "github.com/pachyderm/pachyderm/v2/src/version.AppVersion", *appVersion, "github.com/pachyderm/pachyderm/v2/src/version.AdditionalVersion", *additionalVersion)
+	cmd := exec.Command(*gobin, "build", "-o", *out, "-cover", "-ldflags", ldflags, "-coverpkg=github.com/pachyderm/pachyderm/v2/...", "-covermode=atomic", *target)
 	cmd.Env = []string{"GOPATH=" + filepath.Join(resolvedGopath, *gopath), "GO111MODULE=off", "GOCACHE=" + gocache}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/src/cmd/compile-with-coverage/main_test.go
+++ b/src/cmd/compile-with-coverage/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "src", "a", "b", "c"), 0o755); err != nil {
+		t.Fatalf("make source: %v", err)
+	}
+	content := []byte("hello, world")
+	if err := os.WriteFile(filepath.Join(tmp, "src", "a", "a.txt"), content, 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(tmp, "src", "a", "a.txt"), filepath.Join(tmp, "src", "a", "b", "c", "c.txt")); err != nil {
+		t.Fatalf("link src/a/a.txt -> src/a/b/c/c.txt: %v", err)
+	}
+	if err := resolve(filepath.Join(tmp, "src"), filepath.Join(tmp, "dst")); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	dst := filepath.Join(tmp, "dst", tmp, "src") // destination is the det path + exact path passed to src
+	info, err := os.Lstat(filepath.Join(dst, "a", "b", "c", "c.txt"))
+	if err != nil {
+		t.Fatalf("get info for dst/a/b/c/c.txt: %v", err)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		t.Errorf("dst/a/b/c/c.txt is a symlink: %v", info)
+	}
+	text, err := os.ReadFile(filepath.Join(dst, "a", "b", "c", "c.txt"))
+	if err != nil {
+		t.Fatalf("read dst/a/b/c/c.txt: %v", err)
+	}
+	if got, want := text, content; !bytes.Equal(got, want) {
+		t.Errorf("c.txt:\n  got: %s\n want: %s", got, want)
+	}
+}

--- a/src/server/cmd/pachd/BUILD.bazel
+++ b/src/server/cmd/pachd/BUILD.bazel
@@ -50,12 +50,45 @@ go_path(
 )
 
 genrule(
+    name = "gen_app_version",
+    outs = ["app_version.txt"],
+    cmd_bash = """
+    version=$$(grep ^STABLE_APP_VERSION bazel-out/stable-status.txt | cut -d' ' -f2); \
+    printf '%s' $$version > $@
+    """,
+    stamp = 1,
+)
+
+genrule(
+    name = "gen_additional_version",
+    outs = ["additional_version.txt"],
+    cmd_bash = """
+    version=$$(grep ^STABLE_ADDITIONAL_VERSION bazel-out/stable-status.txt | cut -d' ' -f2); \
+    printf '%s' $$version > $@
+    """,
+    stamp = 1,
+)
+
+genrule(
     name = "gen_pachd_coverage",
-    srcs = ["pachd_gopath"],
+    srcs = [
+        "pachd_gopath",
+        "additional_version.txt",
+        "app_version.txt",
+    ],
     outs = ["pachd_coverage"],
-    cmd = "$(location //src/cmd/compile-with-coverage) -target github.com/pachyderm/pachyderm/v2/src/server/cmd/pachd -go $(location @go_sdk//:bin/go) -out $@ -gopath $(location pachd_gopath)",
+    cmd = """
+    $(location //src/cmd/compile-with-coverage) \
+        -target github.com/pachyderm/pachyderm/v2/src/server/cmd/pachd \
+        -go $(location @go_sdk//:bin/go) \
+        -out $@ \
+        -gopath $(location pachd_gopath) \
+        -app_version=$$(cat $(location app_version.txt)) \
+        -additional_version=$$(cat $(location additional_version.txt))
+    """,
     tools = [
         "//src/cmd/compile-with-coverage",
         "@go_sdk//:bin/go",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/src/server/cmd/pachd/BUILD.bazel
+++ b/src/server/cmd/pachd/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_path")
 
 go_library(
     name = "pachd_lib",
@@ -38,4 +38,24 @@ go_binary(
         "github.com/pachyderm/pachyderm/v2/src/version.AppVersion": "{STABLE_APP_VERSION}",
         "github.com/pachyderm/pachyderm/v2/src/version.AdditionalVersion": "{STABLE_ADDITIONAL_VERSION}",
     },
+)
+
+go_path(
+    name = "pachd_gopath",
+    include_data = True,
+    include_pkg = False,
+    include_transitive = True,
+    mode = "copy",
+    deps = ["pachd"],
+)
+
+genrule(
+    name = "gen_pachd_coverage",
+    srcs = ["pachd_gopath"],
+    outs = ["pachd_coverage"],
+    cmd = "$(location //src/cmd/compile-with-coverage) -target github.com/pachyderm/pachyderm/v2/src/server/cmd/pachd -go $(location @go_sdk//:bin/go) -out $@ -gopath $(location pachd_gopath)",
+    tools = [
+        "//src/cmd/compile-with-coverage",
+        "@go_sdk//:bin/go",
+    ],
 )


### PR DESCRIPTION
The k8s tests want to collect code coverage from the binary running in k8s.  `rules_go` does not have a way to do that, so I hacked something together instead.  We use `rules_go` to dump the GOPATH of the transitive closure of pachd into a directory, then we `GO111MODULE=off go build ...`  in that directory.  A snag is that Bazel runfiles can be symlinks, but `//go:embed` does not like symlinks.  So there is a wrapper script, `//src/cmd/compile-with-coverage` that resolves all the symlinks and produces a symlink-free `$GOPATH`.  It then invokes `go build` against that `GOPATH`.  The only downside of this approach is that no caching occurs; if any source file changes, then the entire binary is built from scratch.  That takes about 30s on my 32-core workstation, which is a very long time.

The rest of the PRs are some genrules to plumb all of that into Bazel, so that eventually `//oci:pachd_coverage_image` can be produced using the normal container-building machinery.

Right now, this is somewhat difficult to use.  To run it:

```
$ bazel build //oci:pachd_coverage_image
$ bazel run //src/testing/pachdev -- load-image oci:$(bazel info bazel-bin)/oci/pachd_coverage_image pachd:coverage1234
$ kubectl edit deployment pachd 
<edit to use pachd:coverage1234>
```
Making this simpler to use involves splitting out pachdev's subcommands into individual bazel targets and then making pachdev invoke the correct bazel target.  That's because I don't want to take a dependency from pachdev to //oci:pachd_coverage_image, because any change to any code causes it to be rebuilt from scratch, and that would make every command slow even when you don't want code coverage.  This will all be cleaned up soon.

We also need to convert the output of `pachctl debug profile cover` to LCOV and stick it in $COVERAGE_DIRECTORY.  Then bazel will merge that coverage information into everything else that the tests produce, including the final merged coverage report.

Part of CORE-2081.