### PR TITLE
Replace require.True(cmp.Equal(...)) with require.NoDiff

### DIFF
--- a/src/internal/pfsdb/branches_test.go
+++ b/src/internal/pfsdb/branches_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -23,28 +24,13 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 )
 
-func compareHead(expected, got *pfs.Commit) bool {
-	return expected.Id == got.Id &&
-		expected.Repo.Name == got.Repo.Name &&
-		expected.Repo.Type == got.Repo.Type &&
-		expected.Repo.Project.Name == got.Repo.Project.Name
-}
-
-func compareBranch(expected, got *pfs.Branch) bool {
-	return expected.Name == got.Name &&
-		expected.Repo.Name == got.Repo.Name &&
-		expected.Repo.Type == got.Repo.Type &&
-		expected.Repo.Project.Name == got.Repo.Project.Name
-}
-
 func compareBranchOpts() []cmp.Option {
 	return []cmp.Option{
-		cmpopts.IgnoreUnexported(pfs.BranchInfo{}),
 		cmpopts.SortSlices(func(a, b *pfs.Branch) bool { return a.Key() < b.Key() }), // Note that this is before compareBranch because we need to sort first.
 		cmpopts.SortMaps(func(a, b pfsdb.BranchID) bool { return a < b }),
 		cmpopts.EquateEmpty(),
-		cmp.Comparer(compareBranch),
-		cmp.Comparer(compareHead),
+		protocmp.Transform(),
+		protocmp.IgnoreEmptyMessages(),
 	}
 }
 

--- a/src/internal/pfsdb/branches_test.go
+++ b/src/internal/pfsdb/branches_test.go
@@ -3,10 +3,11 @@ package pfsdb_test
 import (
 	"context"
 	"fmt"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"testing"
 	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -137,10 +138,10 @@ func TestBranchUpsert(t *testing.T) {
 			require.NoError(t, err)
 			gotBranchInfo, err := pfsdb.GetBranchInfo(ctx, tx, id)
 			require.NoError(t, err)
-			require.True(t, cmp.Equal(branchInfo, gotBranchInfo, compareBranchOpts()...))
+			require.NoDiff(t, branchInfo, gotBranchInfo, compareBranchOpts())
 			gotBranchByName, err := pfsdb.GetBranchInfoWithID(ctx, tx, branchInfo.Branch)
 			require.NoError(t, err)
-			require.True(t, cmp.Equal(branchInfo, gotBranchByName.BranchInfo, compareBranchOpts()...))
+			require.NoDiff(t, branchInfo, gotBranchByName.BranchInfo, compareBranchOpts())
 
 			// Update branch to point to second commit
 			commitInfoWithID2 := createCommitInfoWithID(t, ctx, tx, newCommitInfo(repoInfo.Repo, random.String(32), commitInfoWithID1.CommitInfo.Commit))
@@ -150,7 +151,7 @@ func TestBranchUpsert(t *testing.T) {
 			require.Equal(t, id, id2, "UpsertBranch should keep id stable")
 			gotBranchInfo2, err := pfsdb.GetBranchInfo(ctx, tx, id2)
 			require.NoError(t, err)
-			require.True(t, cmp.Equal(branchInfo, gotBranchInfo2, compareBranchOpts()...))
+			require.NoDiff(t, branchInfo, gotBranchInfo2, compareBranchOpts())
 		})
 	})
 }
@@ -211,13 +212,13 @@ func TestBranchProvenance(t *testing.T) {
 				branchInfo := branchInfoWithID.BranchInfo
 				gotDirectProv, err := pfsdb.GetDirectBranchProvenance(ctx, tx, id)
 				require.NoError(t, err)
-				require.True(t, cmp.Equal(branchInfo.DirectProvenance, gotDirectProv, compareBranchOpts()...))
+				require.NoDiff(t, branchInfo.DirectProvenance, gotDirectProv, compareBranchOpts())
 				gotProv, err := pfsdb.GetBranchProvenance(ctx, tx, id)
 				require.NoError(t, err)
-				require.True(t, cmp.Equal(branchInfo.Provenance, gotProv, compareBranchOpts()...))
+				require.NoDiff(t, branchInfo.Provenance, gotProv, compareBranchOpts())
 				gotSubv, err := pfsdb.GetBranchSubvenance(ctx, tx, id)
 				require.NoError(t, err)
-				require.True(t, cmp.Equal(branchInfo.Subvenance, gotSubv, compareBranchOpts()...))
+				require.NoDiff(t, branchInfo.Subvenance, gotSubv, compareBranchOpts())
 			}
 			// Update provenance DAG to A <- B -> C, to test adding and deleting prov relationships
 			branchAInfo.DirectProvenance = nil
@@ -245,13 +246,13 @@ func TestBranchProvenance(t *testing.T) {
 				branchInfo := branchInfoWithID.BranchInfo
 				gotDirectProv, err := pfsdb.GetDirectBranchProvenance(ctx, tx, id)
 				require.NoError(t, err)
-				require.True(t, cmp.Equal(branchInfo.DirectProvenance, gotDirectProv, compareBranchOpts()...))
+				require.NoDiff(t, branchInfo.DirectProvenance, gotDirectProv, compareBranchOpts())
 				gotProv, err := pfsdb.GetBranchProvenance(ctx, tx, id)
 				require.NoError(t, err)
-				require.True(t, cmp.Equal(branchInfo.Provenance, gotProv, compareBranchOpts()...))
+				require.NoDiff(t, branchInfo.Provenance, gotProv, compareBranchOpts())
 				gotSubv, err := pfsdb.GetBranchSubvenance(ctx, tx, id)
 				require.NoError(t, err)
-				require.True(t, cmp.Equal(branchInfo.Subvenance, gotSubv, compareBranchOpts()...))
+				require.NoDiff(t, branchInfo.Subvenance, gotSubv, compareBranchOpts())
 			}
 		})
 	})
@@ -450,7 +451,7 @@ func TestBranchDelete(t *testing.T) {
 			require.NoError(t, err)
 			gotBranchAInfo, err := pfsdb.GetBranchInfo(ctx, tx, branchAID)
 			require.NoError(t, err)
-			require.True(t, cmp.Equal(branchAInfo, gotBranchAInfo, compareBranchOpts()...))
+			require.NoDiff(t, branchAInfo, gotBranchAInfo, compareBranchOpts())
 			// Verify BranchC no longer has BranchB in its provenance, nor does it have the trigger
 			branchCInfo.DirectProvenance = []*pfs.Branch{branchAInfo.Branch}
 			branchCInfo.Provenance = []*pfs.Branch{branchAInfo.Branch}
@@ -459,7 +460,7 @@ func TestBranchDelete(t *testing.T) {
 			require.NoError(t, err)
 			gotBranchCInfo, err := pfsdb.GetBranchInfo(ctx, tx, branchCID)
 			require.NoError(t, err)
-			require.True(t, cmp.Equal(branchCInfo, gotBranchCInfo, compareBranchOpts()...))
+			require.NoDiff(t, branchCInfo, gotBranchCInfo, compareBranchOpts())
 		})
 	})
 }

--- a/src/internal/pfsdb/repos_test.go
+++ b/src/internal/pfsdb/repos_test.go
@@ -3,8 +3,9 @@ package pfsdb_test
 import (
 	"context"
 	"fmt"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -64,10 +65,10 @@ func TestUpsertRepo(t *testing.T) {
 		require.NoError(t, err)
 		getByIDInfo, err := pfsdb.GetRepo(ctx, tx, repoID)
 		require.NoError(t, err)
-		require.True(t, cmp.Equal(expectedInfo, getByIDInfo, cmp.Comparer(compareRepos)))
+		require.NoDiff(t, expectedInfo, getByIDInfo, []cmp.Option{cmp.Comparer(compareRepos)})
 		getByNameInfo, err := pfsdb.GetRepoByName(ctx, tx, expectedInfo.Repo.Project.Name, expectedInfo.Repo.Name, expectedInfo.Repo.Type)
 		require.NoError(t, err)
-		require.True(t, cmp.Equal(expectedInfo, getByNameInfo, cmp.Comparer(compareRepos)))
+		require.NoDiff(t, expectedInfo, getByNameInfo, []cmp.Option{cmp.Comparer(compareRepos)})
 	})
 	withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 		expectedInfo.Description = "new desc"
@@ -76,7 +77,7 @@ func TestUpsertRepo(t *testing.T) {
 		require.Equal(t, repoID, id, "UpsertRepo should keep id stable")
 		getInfo, err := pfsdb.GetRepo(ctx, tx, id)
 		require.NoError(t, err)
-		require.True(t, cmp.Equal(expectedInfo, getInfo, cmp.Comparer(compareRepos)))
+		require.NoDiff(t, expectedInfo, getInfo, []cmp.Option{cmp.Comparer(compareRepos)})
 	})
 }
 
@@ -155,11 +156,11 @@ func TestGetRepo(t *testing.T) {
 		// validate GetRepo.
 		getInfo, err := pfsdb.GetRepo(ctx, tx, repoID)
 		require.NoError(t, err, "should be able to get a repo")
-		require.True(t, cmp.Equal(createInfo, getInfo, cmp.Comparer(compareRepos)))
+		require.NoDiff(t, createInfo, getInfo, []cmp.Option{cmp.Comparer(compareRepos)})
 		// validate GetRepoInfoWithID.
 		getInfoWithID, err := pfsdb.GetRepoInfoWithID(ctx, tx, pfs.DefaultProjectName, testRepoName, testRepoType)
 		require.NoError(t, err, "should be able to get a repo")
-		require.True(t, cmp.Equal(createInfo, getInfoWithID.RepoInfo, cmp.Comparer(compareRepos)))
+		require.NoDiff(t, createInfo, getInfoWithID.RepoInfo, []cmp.Option{cmp.Comparer(compareRepos)})
 		// validate error for attempting to get non-existent repo.
 		_, err = pfsdb.GetRepo(ctx, tx, 3)
 		require.True(t, errors.As(err, &pfsdb.RepoNotFoundError{}))
@@ -188,7 +189,7 @@ func TestForEachRepo(t *testing.T) {
 		}
 		i := 0
 		require.NoError(t, pfsdb.ForEachRepo(ctx, tx, nil, nil, func(repoWithID pfsdb.RepoInfoWithID) error {
-			require.True(t, cmp.Equal(expectedInfos[i], repoWithID.RepoInfo, cmp.Comparer(compareRepos)))
+			require.NoDiff(t, expectedInfos[i], repoWithID.RepoInfo, []cmp.Option{cmp.Comparer(compareRepos)})
 			i++
 			return nil
 		}))

--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -75,6 +75,7 @@ func NotMatch(tb testing.TB, shouldNotMatch string, actual string, msgAndArgs ..
 // NoDiff does a diff, and fails if there are differences.  Use protocmp.Transform() to compare
 // protos.
 func NoDiff(tb testing.TB, expected any, actual any, opts []cmp.Option, msgAndArgs ...any) {
+	tb.Helper()
 	diff := cmp.Diff(expected, actual, opts...)
 	if diff != "" {
 		fatal(tb, msgAndArgs, "expected should match actual (-expected +actual):\n%s", diff)


### PR DESCRIPTION
This also cleans up the pfs branches test to use `protocmp` instead of hand-written comparers.