### PR TITLE
Update node version in main.yml

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -700,7 +700,7 @@ jobs:
             - /home/circleci/.cache # Note, this is different from the cache location for the machine executors
   check-prettier:
     docker:
-      - image: cimg/node:16.11.0
+      - image: cimg/node:20.11.0
     steps:
       - checkout
       - run: sudo npm install -g prettier
@@ -885,7 +885,7 @@ jobs:
   jupyter-extension-frontend-test:
     resource_class: xlarge
     docker:
-      - image: cimg/node:16.11.0
+      - image: cimg/node:20.11.0
     working_directory: ~/project/jupyter-extension
     steps:
       - checkout:


### PR DESCRIPTION
Small little thing I noticed. When I updated the node version in .nvmrc and other parts of build process in a previous PR, I forgot to update these two places. In an ideal world we would have some single source for this value, but might as well make this consistent in the short term.