### PR TITLE
[INT-1231] Remove unnecessary height

### DIFF
--- a/jupyter-extension/src/plugins/mount/mount.css
+++ b/jupyter-extension/src/plugins/mount/mount.css
@@ -8,7 +8,6 @@
 .pachyderm-mount-base {
   color: var(--jp-ui-font-color0);
   background-color: var(--jp-layout-color1);
-  height: 100%;
 }
 
 .pachyderm-mount-base-title {


### PR DESCRIPTION
So I was not actually able to reproduce this error in either chrome or firefox. However the CSS shown in the reproduction gif `height: 100%` that was causing the error can be safely removed so I went ahead and did that. https://pachyderm.atlassian.net/browse/INT-1231

Here is an image showing it is possible to scroll the publish view.
<img width="385" alt="Screenshot 2024-03-14 at 8 29 21 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/fb260d82-ce82-499f-90c0-bc6bbd75e450">
