### PR TITLE
Vendor pfsdb@2.8.6 for clusterstate tests

### DIFF
--- a/src/internal/clusterstate/BUILD.bazel
+++ b/src/internal/clusterstate/BUILD.bazel
@@ -53,11 +53,11 @@ go_test(
     deps = [
         "//src/internal/clusterstate/v2.7.0:v2_7_0",
         "//src/internal/clusterstate/v2.8.0:v2_8_0",
+        "//src/internal/clusterstate/v2.8.0/pfsdb_28x",
         "//src/internal/dockertestenv",
         "//src/internal/migrations",
         "//src/internal/pbutil",
         "//src/internal/pctx",
-        "//src/internal/pfsdb",
         "//src/internal/require",
         "//src/internal/testetcd",
         "//src/pfs",

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/BUILD.bazel
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "pfsdb_28x",
+    srcs = [
+        "branches.go",
+        "commit_provenance.go",
+        "commits.go",
+        "common.go",
+        "model.go",
+        "pfsdb.go",
+        "projects.go",
+        "repos.go",
+    ],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/internal/clusterstate/v2.8.0/pfsdb_28x",
+    visibility = ["//src:__subpackages__"],
+    deps = [
+        "//src/internal/collection",
+        "//src/internal/dbutil",
+        "//src/internal/errors",
+        "//src/internal/pachsql",
+        "//src/internal/pbutil",
+        "//src/internal/randutil",
+        "//src/internal/stream",
+        "//src/internal/uuid",
+        "//src/internal/watch/postgres",
+        "//src/pfs",
+        "//src/server/pfs",
+        "@com_github_jackc_pgconn//:pgconn",
+        "@com_github_jmoiron_sqlx//:sqlx",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/branches.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/branches.go
@@ -1,0 +1,626 @@
+package pfsdb_28x
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+	"github.com/pachyderm/pachyderm/v2/src/internal/watch/postgres"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+const (
+	BranchesChannelName     = "pfs_branches"
+	BranchesRepoChannelName = "pfs_branches_repo_"
+)
+
+const (
+	getBranchBaseQuery = `
+		SELECT
+			branch.id,
+			branch.name,
+			branch.created_at,
+			branch.updated_at,
+			repo.id as "repo.id",
+			repo.name as "repo.name",
+			repo.type as "repo.type",
+			project.id as "repo.project.id",
+			project.name as "repo.project.name",
+			commit.commit_id as "head.commit_id",
+			commit.commit_set_id as "head.commit_set_id",
+			headBranch.name as "head.branch_name",
+			repo.name as "head.repo.name",
+			repo.type as "head.repo.type",
+			project.name as "head.repo.project.name"
+		FROM pfs.branches branch
+			JOIN pfs.repos repo ON branch.repo_id = repo.id
+			JOIN core.projects project ON repo.project_id = project.id
+			JOIN pfs.commits commit ON branch.head = commit.int_id
+			LEFT JOIN pfs.branches headBranch on commit.branch_id = headBranch.id
+	`
+	getBranchByIDQuery   = getBranchBaseQuery + ` WHERE branch.id = $1`
+	getBranchByNameQuery = getBranchBaseQuery + ` WHERE project.name = $1 AND repo.name = $2 AND repo.type = $3 AND branch.name = $4`
+	branchesPageSize     = 100
+)
+
+type branchColumn string
+
+const (
+	BranchColumnID        = branchColumn("branch.id")
+	BranchColumnRepoID    = branchColumn("branch.repo_id")
+	BranchColumnCreatedAt = branchColumn("branch.created_at")
+	BranchColumnUpdatedAt = branchColumn("branch.updated_at")
+)
+
+// Ensures BranchIterator implements the Iterator interface.
+var _ stream.Iterator[BranchInfoWithID] = &BranchIterator{}
+
+// BranchProvCycleError is returned when a cycle is detected at branch creation time.
+type BranchProvCycleError struct {
+	From, To string
+}
+
+func (err *BranchProvCycleError) Error() string {
+	return fmt.Sprintf("cycle detected because %v is already in the subvenance of %v", err.To, err.From)
+}
+
+func (err *BranchProvCycleError) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, err.Error())
+}
+
+// BranchNotFoundError is returned when a branch is not found in postgres.
+type BranchNotFoundError struct {
+	ID        BranchID
+	BranchKey string
+}
+
+func (err *BranchNotFoundError) Error() string {
+	if strings.Contains(err.BranchKey, pfs.UserRepoType) {
+		branchKeyWithoutUser := strings.Replace(err.BranchKey, "."+pfs.UserRepoType, "", 1)
+		return fmt.Sprintf("branch (id=%d, branch=%s) not found", err.ID, branchKeyWithoutUser)
+	}
+	return fmt.Sprintf("branch (id=%d, branch=%s) not found", err.ID, err.BranchKey)
+}
+
+func (err *BranchNotFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, err.Error())
+}
+
+// BranchesInRepoChannel returns the name of the channel that is notified when branches in repo 'repoID' are created, updated, or deleted
+func BranchesInRepoChannel(repoID RepoID) string {
+	return fmt.Sprintf("%s%d", BranchesRepoChannelName, repoID)
+}
+
+type BranchIterator struct {
+	paginator pageIterator[Branch]
+	ext       sqlx.ExtContext
+}
+
+type BranchInfoWithID struct {
+	ID       BranchID
+	Revision int64
+	*pfs.BranchInfo
+}
+
+type OrderByBranchColumn OrderByColumn[branchColumn]
+
+func NewBranchIterator(ctx context.Context, ext sqlx.ExtContext, startPage, pageSize uint64, filter *pfs.Branch, orderBys ...OrderByBranchColumn) (*BranchIterator, error) {
+	var conditions []string
+	var values []any
+	// Note that using ? as the bindvar is okay because we rebind it later.
+	if filter != nil {
+		if filter.Repo.Project != nil && filter.Repo.Project.Name != "" {
+			conditions = append(conditions, "project.name = ?")
+			values = append(values, filter.Repo.Project.Name)
+		}
+		if filter.Repo != nil && filter.Repo.Name != "" {
+			conditions = append(conditions, "repo.name = ?")
+			values = append(values, filter.Repo.Name)
+		}
+		if filter.Repo != nil && filter.Repo.Type != "" {
+			conditions = append(conditions, "repo.type = ?")
+			values = append(values, filter.Repo.Type)
+		}
+		if filter.Name != "" {
+			conditions = append(conditions, "branch.name = ?")
+			values = append(values, filter.Name)
+		}
+	}
+	query := getBranchBaseQuery
+	if len(conditions) > 0 {
+		query += "\n" + fmt.Sprintf("WHERE %s", strings.Join(conditions, " AND "))
+	}
+	// Default ordering is by branch id in ascending order. This is important for pagination.
+	var orderByGeneric []OrderByColumn[branchColumn]
+	if len(orderBys) == 0 {
+		orderByGeneric = []OrderByColumn[branchColumn]{{Column: BranchColumnID, Order: SortOrderAsc}}
+	} else {
+		for _, orderBy := range orderBys {
+			orderByGeneric = append(orderByGeneric, OrderByColumn[branchColumn](orderBy))
+		}
+	}
+	query += "\n" + OrderByQuery[branchColumn](orderByGeneric...)
+	query = ext.Rebind(query)
+	return &BranchIterator{
+		paginator: newPageIterator[Branch](ctx, query, values, startPage, pageSize),
+		ext:       ext,
+	}, nil
+}
+
+func ForEachBranch(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, cb func(branchInfoWithID BranchInfoWithID) error, orderBys ...OrderByBranchColumn) error {
+	iter, err := NewBranchIterator(ctx, tx, 0, 100, filter, orderBys...)
+	if err != nil {
+		return errors.Wrap(err, "for each branch")
+	}
+	if err := stream.ForEach[BranchInfoWithID](ctx, iter, cb); err != nil {
+		return errors.Wrap(err, "for each branch")
+	}
+	return nil
+}
+
+func ListBranches(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, orderBys ...OrderByBranchColumn) ([]BranchInfoWithID, error) {
+	var branches []BranchInfoWithID
+	err := ForEachBranch(ctx, tx, filter, func(branchInfoWithID BranchInfoWithID) error {
+		branches = append(branches, branchInfoWithID)
+		return nil
+	}, orderBys...)
+	if err != nil {
+		return nil, errors.Wrap(err, "list branches")
+	}
+	return branches, nil
+}
+
+func (i *BranchIterator) Next(ctx context.Context, dst *BranchInfoWithID) error {
+	if dst == nil {
+		return errors.Errorf("dst BranchInfo cannot be nil")
+	}
+	branch, rev, err := i.paginator.next(ctx, i.ext)
+	if err != nil {
+		return err
+	}
+	branchInfo, err := fetchBranchInfoByBranch(ctx, i.ext, branch)
+	if err != nil {
+		return err
+	}
+	dst.ID = branch.ID
+	dst.BranchInfo = branchInfo
+	dst.Revision = rev
+	return nil
+}
+
+// GetBranchInfo returns a *pfs.BranchInfo by id.
+func GetBranchInfo(ctx context.Context, tx *pachsql.Tx, id BranchID) (*pfs.BranchInfo, error) {
+	branch := &Branch{}
+	if err := tx.GetContext(ctx, branch, getBranchByIDQuery, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &BranchNotFoundError{ID: id}
+		}
+		return nil, errors.Wrap(err, "could not get branch")
+	}
+	return fetchBranchInfoByBranch(ctx, tx, branch)
+}
+
+// GetBranchInfoWithID returns a *pfs.BranchInfo by name
+func GetBranchInfoWithID(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*BranchInfoWithID, error) {
+	if b == nil {
+		return nil, errors.Errorf("branch cannot be nil")
+	}
+	row := &Branch{}
+	project := b.GetRepo().GetProject().GetName()
+	repo := b.GetRepo().GetName()
+	repoType := b.GetRepo().GetType()
+	branch := b.GetName()
+	if err := tx.GetContext(ctx, row, getBranchByNameQuery, project, repo, repoType, branch); err != nil {
+		if err == sql.ErrNoRows {
+			if _, err := GetRepoByName(ctx, tx, project, repo, repoType); err != nil {
+				if errors.As(err, new(*RepoNotFoundError)) {
+					return nil, errors.Join(err, &BranchNotFoundError{BranchKey: b.Key()})
+				}
+				return nil, errors.Wrapf(err, "get repo for branch info %v", b.Key())
+			}
+			return nil, &BranchNotFoundError{BranchKey: b.Key()}
+		}
+		return nil, errors.Wrap(err, "could not get branch")
+	}
+	branchInfo, err := fetchBranchInfoByBranch(ctx, tx, row)
+	if err != nil {
+		return nil, err
+	}
+	return &BranchInfoWithID{ID: row.ID, BranchInfo: branchInfo}, nil
+}
+
+// GetBranchID returns the id of a branch given a set strings that uniquely identify a branch.
+func GetBranchID(ctx context.Context, tx *pachsql.Tx, branch *pfs.Branch) (BranchID, error) {
+	var id BranchID
+	if err := tx.GetContext(ctx, &id, `
+		SELECT branch.id
+		FROM pfs.branches branch
+			JOIN pfs.repos repo ON branch.repo_id = repo.id
+			JOIN core.projects project ON repo.project_id = project.id
+		WHERE project.name = $1 AND repo.name = $2 AND repo.type = $3 AND branch.name = $4
+	`,
+		branch.Repo.Project.Name,
+		branch.Repo.Name,
+		branch.Repo.Type,
+		branch.Name,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, &BranchNotFoundError{BranchKey: branch.Key()}
+		}
+		return 0, errors.Wrapf(err, "could not get id for branch %s", branch.Key())
+	}
+	return id, nil
+}
+
+// UpsertBranch creates a branch if it does not exist, or updates the head if the branch already exists.
+// If direct provenance is specified, it will be used to update the branch's provenance relationships.
+func UpsertBranch(ctx context.Context, tx *pachsql.Tx, branchInfo *pfs.BranchInfo) (BranchID, error) {
+	if branchInfo.Branch.Repo.Name == "" {
+		return 0, errors.Errorf("repo name required")
+	}
+	if branchInfo.Branch.Repo.Type == "" {
+		return 0, errors.Errorf("repo type required")
+	}
+	if branchInfo.Branch.Repo.Project.Name == "" {
+		return 0, errors.Errorf("project name required")
+	}
+	if branchInfo.Head.Id == "" {
+		return 0, errors.Errorf("head commit required")
+	}
+	if uuid.IsUUIDWithoutDashes(branchInfo.Branch.Name) {
+		return 0, errors.Errorf("branch name cannot be a UUID V4")
+	}
+	var branchID BranchID
+	// TODO stop matching on pfs.commits.commit_id, because that will eventually be deprecated.
+	// Instead, construct the commit_id based on existing project, repo, and commit_set_id fields.
+	if err := tx.QueryRowContext(ctx,
+		`
+		INSERT INTO pfs.branches(repo_id, name, head)
+		VALUES (
+			(SELECT repo.id FROM pfs.repos repo JOIN core.projects project ON repo.project_id = project.id WHERE project.name = $1 AND repo.name = $2 AND repo.type = $3),
+			$4,
+			(SELECT int_id FROM pfs.commits WHERE commit_id = $5)
+		)
+		ON CONFLICT (repo_id, name) DO UPDATE SET head = EXCLUDED.head
+		RETURNING id
+		`,
+		branchInfo.Branch.Repo.Project.Name,
+		branchInfo.Branch.Repo.Name,
+		branchInfo.Branch.Repo.Type,
+		branchInfo.Branch.Name,
+		CommitKey(branchInfo.Head),
+	).Scan(&branchID); err != nil {
+		return 0, errors.Wrap(err, "could not create branch")
+	}
+	// Compute branch provenance, and avoid creating cycles.
+	// We know a cycle exists if the to_branch is in the subvenance of the from_branch.
+	// Note that we get the full subvenance set as an efficiency optimization,
+	// where we avoid having to query the database for each branch in the provenance chain.
+	fullSubv, err := GetBranchSubvenance(ctx, tx, branchID)
+	if err != nil {
+		return branchID, errors.Wrap(err, "could not compute branch subvenance")
+	}
+	fullSubvSet := make(map[string]bool)
+	for _, branch := range fullSubv {
+		fullSubvSet[branch.Key()] = true
+	}
+	for _, toBranch := range branchInfo.DirectProvenance {
+		if fullSubvSet[toBranch.Key()] {
+			return branchID, &BranchProvCycleError{From: branchInfo.Branch.Key(), To: toBranch.Key()}
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM pfs.branch_provenance WHERE from_id = $1`, branchID); err != nil {
+		return branchID, errors.Wrap(err, "could not delete direct branch provenance")
+	}
+	for _, branch := range branchInfo.DirectProvenance {
+		toBranchID, err := GetBranchID(ctx, tx, branch)
+		if err != nil {
+			return branchID, errors.Wrapf(err, "could not get to_branch_id for creating branch provenance")
+		}
+		if err := CreateDirectBranchProvenance(ctx, tx, branchID, toBranchID); err != nil {
+			return branchID, errors.Wrap(err, "could not create branch provenance")
+		}
+	}
+	// Create or update this branch's trigger.
+	if branchInfo.Trigger != nil {
+		toBranchID, err := GetBranchID(ctx, tx, &pfs.Branch{Repo: branchInfo.Branch.Repo, Name: branchInfo.Trigger.Branch})
+		if err != nil {
+			return branchID, errors.Wrap(err, "updating branch trigger")
+		}
+		if err := UpsertBranchTrigger(ctx, tx, branchID, toBranchID, branchInfo.Trigger); err != nil {
+			return branchID, errors.Wrap(err, "updating branch trigger")
+		}
+	} else {
+		// Delete existing branch trigger.
+		if err := DeleteBranchTrigger(ctx, tx, branchID); err != nil {
+			return branchID, errors.Wrap(err, "updating branch trigger")
+		}
+	}
+	return branchID, nil
+}
+
+// DeleteBranch deletes a branch.
+func DeleteBranch(ctx context.Context, tx *pachsql.Tx, id BranchID, force bool) error {
+	deleteProvQuery := `DELETE FROM pfs.branch_provenance WHERE from_id = $1`
+	deleteTriggerQuery := `DELETE FROM pfs.branch_triggers WHERE from_branch_id = $1`
+	if force {
+		deleteProvQuery = `DELETE FROM pfs.branch_provenance WHERE from_id = $1 OR to_id = $1`
+		deleteTriggerQuery = `DELETE FROM pfs.branch_triggers WHERE from_branch_id = $1 OR to_branch_id = $1`
+	}
+	if _, err := tx.ExecContext(ctx, deleteProvQuery, id); err != nil {
+		return errors.Wrapf(err, "could not delete branch provenance for branch %d", id)
+	}
+	if _, err := tx.ExecContext(ctx, deleteTriggerQuery, id); err != nil {
+		return errors.Wrapf(err, "could not delete branch trigger for branch %d", id)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM pfs.branches WHERE id = $1`, id); err != nil {
+		return errors.Wrapf(err, "could not delete branch %d", id)
+	}
+	return nil
+}
+
+// GetDirectBranchProvenance returns the direct provenance of a branch, i.e. all branches that it directly depends on.
+func GetDirectBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID) ([]*pfs.Branch, error) {
+	var branches []Branch
+	if err := sqlx.SelectContext(ctx, ext, &branches, `
+		SELECT
+			branch.id,
+			branch.name,
+			repo.name as "repo.name",
+			repo.type as "repo.type",
+			project.name as "repo.project.name"
+		FROM pfs.branch_provenance bp
+		    JOIN pfs.branches branch ON bp.to_id = branch.id
+			JOIN pfs.repos repo ON branch.repo_id = repo.id
+			JOIN core.projects project ON repo.project_id = project.id
+		WHERE bp.from_id = $1
+	`, id); err != nil {
+		return nil, errors.Wrap(err, "could not get direct branch provenance")
+	}
+	var branchPbs []*pfs.Branch
+	for _, branch := range branches {
+		branchPbs = append(branchPbs, branch.Pb())
+	}
+	return branchPbs, nil
+}
+
+// GetBranchProvenance returns the full provenance of a branch, i.e. all branches that it either directly or transitively depends on.
+func GetBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID) ([]*pfs.Branch, error) {
+	var branches []Branch
+	if err := sqlx.SelectContext(ctx, ext, &branches, `
+		WITH RECURSIVE prov(from_id, to_id) AS (
+		    SELECT from_id, to_id
+		    FROM pfs.branch_provenance
+		    WHERE from_id = $1
+		  UNION ALL
+		    SELECT bp.from_id, bp.to_id
+		    FROM prov JOIN pfs.branch_provenance bp ON prov.to_id = bp.from_id
+		)
+		SELECT DISTINCT
+		    branch.id,
+			branch.name,
+			repo.name as "repo.name",
+			repo.type as "repo.type",
+			project.name as "repo.project.name"
+		FROM pfs.branches branch
+		    JOIN prov ON branch.id = prov.to_id
+			JOIN pfs.repos repo ON branch.repo_id = repo.id
+		    JOIN core.projects project ON repo.project_id = project.id
+		WHERE branch.id != $1
+	`, id); err != nil {
+		return nil, errors.Wrap(err, "could not get branch provenance")
+	}
+	var branchPbs []*pfs.Branch
+	for _, branch := range branches {
+		branchPbs = append(branchPbs, branch.Pb())
+	}
+	return branchPbs, nil
+}
+
+// GetBranchSubvenance returns the full subvenance of a branch, i.e. all branches that either directly or transitively depend on it.
+func GetBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID) ([]*pfs.Branch, error) {
+	var branches []Branch
+	if err := sqlx.SelectContext(ctx, ext, &branches, `
+		WITH RECURSIVE subv(from_id, to_id) AS (
+		    SELECT from_id, to_id
+		    FROM pfs.branch_provenance
+		    WHERE to_id = $1
+		  UNION ALL
+		    SELECT bp.from_id, bp.to_id
+		    FROM subv JOIN pfs.branch_provenance bp ON subv.from_id = bp.to_id
+		)
+		SELECT DISTINCT
+		    branch.id,
+			branch.name,
+			repo.name as "repo.name",
+			repo.type as "repo.type",
+			project.name as "repo.project.name"
+		FROM pfs.branches branch
+		    JOIN subv ON branch.id = subv.from_id
+			JOIN pfs.repos repo ON branch.repo_id = repo.id
+		    JOIN core.projects project ON repo.project_id = project.id
+		WHERE branch.id != $1
+	`, id); err != nil {
+		return nil, errors.Wrap(err, "could not get branch provenance")
+	}
+	var branchPbs []*pfs.Branch
+	for _, branch := range branches {
+		branchPbs = append(branchPbs, branch.Pb())
+	}
+	return branchPbs, nil
+}
+
+// CreateBranchProvenance creates a provenance relationship between two branches.
+func CreateDirectBranchProvenance(ctx context.Context, ext sqlx.ExtContext, from, to BranchID) error {
+	if _, err := ext.ExecContext(ctx, `
+		INSERT INTO pfs.branch_provenance(from_id, to_id)	
+		VALUES ($1, $2)
+		ON CONFLICT DO NOTHING
+	`, from, to); err != nil {
+		return errors.Wrap(err, "could not add branch provenance")
+	}
+	return nil
+}
+
+func GetBranchTrigger(ctx context.Context, ext sqlx.ExtContext, from BranchID) (*pfs.Trigger, error) {
+	trigger := BranchTrigger{}
+	if err := sqlx.GetContext(ctx, ext, &trigger, `
+		SELECT
+			branch.name as "to_branch.name",
+			cron_spec,
+			rate_limit_spec,
+			size,
+			num_commits,
+			all_conditions
+		FROM pfs.branch_triggers trigger
+			JOIN pfs.branches branch ON trigger.to_branch_id = branch.id
+		WHERE trigger.from_branch_id = $1
+	`, from); err != nil {
+		if errors.As(err, sql.ErrNoRows) {
+			// Branches don't need to have triggers
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "could not get branch trigger")
+	}
+	return trigger.Pb(), nil
+}
+
+func UpsertBranchTrigger(ctx context.Context, tx *pachsql.Tx, from BranchID, to BranchID, trigger *pfs.Trigger) error {
+	if trigger == nil {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO pfs.branch_triggers(from_branch_id, to_branch_id, cron_spec, rate_limit_spec, size, num_commits, all_conditions)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (from_branch_id) DO UPDATE SET
+			to_branch_id = EXCLUDED.to_branch_id,
+			cron_spec = EXCLUDED.cron_spec,
+			rate_limit_spec = EXCLUDED.rate_limit_spec,
+			size = EXCLUDED.size,
+			num_commits = EXCLUDED.num_commits,
+			all_conditions = EXCLUDED.all_conditions;
+	`,
+		from,
+		to,
+		trigger.CronSpec,
+		trigger.RateLimitSpec,
+		trigger.Size,
+		trigger.Commits,
+		trigger.All,
+	); err != nil {
+		return errors.Wrapf(err, "could not create trigger for branch %d", from)
+	}
+	return nil
+}
+
+func DeleteBranchTrigger(ctx context.Context, tx *pachsql.Tx, from BranchID) error {
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM pfs.branch_triggers
+		WHERE from_branch_id = $1
+	`, from); err != nil {
+		return errors.Wrapf(err, "could not delete branch trigger for branch %d", from)
+	}
+	return nil
+}
+
+func fetchBranchInfoByBranch(ctx context.Context, ext sqlx.ExtContext, branch *Branch) (*pfs.BranchInfo, error) {
+	if branch == nil {
+		return nil, errors.Errorf("branch cannot be nil")
+	}
+	branchInfo := &pfs.BranchInfo{Branch: branch.Pb(), Head: branch.Head.Pb()}
+	var err error
+	branchInfo.DirectProvenance, err = GetDirectBranchProvenance(ctx, ext, branch.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get direct branch provenance")
+	}
+	branchInfo.Provenance, err = GetBranchProvenance(ctx, ext, branch.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get full branch provenance")
+	}
+	branchInfo.Subvenance, err = GetBranchSubvenance(ctx, ext, branch.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get full branch subvenance")
+	}
+	// trigger info
+	branchInfo.Trigger, err = GetBranchTrigger(ctx, ext, branch.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get branch trigger")
+	}
+	return branchInfo, nil
+}
+
+// Helper functions for watching branches.
+type branchUpsertHandler func(id BranchID, branchInfo *pfs.BranchInfo) error
+type branchDeleteHandler func(id BranchID) error
+
+func WatchBranchesInRepo(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, repoID RepoID, onUpsert branchUpsertHandler, onDelete branchDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString(fmt.Sprintf("watch-branches-in-repo-%d", repoID)), BranchesInRepoChannel(repoID))
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	// Optimized query for getting branches in a repo.
+	query := getBranchBaseQuery + fmt.Sprintf("\nWHERE %s = ?\nORDER BY %s ASC", BranchColumnRepoID, BranchColumnID)
+	query = db.Rebind(query)
+	snapshot := &BranchIterator{paginator: newPageIterator[Branch](ctx, query, []any{repoID}, 0, branchesPageSize), ext: db}
+	return watchBranches(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+func watchBranches(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator[BranchInfoWithID], events <-chan *postgres.Event, onUpsert branchUpsertHandler, onDelete branchDeleteHandler) error {
+	// Handle snapshot.
+	if err := stream.ForEach[BranchInfoWithID](ctx, snapshot, func(b BranchInfoWithID) error {
+		return onUpsert(b.ID, b.BranchInfo)
+	}); err != nil {
+		return err
+	}
+	// Handle events.
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return errors.New("watch branches: events channel closed")
+			}
+			if event.Err != nil {
+				return event.Err
+			}
+			id := BranchID(event.Id)
+			switch event.Type {
+			case postgres.EventDelete:
+				if err := onDelete(id); err != nil {
+					return err
+				}
+			case postgres.EventInsert, postgres.EventUpdate:
+				var branchInfo *pfs.BranchInfo
+				if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
+					var err error
+					branchInfo, err = GetBranchInfo(ctx, tx, id)
+					if err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := onUpsert(id, branchInfo); err != nil {
+					return err
+				}
+			default:
+				return errors.Errorf("unknown event type: %v", event.Type)
+			}
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "watch branches")
+		}
+	}
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/commit_provenance.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/commit_provenance.go
@@ -1,0 +1,169 @@
+package pfsdb_28x
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
+)
+
+// returns the commit of a certain repo in a commit set.
+func ResolveCommitProvenance(tx *pachsql.Tx, repo *pfs.Repo, commitSet string) (*pfs.Commit, error) {
+	cs, err := CommitSetProvenance(tx, commitSet)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range cs {
+		if RepoKey(c.Repo) == RepoKey(repo) {
+			return c, nil
+		}
+	}
+	return nil, pfsserver.ErrCommitNotFound{Commit: &pfs.Commit{Repo: repo, Id: commitSet}}
+}
+
+// CommitSetProvenance returns all the commit IDs that are in the provenance
+// of all the commits in this commit set.
+//
+// TODO(provenance): is 'SELECT DISTINCT commit_id' a performance concern?
+func CommitSetProvenance(tx *pachsql.Tx, id string) (_ []*pfs.Commit, retErr error) {
+	q := `
+          WITH RECURSIVE prov(from_id, to_id) AS (
+            SELECT from_id, to_id
+            FROM pfs.commit_provenance JOIN pfs.commits ON int_id = from_id
+            WHERE commit_set_id = $1
+           UNION ALL
+            SELECT cp.from_id, cp.to_id
+            FROM prov p, pfs.commit_provenance cp
+            WHERE cp.from_id = p.to_id
+          )
+          SELECT DISTINCT commit_id
+          FROM pfs.commits, prov
+          WHERE int_id = prov.to_id AND commit_set_id != $1;`
+	rows, err := tx.Queryx(q, id)
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	defer errors.Close(&retErr, rows, "close rows")
+	cs := make([]*pfs.Commit, 0)
+	for rows.Next() {
+		var commit string
+		if err := rows.Scan(&commit); err != nil {
+			return nil, errors.EnsureStack(err)
+		}
+		cs = append(cs, ParseCommit(commit))
+	}
+	if err = rows.Err(); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return cs, nil
+}
+
+func CommitDirectProvenance(ctx context.Context, extCtx sqlx.ExtContext, id CommitID) ([]*pfs.Commit, error) {
+	var commits []Commit
+	query := `
+	SELECT DISTINCT
+		commit.commit_id,
+		commit.commit_set_id,
+		repo.name as "repo.name",
+		repo.type as "repo.type",
+		project.name as "repo.project.name",
+		branch.name as branch_name
+	FROM pfs.commit_provenance prov
+		JOIN pfs.commits commit ON prov.to_id = commit.int_id
+		JOIN pfs.repos repo ON commit.repo_id = repo.id
+		JOIN core.projects project ON repo.project_id = project.id
+		LEFT JOIN pfs.branches branch ON commit.branch_id = branch.id
+	WHERE prov.from_id = $1
+	`
+	if err := sqlx.SelectContext(ctx, extCtx, &commits, query, id); err != nil {
+		return nil, errors.Wrapf(err, "getting direct commit provenance for commitID=%d", id)
+	}
+	var commitPbs []*pfs.Commit
+	for _, commit := range commits {
+		commitPbs = append(commitPbs, commit.Pb())
+	}
+	return commitPbs, nil
+}
+
+// CommitSetSubvenance returns all the commit IDs that contain commits in this commit set in their
+// full (transitive) provenance
+func CommitSetSubvenance(tx *pachsql.Tx, id string) (_ []*pfs.Commit, retErr error) {
+	q := `
+          WITH RECURSIVE subv(from_id, to_id) AS (
+            SELECT from_id, to_id
+            FROM pfs.commit_provenance JOIN pfs.commits ON int_id = to_id
+            WHERE commit_set_id = $1
+           UNION ALL
+            SELECT cp.from_id, cp.to_id
+            FROM subv s, pfs.commit_provenance cp
+            WHERE cp.to_id = s.from_id
+          )
+          SELECT DISTINCT commit_id
+          FROM pfs.commits, subv
+          WHERE int_id = subv.from_id AND commit_set_id != $1;`
+	rows, err := tx.Queryx(q, id)
+	if err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	defer errors.Close(&retErr, rows, "close rows")
+	cs := make([]*pfs.Commit, 0)
+	for rows.Next() {
+		var commit string
+		if err := rows.Scan(&commit); err != nil {
+			return nil, errors.EnsureStack(err)
+		}
+		cs = append(cs, ParseCommit(commit))
+	}
+	if err = rows.Err(); err != nil {
+		return nil, errors.EnsureStack(err)
+	}
+	return cs, nil
+}
+
+func AddCommit(tx *pachsql.Tx, commit *pfs.Commit) error {
+	stmt := `INSERT INTO pfs.commits(commit_id, commit_set_id) VALUES ($1, $2) ON CONFLICT DO NOTHING;`
+	_, err := tx.Exec(stmt, CommitKey(commit), commit.Id)
+	return errors.Wrapf(err, "insert commit %q into pfs.commits", CommitKey(commit))
+}
+
+func getCommitTableID(tx *pachsql.Tx, commit *pfs.Commit) (_ int, retErr error) {
+	commitKey := CommitKey(commit)
+	query := `SELECT int_id FROM pfs.commits WHERE commit_id = $1;`
+	rows, err := tx.Queryx(query, commitKey)
+	if err != nil {
+		return 0, errors.EnsureStack(err)
+	}
+	defer errors.Close(&retErr, rows, "close rows")
+	var id int
+	for rows.Next() {
+		if err := rows.Scan(&id); err != nil {
+			return 0, errors.EnsureStack(err)
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return 0, errors.EnsureStack(err)
+	}
+	return id, nil
+}
+
+func AddCommitProvenance(tx *pachsql.Tx, from, to *pfs.Commit) error {
+	fromId, err := getCommitTableID(tx, from)
+	if err != nil {
+		return errors.Wrapf(err, "get int id for 'from' commit, %q", CommitKey(from))
+	}
+	toId, err := getCommitTableID(tx, to)
+	if err != nil {
+		return errors.Wrapf(err, "get int id for 'to' commit, %q", CommitKey(to))
+	}
+	return addCommitProvenance(tx, fromId, toId)
+}
+
+func addCommitProvenance(tx *pachsql.Tx, from, to int) error {
+	stmt := `INSERT INTO pfs.commit_provenance(from_id, to_id) VALUES ($1, $2) ON CONFLICT DO NOTHING;`
+	_, err := tx.Exec(stmt, from, to)
+	return errors.Wrapf(err, "add commit provenance")
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/commits.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/commits.go
@@ -1,0 +1,982 @@
+package pfsdb_28x
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+	"github.com/pachyderm/pachyderm/v2/src/internal/watch/postgres"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+const (
+	// CommitsChannelName is used to watch events for the commits table.
+	CommitsChannelName     = "pfs_commits"
+	CommitsRepoChannelName = "pfs_commits_repo_"
+	CommitChannelName      = "pfs_commits_"
+	createCommit           = `
+		WITH repo_row_id AS (SELECT id from pfs.repos WHERE name=$1 AND type=$2 AND project_id=(SELECT id from core.projects WHERE name=$3))
+		INSERT INTO pfs.commits 
+    	(commit_id, 
+    	 commit_set_id, 
+    	 repo_id, 
+    	 branch_id, 
+    	 description, 
+    	 origin, 
+    	 start_time, 
+    	 finishing_time, 
+    	 finished_time, 
+    	 compacting_time_s, 
+    	 validating_time_s, 
+    	 size, 
+    	 error) 
+		VALUES 
+		($4, $5,
+		 (SELECT id from repo_row_id), 
+		 (SELECT id from pfs.branches WHERE name=$6 AND repo_id=(SELECT id from repo_row_id)), 
+		 $7, $8, $9, $10, $11, $12, $13, $14, $15)
+		RETURNING int_id;`
+	updateCommit = `
+		WITH repo_row_id AS (SELECT id from pfs.repos WHERE name=:repo.name AND type=:repo.type AND project_id=(SELECT id from core.projects WHERE name= :repo.project.name))
+		UPDATE pfs.commits SET 
+			commit_id=:commit_id, 
+			commit_set_id=:commit_set_id,
+		    repo_id=(SELECT id from repo_row_id), 
+		    branch_id=(SELECT id from pfs.branches WHERE name=:branch_name AND repo_id=(SELECT id from repo_row_id)), 
+			description=:description, 
+			origin=:origin, 
+			start_time=:start_time, 
+			finishing_time=:finishing_time, 
+			finished_time=:finished_time, 
+		    compacting_time_s=:compacting_time_s, 
+			validating_time_s=:validating_time_s, 
+			size=:size, 
+			error=:error 
+		WHERE int_id=:int_id;`
+	getCommit = `
+		SELECT DISTINCT
+    		commit.int_id, 
+    		commit.commit_id, 
+			commit.commit_set_id,
+    		commit.branch_id, 
+    		commit.origin, 
+    		commit.description, 
+    		commit.start_time, 
+    		commit.finishing_time, 
+    		commit.finished_time, 
+    		commit.compacting_time_s, 
+    		commit.validating_time_s,
+    		commit.error, 
+    		commit.size, 
+    		commit.created_at,
+    		commit.updated_at,
+    		commit.repo_id AS "repo.id", 
+    		repo.name AS "repo.name",
+    		repo.type AS "repo.type",
+    		project.name AS "repo.project.name",
+    		branch.name as branch_name
+		FROM pfs.commits commit
+		JOIN pfs.repos repo ON commit.repo_id = repo.id
+		JOIN core.projects project ON repo.project_id = project.id
+		LEFT JOIN pfs.branches branch ON commit.branch_id = branch.id
+		`
+	getParentCommit = getCommit + `
+		JOIN pfs.commit_ancestry ancestry ON ancestry.parent = commit.int_id`
+	getChildCommit = getCommit + `
+		JOIN pfs.commit_ancestry ancestry ON ancestry.child = commit.int_id`
+	commitsPageSize = 1000
+)
+
+// CommitNotFoundError is returned by GetCommit() when a commit is not found in postgres.
+type CommitNotFoundError struct {
+	RowID    CommitID
+	CommitID string
+}
+
+func (err *CommitNotFoundError) Error() string {
+	return fmt.Sprintf("commit (int_id=%d, commit_id=%s) not found", err.RowID, err.CommitID)
+}
+
+func (err *CommitNotFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, err.Error())
+}
+
+// ParentCommitNotFoundError is returned when a commit's parent is not found in postgres.
+type ParentCommitNotFoundError struct {
+	ChildRowID    CommitID
+	ChildCommitID string
+}
+
+func IsParentCommitNotFound(err error) bool {
+	return dbutil.IsNotNullViolation(err, "parent")
+}
+
+func (err *ParentCommitNotFoundError) Error() string {
+	return fmt.Sprintf("parent commit of commit (int_id=%d, commit_id=%s) not found", err.ChildRowID, err.ChildCommitID)
+}
+
+func (err *ParentCommitNotFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, err.Error())
+}
+
+// ChildCommitNotFoundError is returned when a commit's child is not found in postgres.
+type ChildCommitNotFoundError struct {
+	Repo           string
+	ParentRowID    CommitID
+	ParentCommitID string
+}
+
+func IsChildCommitNotFound(err error) bool {
+	return dbutil.IsNotNullViolation(err, "child")
+}
+
+func (err *ChildCommitNotFoundError) Error() string {
+	return fmt.Sprintf("parent commit of commit (int_id=%d, commit_key=%s) not found", err.ParentRowID, err.ParentCommitID)
+}
+
+func (err *ChildCommitNotFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, err.Error())
+}
+
+// CommitMissingInfoError is returned when a commitInfo is missing a field.
+type CommitMissingInfoError struct {
+	Field string
+}
+
+func (err *CommitMissingInfoError) Error() string {
+	return fmt.Sprintf("commitInfo.%s is missing/nil", err.Field)
+}
+
+func (err *CommitMissingInfoError) GRPCStatus() *status.Status {
+	return status.New(codes.FailedPrecondition, err.Error())
+}
+
+// CommitAlreadyExistsError is returned when a commit with the same name already exists in postgres.
+type CommitAlreadyExistsError struct {
+	CommitID string
+}
+
+// Error satisfies the error interface.
+func (err *CommitAlreadyExistsError) Error() string {
+	return fmt.Sprintf("commit %s already exists", err.CommitID)
+}
+
+func (err *CommitAlreadyExistsError) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, err.Error())
+}
+
+// AncestryOpt allows users to create commitInfos and skip creating the ancestry information.
+// This allows a user to create the commits in an arbitrary order, then create their ancestry later.
+type AncestryOpt struct {
+	SkipChildren bool
+	SkipParent   bool
+}
+
+// CommitsInRepoChannel returns the name of the channel that is notified when commits in repo 'repoID' are created, updated, or deleted
+func CommitsInRepoChannel(repoID RepoID) string {
+	return fmt.Sprintf("%s%d", CommitsRepoChannelName, repoID)
+}
+
+// CreateCommit creates an entry in the pfs.commits table. If the commit has a parent or children,
+// it will attempt to create entries in the pfs.commit_ancestry table unless options are provided to skip
+// ancestry creation.
+func CreateCommit(ctx context.Context, tx *pachsql.Tx, commitInfo *pfs.CommitInfo, opts ...AncestryOpt) (CommitID, error) {
+	if err := validateCommitInfo(commitInfo); err != nil {
+		return 0, err
+	}
+	commit, err := GetCommitWithIDByKey(ctx, tx, commitInfo.Commit)
+	if err == nil {
+		return 0, &CommitAlreadyExistsError{CommitID: commit.CommitInfo.Commit.Key()}
+	}
+	if err != nil {
+		if errors.As(err, new(*ProjectNotFoundError)) || errors.As(err, new(*RepoNotFoundError)) {
+			return 0, err
+		}
+		if !errors.As(err, new(*CommitNotFoundError)) {
+			return 0, err
+		}
+	}
+	opt := AncestryOpt{}
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	branchName := sql.NullString{String: "", Valid: false}
+	if commitInfo.Commit.Branch != nil {
+		branchName = sql.NullString{String: commitInfo.Commit.Branch.Name, Valid: true}
+	}
+	insert := Commit{
+		CommitID:    CommitKey(commitInfo.Commit),
+		CommitSetID: commitInfo.Commit.Id,
+		Repo: Repo{
+			Name: commitInfo.Commit.Repo.Name,
+			Type: commitInfo.Commit.Repo.Type,
+			Project: Project{
+				Name: commitInfo.Commit.Repo.Project.Name,
+			},
+		},
+		BranchName:     branchName,
+		Origin:         commitInfo.Origin.Kind.String(),
+		StartTime:      pbutil.SanitizeTimestampPb(commitInfo.Started),
+		FinishingTime:  pbutil.SanitizeTimestampPb(commitInfo.Finishing),
+		FinishedTime:   pbutil.SanitizeTimestampPb(commitInfo.Finished),
+		Description:    commitInfo.Description,
+		CompactingTime: pbutil.DurationPbToBigInt(commitInfo.Details.CompactingTime),
+		ValidatingTime: pbutil.DurationPbToBigInt(commitInfo.Details.ValidatingTime),
+		Size:           commitInfo.Details.SizeBytes,
+		Error:          commitInfo.Error,
+	}
+	// It would be nice to use a named query here, but sadly there is no NamedQueryRowContext. Additionally,
+	// we run into errors when using named statements: (named statement already exists).
+
+	row := tx.QueryRowxContext(ctx, createCommit, insert.Repo.Name, insert.Repo.Type, insert.Repo.Project.Name,
+		insert.CommitID, insert.CommitSetID, insert.BranchName, insert.Description, insert.Origin, insert.StartTime, insert.FinishingTime,
+		insert.FinishedTime, insert.CompactingTime, insert.ValidatingTime, insert.Size, insert.Error)
+	lastInsertId := 0
+	if err := row.Scan(&lastInsertId); err != nil {
+		return 0, errors.Wrap(err, "scanning id from create commitInfo")
+	}
+	if commitInfo.ParentCommit != nil && !opt.SkipParent {
+		if err := CreateCommitParent(ctx, tx, commitInfo.ParentCommit, CommitID(lastInsertId)); err != nil {
+			return 0, errors.Wrap(err, "linking parent")
+		}
+	}
+	if len(commitInfo.ChildCommits) != 0 && !opt.SkipChildren {
+		if err := CreateCommitChildren(ctx, tx, CommitID(lastInsertId), commitInfo.ChildCommits); err != nil {
+			return 0, errors.Wrap(err, "linking children")
+		}
+	}
+	return CommitID(lastInsertId), nil
+}
+
+// CreateCommitParent inserts a single ancestry relationship where the child is known and parent must be derived.
+func CreateCommitParent(ctx context.Context, tx *pachsql.Tx, parentCommit *pfs.Commit, childCommit CommitID) error {
+	ancestryQuery := `
+		INSERT INTO pfs.commit_ancestry
+		(parent, child)
+		VALUES ((SELECT int_id FROM pfs.commits WHERE commit_id=$1), $2)
+		ON CONFLICT DO NOTHING;
+	`
+	_, err := tx.ExecContext(ctx, ancestryQuery, CommitKey(parentCommit), childCommit)
+	if err != nil {
+		if IsParentCommitNotFound(err) {
+			return &ParentCommitNotFoundError{ChildRowID: childCommit}
+		}
+		return errors.Wrap(err, "putting commit parent")
+	}
+	return nil
+}
+
+// CreateCommitAncestries inserts ancestry relationships where the ids of both parent and children are known.
+func CreateCommitAncestries(ctx context.Context, tx *pachsql.Tx, parentCommit CommitID, childrenCommits []CommitID) error {
+	ancestryQueryTemplate := `
+		INSERT INTO pfs.commit_ancestry
+		(parent, child)
+		VALUES %s
+		ON CONFLICT DO NOTHING;
+	`
+	childValuesTemplate := `($1, $%d)`
+	params := []any{parentCommit}
+	queryVarNum := 2
+	values := make([]string, 0)
+	for _, child := range childrenCommits {
+		values = append(values, fmt.Sprintf(childValuesTemplate, queryVarNum))
+		params = append(params, child)
+		queryVarNum++
+	}
+	_, err := tx.ExecContext(ctx, fmt.Sprintf(ancestryQueryTemplate, strings.Join(values, ",")),
+		params...)
+	if err != nil {
+		if IsChildCommitNotFound(err) {
+			return &ChildCommitNotFoundError{ParentRowID: parentCommit}
+		}
+		return errors.Wrap(err, "putting commit children")
+	}
+	return nil
+}
+
+// CreateCommitChildren inserts ancestry relationships using a single query for all of the children.
+func CreateCommitChildren(ctx context.Context, tx *pachsql.Tx, parentCommit CommitID, childCommits []*pfs.Commit) error {
+	ancestryQueryTemplate := `
+		INSERT INTO pfs.commit_ancestry
+		(parent, child)
+		VALUES %s
+		ON CONFLICT DO NOTHING;
+	`
+	childValuesTemplate := `($1, (SELECT int_id FROM pfs.commits WHERE commit_id=$%d))`
+	params := []any{parentCommit}
+	queryVarNum := 2
+	values := make([]string, 0)
+	for _, child := range childCommits {
+		values = append(values, fmt.Sprintf(childValuesTemplate, queryVarNum))
+		params = append(params, CommitKey(child))
+		queryVarNum++
+	}
+	_, err := tx.ExecContext(ctx, fmt.Sprintf(ancestryQueryTemplate, strings.Join(values, ",")),
+		params...)
+	if err != nil {
+		if IsChildCommitNotFound(err) {
+			return &ChildCommitNotFoundError{ParentRowID: parentCommit}
+		}
+		return errors.Wrap(err, "putting commit children")
+	}
+	return nil
+}
+
+// DeleteCommit deletes an entry in the pfs.commits table. It also repoints the references in the commit_ancestry table.
+// The caller is responsible for updating branchesg.
+func DeleteCommit(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) error {
+	if commit == nil {
+		return &CommitMissingInfoError{Field: "Commit"}
+	}
+	id, err := GetCommitID(ctx, tx, commit)
+	if err != nil {
+		return errors.Wrap(err, "getting commit ID to delete")
+	}
+	parent, children, err := getCommitRelativeRows(ctx, tx, id)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("getting commit relatives for id=%d", id))
+	}
+	// delete commit.parent -> commit and commit -> commit.children if they exist.
+	if parent != nil || children != nil {
+		_, err = tx.ExecContext(ctx, "DELETE FROM pfs.commit_ancestry WHERE parent=$1 OR child=$1;", id)
+		if err != nil {
+			return errors.Wrap(err, "delete commit ancestry")
+		}
+	}
+	// repoint commit.parent -> commit.children
+	if parent != nil && children != nil {
+		childrenIDs := make([]CommitID, 0)
+		for _, child := range children {
+			childrenIDs = append(childrenIDs, child.ID)
+		}
+		if err := CreateCommitAncestries(ctx, tx, parent.ID, childrenIDs); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("repointing id=%d at %v", parent.ID, childrenIDs))
+		}
+	}
+	// delete commit.
+	result, err := tx.ExecContext(ctx, "DELETE FROM pfs.commits WHERE int_id=$1;", id)
+	if err != nil {
+		return errors.Wrap(err, "delete commit")
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "could not get affected rows")
+	}
+	if rowsAffected == 0 {
+		return &CommitNotFoundError{RowID: id}
+	}
+	return nil
+}
+
+// GetCommitID returns the int_id of a commit in postgres.
+func GetCommitID(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) (CommitID, error) {
+	if commit == nil {
+		return 0, &CommitMissingInfoError{Field: "Commit"}
+	}
+	if commit.Repo == nil {
+		return 0, &CommitMissingInfoError{Field: "Repo"}
+	}
+	row, err := getCommitRowByCommitKey(ctx, tx, commit)
+	if err != nil {
+		return 0, errors.Wrap(err, "get commit by commit key")
+	}
+	return row.ID, nil
+}
+
+// GetCommit returns the commitInfo where int_id=id.
+func GetCommit(ctx context.Context, tx *pachsql.Tx, id CommitID) (*pfs.CommitInfo, error) {
+	if id == 0 {
+		return nil, errors.New("invalid id: 0")
+	}
+	row := &Commit{}
+	err := tx.QueryRowxContext(ctx, fmt.Sprintf("%s WHERE int_id=$1", getCommit), id).StructScan(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &CommitNotFoundError{RowID: id}
+		}
+		return nil, errors.Wrap(err, "scanning commit row")
+	}
+	commitInfo, err := getCommitInfoFromCommitRow(ctx, tx, row)
+	if err != nil {
+		return nil, errors.Wrap(err, "get commit info from row")
+	}
+	return commitInfo, err
+}
+
+func GetCommitWithIDByKey(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) (*CommitWithID, error) {
+	row, err := getCommitRowByCommitKey(ctx, tx, commit)
+	if err != nil {
+		return nil, errors.Wrap(err, "get commit by commit key")
+	}
+	commitInfo, err := getCommitInfoFromCommitRow(ctx, tx, row)
+	if err != nil {
+		return nil, errors.Wrap(err, "get commit info from row")
+	}
+	return &CommitWithID{
+		CommitInfo: commitInfo,
+		ID:         row.ID,
+	}, nil
+}
+
+// GetCommitByCommitKey is like GetCommit but derives the int_id on behalf of the caller.
+func GetCommitByCommitKey(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) (*pfs.CommitInfo, error) {
+	pair, err := GetCommitWithIDByKey(ctx, tx, commit)
+	if err != nil {
+		return nil, err
+	}
+	return pair.CommitInfo, nil
+}
+
+// GetCommitParent uses the pfs.commit_ancestry and pfs.commits tables to retrieve a commit given an int_id of
+// one of its children.
+func GetCommitParent(ctx context.Context, tx *pachsql.Tx, childCommit CommitID) (*pfs.Commit, error) {
+	return getCommitParent(ctx, tx, childCommit)
+}
+
+// GetCommitParent uses the pfs.commit_ancestry and pfs.commits tables to retrieve a commit given an int_id of
+// one of its children.
+func getCommitParent(ctx context.Context, extCtx sqlx.ExtContext, childCommit CommitID) (*pfs.Commit, error) {
+	row, err := getCommitParentRow(ctx, extCtx, childCommit)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting parent commit row")
+	}
+	parentCommitInfo := parseCommitInfoFromRow(row)
+	return parentCommitInfo.Commit, nil
+}
+
+// GetCommitChildren uses the pfs.commit_ancestry and pfs.commits tables to retrieve commits of all
+// of the children given an int_id of the parent.
+func GetCommitChildren(ctx context.Context, tx *pachsql.Tx, parentCommit CommitID) ([]*pfs.Commit, error) {
+	return getCommitChildren(ctx, tx, parentCommit)
+}
+
+func getCommitChildren(ctx context.Context, extCtx sqlx.ExtContext, parentCommit CommitID) ([]*pfs.Commit, error) {
+	children := make([]*pfs.Commit, 0)
+	rows, err := extCtx.QueryxContext(ctx, fmt.Sprintf("%s WHERE ancestry.parent=$1", getChildCommit), parentCommit)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &ChildCommitNotFoundError{ParentRowID: parentCommit}
+		}
+		return nil, errors.Wrap(err, "getting commit children")
+	}
+	for rows.Next() {
+		row := &Commit{}
+		if err := rows.StructScan(row); err != nil {
+			return nil, errors.Wrap(err, "scanning commit row for child")
+		}
+		childCommitInfo := parseCommitInfoFromRow(row)
+		children = append(children, childCommitInfo.Commit)
+	}
+	if len(children) == 0 { // QueryxContext does not return an error when the query returns 0 rows.
+		return nil, &ChildCommitNotFoundError{ParentRowID: parentCommit}
+	}
+	return children, nil
+}
+
+func GetCommitSubvenance(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) ([]*pfs.Commit, error) {
+	id, err := GetCommitID(ctx, tx, commit)
+	if err != nil {
+		return nil, err
+	}
+	var commitStrs []string
+	if err := tx.SelectContext(ctx, &commitStrs, `
+		WITH RECURSIVE subv(from_id, to_id) AS (
+		    SELECT from_id, to_id
+		    FROM pfs.commit_provenance
+		    WHERE to_id = $1
+		  UNION ALL
+		    SELECT cp.from_id, cp.to_id
+		    FROM subv s
+		    JOIN pfs.commit_provenance cp ON s.from_id = cp.to_id
+		)
+		SELECT DISTINCT commit_id
+		FROM subv s
+		JOIN pfs.commits c ON s.from_id = c.int_id
+	`, id); err != nil {
+		return nil, errors.Wrap(err, "could not get commit subvenance")
+	}
+	var commits []*pfs.Commit
+	for _, commitStr := range commitStrs {
+		commits = append(commits, ParseCommit(commitStr))
+	}
+	return commits, nil
+}
+
+// UpsertCommit will attempt to insert a commit and its ancestry relationships.
+// If the commit already exists, it will update its description.
+func UpsertCommit(ctx context.Context, tx *pachsql.Tx, commitInfo *pfs.CommitInfo, opts ...AncestryOpt) (CommitID, error) {
+	existingCommit, err := getCommitRowByCommitKey(ctx, tx, commitInfo.Commit)
+	if err != nil {
+		if errors.As(err, &CommitNotFoundError{CommitID: CommitKey(commitInfo.Commit)}) {
+			return CreateCommit(ctx, tx, commitInfo, opts...)
+		}
+		return 0, errors.Wrap(err, "upserting commit")
+	}
+	return existingCommit.ID, UpdateCommit(ctx, tx, existingCommit.ID, commitInfo, opts...)
+}
+
+// UpdateCommit overwrites an existing commit entry by CommitID as well as the corresponding ancestry entries.
+func UpdateCommit(ctx context.Context, tx *pachsql.Tx, id CommitID, commitInfo *pfs.CommitInfo, opts ...AncestryOpt) error {
+	if err := validateCommitInfo(commitInfo); err != nil {
+		return err
+	}
+	opt := AncestryOpt{}
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	branchName := sql.NullString{String: "", Valid: false}
+	if commitInfo.Commit.Branch != nil {
+		branchName = sql.NullString{String: commitInfo.Commit.Branch.Name, Valid: true}
+	}
+	update := Commit{
+		ID:          id,
+		CommitID:    CommitKey(commitInfo.Commit),
+		CommitSetID: commitInfo.Commit.Id,
+		Repo: Repo{
+			Name: commitInfo.Commit.Repo.Name,
+			Type: commitInfo.Commit.Repo.Type,
+			Project: Project{
+				Name: commitInfo.Commit.Repo.Project.Name,
+			},
+		},
+		BranchName:     branchName,
+		Origin:         commitInfo.Origin.Kind.String(),
+		StartTime:      pbutil.SanitizeTimestampPb(commitInfo.Started),
+		FinishingTime:  pbutil.SanitizeTimestampPb(commitInfo.Finishing),
+		FinishedTime:   pbutil.SanitizeTimestampPb(commitInfo.Finished),
+		Description:    commitInfo.Description,
+		CompactingTime: pbutil.DurationPbToBigInt(commitInfo.Details.CompactingTime),
+		ValidatingTime: pbutil.DurationPbToBigInt(commitInfo.Details.ValidatingTime),
+		Size:           commitInfo.Details.SizeBytes,
+		Error:          commitInfo.Error,
+	}
+	query := updateCommit
+	res, err := tx.NamedExecContext(ctx, query, update)
+	if err != nil {
+		return errors.Wrap(err, "exec update commitInfo")
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "rows affected")
+	}
+	if rowsAffected == 0 {
+		_, err := GetRepoByName(ctx, tx, commitInfo.Commit.Repo.Project.Name, commitInfo.Commit.Repo.Name, commitInfo.Commit.Repo.Type)
+		if err != nil {
+			if errors.As(err, new(*RepoNotFoundError)) {
+				return errors.Join(err, &CommitNotFoundError{RowID: id})
+			}
+			return errors.Wrapf(err, "get repo for update commit with row id %v", id)
+		}
+		return &CommitNotFoundError{RowID: id}
+	}
+	if !opt.SkipParent {
+		_, err = tx.ExecContext(ctx, "DELETE FROM pfs.commit_ancestry WHERE child=$1;", id)
+		if err != nil {
+			return errors.Wrap(err, "delete commit parent")
+		}
+		if commitInfo.ParentCommit != nil {
+			if err := CreateCommitParent(ctx, tx, commitInfo.ParentCommit, id); err != nil {
+				return errors.Wrap(err, "linking parent")
+			}
+		}
+	}
+	if opt.SkipChildren {
+		return nil
+	}
+	_, err = tx.ExecContext(ctx, "DELETE FROM pfs.commit_ancestry WHERE parent=$1;", id)
+	if err != nil {
+		return errors.Wrap(err, "delete commit children")
+	}
+	if len(commitInfo.ChildCommits) != 0 {
+		if err := CreateCommitChildren(ctx, tx, id, commitInfo.ChildCommits); err != nil {
+			return errors.Wrap(err, "linking children")
+		}
+	}
+	return nil
+}
+
+// validateCommitInfo returns an error if the commit is not valid and has side effects of instantiating details
+// if they are nil.
+func validateCommitInfo(commitInfo *pfs.CommitInfo) error {
+	if commitInfo.Commit == nil {
+		return &CommitMissingInfoError{Field: "Commit"}
+	}
+	if commitInfo.Commit.Repo == nil {
+		return &CommitMissingInfoError{Field: "Repo"}
+	}
+	if commitInfo.Origin == nil {
+		return &CommitMissingInfoError{Field: "Origin"}
+	}
+	if commitInfo.Details == nil { // stub in an empty details struct to avoid panics.
+		commitInfo.Details = &pfs.CommitInfo_Details{}
+	}
+	switch commitInfo.Origin.Kind {
+	case pfs.OriginKind_ORIGIN_KIND_UNKNOWN, pfs.OriginKind_USER, pfs.OriginKind_AUTO, pfs.OriginKind_FSCK:
+		break
+	default:
+		return errors.New(fmt.Sprintf("invalid origin: %v", commitInfo.Origin.Kind))
+	}
+	return nil
+}
+
+func getCommitInfoFromCommitRow(ctx context.Context, extCtx sqlx.ExtContext, row *Commit) (*pfs.CommitInfo, error) {
+	var err error
+	commitInfo := parseCommitInfoFromRow(row)
+	commitInfo.ParentCommit, commitInfo.ChildCommits, err = getCommitRelatives(ctx, extCtx, row.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get commit relatives")
+	}
+	commitInfo.DirectProvenance, err = CommitDirectProvenance(ctx, extCtx, row.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get provenance for commit")
+	}
+	return commitInfo, err
+}
+
+func getCommitRelatives(ctx context.Context, extCtx sqlx.ExtContext, commitID CommitID) (*pfs.Commit, []*pfs.Commit, error) {
+	parentCommit, err := getCommitParent(ctx, extCtx, commitID)
+	if err != nil && !errors.As(err, &ParentCommitNotFoundError{ChildRowID: commitID}) {
+		return nil, nil, errors.Wrap(err, "getting parent commit")
+		// if parent is missing, assume commit is root of a repo.
+	}
+	childCommits, err := getCommitChildren(ctx, extCtx, commitID)
+	if err != nil && !errors.As(err, &ChildCommitNotFoundError{ParentRowID: commitID}) {
+		return nil, nil, errors.Wrap(err, "getting children commits")
+		// if children is missing, assume commit is HEAD of some branch.
+	}
+	return parentCommit, childCommits, nil
+}
+
+func getCommitParentRow(ctx context.Context, extCtx sqlx.ExtContext, childCommit CommitID) (*Commit, error) {
+	row := &Commit{}
+	if err := sqlx.GetContext(ctx, extCtx, row, fmt.Sprintf("%s WHERE ancestry.child=$1", getParentCommit), childCommit); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &ParentCommitNotFoundError{ChildRowID: childCommit}
+		}
+		return nil, errors.Wrap(err, "scanning commit row for parent")
+	}
+	return row, nil
+}
+
+func getCommitChildrenRows(ctx context.Context, tx *pachsql.Tx, parentCommit CommitID) ([]*Commit, error) {
+	children := make([]*Commit, 0)
+	rows, err := tx.QueryxContext(ctx, fmt.Sprintf("%s WHERE ancestry.parent=$1", getChildCommit), parentCommit)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &ChildCommitNotFoundError{ParentRowID: parentCommit}
+		}
+		return nil, errors.Wrap(err, "getting commit children rows")
+	}
+	for rows.Next() {
+		row := &Commit{}
+		if err := rows.StructScan(row); err != nil {
+			return nil, errors.Wrap(err, "scanning commit row for child")
+		}
+		children = append(children, row)
+	}
+	if len(children) == 0 { // QueryxContext does not return an error when the query returns 0 rows.
+		return nil, &ChildCommitNotFoundError{ParentRowID: parentCommit}
+	}
+	return children, nil
+}
+
+func getCommitRelativeRows(ctx context.Context, tx *pachsql.Tx, commitID CommitID) (*Commit, []*Commit, error) {
+	commitParentRows, err := getCommitParentRow(ctx, tx, commitID)
+	if err != nil && !errors.As(err, &ParentCommitNotFoundError{ChildRowID: commitID}) {
+		return nil, nil, errors.Wrap(err, "getting parent commit")
+		// if parent is missing, assume commit is root of a repo.
+	}
+	commitChildrenRows, err := getCommitChildrenRows(ctx, tx, commitID)
+	if err != nil && !errors.As(err, &ChildCommitNotFoundError{ParentRowID: commitID}) {
+		return nil, nil, errors.Wrap(err, "getting children commits")
+		// if children is missing, assume commit is HEAD of some branch.
+	}
+	return commitParentRows, commitChildrenRows, nil
+}
+
+func getCommitRowByCommitKey(ctx context.Context, tx *pachsql.Tx, commit *pfs.Commit) (*Commit, error) {
+	row := &Commit{}
+	if commit == nil {
+		return nil, &CommitMissingInfoError{Field: "Commit"}
+	}
+	id := CommitKey(commit)
+	err := tx.QueryRowxContext(ctx, fmt.Sprintf("%s WHERE commit_id=$1", getCommit), id).StructScan(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			_, err := GetRepoByName(ctx, tx, commit.Repo.Project.Name, commit.Repo.Name, commit.Repo.Type)
+			if err != nil {
+				if errors.As(err, new(*RepoNotFoundError)) {
+					return nil, errors.Join(err, &CommitNotFoundError{CommitID: id})
+				}
+				return nil, errors.Wrapf(err, "get repo for scan commit row with commit id %v", id)
+			}
+			return nil, &CommitNotFoundError{CommitID: id}
+		}
+		return nil, errors.Wrap(err, "scanning commit row")
+	}
+	return row, nil
+}
+
+func parseCommitInfoFromRow(row *Commit) *pfs.CommitInfo {
+	commitInfo := &pfs.CommitInfo{
+		Commit:      row.Pb(),
+		Origin:      &pfs.CommitOrigin{Kind: pfs.OriginKind(pfs.OriginKind_value[strings.ToUpper(row.Origin)])},
+		Started:     pbutil.TimeToTimestamppb(row.StartTime),
+		Finishing:   pbutil.TimeToTimestamppb(row.FinishingTime),
+		Finished:    pbutil.TimeToTimestamppb(row.FinishedTime),
+		Description: row.Description,
+		Error:       row.Error,
+		Details: &pfs.CommitInfo_Details{
+			CompactingTime: pbutil.BigIntToDurationpb(row.CompactingTime),
+			ValidatingTime: pbutil.BigIntToDurationpb(row.ValidatingTime),
+			SizeBytes:      row.Size,
+		},
+	}
+	return commitInfo
+}
+
+// CommitWithID is returned by the commit iterator.
+type CommitWithID struct {
+	ID         CommitID
+	CommitInfo *pfs.CommitInfo
+	Revision   int64
+}
+
+// this dropped global variable instantiation forces the compiler to check whether CommitIterator implements stream.Iterator.
+var _ stream.Iterator[CommitWithID] = &CommitIterator{}
+
+// commitColumn is used in the ForEachCommit filter and defines specific field names for type safety.
+// This should hopefully prevent a library user from misconfiguring the filter.
+type commitColumn string
+
+var (
+	CommitColumnID        = commitColumn("commit.int_id")
+	CommitColumnSetID     = commitColumn("commit.commit_set_id")
+	CommitColumnRepoID    = commitColumn("commit.repo_id")
+	CommitColumnOrigin    = commitColumn("commit.origin")
+	CommitColumnCreatedAt = commitColumn("commit.created_at")
+	CommitColumnUpdatedAt = commitColumn("commit.updated_at")
+)
+
+type OrderByCommitColumn OrderByColumn[commitColumn]
+
+type CommitIterator struct {
+	paginator pageIterator[Commit]
+	extCtx    sqlx.ExtContext
+}
+
+func (i *CommitIterator) Next(ctx context.Context, dst *CommitWithID) error {
+	if dst == nil {
+		return errors.Errorf("dst CommitInfo cannot be nil")
+	}
+	commit, rev, err := i.paginator.next(ctx, i.extCtx)
+	if err != nil {
+		return err
+	}
+	commitInfo, err := getCommitInfoFromCommitRow(ctx, i.extCtx, commit)
+	if err != nil {
+		return err
+	}
+	dst.ID = commit.ID
+	dst.CommitInfo = commitInfo
+	dst.Revision = rev
+	return nil
+}
+
+func NewCommitsIterator(ctx context.Context, extCtx sqlx.ExtContext, startPage, pageSize uint64, filter *pfs.Commit, orderBys ...OrderByCommitColumn) (*CommitIterator, error) {
+	var conditions []string
+	var values []any
+	// Note that using ? as the bindvar is okay because we rebind it later.
+	if filter != nil {
+		if filter.Repo != nil && filter.Repo.Name != "" {
+			conditions = append(conditions, "repo.name = ?")
+			values = append(values, filter.Repo.Name)
+		}
+		if filter.Repo != nil && filter.Repo.Type != "" {
+			conditions = append(conditions, "repo.type = ?")
+			values = append(values, filter.Repo.Type)
+		}
+		if filter.Repo != nil && filter.Repo.Project != nil && filter.Repo.Project.Name != "" {
+			conditions = append(conditions, "project.name = ?")
+			values = append(values, filter.Repo.Project.Name)
+		}
+		if filter.Id != "" {
+			conditions = append(conditions, "commit.commit_set_id = ?")
+			values = append(values, filter.Id)
+		}
+		if filter.Branch != nil && filter.Branch.Name != "" {
+			conditions = append(conditions, "branch.name = ?")
+			values = append(values, filter.Branch.Name)
+		}
+	}
+	query := getCommit
+	if len(conditions) > 0 {
+		query += "\n" + fmt.Sprintf("WHERE %s", strings.Join(conditions, " AND "))
+	}
+	// Compute ORDER BY
+	var orderByGeneric []OrderByColumn[commitColumn]
+	if len(orderBys) == 0 {
+		orderByGeneric = []OrderByColumn[commitColumn]{{Column: CommitColumnID, Order: SortOrderAsc}}
+	} else {
+		for _, orderBy := range orderBys {
+			orderByGeneric = append(orderByGeneric, OrderByColumn[commitColumn](orderBy))
+		}
+	}
+	query += "\n" + OrderByQuery[commitColumn](orderByGeneric...)
+	query = extCtx.Rebind(query)
+	return &CommitIterator{
+		paginator: newPageIterator[Commit](ctx, query, values, startPage, pageSize),
+		extCtx:    extCtx,
+	}, nil
+}
+
+func ForEachCommit(ctx context.Context, db *pachsql.DB, filter *pfs.Commit, cb func(commitWithID CommitWithID) error, orderBys ...OrderByCommitColumn) error {
+	iter, err := NewCommitsIterator(ctx, db, 0, 100, filter, orderBys...)
+	if err != nil {
+		return errors.Wrap(err, "for each commit")
+	}
+	if err := stream.ForEach[CommitWithID](ctx, iter, cb); err != nil {
+		return errors.Wrap(err, "for each commit")
+	}
+	return nil
+}
+
+func ForEachCommitTxByFilter(ctx context.Context, tx *pachsql.Tx, filter *pfs.Commit, cb func(commitWithID CommitWithID) error, orderBys ...OrderByCommitColumn) error {
+	if filter == nil {
+		return errors.Errorf("filter cannot be empty")
+	}
+	iter, err := NewCommitsIterator(ctx, tx, 0, commitsPageSize, filter, orderBys...)
+	if err != nil {
+		return errors.Wrap(err, "for each commit tx by filter")
+	}
+	if err := stream.ForEach[CommitWithID](ctx, iter, func(commitWithID CommitWithID) error {
+		return cb(commitWithID)
+	}); err != nil {
+		return errors.Wrap(err, "for each commit tx by filter")
+	}
+	return nil
+}
+
+func ListCommitTxByFilter(ctx context.Context, tx *pachsql.Tx, filter *pfs.Commit, orderBys ...OrderByCommitColumn) ([]*pfs.CommitInfo, error) {
+	var commits []*pfs.CommitInfo
+	if err := ForEachCommitTxByFilter(ctx, tx, filter, func(commitWithID CommitWithID) error {
+		commits = append(commits, commitWithID.CommitInfo)
+		return nil
+	}, orderBys...); err != nil {
+		return nil, errors.Wrap(err, "list commits tx by filter")
+	}
+	return commits, nil
+}
+
+// Helper functions for watching commits.
+type commitUpsertHandler func(id CommitID, commitInfo *pfs.CommitInfo) error
+type commitDeleteHandler func(id CommitID) error
+
+// WatchCommits creates a watcher and watches the pfs.commits table for changes.
+func WatchCommits(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString("watch-commits-"), CommitsChannelName)
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	snapshot, err := NewCommitsIterator(ctx, db, 0, commitsPageSize, nil, OrderByCommitColumn{Column: CommitColumnID, Order: SortOrderAsc})
+	if err != nil {
+		return err
+	}
+	return watchCommits(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+// WatchCommitsInRepo creates a watcher and watches for commits in a repo.
+func WatchCommitsInRepo(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, repoID RepoID, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString(fmt.Sprintf("watch-commits-in-repo-%d", repoID)), CommitsInRepoChannel(repoID))
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	// Optimized query for getting commits in a repo.
+	query := getCommit + fmt.Sprintf(" WHERE %s = ?  ORDER BY %s ASC", CommitColumnRepoID, CommitColumnID)
+	query = db.Rebind(query)
+	snapshot := &CommitIterator{paginator: newPageIterator[Commit](ctx, query, []any{repoID}, 0, commitsPageSize), extCtx: db}
+	return watchCommits(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+// WatchCommit creates a watcher and watches for changes to a single commit.
+func WatchCommit(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, commitID CommitID, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString(fmt.Sprintf("watch-commit-%d-", commitID)), fmt.Sprintf("%s%d", CommitChannelName, commitID))
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	var commitWithID CommitWithID
+	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
+		commitInfo, err := GetCommit(ctx, tx, commitID)
+		if err != nil {
+			return errors.Wrap(err, "watch commit")
+		}
+		commitWithID = CommitWithID{ID: commitID, CommitInfo: commitInfo}
+		return nil
+	}); err != nil {
+		return err
+	}
+	snapshot := stream.NewSlice([]CommitWithID{commitWithID})
+	return watchCommits(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+func watchCommits(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator[CommitWithID], events <-chan *postgres.Event, onUpsert commitUpsertHandler, onDelete commitDeleteHandler) error {
+	// Handle snapshot
+	if err := stream.ForEach[CommitWithID](ctx, snapshot, func(commitWith CommitWithID) error {
+		return onUpsert(commitWith.ID, commitWith.CommitInfo)
+	}); err != nil {
+		return err
+	}
+	// Handle delta
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return errors.Errorf("watcher closed")
+			}
+			if event.Err != nil {
+				return event.Err
+			}
+			id := CommitID(event.Id)
+			switch event.Type {
+			case postgres.EventDelete:
+				if err := onDelete(id); err != nil {
+					return err
+				}
+			case postgres.EventInsert, postgres.EventUpdate:
+				var commitInfo *pfs.CommitInfo
+				if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
+					var err error
+					commitInfo, err = GetCommit(ctx, tx, id)
+					if err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := onUpsert(id, commitInfo); err != nil {
+					return err
+				}
+			default:
+				return errors.Errorf("unknown event type: %v", event.Type)
+			}
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "watcher cancelled")
+		}
+	}
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/common.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/common.go
@@ -1,0 +1,109 @@
+package pfsdb_28x
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+)
+
+type sortOrder string
+
+const (
+	SortOrderNone = sortOrder("")
+	SortOrderAsc  = sortOrder("ASC")
+	SortOrderDesc = sortOrder("DESC")
+)
+
+type (
+	ModelType interface {
+		Repo | Commit | Branch | Project
+		GetCreatedAtUpdatedAt() CreatedAtUpdatedAt
+	}
+	ColumnName interface {
+		string | projectColumn | branchColumn | commitColumn | repoColumn
+	}
+)
+
+type OrderByColumn[T ColumnName] struct {
+	Column T
+	Order  sortOrder
+}
+
+func OrderByQuery[T ColumnName](orderBys ...OrderByColumn[T]) string {
+	if len(orderBys) == 0 {
+		return ""
+	}
+	values := make([]string, len(orderBys))
+	for i, col := range orderBys {
+		values[i] = fmt.Sprintf("%s %s", col.Column, col.Order)
+	}
+	return "ORDER BY " + strings.Join(values, ", ")
+}
+
+type pageIterator[T ModelType] struct {
+	query         string
+	values        []any
+	limit, offset uint64
+	page          []T
+	pageIdx       int
+	lastTimestamp time.Time
+	revision      int64
+}
+
+func newPageIterator[T ModelType](ctx context.Context, query string, values []any, startPage, pageSize uint64) pageIterator[T] {
+	return pageIterator[T]{
+		query:    query,
+		values:   values,
+		revision: -1, // first revision should be 0 and we increment before returning.
+		limit:    pageSize,
+		offset:   startPage * pageSize,
+	}
+}
+
+func (i *pageIterator[T]) nextPage(ctx context.Context, extCtx sqlx.ExtContext) (err error) {
+	var page []T
+	query := i.query + fmt.Sprintf("\nLIMIT %d OFFSET %d", i.limit, i.offset)
+	if err := sqlx.SelectContext(ctx, extCtx, &page, query, i.values...); err != nil {
+		return errors.Wrap(err, "getting page")
+	}
+	if len(page) == 0 {
+		return stream.EOS()
+	}
+	i.page = page
+	i.pageIdx = 0
+	i.offset += i.limit
+	return nil
+}
+
+func (i *pageIterator[T]) hasNext() bool {
+	return i.pageIdx < len(i.page)
+}
+
+func (i *pageIterator[T]) next(ctx context.Context, extCtx sqlx.ExtContext) (*T, int64, error) {
+	if !i.hasNext() {
+		if err := i.nextPage(ctx, extCtx); err != nil {
+			return nil, 0, err
+		}
+	}
+	t := i.page[i.pageIdx]
+	createdAt := t.GetCreatedAtUpdatedAt().CreatedAt
+	if i.lastTimestamp.Before(createdAt) {
+		i.revision++
+		i.lastTimestamp = createdAt
+	}
+	i.pageIdx++
+	return &t, i.revision, nil
+}
+
+func IsNotFoundError(err error) bool {
+	return errors.As(err, &RepoNotFoundError{}) ||
+		errors.As(err, &ProjectNotFoundError{}) ||
+		errors.As(err, &CommitNotFoundError{}) ||
+		errors.As(err, &BranchNotFoundError{})
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/model.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/model.go
@@ -1,0 +1,188 @@
+package pfsdb_28x
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+// A separate type is defined for safety so row ids must be explicitly cast for use in another table.
+
+// ProjectID is the row id for a project entry in postgres.
+type ProjectID uint64
+
+// RepoID is the row id for a repo entry in postgres.
+type RepoID uint64
+
+// CommitID is the row id for a commit entry in postgres.
+type CommitID uint64
+
+// BranchID is the row id for a branch entry in postgres.
+type BranchID uint64
+
+type CreatedAtUpdatedAt struct {
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+type Project struct {
+	ID          ProjectID `db:"id"`
+	Name        string    `db:"name"`
+	Description string    `db:"description"`
+	CreatedAtUpdatedAt
+}
+
+func (project *Project) Pb() *pfs.Project {
+	return &pfs.Project{
+		Name: project.Name,
+	}
+}
+
+func (project *Project) PbInfo() *pfs.ProjectInfo {
+	return &pfs.ProjectInfo{
+		Project: &pfs.Project{
+			Name: project.Name,
+		},
+		Description: project.Description,
+		CreatedAt:   timestamppb.New(project.CreatedAt),
+	}
+}
+
+func (project Project) GetCreatedAtUpdatedAt() CreatedAtUpdatedAt {
+	return project.CreatedAtUpdatedAt
+}
+
+// Repo is a row in the pfs.repos table.
+type Repo struct {
+	ID          RepoID  `db:"id"`
+	Project     Project `db:"project"`
+	Name        string  `db:"name"`
+	Type        string  `db:"type"`
+	Description string  `db:"description"`
+	CreatedAtUpdatedAt
+	BranchesNames string `db:"branches"`
+}
+
+func (repo Repo) GetCreatedAtUpdatedAt() CreatedAtUpdatedAt {
+	return repo.CreatedAtUpdatedAt
+}
+
+func (repo *Repo) Pb() *pfs.Repo {
+	return &pfs.Repo{
+		Name:    repo.Name,
+		Type:    repo.Type,
+		Project: repo.Project.Pb(),
+	}
+}
+
+func (repo *Repo) PbInfo() (*pfs.RepoInfo, error) {
+	branches, err := parseBranches(repo)
+	if err != nil {
+		return nil, err
+	}
+	return &pfs.RepoInfo{
+		Repo:        repo.Pb(),
+		Description: repo.Description,
+		Branches:    branches,
+		Created:     timestamppb.New(repo.CreatedAt),
+	}, nil
+}
+
+func parseBranches(repo *Repo) ([]*pfs.Branch, error) {
+	var branches []*pfs.Branch
+	if repo.BranchesNames == noBranches {
+		return branches, nil
+	}
+	// after aggregation, braces, quotes, and leading hex prefixes need to be removed from the encoded branch strings.
+	for _, branchName := range strings.Split(strings.Trim(repo.BranchesNames, "{}"), ",") {
+		branch := &pfs.Branch{
+			Name: branchName,
+			Repo: repo.Pb(),
+		}
+		branches = append(branches, branch)
+	}
+	return branches, nil
+}
+
+type Commit struct {
+	ID             CommitID      `db:"int_id"`
+	CommitSetID    string        `db:"commit_set_id"`
+	CommitID       string        `db:"commit_id"`
+	Origin         string        `db:"origin"`
+	Description    string        `db:"description"`
+	StartTime      sql.NullTime  `db:"start_time"`
+	FinishingTime  sql.NullTime  `db:"finishing_time"`
+	FinishedTime   sql.NullTime  `db:"finished_time"`
+	CompactingTime sql.NullInt64 `db:"compacting_time_s"`
+	ValidatingTime sql.NullInt64 `db:"validating_time_s"`
+	Error          string        `db:"error"`
+	Size           int64         `db:"size"`
+	// BranchName is used to derive the BranchID in commit related queries.
+	BranchName sql.NullString `db:"branch_name"`
+	BranchID   sql.NullInt64  `db:"branch_id"`
+	Repo       Repo           `db:"repo"`
+	CreatedAtUpdatedAt
+}
+
+func (commit Commit) GetCreatedAtUpdatedAt() CreatedAtUpdatedAt {
+	return commit.CreatedAtUpdatedAt
+}
+
+func (commit *Commit) Pb() *pfs.Commit {
+	pb := &pfs.Commit{
+		Id:   commit.CommitSetID,
+		Repo: commit.Repo.Pb(),
+	}
+	if commit.BranchName.Valid {
+		pb.Branch = &pfs.Branch{
+			Repo: pb.Repo,
+			Name: commit.BranchName.String,
+		}
+	}
+	return pb
+}
+
+// Branch is a row in the pfs.branches table.
+type Branch struct {
+	ID   BranchID `db:"id"`
+	Head Commit   `db:"head"`
+	Repo Repo     `db:"repo"`
+	Name string   `db:"name"`
+	CreatedAtUpdatedAt
+}
+
+func (branch Branch) GetCreatedAtUpdatedAt() CreatedAtUpdatedAt {
+	return branch.CreatedAtUpdatedAt
+}
+
+func (branch *Branch) Pb() *pfs.Branch {
+	return &pfs.Branch{
+		Name: branch.Name,
+		Repo: branch.Repo.Pb(),
+	}
+}
+
+type BranchTrigger struct {
+	FromBranch    Branch `db:"from_branch"`
+	ToBranch      Branch `db:"to_branch"`
+	CronSpec      string `db:"cron_spec"`
+	RateLimitSpec string `db:"rate_limit_spec"`
+	Size          string `db:"size"`
+	NumCommits    int64  `db:"num_commits"`
+	AllConditions bool   `db:"all_conditions"`
+}
+
+func (trigger *BranchTrigger) Pb() *pfs.Trigger {
+	return &pfs.Trigger{
+		Branch:        trigger.ToBranch.Name,
+		CronSpec:      trigger.CronSpec,
+		RateLimitSpec: trigger.RateLimitSpec,
+		Size:          trigger.Size,
+		Commits:       trigger.NumCommits,
+		All:           trigger.AllConditions,
+	}
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/pfsdb.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/pfsdb.go
@@ -1,0 +1,169 @@
+// Package pfsdb_28x contains the database schema that PFS uses.
+//
+// This is copied from src/internal/pfsdb as of v2.8.6.
+package pfsdb_28x
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	col "github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	pfsserver "github.com/pachyderm/pachyderm/v2/src/server/pfs"
+)
+
+const (
+	branchesCollectionName = "branches"
+	commitsCollectionName  = "commits"
+)
+
+func ProjectKey(project *pfs.Project) string {
+	return project.Name
+}
+
+func RepoKey(repo *pfs.Repo) string {
+	return repo.Project.Name + "/" + repo.Name + "." + repo.Type
+}
+
+func ParseRepo(key string) *pfs.Repo {
+	slashSplit := strings.Split(key, "/")
+	dotSplit := strings.Split(slashSplit[1], ".")
+	return &pfs.Repo{
+		Project: &pfs.Project{Name: slashSplit[0]},
+		Name:    dotSplit[0],
+		Type:    dotSplit[1],
+	}
+}
+
+func repoKeyCheck(key string) error {
+	parts := strings.Split(key, ".")
+	if len(parts) < 2 || len(parts[1]) == 0 {
+		return errors.Errorf("repo must have a specified type")
+	}
+	return nil
+}
+
+var CommitsRepoIndex = &col.Index{
+	Name: "repo",
+	Extract: func(val proto.Message) string {
+		return RepoKey(val.(*pfs.CommitInfo).Commit.Repo)
+	},
+}
+
+var CommitsBranchlessIndex = &col.Index{
+	Name: "branchless",
+	Extract: func(val proto.Message) string {
+		return CommitKey(val.(*pfs.CommitInfo).Commit)
+	},
+}
+
+var CommitsCommitSetIndex = &col.Index{
+	Name: "commitset",
+	Extract: func(val proto.Message) string {
+		return val.(*pfs.CommitInfo).Commit.Id
+	},
+}
+
+var commitsIndexes = []*col.Index{CommitsRepoIndex, CommitsBranchlessIndex, CommitsCommitSetIndex}
+
+func ParseCommit(key string) *pfs.Commit {
+	split := strings.Split(key, "@")
+	return &pfs.Commit{
+		Repo: ParseRepo(split[0]),
+		Id:   split[1],
+	}
+}
+
+func CommitKey(commit *pfs.Commit) string {
+	return RepoKey(commit.Repo) + "@" + commit.Id
+}
+
+// Commits returns a collection of commits
+func Commits(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
+	return col.NewPostgresCollection(
+		commitsCollectionName,
+		db,
+		listener,
+		&pfs.CommitInfo{},
+		commitsIndexes,
+		col.WithKeyGen(func(key interface{}) (string, error) {
+			if commit, ok := key.(*pfs.Commit); !ok {
+				return "", errors.New("key must be a commit")
+			} else {
+				return CommitKey(commit), nil
+			}
+		}),
+		col.WithNotFoundMessage(func(key interface{}) string {
+			return pfsserver.ErrCommitNotFound{Commit: key.(*pfs.Commit)}.Error()
+		}),
+		col.WithExistsMessage(func(key interface{}) string {
+			return pfsserver.ErrCommitExists{Commit: key.(*pfs.Commit)}.Error()
+		}),
+		col.WithPutHook(func(tx *pachsql.Tx, commitInfo interface{}) error {
+			ci := commitInfo.(*pfs.CommitInfo)
+			if ci.Commit.Repo == nil {
+				return errors.New("Commits must have the repo field populated")
+			}
+			return AddCommit(tx, ci.Commit)
+		}),
+	)
+}
+
+var BranchesRepoIndex = &col.Index{
+	Name: "repo",
+	Extract: func(val proto.Message) string {
+		return RepoKey(val.(*pfs.BranchInfo).Branch.Repo)
+	},
+}
+
+var branchesIndexes = []*col.Index{BranchesRepoIndex}
+
+func ParseBranch(key string) *pfs.Branch {
+	split := strings.Split(key, "@")
+	return &pfs.Branch{
+		Repo: ParseRepo(split[0]),
+		Name: split[1],
+	}
+}
+
+func BranchKey(branch *pfs.Branch) string {
+	return RepoKey(branch.Repo) + "@" + branch.Name
+}
+
+// Branches returns a collection of branches
+func Branches(db *pachsql.DB, listener col.PostgresListener) col.PostgresCollection {
+	return col.NewPostgresCollection(
+		branchesCollectionName,
+		db,
+		listener,
+		&pfs.BranchInfo{},
+		branchesIndexes,
+		col.WithKeyGen(func(key interface{}) (string, error) {
+			if branch, ok := key.(*pfs.Branch); !ok {
+				return "", errors.New("key must be a branch")
+			} else {
+				return BranchKey(branch), nil
+			}
+		}),
+		col.WithKeyCheck(func(key string) error {
+			keyParts := strings.Split(key, "@")
+			if len(keyParts) != 2 {
+				return errors.Errorf("branch key %s isn't valid, use BranchKey to generate it", key)
+			}
+			if uuid.IsUUIDWithoutDashes(keyParts[1]) {
+				return errors.Errorf("branch name cannot be a UUID V4")
+			}
+			return repoKeyCheck(keyParts[0])
+		}),
+		col.WithNotFoundMessage(func(key interface{}) string {
+			return pfsserver.ErrBranchNotFound{Branch: key.(*pfs.Branch)}.Error()
+		}),
+		col.WithExistsMessage(func(key interface{}) string {
+			return pfsserver.ErrBranchExists{Branch: key.(*pfs.Branch)}.Error()
+		}),
+	)
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/projects.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/projects.go
@@ -1,0 +1,247 @@
+package pfsdb_28x
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+// ProjectNotFoundError is returned by GetProject() when a project is not found in postgres.
+type ProjectNotFoundError struct {
+	Name string
+	ID   ProjectID
+}
+
+// Error satisfies the error interface.
+func (err *ProjectNotFoundError) Error() string {
+	if n := err.Name; n != "" {
+		return fmt.Sprintf("project %q not found", n)
+	}
+	if id := err.ID; id != 0 {
+		return fmt.Sprintf("project id=%d not found", id)
+	}
+	return "project not found"
+}
+
+func (err *ProjectNotFoundError) Is(other error) bool {
+	_, ok := other.(*ProjectNotFoundError)
+	return ok
+}
+
+func (err *ProjectNotFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, err.Error())
+}
+
+// ProjectAlreadyExistsError is returned by CreateProject() when a project with the same name already exists in postgres.
+type ProjectAlreadyExistsError struct {
+	Name string
+}
+
+// Error satisfies the error interface.
+func (err *ProjectAlreadyExistsError) Error() string {
+	if n := err.Name; n != "" {
+		return fmt.Sprintf("project %q already exists", n)
+	}
+
+	return "project already exists"
+}
+
+func (err *ProjectAlreadyExistsError) Is(other error) bool {
+	_, ok := other.(*ProjectAlreadyExistsError)
+	return ok
+}
+
+func (err *ProjectAlreadyExistsError) GRPCStatus() *status.Status {
+	return status.New(codes.AlreadyExists, err.Error())
+}
+
+func IsErrProjectAlreadyExists(err error) bool {
+	return strings.Contains(err.Error(), "SQLSTATE 23505")
+}
+
+type projectColumn string
+
+var (
+	ProjectColumnID        = projectColumn("project.id")
+	ProjectColumnCreatedAt = projectColumn("project.created_at")
+	ProjectColumnUpdatedAt = projectColumn("project.updated_at")
+)
+
+type OrderByProjectColumn OrderByColumn[projectColumn]
+
+type ProjectIterator struct {
+	paginator pageIterator[Project]
+	extCtx    sqlx.ExtContext
+}
+
+type ProjectWithID struct {
+	ProjectInfo *pfs.ProjectInfo
+	ID          ProjectID
+	Revision    int64
+}
+
+func (i *ProjectIterator) Next(ctx context.Context, dst *ProjectWithID) error {
+	if dst == nil {
+		return errors.Errorf("dst ProjectInfo cannot be nil")
+	}
+	project, rev, err := i.paginator.next(ctx, i.extCtx)
+	if err != nil {
+		return err
+	}
+	projectInfo := project.PbInfo()
+	dst.ID = project.ID
+	dst.ProjectInfo = projectInfo
+	dst.Revision = rev
+	return nil
+}
+
+func NewProjectIterator(ctx context.Context, extCtx sqlx.ExtContext, startPage, pageSize uint64, filter *pfs.Project, orderBys ...OrderByProjectColumn) (*ProjectIterator, error) {
+	var conditions []string
+	var values []any
+	if filter != nil {
+		if filter.Name != "" {
+			conditions = append(conditions, "project.name = ?")
+			values = append(values, filter.Name)
+		}
+	}
+	query := "SELECT id,name,description,created_at FROM core.projects project"
+	if len(conditions) > 0 {
+		query += "\n" + fmt.Sprintf("WHERE %s", strings.Join(conditions, " AND "))
+	}
+	// Compute ORDER BY
+	var orderByGeneric []OrderByColumn[projectColumn]
+	if len(orderBys) == 0 {
+		orderByGeneric = []OrderByColumn[projectColumn]{{Column: ProjectColumnID, Order: SortOrderAsc}}
+	} else {
+		for _, orderBy := range orderBys {
+			orderByGeneric = append(orderByGeneric, OrderByColumn[projectColumn](orderBy))
+		}
+	}
+	query += "\n" + OrderByQuery[projectColumn](orderByGeneric...)
+	query = extCtx.Rebind(query)
+	return &ProjectIterator{
+		paginator: newPageIterator[Project](ctx, query, values, startPage, pageSize),
+		extCtx:    extCtx,
+	}, nil
+}
+
+func ForEachProject(ctx context.Context, tx *pachsql.Tx, cb func(projectWithID ProjectWithID) error) error {
+	iter, err := NewProjectIterator(ctx, tx, 0, 100, nil)
+	if err != nil {
+		return errors.Wrap(err, "for each project")
+	}
+	if err = stream.ForEach[ProjectWithID](ctx, iter, cb); err != nil {
+		return errors.Wrap(err, "for each project")
+	}
+	return nil
+}
+
+func ListProject(ctx context.Context, tx *pachsql.Tx) ([]ProjectWithID, error) {
+	var projects []ProjectWithID
+	if err := ForEachProject(ctx, tx, func(projectWithID ProjectWithID) error {
+		projects = append(projects, projectWithID)
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "list project")
+	}
+	return projects, nil
+}
+
+// CreateProject creates an entry in the core.projects table.
+func CreateProject(ctx context.Context, tx *pachsql.Tx, project *pfs.ProjectInfo) error {
+	_, err := tx.ExecContext(ctx, "INSERT INTO core.projects (name, description) VALUES ($1, $2);", project.Project.Name, project.Description)
+	//todo: insert project.authInfo into auth table.
+	if err != nil && IsErrProjectAlreadyExists(err) {
+		return &ProjectAlreadyExistsError{Name: project.Project.Name}
+	}
+	return errors.Wrap(err, "create project")
+}
+
+// DeleteProject deletes an entry in the core.projects table.
+func DeleteProject(ctx context.Context, tx *pachsql.Tx, projectName string) error {
+	result, err := tx.ExecContext(ctx, "DELETE FROM core.projects WHERE name = $1;", projectName)
+	if err != nil {
+		return errors.Wrap(err, "delete project")
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "could not get affected rows")
+	}
+	if rowsAffected == 0 {
+		return &ProjectNotFoundError{
+			Name: projectName,
+		}
+	}
+	return nil
+}
+
+// GetProject is like GetProjectByName, but retrieves an entry using the row id.
+func GetProject(ctx context.Context, tx *pachsql.Tx, id ProjectID) (*pfs.ProjectInfo, error) {
+	return getProject(ctx, tx, "id", id)
+}
+
+// GetProjectByName retrieves an entry from the core.projects table by project name.
+func GetProjectByName(ctx context.Context, tx *pachsql.Tx, projectName string) (*pfs.ProjectInfo, error) {
+	return getProject(ctx, tx, "name", projectName)
+}
+
+func getProject(ctx context.Context, tx *pachsql.Tx, where string, whereVal interface{}) (*pfs.ProjectInfo, error) {
+	row := tx.QueryRowxContext(ctx, fmt.Sprintf("SELECT name, description, created_at FROM core.projects WHERE %s = $1", where), whereVal)
+	project := &pfs.ProjectInfo{Project: &pfs.Project{}}
+	var createdAt time.Time
+	err := row.Scan(&project.Project.Name, &project.Description, &createdAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			if name, ok := whereVal.(string); ok {
+				return nil, &ProjectNotFoundError{Name: name}
+			}
+			return nil, &ProjectNotFoundError{ID: whereVal.(ProjectID)}
+		}
+		return nil, errors.Wrap(err, "scanning project row")
+	}
+	project.CreatedAt = timestamppb.New(createdAt)
+	return project, nil
+}
+
+// UpsertProject updates all fields of an existing project entry in the core.projects table by name. If 'upsert' is set to true, UpsertProject()
+// will attempt to call CreateProject() if the entry does not exist.
+func UpsertProject(ctx context.Context, tx *pachsql.Tx, project *pfs.ProjectInfo) error {
+	return updateProject(ctx, tx, project, "name", project.Project.Name, true)
+}
+
+// UpdateProject overwrites an existing project entry by ID.
+func UpdateProject(ctx context.Context, tx *pachsql.Tx, id ProjectID, project *pfs.ProjectInfo) error {
+	return updateProject(ctx, tx, project, "id", id, false)
+}
+
+func updateProject(ctx context.Context, tx *pachsql.Tx, project *pfs.ProjectInfo, where string, whereVal interface{}, upsert bool) error {
+	res, err := tx.ExecContext(ctx, fmt.Sprintf("UPDATE core.projects SET name = $1, description = $2 WHERE %s = $3;", where),
+		project.Project.Name, project.Description, whereVal)
+	if err != nil {
+		return errors.Wrap(err, "update project")
+	}
+	numRows, err := res.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "get affected rows")
+	}
+	if numRows == 0 {
+		if upsert {
+			return CreateProject(ctx, tx, project)
+		}
+		return errors.New(fmt.Sprintf("%s not found in core.projects", project.Project.Name))
+	}
+	return nil
+}

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/repos.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/repos.go
@@ -1,0 +1,349 @@
+package pfsdb_28x
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgconn"
+	"github.com/jmoiron/sqlx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/collection"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/stream"
+	"github.com/pachyderm/pachyderm/v2/src/internal/watch/postgres"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+)
+
+const (
+	// ReposChannelName is used to watch events for the repos table.
+	ReposChannelName = "pfs_repos"
+
+	getRepoAndBranches = `
+		SELECT
+			repo.id,
+			repo.name,
+			repo.type,
+			repo.description,
+			repo.project_id AS "project.id",
+			project.name AS "project.name",
+			array_agg(branch.name) AS "branches",
+			repo.created_at,
+			repo.updated_at
+		FROM pfs.repos repo 
+			JOIN core.projects project ON repo.project_id = project.id
+			LEFT JOIN pfs.branches branch ON branch.repo_id = repo.id
+	`
+	noBranches    = "{NULL}"
+	reposPageSize = 100
+)
+
+// RepoNotFoundError is returned by GetRepo() when a repo is not found in postgres.
+type RepoNotFoundError struct {
+	Project string
+	Name    string
+	Type    string
+	ID      RepoID
+}
+
+// Error satisfies the error interface.
+func (err *RepoNotFoundError) Error() string {
+	return fmt.Sprintf("repo (id=%d, project=%s, name=%s, type=%s) not found", err.ID, err.Project, err.Name, err.Type)
+}
+
+func (err *RepoNotFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, err.Error())
+}
+
+func IsErrRepoNotFound(err error) bool {
+	return errors.As(err, &RepoNotFoundError{})
+}
+
+func IsDuplicateKeyErr(err error) bool {
+	targetErr := &pgconn.PgError{}
+	ok := errors.As(err, targetErr)
+	if !ok {
+		return false
+	}
+	return targetErr.Code == "23505" // duplicate key SQLSTATE
+}
+
+// RepoInfoWithID is an (id, repoInfo) tuple returned by the repo iterator.
+type RepoInfoWithID struct {
+	ID       RepoID
+	RepoInfo *pfs.RepoInfo
+	Revision int64
+}
+
+// this dropped global variable instantiation forces the compiler to check whether RepoIterator implements stream.Iterator.
+var _ stream.Iterator[RepoInfoWithID] = &RepoIterator{}
+
+// DeleteRepo deletes an entry in the pfs.repos table.
+func DeleteRepo(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repoType string) error {
+	result, err := tx.ExecContext(ctx, "DELETE FROM pfs.repos "+
+		"WHERE project_id=(SELECT id FROM core.projects WHERE name=$1) AND name=$2 AND type=$3;", repoProject, repoName, repoType)
+	if err != nil {
+		return errors.Wrap(err, "delete repo")
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "could not get affected rows")
+	}
+	if rowsAffected == 0 {
+		if _, err := GetProjectByName(ctx, tx, repoProject); err != nil {
+			if errors.As(err, new(*ProjectNotFoundError)) {
+				return errors.Join(err, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType})
+			}
+			return errors.Wrapf(err, "could not get project %v for delete repo", repoProject)
+		}
+		return &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType}
+	}
+	return nil
+}
+
+func GetRepoID(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repoType string) (RepoID, error) {
+	row, err := getRepoByName(ctx, tx, repoProject, repoName, repoType)
+	if err != nil {
+		return 0, err
+	}
+	return row.ID, nil
+}
+
+// todo(fahad): rewrite branch related code during the branches migration.
+// GetRepo retrieves an entry from the pfs.repos table by using the row id.
+func GetRepo(ctx context.Context, tx *pachsql.Tx, id RepoID) (*pfs.RepoInfo, error) {
+	if id == 0 {
+		return nil, errors.New("invalid id: 0")
+	}
+	repo := &Repo{}
+	err := tx.GetContext(ctx, repo, fmt.Sprintf("%s WHERE repo.id=$1 GROUP BY repo.id, project.name, project.id;", getRepoAndBranches), id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &RepoNotFoundError{ID: id}
+		}
+		return nil, errors.Wrap(err, "scanning repo row")
+	}
+	return repo.PbInfo()
+}
+
+// GetRepoByName retrieves an entry from the pfs.repos table by project, repo name, and type.
+func GetRepoByName(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repoType string) (*pfs.RepoInfo, error) {
+	repo, err := getRepoByName(ctx, tx, repoProject, repoName, repoType)
+	if err != nil {
+		return nil, err
+	}
+	return repo.PbInfo()
+}
+
+func getRepoByName(ctx context.Context, tx *pachsql.Tx, repoProject, repoName, repoType string) (*Repo, error) {
+	if repoProject == "" {
+		repoProject = pfs.DefaultProjectName
+	}
+	repo := &Repo{}
+	if err := tx.GetContext(ctx, repo,
+		fmt.Sprintf("%s WHERE repo.project_id=(SELECT id from core.projects where name=$1) "+
+			"AND repo.name=$2 AND repo.type=$3 GROUP BY repo.id, project.name, project.id;", getRepoAndBranches),
+		repoProject, repoName, repoType,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			if _, err := GetProjectByName(ctx, tx, repoProject); err != nil {
+				if errors.As(err, new(*ProjectNotFoundError)) {
+					return nil, errors.Join(err, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType})
+				}
+				return nil, errors.Wrapf(err, "could not get project for get repo", repoProject)
+			}
+			return nil, &RepoNotFoundError{Project: repoProject, Name: repoName, Type: repoType}
+		}
+		return nil, errors.Wrap(err, "scanning repo row")
+	}
+	return repo, nil
+}
+
+// UpsertRepo will attempt to insert a repo, and return its ID. If the repo already exists, it will update its description.
+func UpsertRepo(ctx context.Context, tx *pachsql.Tx, repo *pfs.RepoInfo) (RepoID, error) {
+	if repo.Repo.Name == "" {
+		return 0, errors.Errorf("repo name is required: %+v", repo.Repo)
+	}
+	if repo.Repo.Type == "" {
+		return 0, errors.Errorf("repo type is required: %+v", repo.Repo)
+	}
+	if repo.Repo.Project == nil {
+		return 0, errors.Errorf("project is required: %+v", repo.Repo)
+	}
+	var repoID RepoID
+	if err := tx.QueryRowContext(ctx,
+		`
+		INSERT INTO pfs.repos (name, type, project_id, description)
+		VALUES ($1, $2, (SELECT id from core.projects where name=$3), $4)
+		ON CONFLICT (name, type, project_id) DO UPDATE SET description= EXCLUDED.description
+		RETURNING id
+		`,
+		repo.Repo.Name, repo.Repo.Type, repo.Repo.Project.Name, repo.Description,
+	).Scan(&repoID); err != nil {
+		return 0, errors.Wrap(err, "upsert repo")
+	}
+	return repoID, nil
+}
+
+type repoColumn string
+
+const (
+	RepoColumnID        = repoColumn("repo.id")
+	RepoColumnCreatedAt = repoColumn("repo.created_at")
+	RepoColumnUpdatedAt = repoColumn("repo.updated_at")
+)
+
+type OrderByRepoColumn OrderByColumn[repoColumn]
+
+func NewRepoIterator(ctx context.Context, ext sqlx.ExtContext, startPage, pageSize uint64, filter *pfs.Repo, orderBys ...OrderByRepoColumn) (*RepoIterator, error) {
+	var conditions []string
+	var values []any
+	if filter != nil {
+		if filter.Project != nil && filter.Project.Name != "" {
+			conditions = append(conditions, "project.name = ?")
+			values = append(values, filter.Project.Name)
+		}
+		if filter.Name != "" {
+			conditions = append(conditions, "repo.name = ?")
+			values = append(values, filter.Name)
+		}
+		if filter.Type != "" {
+			conditions = append(conditions, "repo.type = ?")
+			values = append(values, filter.Type)
+		}
+	}
+	query := getRepoAndBranches
+	if len(conditions) > 0 {
+		query += fmt.Sprintf("\nWHERE %s", strings.Join(conditions, " AND "))
+	}
+	query += "\nGROUP BY repo.id, project.name, project.id"
+	var orderByGeneric []OrderByColumn[repoColumn]
+	if len(orderBys) == 0 {
+		orderByGeneric = []OrderByColumn[repoColumn]{{Column: RepoColumnID, Order: SortOrderAsc}}
+	} else {
+		for _, orderBy := range orderBys {
+			orderByGeneric = append(orderByGeneric, OrderByColumn[repoColumn](orderBy))
+		}
+	}
+	query += "\n" + OrderByQuery[repoColumn](orderByGeneric...)
+	query = ext.Rebind(query)
+	return &RepoIterator{
+		paginator: newPageIterator[Repo](ctx, query, values, startPage, pageSize),
+		ext:       ext,
+	}, nil
+}
+
+func ForEachRepo(ctx context.Context, tx *pachsql.Tx, filter *pfs.Repo, cb func(repoWithID RepoInfoWithID) error, orderBys ...OrderByRepoColumn) error {
+	iter, err := NewRepoIterator(ctx, tx, 0, 100, filter, orderBys...)
+	if err != nil {
+		return errors.Wrap(err, "for each repo")
+	}
+	if err := stream.ForEach[RepoInfoWithID](ctx, iter, cb); err != nil {
+		return errors.Wrap(err, "for each repo")
+	}
+	return nil
+}
+
+func ListRepo(ctx context.Context, tx *pachsql.Tx, filter *pfs.Repo, orderBys ...OrderByRepoColumn) ([]RepoInfoWithID, error) {
+	var repos []RepoInfoWithID
+	if err := ForEachRepo(ctx, tx, filter, func(repoWithID RepoInfoWithID) error {
+		repos = append(repos, repoWithID)
+		return nil
+	}, orderBys...); err != nil {
+		return nil, errors.Wrap(err, "list repo")
+	}
+	return repos, nil
+}
+
+type RepoIterator struct {
+	paginator pageIterator[Repo]
+	ext       sqlx.ExtContext
+}
+
+func (i *RepoIterator) Next(ctx context.Context, dst *RepoInfoWithID) error {
+	if dst == nil {
+		return errors.Errorf("dst RepoInfo cannot be nil")
+	}
+	repo, rev, err := i.paginator.next(ctx, i.ext)
+	if err != nil {
+		return err
+	}
+	repoInfo, err := repo.PbInfo()
+	if err != nil {
+		return err
+	}
+	dst.ID = repo.ID
+	dst.RepoInfo = repoInfo
+	dst.Revision = rev
+	return nil
+}
+
+// Helper functions for watching repos.
+type repoUpsertHandler func(id RepoID, repoInfo *pfs.RepoInfo) error
+type repoDeleteHandler func(id RepoID) error
+
+func WatchRepos(ctx context.Context, db *pachsql.DB, listener collection.PostgresListener, onUpsert repoUpsertHandler, onDelete repoDeleteHandler) error {
+	watcher, err := postgres.NewWatcher(db, listener, randutil.UniqueString("watch-repos-"), ReposChannelName)
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+	snapshot, err := NewRepoIterator(ctx, db, 0, reposPageSize, nil, OrderByRepoColumn{Column: RepoColumnID, Order: SortOrderAsc})
+	if err != nil {
+		return err
+	}
+	return watchRepos(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
+}
+
+func watchRepos(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator[RepoInfoWithID], events <-chan *postgres.Event, onUpsert repoUpsertHandler, onDelete repoDeleteHandler) error {
+	// Handle snapshot.
+	if err := stream.ForEach[RepoInfoWithID](ctx, snapshot, func(r RepoInfoWithID) error {
+		return onUpsert(r.ID, r.RepoInfo)
+	}); err != nil {
+		return err
+	}
+	// Handle events.
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return errors.New("watch repos: events channel closed")
+			}
+			if event.Err != nil {
+				return event.Err
+			}
+			id := RepoID(event.Id)
+			switch event.Type {
+			case postgres.EventDelete:
+				if err := onDelete(id); err != nil {
+					return err
+				}
+			case postgres.EventInsert, postgres.EventUpdate:
+				var repoInfo *pfs.RepoInfo
+				if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
+					var err error
+					repoInfo, err = GetRepo(ctx, tx, id)
+					if err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+				if err := onUpsert(id, repoInfo); err != nil {
+					return err
+				}
+			default:
+				return errors.Errorf("unknown event type: %v", event.Type)
+			}
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "watch repos")
+		}
+	}
+}

--- a/src/internal/clusterstate/v2.8.0_test.go
+++ b/src/internal/clusterstate/v2.8.0_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 
 	v2_8_0 "github.com/pachyderm/pachyderm/v2/src/internal/clusterstate/v2.8.0"
+	pfsdb "github.com/pachyderm/pachyderm/v2/src/internal/clusterstate/v2.8.0/pfsdb_28x"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"


### PR DESCRIPTION
This adds `pfsdb` as it existed in v2.8.6 to the clusterstate directory, so that the v2.8.0 upgrade tests look at the v2.8.0 database with a v2.8.0 database library.  v2.10.x adds new columns to the tables there, so src/internal/pfsdb as it exists in v2.10.x can't be used anymore.

I deleted the tests when copying things over; the tests don't work because they migrate up to the current version, and a bunch of internal APIs they use have since changed.   I think it's cleanest to do things this way; if the 2.8.x pfsdb code needs to change, change it in that branch and then copy in the library again.