### PR TITLE
Allow setting a unique tag for the worker image

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -124,7 +124,7 @@ spec:
           value: {{ .Values.pachd.storage.local.hostPath | default $randHostPath }}pachd
         {{- end }}
         - name: WORKER_IMAGE
-          value: "{{ .Values.global.image.registry }}{{ .Values.pachd.worker.image.repository }}:{{ default .Chart.AppVersion .Values.pachd.image.tag }}"
+          value: "{{ .Values.global.image.registry }}{{ .Values.pachd.worker.image.repository }}:{{ default .Chart.AppVersion (or .Values.pachd.worker.image.tag .Values.pachd.image.tag) }}"
         {{- if and (eq ( include "pachyderm.storageBackend" . ) "LOCAL") .Values.pachd.storage.local.requireRoot }}
         - name: WORKER_USES_ROOT
           value: "True"
@@ -415,15 +415,15 @@ spec:
         {{- end }}
         {{- if ne .Values.pachd.determined.credentialsSecretName "" }}
         - name: DETERMINED_USERNAME
-          valueFrom:          
+          valueFrom:
             secretKeyRef:
               name: {{ .Values.pachd.determined.credentialsSecretName }}
               key: determined-username
         - name: DETERMINED_PASSWORD
-          valueFrom:          
+          valueFrom:
             secretKeyRef:
-              name: {{ .Values.pachd.determined.credentialsSecretName }}              
-              key: determined-password          
+              name: {{ .Values.pachd.determined.credentialsSecretName }}
+              key: determined-password
         {{- end }}
         {{- if ne .Values.pachd.determined.apiEndpoint "" }}
         - name: DETERMINED_API_URL
@@ -432,7 +432,7 @@ spec:
         {{- if .Values.determined.tlsSecret }}
         - name: DETERMINED_TLS
           value: "true"
-        {{- end }}                
+        {{- end }}
         {{- if ne .Values.pachd.defaultSidecarCPURequest "" }}
         - name: SIDECAR_DEFAULT_CPU_REQUEST
           value: {{ .Values.pachd.defaultSidecarCPURequest | quote }}

--- a/src/internal/kindenv/pachyderm.go
+++ b/src/internal/kindenv/pachyderm.go
@@ -40,6 +40,7 @@ func getPachydermVersions() (string, string, error) {
 		return "", "", errors.Wrap(err, "get worker image digest")
 	}
 	workerVersion = bytes.TrimRight(workerVersion[7:], "\n")
+	fmt.Printf("pachd=%s\nworker=%s\n", pachdVersion, workerVersion)
 	return string(pachdVersion), string(workerVersion), nil
 }
 
@@ -99,9 +100,9 @@ func (c *Cluster) helmFlags(ctx context.Context, install *HelmConfig) ([]string,
 		strings.Join([]string{
 			// Configure images.
 			"pachd.image.repository=" + path.Join(cfg.ImagePullPath, "pachd"),
-			"worker.image.repository=" + path.Join(cfg.ImagePullPath, "worker"),
+			"pachd.worker.image.repository=" + path.Join(cfg.ImagePullPath, "worker"),
 			"pachd.image.tag=" + pachdVersion,
-			"worker.image.tag=" + workerVersion,
+			"pachd.worker.image.tag=" + workerVersion,
 			// Configure the external hostname.
 			"proxy.host=" + cfg.Hostname,
 		}, ","),


### PR DESCRIPTION
I assumed this worked without testing it.  It doesn't.  But now it does.