### PR TITLE
adjust workspace_status to respect tags

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -11,14 +11,11 @@ echo "GIT_BRANCH $git_branch"
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
 echo "GIT_TREE_STATUS $git_tree_status"
 
-most_recent_tag=$(git tag -l 'v*' --sort=creatordate | tail -n1)
-echo "STABLE_VERSION $most_recent_tag"
+exact=$(git describe --exact-match 2>/dev/null | sed -e s/^v// | cut -d - -f 1 || echo 2.10.0)
+echo "STABLE_APP_VERSION $exact"
 
-# TODO(jrockway): Read these from the git tags when the branch is named "2.x".
-echo "STABLE_APP_VERSION 2.9.0"
-
-additional_version=$(git diff-index --quiet HEAD -- && echo "-${commit_sha}" || echo "-${commit_sha}+dirty")
-echo "STABLE_ADDITIONAL_VERSION $additional_version"
+additional_version=$(git describe --exact-match 2>/dev/null | cut -d - -f 2- || echo "pre.$(git describe --long --dirty=x | rev | cut -d - -f 1 | rev)")
+echo "STABLE_ADDITIONAL_VERSION -$additional_version"
 
 ci_runner_image_version="$(date +%Y%m%d)-${commit_sha}"
 echo "STABLE_CI_RUNNER_IMAGE_VERSION ${ci_runner_image_version}"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -14,7 +14,7 @@ echo "GIT_TREE_STATUS $git_tree_status"
 exact=$(git describe --exact-match 2>/dev/null | sed -e s/^v// | cut -d - -f 1 || echo 2.10.0)
 echo "STABLE_APP_VERSION $exact"
 
-additional_version=$(git describe --exact-match 2>/dev/null | cut -d - -f 2- || echo "pre.$(git describe --long --dirty=x | rev | cut -d - -f 1 | rev)")
+additional_version=$(git describe --exact-match 2>/dev/null | cut -d - -f 2- || echo "pre.$(git describe --long --dirty=".$(git diff HEAD | sha256sum | cut -c 1-10)" | rev | cut -d - -f 1 | rev)")
 echo "STABLE_ADDITIONAL_VERSION -$additional_version"
 
 ci_runner_image_version="$(date +%Y%m%d)-${commit_sha}"


### PR DESCRIPTION
This is somewhat hairy.  I tested against master (`2.10.0-pre.g1828ed42e4`) and `v2.9.0-rc.1`.  In the case where HEAD isn't an exact tag, we fall back to the 2.10.0 + pre.gXXXXXX.  In the case where HEAD is an exact tag, we strip off the v and split at the first -; v2.9.0-rc.1 becomes APP_VERSION 2.9.0 ADDITIONAL_VERSION -rc.1.  

Some attention is paid to the status of the working copy.  As you edit the code, you create new versions, but git has no way to know this.  Prior to this commit, we just tacked on "dirty", but that means when you have a dirty version running and want to re-push, the version checking logic in pachdev can't know if the new code is running or not.  For that reason, the "dirty" annotation is now the first 10 bytes of the sha256 of the diffs.  It sounds crazy, but basically only changes when you edit stuff, so should result in perfect fidelity.  It's also not noticeably slow on my machine.

I think this is the algorithm we want.