### PR TITLE
[Jupyter] Allow uninstantiated pachyderm clients

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/__init__.py
+++ b/jupyter-extension/jupyterlab_pachyderm/__init__.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from .env import PACH_CONFIG
 from .handlers import setup_handlers
 
 
@@ -26,7 +27,7 @@ def _load_jupyter_server_extension(server_app):
     server_app: jupyterlab.labapp.LabApp
         JupyterLab application instance
     """
-    setup_handlers(server_app.web_app)
+    setup_handlers(server_app.web_app, PACH_CONFIG)
     server_app.log.info("Registered Pachyderm extension at URL path /pachyderm")
 
 

--- a/jupyter-extension/jupyterlab_pachyderm/dev_server.py
+++ b/jupyter-extension/jupyterlab_pachyderm/dev_server.py
@@ -5,6 +5,7 @@ from jupyter_server.auth.identity import IdentityProvider, User
 from jupyter_server.base.handlers import JupyterHandler
 
 from . import setup_handlers
+from .env import PACH_CONFIG
 
 
 class TestIdentityProvider(IdentityProvider):
@@ -17,7 +18,7 @@ class TestIdentityProvider(IdentityProvider):
 
 if __name__ == "__main__":
     app = tornado.web.Application(base_url="/")
-    setup_handlers(app)
+    setup_handlers(app, PACH_CONFIG)
 
     # Disable authorization checks between test API and dev-server
     app.settings["identity_provider"] = TestIdentityProvider()

--- a/jupyter-extension/jupyterlab_pachyderm/dev_server.py
+++ b/jupyter-extension/jupyterlab_pachyderm/dev_server.py
@@ -24,5 +24,5 @@ if __name__ == "__main__":
     app.settings["identity_provider"] = TestIdentityProvider()
     app.settings["disable_check_xsrf"] = True
 
-    app.listen(8889)
+    app.listen(8888)
     tornado.ioloop.IOLoop.current().start()

--- a/jupyter-extension/jupyterlab_pachyderm/dev_server.py
+++ b/jupyter-extension/jupyterlab_pachyderm/dev_server.py
@@ -23,5 +23,5 @@ if __name__ == "__main__":
     app.settings["identity_provider"] = TestIdentityProvider()
     app.settings["disable_check_xsrf"] = True
 
-    app.listen(8888)
+    app.listen(8889)
     tornado.ioloop.IOLoop.current().start()

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -30,7 +30,9 @@ VERSION = "v2"
 
 
 class BaseHandler(APIHandler):
-    _no_client_error = tornado.web.HTTPError(reason="no instantiated pachyderm client")
+    _no_client_error = tornado.web.HTTPError(
+        status_code=401, reason="no instantiated pachyderm client"
+    )
 
     @property
     def client(self) -> Client:

--- a/jupyter-extension/jupyterlab_pachyderm/tests/conftest.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/conftest.py
@@ -1,0 +1,84 @@
+import socket
+from pathlib import Path
+from shutil import copyfile
+from typing import Tuple
+
+import asyncio
+import httpx
+import pytest
+import tornado.web
+from tornado.httpserver import HTTPServer
+
+from jupyterlab_pachyderm.handlers import NAMESPACE, VERSION, setup_handlers
+from jupyterlab_pachyderm.env import PACH_CONFIG
+
+PortType = Tuple[socket.socket, int]
+
+
+@pytest.fixture
+def pach_config(request, tmp_path) -> Path:
+    """Temporary path used to write the pach config for tests.
+
+    If the test is marked with @pytest.mark.no_config then the config
+      file is not written.
+    """
+    config_path = tmp_path / "config.json"
+    if not request.node.get_closest_marker("no_config"):
+        copyfile(PACH_CONFIG, config_path)
+    yield Path(config_path)
+
+
+@pytest.fixture
+def app(pach_config) -> tornado.web.Application:
+    """Create a instance of our application.
+    This fixture is used by the http_server fixture.
+    """
+    from jupyter_server.auth.identity import IdentityProvider, User
+    from jupyter_server.base.handlers import JupyterHandler
+
+    class TestIdentityProvider(IdentityProvider):
+        """An identity provider for the tests, disable auth checks made."""
+
+        def get_user(self, handler: JupyterHandler) -> User:
+            """Get the user."""
+            return User("test-user")
+
+    app = tornado.web.Application(base_url="/")
+    setup_handlers(app, pach_config)
+    app.settings["identity_provider"] = TestIdentityProvider()
+    app.settings["disable_check_xsrf"] = True
+    return app
+
+
+@pytest.fixture
+def http_server_port() -> PortType:
+    """Port used by `http_server`"""
+    return tornado.testing.bind_unused_port()
+
+
+@pytest.yield_fixture
+def http_server(app, event_loop: asyncio.BaseEventLoop, http_server_port: PortType):
+    """Start a tornado HTTP server that listens on all available handlers.
+    ref: github.com/eukaryote/pytest-tornasync/blob/0.6.0.post2/src/pytest_tornasync/plugin.py
+
+    The event_loop fixture is from the pytest-asyncio package.
+    """
+    server = tornado.httpserver.HTTPServer(app)
+    server.add_socket(http_server_port[0])
+
+    yield server
+
+    server.stop()
+
+    if hasattr(server, "close_all_connections"):
+        event_loop.run_until_complete(
+            server.close_all_connections()
+        )
+
+
+@pytest.fixture
+async def http_client(http_server_port: PortType) -> httpx.AsyncClient:
+    """Creates a httpx.AsyncClient set with the correct base_url to hit our handlers."""
+    base_url = f"http://127.0.0.1:{http_server_port[1]}/{NAMESPACE}/{VERSION}"
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        yield client

--- a/jupyter-extension/jupyterlab_pachyderm/tests/conftest.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/conftest.py
@@ -56,8 +56,12 @@ def http_server_port() -> PortType:
     return tornado.testing.bind_unused_port()
 
 
-@pytest.yield_fixture
-def http_server(app, event_loop: asyncio.BaseEventLoop, http_server_port: PortType):
+@pytest.yield_fixture(name="http_server")
+def http_server_fixture(
+    app: tornado.web.Application,
+    event_loop: asyncio.BaseEventLoop,
+    http_server_port: PortType
+) -> tornado.httpserver.HTTPServer:
     """Start a tornado HTTP server that listens on all available handlers.
     ref: github.com/eukaryote/pytest-tornasync/blob/0.6.0.post2/src/pytest_tornasync/plugin.py
 
@@ -77,8 +81,12 @@ def http_server(app, event_loop: asyncio.BaseEventLoop, http_server_port: PortTy
 
 
 @pytest.fixture
-async def http_client(http_server_port: PortType) -> httpx.AsyncClient:
+async def http_client(
+    http_server: tornado.httpserver.HTTPServer,
+    http_server_port: PortType,
+) -> httpx.AsyncClient:
     """Creates a httpx.AsyncClient set with the correct base_url to hit our handlers."""
+    assert http_server  # Ensure server is created for tests.
     base_url = f"http://127.0.0.1:{http_server_port[1]}/{NAMESPACE}/{VERSION}"
     async with httpx.AsyncClient(base_url=base_url) as client:
         yield client

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -3,7 +3,6 @@ import sys
 import subprocess
 import time
 import json
-from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from random import randint
@@ -12,7 +11,6 @@ import urllib
 import pytest
 import requests
 from httpx import AsyncClient
-from tornado.httpserver import HTTPServer
 from tornado.web import Application
 
 from jupyterlab_pachyderm.handlers import NAMESPACE, VERSION
@@ -24,7 +22,7 @@ from pachyderm_sdk.config import ConfigFile
 
 from jupyterlab_pachyderm.tests import TEST_NOTEBOOK
 
-ADDRESS = "http://localhost:8889"
+ADDRESS = "http://localhost:8888"
 BASE_URL = f"{ADDRESS}/{NAMESPACE}/{VERSION}"
 ROOT_TOKEN = "iamroot"
 DEFAULT_PROJECT = "default"
@@ -56,9 +54,8 @@ def pachyderm_resources():
         client.pfs.delete_repo(repo=pfs.Repo(name=repo))
 
 
-@contextmanager
+@pytest.fixture(scope="module")
 def dev_server(pach_config: Path):
-    """A context manager for creating a dev-server instance manually."""
     print("starting development server...")
     p = subprocess.Popen(
         [sys.executable, "-m", "jupyterlab_pachyderm.dev_server"],
@@ -86,11 +83,6 @@ def dev_server(pach_config: Path):
         p.wait()
         time.sleep(1)
 
-
-@pytest.fixture(name='dev_server', scope="module")
-def dev_server_fixture(pach_config: Path):
-    with dev_server(pach_config):
-        yield
 
 @pytest.fixture
 def dev_server_with_unmount(dev_server):
@@ -595,7 +587,7 @@ class TestConfigHandler:
 
     @staticmethod
     @pytest.mark.no_config
-    async def test_config_no_file(app: Application, http_client: AsyncClient, http_server: HTTPServer):
+    async def test_config_no_file(app: Application, http_client: AsyncClient):
         """Test that if there is no config file present, the extension does not
         use a default config."""
         # Arrange

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -65,14 +65,7 @@ def pach_config(tmpdir_factory) -> Path:
 
 @contextmanager
 def dev_server(pach_config: Path):
-    """A context manager for creating a dev-server instance manually.
-
-    Example
-    -------
-    >>> config: Path
-    >>> with dev_server(config):
-    >>>     ...  # do test
-    """
+    """A context manager for creating a dev-server instance manually."""
     print("starting development server...")
     p = subprocess.Popen(
         [sys.executable, "-m", "jupyterlab_pachyderm.dev_server"],
@@ -615,8 +608,14 @@ class TestConfigHandler:
         pach_config.unlink()
 
         with dev_server(pach_config):
-            with pytest.raises(tornado.web.HTTPError):
-                requests.get(f"{BASE_URL}/config")
+            # Act
+            response = requests.get(f"{BASE_URL}/config")
+
+            # Assert
+            response.raise_for_status()
+            payload = response.json()
+            assert payload["cluster_status"] == "INVALID"
+            assert payload["pachd_address"] == ""
 
     @staticmethod
     @pytest.mark.usefixtures("dev_server")

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -54,7 +54,7 @@ def pachyderm_resources():
         client.pfs.delete_repo(repo=pfs.Repo(name=repo))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def dev_server(pach_config: Path):
     print("starting development server...")
     p = subprocess.Popen(

--- a/jupyter-extension/pyproject.toml
+++ b/jupyter-extension/pyproject.toml
@@ -15,3 +15,7 @@ npm = ["npm"]
 
 [tool.check-manifest]
 ignore = ["jupyterlab_pachyderm/labextension/**", ".*", "package-lock.json"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = ["no_config"]

--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -28,10 +28,9 @@ python_requires = >=3.8,<4
 [options.extras_require]
 dev=
   black
+  httpx>=0.26.0,<0.27.0
   jupyter_packaging~=0.10.0,<2
   jupyterlab>=3.0.14,<4
   pre-commit
   pytest
   pytest-asyncio
-  pytest-tornasync
-  pytest-jupyter


### PR DESCRIPTION
Currently when trying to start the extension, if a pachyderm config file is not present, we create a pachyderm client that connects to `localhost:30650`. In doing this, the FE is not able to know if the user entered this config or not. This PR allows an uninstantiated pachyderm client on startup, and adds checks when accessing any functionality which requires the pachyderm client. Additionally, the config file is now passed into the `setup_handlers` method and added to the application settings.

Additionally to test this functionality I needed a bit more flexibility in creating the server that we test against. This led to an exploration into running both client and server asynchronously within the same thread. Only the new test uses this functionality at this time.