### PR TITLE
add auth cluster to jupyter extension tests

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -803,12 +803,6 @@ jobs:
             . venv/bin/activate
             python3 -m pip install -e '.[dev]'
 
-            nohup pachctl port-forward &
-
-            touch /tmp/mount-server.log # mount-server will truncate on startup
-            tail -F /tmp/mount-server.log &
-            export MOUNT_SERVER_LOG_FILE=/tmp/mount-server.log \
-
             mkdir pfs
             export PFS_MOUNT_DIR=$(pwd)/pfs
 
@@ -2169,15 +2163,35 @@ commands:
               --set-string pachd.storage.minio.secure=false \
               --set pachd.service.type=NodePort \
               --set pachd.image.tag=${CIRCLE_SHA1}
+            kubectl create namespace enterprise --dry-run=client -o yaml | kubectl apply -f -
+            helm install pachd-enterprise ../etc/helm/pachyderm \
+              --namespace enterprise \
+              --set deployTarget=custom \
+              --set pachd.storage.backend=MINIO \
+              --set pachd.storage.minio.bucket=pachyderm-test \
+              --set pachd.storage.minio.endpoint=minio.default.svc.cluster.local:9000 \
+              --set pachd.storage.minio.id=minioadmin \
+              --set pachd.storage.minio.secret=minioadmin \
+              --set-string pachd.storage.minio.signature="" \
+              --set-string pachd.storage.minio.secure=false \
+              --set proxy.service.type=NodePort \
+              --set pachd.image.tag=${CIRCLE_SHA1} \
+              --set proxy.service.httpNodePort=30081 \
+              --set pachd.enterpriseLicenseKey=${ENT_ACT_CODE} \
+              --set pachd.rootToken=roottoken1234
       - run:
           name: Wait for pach # need to wait before testing kubectl as pach is not visible to kubectl yet
           command: |
             sleep 20
-            kubectl wait --for=condition=ready pod -l app=pachd --timeout=5m
+            kubectl wait -A --for=condition=ready pod -l app=pachd --timeout=5m
             pachctl version
       - run:
           name: Setup pach # Get Kind node IP and pass that to pachctl
           command: |-
+            echo '{"pachd_address": "grpc://'"$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)":30081'"}' | pachctl config set context local --overwrite
+            pachctl config set active-context local
+            echo 'roottoken1234' | pachctl auth use-auth-token
+            mv ${HOME}/.pachyderm/config.json ${HOME}/.pachyderm/auth_config.json
             echo '{"pachd_address": "grpc://'"$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)":30650'"}' | pachctl config set context local --overwrite
             pachctl config set active-context local
   install-pulumi-deps:

--- a/jupyter-extension/jupyterlab_pachyderm/tests/conftest.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/conftest.py
@@ -14,6 +14,7 @@ from jupyterlab_pachyderm.env import PACH_CONFIG
 
 PortType = Tuple[socket.socket, int]
 ENV_VAR_TEST_ADDR = "foo.pachyderm.bar:1234"
+PACH_AUTH_CONFIG = Path.home().joinpath(".pachyderm", "auth_config.json")
 
 
 @pytest.fixture
@@ -22,10 +23,16 @@ def pach_config(request, tmp_path) -> Path:
 
     If the test is marked with @pytest.mark.no_config then the config
       file is not written.
+
+    If the test is marked with @pytest.mark.auth_enabled then the auth
+      enabled config file is used.
     """
     config_path = tmp_path / "config.json"
     if not request.node.get_closest_marker("no_config"):
-        copyfile(PACH_CONFIG, config_path)
+        if request.node.get_closest_marker("auth_enabled"):
+            copyfile(PACH_AUTH_CONFIG, config_path)
+        else:
+            copyfile(PACH_CONFIG, config_path)
     yield Path(config_path)
 
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_config.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_config.py
@@ -33,6 +33,26 @@ async def test_config_no_file(app: Application, http_client: AsyncClient):
     assert config_payload["pachd_address"] == ""
 
 
+@pytest.mark.auth_enabled
+async def test_auth_config(app: Application, http_client: AsyncClient):
+    """Test that the extension correctly loads an auth-enabled config file."""
+    # Arrange
+    config_file = app.settings.get("pachyderm_config_file")
+    assert config_file is not None and config_file.exists()
+
+    # Act
+    config_response = await http_client.get("/config")
+    health_response = await http_client.get("/health")
+
+    # Assert
+    config_response.raise_for_status()
+    health_response.raise_for_status()
+    config_payload = config_response.json()
+    health_payload = health_response.json()
+    assert health_payload["status"] == "HEALTHY_LOGGED_IN"
+    assert config_payload["pachd_address"]
+
+
 @pytest.mark.no_config
 @pytest.mark.env_var_addr
 async def test_config_env_var(app: Application, http_client: AsyncClient):


### PR DESCRIPTION
adds an auth-enabled cluster running alongside the existing pachyderm cluster deployment for testing in the extension

[INT-1233](https://pachyderm.atlassian.net/browse/INT-1233)

[INT-1233]: https://pachyderm.atlassian.net/browse/INT-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ