### PR TITLE
implement project, repo, and commit picker parsers

### DIFF
--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -72,6 +72,15 @@ func NotMatch(tb testing.TB, shouldNotMatch string, actual string, msgAndArgs ..
 	}
 }
 
+// NoDiff does a diff, and fails if there are differences.  Use protocmp.Transform() to compare
+// protos.
+func NoDiff(tb testing.TB, expected any, actual any, opts []cmp.Option, msgAndArgs ...any) {
+	diff := cmp.Diff(expected, actual, opts...)
+	if diff != "" {
+		fatal(tb, msgAndArgs, "expected should match actual (-expected +actual):\n%s", diff)
+	}
+}
+
 // Equal checks the equality of two values
 func Equal(tb testing.TB, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	tb.Helper()

--- a/src/pfs/BUILD.bazel
+++ b/src/pfs/BUILD.bazel
@@ -44,7 +44,11 @@ go_test(
     size = "small",
     srcs = ["pfs_test.go"],
     embed = [":pfs"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//src/internal/require",
+        "@com_github_google_go_cmp//cmp",
+        "@org_golang_google_protobuf//testing/protocmp",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
This handles parsing "partial" syntax, i.e. "images@master" instead of "default/images@master".  This way, pachctl can fill in the project with the configuration context's default value.