### PR TITLE
[Jupyter] Prevent error popups when no connected to cluster

### DIFF
--- a/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
+++ b/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
@@ -21,7 +21,7 @@ import {mockedRequestAPI} from 'utils/testUtils';
 import {MountPlugin} from '../mount';
 import * as requestAPI from '../../../handler';
 import {waitFor} from '@testing-library/react';
-import {Mount, MountSettings} from '../types';
+import {MountSettings} from '../types';
 
 jest.mock('../../../handler');
 
@@ -189,6 +189,23 @@ describe('mount plugin', () => {
     expect(plugin.layout.widgets[3]).toBeInstanceOf(ReactWidget); // Config
     expect(plugin.layout.widgets[4]).toBeInstanceOf(ReactWidget); // Loader
     expect(plugin.layout.widgets[5]).toBeInstanceOf(ReactWidget); // Error
+  });
+
+  it('should show config screen when not connected to a cluster', async () => {
+    mockRequestAPI.requestAPI.mockImplementation(
+      mockedRequestAPI({cluster_status: 'UNKNOWN', pachd_address: ''}),
+    );
+
+    const plugin = new MountPlugin(
+      app,
+      settings,
+      docManager,
+      factory,
+      restorer,
+      widgetTracker,
+    );
+
+    expect(plugin.layout.currentWidget?.title.label === 'Config');
   });
   /* TODO: tests must be updated for the new FUSE-less impl
   it('return from pipeline view to the correct layout', async () => {

--- a/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
+++ b/jupyter-extension/src/plugins/mount/__tests__/mount.test.tsx
@@ -1,5 +1,5 @@
 // Force animation frames to resolve immediately. Necessary for executing deferred code from Lumino Polls
-window.requestAnimationFrame = (cb: any) => { return cb() }
+window.requestAnimationFrame = (cb: any) => { return cb(); }; // prettier-ignore
 
 import {ReactWidget, WidgetTracker} from '@jupyterlab/apputils';
 import {

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -43,6 +43,13 @@ const createCustomFileBrowser = (
     // select and scroll to the file opened on a delay. The file attempting to be selected may not be visible and
     // if it is then it interferes with the user scrolling immediately.
     state: null,
+
+    // Setting this to false fixes an issue where the file browser was making requests
+    // to our backend before the backend was capable of handling them, i.e. before the
+    // user is connected to their pachd instance. When set to false, the poller that
+    // refreshes the file browser contents every `refreshInterval` ms is initiated on
+    // the first `cd` call that the file browser handles. This is compatible with how
+    // the plugin currently utilizes the file browser.
     auto: false,
     restore: false,
   });

--- a/jupyter-extension/src/plugins/mount/customFileBrowser.ts
+++ b/jupyter-extension/src/plugins/mount/customFileBrowser.ts
@@ -43,7 +43,7 @@ const createCustomFileBrowser = (
     // select and scroll to the file opened on a delay. The file attempting to be selected may not be visible and
     // if it is then it interferes with the user scrolling immediately.
     state: null,
-    auto: true,
+    auto: false,
     restore: false,
   });
 

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -91,7 +91,7 @@ export class MountPlugin implements IMountPlugin {
     // This is used to detect if the config goes bad (pachd address changes)
     this._poller.configSignal.connect((_, config) => {
       const status = config.cluster_status;
-      if (status === 'INVALID' || status === 'VALID_LOGGED_OUT') {
+      if (['UNKNOWN', 'INVALID', 'VALID_LOGGED_OUT'].includes(status)) {
         this._panel.tabBar.hide();
         this.setCurrentView(this._configScreen);
       } else {

--- a/jupyter-extension/src/plugins/mount/pollMounts.ts
+++ b/jupyter-extension/src/plugins/mount/pollMounts.ts
@@ -168,8 +168,8 @@ export class PollMounts {
       const config = await requestAPI<AuthConfig>('config', 'GET');
       this.config = config;
       if (
-        config.cluster_status !== 'INVALID' &&
-        config.cluster_status !== 'VALID_LOGGED_OUT'
+        config.cluster_status === 'VALID_NO_AUTH' ||
+        config.cluster_status === 'VALID_LOGGED_IN'
       ) {
         const data = await requestAPI<ListMountsResponse>('mounts', 'GET');
         this.status = {code: 200};


### PR DESCRIPTION
The polling from the filebrowsers trying to refresh were causing error popups. Switching `auto=false` fixes that issue so that it doesn't automatically load the initial path and start refreshing. The extension then starts the polling automatically when loading/mounting files.

Also added a couple more checks for an `UNKNOWN` state within the poller/frontend.

![image](https://github.com/pachyderm/pachyderm/assets/28938409/4d75cb87-1a06-432e-a89f-1eeba2dd5fe6)