### PR TITLE
[INT-1190] Center gear tab

### DIFF
--- a/jupyter-extension/src/plugins/mount/mount.css
+++ b/jupyter-extension/src/plugins/mount/mount.css
@@ -467,3 +467,7 @@ textarea {
 .pachyderm-pipeline-error {
   color: red;
 }
+
+.pachyderm-config-tab .p-TabBar-tabIcon svg {
+  transform: translate(-1px, 3px)
+}


### PR DESCRIPTION
The gear tab was slightly off center both vertically and horizontally. Since it is an svg the best way to fix this is by applying a transform in pixels to correct this. The transform will ensure that regardless of the position of the svg on the page it is offset by exactly that much relative to it's position in the parent element. I measured the center using the screenshot tool and it should be exactly 46 pixels from all four sides.

![Screenshot 2024-02-22 at 9 17 52 AM](https://github.com/pachyderm/pachyderm/assets/401518/26148fb8-fca2-46ed-a47c-4a8a99686fe7)
![Screenshot 2024-02-22 at 9 17 45 AM](https://github.com/pachyderm/pachyderm/assets/401518/b4e171ae-a0ef-4b49-8ac9-3c4af06d1894)
