### PR TITLE
[Backport - 2.8] Change Auth Token Env Var Name #9687

### DIFF
--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -578,11 +578,11 @@ func newOnUserMachine(ctx context.Context, cfg *config.Config, context *config.C
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not connect to pachd at %q", pachdAddress.Qualified())
 	}
-	// if PACH_ID_TOKEN exists in env, try to produce a session token from it if one does not exist
-	if idToken := os.Getenv("PACH_ID_TOKEN"); idToken != "" && context.SessionToken == "" {
+	// if DEX_TOKEN exists in env, try to produce a session token from it if one does not exist
+	if idToken := os.Getenv("DEX_TOKEN"); idToken != "" && context.SessionToken == "" {
 		if r, err := client.Authenticate(ctx, &auth.AuthenticateRequest{IdToken: idToken}); err != nil {
 			if !auth.IsErrNotActivated(err) {
-				log.Error(ctx, "failed to exchange PACH_ID_TOKEN from environment for a pachyderm session token", zap.Error(err))
+				log.Error(ctx, "failed to exchange DEX_TOKEN from environment for a pachyderm session token", zap.Error(err))
 			}
 		} else {
 			context.SessionToken = r.PachToken

--- a/src/server/auth/cmds/cmds_test.go
+++ b/src/server/auth/cmds/cmds_test.go
@@ -195,7 +195,7 @@ func TestIDTokenFromEnv(t *testing.T) {
 	).Run())
 	require.NoError(t, tu.PachctlBashCmd(t, c, `
                 echo "" | pachctl auth use-auth-token;
-                export PACH_ID_TOKEN={{.token}};
+                export DEX_TOKEN={{.token}};
                 pachctl auth whoami | match user:{{.user}}`,
 		"user", tu.DexMockConnectorEmail,
 		"token", token,


### PR DESCRIPTION
Use DEX_TOKEN instead of PACH_ID_TOKEN