### PR TITLE
Bazelify etc/generate-envoy-config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -150,7 +150,6 @@ test_suite(
     tests = [
         ":buildifier_test",
         "//etc/generate-envoy-config:update_test",
-        "//etc/helm/pachyderm:helm_lint",
         "//src/proto:run_test",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@ licenses(["notice"])
 exports_files([
     "LICENSE",
     ".bazelversion",
+    "MODULE.bazel",
 ])
 
 # Conifigure supported architectures.  Note that some architectures are only supported for tooling
@@ -148,6 +149,7 @@ test_suite(
     ],
     tests = [
         ":buildifier_test",
+        "//etc/generate-envoy-config:update_test",
         "//etc/helm/pachyderm:helm_lint",
         "//src/proto:check_generated_protos",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -141,6 +141,9 @@ test_suite(
     ],
 )
 
+# Style tests are style tests that have to be run manually, because they look at a lot of files in
+# the workspace.  Hermetic style tests (that depend on a few named files, for example) don't need to
+# be added here.  If the original test doesn't have the "manual" tag, you don't need to add it here.
 test_suite(
     name = "style_tests",
     tags = [
@@ -149,7 +152,6 @@ test_suite(
     ],
     tests = [
         ":buildifier_test",
-        "//etc/generate-envoy-config:update_test",
         "//src/proto:run_test",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -151,6 +151,6 @@ test_suite(
         ":buildifier_test",
         "//etc/generate-envoy-config:update_test",
         "//etc/helm/pachyderm:helm_lint",
-        "//src/proto:check_generated_protos",
+        "//src/proto:run_test",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     repo_name = "com_github_pachyderm_pachyderm",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.0")  # Needed for arm64 jq and rules_oci/#425.
+bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")  # Needed for arm64 jq and rules_oci/#425.
 bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "gazelle", version = "0.35.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "b8432a6008bc70f1892a1f50f0dd5da02e159e8a1e3a297bfdda8b5a55bcf5c8",
+  "moduleFileHash": "757be36ed0d7988961ee39f647f2f54d14d90909ca8e52d106513cb7b7686ca6",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -746,9 +746,9 @@
               "attributeValues": {
                 "hub_name": "jupyter-pip-requirements-dev",
                 "python_version": "3.9",
-                "requirements_lock": "//jupyter-extension:requirements-dev-lock.txt",
                 "requirements_darwin": "//jupyter-extension:requirements-dev-lock-darwin.txt",
-                "requirements_linux": "//jupyter-extension:requirements-dev-lock-linux.txt"
+                "requirements_linux": "//jupyter-extension:requirements-dev-lock-linux.txt",
+                "requirements_lock": "//jupyter-extension:requirements-dev-lock.txt"
               },
               "devDependency": false,
               "location": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -763,7 +763,7 @@
         }
       ],
       "deps": {
-        "aspect_bazel_lib": "aspect_bazel_lib@2.5.0",
+        "aspect_bazel_lib": "aspect_bazel_lib@2.5.3",
         "container_structure_test": "container_structure_test@1.16.0",
         "gazelle": "gazelle@0.35.0",
         "jsonnet_go": "jsonnet_go@0.20.0",
@@ -775,10 +775,10 @@
         "local_config_platform": "local_config_platform@_"
       }
     },
-    "aspect_bazel_lib@2.5.0": {
+    "aspect_bazel_lib@2.5.3": {
       "name": "aspect_bazel_lib",
-      "version": "2.5.0",
-      "key": "aspect_bazel_lib@2.5.0",
+      "version": "2.5.3",
+      "key": "aspect_bazel_lib@2.5.3",
       "repoName": "aspect_bazel_lib",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [
@@ -798,9 +798,9 @@
         {
           "extensionBzlFile": "@aspect_bazel_lib//lib:extensions.bzl",
           "extensionName": "toolchains",
-          "usingModule": "aspect_bazel_lib@2.5.0",
+          "usingModule": "aspect_bazel_lib@2.5.3",
           "location": {
-            "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
             "line": 17,
             "column": 37
           },
@@ -821,7 +821,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 18,
                 "column": 36
               }
@@ -831,7 +831,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 19,
                 "column": 39
               }
@@ -841,7 +841,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 20,
                 "column": 24
               }
@@ -851,7 +851,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 21,
                 "column": 24
               }
@@ -861,7 +861,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 22,
                 "column": 31
               }
@@ -871,7 +871,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 23,
                 "column": 25
               }
@@ -881,7 +881,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 24,
                 "column": 37
               }
@@ -891,7 +891,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/MODULE.bazel",
                 "line": 25,
                 "column": 26
               }
@@ -913,13 +913,13 @@
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
-            "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.0/bazel-lib-v2.5.0.tar.gz"
+            "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.3/bazel-lib-v2.5.3.tar.gz"
           ],
-          "integrity": "sha256-9ep2aCsgnMC9kND1o7JtL3pqKIXwxfYV5ykT9IBduw0=",
-          "strip_prefix": "bazel-lib-2.5.0",
+          "integrity": "sha256-bCXFlYEEHt4x4RdpMEf5csxHAMiaz5E2WNyJ0Ewzj40=",
+          "strip_prefix": "bazel-lib-2.5.3",
           "remote_patches": {
-            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/patches/go_dev_dep.patch": "sha256-KgABwDzOT+DugUHn9tHLOz05osnk2FLsS10d5zqG/M0=",
-            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.0/patches/module_dot_bazel_version.patch": "sha256-Goo+3Jt++n8fe6jssy24AABw0FjsH0yA592LrOVNDSI="
+            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/patches/go_dev_dep.patch": "sha256-KgABwDzOT+DugUHn9tHLOz05osnk2FLsS10d5zqG/M0=",
+            "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/patches/module_dot_bazel_version.patch": "sha256-lJcPl3qi//Az5K9CO6WnDIL8gtJVzpOWhyailCiKeVY="
           },
           "remote_patch_strip": 1
         }
@@ -954,7 +954,7 @@
         }
       ],
       "deps": {
-        "aspect_bazel_lib": "aspect_bazel_lib@2.5.0",
+        "aspect_bazel_lib": "aspect_bazel_lib@2.5.3",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
@@ -1312,7 +1312,7 @@
         }
       ],
       "deps": {
-        "aspect_bazel_lib": "aspect_bazel_lib@2.5.0",
+        "aspect_bazel_lib": "aspect_bazel_lib@2.5.3",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "platforms": "platforms@0.0.8",
         "bazel_tools": "bazel_tools@_",
@@ -3167,7 +3167,7 @@
     },
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "g43D7f6o/mI05HhDVGSud1FKK+ux/+zT0pkQYOsjjz4=",
+        "bzlTransitiveDigest": "H6ezdphBae7pq8EW1mSupf+FjMuk8mtYNgMZ8pclWPc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -11489,7 +11489,7 @@
     },
     "@@rules_oci~//oci:extensions.bzl%oci": {
       "general": {
-        "bzlTransitiveDigest": "DR8HXAtKwBoZokxP8w+hJDknoxxG2cKygm8oQVLnF5w=",
+        "bzlTransitiveDigest": "sc4ImaORwL2F0PHtQ1agdDLeiifN7LChBDSCJkP4K3I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/etc/generate-envoy-config/BUILD.bazel
+++ b/etc/generate-envoy-config/BUILD.bazel
@@ -1,15 +1,22 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("//private/rules:rules.bzl", "copy_to_workspace")
 
-files = ["envoy", "envoy-tls"]
+files = [
+    "envoy",
+    "envoy-tls",
+]
 
 [
     genrule(
         name = "gen_" + x,
-        srcs = ["envoy.libsonnet", "pachyderm-services.libsonnet", x + ".jsonnet"],
-        tools = ["@jsonnet_go//cmd/jsonnet"],
+        srcs = [
+            "envoy.libsonnet",
+            "pachyderm-services.libsonnet",
+            x + ".jsonnet",
+        ],
         outs = [x + ".json"],
         cmd = "$(location @jsonnet_go//cmd/jsonnet) $(location :" + x + ".jsonnet) > $@",
+        tools = ["@jsonnet_go//cmd/jsonnet"],
         visibility = ["//etc/helm/pachyderm:__pkg__"],
     )
     for x in files
@@ -27,4 +34,5 @@ tar(
 copy_to_workspace(
     name = "update",
     src = ":envoy_config_bundle",
+    message = "Envoy configs are outdated.  Run 'bazel run //etc/generate-envoy-config:update' to update them.",
 )

--- a/etc/generate-envoy-config/BUILD.bazel
+++ b/etc/generate-envoy-config/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
-load("//private/rules:rules.bzl", "copy_to_workspace")
 
 files = [
     "envoy",
@@ -17,7 +16,6 @@ files = [
         outs = [x + ".json"],
         cmd = "$(location @jsonnet_go//cmd/jsonnet) $(location :" + x + ".jsonnet) > $@",
         tools = ["@jsonnet_go//cmd/jsonnet"],
-        visibility = ["//etc/helm/pachyderm:__pkg__"],
     )
     for x in files
 ]
@@ -29,10 +27,5 @@ tar(
         "etc/helm/pachyderm/envoy.json uid=0 gid=0 time=0 mode=0644 type=file content=$(location envoy.json)",
         "etc/helm/pachyderm/envoy-tls.json uid=0 gid=0 time=0 mode=0644 type=file content=$(location envoy-tls.json)",
     ],
-)
-
-copy_to_workspace(
-    name = "update",
-    src = ":envoy_config_bundle",
-    message = "Envoy configs are outdated.  Run 'bazel run //etc/generate-envoy-config:update' to update them.",
+    visibility = ["//etc/helm/pachyderm:__pkg__"],
 )

--- a/etc/generate-envoy-config/BUILD.bazel
+++ b/etc/generate-envoy-config/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("//private/rules:rules.bzl", "copy_to_workspace")
+
+files = ["envoy", "envoy-tls"]
+
+[
+    genrule(
+        name = "gen_" + x,
+        srcs = ["envoy.libsonnet", "pachyderm-services.libsonnet", x + ".jsonnet"],
+        tools = ["@jsonnet_go//cmd/jsonnet"],
+        outs = [x + ".json"],
+        cmd = "$(location @jsonnet_go//cmd/jsonnet) $(location :" + x + ".jsonnet) > $@",
+        visibility = ["//etc/helm/pachyderm:__pkg__"],
+    )
+    for x in files
+]
+
+tar(
+    name = "envoy_config_bundle",
+    srcs = [x + ".json" for x in files],
+    mtree = [
+        "etc/helm/pachyderm/envoy.json uid=0 gid=0 time=0 mode=0644 type=file content=$(location envoy.json)",
+        "etc/helm/pachyderm/envoy-tls.json uid=0 gid=0 time=0 mode=0644 type=file content=$(location envoy-tls.json)",
+    ],
+)
+
+copy_to_workspace(
+    name = "update",
+    src = ":envoy_config_bundle",
+)

--- a/etc/helm/pachyderm/BUILD.bazel
+++ b/etc/helm/pachyderm/BUILD.bazel
@@ -1,7 +1,19 @@
+load("//private/rules:rules.bzl", "copy_to_workspace")
+
 filegroup(
     name = "pachyderm",
     srcs = glob(["**/*"]),
     visibility = ["//visibility:public"],
+)
+
+copy_to_workspace(
+    name = "update_envoy_config",
+    src = "//etc/generate-envoy-config:envoy_config_bundle",
+    outs = [
+        "//etc/helm/pachyderm:envoy.json",
+        "//etc/helm/pachyderm:envoy-tls.json",
+    ],
+    message = "Envoy configs are outdated.  Run 'bazel run //etc/helm/pachyderm:update_envoy_config' to update them.",
 )
 
 sh_test(

--- a/private/rules/BUILD.bazel
+++ b/private/rules/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
-    name = "multiarch",
+    name = "rules",
     srcs = ["rules.bzl"],
     visibility = ["//:__pkg__"],
 )

--- a/private/rules/rules.bzl
+++ b/private/rules/rules.bzl
@@ -90,7 +90,7 @@ def _copy_to_workspace_impl(ctx):
         output = copier,
         content = _PROTOTAR_APPLY_TMPL.format(
             MSG = repr(""),
-            SRC = ctx.attr.src.files.to_list()[0].path,
+            SRC = "$(rlocation {})".format(repr(ctx.workspace_name + "/" + ctx.file.src.short_path)),
             BASH_RLOCATION_FUNCTION = BASH_RLOCATION_FUNCTION,
         ),
         is_executable = True,
@@ -107,6 +107,7 @@ _copy_to_workspace = rule(
     implementation = _copy_to_workspace_impl,
     attrs = {
         "src": attr.label(
+            allow_single_file = True,
             doc = "Tar to extract into the workspace.",
         ),
         "_runfiles": attr.label_list(default = ["@bazel_tools//tools/bash/runfiles", "//src/proto/prototar"]),

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//private/rules:rules.bzl", "host_native_binary")
+load("//private/rules:rules.bzl", "copy_to_workspace", "host_native_binary")
 
 host_native_binary(
     name = "protoc-gen-go",
@@ -86,38 +86,10 @@ genrule(
     ],
 )
 
-sh_binary(
-    name = "extract_sh",
-    srcs = ["extract.sh"],
-    args = ["$(location go_protos.tar)"],
-    data = [
-        "go_protos.tar",
-        "//src/proto/prototar",
-    ],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
-)
-
 # bazel build //src/proto:run will regenerate the protos in your working copy.
-alias(
+copy_to_workspace(
     name = "run",
-    actual = "extract_sh",
+    src = "gen_go_proto_bundle",
+    message = "Go protos are outdated.  Run 'bazel run //:make_proto' to update them.",
     visibility = ["//visibility:public"],
-)
-
-sh_test(
-    name = "check_generated_protos",
-    size = "small",
-    srcs = ["test.sh"],
-    data = [
-        "go_protos.tar",
-        "//src/proto/prototar",
-    ],
-    tags = [
-        "external",
-        "manual",
-        "no-cache",
-        "no-sandbox",
-        "style",
-    ],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -89,7 +89,7 @@ genrule(
 # bazel build //src/proto:run will regenerate the protos in your working copy.
 copy_to_workspace(
     name = "run",
-    src = "gen_go_proto_bundle",
+    src = "go_protos.tar",
     message = "Go protos are outdated.  Run 'bazel run //:make_proto' to update them.",
     visibility = ["//visibility:public"],
 )

--- a/src/proto/prototar/main_test.go
+++ b/src/proto/prototar/main_test.go
@@ -95,7 +95,7 @@ func TestCreateAndApply(t *testing.T) {
 	// Apply the tar we generated above
 	t.Run("apply_1", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
-		gotReport, err := apply(ctx, bytes.NewReader(tar), false)
+		gotReport, err := apply(ctx, bytes.NewReader(tar), false, true)
 		if err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -116,7 +116,7 @@ func TestCreateAndApply(t *testing.T) {
 		ctx := pctx.TestContext(t)
 		write(t, filepath.Join("src", "internal", "jsonschema", "old_v2", "Old.schema.json"), []byte(`{"old":"schema"}`))
 		write(t, filepath.Join("src", "internal", "jsonschema", "jsonschema.go"), []byte("some go code to not delete"))
-		gotReport, err := apply(ctx, bytes.NewReader(tar), false)
+		gotReport, err := apply(ctx, bytes.NewReader(tar), false, true)
 		if err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -132,7 +132,7 @@ func TestCreateAndApply(t *testing.T) {
 	// Finally we should be able to run this again and see only unchanged files.
 	t.Run("apply_3", func(t *testing.T) {
 		ctx := pctx.TestContext(t)
-		gotReport, err := apply(ctx, bytes.NewReader(tar), false)
+		gotReport, err := apply(ctx, bytes.NewReader(tar), false, true)
 		if err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -150,7 +150,7 @@ func TestCreateAndApply(t *testing.T) {
 			t.Fatalf("chdir /: %v", err)
 		}
 		ctx := pctx.TestContext(t)
-		gotReport, err := apply(ctx, bytes.NewReader(tar), true)
+		gotReport, err := apply(ctx, bytes.NewReader(tar), true, true)
 		if err != nil {
 			t.Fatalf("apply: %v", err)
 		}


### PR DESCRIPTION
This just cleans up regenerating envoy.json and friends.

We add a rule `copy_to_workspace` that invokes `prototar` to do our dirty work.  `//src/proto:run` is now implemented in terms of this rule, and `//etc/helm/pachyderm:update_envoy_config` is too.  `copy_to_workspace` automatically generates a test that reminds you to regenerate files when necessary, and the test can be hermetic and cacheable if you know the names of the files you're generating at build time.  (For protos, we don't.  For envoy configs, we do.)

Future work in this category involves running jsonnetfmt tests and jsonnet-lint tests on the jsonnet files; this is currently done outside of bazel.  It would also be nice to run the envoy config validation tests inside bazel.  That requires writing something to copy envoy out of a docker container because they don't have binaries for linux.