### PR TITLE
[Jupyter] Prevent a bad config from being stored

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -389,7 +389,7 @@ class ConfigHandler(BaseHandler):
         body = self.get_json_body()
         address = body.get("pachd_address")
         if not address:
-            get_logger().error("_config/put: no pachd address provided")
+            get_logger().error("config/put: no pachd address provided")
             raise tornado.web.HTTPError(500, "no pachd address provided")
         cas = bytes(body["server_cas"], "utf-8") if "server_cas" in body else None
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -604,6 +604,25 @@ class TestConfigHandler:
         assert payload["pachd_address"] == ""
 
     @staticmethod
+    @pytest.mark.no_config
+    async def test_do_not_set_invalid_config(app: Application, http_client: AsyncClient):
+        """Test that PUT /config does not store an invalid config."""
+        # Arrange
+        assert app.settings.get("pachyderm_client") is None
+        invalid_address = "localhost:33333"
+        data = {"pachd_address": invalid_address}
+
+        # Act
+        response = await http_client.put("/config", json=data)
+
+        # Assert
+        response.raise_for_status()
+        payload = response.json()
+        assert payload["cluster_status"] == "INVALID"
+        assert payload["pachd_address"] == invalid_address
+        assert app.settings.get("pachyderm_client") is None
+
+    @staticmethod
     @pytest.mark.usefixtures("dev_server")
     def test_config(pach_config):
         # PUT request


### PR DESCRIPTION
When handling `PUT /config` the backend was setting the config and then testing it. Now we test the new config and store it only if the config is _not_ invalid. Doing so prevents a user from inputting a bad pachd_address on the config screen and having the UI present it like it's a valid address. Surprisingly this didn't require and front end changes.