### PR TITLE
bump console version 2.8.4

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -389,7 +389,7 @@ console:
     pullPolicy: "IfNotPresent"
     # tag is the image repo to pull from; together with repository it
     # replicates the --console-image argument to pachctl deploy.
-    tag: "2.8.2"
+    tag: "2.8.4"
   priorityClassName: ""
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
In case your wondering why this went from 2.8.2 to 2.8.4. the 2.8.3 release bump was missed so we had to manually run the publish helm job with corrected version. this will no longer require a manual bump 2.9.0> since it will be in lock step with the chart version. 