### PR TITLE
clear mounted datums before new datums

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
@@ -563,6 +563,7 @@ class DatumManager(FileContentsManager):
             self._datum_list = list(self._client.pps.list_datum(input=input))
             self._datum_index = 0
             self._mount_time = datetime.datetime.now()
+            self._repo_names.clear()
             self._populate_name_table(input=input)
             if len(self._datum_list) == 0:
                 self._reset()


### PR DESCRIPTION
the mounted repo names table was not getting cleared when we mount a new datum. this would result in errors when re-mounting the same repo as well as old repos staying mounted