### PR TITLE
add a command to run subprocesses like the worker

### DIFF
--- a/src/internal/cmd/run_like_worker/BUILD.bazel
+++ b/src/internal/cmd/run_like_worker/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("//private/rules:rules.bzl", "installable_binary")
+go_library(
+    name = "run_like_worker_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/internal/cmd/run_like_worker",
+    visibility = ["//src:__subpackages__"],
+    deps = [
+        "//src/internal/log",
+        "//src/internal/pctx",
+        "//src/pfs",
+        "//src/pps",
+        "//src/server/worker/driver",
+        "//src/server/worker/logs",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_binary(
+    name = "run_like_worker",
+    embed = [":run_like_worker_lib"],
+    visibility = ["//src:__subpackages__"],
+)
+
+installable_binary(
+    name = "install",
+    installed_name = "run_like_worker",
+    target = ":run_like_worker",
+)

--- a/src/internal/cmd/run_like_worker/main.go
+++ b/src/internal/cmd/run_like_worker/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
+	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/driver"
+	"github.com/pachyderm/pachyderm/v2/src/server/worker/logs"
+	"go.uber.org/zap"
+)
+
+func main() {
+	log.InitWorkerLogger()
+	log.SetLevel(log.DebugLevel)
+	rctx, rcancel := pctx.Interactive()
+
+	p := &pps.PipelineInfo{
+		Pipeline: &pps.Pipeline{
+			Name: "test",
+			Project: &pfs.Project{
+				Name: "default",
+			},
+		},
+		Type: pps.PipelineInfo_PIPELINE_TYPE_TRANSFORM,
+		Details: &pps.PipelineInfo_Details{
+			Transform: &pps.Transform{
+				Cmd: os.Args[1:],
+			},
+		},
+	}
+
+	lineCh := make(chan string)
+	go func() {
+		s := bufio.NewScanner(os.Stdin)
+		for s.Scan() {
+			lineCh <- s.Text()
+		}
+		close(lineCh)
+		rcancel()
+	}()
+	for i := 0; ; i++ {
+		ctx, cancel := pctx.WithCancel(pctx.Child(rctx, fmt.Sprintf("run %d", i)))
+		ch := make(chan struct{})
+		d := driver.NewEmptyDriver(ctx, p)
+		go func() {
+			select {
+			case <-lineCh:
+				log.Info(ctx, "killing user code")
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+		go func() {
+			log.Info(ctx, "starting user code")
+			l := logs.New(pctx.Child(ctx, "RunUserCode"))
+			err := d.RunUserCode(ctx, l, os.Environ())
+			log.Info(ctx, "user code done", zap.Error(err))
+			close(ch)
+		}()
+		<-ch
+		select {
+		case <-rctx.Done():
+			os.Exit(0)
+		default:
+		}
+	}
+}

--- a/src/internal/proc/proc.go
+++ b/src/internal/proc/proc.go
@@ -236,7 +236,7 @@ func MonitorProcessGroup(ctx context.Context, pid int) {
 		}
 		stats, err := getProcessStats(fs, pid)
 		if err != nil {
-			log.Info(ctx, "problem getting self stats", zap.Error(err))
+			log.Info(ctx, "problem getting child stats", zap.Error(err))
 			continue
 		}
 		meters.Set(ctx, "open_fd_count", stats.FDCount)

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -137,6 +137,17 @@ type driver struct {
 	inputDir string
 }
 
+func NewEmptyDriver(ctx context.Context, pipelineInfo *pps.PipelineInfo) Driver {
+	wd, _ := os.Getwd()
+	return &driver{
+		ctx:             ctx,
+		pipelineInfo:    pipelineInfo,
+		activeDataMutex: &sync.Mutex{},
+		rootDir:         wd,
+		inputDir:        "/tmp",
+	}
+}
+
 // NewDriver constructs a Driver object using the given clients and pipeline
 // settings.  It makes blocking calls to determine the user/group to use with
 // the user code on the current worker node, as well as determining if


### PR DESCRIPTION
This lets you run things as though the worker is running them.

I tried `run_like_worker sh -c 'streamlit run foo.py'` to see if streamlit is doing something weird, but it's not.