### PR TITLE
Remove PACHD_ADDRESS deprecation warning

### DIFF
--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -405,7 +405,6 @@ func getUserMachineAddrAndOpts(context *config.Context) (*grpcutil.PachdAddress,
 
 	// 1) PACHD_ADDRESS environment variable (shell-local) overrides global config
 	if envAddrStr, ok := os.LookupEnv("PACHD_ADDRESS"); ok {
-		fmt.Fprintln(os.Stderr, "WARNING: 'PACHD_ADDRESS' is deprecated and will be removed in a future release, use Pachyderm contexts instead.")
 
 		envAddr, err := grpcutil.ParsePachdAddress(envAddrStr)
 		if err != nil {


### PR DESCRIPTION
PACHD_ADDRESS is no longer deprecated as it is being used in determined notebooks.