### PR TITLE
Add a parser for the metadata CLI

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -162,6 +162,7 @@ use_repo(
     go_deps,
     "com_github_adrg_xdg",
     "com_github_alecthomas_jsonschema",
+    "com_github_alecthomas_participle_v2",
     "com_github_alessio_shellescape",
     "com_github_aws_aws_lambda_go",
     "com_github_aws_aws_sdk_go",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "568e7d43327241e219ccefaacdff563d031352e4fce2985bb8bf79bf1869ab3c",
+  "moduleFileHash": "5f0940b8166f8e621c9d974e340fba24aa0dd158e21e3d1758e51327c14e6c90",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -79,6 +79,7 @@
           "imports": {
             "com_github_adrg_xdg": "com_github_adrg_xdg",
             "com_github_alecthomas_jsonschema": "com_github_alecthomas_jsonschema",
+            "com_github_alecthomas_participle_v2": "com_github_alecthomas_participle_v2",
             "com_github_alessio_shellescape": "com_github_alessio_shellescape",
             "com_github_aws_aws_lambda_go": "com_github_aws_aws_lambda_go",
             "com_github_aws_aws_sdk_go": "com_github_aws_aws_sdk_go",
@@ -524,7 +525,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 288,
+            "line": 289,
             "column": 32
           },
           "imports": {
@@ -607,7 +608,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 362,
+            "line": 363,
             "column": 20
           },
           "imports": {
@@ -632,7 +633,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 365,
+                "line": 366,
                 "column": 9
               }
             },
@@ -650,7 +651,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 376,
+                "line": 377,
                 "column": 9
               }
             },
@@ -664,7 +665,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 387,
+                "line": 388,
                 "column": 9
               }
             },
@@ -678,7 +679,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 392,
+                "line": 393,
                 "column": 9
               }
             }
@@ -692,7 +693,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 400,
+            "line": 401,
             "column": 23
           },
           "imports": {},
@@ -706,7 +707,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 401,
+                "line": 402,
                 "column": 17
               }
             }
@@ -720,7 +721,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 406,
+            "line": 407,
             "column": 20
           },
           "imports": {
@@ -739,7 +740,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 407,
+                "line": 408,
                 "column": 10
               }
             },
@@ -755,7 +756,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 412,
+                "line": 413,
                 "column": 10
               }
             }
@@ -3829,6 +3830,31 @@
         ]
       }
     },
+    "@@buildozer~//:buildozer_binary.bzl%buildozer_binary": {
+      "general": {
+        "bzlTransitiveDigest": "EleDU/FQ1+e/RgkW3aIDmdaxZEthvoWQhsqFTxiSgMI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "buildozer_binary": {
+            "bzlFile": "@@buildozer~//private:buildozer_binary.bzl",
+            "ruleClassName": "_buildozer_binary_repo",
+            "attributes": {
+              "sha256": {
+                "darwin-amd64": "d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e",
+                "darwin-arm64": "9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d",
+                "linux-amd64": "8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119",
+                "linux-arm64": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa",
+                "windows-amd64": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b"
+              },
+              "version": "6.4.0"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@container_structure_test~//:repositories.bzl%extension": {
       "general": {
         "bzlTransitiveDigest": "/vl5vOyGN/nxHtUF3SxoDZnTDgDklt4HUpLQD5LE8+k=",
@@ -3901,11 +3927,11 @@
       "general": {
         "bzlTransitiveDigest": "D1+rhhbwX4ufoTmeUVxDpPg+Sknv3QzVXZnyK2zOjj4=",
         "recordedFileInputs": {
-          "@@//go.mod": "1b0eec7d9fb69542885759723e31b2c1780cf2ca45e9809de0c002ac53197acf",
+          "@@//go.mod": "f2e4c2ef5d8557509a07ada747c33cb10297f5c5b9fb8c58a090e7a6a6b02362",
           "@@rules_go~//go.mod": "de22304b720f7f61350ec1c9739de6c0a1b1103fd22bfeb6e92c6c843ddc6d6e",
           "@@gazelle~//go.sum": "7c4460e8ecb5dd8691a51d4fa2e9e4751108b933636497ce46db499fc2e7a88d",
           "@@jsonnet_go~//go.mod": "35238699c0cd09f5e79619863a0014f01129615f811c8a30239b80e8e3a58145",
-          "@@//go.sum": "9f761a5807987fdac8160efba2d756ec735570e20a31f55b18e84198f0c3acd5",
+          "@@//go.sum": "6f473374cc4e7b9e5fb643e2af3c3746e22f3411de6dee13ed656c571492656a",
           "@@rules_go~//go.sum": "d56fdb19b21a5f12bcf625c49432371ac39c2def0f564098fbda107f7c080f40",
           "@@gazelle~//go.mod": "48dc6e771c3028ee1c18b9ffc81e596fd5f6d7e0016c5ef280e30f2821f60473",
           "@@jsonnet_go~//go.sum": "cf6cba94b78ec389dcea5dda9207b611deea699e8dbbe45e98b7a7f990482bb4"
@@ -6812,6 +6838,7 @@
                 "com_github_azure_azure_sdk_for_go": "github.com/Azure/azure-sdk-for-go",
                 "com_github_data_dog_go_sqlmock": "github.com/DATA-DOG/go-sqlmock",
                 "com_github_adrg_xdg": "github.com/adrg/xdg",
+                "com_github_alecthomas_participle_v2": "github.com/alecthomas/participle/v2",
                 "com_github_aws_aws_lambda_go": "github.com/aws/aws-lambda-go",
                 "com_github_aws_aws_sdk_go": "github.com/aws/aws-sdk-go",
                 "@rules_go~": "github.com/bazelbuild/rules_go",
@@ -8876,6 +8903,21 @@
               "version": "v1.4.0"
             }
           },
+          "com_github_alecthomas_participle_v2": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/alecthomas/participle/v2",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=",
+              "replace": "",
+              "version": "v2.1.1"
+            }
+          },
           "com_github_fatih_camelcase": {
             "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
@@ -9897,6 +9939,7 @@
             "com_github_azure_azure_sdk_for_go",
             "com_github_data_dog_go_sqlmock",
             "com_github_adrg_xdg",
+            "com_github_alecthomas_participle_v2",
             "com_github_aws_aws_lambda_go",
             "com_github_aws_aws_sdk_go",
             "com_github_c_bata_go_prompt",

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/adrg/xdg v0.4.0
+	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/aws/aws-lambda-go v1.17.0
 	github.com/aws/aws-sdk-go v1.44.68
 	github.com/bazelbuild/rules_go v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -241,7 +241,13 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
+github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/jsonschema v0.0.0-20210918223802-a1d3f4b43d7b/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
+github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
+github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
+github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -1167,6 +1173,8 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
 github.com/hetznercloud/hcloud-go v1.33.1/go.mod h1:XX/TQub3ge0yWR2yHWmnDVIrB+MQbda1pHxkUmDlUME=
 github.com/hetznercloud/hcloud-go v1.35.0/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/src/internal/kvparse/BUILD.bazel
+++ b/src/internal/kvparse/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "kvparse",
+    srcs = ["kvparse.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/internal/kvparse",
+    visibility = ["//src:__subpackages__"],
+    deps = [
+        "//src/internal/errors",
+        "//src/internal/kvparse/kvgrammar",
+        "@com_github_alecthomas_participle_v2//:participle",
+        "@com_github_alecthomas_participle_v2//lexer",
+    ],
+)
+
+go_test(
+    name = "kvparse_test",
+    srcs = ["kvparse_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":kvparse"],
+    deps = [
+        "//src/internal/cmputil",
+        "//src/internal/require",
+        "@com_github_google_go_cmp//cmp",
+    ],
+)

--- a/src/internal/kvparse/kvgrammar/BUILD.bazel
+++ b/src/internal/kvparse/kvgrammar/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "kvgrammar",
+    srcs = ["kvgrammar.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/internal/kvparse/kvgrammar",
+    visibility = ["//src/internal/kvparse:__subpackages__"],
+    deps = ["@com_github_alecthomas_participle_v2//lexer"],
+)

--- a/src/internal/kvparse/kvgrammar/kvgrammar.go
+++ b/src/internal/kvparse/kvgrammar/kvgrammar.go
@@ -1,7 +1,6 @@
 package kvgrammar
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -114,7 +113,8 @@ func (s *DoubleQuoted) String() string {
 		if e := part.Escaped; e != nil {
 			val, _, _, err := strconv.UnquoteChar(*e, '"')
 			if err != nil {
-				panic(fmt.Sprintf("problem with parser; can't unescape %v", *e))
+				buf.WriteString(*e) // example: \ud800; this isn't a character, but is "grammatically" correct
+				continue
 			}
 			buf.WriteRune(val)
 		}

--- a/src/internal/kvparse/kvgrammar/kvgrammar.go
+++ b/src/internal/kvparse/kvgrammar/kvgrammar.go
@@ -45,7 +45,7 @@ var Lexer = lexer.Rules{
 	"DoubleQuotedString": {
 		{
 			Name:    "Escaped",
-			Pattern: `\\(?:["'\\abfnrtv]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})`, // go allows \U<hex digit>{8}, but we don't.
+			Pattern: `\\(?:["\\abfnrtv]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})`, // go allows \U<hex digit>{8}, but we don't.
 		},
 		{
 			Name:    "DoubleQuotedStringEnd",

--- a/src/internal/kvparse/kvgrammar/kvgrammar.go
+++ b/src/internal/kvparse/kvgrammar/kvgrammar.go
@@ -1,0 +1,179 @@
+package kvgrammar
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+var Lexer = lexer.Rules{
+	"Root": {
+		{
+			Name:    "Whitespace",
+			Pattern: `\s+`,
+		},
+		{
+			Name:    "DoubleQuotedString",
+			Pattern: `"`,
+			Action:  lexer.Push("DoubleQuotedString"),
+		},
+		{
+			Name:    "SingleQuotedString",
+			Pattern: `'`,
+			Action:  lexer.Push("SingleQuotedString"),
+		},
+		{
+			Name:    "JSON",
+			Pattern: `{`,
+			Action:  lexer.Push("JSON"),
+		},
+		{
+			Name:    "Terminator",
+			Pattern: `;`,
+		},
+		{
+			Name:    "Equals",
+			Pattern: `=`,
+		},
+		{
+			Name:    "String",
+			Pattern: `[^;="'\s]+`,
+		},
+	},
+	"DoubleQuotedString": {
+		{
+			Name:    "Escaped",
+			Pattern: `\\(?:["'\\abfnrtv]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})`, // go allows \U<hex digit>{8}, but we don't.
+		},
+		{
+			Name:    "DoubleQuotedStringEnd",
+			Pattern: `"`,
+			Action:  lexer.Pop(),
+		},
+		{
+			Name:    "DoubleQuotedChars",
+			Pattern: `[^"\\]+`,
+		},
+	},
+	"SingleQuotedString": {
+		{
+			Name:    "SingleQuotedStringEnd",
+			Pattern: `'`,
+			Action:  lexer.Pop(),
+		},
+		{
+			Name:    "SingleQuotedChars",
+			Pattern: `[^']+`,
+		},
+	},
+	"JSON": {
+		{
+			Name:    "JSONEnd",
+			Pattern: `}`,
+			Action:  lexer.Pop(),
+		},
+		{
+			Name:    "Whitespace",
+			Pattern: `\s+`,
+		},
+		{
+			Name:    "DoubleQuotedString",
+			Pattern: `"`,
+			Action:  lexer.Push("DoubleQuotedString"),
+		},
+		{
+			Name:    "Colon",
+			Pattern: `:`,
+		},
+		{
+			Name:    "Comma",
+			Pattern: `,`,
+		},
+	},
+}
+
+type DoubleQuotedPart struct {
+	Escaped *string `parser:"(@Escaped"`
+	String  *string `parser:"|@DoubleQuotedChars)"`
+}
+
+type DoubleQuoted struct {
+	Start string             `parser:"@DoubleQuotedString"`
+	Parts []DoubleQuotedPart `parser:"@@+"`
+	End   string             `parser:"@DoubleQuotedStringEnd"`
+}
+
+func (s *DoubleQuoted) String() string {
+	var buf strings.Builder
+	for _, part := range s.Parts {
+		if s := part.String; s != nil {
+			buf.WriteString(*s)
+		}
+		if e := part.Escaped; e != nil {
+			val, _, _, err := strconv.UnquoteChar(*e, '"')
+			if err != nil {
+				panic(fmt.Sprintf("problem with parser; can't unescape %v", *e))
+			}
+			buf.WriteRune(val)
+		}
+	}
+	return buf.String()
+}
+
+type SingleQuoted struct {
+	Start  string `parser:"@SingleQuotedString"`
+	String string `parser:"@SingleQuotedChars"`
+	End    string `parser:"@SingleQuotedStringEnd"`
+}
+
+type Str struct {
+	Literal      string        `parser:"(@String"`
+	DoubleQuoted *DoubleQuoted `parser:"| @@"`
+	SingleQuoted *SingleQuoted `parser:"| @@)"`
+}
+
+func (s Str) String() string {
+	if s.Literal != "" {
+		return s.Literal
+	}
+	if s.DoubleQuoted != nil {
+		return s.DoubleQuoted.String()
+	}
+	if s.SingleQuoted != nil {
+		return s.SingleQuoted.String
+	}
+	return ""
+}
+
+type KV struct {
+	Key        Str    `parser:"@@"`
+	Equals     string `parser:"@Equals"`
+	Value      Str    `parser:"@@?"` // The value can be the empty string.
+	Terminator string `parser:"(@Terminator|@EOF)"`
+}
+
+type JSONPair struct {
+	Key   DoubleQuoted `parser:"@@"`
+	Colon string       `parser:"@Colon"`
+	Value DoubleQuoted `parser:"@@"`
+}
+
+type TerminatedJSONPair struct {
+	Key   DoubleQuoted `parser:"@@"`
+	Colon string       `parser:"@Colon"`
+	Value DoubleQuoted `parser:"@@"`
+	Comma string       `parser:"@Comma?"`
+}
+
+type JSON struct {
+	Start string               `parser:"@JSON"`
+	Pairs []TerminatedJSONPair `parser:"@@*"`
+	End   string               `parser:"@JSONEnd"`
+}
+
+type KVs struct {
+	JSON  JSON `parser:"(@@"`
+	Pairs []KV `parser:"|@@+)"`
+}

--- a/src/internal/kvparse/kvparse.go
+++ b/src/internal/kvparse/kvparse.go
@@ -1,0 +1,59 @@
+// Package kvparse implements a language for representing key/value pairs.
+package kvparse
+
+import (
+	"strings"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/kvparse/kvgrammar"
+)
+
+// KV is a parsed key/value pair.
+type KV struct {
+	Key   string
+	Value string
+}
+
+var lex = lexer.MustStateful(kvgrammar.Lexer)
+
+func ParseOne(in string) (KV, error) {
+	parser, err := participle.Build[kvgrammar.KV](participle.Lexer(lex), participle.Elide("Whitespace"))
+	if err != nil {
+		return KV{}, errors.Wrap(err, "build kv parser")
+	}
+	kv, err := parser.ParseString("", in)
+	if err != nil {
+		return KV{}, errors.Wrap(err, "parse kv")
+	}
+	return KV{Key: kv.Key.String(), Value: kv.Value.String()}, nil
+}
+
+func ParseMany(in string) ([]KV, error) {
+	if strings.TrimSpace(in) == "" {
+		return nil, nil
+	}
+	parser, err := participle.Build[kvgrammar.KVs](participle.Lexer(lex), participle.Elide("Whitespace"))
+	if err != nil {
+		return nil, errors.Wrap(err, "build kv parser")
+	}
+	kvs, err := parser.ParseString("", in)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse kv")
+	}
+	var result []KV
+	for _, kv := range kvs.Pairs {
+		result = append(result, KV{
+			Key:   kv.Key.String(),
+			Value: kv.Value.String(),
+		})
+	}
+	for _, kv := range kvs.JSON.Pairs {
+		result = append(result, KV{
+			Key:   kv.Key.String(),
+			Value: kv.Value.String(),
+		})
+	}
+	return result, nil
+}

--- a/src/internal/kvparse/kvparse_test.go
+++ b/src/internal/kvparse/kvparse_test.go
@@ -1,0 +1,248 @@
+package kvparse
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pachyderm/pachyderm/v2/src/internal/cmputil"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+)
+
+func TestParseOne(t *testing.T) {
+	testData := []struct {
+		input   string
+		want    KV
+		wantErr string
+	}{
+		{
+			input:   "",
+			wantErr: `/unexpected token "<EOF>"/`,
+		},
+		{
+			input: "key=value",
+			want:  KV{Key: "key", Value: "value"},
+		},
+		{
+			input: `"key with space"="value with space"`,
+			want:  KV{Key: "key with space", Value: "value with space"},
+		},
+		{
+			input: `'key with "double quotes"'="value with 'single quotes'"`,
+			want:  KV{Key: `key with "double quotes"`, Value: "value with 'single quotes'"},
+		},
+		{
+			input: `";"=';'`,
+			want:  KV{Key: `;`, Value: ";"},
+		},
+		{
+			input: `"="="="`,
+			want:  KV{Key: "=", Value: "="},
+		},
+		{
+			input: `"=\""="="`,
+			want:  KV{Key: `="`, Value: `=`},
+		},
+		{
+			input:   `{this is=not json}`,
+			wantErr: `/invalid input text/`,
+			// We could use a different lexer for single a KV pair to allow this.
+		},
+		{
+			input: `💯=100`,
+			want:  KV{Key: "💯", Value: "100"},
+		},
+		{
+			input: `'💯'=100`,
+			want:  KV{Key: "💯", Value: "100"},
+		},
+		{
+			input: `"💯"=100`,
+			want:  KV{Key: "💯", Value: "100"},
+		},
+		{
+			input: `♁=🌎`,
+			want:  KV{Key: "♁", Value: "🌎"},
+		},
+		{
+			input:   `=`,
+			wantErr: `/unexpected token "="/`,
+		},
+		{
+			input:   `=;`,
+			wantErr: `/unexpected token "="/`,
+		},
+		{
+			input: `k=`,
+			want:  KV{Key: "k"},
+		},
+		{
+			input: `k=;`,
+			want:  KV{Key: "k"},
+		},
+		{
+			input: `"\u2641"="\x0a"`,
+			want:  KV{Key: "♁", Value: "\n"},
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.input, func(t *testing.T) {
+			got, err := ParseOne(test.input)
+			if test.wantErr != "" {
+				msg := "<nil>"
+				if err != nil {
+					msg = err.Error()
+				}
+				require.NoDiff(t, test.wantErr, msg, []cmp.Option{cmputil.RegexpStrings()}, "error should match")
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.NoDiff(t, test.want, got, nil, "parser output should match")
+		})
+	}
+}
+
+func TestParseMany(t *testing.T) {
+	testData := []struct {
+		name    string
+		input   string
+		want    []KV
+		wantErr string
+	}{
+		{
+			name: "empty",
+			want: nil,
+		},
+		{
+			name:  "empty json",
+			input: `{ }`,
+			want:  nil,
+		},
+		{
+			name:  "single",
+			input: "key=value",
+			want: []KV{
+				{Key: "key", Value: "value"},
+			},
+		},
+		{
+			name:  "single terminated",
+			input: "key=value;  ",
+			want: []KV{
+				{Key: "key", Value: "value"},
+			},
+		},
+		{
+			name:    "not json",
+			input:   `{"this is not:"="json"}`,
+			wantErr: `/invalid input/`,
+		},
+		{
+			name:  "simple json",
+			input: `{"key":"value"}`,
+			want: []KV{
+				{Key: "key", Value: "value"},
+			},
+		},
+		{
+			name:  "simple json with spaces",
+			input: `{	"key"  :	"value" }`,
+			want: []KV{
+				{Key: "key", Value: "value"},
+			},
+		},
+		{
+			name:  "simple json with trailing comma",
+			input: `{"key":"value",}`,
+			want: []KV{
+				{Key: "key", Value: "value"},
+			},
+		},
+		{
+			name:  "complex json",
+			input: `{"key":"value","key2":"value2",";":"=","'":"\"",":":"}"}`,
+			want: []KV{
+				{Key: "key", Value: "value"},
+				{Key: "key2", Value: "value2"},
+				{Key: ";", Value: "="},
+				{Key: "'", Value: `"`},
+				{Key: ":", Value: `}`},
+			},
+		},
+		{
+			name: "json with trailing comma and spaces",
+			input: `{ "key":   "value"  ,   "key2"	:"value2"
+				,";":"=",
+				"'":"\"",":": "}",
+			}`,
+			want: []KV{
+				{Key: "key", Value: "value"},
+				{Key: "key2", Value: "value2"},
+				{Key: ";", Value: "="},
+				{Key: "'", Value: `"`},
+				{Key: ":", Value: `}`},
+			},
+		},
+		{
+			name: "doc example",
+			input: `key=value;key2=value2;"key with space"="value with space";
+'key with "double quotes"'="value with 'single quotes'";
+'";"'="';'";"="="="`,
+			want: []KV{
+				{Key: "key", Value: "value"},
+				{Key: "key2", Value: "value2"},
+				{Key: "key with space", Value: "value with space"},
+				{Key: `key with "double quotes"`, Value: "value with 'single quotes'"},
+				{Key: `";"`, Value: "';'"},
+				{Key: "=", Value: "="},
+			},
+		},
+		{
+			name:    "0",
+			input:   `0`,
+			wantErr: `/must match at least once/`,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseMany(test.input)
+			if test.wantErr != "" {
+				msg := "<nil>"
+				if err != nil {
+					msg = err.Error()
+				}
+				require.NoDiff(t, test.wantErr, msg, []cmp.Option{cmputil.RegexpStrings()}, "error should match")
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.NoDiff(t, test.want, got, nil, "parser output should match")
+		})
+	}
+}
+
+func FuzzParseOne(f *testing.F) {
+	f.Add("key=value")
+	f.Add("key=value;")
+	f.Add(`"key"="value"`)
+	f.Add(`'key'='value'`)
+	f.Fuzz(func(t *testing.T, in string) {
+		ParseOne(in) //nolint:errcheck
+	})
+}
+
+func FuzzParseMany(f *testing.F) {
+	f.Add("key=value")
+	f.Add("key=value;key2=value2")
+	f.Add(`"key"="value"`)
+	f.Add(`'key'='value'`)
+	f.Add(`{"key":"value"}`)
+	f.Add(`{"key":"value","key2": "value2"}`)
+	f.Fuzz(func(t *testing.T, in string) {
+		ParseMany(in) //nolint:errcheck
+	})
+}

--- a/src/internal/kvparse/printebnf/BUILD.bazel
+++ b/src/internal/kvparse/printebnf/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "printebnf_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/src/internal/kvparse/printebnf",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/internal/kvparse/kvgrammar",
+        "@com_github_alecthomas_participle_v2//:participle",
+        "@com_github_alecthomas_participle_v2//lexer",
+    ],
+)
+
+go_binary(
+    name = "printebnf",
+    embed = [":printebnf_lib"],
+    visibility = ["//src:__subpackages__"],
+)

--- a/src/internal/kvparse/printebnf/main.go
+++ b/src/internal/kvparse/printebnf/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/pachyderm/pachyderm/v2/src/internal/kvparse/kvgrammar"
+)
+
+func main() {
+	lex := participle.Lexer(lexer.MustStateful(kvgrammar.Lexer))
+	fmt.Println(participle.MustBuild[kvgrammar.KV](lex).String())
+	fmt.Println()
+	fmt.Println(participle.MustBuild[kvgrammar.KVs](lex).String())
+}

--- a/src/internal/kvparse/testdata/fuzz/FuzzParseMany/6b51559fb671b56b
+++ b/src/internal/kvparse/testdata/fuzz/FuzzParseMany/6b51559fb671b56b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0=\"\\ud800\"")

--- a/src/internal/kvparse/testdata/fuzz/FuzzParseMany/771e938e4458e983
+++ b/src/internal/kvparse/testdata/fuzz/FuzzParseMany/771e938e4458e983
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0")

--- a/src/internal/kvparse/testdata/fuzz/FuzzParseMany/8521cd8776bccde8
+++ b/src/internal/kvparse/testdata/fuzz/FuzzParseMany/8521cd8776bccde8
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\"0\"=\"\\a\\'\\a0\"")

--- a/src/server/metadata/cmds/BUILD.bazel
+++ b/src/server/metadata/cmds/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//src/internal/cmdutil",
         "//src/internal/config",
         "//src/internal/errors",
+        "//src/internal/kvparse",
         "//src/internal/pachctl",
         "//src/metadata",
         "//src/pfs",

--- a/src/server/metadata/cmds/cmds.go
+++ b/src/server/metadata/cmds/cmds.go
@@ -1,7 +1,6 @@
 package cmds
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -49,22 +48,6 @@ func Cmds(pachCtx *config.Context, pachctlCfg *pachctl.Config) []*cobra.Command 
 	commands = append(commands, cmdutil.CreateAlias(editMetadata, "edit metadata"))
 
 	return commands
-}
-
-func parseKV(data string) (k, v string) {
-	// TODO(jrockway, CORE-2228): Allow keys and values with = in them.
-	parts := strings.SplitN(data, "=", 2)
-	return parts[0], parts[1]
-}
-
-func parseData(data string) (result map[string]string, _ error) {
-	if len(data) == 0 || data[0] != '{' {
-		return nil, errors.New("data must be a JSON object")
-	}
-	if err := json.Unmarshal([]byte(data), &result); err != nil {
-		return nil, errors.Wrap(err, "parse json data")
-	}
-	return
 }
 
 func parseEditMetadataCmdline(args []string, defaultProject string) (*metadata.EditMetadataRequest, error) {

--- a/src/server/metadata/cmds/cmds_test.go
+++ b/src/server/metadata/cmds/cmds_test.go
@@ -470,7 +470,7 @@ func TestEditMetadata(t *testing.T) {
 		{
 			name: "cluster",
 			code: `
-				pachctl edit metadata cluster . set '{"key":"value"}'
+				pachctl edit metadata cluster . replace '{"key":"value"}'
 				pachctl inspect cluster --raw | match '"key":[[:space:]]+"value"'
 			`,
 		},

--- a/src/server/metadata/cmds/cmds_test.go
+++ b/src/server/metadata/cmds/cmds_test.go
@@ -198,8 +198,30 @@ func TestParseEditMetadataCmdline(t *testing.T) {
 			},
 		},
 		{
+			name: "set metadata for a project",
+			args: []string{"project", "default", "set", "key=new"},
+			want: &metadata.EditMetadataRequest{
+				Edits: []*metadata.Edit{
+					{
+						Target: &metadata.Edit_Project{
+							Project: &pfs.ProjectPicker{
+								Picker: &pfs.ProjectPicker_Name{
+									Name: "default",
+								},
+							},
+						},
+						Op: &metadata.Edit_Replace_{
+							Replace: &metadata.Edit_Replace{
+								Replacement: map[string]string{"key": "new"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:    "wrong syntax for set",
-			args:    []string{"project", "default", "set", "key=value"},
+			args:    []string{"project", "default", "set", ";key=value"},
 			wantErr: true,
 		},
 		{

--- a/src/server/metadata/cmds/cmds_test.go
+++ b/src/server/metadata/cmds/cmds_test.go
@@ -31,8 +31,8 @@ func TestParseEditMetadataCmdline(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "set project",
-			args: []string{"project", "default", "set", `{"key":"value", "key2":"value2"}`},
+			name: "replace project",
+			args: []string{"project", "default", "replace", `{"key":"value", "key2":"value2"}`},
 			want: &metadata.EditMetadataRequest{
 				Edits: []*metadata.Edit{
 					{
@@ -126,7 +126,7 @@ func TestParseEditMetadataCmdline(t *testing.T) {
 		{
 			name: "do everything to a project",
 			args: []string{
-				"project", "default", "set", `{"key":"value", "key2":"value2"}`,
+				"project", "default", "replace", `{"key":"value", "key2":"value2"}`,
 				"project", "default", "add", "key3=value",
 				"project", "default", "edit", "key=new",
 				"project", "default", "delete", "key",
@@ -198,8 +198,8 @@ func TestParseEditMetadataCmdline(t *testing.T) {
 			},
 		},
 		{
-			name: "set metadata for a project",
-			args: []string{"project", "default", "set", "key=new"},
+			name: "replace metadata for a project",
+			args: []string{"project", "default", "replace", "key=new"},
 			want: &metadata.EditMetadataRequest{
 				Edits: []*metadata.Edit{
 					{
@@ -220,8 +220,8 @@ func TestParseEditMetadataCmdline(t *testing.T) {
 			},
 		},
 		{
-			name:    "wrong syntax for set",
-			args:    []string{"project", "default", "set", ";key=value"},
+			name:    "wrong syntax for replace",
+			args:    []string{"project", "default", "replace", ";key=value"},
 			wantErr: true,
 		},
 		{
@@ -449,21 +449,21 @@ func TestEditMetadata(t *testing.T) {
 		{
 			name: "commit",
 			code: `
-				pachctl edit metadata commit test@master set '{"key":"value"}'
+				pachctl edit metadata commit test@master replace '{"key":"value"}'
 				pachctl inspect commit test@master --raw | match '"key":[[:space:]]+"value"'
 			`,
 		},
 		{
 			name: "branch",
 			code: `
-				pachctl edit metadata branch test@master set '{"key":"value"}'
+				pachctl edit metadata branch test@master replace '{"key":"value"}'
 				pachctl inspect branch test@master --raw | match '"key":[[:space:]]+"value"'
 			`,
 		},
 		{
 			name: "repo",
 			code: `
-				pachctl edit metadata repo test set '{"key":"value"}'
+				pachctl edit metadata repo test replace '{"key":"value"}'
 				pachctl inspect repo test --raw | match '"key":[[:space:]]+"value"'
 			`,
 		},
@@ -479,7 +479,7 @@ func TestEditMetadata(t *testing.T) {
 			code: `
 				pachctl inspect project default
 				pachctl edit metadata \
-					project default set '{"key":"value","key2":"value"}' \
+					project default replace '{"key":"value","key2":"value"}' \
 					project default add key3=value3 \
 					project default delete key \
 					project default edit key2=value2


### PR DESCRIPTION
This replaces an inflexible parser that's 1 line of code with a more complicated one that can parse any valid metadata.  I changed the "replace" metadata op to `replace` in the CLI.  `set` is short, but I can never remember it.

The grammar looks like this:

![kvs](https://github.com/pachyderm/pachyderm/assets/2367/d3a2bfdc-2c1b-41ae-bbdc-85051d2d819a)

`add` and `edit` take a `KV`.  `replace` takes a `KVs`.

Double-quoted strings are the same as Go's, except that `\U12345678` syntax isn't supported because the spec doesn't explain how it works and I don't know how it works.

Single-quoted strings are very simple; they can't have any escapes in them.

Our variant of JSON is more liberal than the official JSON spec out of convenience.  You can now have vertical linefeeds and `\x??` in your JSON.  You can also have a trailing comma.  Finally, you can probably write `{"key":"value""key2":"value2"}`.

I have fuzz tested the parser for about 12 hours x 32 cores, because it will panic when the parser selects a path that causes the lexer to not advance.  These are mostly caused by `@@*` ("pick 0 or more of this big subobject") directives; that is why an entirely empty KVs is handled by checking that `strings.TrimSpaces() == ""`.  Allowing empty KVs in the grammar is hard to get right without lookahead (which makes error messages bad); lookahead is especially bad for this grammar because how many tokens you need to look ahead depends on the exact content of double-quoted strings (because `(escape | double quoted chars)*` is the content of the string and different strings have different numbers of tokens).  So we avoid lookahead entirely and deal with requring some valid data to parse.  The JSON parser is also not the ideal implementation which is why quirks like omitting commas works.  Frankly, JSON made its grammar harder to implement than it needed to be to make it more restrictive than it needed to be.  With all that in mind, although we allow a bunch of weird stuff, we don't reject or misparse anything valid, so I'm happy.
