### PR TITLE
[CORE-2226] Fix testing pachd when test name includes an underscore

### DIFF
--- a/src/internal/dockertestenv/minio.go
+++ b/src/internal/dockertestenv/minio.go
@@ -51,6 +51,7 @@ func testBucketName(t testing.TB) string {
 	tname := t.Name()
 	tname = strings.ToLower(tname)
 	tname = strings.ReplaceAll(tname, "/", "-")
+	tname = strings.ReplaceAll(tname, "_", "-")
 	return fmt.Sprintf("%s-%x", tname, buf[:])
 }
 

--- a/src/internal/pachd/testpachd_test.go
+++ b/src/internal/pachd/testpachd_test.go
@@ -1,0 +1,15 @@
+package pachd_test
+
+import (
+	"testing"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
+)
+
+func TestNewTestPachd(t *testing.T) {
+	pachd.NewTestPachd(t)
+}
+
+func TestNewTestPachd_underscore(t *testing.T) {
+	pachd.NewTestPachd(t)
+}


### PR DESCRIPTION
Go function names may include underscores; they are rare but conventionally used in e.g. [example tests](https://pkg.go.dev/testing#hdr-Examples). Minio does not allow bucket names with underscores.

This PR simply turns underscores into hyphens when creating a testing bucket name.