### PR TITLE
sync values for upgrades

### DIFF
--- a/src/testing/deploy/deploy_test.go
+++ b/src/testing/deploy/deploy_test.go
@@ -35,7 +35,7 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 		Enterprise:   true,
 		PortOffset:   portOffset,
 		Determined:   true,
-		CleanupAfter: true,
+		CleanupAfter: false,
 	}
 	valueOverrides["pachd.replicas"] = "1"
 	opts.ValueOverrides = valueOverrides
@@ -47,7 +47,7 @@ func TestInstallAndUpgradeEnterpriseWithEnv(t *testing.T) {
 	c.SetAuthToken("")
 	mockIDPLogin(t, c)
 	// Test Upgrade
-	opts.CleanupAfter = false
+	opts.CleanupAfter = true
 	// set new root token via env
 	opts.AuthUser = ""
 	token := "new-root-token"


### PR DESCRIPTION
For Determined tests, we needed to set `createNonNamespacedObjects`. My original fix for this, only worked on initial deploy and I missed upgrades. For upgrades we also need to keep both options in sync so that the upgrade can know if it needs to keep the Priority Classes or not. Installing with priority classes, and then not including them on a subsequent update breaks the upgrade.