### PR TITLE
read CommitInfo before overwriting it with stale data

### DIFF
--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -395,7 +395,10 @@ func (d *driver) compactTotalFileSet(ctx context.Context, compactor *compactor, 
 func (d *driver) finalizeCommit(ctx context.Context, commitWithID *pfsdb.CommitWithID, validationError string, details *pfs.CommitInfo_Details, totalId *fileset.ID) error {
 	return log.LogStep(ctx, "finalizeCommit", func(ctx context.Context) error {
 		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-			commitInfo := commitWithID.CommitInfo
+			commitInfo, err := pfsdb.GetCommit(ctx, txnCtx.SqlTx, commitWithID.ID)
+			if err != nil {
+				return errors.Wrap(err, "refresh commitInfo")
+			}
 			commitInfo.Finished = txnCtx.Timestamp
 			if details != nil {
 				commitInfo.SizeBytesUpperBound = details.SizeBytes


### PR DESCRIPTION
Refresh CommitInfo before overwriting it.  This avoids a rare race:

A commit is created.
Finalization starts.
Metadata on the commit is changed.
The metadata update is overwritten when the PFS master writes the finalization time / status to the commit.

The metadata tests are fast enough to cause this, and it happened pretty consistently.

This probably needs to be done in more places; we should always read before writing when only changing one field.