### PR TITLE
[PFS-207] Add CommitAncestry For Commit Pickers

### DIFF
--- a/src/internal/pfsdb/BUILD.bazel
+++ b/src/internal/pfsdb/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//src/internal/collection",
         "//src/internal/dbutil",
         "//src/internal/errors",
+        "//src/internal/log",
         "//src/internal/pachsql",
         "//src/internal/pbutil",
         "//src/internal/randutil",
@@ -32,6 +33,7 @@ go_library(
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_uber_go_zap//:zap",
     ],
 )
 

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -22,6 +22,8 @@ import (
 )
 
 const (
+	DefaultMaxSearchDepth = 1000
+
 	// CommitsChannelName is used to watch events for the commits table.
 	CommitsChannelName     = "pfs_commits"
 	CommitsRepoChannelName = "pfs_commits_repo_"
@@ -175,6 +177,21 @@ func (err *CommitAlreadyExistsError) Error() string {
 
 func (err *CommitAlreadyExistsError) GRPCStatus() *status.Status {
 	return status.New(codes.AlreadyExists, err.Error())
+}
+
+// MaxDepthReachedError is returned when a recursive query iterates beyond a maximum depth.
+type MaxDepthReachedError struct {
+	LastCommitSearched CommitID
+	Depth              int
+}
+
+// Error satisfies the error interface.
+func (err *MaxDepthReachedError) Error() string {
+	return fmt.Sprintf("max depth reached: %d\n", err.Depth)
+}
+
+func (err *MaxDepthReachedError) GRPCStatus() *status.Status {
+	return status.New(codes.ResourceExhausted, err.Error())
 }
 
 // AncestryOpt allows users to create commitInfos and skip creating the ancestry information.
@@ -485,6 +502,78 @@ func getCommitChildren(ctx context.Context, extCtx sqlx.ExtContext, parentCommit
 	return children, nil
 }
 
+// CommitAncestry models a lineage of the CommitID values of the ancestors of Start.
+type CommitAncestry struct {
+	Start              CommitID
+	Lineage            map[CommitID]CommitID
+	EarliestDiscovered CommitID // EarliestDiscovered is the root of the commit ancestry tree if FoundRoot is true.
+	FoundRoot          bool     // FoundRoot is true if GetCommitAncestry reaches a root of a commit ancestry tree.
+}
+
+// GetCommitAncestry returns a CommitAncestry from startId up to maxDepth.
+func GetCommitAncestry(ctx context.Context, extCtx sqlx.ExtContext, startId CommitID, maxDepth uint) (*CommitAncestry, error) {
+	ancestry := &CommitAncestry{
+		Start:     startId,
+		Lineage:   make(map[CommitID]CommitID),
+		FoundRoot: true,
+	}
+	earliestAncestor := make(map[CommitID]bool)
+	if err := ForEachCommitAncestor(ctx, extCtx, startId, maxDepth, func(parentId, childId CommitID) error {
+		ancestry.Lineage[parentId] = childId
+		delete(earliestAncestor, childId)
+		earliestAncestor[parentId] = true
+		return nil
+	}); err != nil {
+		if errors.As(err, new(*MaxDepthReachedError)) {
+			ancestry.FoundRoot = false
+		} else {
+			return nil, errors.Wrap(err, "get commit ancestry")
+		}
+	}
+	for i := range earliestAncestor {
+		ancestry.EarliestDiscovered = i
+	}
+	return ancestry, nil
+}
+
+// ForEachCommitAncestor queries postgres for ancestors of startId up to the maxDepth. cb() is called for each ancestor.
+// maxDepth is optional.
+func ForEachCommitAncestor(ctx context.Context, extCtx sqlx.ExtContext, startId CommitID, maxDepth uint, cb func(parentId, childId CommitID) error) error {
+	query := `
+		WITH RECURSIVE ancestry AS (
+			SELECT parent, child FROM pfs.commit_ancestry WHERE child = $1 
+			UNION
+			SELECT ca.parent, ca.child FROM pfs.commit_ancestry ca
+			JOIN ancestry a ON ca.child = a.parent
+		)
+		SELECT a.parent, a.child
+		FROM ancestry a;
+			`
+	rows, err := extCtx.QueryContext(ctx, query, startId)
+	if err != nil {
+		return errors.Wrap(err, "get oldest commit ancestor")
+	}
+	defer rows.Close()
+	if maxDepth == 0 {
+		maxDepth = DefaultMaxSearchDepth
+	}
+	depth := uint(0)
+	for rows.Next() {
+		var parent, child CommitID
+		if err := rows.Scan(&parent, &child); err != nil {
+			return errors.Wrap(err, "scanning parent and child row")
+		}
+		if err := cb(parent, child); err != nil {
+			return errors.Wrap(err, "calling cb() on parent and child")
+		}
+		depth++
+		if depth >= maxDepth {
+			return &MaxDepthReachedError{LastCommitSearched: parent}
+		}
+	}
+	return nil
+}
+
 func GetCommitSubvenance(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) ([]*pfs.Commit, error) {
 	id, err := GetCommitID(ctx, tx, commit)
 	if err != nil {
@@ -749,9 +838,9 @@ func parseCommitInfoFromRow(row *Commit) *pfs.CommitInfo {
 
 // CommitWithID is returned by the commit iterator.
 type CommitWithID struct {
-	ID         CommitID
-	CommitInfo *pfs.CommitInfo
-	Revision   int64
+	ID CommitID
+	*pfs.CommitInfo
+	Revision int64
 }
 
 // this dropped global variable instantiation forces the compiler to check whether CommitIterator implements stream.Iterator.

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -542,10 +542,10 @@ func ForEachCommitAncestor(ctx context.Context, extCtx sqlx.ExtContext, startId 
 			SELECT parent, child, 0 as depth FROM pfs.commit_ancestry WHERE child = $1
 			UNION
 			SELECT ca.parent, ca.child, a.depth+1 FROM pfs.commit_ancestry ca
-			JOIN ancestry a ON ca.child = a.parent
+			JOIN ancestry a ON ca.child = a.parent WHERE depth <= $2
 		)
 		SELECT a.parent, a.child, depth
-		FROM ancestry a WHERE depth <= $2;`
+		FROM ancestry a;`
 	rows, err := extCtx.QueryContext(ctx, query, startId, maxDepth)
 	if err != nil {
 		return errors.Wrap(err, "get oldest commit ancestor")

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -517,11 +517,9 @@ func GetCommitAncestry(ctx context.Context, extCtx sqlx.ExtContext, startId Comm
 		Lineage:   make(map[CommitID]CommitID),
 		FoundRoot: true,
 	}
-	earliestAncestor := make(map[CommitID]bool)
 	if err := ForEachCommitAncestor(ctx, extCtx, startId, maxDepth, func(parentId, childId CommitID) error {
 		ancestry.Lineage[parentId] = childId
-		delete(earliestAncestor, childId)
-		earliestAncestor[parentId] = true
+		ancestry.EarliestDiscovered = parentId
 		return nil
 	}); err != nil {
 		if errors.As(err, new(*MaxDepthReachedError)) {
@@ -529,9 +527,6 @@ func GetCommitAncestry(ctx context.Context, extCtx sqlx.ExtContext, startId Comm
 		} else {
 			return nil, errors.Wrap(err, "get commit ancestry")
 		}
-	}
-	for i := range earliestAncestor {
-		ancestry.EarliestDiscovered = i
 	}
 	return ancestry, nil
 }

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -512,10 +512,10 @@ func ForEachCommitAncestor(ctx context.Context, extCtx sqlx.ExtContext, startId 
 		SELECT parent, child, 1 as depth FROM pfs.commit_ancestry WHERE child = $1
 		UNION
 		SELECT ca.parent, ca.child, depth+1 FROM pfs.commit_ancestry ca
-		JOIN ancestry a ON ca.child = a.parent WHERE depth <= $2
+		JOIN ancestry a ON ca.child = a.parent WHERE depth < $2
 	)
 	SELECT a.parent, a.child, depth
-	FROM ancestry a WHERE depth <= $2;`
+	FROM ancestry a;`
 	rows, err := extCtx.QueryContext(ctx, query, startId, maxDepth)
 	if err != nil {
 		return errors.Wrap(err, "get commit ancestry")

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -489,14 +489,6 @@ func getCommitChildren(ctx context.Context, extCtx sqlx.ExtContext, parentCommit
 	return children, nil
 }
 
-// CommitAncestry models a lineage of the CommitID values of the ancestors of Start.
-type CommitAncestry struct {
-	Start              CommitID
-	Lineage            map[CommitID]CommitID
-	EarliestDiscovered CommitID // EarliestDiscovered is the root of the commit ancestry tree if FoundRoot is true.
-	FoundRoot          bool     // FoundRoot is true if GetCommitAncestry reaches a root of a commit ancestry tree.
-}
-
 // GetCommitAncestry returns a CommitAncestry from startId up to maxDepth.
 func GetCommitAncestry(ctx context.Context, extCtx sqlx.ExtContext, startId CommitID, maxDepth uint) (map[CommitID]CommitID, error) {
 	ancestry := make(map[CommitID]CommitID)

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -489,11 +489,11 @@ func getCommitChildren(ctx context.Context, extCtx sqlx.ExtContext, parentCommit
 	return children, nil
 }
 
-// GetCommitAncestry returns a CommitAncestry from startId up to maxDepth.
+// GetCommitAncestry returns a map of child CommitID values to parent CommitIDs including the startId up to maxDepth.
 func GetCommitAncestry(ctx context.Context, extCtx sqlx.ExtContext, startId CommitID, maxDepth uint) (map[CommitID]CommitID, error) {
 	ancestry := make(map[CommitID]CommitID)
 	if err := ForEachCommitAncestor(ctx, extCtx, startId, maxDepth, func(parentId, childId CommitID) error {
-		ancestry[parentId] = childId
+		ancestry[childId] = parentId
 		return nil
 	}); err != nil {
 		return nil, errors.Wrap(err, "get commit ancestry")
@@ -535,6 +535,9 @@ func ForEachCommitAncestor(ctx context.Context, extCtx sqlx.ExtContext, startId 
 		if err := cb(parent, child); err != nil {
 			return errors.Wrap(err, "calling cb() on parent and child")
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(err, "iterating over commit ancestry")
 	}
 	return nil
 }

--- a/src/internal/pfsdb/commits_test.go
+++ b/src/internal/pfsdb/commits_test.go
@@ -622,7 +622,7 @@ func TestGetCommitAncestryMaxDepth(t *testing.T) {
 		makeCommitTree(ctx, t, 10, db)
 		startId := pfsdb.CommitID(10)
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
-			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 5)
+			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 4) // includes startId
 			require.NoError(t, err, "should be able to get ancestry")
 			require.Equal(t, ancestry.EarliestDiscovered, pfsdb.CommitID(5), "earliest discovered is incorrect")
 			require.Equal(t, ancestry.FoundRoot, false, "root should not have been found")

--- a/src/internal/pfsdb/commits_test.go
+++ b/src/internal/pfsdb/commits_test.go
@@ -3,6 +3,8 @@ package pfsdb_test
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
 
@@ -592,6 +594,60 @@ func TestListCommitRevision(t *testing.T) {
 				require.True(t, revMap[i], "revision should exist.")
 			}
 		})
+	})
+}
+
+func TestGetCommitAncestry(t *testing.T) {
+	withDB(t, func(ctx context.Context, t *testing.T, db *pachsql.DB) {
+		for trees := 0; trees < 5; trees++ {
+			makeCommitTree(ctx, t, 5, db)
+		}
+		startId := pfsdb.CommitID(12)
+		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
+			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 0)
+			require.NoError(t, err, "should be able to get ancestry")
+			require.Equal(t, ancestry.EarliestDiscovered, pfsdb.CommitID(7), "root should be 7, (1-6) should be a separate tree")
+			require.Equal(t, ancestry.FoundRoot, true, "root should have been found")
+			expected := map[pfsdb.CommitID]pfsdb.CommitID{7: 8, 8: 9, 9: 10, 10: 11, 11: 12}
+			if diff := cmp.Diff(expected, ancestry.Lineage,
+				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)
+			}
+		})
+	})
+}
+
+func TestGetCommitAncestryMaxDepth(t *testing.T) {
+	withDB(t, func(ctx context.Context, t *testing.T, db *pachsql.DB) {
+		makeCommitTree(ctx, t, 10, db)
+		startId := pfsdb.CommitID(10)
+		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
+			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 5)
+			require.NoError(t, err, "should be able to get ancestry")
+			require.Equal(t, ancestry.EarliestDiscovered, pfsdb.CommitID(5), "earliest discovered is incorrect")
+			require.Equal(t, ancestry.FoundRoot, false, "root should not have been found")
+			expected := map[pfsdb.CommitID]pfsdb.CommitID{9: 10, 8: 9, 7: 8, 6: 7, 5: 6}
+			if diff := cmp.Diff(expected, ancestry.Lineage,
+				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)
+			}
+		})
+	})
+}
+
+func makeCommitTree(ctx context.Context, t *testing.T, depth int, db *pachsql.DB) {
+	withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
+		rootCommit := testCommit(ctx, t, tx, testRepoName)
+		_, err := pfsdb.CreateCommit(ctx, tx, rootCommit)
+		require.NoError(t, err, "should be able to create root commit")
+		parent := rootCommit
+		for i := 0; i < depth; i++ {
+			child := testCommit(ctx, t, tx, testRepoName)
+			child.ParentCommit = parent.Commit
+			_, err := pfsdb.CreateCommit(ctx, tx, child)
+			require.NoError(t, err, "should be able to create commit")
+			parent = child
+		}
 	})
 }
 

--- a/src/internal/pfsdb/commits_test.go
+++ b/src/internal/pfsdb/commits_test.go
@@ -622,7 +622,7 @@ func TestGetCommitAncestryMaxDepth(t *testing.T) {
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 4) // includes startId
 			require.NoError(t, err, "should be able to get ancestry")
-			expected := map[pfsdb.CommitID]pfsdb.CommitID{9: 10, 8: 9, 7: 8, 6: 7, 5: 6}
+			expected := map[pfsdb.CommitID]pfsdb.CommitID{9: 10, 8: 9, 7: 8, 6: 7}
 			if diff := cmp.Diff(expected, ancestry,
 				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)

--- a/src/internal/pfsdb/commits_test.go
+++ b/src/internal/pfsdb/commits_test.go
@@ -606,10 +606,8 @@ func TestGetCommitAncestry(t *testing.T) {
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 0)
 			require.NoError(t, err, "should be able to get ancestry")
-			require.Equal(t, ancestry.EarliestDiscovered, pfsdb.CommitID(7), "root should be 7, (1-6) should be a separate tree")
-			require.Equal(t, ancestry.FoundRoot, true, "root should have been found")
 			expected := map[pfsdb.CommitID]pfsdb.CommitID{7: 8, 8: 9, 9: 10, 10: 11, 11: 12}
-			if diff := cmp.Diff(expected, ancestry.Lineage,
+			if diff := cmp.Diff(expected, ancestry,
 				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)
 			}
@@ -624,10 +622,8 @@ func TestGetCommitAncestryMaxDepth(t *testing.T) {
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 4) // includes startId
 			require.NoError(t, err, "should be able to get ancestry")
-			require.Equal(t, ancestry.EarliestDiscovered, pfsdb.CommitID(5), "earliest discovered is incorrect")
-			require.Equal(t, ancestry.FoundRoot, false, "root should not have been found")
 			expected := map[pfsdb.CommitID]pfsdb.CommitID{9: 10, 8: 9, 7: 8, 6: 7, 5: 6}
-			if diff := cmp.Diff(expected, ancestry.Lineage,
+			if diff := cmp.Diff(expected, ancestry,
 				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)
 			}

--- a/src/internal/pfsdb/commits_test.go
+++ b/src/internal/pfsdb/commits_test.go
@@ -606,7 +606,7 @@ func TestGetCommitAncestry(t *testing.T) {
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 0)
 			require.NoError(t, err, "should be able to get ancestry")
-			expected := map[pfsdb.CommitID]pfsdb.CommitID{7: 8, 8: 9, 9: 10, 10: 11, 11: 12}
+			expected := map[pfsdb.CommitID]pfsdb.CommitID{8: 7, 9: 8, 10: 9, 11: 10, 12: 11}
 			if diff := cmp.Diff(expected, ancestry,
 				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)
@@ -622,7 +622,7 @@ func TestGetCommitAncestryMaxDepth(t *testing.T) {
 		withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 			ancestry, err := pfsdb.GetCommitAncestry(ctx, tx, startId, 4) // includes startId
 			require.NoError(t, err, "should be able to get ancestry")
-			expected := map[pfsdb.CommitID]pfsdb.CommitID{9: 10, 8: 9, 7: 8, 6: 7}
+			expected := map[pfsdb.CommitID]pfsdb.CommitID{10: 9, 9: 8, 8: 7, 7: 6}
 			if diff := cmp.Diff(expected, ancestry,
 				cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("commits ancestries differ: (-want +got)\n%s", diff)


### PR DESCRIPTION
As per the [resource selectors](https://www.notion.so/Resource-Selectors-3161b243abbf4421bcae13f92ea6ce26?pvs=13), design document, the PFS team wants commits to be _pickable_ via branch head, commit global id, offset from an ancestor, and offset from a branch root. 

This change supports the last two cases by adding an exported function to pfsdb that recursively resolves the ancestry up to a max depth. In testing, this was 10x faster than resolving the ancestors in go (which required separate queries). 
```
| trees | depth  | using go      |  using postgres   |
+-------+--------+---------------+-------------------|
| 10    | 100    | 113.324929ms  | 10.670579ms       |
+-------+--------+---------------+-------------------|
| 10    | 1000   | 4.420041276s  | 108.554151ms      |
```
Link to full thread: https://hpe-aiatscale.slack.com/archives/C05AH398ACB/p1708619955518039