### PR TITLE
disable logging for pulumi iac for now

### DIFF
--- a/etc/testing/circle/workloads/pulumi/aws/app.go
+++ b/etc/testing/circle/workloads/pulumi/aws/app.go
@@ -183,7 +183,9 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 		},
 		"pachd": pulumi.Map{
 			"localhostIssuer": pulumi.String("true"),
-			"logLevel":        pulumi.String("debug"),
+			"logLevel":        pulumi.String("info"),
+			"lokiDeploy":      pulumi.Bool(false),
+			"lokiLogging":     pulumi.Bool(false),
 			"image": pulumi.Map{
 				"tag": pulumi.String(pachdImageTag),
 			},


### PR DESCRIPTION
pulumi's k8s helm doesn't like that promtail doesnt have anything to do on bigger cluster at deploy time. for now will disable it, so deployments can get smoked tested. will look into a another way to get it to no fail a `pulumi up`