### PR TITLE
Remove malformed key check

### DIFF
--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -67,15 +67,7 @@ func (es *etcdService) List(ctx context.Context, namespace, group string, cb fun
 		if taskData.State == State_RUNNING && etcdCols.claimCol.ReadOnly(ctx).Get(key, &claim) == nil {
 			claimed = true
 		}
-		// parse out namespace and group from key in case they weren't provided
-		fullKey := strings.TrimPrefix(path.Join(prefix, key), "/")
-
-		// namespace/group/doerID/taskID
-		keyParts := strings.Split(fullKey, "/")
-		if len(keyParts) != 4 {
-			return errors.Errorf("malformed task key %s", fullKey)
-		}
-		return cb(keyParts[0], keyParts[1], &taskData, claimed)
+		return cb(namespace, group, &taskData, claimed)
 	}))
 }
 


### PR DESCRIPTION
This PR removes the malformed key check in the etcd task service list functionality. This check creates an unnecessary constraint on namespaces (i.e. they cannot contain slashes). Namespaces are just prefixes for task service operations, so it is fine for them to contain slashes.