### PR TITLE
Fix regex used on tags for checking whether coverage builds are used

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -90,7 +90,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*) ]]
+            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*) ]]
             then
               echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
             else
@@ -155,7 +155,7 @@ jobs:
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
             echo 'export RUNNER_INDEX="$CIRCLE_NODE_INDEX"' >> $BASH_ENV
 
-            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*) ]]
+            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*) ]]
             then
               echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
             else
@@ -517,7 +517,7 @@ jobs:
 
             echo 'export PATH=/home/circleci/project/cached-deps:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(.*) ]]
+            if [[ "$CIRCLE_BRANCH" -eq "" ]] && [[ "$CIRCLE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(.*) ]]
             then
               echo 'export TEST_IMAGE_SHA=$CIRCLE_SHA1' >> $BASH_ENV
             else


### PR DESCRIPTION
The `=~` shell operator does not support using `\d` to represent the set of digits (or any other similar backslash+letter classes). You can confirm by running

    [[ 1 =~ [0-9] ]]
    echo $?
    [[ 1 =~ \d ]]
    echo $?

which should print `0` and then `1`, indicating that the first match succeeded and the second failed.

These patterns were working fine before, but now we've reached 2.10 and the second digit needs to be matched.