### PR TITLE
Add an option to add Loki to testpachd

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3679,6 +3679,27 @@
         "recordedRepoMappingEntries": []
       }
     },
+    "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
+      "general": {
+        "bzlTransitiveDigest": "l5mcjH2gWmbmIycx97bzI2stD0Q0M5gpDc0aLOHKIm8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "remote_coverage_tools": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
+              "urls": [
+                "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@buildifier_prebuilt~//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
         "bzlTransitiveDigest": "uAKOFsVgkdVxGK8RC6cNqxYMcezLf942BzB5DqaZxDQ=",

--- a/src/internal/lokiutil/testloki/BUILD.bazel
+++ b/src/internal/lokiutil/testloki/BUILD.bazel
@@ -1,9 +1,13 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
+# gazelle:go_test file
+
 go_library(
     name = "testloki",
-    testonly = 1,
-    srcs = ["testloki.go"],
+    srcs = [
+        "logger.go",
+        "testloki.go",
+    ],
     data = [
         "config.yaml",
         "//tools/loki",
@@ -14,10 +18,14 @@ go_library(
         "//src/internal/errors",
         "//src/internal/log",
         "//src/internal/lokiutil/client",
+        "//src/internal/pachconfig",
+        "//src/internal/pachd",
         "//src/internal/pctx",
         "//src/internal/promutil",
+        "//src/internal/randutil",
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zapcore",
         "@rules_go//go/runfiles:go_default_library",
         "@rules_go//go/tools/bazel:go_default_library",
     ],
@@ -32,5 +40,18 @@ go_test(
         "//src/internal/lokiutil/client",
         "//src/internal/pctx",
         "@com_github_google_go_cmp//cmp",
+    ],
+)
+
+go_test(
+    name = "logger_test",
+    size = "small",
+    srcs = ["logger_test.go"],
+    deps = [
+        ":testloki",
+        "//src/internal/pachd",
+        "//src/internal/pctx",
+        "//src/logs",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/src/internal/lokiutil/testloki/logger.go
+++ b/src/internal/lokiutil/testloki/logger.go
@@ -1,0 +1,117 @@
+package testloki
+
+import (
+	"context"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/randutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func WithTestLoki(l *TestLoki) pachd.TestPachdOption {
+	return pachd.TestPachdOption{
+		MutateEnv: func(env *pachd.Env) {
+			env.GetLokiClient = func() (*client.Client, error) {
+				return l.Client, nil
+			}
+		},
+		MutateConfig: func(config *pachconfig.PachdFullConfiguration) {
+			config.LokiLogging = true
+		},
+		MutateContext: func(ctx context.Context) context.Context {
+			return pctx.Child(ctx, "", pctx.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+				return zapcore.NewTee(c, l.NewZapCore(ctx))
+			})))
+		},
+	}
+}
+
+// NewZapCore returns a zapcore.Core that sends logs to this Loki instance.
+func (l *TestLoki) NewZapCore(ctx context.Context) zapcore.Core {
+	return &lokiCore{
+		ctx: ctx,
+		l:   l,
+		enc: zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+			TimeKey:        "time",
+			EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
+			LevelKey:       "severity",
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			MessageKey:     "message",
+			NameKey:        "logger",
+			CallerKey:      "caller",
+			FunctionKey:    zapcore.OmitKey,
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeDuration: zapcore.SecondsDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		}),
+		podTemplateHash: randutil.UniqueString("")[0:10],
+	}
+}
+
+type lokiCore struct {
+	ctx             context.Context
+	l               *TestLoki
+	enc             zapcore.Encoder
+	podTemplateHash string
+	fields          []zapcore.Field
+}
+
+var _ zapcore.Core = (*lokiCore)(nil)
+
+// Enabled implements zapcore.LevelEnabler.
+func (c *lokiCore) Enabled(zapcore.Level) bool {
+	return true
+}
+
+// With implements zapcore.Core.
+func (c *lokiCore) With(f []zapcore.Field) zapcore.Core {
+	var fields []zapcore.Field
+	fields = append(fields, c.fields...)
+	fields = append(fields, f...)
+	return &lokiCore{ctx: c.ctx, l: c.l, enc: c.enc, podTemplateHash: c.podTemplateHash, fields: fields}
+}
+
+// Check implements zapcore.Core.
+func (c *lokiCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(e.Level) {
+		return ce.AddCore(e, c)
+	}
+	return ce
+}
+
+// Write implements zapcore.Core.
+func (c *lokiCore) Write(e zapcore.Entry, fields []zapcore.Field) error {
+	buf, err := c.enc.EncodeEntry(e, fields)
+	if err != nil {
+		return errors.Wrap(err, "encode log entry")
+	}
+	if err := c.l.AddLog(c.ctx, &Log{
+		Time: time.Now(),
+		Labels: map[string]string{
+			"host":              "localhost",
+			"app":               "pachd",
+			"container":         "pachd",
+			"node_name":         "localhost",
+			"pod":               "pachd-" + c.podTemplateHash + c.podTemplateHash[0:5],
+			"pod_template_hash": c.podTemplateHash,
+			"stream":            "stderr",
+			"suite":             "pachyderm",
+		},
+		Message: string(buf.Bytes()),
+	}); err != nil {
+		return errors.Wrap(err, "send log to loki")
+	}
+	return nil
+}
+
+// Sync implements zapcore.Core.
+func (c *lokiCore) Sync() error {
+	return nil
+}

--- a/src/internal/lokiutil/testloki/logger_test.go
+++ b/src/internal/lokiutil/testloki/logger_test.go
@@ -1,0 +1,54 @@
+package testloki_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/testloki"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/logs"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestTestPachd(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	l, err := testloki.New(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := l.Close(); err != nil {
+			t.Fatalf("close loki: %v", err)
+		}
+	})
+	pd := pachd.NewTestPachd(t, testloki.WithTestLoki(l))
+
+	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	gls, err := pd.LogsClient.GetLogs(tctx, &logs.GetLogsRequest{
+		Query: &logs.LogQuery{
+			QueryType: &logs.LogQuery_Admin{
+				Admin: &logs.AdminLogQuery{
+					AdminType: &logs.AdminLogQuery_Logql{
+						Logql: `{host=~ ".+"}`,
+					},
+				},
+			},
+		},
+		Filter: &logs.LogFilter{
+			Limit: 1,
+		},
+		LogFormat: logs.LogFormat_LOG_FORMAT_VERBATIM_WITH_TIMESTAMP,
+	})
+	if err != nil {
+		t.Fatalf("GetLogs: %v", err)
+	}
+	res, err := gls.Recv()
+	if err != nil {
+		// io.EOF is an error here.
+		t.Fatalf("Recv: %v", err)
+	}
+	t.Log(protojson.Format(res))
+}

--- a/src/internal/pachd/BUILD.bazel
+++ b/src/internal/pachd/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//src/internal/middleware/auth",
         "//src/internal/middleware/errors",
         "//src/internal/middleware/logging",
+        "//src/internal/middleware/logging/client",
         "//src/internal/middleware/validation",
         "//src/internal/middleware/version",
         "//src/internal/migrations",

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	lokiclient "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
 	auth_interceptor "github.com/pachyderm/pachyderm/v2/src/internal/middleware/auth"
+	clientlog_interceptor "github.com/pachyderm/pachyderm/v2/src/internal/middleware/logging/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/obj"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachconfig"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
@@ -513,7 +514,14 @@ func (pd *Full) PachClient(ctx context.Context) (*client.APIClient, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "parse pachd address")
 	}
-	c, err := client.NewFromPachdAddress(ctx, addr)
+	c, err := client.NewFromPachdAddress(ctx, addr,
+		client.WithAdditionalUnaryClientInterceptors(
+			clientlog_interceptor.LogUnary,
+		),
+		client.WithAdditionalStreamClientInterceptors(
+			clientlog_interceptor.LogStream,
+		),
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "NewPachdFromAddress")
 	}
@@ -529,7 +537,14 @@ func (pd *Full) mustGetPachClient(ctx context.Context) *client.APIClient {
 	if err != nil {
 		panic(fmt.Sprintf("parse pachd address: %v", err))
 	}
-	c, err := client.NewFromPachdAddress(ctx, addr)
+	c, err := client.NewFromPachdAddress(ctx, addr,
+		client.WithAdditionalUnaryClientInterceptors(
+			clientlog_interceptor.LogUnary,
+		),
+		client.WithAdditionalStreamClientInterceptors(
+			clientlog_interceptor.LogStream,
+		),
+	)
 	if err != nil {
 		panic(fmt.Sprintf("NewFromPachdAddress: %v", err))
 	}

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -34,9 +34,11 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/task"
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv"
 	"github.com/pachyderm/pachyderm/v2/src/license"
+	"github.com/pachyderm/pachyderm/v2/src/logs"
 	"github.com/pachyderm/pachyderm/v2/src/metadata"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+	"github.com/pachyderm/pachyderm/v2/src/proxy"
 	admin_server "github.com/pachyderm/pachyderm/v2/src/server/admin/server"
 	auth_iface "github.com/pachyderm/pachyderm/v2/src/server/auth"
 	auth_server "github.com/pachyderm/pachyderm/v2/src/server/auth/server"
@@ -44,11 +46,13 @@ import (
 	entiface "github.com/pachyderm/pachyderm/v2/src/server/enterprise"
 	ent_server "github.com/pachyderm/pachyderm/v2/src/server/enterprise/server"
 	license_server "github.com/pachyderm/pachyderm/v2/src/server/license/server"
+	logs_server "github.com/pachyderm/pachyderm/v2/src/server/logs/server"
 	metadata_server "github.com/pachyderm/pachyderm/v2/src/server/metadata/server"
 	pfsiface "github.com/pachyderm/pachyderm/v2/src/server/pfs"
 	pfs_server "github.com/pachyderm/pachyderm/v2/src/server/pfs/server"
 	ppsiface "github.com/pachyderm/pachyderm/v2/src/server/pps"
 	pps_server "github.com/pachyderm/pachyderm/v2/src/server/pps/server"
+	proxy_server "github.com/pachyderm/pachyderm/v2/src/server/proxy/server"
 	txn_server "github.com/pachyderm/pachyderm/v2/src/server/transaction/server"
 	"github.com/pachyderm/pachyderm/v2/src/transaction"
 	version_server "github.com/pachyderm/pachyderm/v2/src/version"
@@ -194,6 +198,8 @@ type Full struct {
 	enterpriseSrv enterprise.APIServer
 	licenseSrv    license.APIServer
 	debugSrv      debug.DebugServer
+	proxySrv      proxy.APIServer
+	logsSrv       logs.APIServer
 
 	pfsWorker   *pfs_server.Worker
 	ppsWorker   *pps_server.Worker
@@ -423,6 +429,28 @@ func NewFull(env Env, config pachconfig.PachdFullConfiguration) *Full {
 				return nil
 			},
 		},
+		setupStep{
+			Name: "initProxyServer",
+			Fn: func(ctx context.Context) error {
+				pd.proxySrv = proxy_server.NewAPIServer(proxy_server.Env{
+					Listener: pd.dbListener,
+				})
+				return nil
+			},
+		},
+		setupStep{
+			Name: "initLogsServer",
+			Fn: func(ctx context.Context) error {
+				var err error
+				pd.logsSrv, err = logs_server.NewAPIServer(logs_server.Env{
+					GetLokiClient: env.GetLokiClient,
+				})
+				if err != nil {
+					return errors.Wrap(err, "logs_server.NewAPIServer")
+				}
+				return nil
+			},
+		},
 
 		// Workers
 		initPFSWorker(&pd.pfsWorker, config.StorageConfiguration, func() pfs_server.WorkerEnv {
@@ -454,9 +482,11 @@ func NewFull(env Env, config pachconfig.PachdFullConfiguration) *Full {
 		enterprise.RegisterAPIServer(gs, pd.enterpriseSrv)
 		grpc_health_v1.RegisterHealthServer(gs, pd.healthSrv)
 		license.RegisterAPIServer(gs, pd.licenseSrv)
+		logs.RegisterAPIServer(gs, pd.logsSrv)
 		metadata.RegisterAPIServer(gs, pd.metadataSrv)
 		pfs.RegisterAPIServer(gs, pd.pfsSrv)
 		pps.RegisterAPIServer(gs, pd.ppsSrv)
+		proxy.RegisterAPIServer(gs, pd.proxySrv)
 		version.RegisterAPIServer(gs, pd.version)
 	}))
 	pd.addBackground("bootstrap", func(ctx context.Context) error {

--- a/src/internal/pachd/testpachd.go
+++ b/src/internal/pachd/testpachd.go
@@ -35,10 +35,11 @@ import (
 
 // TestPachdOptions allow a testpachd to be customized.
 type TestPachdOption struct {
-	noLogToFile  bool // A flag to turn off the LogToFileOption when it's the default.
-	MutateEnv    func(env *Env)
-	MutateConfig func(config *pachconfig.PachdFullConfiguration)
-	MutatePachd  func(full *Full)
+	noLogToFile   bool // A flag to turn off the LogToFileOption when it's the default.
+	MutateContext func(ctx context.Context) context.Context
+	MutateEnv     func(env *Env)
+	MutateConfig  func(config *pachconfig.PachdFullConfiguration)
+	MutatePachd   func(full *Full)
 }
 
 // NoLogToFileOption is an option that disable's NewTestPachd's default behavior of logging pachd
@@ -85,6 +86,7 @@ func NewTestPachd(t testing.TB, opts ...TestPachdOption) *client.APIClient {
 			return logger.Core()
 		})))
 	}
+	ctx = mutateContext(ctx, opts...)
 
 	dbcfg := dockertestenv.NewTestDBConfig(t)
 	db := testutil.OpenDB(t, dbcfg.PGBouncer.DBOptions()...)
@@ -122,6 +124,15 @@ func NewTestPachd(t testing.TB, opts ...TestPachdOption) *client.APIClient {
 	require.NoError(t, err)
 	require.NoErrorWithinTRetry(t, 5*time.Second, func() error { return pachClient.Health() })
 	return pachClient
+}
+
+func mutateContext(ctx context.Context, opts ...TestPachdOption) context.Context {
+	for _, o := range opts {
+		if o.MutateContext != nil {
+			ctx = o.MutateContext(ctx)
+		}
+	}
+	return ctx
 }
 
 func newTestPachd(env Env, opts []TestPachdOption) *Full {
@@ -162,6 +173,9 @@ func newTestPachd(env Env, opts []TestPachdOption) *Full {
 // handler frees all ephemeral resources associated with the instance.
 func BuildTestPachd(ctx context.Context, opts ...TestPachdOption) (*Full, *cleanup.Cleaner, error) {
 	cleaner := new(cleanup.Cleaner)
+
+	// setup context
+	ctx = mutateContext(ctx, opts...)
 
 	// tmpdir
 	tmpdir, err := os.MkdirTemp("", "testpachd-")

--- a/src/testing/testpachd/BUILD.bazel
+++ b/src/testing/testpachd/BUILD.bazel
@@ -6,10 +6,12 @@ go_library(
     importpath = "github.com/pachyderm/pachyderm/v2/src/testing/testpachd",
     visibility = ["//visibility:private"],
     deps = [
+        "//src/internal/cleanup",
         "//src/internal/client",
         "//src/internal/config",
         "//src/internal/errors",
         "//src/internal/log",
+        "//src/internal/lokiutil/testloki",
         "//src/internal/pachd",
         "//src/internal/pctx",
         "@org_uber_go_zap//:zap",

--- a/src/testing/testpachd/main.go
+++ b/src/testing/testpachd/main.go
@@ -63,6 +63,9 @@ func main() {
 			exitErr = err
 			return
 		}
+		clean.AddCleanup("loki files", func() error {
+			return errors.Wrapf(os.RemoveAll(tmpdir), "cleanup loki tmpdir %v", tmpdir)
+		})
 		l, err := testloki.New(ctx, tmpdir)
 		if err != nil {
 			log.Error(ctx, "problem starting loki", zap.Error(err))

--- a/src/testing/testpachd/main.go
+++ b/src/testing/testpachd/main.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/cleanup"
 	"github.com/pachyderm/pachyderm/v2/src/internal/client"
 	"github.com/pachyderm/pachyderm/v2/src/internal/config"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/testloki"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachd"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"go.uber.org/zap"
@@ -25,6 +27,7 @@ var (
 	verbose      = flag.Bool("v", false, "if true, show debug level logs (they always end up in logfile, though)")
 	pachCtx      = flag.String("context", "testpachd", "if set, setup the named pach context to connect to this server, and switch to it")
 	activateAuth = flag.Bool("auth", false, "if true, activate auth")
+	useLoki      = flag.Bool("loki", false, "if true, start a loki sidecar and send pachd logs there")
 )
 
 func main() {
@@ -36,28 +39,45 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	// Init testpachd options.
-	var opts []pachd.TestPachdOption
-	if *activateAuth {
-		opts = append(opts, pachd.ActivateAuthOption(rootToken))
-	}
-
-	// Build pachd.
+	// Handle cleaning up on exit.
 	ctx, cancel := pctx.Interactive()
 	var exitErr error
-	pd, cleanup, err := pachd.BuildTestPachd(ctx, opts...)
-
-	// Cleanup pachd on return.
+	var clean cleanup.Cleaner
 	defer func() {
 		ctx = pctx.Background("cleanup")
-		if err := cleanup.Cleanup(ctx); err != nil {
+		if err := clean.Cleanup(ctx); err != nil {
 			log.Error(ctx, "problem cleaning up", zap.Error(err))
 		}
 		done(exitErr)
 	}()
 
-	// If pachd failed to build, exit now.
+	// Init testpachd options.
+	var opts []pachd.TestPachdOption
+	if *activateAuth {
+		opts = append(opts, pachd.ActivateAuthOption(rootToken))
+	}
+	if *useLoki {
+		tmpdir, err := os.MkdirTemp("", "testpachd-loki-")
+		if err != nil {
+			log.Error(ctx, "problem making tmpdir for loki", zap.Error(err))
+			exitErr = err
+			return
+		}
+		l, err := testloki.New(ctx, tmpdir)
+		if err != nil {
+			log.Error(ctx, "problem starting loki", zap.Error(err))
+			exitErr = err
+			return
+		}
+		clean.AddCleanup("loki", l.Close)
+		opts = append(opts, testloki.WithTestLoki(l))
+	}
+
+	// Build pachd.
+	pd, cleanupPachd, err := pachd.BuildTestPachd(ctx, opts...)
+	clean.Subsume(cleanupPachd)
 	if err != nil {
+		// If pachd failed to build, exit now.
 		log.Error(ctx, "problem building pachd", zap.Error(err))
 		exitErr = err
 		return
@@ -91,13 +111,14 @@ func main() {
 	if *pachCtx != "" {
 		oldContext, err := setupPachctlConfig(ctx, *pachCtx, *activateAuth, pachClient)
 		if err != nil {
+			log.Error(ctx, "problem reading pachctl config", zap.Error(err))
 			exitErr = err
 			cancel()
 			return
 		}
 		if oldContext != "" && oldContext != *pachCtx {
 			// Restore the context they were currently pointing at on exit.
-			cleanup.AddCleanupCtx("restore pach context", func(ctx context.Context) error {
+			clean.AddCleanupCtx("restore pach context", func(ctx context.Context) error {
 				cfg, err := config.Read(true, false)
 				if err != nil {
 					return errors.Wrap(err, "read pachctl config")


### PR DESCRIPTION
If set, this option starts Loki and sends all "pachd" logs to it.  That means running `pachctl logs` attached to this testpachd returns the same thing you'd see if a real pachd were running.

I also enabled RPC logs for test pachd, at level Debug (hidden by default, but sent to Loki and the log file).