### PR TITLE
[Backport - 2.9] Fix recursive put file logic (#9744)

### DIFF
--- a/src/server/pfs/cmds/cmds.go
+++ b/src/server/pfs/cmds/cmds.go
@@ -1617,10 +1617,8 @@ func Cmds(mainCtx context.Context, pachCtx *config.Context, pachctlCfg *pachctl.
 							return err
 						}
 					} else if len(sources) == 1 {
-						// We have a single source and the user has specified a path,
-						// we check if the path ends with a '/' and join with target if it does.
 						finalPath := file.Path
-						if strings.HasSuffix(file.Path, "/") {
+						if recursive && fullPath || !recursive && strings.HasSuffix(file.Path, "/") {
 							finalPath = joinPaths(file.Path, target)
 						}
 						if err := putFileHelper(mf, finalPath, source, recursive, appendFile, untar); err != nil {


### PR DESCRIPTION
This PR corrects an issue introduced in #9636.

- Before #9636 when you ran `pachctl put file repo@branch:/ -r -f /path/to/dir` and `/path/to/dir` has files `a.txt` and `b.txt` you would end up with two files `repo@branch:/a.txt` and `repo@branch:/b.txt"`
- After #9636 when running `pachctl put file repo@branch:/ -r -f /path/to/dir` and `/path/to/dir` has files `a.txt` and `b.txt` you end up with two files with the `dir` prefix: `repo@branch:/dir/a.txt` and `repo@branch:/dir/b.txt`

Now after this PR the behavior has been corrected so the files are put at the root.

This PR also adds two tests that cover `pachctl put file repo@branch:/ -r -f /path/to/dir --full-path` and `pachctl put file repo@branch:/ -r -f /path/to/dir`

---------