### PR TITLE
check for priority classes on retry

### DIFF
--- a/src/internal/minikubetestenv/deploy.go
+++ b/src/internal/minikubetestenv/deploy.go
@@ -897,6 +897,13 @@ func putRelease(t testing.TB, ctx context.Context, namespace string, kubeClient 
 				time.Minute,
 				func() error {
 					deleteRelease(t, context.Background(), namespace, kubeClient)
+					if opts.Determined {
+						if determinedPriorityClassesExist(t, ctx, kubeClient) {
+							helmOpts.SetValues["determined.createNonNamespacedObjects"] = "false"
+						} else {
+							helmOpts.SetValues["determined.createNonNamespacedObjects"] = "true"
+						}
+					}
 					return errors.EnsureStack(helm.InstallE(t, helmOpts, chartPath, namespace))
 				})
 		}


### PR DESCRIPTION
Should fix INFENG-430. https://hpe-aiatscale.atlassian.net/browse/INFENG-430

Determined helm has custom priority classes. These are non-namespaced objects and so having two tests try to install them at once doesn't work. There wwas an initial check, but if two tests checked at the same time they could still race to install first. This does a check on retry. This isn't a common issue currently but testing the fuzz tester shuffled the tests around in CI and this became a very big problem. I test the fix on https://github.com/pachyderm/pachyderm/tree/djanicek/infraneg-295/first-test and confirmed it resolve the issue.