### PR TITLE
Get logs for all pipelines, even if they're not running

### DIFF
--- a/src/server/debug/server/server_test.go
+++ b/src/server/debug/server/server_test.go
@@ -701,14 +701,14 @@ func TestListApps(t *testing.T) {
 			},
 		},
 	}
-	got, err := s.listApps(ctx, []*pps.Pipeline{
+	gotRunning, gotPossible, err := s.listApps(ctx, []*pps.Pipeline{
 		{Project: &pfs.Project{Name: "default"}, Name: "edges"},
 		{Project: &pfs.Project{Name: "default"}, Name: "montage"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []*debug.App{
+	wantPossible := []*debug.App{
 		{
 			Name: "default/edges",
 			Pipeline: &debug.Pipeline{
@@ -746,7 +746,12 @@ func TestListApps(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-		t.Errorf("apps (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantPossible, gotPossible, protocmp.Transform()); diff != "" {
+		t.Errorf("possible apps (-want +got):\n%s", diff)
+	}
+
+	wantRunning := []*debug.App{wantPossible[0], wantPossible[2]}
+	if diff := cmp.Diff(wantRunning, gotRunning, protocmp.Transform()); diff != "" {
+		t.Errorf("running apps (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
The current algorithm for determining which pods to get logs for involves looking at running pods.  This is not correct for pipelines; a pipeline could be autoscaled to 0.  This PR adjusts the algorithm to add in any pipelines that don't currently have pods to the lokiLogs request.  For example:

```
$ pachctl debug template
...
    describes:
        - name: console
        - name: default/edges
          pipeline:
            name: edges
            project: default
        - name: etcd
        - name: pachd
        - name: pachyderm-kube-event-tail
        - name: pachyderm-proxy
        - name: pg-bouncer
    logs:
        - name: console
        - name: default/edges
          pipeline:
            name: edges
            project: default
        - name: etcd
        - name: pachd
        - name: pachyderm-kube-event-tail
        - name: pachyderm-proxy
        - name: pg-bouncer
    lokiLogs:
        - name: console
        - name: default/edges
          pipeline:
            name: edges
            project: default
        - name: default/montage
          pipeline:
            name: montage
            project: default
        - name: etcd
        - name: pachd
        - name: pachyderm-kube-event-tail
        - name: pachyderm-proxy
        - name: pg-bouncer
...
```
Montage has autoscaling and isn't currently up; it now appears in lokiLogs, but not logs or describes.