### PR TITLE
Add rules to install pachctl binaries

### DIFF
--- a/BAZEL.md
+++ b/BAZEL.md
@@ -181,9 +181,16 @@ in sync. If you forget to run this, nothing will work, so it's unlikely that you
 
 ### pachctl
 
-To run pachctl, `bazel run //:pachctl`. You can also build the binary and copy it to $PATH, if you
-like. After `bazel run //:pachctl` or `bazel build //:pachctl`, it will be in
-`bazel-bin/src/server/cmd/pachctl/pachctl_/pachctl`.
+To run pachctl, `bazel run //:pachctl`.
+
+If you want to install `pachctl` from this source tree, run
+`bazel run //src/server/cmd/pachctl:install` or `bazel run //src/serer/cmd/pachctl:install_nostamp`.
+The `nostamp` variant doesn't have a version number baked into it, much like a normal
+`go install ./src/server/cmd/pachctl`. This avoids it printing a message when it's not the same
+version as pachd. From a release tag, you probably want the stamped version. From a random working
+copy, you probably want the nostamp version. (The warning about version mismatches is annoying, but
+important if you're working on pachd and pachctl at the same time; it probably means you forgot to
+restart pachd after your change, so it potentially reminds you.)
 
 ## Hints
 

--- a/src/server/cmd/pachctl/BUILD.bazel
+++ b/src/server/cmd/pachctl/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//private/rules:rules.bzl", "installable_binary")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -36,4 +37,21 @@ go_binary(
     embed = [":pachctl_lib"],
     pure = "on",
     visibility = ["//visibility:public"],
+)
+
+# This installs a pachctl binary into your $PATH.  It has the version built into it, so when you're
+# installing from a commit that's not tagged with a release, it's going to whine at you every time
+# you run it unless your pachd is the same exact version.
+installable_binary(
+    name = "install",
+    installed_name = "pachctl",
+    target = ":pachctl",
+)
+
+# This installs a pachctl binary into your $PATH.  It does not have the version built into it, so
+# the whining about incompatibility is suppressed.  Here be dragons and all that.
+installable_binary(
+    name = "install_nostamp",
+    installed_name = "pachctl",
+    target = ":pachctl_nostamp",
 )

--- a/src/server/cmd/pachctl/BUILD.bazel
+++ b/src/server/cmd/pachctl/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//private/rules:rules.bzl", "installable_binary")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("//private/rules:rules.bzl", "installable_binary")
 
 go_library(
     name = "pachctl_lib",


### PR DESCRIPTION
Sometimes you don't want to `bazel run` it.  So this lets you install it.

```
bazel run //src/server/cmd/pachctl:install # with version checks
bazel run //src/server/cmd/pachctl:install_nostamp # without version checks
```
