### PR TITLE
[Jupyter] Add UNKNOWN cluster status state

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -429,7 +429,7 @@ class ConfigHandler(BaseHandler):
         try:
             client = self.client
         except tornado.web.HTTPError:
-            payload = {"cluster_status": self.CLUSTER_NO_CONFIG, "pachd_address": ""}
+            payload = {"cluster_status": self.CLUSTER_UNKNOWN, "pachd_address": ""}
         else:
             cluster_status = self.cluster_status(client)
             payload = {
@@ -517,13 +517,6 @@ class AuthLogoutHandler(BaseHandler):
             raise tornado.web.HTTPError(
                 status_code=500, reason=f"Error logging out of auth: {e}."
             )
-
-
-class HealthHandler(APIHandler):
-    @tornado.web.authenticated
-    async def get(self):
-        response = {"status": "running"}
-        await self.finish(response)
 
 
 class PPSCreateHandler(BaseHandler):
@@ -660,7 +653,6 @@ def setup_handlers(web_app, config_file: Path):
     web_app.settings["pachyderm_config_file"] = config_file
 
     _handlers = [
-        ("/health", HealthHandler),
         ("/mounts", MountsHandler),
         ("/projects", ProjectsHandler),
         ("/_mount", MountHandler),

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -357,12 +357,20 @@ class ViewDatumHandler(ContentsHandler):
 
 
 class ConfigHandler(BaseHandler):
+    CLUSTER_UNKNOWN = "UNKNOWN"
+    """An UNKNOWN status indicates that the server is running, but we are unable to
+    determine the validity of the cluster config."""
+
     CLUSTER_INVALID = "INVALID"
     CLUSTER_VALID_NO_AUTH = "VALID_NO_AUTH"
     CLUSTER_VALID_LOGGED_IN = "VALID_LOGGED_IN"
     CLUSTER_VALID_LOGGED_OUT = "VALID_LOGGED_OUT"
 
     def cluster_status(self, client: Client) -> str:
+        """Determines the status of the client's connection to the cluster.
+
+        NOTE: This _will not_ error.
+        """
         try:
             client.auth.who_am_i()
         except grpc.RpcError as err:
@@ -380,6 +388,9 @@ class ConfigHandler(BaseHandler):
             return self.CLUSTER_VALID_NO_AUTH
         except ConnectionError:
             return self.CLUSTER_INVALID
+        except Exception:
+            # Something went wrong -- a worse state than INVALID.
+            return self.CLUSTER_UNKNOWN
         else:
             return self.CLUSTER_VALID_LOGGED_IN
 
@@ -394,21 +405,11 @@ class ConfigHandler(BaseHandler):
         cas = bytes(body["server_cas"], "utf-8") if "server_cas" in body else None
 
         # Attempt to instantiate client and test connection
-        try:
-            client = Client.from_pachd_address(address, root_certs=cas)
-            cluster_status = self.cluster_status(client)
-            get_logger().info(f"({address}) cluster status: {cluster_status}")
-        except Exception as e:
-            get_logger().error(
-                f"Error updating config with endpoint {body['pachd_address']}.",
-                exc_info=True,
-            )
-            raise tornado.web.HTTPError(
-                status_code=500,
-                reason=f"Error updating config with endpoint {body['pachd_address']}: {e}.",
-            )
+        client = Client.from_pachd_address(address, root_certs=cas)
+        cluster_status = self.cluster_status(client)
+        get_logger().info(f"({address}) cluster status: {cluster_status}")
 
-        if cluster_status != self.CLUSTER_INVALID:
+        if cluster_status not in {self.CLUSTER_INVALID, self.CLUSTER_UNKNOWN}:
             self.client = client  # Set client only if valid.
             # Attempt to write new pachyderm context to config.
             try:
@@ -427,25 +428,14 @@ class ConfigHandler(BaseHandler):
         # Try to get a pachyderm client.
         try:
             client = self.client
-        except tornado.web.HTTPError as err:
-            if err.reason != self._no_client_error.reason:
-                raise err
-            payload = {"cluster_status": self.CLUSTER_INVALID, "pachd_address": ""}
-            await self.finish(json.dumps(payload))
-            return
-
-        try:
+        except tornado.web.HTTPError:
+            payload = {"cluster_status": self.CLUSTER_NO_CONFIG, "pachd_address": ""}
+        else:
             cluster_status = self.cluster_status(client)
-        except Exception as e:
-            get_logger().error("Error getting config.", exc_info=True)
-            raise tornado.web.HTTPError(
-                status_code=500, reason=f"Error getting config: {e}."
-            )
-
-        payload = {
-            "cluster_status": cluster_status,
-            "pachd_address": client.address,
-        }
+            payload = {
+                "cluster_status": cluster_status,
+                "pachd_address": client.address,
+            }
         await self.finish(json.dumps(payload))
 
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_config.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_config.py
@@ -24,7 +24,7 @@ async def test_config_no_file(app: Application, http_client: AsyncClient):
     # Assert
     response.raise_for_status()
     payload = response.json()
-    assert payload["cluster_status"] == "INVALID"
+    assert payload["cluster_status"] == "UNKNOWN"
     assert payload["pachd_address"] == ""
 
 

--- a/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
@@ -35,7 +35,9 @@ export const useConfig = (
 
   useEffect(() => {
     setClusterStatus(authConfig.cluster_status);
-    setShouldShowAddressInput(authConfig.cluster_status === 'INVALID');
+    setShouldShowAddressInput(
+      ['NO_CONFIG', 'UNKNOWN', 'INVALID'].includes(authConfig.cluster_status),
+    );
     setErrorMessage('');
     setAddressField('');
     setServerCa('');
@@ -62,6 +64,10 @@ export const useConfig = (
 
         if (response.cluster_status === 'INVALID') {
           setErrorMessage('Invalid address.');
+        } else if (response.cluster_status === 'UNKNOWN') {
+          setErrorMessage(
+            'An unexpected error occurred when attempting to set the address.',
+          );
         } else {
           updateConfig(response);
         }

--- a/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
@@ -36,7 +36,7 @@ export const useConfig = (
   useEffect(() => {
     setClusterStatus(authConfig.cluster_status);
     setShouldShowAddressInput(
-      ['NO_CONFIG', 'UNKNOWN', 'INVALID'].includes(authConfig.cluster_status),
+      ['NONE', 'UNKNOWN', 'INVALID'].includes(authConfig.cluster_status),
     );
     setErrorMessage('');
     setAddressField('');

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -14,6 +14,7 @@ export type mountState =
 
 export type clusterStatus =
   | 'NONE'
+  | 'UNKNOWN'
   | 'INVALID'
   | 'VALID_NO_AUTH'
   | 'VALID_LOGGED_IN'


### PR DESCRIPTION
Adding this state makes the `GET /config` endpoint (at least our code) no longer able to error. This makes it a suitable replacement for, and improvement from, the `GET /health` endpoint.