### PR TITLE
[INT-1163] Search in file explorer

### DIFF
--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -24,27 +24,27 @@ const createCustomFileBrowser = (
   downloadPath: string,
   nameSuffix: string,
 ): FileBrowser => {
-  const drive = new MountDrive(app.docRegistry, path, nameSuffix, async () => {
-    await browser.model.cd();
-    await paging.update();
-  });
+  const id = `jupyterlab-pachyderm-browser-${nameSuffix}`; 
+  const drive = new MountDrive(
+    app.docRegistry, 
+    path, 
+    nameSuffix,
+    id,
+    async () => {
+      await browser.model.cd();
+    }, 
+    () => { paging.update() }
+  );
   manager.services.contents.addDrive(drive);
 
   const browser = factory.createFileBrowser(
-    'jupyterlab-pachyderm-browser-' + nameSuffix,
+    id,
     {
       driveName: drive.name,
       state: null,
       refreshInterval: 10000,
     },
   );
-
-  const filenameSearcher = browser.node
-    .getElementsByClassName('jp-FileBrowser-filterBox')
-    .item(0);
-  if (filenameSearcher) {
-    browser.node.removeChild(filenameSearcher);
-  }
 
   const toolbar = browser.node
     .getElementsByClassName('jp-FileBrowser-toolbar')
@@ -154,11 +154,6 @@ const createCustomFileBrowser = (
   const paging = new Paging({
     browser_model: browser.model,
     page_model: drive.model,
-  });
-  browser.model.pathChanged.connect(async (_, __) => {
-    // If the FileBrowser path has changed, then the MountDrive has reset the pagination model.
-    // Therefore, the pagination widget needs to be re-rendered.
-    paging.update();
   });
   browser.layout.addWidget(paging);
 

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -24,27 +24,26 @@ const createCustomFileBrowser = (
   downloadPath: string,
   nameSuffix: string,
 ): FileBrowser => {
-  const id = `jupyterlab-pachyderm-browser-${nameSuffix}`; 
+  const id = `jupyterlab-pachyderm-browser-${nameSuffix}`;
   const drive = new MountDrive(
-    app.docRegistry, 
-    path, 
+    app.docRegistry,
+    path,
     nameSuffix,
     id,
     async () => {
       await browser.model.cd();
-    }, 
-    () => { paging.update() }
+    },
+    () => {
+      paging.update();
+    },
   );
   manager.services.contents.addDrive(drive);
 
-  const browser = factory.createFileBrowser(
-    id,
-    {
-      driveName: drive.name,
-      state: null,
-      refreshInterval: 10000,
-    },
-  );
+  const browser = factory.createFileBrowser(id, {
+    driveName: drive.name,
+    state: null,
+    refreshInterval: 10000,
+  });
 
   const toolbar = browser.node
     .getElementsByClassName('jp-FileBrowser-toolbar')

--- a/jupyter-extension/src/plugins/mount/mountDrive.ts
+++ b/jupyter-extension/src/plugins/mount/mountDrive.ts
@@ -8,8 +8,10 @@ import {requestAPI} from '../../handler';
 import {Paging} from './paging';
 import {MOUNT_BROWSER_PREFIX} from './mount';
 
-const MAX_NUM_CONTENTS_PAGE = 100; // How many files to render in the FileBrowser UI per page
-const PAGINATION_NUMBER = 400; // How many items to request per page
+// How many files to render in the FileBrowser UI per page
+const MAX_NUM_CONTENTS_PAGE = 100;
+// How many items to request per page
+const PAGINATION_NUMBER = 400; 
 const DEFAULT_CONTENT_MODEL: Contents.IModel = {
   name: '',
   path: '',
@@ -32,27 +34,40 @@ export class MountDrive implements Contents.IDrive {
   private _loading = new Signal<this, boolean>(this);
   private _serverSettings = ServerConnection.makeSettings();
   private _isDisposed = false;
-  private _cache: {key: string | null; now: number | null; contents: any};
+  private _cache: {key: string | null; now: number | null; contents: Contents.IModel[]};
   private _path: string;
-  private _name_suffix: string;
-  private _refreshFileBrowser: () => Promise<void>; // A function that refresh the file browser
+  private _nameSuffix: string;
+  // DOM Node ID of the FileBrowser
+  private _id: string;
+  // Triggers a cd event without changing the current path in the FileBrowser which forces a re-render of the FileBrowser
+  private _changeDirectory: () => Promise<void>; 
+  // Updates the pagination UI after changes in page, contents, or maxPage have been made.
+  private _pagingUpdate: () => void;
+  // Previous search filter used last time get was called. Used to track if the current page needs to be reset
+  // to zero.
+  private _previousFilter: string | null;
 
   constructor(
     registry: DocumentRegistry,
     path: string,
-    name_suffix: string,
-    refreshFileBrowser: () => Promise<void>,
+    nameSuffix: string,
+    id: string,
+    _changeDirectory: () => Promise<void>,
+    _pagingUpdate: () => void,
   ) {
     this._registry = registry;
     this._model = {page: 0, max_page: 0};
-    this._cache = {key: null, now: null, contents: DEFAULT_CONTENT_MODEL};
+    this._cache = {key: null, now: null, contents: []};
     this._path = path;
-    this._name_suffix = name_suffix;
-    this._refreshFileBrowser = refreshFileBrowser;
+    this._nameSuffix = nameSuffix;
+    this._id = id;
+    this._changeDirectory = _changeDirectory;
+    this._pagingUpdate = _pagingUpdate;
+    this._previousFilter = null;
   }
 
   get name(): string {
-    return MOUNT_BROWSER_PREFIX + this._name_suffix;
+    return MOUNT_BROWSER_PREFIX + this._nameSuffix;
   }
 
   get model(): Paging.IModel {
@@ -75,17 +90,6 @@ export class MountDrive implements Contents.IDrive {
     return this._isDisposed;
   }
 
-  async _get(
-    url: string,
-    options: PartialJSONObject,
-  ): Promise<Contents.IModel> {
-    url += URLExt.objectToQueryString(options);
-    return requestAPI<Contents.IModel>(url, 'GET');
-  }
-
-  // We might be able to pass pagination to the ContentsManager backend by including
-  // it in the URI specifier. This would require a custom ContentsManager which
-  // supports pagination.
   async get(
     localPath: string,
     options?: Contents.IFetchOptions,
@@ -122,17 +126,35 @@ export class MountDrive implements Contents.IDrive {
       const response = await this._get(url, getOptions);
       this._loading.emit(false);
       this._model.page = 1;
-      this._model.max_page = Math.ceil(
-        response.content.length / MAX_NUM_CONTENTS_PAGE,
-      );
       const now = Date.now();
       this._cache = {key: localPath, now, contents: response.content};
       this._fetchNextPage(response, now, url, getOptions);
     }
 
+    // Filter contents if filter defined
+    const filter = this.getFilter();
+    const contents = !filter ? 
+      this._cache.contents : 
+      this._cache.contents.filter((content: Contents.IModel) => {
+        return content.name.toLowerCase().includes(filter);
+      });
+
+    // Reset page to 1 if the filter has changed and update the previousFilter for this check
+    // on the next call of this method.
+    if (filter !== this._previousFilter) {
+      this._model.page = 1;
+    }
+    this._previousFilter = filter;
+
+    // Update max page and pagination UI after contents have changed.
+    this._model.max_page = Math.ceil(
+      contents.length / MAX_NUM_CONTENTS_PAGE,
+    );
+    this._pagingUpdate();
+
     return {
       ...shallowResponse,
-      content: this._cache.contents.slice(
+      content: contents.slice(
         (this._model.page - 1) * MAX_NUM_CONTENTS_PAGE,
         this._model.page * MAX_NUM_CONTENTS_PAGE,
       ),
@@ -167,10 +189,9 @@ export class MountDrive implements Contents.IDrive {
       // Update the cache contents and refresh the FileBrowser. Note this will not cause any changes in the current scroll position or file selection.
       // It will just add new pages and update the page selector without disrupting the user.
       this._cache.contents = this._cache.contents.concat(nextResponse.content);
-      this._model.max_page = Math.ceil(
-        this._cache.contents.length / MAX_NUM_CONTENTS_PAGE,
-      );
-      await this._refreshFileBrowser();
+
+      // Trigger a change directory event without a path change to force re-render the FileBrowser, then fetch the next page of results async.
+      await this._changeDirectory();
       this._fetchNextPage(
         nextResponse,
         timeOfLastDirectoryChange,
@@ -220,5 +241,20 @@ export class MountDrive implements Contents.IDrive {
     }
     this._isDisposed = true;
     Signal.clearData(this);
+  }
+
+  // Gets the user defined file name filter from the JupyterLab FilterBox.
+  private getFilter(): string | null {
+    const selector = `#${this._id} .jp-FileBrowser-filterBox .jp-FilterBox input`
+    const node: HTMLInputElement | null = document.querySelector(selector);
+    return node?.value?.toLowerCase() || null;
+  }
+
+  private async _get(
+    url: string,
+    options: PartialJSONObject,
+  ): Promise<Contents.IModel> {
+    url += URLExt.objectToQueryString(options);
+    return requestAPI<Contents.IModel>(url, 'GET');
   }
 }

--- a/jupyter-extension/src/plugins/mount/mountDrive.ts
+++ b/jupyter-extension/src/plugins/mount/mountDrive.ts
@@ -11,7 +11,7 @@ import {MOUNT_BROWSER_PREFIX} from './mount';
 // How many files to render in the FileBrowser UI per page
 const MAX_NUM_CONTENTS_PAGE = 100;
 // How many items to request per page
-const PAGINATION_NUMBER = 400; 
+const PAGINATION_NUMBER = 400;
 const DEFAULT_CONTENT_MODEL: Contents.IModel = {
   name: '',
   path: '',
@@ -34,13 +34,17 @@ export class MountDrive implements Contents.IDrive {
   private _loading = new Signal<this, boolean>(this);
   private _serverSettings = ServerConnection.makeSettings();
   private _isDisposed = false;
-  private _cache: {key: string | null; now: number | null; contents: Contents.IModel[]};
+  private _cache: {
+    key: string | null;
+    now: number | null;
+    contents: Contents.IModel[];
+  };
   private _path: string;
   private _nameSuffix: string;
   // DOM Node ID of the FileBrowser
   private _id: string;
   // Triggers a cd event without changing the current path in the FileBrowser which forces a re-render of the FileBrowser
-  private _changeDirectory: () => Promise<void>; 
+  private _changeDirectory: () => Promise<void>;
   // Updates the pagination UI after changes in page, contents, or maxPage have been made.
   private _pagingUpdate: () => void;
   // Previous search filter used last time get was called. Used to track if the current page needs to be reset
@@ -133,11 +137,11 @@ export class MountDrive implements Contents.IDrive {
 
     // Filter contents if filter defined
     const filter = this.getFilter();
-    const contents = !filter ? 
-      this._cache.contents : 
-      this._cache.contents.filter((content: Contents.IModel) => {
-        return content.name.toLowerCase().includes(filter);
-      });
+    const contents = !filter
+      ? this._cache.contents
+      : this._cache.contents.filter((content: Contents.IModel) => {
+          return content.name.toLowerCase().includes(filter);
+        });
 
     // Reset page to 1 if the filter has changed and update the previousFilter for this check
     // on the next call of this method.
@@ -147,9 +151,7 @@ export class MountDrive implements Contents.IDrive {
     this._previousFilter = filter;
 
     // Update max page and pagination UI after contents have changed.
-    this._model.max_page = Math.ceil(
-      contents.length / MAX_NUM_CONTENTS_PAGE,
-    );
+    this._model.max_page = Math.ceil(contents.length / MAX_NUM_CONTENTS_PAGE);
     this._pagingUpdate();
 
     return {
@@ -245,7 +247,7 @@ export class MountDrive implements Contents.IDrive {
 
   // Gets the user defined file name filter from the JupyterLab FilterBox.
   private getFilter(): string | null {
-    const selector = `#${this._id} .jp-FileBrowser-filterBox .jp-FilterBox input`
+    const selector = `#${this._id} .jp-FileBrowser-filterBox .jp-FilterBox input`;
     const node: HTMLInputElement | null = document.querySelector(selector);
     return node?.value?.toLowerCase() || null;
   }


### PR DESCRIPTION
FileBrowser Search has the following features and uses the default JuypterLab FilterBox UI

* Case insensitive
* Highlights the matching segment in the filename with bold text
* Looks for a matching segment in the filename without any tokenization or whitespace removal.
* Each character a user types in to the filter input updates the results in real time and resets the current page to 1.

This PR also includes some small changes like updating typing where it was missing, `name_suffix` -> `nameSuffix` to match TS naming standards, and removing outdated comments.

One change to `setup_large_repo.py` also included comes from the fact that upon needing to run the script for a second time as part of this work, I ran into an issue where the files never finished processing. Only when I broke up the putting of files into smaller commits of 10 files each and waited after each commit did my local Pachyderm instance actually finish processing the files. I am not exactly sure why so maybe this is just a local environment issue.

# View Datum Demo
https://github.com/pachyderm/pachyderm/assets/401518/3abfb9c5-38d4-4e5e-a662-a309a21b573e

# Explore Repo Demo
https://github.com/pachyderm/pachyderm/assets/401518/c25ac5be-9a55-49b6-ab6c-d19790e9cab9