### PR TITLE
Jupyter Extension - some fixes to the config page

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_config.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_config.py
@@ -45,14 +45,16 @@ async def test_do_not_set_invalid_config(app: Application, http_client: AsyncCli
     # Act
     config_response = await http_client.put("/config", json=data)
     health_response = await http_client.get("/health")
+    config_get_response = await http_client.get("/config")
 
     # Assert
-    config_response.raise_for_status()
+    assert config_response.status_code == 400
+    config_get_response.raise_for_status()
     health_response.raise_for_status()
-    config_payload = config_response.json()
     health_payload = health_response.json()
+    config_get_payload = config_get_response.json()
     assert health_payload["status"] == "HEALTHY_INVALID_CLUSTER"
-    assert config_payload["pachd_address"] == invalid_address
+    assert config_get_payload["pachd_address"] == ""
     assert app.settings.get("pachyderm_client") is None
 
     # Ensure that no config file was created.

--- a/jupyter-extension/src/plugins/mount/components/Config/Config.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/Config.tsx
@@ -87,7 +87,10 @@ const Config: React.FC<ConfigProps> = ({
                   marginBottom: '1rem',
                 }}
               >
-                <span className="pachyderm-mount-config-subheading">
+                <span
+                  className="pachyderm-mount-config-subheading"
+                  data-testid="Config__mountConfigSubheading"
+                >
                   {authConfig.pachd_address
                     ? 'Update Configuration'
                     : 'Connect To a Cluster'}

--- a/jupyter-extension/src/plugins/mount/components/Config/Config.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/Config.tsx
@@ -36,7 +36,7 @@ const Config: React.FC<ConfigProps> = ({
     setShowAdvancedOptions,
     serverCa,
     setServerCa,
-  } = useConfig(updateConfig, healthCheck, authConfig, refresh);
+  } = useConfig(updateConfig, healthCheck, refresh);
   const authEnabled =
     status === 'HEALTHY_LOGGED_IN' || status === 'HEALTHY_LOGGED_OUT';
   return (

--- a/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, waitFor} from '@testing-library/react';
+import {findByTestId, render, waitFor} from '@testing-library/react';
 
 import * as requestAPI from '../../../../../handler';
 import {mockedRequestAPI} from 'utils/testUtils';
@@ -117,6 +117,30 @@ describe('config screen', () => {
       });
     });
 
+    it('logged in should display option to change address', async () => {
+      const healthCheck: HealthCheck = {
+        status: 'HEALTHY_LOGGED_IN',
+      };
+
+      const {getByTestId, queryByTestId} = render(
+        <Config
+          updateConfig={updateConfig}
+          healthCheck={healthCheck}
+          authConfig={authConfig}
+          refresh={jest.fn()}
+        />,
+      );
+
+      await getByTestId('Config__pachdAddressUpdate').click();
+      expect(getByTestId('Config__mountConfigSubheading')).toHaveTextContent(
+        'Update Configuration',
+      );
+      await getByTestId('Config__pachdAddressCancel').click();
+      expect(getByTestId('Config__pachdAddress')).toHaveTextContent(
+        'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
+      );
+    });
+
     it('should allow user to login', async () => {
       const healthCheck: HealthCheck = {
         status: 'HEALTHY_LOGGED_OUT',
@@ -172,6 +196,30 @@ describe('config screen', () => {
       getByTestId('Config__pachdAddressUpdate');
       expect(queryByTestId('Config__login')).not.toBeInTheDocument();
       expect(queryByTestId('Config__logout')).not.toBeInTheDocument();
+    });
+
+    it('should display option to change address', async () => {
+      const healthCheck: HealthCheck = {
+        status: 'HEALTHY_NO_AUTH',
+      };
+
+      const {getByTestId, queryByTestId} = render(
+        <Config
+          updateConfig={updateConfig}
+          healthCheck={healthCheck}
+          authConfig={authConfig}
+          refresh={jest.fn()}
+        />,
+      );
+
+      await getByTestId('Config__pachdAddressUpdate').click();
+      expect(getByTestId('Config__mountConfigSubheading')).toHaveTextContent(
+        'Update Configuration',
+      );
+      await getByTestId('Config__pachdAddressCancel').click();
+      expect(getByTestId('Config__pachdAddress')).toHaveTextContent(
+        'grpcs://hub-c0-jwn7iwcca9.clusters.pachyderm.io:31400',
+      );
     });
   });
 

--- a/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
@@ -23,7 +23,6 @@ export type useConfigResponse = {
 export const useConfig = (
   updateConfig: (shouldShow: AuthConfig) => void,
   healthCheck: HealthCheck,
-  authConfig: AuthConfig,
   refresh: () => Promise<void>,
 ): useConfigResponse => {
   const [loading, setLoading] = useState(false);
@@ -41,11 +40,11 @@ export const useConfig = (
       ['UNHEALTHY', 'HEALTHY_INVALID_CLUSTER'].includes(healthCheck.status),
     );
     setErrorMessage('');
-    setAddressField(authConfig.pachd_address ? authConfig.pachd_address : '');
+    setAddressField('');
     setServerCa('');
     setShowAdvancedOptions(false);
     setStatus(healthCheck.status);
-  }, [healthCheck, authConfig]);
+  }, [healthCheck]);
 
   const updatePachdAddress = async () => {
     setLoading(true);

--- a/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/hooks/useConfig.tsx
@@ -41,11 +41,11 @@ export const useConfig = (
       ['UNHEALTHY', 'HEALTHY_INVALID_CLUSTER'].includes(healthCheck.status),
     );
     setErrorMessage('');
-    setAddressField('');
+    setAddressField(authConfig.pachd_address ? authConfig.pachd_address : '');
     setServerCa('');
     setShowAdvancedOptions(false);
     setStatus(healthCheck.status);
-  }, [healthCheck]);
+  }, [healthCheck, authConfig]);
 
   const updatePachdAddress = async () => {
     setLoading(true);

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -120,7 +120,7 @@ export class MountPlugin implements IMountPlugin {
                 authConfig={config ? config : this._poller.config}
                 refresh={this._poller.refresh}
               />
-          )}
+            )}
           </UseSignal>
         )}
       </UseSignal>,

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -112,12 +112,16 @@ export class MountPlugin implements IMountPlugin {
     this._configScreen = ReactWidget.create(
       <UseSignal signal={this._poller.healthSignal}>
         {(_, healthCheck) => (
-          <Config
-            updateConfig={this.updateConfig}
-            healthCheck={healthCheck ? healthCheck : this._poller.health}
-            authConfig={this._poller.config}
-            refresh={this._poller.refresh}
-          />
+          <UseSignal signal={this._poller.configSignal}>
+            {(_, config) => (
+              <Config
+                updateConfig={this.updateConfig}
+                healthCheck={healthCheck ? healthCheck : this._poller.health}
+                authConfig={config ? config : this._poller.config}
+                refresh={this._poller.refresh}
+              />
+          )}
+          </UseSignal>
         )}
       </UseSignal>,
     );

--- a/jupyter-extension/src/plugins/mount/pollMounts.ts
+++ b/jupyter-extension/src/plugins/mount/pollMounts.ts
@@ -157,6 +157,8 @@ export class PollMounts {
         healthCheck.status === 'HEALTHY_LOGGED_IN' ||
         healthCheck.status === 'HEALTHY_NO_AUTH'
       ) {
+        const config = await requestAPI<AuthConfig>('config', 'GET');
+        this.config = config;
         const data = await requestAPI<ListMountsResponse>('mounts', 'GET');
         this.updateData(data);
         const project = await requestAPI<ProjectInfo[]>('projects', 'GET');


### PR DESCRIPTION
The config settings page was broken due to not populating the input box correctly and not signaling on config updates. This change fixes those issues.

[INT-1218](https://pachyderm.atlassian.net/browse/INT-1218)

[INT-1218]: https://pachyderm.atlassian.net/browse/INT-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ