### PR TITLE
Update `stream.Collect()` to stop iteration after collecting `max`

### DIFF
--- a/src/internal/stream/iterator.go
+++ b/src/internal/stream/iterator.go
@@ -80,8 +80,8 @@ func Read[T any](ctx context.Context, it Iterator[T], buf []T) (n int, _ error) 
 // Collect reads at most max from the iterator into a buffer and returns it.
 func Collect[T any](ctx context.Context, it Iterator[T], max int) (ret []T, _ error) {
 	for {
-		if len(ret) > max {
-			return nil, errors.Errorf("stream.Collect: iterator produced too many elements. max=%d", max)
+		if len(ret) == max {
+			break
 		}
 		if err := appendNext(ctx, it, &ret); err != nil {
 			if IsEOS(err) {


### PR DESCRIPTION
This PR changes `stream.Collect()` to return the collected messages after it hits the specified `max`, rather than error and return no messages. The use case for this is if a server response stream sends messages back but doesn't terminate yet, the function doesn't know whether it should return the collected messages or keep waiting for more. The `max` parameter can be used as a threshold.

With this change, the functionality we lose is returning an error that more messages were returned on the stream than expected. I'm wondering if that should be retained. If so, I can create a separate function for this change.