### PR TITLE
Enable and split object storage provider tests

### DIFF
--- a/src/internal/obj/integrationtests/BUILD.bazel
+++ b/src/internal/obj/integrationtests/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
+# gazelle:go_test file
+
 go_library(
     name = "integrationtests",
     srcs = [
@@ -12,22 +14,47 @@ go_library(
 )
 
 go_test(
-    name = "integrationtests_test",
-    srcs = [
-        "amazon_test.go",
-        "google_test.go",
-        "microsoft_test.go",
-        "minio_test.go",
-    ],
+    name = "amazon_test",
+    srcs = ["amazon_test.go"],
     embed = [":integrationtests"],
-    tags = [
-        "external",
-        "manual",
-    ],
+    tags = ["external"],
     deps = [
         "//src/internal/obj",
         "//src/internal/pctx",
         "//src/internal/require",
+    ],
+)
+
+go_test(
+    name = "google_test",
+    srcs = ["google_test.go"],
+    embed = [":integrationtests"],
+    tags = ["external"],
+    deps = [
+        "//src/internal/obj",
+        "//src/internal/require",
         "@org_golang_google_api//option",
+    ],
+)
+
+go_test(
+    name = "microsoft_test",
+    srcs = ["microsoft_test.go"],
+    embed = [":integrationtests"],
+    tags = ["external"],
+    deps = [
+        "//src/internal/obj",
+        "//src/internal/require",
+    ],
+)
+
+go_test(
+    name = "minio_test",
+    srcs = ["minio_test.go"],
+    embed = [":integrationtests"],
+    tags = ["external"],
+    deps = [
+        "//src/internal/obj",
+        "//src/internal/require",
     ],
 )


### PR DESCRIPTION
I think these were not running before.  Also, since they can run in parallel with each other, I've split them into separate test targets.