### PR TITLE
[2.9.x] debug: jobs: assume limit == 0 means "no limit"

### DIFF
--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -1333,10 +1333,9 @@ func (s *debugServer) collectJobs(dfs DumpFS, pachClient *client.APIClient, pipe
 		},
 	}
 	if err := dfs.Write(filepath.Join(pipeline.Project.Name, pipeline.Name, "jobs.json"), func(w io.Writer) error {
-		// TODO: The limiting should eventually be a feature of list job.
 		var count int64
 		return pachClient.ListJobF(pipeline.Project.Name, pipeline.Name, nil, -1, false, func(ji *pps.JobInfo) error {
-			if count >= limit {
+			if limit != 0 && count >= limit {
 				return errutil.ErrBreak
 			}
 			count++


### PR DESCRIPTION
This fixes an issue where jobs are not returned during debug dumps.

https://pachyderm.atlassian.net/browse/CORE-2143