### PR TITLE
Handle the proto-copying with Go

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1561,23 +1561,12 @@ jobs:
       - image: << pipeline.parameters.ci_runner_image >>
     steps:
       - checkout
-      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:make_proto
-      - run: git checkout MODULE.bazel.lock # For OSX-only changes.
-      - run:
-          name: Check that you ran make proto
-          command: |
-            echo "If you see diffs here, it means that you forgot to run `bazel run //:make_proto`"
-            git diff --exit-code
       - run:
           name: Check that you ran gazelle
           command: |
             echo "If you see an error here, it means you forgot to `bazel run //:gazelle`"
             bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle --  -mode=diff
-      - run:
-          name: Check that you ran buildifier
-          command: |
-            echo "If you see an error here, it means you forgot to `bazel run //:buildifier`"
-            bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:buildifier_test
+      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:style_tests
       - run:
           command: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
           when: always

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1566,7 +1566,7 @@ jobs:
           command: |
             echo "If you see an error here, it means you forgot to `bazel run //:gazelle`"
             bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:gazelle --  -mode=diff
-      - run: bazel run --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:style_tests
+      - run: bazel test --config=remotecache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} //:style_tests
       - run:
           command: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
           when: always

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -99,6 +99,7 @@ buildifier_test(
     lint_mode = "warn",
     mode = "diff",
     no_sandbox = True,
+    tags = ["style"],
     workspace = "//:MODULE.bazel",
 )
 
@@ -136,5 +137,17 @@ test_suite(
     tags = ["manual"],
     tests = [
         "//src/server/pfs/fuse:fuse_test",
+    ],
+)
+
+test_suite(
+    name = "style_tests",
+    tags = [
+        "manual",
+        "style",
+    ],
+    tests = [
+        ":buildifier_test",
+        "//src/proto:check_generated_protos",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     repo_name = "com_github_pachyderm_pachyderm",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.1.0")  # Needed for arm64 jq and rules_oci/#425.
+bazel_dep(name = "aspect_bazel_lib", version = "2.5.0")  # Needed for arm64 jq and rules_oci/#425.
 bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "gazelle", version = "0.35.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "2b15d5eb0804fe31677922026b82edc575f41de2df9d3d48db3b980b647a6b34",
+  "moduleFileHash": "f61027bbf2a6c93f62c02e8e13511c33ff8e1c3432c0b1b1f8492b6d2c0f4cb6",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -714,7 +714,7 @@
         }
       ],
       "deps": {
-        "aspect_bazel_lib": "aspect_bazel_lib@2.1.0",
+        "aspect_bazel_lib": "aspect_bazel_lib@2.5.0",
         "container_structure_test": "container_structure_test@1.16.0",
         "gazelle": "gazelle@0.35.0",
         "jsonnet_go": "jsonnet_go@0.20.0",
@@ -726,10 +726,10 @@
         "local_config_platform": "local_config_platform@_"
       }
     },
-    "aspect_bazel_lib@2.1.0": {
+    "aspect_bazel_lib@2.5.0": {
       "name": "aspect_bazel_lib",
-      "version": "2.1.0",
-      "key": "aspect_bazel_lib@2.1.0",
+      "version": "2.5.0",
+      "key": "aspect_bazel_lib@2.5.0",
       "repoName": "aspect_bazel_lib",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [
@@ -749,9 +749,9 @@
         {
           "extensionBzlFile": "@aspect_bazel_lib//lib:extensions.bzl",
           "extensionName": "toolchains",
-          "usingModule": "aspect_bazel_lib@2.1.0",
+          "usingModule": "aspect_bazel_lib@2.5.0",
           "location": {
-            "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
             "line": 17,
             "column": 37
           },
@@ -772,7 +772,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 18,
                 "column": 36
               }
@@ -782,7 +782,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 19,
                 "column": 39
               }
@@ -792,7 +792,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 20,
                 "column": 24
               }
@@ -802,7 +802,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 21,
                 "column": 24
               }
@@ -812,7 +812,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 22,
                 "column": 31
               }
@@ -822,7 +822,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 23,
                 "column": 25
               }
@@ -832,7 +832,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 24,
                 "column": 37
               }
@@ -842,7 +842,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
                 "line": 25,
                 "column": 26
               }
@@ -854,7 +854,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "io_bazel_stardoc": "stardoc@0.5.4",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -863,15 +863,15 @@
         "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "aspect_bazel_lib~2.1.0",
+          "name": "aspect_bazel_lib~2.5.0",
           "urls": [
-            "https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"
+            "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.0/bazel-lib-v2.5.0.tar.gz"
           ],
-          "integrity": "sha256-/IvWcDgOq6UxR2mrvp/uIdZB49oG2dJrgHOjAfbWIzI=",
-          "strip_prefix": "bazel-lib-2.1.0",
+          "integrity": "sha256-9ep2aCsgnMC9kND1o7JtL3pqKIXwxfYV5ykT9IBduw0=",
+          "strip_prefix": "bazel-lib-2.5.0",
           "remote_patches": {
-            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/patches/go_dev_dep.patch": "sha256-KgABwDzOT+DugUHn9tHLOz05osnk2FLsS10d5zqG/M0=",
-            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.1.0/patches/module_dot_bazel_version.patch": "sha256-RNSVF8mNxR8RUGjBJFztw241W9W3/GFH6XJ9h+zltFM="
+            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/patches/go_dev_dep.patch": "sha256-KgABwDzOT+DugUHn9tHLOz05osnk2FLsS10d5zqG/M0=",
+            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/patches/module_dot_bazel_version.patch": "sha256-Goo+3Jt++n8fe6jssy24AABw0FjsH0yA592LrOVNDSI="
           },
           "remote_patch_strip": 1
         }
@@ -906,9 +906,9 @@
         }
       ],
       "deps": {
-        "aspect_bazel_lib": "aspect_bazel_lib@2.1.0",
+        "aspect_bazel_lib": "aspect_bazel_lib@2.5.0",
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1201,7 +1201,7 @@
       "deps": {
         "io_bazel_rules_go_bazel_features": "bazel_features@1.1.1",
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
         "gazelle": "gazelle@0.35.0",
@@ -1268,9 +1268,9 @@
         }
       ],
       "deps": {
-        "aspect_bazel_lib": "aspect_bazel_lib@2.1.0",
+        "aspect_bazel_lib": "aspect_bazel_lib@2.5.0",
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1379,7 +1379,7 @@
       "deps": {
         "bazel_features": "bazel_features@1.1.1",
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
         "bazel_tools": "bazel_tools@_",
@@ -1432,7 +1432,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1580,7 +1580,7 @@
         "rules_license": "rules_license@0.0.7",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_python": "rules_python@0.27.1",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.3",
         "build_bazel_apple_support": "apple_support@1.5.0",
@@ -1596,7 +1596,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_"
       }
     },
@@ -1612,7 +1612,7 @@
       ],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1631,10 +1631,10 @@
         }
       }
     },
-    "platforms@0.0.7": {
+    "platforms@0.0.8": {
       "name": "platforms",
-      "version": "0.0.7",
-      "key": "platforms@0.0.7",
+      "version": "0.0.8",
+      "key": "platforms@0.0.8",
       "repoName": "platforms",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [],
@@ -1650,9 +1650,9 @@
         "attributes": {
           "name": "platforms",
           "urls": [
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
           ],
-          "integrity": "sha256-OlYcmee9vpFzqmU/1Xn+hJ8djWc5V4CrR3Cx84FDHVE=",
+          "integrity": "sha256-gVBAZgU4ns7LbaB8vLUJ1WN6OrmiS8abEQFTE2fYnXQ=",
           "strip_prefix": "",
           "remote_patches": {},
           "remote_patch_strip": 0
@@ -1933,7 +1933,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -2032,7 +2032,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "rules_proto": "rules_proto@5.3.0-21.7",
@@ -2091,7 +2091,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -2145,7 +2145,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -2206,7 +2206,7 @@
       "extensionUsages": [],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -2240,7 +2240,7 @@
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
         "com_google_absl": "abseil-cpp@20211102.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -2356,7 +2356,7 @@
       "extensionUsages": [],
       "deps": {
         "com_google_absl": "abseil-cpp@20211102.0",
-        "platforms": "platforms@0.0.7",
+        "platforms": "platforms@0.0.8",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -2962,184 +2962,184 @@
         ]
       }
     },
-    "@@aspect_bazel_lib~2.1.0//lib:extensions.bzl%toolchains": {
+    "@@aspect_bazel_lib~2.5.0//lib:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "EYX5uBBsxFhsuNGpA+q60j5Nx3RJR3S0VTlpd3QvRU8=",
+        "bzlTransitiveDigest": "920imlyu0s6sCUlVmkDsMglkEyu6tt0LwO7b+99x9bg=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "expand_template_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_windows_amd64",
               "platform": "windows_amd64"
             }
           },
           "copy_to_directory_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_windows_amd64",
               "platform": "windows_amd64"
             }
           },
           "bsd_tar_host": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:tar_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:tar_toolchain.bzl",
             "ruleClassName": "bsdtar_binary_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bsd_tar_host",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bsd_tar_host",
               "platform": "host"
             }
           },
           "jq_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq_darwin_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq_darwin_amd64",
               "platform": "darwin_amd64",
               "version": "1.7"
             }
           },
           "copy_to_directory_freebsd_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_freebsd_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_freebsd_amd64",
               "platform": "freebsd_amd64"
             }
           },
           "expand_template_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_linux_amd64",
               "platform": "linux_amd64"
             }
           },
           "jq_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq_linux_arm64",
               "platform": "linux_arm64",
               "version": "1.7"
             }
           },
           "coreutils_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~coreutils_darwin_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~coreutils_darwin_arm64",
               "platform": "darwin_arm64",
               "version": "0.0.23"
             }
           },
           "copy_to_directory_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_linux_arm64",
               "platform": "linux_arm64"
             }
           },
           "bsd_tar_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:tar_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:tar_toolchain.bzl",
             "ruleClassName": "bsdtar_binary_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bsd_tar_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bsd_tar_linux_arm64",
               "platform": "linux_arm64"
             }
           },
           "copy_directory_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_darwin_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_darwin_amd64",
               "platform": "darwin_amd64"
             }
           },
           "coreutils_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~coreutils_darwin_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~coreutils_darwin_amd64",
               "platform": "darwin_amd64",
               "version": "0.0.23"
             }
           },
           "coreutils_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~coreutils_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~coreutils_linux_arm64",
               "platform": "linux_arm64",
               "version": "0.0.23"
             }
           },
           "yq_linux_s390x": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_linux_s390x",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_linux_s390x",
               "platform": "linux_s390x",
               "version": "4.25.2"
             }
           },
           "yq": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_host_alias_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq"
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq"
             }
           },
           "expand_template_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_darwin_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_darwin_amd64",
               "platform": "darwin_amd64"
             }
           },
           "copy_directory_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_linux_amd64",
               "platform": "linux_amd64"
             }
           },
           "jq_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq_darwin_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq_darwin_arm64",
               "platform": "darwin_arm64",
               "version": "1.7"
             }
           },
           "yq_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_darwin_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_darwin_amd64",
               "platform": "darwin_amd64",
               "version": "4.25.2"
             }
           },
           "copy_directory_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_linux_arm64",
               "platform": "linux_arm64"
             }
           },
           "expand_template_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_toolchains",
               "user_repository_name": "expand_template"
             }
           },
@@ -3147,7 +3147,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bats_assert",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bats_assert",
               "sha256": "98ca3b685f8b8993e48ec057565e6e2abcc541034ed5b0e81f191505682037fd",
               "urls": [
                 "https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz"
@@ -3157,26 +3157,26 @@
             }
           },
           "copy_to_directory_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_darwin_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_darwin_amd64",
               "platform": "darwin_amd64"
             }
           },
           "bsd_tar_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:tar_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:tar_toolchain.bzl",
             "ruleClassName": "bsdtar_binary_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bsd_tar_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bsd_tar_linux_amd64",
               "platform": "linux_amd64"
             }
           },
           "yq_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_toolchains",
               "user_repository_name": "yq"
             }
           },
@@ -3184,7 +3184,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bats_support",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bats_support",
               "sha256": "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
               "urls": [
                 "https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz"
@@ -3194,83 +3194,83 @@
             }
           },
           "bsd_tar_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:tar_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:tar_toolchain.bzl",
             "ruleClassName": "bsdtar_binary_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bsd_tar_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bsd_tar_windows_amd64",
               "platform": "windows_amd64"
             }
           },
           "jq": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_host_alias_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq"
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq"
             }
           },
           "expand_template_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_darwin_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_darwin_arm64",
               "platform": "darwin_arm64"
             }
           },
           "copy_to_directory_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_linux_amd64",
               "platform": "linux_amd64"
             }
           },
           "coreutils_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~coreutils_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~coreutils_linux_amd64",
               "platform": "linux_amd64",
               "version": "0.0.23"
             }
           },
           "copy_directory_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_toolchains",
               "user_repository_name": "copy_directory"
             }
           },
           "yq_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_linux_amd64",
               "platform": "linux_amd64",
               "version": "4.25.2"
             }
           },
           "copy_to_directory_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_darwin_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_darwin_arm64",
               "platform": "darwin_arm64"
             }
           },
           "coreutils_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~coreutils_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~coreutils_toolchains",
               "user_repository_name": "coreutils"
             }
           },
           "copy_directory_freebsd_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_freebsd_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_freebsd_amd64",
               "platform": "freebsd_amd64"
             }
           },
@@ -3278,7 +3278,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bats_file",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bats_file",
               "sha256": "9b69043241f3af1c2d251f89b4fcafa5df3f05e97b89db18d7c9bdf5731bb27a",
               "urls": [
                 "https://github.com/bats-core/bats-file/archive/v0.4.0.tar.gz"
@@ -3288,27 +3288,27 @@
             }
           },
           "expand_template_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_linux_arm64",
               "platform": "linux_arm64"
             }
           },
           "jq_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq_linux_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq_linux_amd64",
               "platform": "linux_amd64",
               "version": "1.7"
             }
           },
           "bsd_tar_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:tar_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:tar_toolchain.bzl",
             "ruleClassName": "tar_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bsd_tar_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bsd_tar_toolchains",
               "user_repository_name": "bsd_tar"
             }
           },
@@ -3316,7 +3316,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~bats_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~bats_toolchains",
               "sha256": "a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd",
               "urls": [
                 "https://github.com/bats-core/bats-core/archive/v1.10.0.tar.gz"
@@ -3326,95 +3326,95 @@
             }
           },
           "yq_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_windows_amd64",
               "platform": "windows_amd64",
               "version": "4.25.2"
             }
           },
           "jq_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq_windows_amd64",
               "platform": "windows_amd64",
               "version": "1.7"
             }
           },
           "expand_template_freebsd_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:expand_template_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:expand_template_toolchain.bzl",
             "ruleClassName": "expand_template_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~expand_template_freebsd_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~expand_template_freebsd_amd64",
               "platform": "freebsd_amd64"
             }
           },
           "yq_linux_ppc64le": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_linux_ppc64le",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_linux_ppc64le",
               "platform": "linux_ppc64le",
               "version": "4.25.2"
             }
           },
           "copy_to_directory_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_to_directory_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_to_directory_toolchains",
               "user_repository_name": "copy_to_directory"
             }
           },
           "jq_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_toolchains_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~jq_toolchains",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~jq_toolchains",
               "user_repository_name": "jq"
             }
           },
           "copy_directory_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_darwin_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_darwin_arm64",
               "platform": "darwin_arm64"
             }
           },
           "copy_directory_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_directory_toolchain.bzl",
             "ruleClassName": "copy_directory_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~copy_directory_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~copy_directory_windows_amd64",
               "platform": "windows_amd64"
             }
           },
           "yq_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_darwin_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_darwin_arm64",
               "platform": "darwin_arm64",
               "version": "4.25.2"
             }
           },
           "coreutils_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~coreutils_windows_amd64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~coreutils_windows_amd64",
               "platform": "windows_amd64",
               "version": "0.0.23"
             }
           },
           "yq_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
-              "name": "aspect_bazel_lib~2.1.0~toolchains~yq_linux_arm64",
+              "name": "aspect_bazel_lib~2.5.0~toolchains~yq_linux_arm64",
               "platform": "linux_arm64",
               "version": "4.25.2"
             }
@@ -3422,17 +3422,17 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "aspect_bazel_lib~2.1.0",
+            "aspect_bazel_lib~2.5.0",
             "aspect_bazel_lib",
-            "aspect_bazel_lib~2.1.0"
+            "aspect_bazel_lib~2.5.0"
           ],
           [
-            "aspect_bazel_lib~2.1.0",
+            "aspect_bazel_lib~2.5.0",
             "bazel_skylib",
             "bazel_skylib~1.5.0"
           ],
           [
-            "aspect_bazel_lib~2.1.0",
+            "aspect_bazel_lib~2.5.0",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -11783,7 +11783,7 @@
     },
     "@@rules_oci~1.5.1//oci:extensions.bzl%oci": {
       "general": {
-        "bzlTransitiveDigest": "bKrpjTmBOcdRmQewuGNd18CF6l+e2SG37cMFMA4wFZo=",
+        "bzlTransitiveDigest": "nG275aBemoE385i0uvJfW/e7iB/rzLHvNIViD0GhD7o=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -11813,7 +11813,7 @@
             }
           },
           "copy_to_directory_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_windows_amd64",
@@ -11821,7 +11821,7 @@
             }
           },
           "jq_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq_darwin_amd64",
@@ -11830,7 +11830,7 @@
             }
           },
           "copy_to_directory_freebsd_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_freebsd_amd64",
@@ -11847,7 +11847,7 @@
             }
           },
           "jq_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq_linux_arm64",
@@ -11856,7 +11856,7 @@
             }
           },
           "coreutils_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~coreutils_darwin_arm64",
@@ -11865,7 +11865,7 @@
             }
           },
           "copy_to_directory_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_linux_arm64",
@@ -11896,7 +11896,7 @@
             }
           },
           "coreutils_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~coreutils_darwin_amd64",
@@ -11905,7 +11905,7 @@
             }
           },
           "coreutils_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~coreutils_linux_arm64",
@@ -11914,7 +11914,7 @@
             }
           },
           "yq_linux_s390x": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_linux_s390x",
@@ -11923,7 +11923,7 @@
             }
           },
           "yq": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_host_alias_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq"
@@ -11939,7 +11939,7 @@
             }
           },
           "jq_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq_darwin_arm64",
@@ -11948,7 +11948,7 @@
             }
           },
           "yq_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_darwin_amd64",
@@ -12032,7 +12032,7 @@
             }
           },
           "copy_to_directory_darwin_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_darwin_amd64",
@@ -12040,7 +12040,7 @@
             }
           },
           "yq_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_toolchains_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_toolchains",
@@ -12080,7 +12080,7 @@
             }
           },
           "jq": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_host_alias_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq"
@@ -12096,7 +12096,7 @@
             }
           },
           "copy_to_directory_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_linux_amd64",
@@ -12104,7 +12104,7 @@
             }
           },
           "coreutils_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~coreutils_linux_amd64",
@@ -12113,7 +12113,7 @@
             }
           },
           "yq_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_linux_amd64",
@@ -12131,7 +12131,7 @@
             }
           },
           "copy_to_directory_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_darwin_arm64",
@@ -12139,7 +12139,7 @@
             }
           },
           "coreutils_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_toolchains_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~coreutils_toolchains",
@@ -12161,7 +12161,7 @@
             }
           },
           "jq_linux_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq_linux_amd64",
@@ -12196,7 +12196,7 @@
             }
           },
           "yq_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_windows_amd64",
@@ -12223,7 +12223,7 @@
             }
           },
           "jq_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq_windows_amd64",
@@ -12232,7 +12232,7 @@
             }
           },
           "yq_linux_ppc64le": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_linux_ppc64le",
@@ -12241,7 +12241,7 @@
             }
           },
           "jq_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:jq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:jq_toolchain.bzl",
             "ruleClassName": "jq_toolchains_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~jq_toolchains",
@@ -12249,7 +12249,7 @@
             }
           },
           "copy_to_directory_toolchains": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:copy_to_directory_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:copy_to_directory_toolchain.bzl",
             "ruleClassName": "copy_to_directory_toolchains_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~copy_to_directory_toolchains",
@@ -12257,7 +12257,7 @@
             }
           },
           "yq_darwin_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_darwin_arm64",
@@ -12273,7 +12273,7 @@
             }
           },
           "coreutils_windows_amd64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:coreutils_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:coreutils_toolchain.bzl",
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~coreutils_windows_amd64",
@@ -12282,7 +12282,7 @@
             }
           },
           "yq_linux_arm64": {
-            "bzlFile": "@@aspect_bazel_lib~2.1.0//lib/private:yq_toolchain.bzl",
+            "bzlFile": "@@aspect_bazel_lib~2.5.0//lib/private:yq_toolchain.bzl",
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "name": "rules_oci~1.5.1~oci~yq_linux_arm64",
@@ -12293,14 +12293,14 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "aspect_bazel_lib~2.1.0",
+            "aspect_bazel_lib~2.5.0",
             "bazel_tools",
             "bazel_tools"
           ],
           [
             "rules_oci~1.5.1",
             "aspect_bazel_lib",
-            "aspect_bazel_lib~2.1.0"
+            "aspect_bazel_lib~2.5.0"
           ],
           [
             "rules_oci~1.5.1",

--- a/proto-docs.json
+++ b/proto-docs.json
@@ -9171,6 +9171,24 @@
           ]
         },
         {
+          "name": "FileSetType",
+          "longName": "GetFileSetRequest.FileSetType",
+          "fullName": "pfs_v2.GetFileSetRequest.FileSetType",
+          "description": "",
+          "values": [
+            {
+              "name": "TOTAL",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "DIFF",
+              "number": "1",
+              "description": ""
+            }
+          ]
+        },
+        {
           "name": "OriginKind",
           "longName": "OriginKind",
           "fullName": "pfs_v2.OriginKind",
@@ -11387,6 +11405,18 @@
               "type": "Commit",
               "longType": "Commit",
               "fullType": "pfs_v2.Commit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "FileSetType",
+              "longType": "GetFileSetRequest.FileSetType",
+              "fullType": "pfs_v2.GetFileSetRequest.FileSetType",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",

--- a/proto-docs.json
+++ b/proto-docs.json
@@ -9073,6 +9073,825 @@
       ]
     },
     {
+      "name": "logs/logs.proto",
+      "description": "",
+      "package": "logs",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "LogFormat",
+          "longName": "LogFormat",
+          "fullName": "logs.LogFormat",
+          "description": "",
+          "values": [
+            {
+              "name": "LOG_FORMAT_UNKNOWN",
+              "number": "0",
+              "description": "error"
+            },
+            {
+              "name": "LOG_FORMAT_VERBATIM_WITH_TIMESTAMP",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "LOG_FORMAT_PARSED_JSON",
+              "number": "2",
+              "description": ""
+            },
+            {
+              "name": "LOG_FORMAT_PPS_LOGMESSAGE",
+              "number": "3",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "LogLevel",
+          "longName": "LogLevel",
+          "fullName": "logs.LogLevel",
+          "description": "",
+          "values": [
+            {
+              "name": "LOG_LEVEL_DEBUG",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "LOG_LEVEL_INFO",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "LOG_LEVEL_ERROR",
+              "number": "2",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "AdminLogQuery",
+          "longName": "AdminLogQuery",
+          "fullName": "logs.AdminLogQuery",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "logql",
+              "description": "Arbitrary LogQL query",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod",
+              "description": "A pod's logs (all containers)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "pod_container",
+              "description": "One container",
+              "label": "",
+              "type": "PodContainer",
+              "longType": "PodContainer",
+              "fullType": "logs.PodContainer",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "app",
+              "description": "One \"app\" (logql -\u003e {app=X})",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "master",
+              "description": "All master worker lines from a pipeline",
+              "label": "",
+              "type": "PipelineLogQuery",
+              "longType": "PipelineLogQuery",
+              "fullType": "logs.PipelineLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "storage",
+              "description": "All storage container lines from a pipeline",
+              "label": "",
+              "type": "PipelineLogQuery",
+              "longType": "PipelineLogQuery",
+              "fullType": "logs.PipelineLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "user",
+              "description": "All worker lines from a pipeline/job",
+              "label": "",
+              "type": "UserLogQuery",
+              "longType": "UserLogQuery",
+              "fullType": "logs.UserLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "admin_type",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetLogsRequest",
+          "longName": "GetLogsRequest",
+          "fullName": "logs.GetLogsRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "query",
+              "description": "",
+              "label": "",
+              "type": "LogQuery",
+              "longType": "LogQuery",
+              "fullType": "logs.LogQuery",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "filter",
+              "description": "",
+              "label": "",
+              "type": "LogFilter",
+              "longType": "LogFilter",
+              "fullType": "logs.LogFilter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tail",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "want_paging_hint",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "log_format",
+              "description": "",
+              "label": "",
+              "type": "LogFormat",
+              "longType": "LogFormat",
+              "fullType": "logs.LogFormat",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetLogsResponse",
+          "longName": "GetLogsResponse",
+          "fullName": "logs.GetLogsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "paging_hint",
+              "description": "",
+              "label": "",
+              "type": "PagingHint",
+              "longType": "PagingHint",
+              "fullType": "logs.PagingHint",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "response_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "log",
+              "description": "",
+              "label": "",
+              "type": "LogMessage",
+              "longType": "LogMessage",
+              "fullType": "logs.LogMessage",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "response_type",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LogFilter",
+          "longName": "LogFilter",
+          "fullName": "logs.LogFilter",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "time_range",
+              "description": "",
+              "label": "",
+              "type": "TimeRangeLogFilter",
+              "longType": "TimeRangeLogFilter",
+              "fullType": "logs.TimeRangeLogFilter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "limit",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "regex",
+              "description": "",
+              "label": "",
+              "type": "RegexLogFilter",
+              "longType": "RegexLogFilter",
+              "fullType": "logs.RegexLogFilter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "level",
+              "description": "Minimum log level to return; worker will always run at level debug, but setting INFO here restores original behavior",
+              "label": "",
+              "type": "LogLevel",
+              "longType": "LogLevel",
+              "fullType": "logs.LogLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LogMessage",
+          "longName": "LogMessage",
+          "fullName": "logs.LogMessage",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "verbatim",
+              "description": "",
+              "label": "",
+              "type": "VerbatimLogMessage",
+              "longType": "VerbatimLogMessage",
+              "fullType": "logs.VerbatimLogMessage",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "log_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "json",
+              "description": "",
+              "label": "",
+              "type": "ParsedJSONLogMessage",
+              "longType": "ParsedJSONLogMessage",
+              "fullType": "logs.ParsedJSONLogMessage",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "log_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "pps_log_message",
+              "description": "",
+              "label": "",
+              "type": "LogMessage",
+              "longType": "pps_v2.LogMessage",
+              "fullType": "pps_v2.LogMessage",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "log_type",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LogQuery",
+          "longName": "LogQuery",
+          "fullName": "logs.LogQuery",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "user",
+              "description": "",
+              "label": "",
+              "type": "UserLogQuery",
+              "longType": "UserLogQuery",
+              "fullType": "logs.UserLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "query_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "admin",
+              "description": "",
+              "label": "",
+              "type": "AdminLogQuery",
+              "longType": "AdminLogQuery",
+              "fullType": "logs.AdminLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "query_type",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PagingHint",
+          "longName": "PagingHint",
+          "fullName": "logs.PagingHint",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "older",
+              "description": "",
+              "label": "",
+              "type": "GetLogsRequest",
+              "longType": "GetLogsRequest",
+              "fullType": "logs.GetLogsRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "newer",
+              "description": "",
+              "label": "",
+              "type": "GetLogsRequest",
+              "longType": "GetLogsRequest",
+              "fullType": "logs.GetLogsRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ParsedJSONLogMessage",
+          "longName": "ParsedJSONLogMessage",
+          "fullName": "logs.ParsedJSONLogMessage",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "verbatim",
+              "description": "The verbatim line from Loki",
+              "label": "",
+              "type": "VerbatimLogMessage",
+              "longType": "VerbatimLogMessage",
+              "fullType": "logs.VerbatimLogMessage",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "object",
+              "description": "A raw JSON parse of the entire line",
+              "label": "",
+              "type": "Struct",
+              "longType": "google.protobuf.Struct",
+              "fullType": "google.protobuf.Struct",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "native_timestamp",
+              "description": "If a parseable timestamp was found in `fields`",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pps_log_message",
+              "description": "For code that wants to filter on pipeline/job/etc",
+              "label": "",
+              "type": "LogMessage",
+              "longType": "pps_v2.LogMessage",
+              "fullType": "pps_v2.LogMessage",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PipelineJobLogQuery",
+          "longName": "PipelineJobLogQuery",
+          "fullName": "logs.PipelineJobLogQuery",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "PipelineLogQuery",
+              "longType": "PipelineLogQuery",
+              "fullType": "logs.PipelineLogQuery",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "job",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PipelineLogQuery",
+          "longName": "PipelineLogQuery",
+          "fullName": "logs.PipelineLogQuery",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PodContainer",
+          "longName": "PodContainer",
+          "fullName": "logs.PodContainer",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pod",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "container",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RegexLogFilter",
+          "longName": "RegexLogFilter",
+          "fullName": "logs.RegexLogFilter",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pattern",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "negate",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TimeRangeLogFilter",
+          "longName": "TimeRangeLogFilter",
+          "fullName": "logs.TimeRangeLogFilter",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "from",
+              "description": "Can be null",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "until",
+              "description": "Can be null",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UserLogQuery",
+          "longName": "UserLogQuery",
+          "fullName": "logs.UserLogQuery",
+          "description": "Only returns \"user\" logs",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "project",
+              "description": "All pipelines in the project",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "user_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline",
+              "description": "One pipeline in a project",
+              "label": "",
+              "type": "PipelineLogQuery",
+              "longType": "PipelineLogQuery",
+              "fullType": "logs.PipelineLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "user_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "datum",
+              "description": "One datum.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "user_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "job",
+              "description": "One job, across pipelines and projects",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "user_type",
+              "defaultValue": ""
+            },
+            {
+              "name": "pipeline_job",
+              "description": "One job in one pipeline",
+              "label": "",
+              "type": "PipelineJobLogQuery",
+              "longType": "PipelineJobLogQuery",
+              "fullType": "logs.PipelineJobLogQuery",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "user_type",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "VerbatimLogMessage",
+          "longName": "VerbatimLogMessage",
+          "fullName": "logs.VerbatimLogMessage",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "line",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timestamp",
+              "description": "",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "google.protobuf.Timestamp",
+              "fullType": "google.protobuf.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "API",
+          "longName": "API",
+          "fullName": "logs.API",
+          "description": "",
+          "methods": [
+            {
+              "name": "GetLogs",
+              "description": "",
+              "requestType": "GetLogsRequest",
+              "requestLongType": "GetLogsRequest",
+              "requestFullType": "logs.GetLogsRequest",
+              "requestStreaming": false,
+              "responseType": "GetLogsResponse",
+              "responseLongType": "GetLogsResponse",
+              "responseFullType": "logs.GetLogsResponse",
+              "responseStreaming": true
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "pfs/pfs.proto",
       "description": "",
       "package": "pfs_v2",
@@ -9212,6 +10031,19 @@
             {
               "name": "FSCK",
               "number": "3",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "Ordering",
+          "longName": "RepoPage.Ordering",
+          "fullName": "pfs_v2.RepoPage.Ordering",
+          "description": "",
+          "values": [
+            {
+              "name": "PROJECT_REPO",
+              "number": "0",
               "description": ""
             }
           ]
@@ -11967,7 +12799,7 @@
           "fields": [
             {
               "name": "type",
-              "description": "type is the type of (system) repos that should be returned\nan empty string requests all repos",
+              "description": "Type is the type of (system) repo that should be returned.\nAn empty string requests all repos.",
               "label": "",
               "type": "string",
               "longType": "string",
@@ -11979,11 +12811,23 @@
             },
             {
               "name": "projects",
-              "description": "projects filters out repos that do not belong in the list, while no projects means list all repos.",
+              "description": "Filters out repos whos project isn't represented.\nAn empty list of projects doesn't filter repos by their project.",
               "label": "repeated",
               "type": "Project",
               "longType": "Project",
               "fullType": "pfs_v2.Project",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "page",
+              "description": "Specifies which page of repos should be returned.\nIf page isn't specified, a single page containing all the relevant repos is returned.",
+              "label": "",
+              "type": "RepoPage",
+              "longType": "RepoPage",
+              "fullType": "pfs_v2.RepoPage",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",
@@ -12492,6 +13336,54 @@
           ]
         },
         {
+          "name": "RepoPage",
+          "longName": "RepoPage",
+          "fullName": "pfs_v2.RepoPage",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "",
+              "label": "",
+              "type": "Ordering",
+              "longType": "RepoPage.Ordering",
+              "fullType": "pfs_v2.RepoPage.Ordering",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "page_size",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "page_index",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
           "name": "SQLDatabaseEgress",
           "longName": "SQLDatabaseEgress",
           "fullName": "pfs_v2.SQLDatabaseEgress",
@@ -12615,7 +13507,7 @@
           "name": "ShardFileSetRequest",
           "longName": "ShardFileSetRequest",
           "fullName": "pfs_v2.ShardFileSetRequest",
-          "description": "",
+          "description": "If both num_files and size_bytes are set, shards are created\nbased on whichever threshold is surpassed first. If a shard\nconfiguration field (num_files, size_bytes) is unset, the\nstorage's default value is used.",
           "hasExtensions": false,
           "hasFields": true,
           "hasOneofs": false,
@@ -12628,6 +13520,30 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "num_files",
+              "description": "Number of files targeted in each shard",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_bytes",
+              "description": "Size (in bytes) targeted for each shard",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",
@@ -15173,6 +16089,42 @@
               "type": "CreatePipelineRequest",
               "longType": "CreatePipelineRequest",
               "fullType": "pps_v2.CreatePipelineRequest",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CreateDatumRequest",
+          "longName": "CreateDatumRequest",
+          "fullName": "pps_v2.CreateDatumRequest",
+          "description": "Emits a stream of datums as they are created from the given input. Client\nmust cancel the stream when it no longer wants to receive datums.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "input",
+              "description": "Input is the input to list datums from. The datums listed are the ones \nthat would be run if a pipeline was created with the provided input.\nThe input field is only required for the first request. The server\nignores subsequent requests' input field.",
+              "label": "",
+              "type": "Input",
+              "longType": "Input",
+              "fullType": "pps_v2.Input",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number",
+              "description": "Number of datums to return in next response",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",
@@ -20930,6 +21882,18 @@
               "responseStreaming": true
             },
             {
+              "name": "CreateDatum",
+              "description": "",
+              "requestType": "CreateDatumRequest",
+              "requestLongType": "CreateDatumRequest",
+              "requestFullType": "pps_v2.CreateDatumRequest",
+              "requestStreaming": true,
+              "responseType": "DatumInfo",
+              "responseLongType": "DatumInfo",
+              "responseFullType": "pps_v2.DatumInfo",
+              "responseStreaming": true
+            },
+            {
               "name": "RestartDatum",
               "description": "",
               "requestType": "RestartDatumRequest",
@@ -25875,6 +26839,18 @@
               "isoneof": false,
               "oneofdecl": "",
               "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
             }
           ]
         },
@@ -25967,6 +26943,18 @@
               "type": "PathRange",
               "longType": "pfs_v2.PathRange",
               "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",
@@ -26087,6 +27075,18 @@
               "type": "PathRange",
               "longType": "pfs_v2.PathRange",
               "fullType": "pfs_v2.PathRange",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auth_token",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",

--- a/proto-docs.md
+++ b/proto-docs.md
@@ -265,6 +265,28 @@
   
     - [API](#license_v2-API)
   
+- [logs/logs.proto](#logs_logs-proto)
+    - [AdminLogQuery](#logs-AdminLogQuery)
+    - [GetLogsRequest](#logs-GetLogsRequest)
+    - [GetLogsResponse](#logs-GetLogsResponse)
+    - [LogFilter](#logs-LogFilter)
+    - [LogMessage](#logs-LogMessage)
+    - [LogQuery](#logs-LogQuery)
+    - [PagingHint](#logs-PagingHint)
+    - [ParsedJSONLogMessage](#logs-ParsedJSONLogMessage)
+    - [PipelineJobLogQuery](#logs-PipelineJobLogQuery)
+    - [PipelineLogQuery](#logs-PipelineLogQuery)
+    - [PodContainer](#logs-PodContainer)
+    - [RegexLogFilter](#logs-RegexLogFilter)
+    - [TimeRangeLogFilter](#logs-TimeRangeLogFilter)
+    - [UserLogQuery](#logs-UserLogQuery)
+    - [VerbatimLogMessage](#logs-VerbatimLogMessage)
+  
+    - [LogFormat](#logs-LogFormat)
+    - [LogLevel](#logs-LogLevel)
+  
+    - [API](#logs-API)
+  
 - [pfs/pfs.proto](#pfs_pfs-proto)
     - [ActivateAuthRequest](#pfs_v2-ActivateAuthRequest)
     - [ActivateAuthResponse](#pfs_v2-ActivateAuthResponse)
@@ -343,6 +365,7 @@
     - [Repo](#pfs_v2-Repo)
     - [RepoInfo](#pfs_v2-RepoInfo)
     - [RepoInfo.Details](#pfs_v2-RepoInfo-Details)
+    - [RepoPage](#pfs_v2-RepoPage)
     - [SQLDatabaseEgress](#pfs_v2-SQLDatabaseEgress)
     - [SQLDatabaseEgress.FileFormat](#pfs_v2-SQLDatabaseEgress-FileFormat)
     - [SQLDatabaseEgress.Secret](#pfs_v2-SQLDatabaseEgress-Secret)
@@ -361,6 +384,7 @@
     - [FileType](#pfs_v2-FileType)
     - [GetFileSetRequest.FileSetType](#pfs_v2-GetFileSetRequest-FileSetType)
     - [OriginKind](#pfs_v2-OriginKind)
+    - [RepoPage.Ordering](#pfs_v2-RepoPage-Ordering)
     - [SQLDatabaseEgress.FileFormat.Type](#pfs_v2-SQLDatabaseEgress-FileFormat-Type)
   
     - [API](#pfs_v2-API)
@@ -404,6 +428,7 @@
     - [CheckStatusRequest](#pps_v2-CheckStatusRequest)
     - [CheckStatusResponse](#pps_v2-CheckStatusResponse)
     - [ClusterDefaults](#pps_v2-ClusterDefaults)
+    - [CreateDatumRequest](#pps_v2-CreateDatumRequest)
     - [CreatePipelineRequest](#pps_v2-CreatePipelineRequest)
     - [CreatePipelineTransaction](#pps_v2-CreatePipelineTransaction)
     - [CreatePipelineV2Request](#pps_v2-CreatePipelineV2Request)
@@ -4276,6 +4301,315 @@ Note: Updates of the enterprise-server field are not allowed. In the worst case,
 
 
 
+<a name="logs_logs-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## logs/logs.proto
+
+
+
+<a name="logs-AdminLogQuery"></a>
+
+### AdminLogQuery
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| logql | [string](#string) |  | Arbitrary LogQL query |
+| pod | [string](#string) |  | A pod&#39;s logs (all containers) |
+| pod_container | [PodContainer](#logs-PodContainer) |  | One container |
+| app | [string](#string) |  | One &#34;app&#34; (logql -&gt; {app=X}) |
+| master | [PipelineLogQuery](#logs-PipelineLogQuery) |  | All master worker lines from a pipeline |
+| storage | [PipelineLogQuery](#logs-PipelineLogQuery) |  | All storage container lines from a pipeline |
+| user | [UserLogQuery](#logs-UserLogQuery) |  | All worker lines from a pipeline/job |
+
+
+
+
+
+
+<a name="logs-GetLogsRequest"></a>
+
+### GetLogsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| query | [LogQuery](#logs-LogQuery) |  |  |
+| filter | [LogFilter](#logs-LogFilter) |  |  |
+| tail | [bool](#bool) |  |  |
+| want_paging_hint | [bool](#bool) |  |  |
+| log_format | [LogFormat](#logs-LogFormat) |  |  |
+
+
+
+
+
+
+<a name="logs-GetLogsResponse"></a>
+
+### GetLogsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| paging_hint | [PagingHint](#logs-PagingHint) |  |  |
+| log | [LogMessage](#logs-LogMessage) |  |  |
+
+
+
+
+
+
+<a name="logs-LogFilter"></a>
+
+### LogFilter
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| time_range | [TimeRangeLogFilter](#logs-TimeRangeLogFilter) |  |  |
+| limit | [uint64](#uint64) |  |  |
+| regex | [RegexLogFilter](#logs-RegexLogFilter) |  |  |
+| level | [LogLevel](#logs-LogLevel) |  | Minimum log level to return; worker will always run at level debug, but setting INFO here restores original behavior |
+
+
+
+
+
+
+<a name="logs-LogMessage"></a>
+
+### LogMessage
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| verbatim | [VerbatimLogMessage](#logs-VerbatimLogMessage) |  |  |
+| json | [ParsedJSONLogMessage](#logs-ParsedJSONLogMessage) |  |  |
+| pps_log_message | [pps_v2.LogMessage](#pps_v2-LogMessage) |  |  |
+
+
+
+
+
+
+<a name="logs-LogQuery"></a>
+
+### LogQuery
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| user | [UserLogQuery](#logs-UserLogQuery) |  |  |
+| admin | [AdminLogQuery](#logs-AdminLogQuery) |  |  |
+
+
+
+
+
+
+<a name="logs-PagingHint"></a>
+
+### PagingHint
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| older | [GetLogsRequest](#logs-GetLogsRequest) |  |  |
+| newer | [GetLogsRequest](#logs-GetLogsRequest) |  |  |
+
+
+
+
+
+
+<a name="logs-ParsedJSONLogMessage"></a>
+
+### ParsedJSONLogMessage
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| verbatim | [VerbatimLogMessage](#logs-VerbatimLogMessage) |  | The verbatim line from Loki |
+| object | [google.protobuf.Struct](#google-protobuf-Struct) |  | A raw JSON parse of the entire line |
+| native_timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | If a parseable timestamp was found in `fields` |
+| pps_log_message | [pps_v2.LogMessage](#pps_v2-LogMessage) |  | For code that wants to filter on pipeline/job/etc |
+
+
+
+
+
+
+<a name="logs-PipelineJobLogQuery"></a>
+
+### PipelineJobLogQuery
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pipeline | [PipelineLogQuery](#logs-PipelineLogQuery) |  |  |
+| job | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="logs-PipelineLogQuery"></a>
+
+### PipelineLogQuery
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [string](#string) |  |  |
+| pipeline | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="logs-PodContainer"></a>
+
+### PodContainer
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pod | [string](#string) |  |  |
+| container | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="logs-RegexLogFilter"></a>
+
+### RegexLogFilter
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| pattern | [string](#string) |  |  |
+| negate | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="logs-TimeRangeLogFilter"></a>
+
+### TimeRangeLogFilter
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| from | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Can be null |
+| until | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Can be null |
+
+
+
+
+
+
+<a name="logs-UserLogQuery"></a>
+
+### UserLogQuery
+Only returns &#34;user&#34; logs
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [string](#string) |  | All pipelines in the project |
+| pipeline | [PipelineLogQuery](#logs-PipelineLogQuery) |  | One pipeline in a project |
+| datum | [string](#string) |  | One datum. |
+| job | [string](#string) |  | One job, across pipelines and projects |
+| pipeline_job | [PipelineJobLogQuery](#logs-PipelineJobLogQuery) |  | One job in one pipeline |
+
+
+
+
+
+
+<a name="logs-VerbatimLogMessage"></a>
+
+### VerbatimLogMessage
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| line | [bytes](#bytes) |  |  |
+| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="logs-LogFormat"></a>
+
+### LogFormat
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| LOG_FORMAT_UNKNOWN | 0 | error |
+| LOG_FORMAT_VERBATIM_WITH_TIMESTAMP | 1 |  |
+| LOG_FORMAT_PARSED_JSON | 2 |  |
+| LOG_FORMAT_PPS_LOGMESSAGE | 3 |  |
+
+
+
+<a name="logs-LogLevel"></a>
+
+### LogLevel
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| LOG_LEVEL_DEBUG | 0 |  |
+| LOG_LEVEL_INFO | 1 |  |
+| LOG_LEVEL_ERROR | 2 |  |
+
+
+ 
+
+ 
+
+
+<a name="logs-API"></a>
+
+### API
+
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| GetLogs | [GetLogsRequest](#logs-GetLogsRequest) | [GetLogsResponse](#logs-GetLogsResponse) stream |  |
+
+ 
+
+
+
 <a name="pfs_pfs-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
@@ -5360,8 +5694,9 @@ DeleteReposRequest is used to delete more than one repo at once.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| type | [string](#string) |  | type is the type of (system) repos that should be returned an empty string requests all repos |
-| projects | [Project](#pfs_v2-Project) | repeated | projects filters out repos that do not belong in the list, while no projects means list all repos. |
+| type | [string](#string) |  | Type is the type of (system) repo that should be returned. An empty string requests all repos. |
+| projects | [Project](#pfs_v2-Project) | repeated | Filters out repos whos project isn&#39;t represented. An empty list of projects doesn&#39;t filter repos by their project. |
+| page | [RepoPage](#pfs_v2-RepoPage) |  | Specifies which page of repos should be returned. If page isn&#39;t specified, a single page containing all the relevant repos is returned. |
 
 
 
@@ -5537,6 +5872,23 @@ Details are only provided when explicitly requested
 
 
 
+<a name="pfs_v2-RepoPage"></a>
+
+### RepoPage
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| order | [RepoPage.Ordering](#pfs_v2-RepoPage-Ordering) |  |  |
+| page_size | [int64](#int64) |  |  |
+| page_index | [int64](#int64) |  |  |
+
+
+
+
+
+
 <a name="pfs_v2-SQLDatabaseEgress"></a>
 
 ### SQLDatabaseEgress
@@ -5589,12 +5941,17 @@ Details are only provided when explicitly requested
 <a name="pfs_v2-ShardFileSetRequest"></a>
 
 ### ShardFileSetRequest
-
+If both num_files and size_bytes are set, shards are created
+based on whichever threshold is surpassed first. If a shard
+configuration field (num_files, size_bytes) is unset, the
+storage&#39;s default value is used.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | file_set_id | [string](#string) |  |  |
+| num_files | [int64](#int64) |  | Number of files targeted in each shard |
+| size_bytes | [int64](#int64) |  | Size (in bytes) targeted for each shard |
 
 
 
@@ -5802,6 +6159,17 @@ These are the different places where a commit may be originated from
 | USER | 1 |  |
 | AUTO | 2 |  |
 | FSCK | 3 |  |
+
+
+
+<a name="pfs_v2-RepoPage-Ordering"></a>
+
+### RepoPage.Ordering
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PROJECT_REPO | 0 |  |
 
 
 
@@ -6435,6 +6803,23 @@ Response for check status request. Provides alerts if any.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | create_pipeline_request | [CreatePipelineRequest](#pps_v2-CreatePipelineRequest) |  | CreatePipelineRequest contains the default JSON CreatePipelineRequest into which pipeline specs are merged to form the effective spec used to create a pipeline. |
+
+
+
+
+
+
+<a name="pps_v2-CreateDatumRequest"></a>
+
+### CreateDatumRequest
+Emits a stream of datums as they are created from the given input. Client
+must cancel the stream when it no longer wants to receive datums.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| input | [Input](#pps_v2-Input) |  | Input is the input to list datums from. The datums listed are the ones that would be run if a pipeline was created with the provided input. The input field is only required for the first request. The server ignores subsequent requests&#39; input field. |
+| number | [int64](#int64) |  | Number of datums to return in next response |
 
 
 
@@ -8188,6 +8573,7 @@ TolerationOperator relates a Toleration&#39;s key to its value.
 | StopJob | [StopJobRequest](#pps_v2-StopJobRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
 | InspectDatum | [InspectDatumRequest](#pps_v2-InspectDatumRequest) | [DatumInfo](#pps_v2-DatumInfo) |  |
 | ListDatum | [ListDatumRequest](#pps_v2-ListDatumRequest) | [DatumInfo](#pps_v2-DatumInfo) stream | ListDatum returns information about each datum fed to a Pachyderm job |
+| CreateDatum | [CreateDatumRequest](#pps_v2-CreateDatumRequest) stream | [DatumInfo](#pps_v2-DatumInfo) stream |  |
 | RestartDatum | [RestartDatumRequest](#pps_v2-RestartDatumRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
 | RerunPipeline | [RerunPipelineRequest](#pps_v2-RerunPipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
 | CreatePipeline | [CreatePipelineRequest](#pps_v2-CreatePipelineRequest) | [.google.protobuf.Empty](#google-protobuf-Empty) |  |
@@ -9520,6 +9906,7 @@ WellKnownRegex contain some well-known patterns.
 | file_set_id | [string](#string) |  |  |
 | path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
 | set_spec | [datum.SetSpec](#datum-SetSpec) |  |  |
+| auth_token | [string](#string) |  |  |
 
 
 
@@ -9554,6 +9941,7 @@ WellKnownRegex contain some well-known patterns.
 | file_set_id | [string](#string) |  |  |
 | base_file_set_id | [string](#string) |  |  |
 | path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| auth_token | [string](#string) |  |  |
 
 
 
@@ -9590,6 +9978,7 @@ WellKnownRegex contain some well-known patterns.
 | base_meta_commit | [pfs_v2.Commit](#pfs_v2-Commit) |  |  |
 | no_skip | [bool](#bool) |  |  |
 | path_range | [pfs_v2.PathRange](#pfs_v2-PathRange) |  |  |
+| auth_token | [string](#string) |  |  |
 
 
 

--- a/proto-docs.md
+++ b/proto-docs.md
@@ -359,6 +359,7 @@
     - [CommitState](#pfs_v2-CommitState)
     - [Delimiter](#pfs_v2-Delimiter)
     - [FileType](#pfs_v2-FileType)
+    - [GetFileSetRequest.FileSetType](#pfs_v2-GetFileSetRequest-FileSetType)
     - [OriginKind](#pfs_v2-OriginKind)
     - [SQLDatabaseEgress.FileFormat.Type](#pfs_v2-SQLDatabaseEgress-FileFormat-Type)
   
@@ -5123,6 +5124,7 @@ DeleteReposRequest is used to delete more than one repo at once.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | commit | [Commit](#pfs_v2-Commit) |  |  |
+| type | [GetFileSetRequest.FileSetType](#pfs_v2-GetFileSetRequest-FileSetType) |  |  |
 
 
 
@@ -5774,6 +5776,18 @@ The states are increasingly specific, i.e. a commit that is FINISHED also counts
 | RESERVED | 0 |  |
 | FILE | 1 |  |
 | DIR | 2 |  |
+
+
+
+<a name="pfs_v2-GetFileSetRequest-FileSetType"></a>
+
+### GetFileSetRequest.FileSetType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| TOTAL | 0 |  |
+| DIFF | 1 |  |
 
 
 

--- a/src/internal/log/loggers.go
+++ b/src/internal/log/loggers.go
@@ -214,12 +214,12 @@ func InitBatchLogger(logFile string) func(err error) {
 			if logFile == "" {
 				var err error
 				// On error, out is set to "" again.
-				logFile, err = xdg.CacheFile(fmt.Sprintf("pachyderm/log/%s.%s.log", name, time.Now().In(time.UTC).Format("20060102T150405Z")))
+				name := fmt.Sprintf("%s.%s.log", name, time.Now().In(time.UTC).Format("20060102T150405Z"))
+				logFile, err = xdg.CacheFile(filepath.Join("pachyderm/log", name))
 				if err != nil {
-					addInitWarningf("problem creating log file in xdg cache dir: %v", err)
-					logFile = ""
-					keepLog = false
-					return c
+					// When xdg.CacheFile doesn't work, use $PWD.  This works
+					// fine for, say, Bazel genrules.
+					logFile = name
 				}
 			} else {
 				if stat, err := os.Stat(logFile); err == nil {

--- a/src/internal/pctx/context.go
+++ b/src/internal/pctx/context.go
@@ -2,6 +2,8 @@ package pctx
 
 import (
 	"context"
+	"os"
+	"os/signal"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
@@ -19,6 +21,11 @@ func TODO() context.Context {
 func Background(process string) context.Context {
 	ctx := log.AddLogger(context.Background())
 	return Child(ctx, process)
+}
+
+// Interactive returns a context for use in command-line apps.
+func Interactive() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(log.AddLogger(context.Background()), os.Interrupt)
 }
 
 // Option is an option for customizing a child context.

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -75,7 +75,10 @@ sh_binary(
 
 genrule(
     name = "gen_go_proto_bundle",
-    outs = ["go_protos.tar", "go_protos_forgotten_files.txt"],
+    outs = [
+        "go_protos.tar",
+        "go_protos_forgotten_files.txt",
+    ],
     cmd = "$(location compile_sh) $(location go_protos.tar) $(location go_protos_forgotten_files.txt) $(locations //src:all_protos)",
     tools = [
         "compile_sh",
@@ -99,4 +102,19 @@ alias(
     name = "run",
     actual = "extract_sh",
     visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "check_generated_protos",
+    srcs = ["test.sh"],
+    data = [
+        "go_protos.tar",
+        "//src/proto/prototar",
+    ],
+    tags = [
+        "manual",
+        "no-sandbox",
+        "style",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -48,11 +48,9 @@ host_native_binary(
     target = ":bin/protoc",
 )
 
-# bazel build //src/proto:run will regenerate the protos in your working copy.
 sh_binary(
-    name = "run",
-    srcs = ["run.sh"],
-    args = ["$(locations //src:all_protos)"],
+    name = "compile_sh",
+    srcs = ["compile.sh"],
     data = [
         ":gopatch_bin",
         ":proto.patch",
@@ -63,15 +61,42 @@ sh_binary(
         ":protoc-gen-openapiv2_bin",
         ":protoc-gen-validate-go_bin",
         ":protoc_bin",
-        "//src:all_protos",
         "//src/proto/pachgen",
         "//src/proto/protoc-gen-zap",
+        "//src/proto/prototar",
         "@com_github_chrusty_protoc_gen_jsonschema//cmd/protoc-gen-jsonschema",
         "@com_google_protobuf//:descriptor_proto_srcs",
         "@com_google_protobuf//:well_known_type_protos",
         "@go_sdk//:bin/gofmt",
         "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
     ],
-    visibility = ["//:__pkg__"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+genrule(
+    name = "gen_go_proto_bundle",
+    outs = ["go_protos.tar"],
+    cmd = "$(location //src/proto:compile_sh) $@ $(locations //src:all_protos)",
+    tools = [
+        "compile_sh",
+        "//src:all_protos",
+    ],
+)
+
+# bazel build //src/proto:run will regenerate the protos in your working copy.
+sh_binary(
+    name = "extract_sh",
+    srcs = ["extract.sh"],
+    args = ["$(location go_protos.tar)"],
+    data = [
+        "go_protos.tar",
+        "//src/proto/prototar",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+alias(
+    name = "run",
+    actual = "extract_sh",
+    visibility = ["//visibility:public"],
 )

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -86,7 +86,6 @@ genrule(
     ],
 )
 
-# bazel build //src/proto:run will regenerate the protos in your working copy.
 sh_binary(
     name = "extract_sh",
     srcs = ["extract.sh"],
@@ -98,6 +97,7 @@ sh_binary(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
+# bazel build //src/proto:run will regenerate the protos in your working copy.
 alias(
     name = "run",
     actual = "extract_sh",
@@ -106,6 +106,7 @@ alias(
 
 sh_test(
     name = "check_generated_protos",
+    size = "small",
     srcs = ["test.sh"],
     data = [
         "go_protos.tar",

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -75,8 +75,8 @@ sh_binary(
 
 genrule(
     name = "gen_go_proto_bundle",
-    outs = ["go_protos.tar"],
-    cmd = "$(location //src/proto:compile_sh) $@ $(locations //src:all_protos)",
+    outs = ["go_protos.tar", "go_protos_forgotten_files.txt"],
+    cmd = "$(location compile_sh) $(location go_protos.tar) $(location go_protos_forgotten_files.txt) $(locations //src:all_protos)",
     tools = [
         "compile_sh",
         "//src:all_protos",

--- a/src/proto/compile.sh
+++ b/src/proto/compile.sh
@@ -88,5 +88,5 @@ echo -n "gofmt..."
 echo "done."
 
 echo "package result..."
-"$(rlocation _main/src/proto/prototar/prototar_/prototar)" create $TAR $FORGOTTEN out/pachyderm out/github.com/pachyderm/pachyderm/v2
+"$(rlocation _main/src/proto/prototar/prototar_/prototar)" create "$TAR" "$FORGOTTEN" out/pachyderm out/github.com/pachyderm/pachyderm/v2
 echo "done."

--- a/src/proto/compile.sh
+++ b/src/proto/compile.sh
@@ -79,14 +79,11 @@ done
 echo -n "gopatch..."
 "$(rlocation _main/src/proto/gopatch)" ./... -p="$(rlocation _main/src/proto/proto.patch)"
 echo "done."
+
 echo -n "gofmt..."
 "$(rlocation go_sdk/bin/gofmt)" -w .
 echo "done."
 
-# echo -n "copy generated files into workspace..."
-# find src/internal/jsonschema -name \*.schema.json -exec rm {} '+'
-# cp -a $OUT/src/ .
-# cp -a $OUT/github.com/pachyderm/pachyderm/v2/src/ .
-echo "package up result..."
+echo "package result..."
 "$(rlocation _main/src/proto/prototar/prototar_/prototar)" create $TAR out/pachyderm out/github.com/pachyderm/pachyderm/v2
 echo "done."

--- a/src/proto/compile.sh
+++ b/src/proto/compile.sh
@@ -15,12 +15,11 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
+# args: <output tar> <forgotten files report> <proto1.proto> <proto2.proto> ...
 TAR="$1"
+FORGOTTEN="$2"
 shift
-
-mkdir -p out/pachyderm/src/internal/jsonschema
-mkdir -p out/pachyderm/src/openapi
-mkdir -p out/pachyderm/src/typescript
+shift
 
 PROTOS=("$@")
 
@@ -30,6 +29,10 @@ for i in "${PROTOS[@]}"; do \
         exit 1
     fi
 done
+
+mkdir -p out/pachyderm/src/internal/jsonschema
+mkdir -p out/pachyderm/src/openapi
+mkdir -p out/pachyderm/src/typescript
 
 "$(rlocation _main/src/proto/protoc)" \
     -I"$(dirname "$(dirname "$(dirname "$(rlocation com_google_protobuf/src/google/protobuf/any.proto)")")")" \
@@ -85,5 +88,5 @@ echo -n "gofmt..."
 echo "done."
 
 echo "package result..."
-"$(rlocation _main/src/proto/prototar/prototar_/prototar)" create $TAR out/pachyderm out/github.com/pachyderm/pachyderm/v2
+"$(rlocation _main/src/proto/prototar/prototar_/prototar)" create $TAR $FORGOTTEN out/pachyderm out/github.com/pachyderm/pachyderm/v2
 echo "done."

--- a/src/proto/compile.sh
+++ b/src/proto/compile.sh
@@ -80,7 +80,7 @@ mkdir -p out/pachyderm/src/typescript
     "${PROTOS[@]}"
 
 echo -n "gopatch..."
-"$(rlocation _main/src/proto/gopatch)" ./... -p="$(rlocation _main/src/proto/proto.patch)"
+"$(rlocation _main/src/proto/gopatch)" ./out/pachyderm/... ./out/github.com/pachyderm/pachyderm/v2/... -p="$(rlocation _main/src/proto/proto.patch)"
 echo "done."
 
 echo -n "gofmt..."

--- a/src/proto/compile.sh
+++ b/src/proto/compile.sh
@@ -15,20 +15,12 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-cd "$BUILD_WORKSPACE_DIRECTORY" # Where your working copy is.
+TAR="$1"
+shift
 
-OUT=/tmp/pachyderm-gen-proto-out
-
-rm -rf $OUT
-function cleanup(){
-    rm -rf $OUT
-}
-trap cleanup EXIT
-
-mkdir -p $OUT/src
-mkdir -p $OUT/src/internal/jsonschema
-mkdir -p $OUT/src/openapi
-mkdir -p $OUT/src/typescript
+mkdir -p out/pachyderm/src/internal/jsonschema
+mkdir -p out/pachyderm/src/openapi
+mkdir -p out/pachyderm/src/typescript
 
 PROTOS=("$@")
 
@@ -53,17 +45,17 @@ done
     --plugin=protoc-gen-openapiv2="$(rlocation _main/src/proto/protoc-gen-openapiv2)" \
     --plugin=protoc-gen-grpc-gateway="$(rlocation _main/src/proto/protoc-gen-grpc-gateway)" \
     --plugin=protoc-gen-grpc-gateway-ts="$(rlocation _main/src/proto/protoc-gen-grpc-gateway-ts)" \
-    --zap_out="$OUT" \
-    --pach_out="$OUT/src" \
-    --go_out="$OUT" \
-    --go-grpc_out="$OUT" \
-    --jsonschema_out="$OUT/src/internal/jsonschema" \
-    --validate_out="$OUT" \
-    --doc_out="$OUT" \
-    --doc2_out="$OUT" \
-    --openapiv2_out="$OUT/src/openapi" \
-    --grpc-gateway_out="$OUT" \
-    --grpc-gateway-ts_out="$OUT/src/typescript" \
+    --zap_out="out" \
+    --pach_out="out/pachyderm/src" \
+    --go_out="out" \
+    --go-grpc_out="out" \
+    --jsonschema_out="out/pachyderm/src/internal/jsonschema" \
+    --validate_out="out" \
+    --doc_out="out/pachyderm" \
+    --doc2_out="out/pachyderm" \
+    --openapiv2_out="out/pachyderm/src/openapi" \
+    --grpc-gateway_out="out" \
+    --grpc-gateway-ts_out="out/pachyderm/src/typescript" \
     --jsonschema_opt="enforce_oneof" \
     --jsonschema_opt="file_extension=schema.json" \
     --jsonschema_opt="disallow_additional_properties" \
@@ -84,17 +76,17 @@ done
     --openapiv2_opt merge_file_name=pachyderm_api \
     "${PROTOS[@]}"
 
-pushd $OUT >/dev/null
 echo -n "gopatch..."
 "$(rlocation _main/src/proto/gopatch)" ./... -p="$(rlocation _main/src/proto/proto.patch)"
 echo "done."
 echo -n "gofmt..."
 "$(rlocation go_sdk/bin/gofmt)" -w .
 echo "done."
-popd >/dev/null
 
-echo -n "copy generated files into workspace..."
-find src/internal/jsonschema -name \*.schema.json -exec rm {} '+'
-cp -a $OUT/src/ .
-cp -a $OUT/github.com/pachyderm/pachyderm/v2/src/ .
+# echo -n "copy generated files into workspace..."
+# find src/internal/jsonschema -name \*.schema.json -exec rm {} '+'
+# cp -a $OUT/src/ .
+# cp -a $OUT/github.com/pachyderm/pachyderm/v2/src/ .
+echo "package up result..."
+"$(rlocation _main/src/proto/prototar/prototar_/prototar)" create $TAR out/pachyderm out/github.com/pachyderm/pachyderm/v2
 echo "done."

--- a/src/proto/extract.sh
+++ b/src/proto/extract.sh
@@ -16,6 +16,6 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 # --- end runfiles.bash initialization v3 ---
 
 INPUT="${PWD}/${1}"
-cd $BUILD_WORKSPACE_DIRECTORY # Where your working copy is.
+cd "$BUILD_WORKSPACE_DIRECTORY" # Where your working copy is.
 find src/internal/jsonschema -name \*.schema.json -exec rm {} '+'
-exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" apply $INPUT
+exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" apply "$INPUT"

--- a/src/proto/extract.sh
+++ b/src/proto/extract.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck source=/dev/null.
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+cd "${BUILD_WORKSPACE_DIRECTORY}/src" # Where your working copy is.
+exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" apply $1

--- a/src/proto/extract.sh
+++ b/src/proto/extract.sh
@@ -15,5 +15,7 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-cd "${BUILD_WORKSPACE_DIRECTORY}/src" # Where your working copy is.
-exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" apply $1
+INPUT="${PWD}/${1}"
+cd $BUILD_WORKSPACE_DIRECTORY # Where your working copy is.
+find src/internal/jsonschema -name \*.schema.json -exec rm {} '+'
+exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" apply $INPUT

--- a/src/proto/prototar/BUILD.bazel
+++ b/src/proto/prototar/BUILD.bazel
@@ -25,5 +25,9 @@ go_test(
     name = "prototar_test",
     srcs = ["main_test.go"],
     embed = [":prototar_lib"],
-    deps = ["//src/internal/pctx"],
+    deps = [
+        "//src/internal/pctx",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+    ],
 )

--- a/src/proto/prototar/BUILD.bazel
+++ b/src/proto/prototar/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "prototar_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/proto/prototar",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/internal/errors",
+        "//src/internal/log",
+        "//src/internal/pctx",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_github_zeebo_xxh3//:xxh3",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_binary(
+    name = "prototar",
+    embed = [":prototar_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "prototar_test",
+    srcs = ["main_test.go"],
+    embed = [":prototar_lib"],
+    deps = ["//src/internal/pctx"],
+)

--- a/src/proto/prototar/main.go
+++ b/src/proto/prototar/main.go
@@ -93,9 +93,10 @@ func applyOne(ctx context.Context, h *tar.Header, r io.Reader) (retErr error) {
 	if err != nil {
 		return errors.Wrap(err, "check existing file")
 	}
-	dir, _ := filepath.Split(h.Name)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return errors.Wrapf(err, "create output dir %v", dir)
+	if dir, _ := filepath.Split(h.Name); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return errors.Wrapf(err, "create output dir %v", dir)
+		}
 	}
 	hash := xxh3.New()
 	dst, err := os.OpenFile(h.Name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)

--- a/src/proto/prototar/main.go
+++ b/src/proto/prototar/main.go
@@ -316,11 +316,6 @@ func main() {
 		Short: "Test that input.tar matches the content of the current working directory.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if wd := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); wd != "" {
-				if err := os.Chdir(wd); err != nil {
-					return errors.Wrapf(err, "chdir to workspace directory %v", wd)
-				}
-			}
 			in := args[0]
 			fh, err := os.Open(in)
 			if err != nil {
@@ -334,7 +329,7 @@ func main() {
 				fmt.Printf("%d file(s) ok\n", len(report.Unchanged))
 				return nil
 			}
-			fmt.Fprintf(os.Stderr, "It looks like you might need to regenerate the protos in your working copy.")
+			fmt.Fprintf(os.Stderr, "\n*** It looks like you might need to regenerate the protos in your working copy.\n")
 			return ErrExit1
 		},
 	}}...)

--- a/src/proto/prototar/main.go
+++ b/src/proto/prototar/main.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/spf13/cobra"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+)
+
+func addToArchive(ctx context.Context, tw *tar.Writer, f fs.FS) error {
+	// TODO(jrockway): For this to be hermetic, WalkDir needs to always visit files in the same
+	// order.  This is a detail of the underlying filesystem, probably.
+	if err := fs.WalkDir(f, ".", func(path string, d fs.DirEntry, err error) (retErr error) {
+		if err != nil {
+			return errors.Wrap(err, "WalkFn called with error")
+		}
+		if d.IsDir() {
+			return nil
+		}
+		log.Debug(ctx, "adding file", zap.String("path", path), zap.Any("entry", d))
+		fh, err := f.Open(path)
+		if err != nil {
+			return errors.Wrap(err, "open source")
+		}
+		defer errors.Close(&retErr, fh, "close source")
+		info, err := fh.Stat()
+		if err != nil {
+			return errors.Wrap(err, "stat source")
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:       path,
+			Size:       info.Size(),
+			Uid:        0,
+			Uname:      "",
+			Gid:        0,
+			Gname:      "",
+			ModTime:    time.Unix(0, 0),
+			AccessTime: time.Unix(0, 0),
+			ChangeTime: time.Unix(0, 0),
+			Mode:       0o600,
+		}); err != nil {
+			return errors.Wrapf(err, "write header for %v", path)
+		}
+		if n, err := io.Copy(tw, fh); err != nil {
+			return errors.Wrapf(err, "copy %v into tar (%v bytes)", path, n)
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %v", f)
+	}
+	return nil
+}
+
+func create(ctx context.Context, w io.Writer, srcs ...fs.FS) (retErr error) {
+	tw := tar.NewWriter(w)
+	defer errors.Close(&retErr, tw, "close tar")
+	for i, src := range srcs {
+		if err := addToArchive(ctx, tw, src); err != nil {
+			return errors.Wrapf(err, "add fs %v (%v)", i, src)
+		}
+	}
+	return nil
+}
+
+func check(name string) (result xxh3.Uint128, retErr error) {
+	fh, err := os.Open(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		return result, errors.Wrapf(err, "open current version of %v", name)
+	}
+	defer errors.Close(&retErr, fh, "close current version of %v", name)
+	h := xxh3.New()
+	if _, err := io.Copy(h, fh); err != nil {
+		return result, errors.Wrapf(err, "write current version of %v into hash", name)
+	}
+	return h.Sum128(), nil
+}
+
+func applyOne(ctx context.Context, h *tar.Header, r io.Reader) (retErr error) {
+	currentHash, err := check(h.Name) // quick hash to see if the file is new
+	if err != nil {
+		return errors.Wrap(err, "check existing file")
+	}
+	dir, _ := filepath.Split(h.Name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errors.Wrapf(err, "create output dir %v", dir)
+	}
+	hash := xxh3.New()
+	dst, err := os.OpenFile(h.Name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return errors.Wrap(err, "open destination")
+	}
+	defer errors.Close(&retErr, dst, "close destination")
+
+	w := io.MultiWriter(hash, dst)
+	if _, err := io.Copy(w, r); err != nil {
+		return errors.Wrap(err, "copy file")
+	}
+	newHash := hash.Sum128()
+	switch currentHash {
+	case xxh3.Uint128{}:
+		log.Info(ctx, "created new file", zap.String("name", h.Name))
+	case newHash:
+		log.Debug(ctx, "unchanged file", zap.String("name", h.Name))
+	default:
+		log.Info(ctx, "updated file", zap.String("name", h.Name))
+	}
+	return nil
+}
+
+func apply(ctx context.Context, r io.Reader) error {
+	tr := tar.NewReader(r)
+	for {
+		h, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+		}
+		if err := applyOne(ctx, h, tr); err != nil {
+			return errors.Wrapf(err, "extract one file %v", h.Name)
+		}
+	}
+}
+
+func test(r io.Reader) (bool, error) {
+	return false, nil
+}
+
+var ErrExit1 = errors.New("exit status 1")
+
+func main() {
+	report := log.InitBatchLogger("")
+	ctx, c := pctx.Interactive()
+	defer c()
+	root := &cobra.Command{
+		Use:           "prototar",
+		Short:         "Archive, un-archive, and test proto bundles.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// It would be nice to be verbose by default, but Bazel fails genrules if
+			// they produce too much stderr output.  So this is the escape hatch;
+			// disable sandboxing and set this environment variable to see what's going
+			// on when needed.
+			if x := os.Getenv("PACHYDERM_TOOL_VERBOSE"); x != "" {
+				log.SetLevel(log.DebugLevel)
+			}
+		},
+	}
+	root.AddCommand([]*cobra.Command{{
+		Use:   "create <output.tar> <input...>",
+		Short: "Archive the given directories.",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := args[0]
+			var srcs []fs.FS
+			for _, src := range args[1:] {
+				srcs = append(srcs, os.DirFS(src))
+			}
+			ow, err := os.Create(out)
+			if err != nil {
+				return errors.Wrap(err, "create output")
+			}
+			if err := create(cmd.Context(), ow, srcs...); err != nil {
+				return errors.Wrap(err, "create archive")
+			}
+			return nil
+		},
+	}, {
+		Use:   "apply <input.tar>",
+		Short: "Extract the archive into the current working directory.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			in := args[0]
+			fh, err := os.Open(in)
+			if err != nil {
+				return errors.Wrap(err, "open input")
+			}
+			if err := apply(cmd.Context(), fh); err != nil {
+				return errors.Wrap(err, "apply archive")
+			}
+			return nil
+		},
+	}, {
+		Use:   "test <input.tar>",
+		Short: "Test that input.tar matches the content of the current working directory.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			in := args[0]
+			fh, err := os.Open(in)
+			if err != nil {
+				return errors.Wrap(err, "open input")
+			}
+			ok, err := test(fh)
+			if err != nil {
+				return errors.Wrap(err, "test archive")
+			}
+			if !ok {
+				return ErrExit1
+			}
+			return nil
+		},
+	}}...)
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		if errors.Is(err, ErrExit1) {
+			report(nil)
+			os.Exit(1)
+		}
+		log.Error(ctx, "job failed", zap.Error(err))
+		report(err)
+		os.Exit(1)
+	}
+	report(nil)
+	os.Exit(0)
+}

--- a/src/proto/prototar/main.go
+++ b/src/proto/prototar/main.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -201,7 +202,9 @@ func apply(ctx context.Context, r io.Reader, dryRun bool) (*ApplicationReport, e
 		if d.IsDir() {
 			return nil
 		}
-		jsonSchemas[path.Join("src/internal/jsonschema", file)] = struct{}{}
+		if strings.HasSuffix(file, ".schema.json") {
+			jsonSchemas[path.Join("src/internal/jsonschema", file)] = struct{}{}
+		}
 		return nil
 	}); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {

--- a/src/proto/prototar/main_test.go
+++ b/src/proto/prototar/main_test.go
@@ -115,6 +115,7 @@ func TestCreateAndApply(t *testing.T) {
 	t.Run("apply_2", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
 		write(t, filepath.Join("src", "internal", "jsonschema", "old_v2", "Old.schema.json"), []byte(`{"old":"schema"}`))
+		write(t, filepath.Join("src", "internal", "jsonschema", "jsonschema.go"), []byte("some go code to not delete"))
 		gotReport, err := apply(ctx, bytes.NewReader(tar), false)
 		if err != nil {
 			t.Fatalf("apply: %v", err)

--- a/src/proto/prototar/main_test.go
+++ b/src/proto/prototar/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+)
+
+func write(t *testing.T, name string, content []byte) {
+	t.Helper()
+	dir, _ := filepath.Split(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("make parent: %v", err)
+	}
+	if err := os.WriteFile(name, content, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestCreateAndApply(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatalf("change back to original working directory: %v", err)
+		}
+	})
+
+	now := time.Now()
+	a, b := fstest.MapFS{
+		"src/new/new.pb.go": &fstest.MapFile{
+			Data:    []byte("new file"),
+			Mode:    fs.ModePerm,
+			ModTime: now,
+		},
+		"src/existing/existing.pb.go": &fstest.MapFile{
+			Data:    []byte("existing file"),
+			Mode:    fs.ModePerm,
+			ModTime: now,
+		},
+	}, fstest.MapFS{
+		"src/modified/modified.pb.go": &fstest.MapFile{
+			Data:    []byte("new content"),
+			Mode:    fs.ModePerm,
+			ModTime: now,
+		},
+	}
+	w := new(bytes.Buffer)
+	if err := create(ctx, w, a, b); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	write(t, filepath.Join(tmp, "src", "existing", "existing.pb.go"), []byte("existing file"))
+	write(t, filepath.Join(tmp, "src", "modified", "modified.pb.go"), []byte("old content"))
+	if err := apply(ctx, w); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+}

--- a/src/proto/prototar/main_test.go
+++ b/src/proto/prototar/main_test.go
@@ -37,6 +37,11 @@ func TestCreateAndApply(t *testing.T) {
 
 	now := time.Now()
 	a, b := fstest.MapFS{
+		"proto-docs.json": &fstest.MapFile{
+			Data:    []byte("{}"),
+			Mode:    fs.ModePerm,
+			ModTime: now,
+		},
 		"src/new/new.pb.go": &fstest.MapFile{
 			Data:    []byte("new file"),
 			Mode:    fs.ModePerm,

--- a/src/proto/test.sh
+++ b/src/proto/test.sh
@@ -15,6 +15,5 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-printenv
-cd "$BUILD_WORKSPACE_DIRECTORY"
+cd ../../../../../../..
 exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" test "$(rlocation _main/src/proto/go_protos.tar)"

--- a/src/proto/test.sh
+++ b/src/proto/test.sh
@@ -15,6 +15,6 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f; this script must be run with 'bazel run'"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-INPUT="${PWD}/${1}"
-cd "$BUILD_WORKSPACE_DIRECTORY" # Where your working copy is.
-exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" apply "$INPUT"
+printenv
+cd "$BUILD_WORKSPACE_DIRECTORY"
+exec "$(rlocation _main/src/proto/prototar/prototar_/prototar)" test "$(rlocation _main/src/proto/go_protos.tar)"

--- a/src/testing/pachdev/BUILD.bazel
+++ b/src/testing/pachdev/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//src/internal/log",
         "//src/internal/pachdev",
         "//src/internal/pctx",
-        "//src/internal/signals",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/src/testing/pachdev/main.go
+++ b/src/testing/pachdev/main.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"os/signal"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachdev"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
-	"github.com/pachyderm/pachyderm/v2/src/internal/signals"
 )
 
 var verbose bool
@@ -37,7 +34,7 @@ func main() {
 
 	// Run a command.
 	log.InitPachctlLogger()
-	ctx, c := signal.NotifyContext(pctx.Background(""), signals.TerminationSignals...)
+	ctx, c := pctx.Interactive()
 	defer c()
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		log.Exit(ctx, err.Error())


### PR DESCRIPTION
People are having trouble generating the protos on Mac because `cp` behaves differently compared to Linux.  This is annoying, so I have moved most of the logic to Go; we still have a shell script to run protoc and gopatch, but we do everything else with a custom program.  We have also had trouble with GNU tar vs. BSD tar before, so again, I avoided trying to invoke tar in the shell script and just use archive/tar.

The actual proto generation now runs as a genrule, which means that it's cached when the protos don't change.

I added a "test" mode and a test to check that your working copy matches what came out of the genrule.  If it doesn't match, then run "extract" (still aliased to //:make_proto).  The test output, and the output of make proto, look something like this:

```
INFO prototar/main.go:187 updated file {"name": "proto-docs.json"}
INFO prototar/main.go:187 updated file {"name": "proto-docs.md"}
INFO prototar/main.go:187 updated file {"name": "src/internal/jsonschema/admin_v2/ClusterInfo.schema.json"}
INFO prototar/main.go:187 updated file {"name": "src/openapi/pachyderm_api.swagger.json"}
INFO prototar/main.go:187 updated file {"name": "src/typescript/admin/admin.pb.ts"}
INFO prototar/main.go:187 updated file {"name": "src/admin/admin.pb.go"}
INFO prototar/main.go:187 updated file {"name": "src/admin/admin.pb.validate.go"}
INFO prototar/main.go:187 updated file {"name": "src/admin/admin.pb.zap.go"}

*** It looks like you might need to regenerate the protos in your working copy.
```

It will also print files that are unchanged (in debug mode) and files that it's deleting (when you remove a message from a proto and the JSON schema file needs to be killed).

I added a feature that lets you see "forgotten" files that you might have forgotten to copy over because they were generated in a weird location.  Do something like `bazel build //src/proto:gen_go_proto_bundle; cat bazel-bin/src/proto/go_protos_forgotten_files.txt` to see them.  This looks something like:

```
out/github.com/chrusty/protoc-gen-jsonschema/json-schema-options.pb.go
out/github.com/chrusty/protoc-gen-jsonschema/json-schema-options.pb.validate.go
out/github.com/chrusty/protoc-gen-jsonschema/json-schema-options.pb.zap.go
out/github.com/envoyproxy/protoc-gen-validate/validate/validate.pb.go
out/github.com/envoyproxy/protoc-gen-validate/validate/validate.pb.validate.go
out/github.com/envoyproxy/protoc-gen-validate/validate/validate.pb.zap.go
```

Indeed, we don't want those.  But now we can be sure that nothing is being forgotten, which will be helpful when someone adds a weird plugin.
