### PR TITLE
[INT-1227] Follow-up bug fix for malformed svg

### DIFF
--- a/jupyter-extension/src/utils/icons.ts
+++ b/jupyter-extension/src/utils/icons.ts
@@ -3,19 +3,16 @@ import {LabIcon} from '@jupyterlab/ui-components';
 // This cannot be imported via the module system because our webpack config imports svg wrapped as ReactComponent.
 // LabIcon expects a string in order to properly validate the content.
 // `class="jp-icon3"` must be added to the first path element in this svg to be a LabIcon
-const fileSvg = `
-<?xml version="1.0" encoding="UTF-8"?>
+const fileSvg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 21 31" width="21px" height="31px"
   xmlns="http://www.w3.org/2000/svg">
   <path class="jp-icon3" d="M.85.001C.365.055-.003.491 0 1.008v28.19c0 .556.425 1.007.95 1.007h18.98c.524 0 .949-.45.949-1.007V6.608a1.04 1.04 0 00-.277-.713l-5.299-5.6a.923.923 0 00-.662-.294H.949a.895.895 0 00-.099 0zm1.048 2.014h11.705v4.698c0 .556.425 1.007.949 1.007h4.429v20.472H1.898V2.015zm13.603 1.332l2.234 2.36h-2.234v-2.36zM4.646 12.083a.949.949 0 00-.797.549c-.154.32-.135.704.05 1.007a.935.935 0 00.846.457h6.327a.94.94 0 00.833-.499 1.06 1.06 0 000-1.015.94.94 0 00-.833-.5H4.745a.895.895 0 00-.099 0zm0 4.698a.949.949 0 00-.797.549c-.154.32-.135.705.05 1.007a.935.935 0 00.846.458h11.389a.94.94 0 00.833-.5 1.06 1.06 0 000-1.015.94.94 0 00-.833-.499H4.745a.895.895 0 00-.099 0zm0 4.699a.949.949 0 00-.797.548c-.154.321-.135.705.05 1.007a.935.935 0 00.846.458h11.389a.94.94 0 00.833-.5 1.06 1.06 0 000-1.014.94.94 0 00-.833-.5H4.745a.895.895 0 00-.099 0z" fill="#582F6B" fill-rule="nonzero"/>
-</svg>
-`;
+</svg>`;
 
 // This cannot be imported via the module system because our webpack config imports svg wrapped as ReactComponent.
 // LabIcon expects a string in order to properly validate the content.
 // `class="jp-icon3"` must be added to the first path element in this svg to be a LabIcon
-const mountLogoSvg = `
-<?xml version="1.0" encoding="UTF-8"?>
+const mountLogoSvg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -42,8 +39,7 @@ const mountLogoSvg = `
 // This cannot be imported via the module system because our webpack config imports svg wrapped as ReactComponent.
 // LabIcon expects a string in order to properly validate the content.
 // `class="jp-icon3"` must be added to the first path element in this svg to be a LabIcon
-const repoSvg = `
-<?xml version="1.0" encoding="UTF-8"?>
+const repoSvg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -64,8 +60,7 @@ const repoSvg = `
             </g>
         </g>
     </g>
-</svg>
-`;
+</svg>`;
 
 // This cannot be imported via the module system because our webpack config imports svg wrapped as ReactComponent.
 // LabIcon expects a string in order to properly validate the content.
@@ -87,8 +82,7 @@ const infoSvg = `<?xml version="1.0" encoding="UTF-8"?>
             <path class="jp-icon3" d="M0 0h20v20H0z"/>
         </g>
     </g>
-</svg>
-`;
+</svg>`;
 
 export const fileIcon = new LabIcon({
   name: 'jupyterlab-pachyderm:file',


### PR DESCRIPTION
For some reason including a new line before and after the string svgs caused them to be considered malformed then not rendered. Removing those new lines fixes the issue.

Before
![image](https://github.com/pachyderm/pachyderm/assets/401518/2a8e3609-ec81-4d52-a367-a396a3b6d106)

After
<img width="448" alt="Screenshot 2024-03-12 at 11 16 36 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/3b441992-0f66-49c1-9dcf-014daea935ab">
