### PR TITLE
[minor] Fail on all console statements

### DIFF
--- a/jupyter-extension/scripts/jest.setup.js
+++ b/jupyter-extension/scripts/jest.setup.js
@@ -18,6 +18,11 @@ const ignoredWarnings = [
 ]
 
 failOnConsole({
+  shouldFailOnAssert: true,
+  shouldFailOnDebug: true,
+  shouldFailOnError: true,
+  shouldFailOnInfo: true,
+  shouldFailOnLog: true,
   shouldFailOnWarn: true,
   silenceMessage: (message, methodName) => {
     if (methodName === 'error') {


### PR DESCRIPTION
I recently added failOnConsole to our jest tests so that any console statements left in the tests would fail them. However I forgot to turn on the fail settings for all console statements. This PR fixes that.