### PR TITLE
[PFS-204] Fix path range directories

### DIFF
--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -61,10 +61,6 @@ func NewSource(commitInfo *pfs.CommitInfo, fs fileset.FileSet, opts ...SourceOpt
 		// emit /d1/f1 and /d2/.
 		pr := &index.PathRange{
 			Lower: sc.pathRange.Lower,
-			Upper: sc.pathRange.Upper,
-		}
-		if pr.Upper != "" {
-			pr.Upper += string(rune(0))
 		}
 		s.fileIndexOpts = append(s.fileIndexOpts, index.WithRange(pr))
 		s.upper = sc.pathRange.Upper


### PR DESCRIPTION
This PR fixes an issue with directories when using path range functionality. If the upper bound of the path range is past the directory path, but before the first file path in the directory, then the directory would not get emitted. Fixing this issue was as simple as removing the upper bound for the fileset iterator in the file source. This was the only change needed because we mostly fixed this issue with a prior fix involving directories not emitting when they were the last path that should be emitted. Removing the upper bound from the fileset iterator generalizes that solution such that we always extend past the end of the path range by one file to ensure directories are emitted. The upper bound is enforced within the callback of the fileset iterator.