### PR TITLE
[INT-1226] Add toast notification for datum order not guarenteed

### DIFF
--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -6,14 +6,15 @@ import {
   CurrentDatumResponse,
   PfsInput,
 } from 'plugins/mount/types';
-import {
-  ReadonlyPartialJSONObject
-} from '@lumino/coreutils';
+import {ReadonlyPartialJSONObject} from '@lumino/coreutils';
 
 type DatumProps = {
   open: (path: string) => void;
   pollRefresh: () => Promise<void>;
-  executeCommand: (id: string, args?: ReadonlyPartialJSONObject | undefined) => void;
+  executeCommand: (
+    id: string,
+    args?: ReadonlyPartialJSONObject | undefined,
+  ) => void;
   currentDatumInfo?: CurrentDatumResponse;
   repoViewInputSpec: CrossInputSpec | PfsInput;
 };

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -6,10 +6,14 @@ import {
   CurrentDatumResponse,
   PfsInput,
 } from 'plugins/mount/types';
+import {
+  ReadonlyPartialJSONObject
+} from '@lumino/coreutils';
 
 type DatumProps = {
   open: (path: string) => void;
   pollRefresh: () => Promise<void>;
+  executeCommand: (id: string, args?: ReadonlyPartialJSONObject | undefined) => void;
   currentDatumInfo?: CurrentDatumResponse;
   repoViewInputSpec: CrossInputSpec | PfsInput;
 };
@@ -22,6 +26,7 @@ const placeholderText = `pfs:
 const Datum: React.FC<DatumProps> = ({
   open,
   pollRefresh,
+  executeCommand,
   currentDatumInfo,
   repoViewInputSpec,
 }) => {
@@ -87,7 +92,16 @@ const Datum: React.FC<DatumProps> = ({
           <button
             data-testid="Datum__loadDatums"
             className="pachyderm-button-link"
-            onClick={callMountDatums}
+            onClick={() => {
+              executeCommand('apputils:notify', {
+                message: 'Datum order not guaranteed when loading datums.',
+                type: 'info',
+                options: {
+                  autoClose: 10000, // 10 seconds
+                },
+              });
+              callMountDatums();
+            }}
             style={{padding: '0.5rem'}}
           >
             Load Datums

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -38,6 +38,7 @@ describe('datum screen', () => {
 
       const {getByTestId, queryByTestId, findByTestId} = render(
         <Datum
+          executeCommand={jest.fn()}
           open={jest.fn()}
           pollRefresh={jest.fn()}
           repoViewInputSpec={{}}
@@ -84,6 +85,7 @@ describe('datum screen', () => {
 
       const {getByTestId, findByTestId} = render(
         <Datum
+          executeCommand={jest.fn()}
           open={jest.fn()}
           pollRefresh={jest.fn()}
           repoViewInputSpec={{}}
@@ -127,6 +129,7 @@ describe('datum screen', () => {
     it('error if bad syntax in input spec', async () => {
       const {getByTestId, findByTestId} = render(
         <Datum
+          executeCommand={jest.fn()}
           open={jest.fn()}
           pollRefresh={jest.fn()}
           repoViewInputSpec={{}}
@@ -154,6 +157,7 @@ describe('datum screen', () => {
 
       const {getByTestId, findByTestId} = render(
         <Datum
+          executeCommand={jest.fn()}
           open={jest.fn()}
           pollRefresh={jest.fn()}
           repoViewInputSpec={{}}
@@ -179,6 +183,7 @@ describe('datum screen', () => {
     it('valid json input spec', async () => {
       const {getByTestId, findByTestId} = render(
         <Datum
+          executeCommand={jest.fn()}
           open={jest.fn()}
           pollRefresh={jest.fn()}
           repoViewInputSpec={{}}
@@ -202,6 +207,7 @@ describe('datum screen', () => {
     it('valid yaml input spec', async () => {
       const {getByTestId, findByTestId} = render(
         <Datum
+          executeCommand={jest.fn()}
           open={jest.fn()}
           pollRefresh={jest.fn()}
           repoViewInputSpec={{}}
@@ -220,6 +226,31 @@ describe('datum screen', () => {
       expect(getByTestId('Datum__errorMessage')).toHaveTextContent(
         'This could take a few minutes...',
       );
+    });
+
+    it('executes command for toast notification on load.', async () => {
+      const executeCommand = jest.fn();
+      const {getByTestId, findByTestId} = render(
+        <Datum
+          executeCommand={executeCommand}
+          open={jest.fn()}
+          pollRefresh={jest.fn()}
+          repoViewInputSpec={{}}
+        />,
+      );
+
+      const input = await findByTestId('Datum__inputSpecInput');
+      const submit = await findByTestId('Datum__loadDatums');
+      userEvent.type(input, YAML.stringify({pfs: 'repo'}));
+      submit.click();
+
+      expect(executeCommand).toBeCalledWith('apputils:notify', {
+        message: 'Datum order not guaranteed when loading datums.',
+        type: 'info',
+        options: {
+          autoClose: 10000, // 10 seconds
+        },
+      })
     });
   });
 });

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -230,7 +230,7 @@ describe('datum screen', () => {
 
     it('executes command for toast notification on load.', async () => {
       const executeCommand = jest.fn();
-      const {getByTestId, findByTestId} = render(
+      const {findByTestId} = render(
         <Datum
           executeCommand={executeCommand}
           open={jest.fn()}
@@ -244,13 +244,13 @@ describe('datum screen', () => {
       userEvent.type(input, YAML.stringify({pfs: 'repo'}));
       submit.click();
 
-      expect(executeCommand).toBeCalledWith('apputils:notify', {
+      expect(executeCommand).toHaveBeenCalledWith('apputils:notify', {
         message: 'Datum order not guaranteed when loading datums.',
         type: 'info',
         options: {
           autoClose: 10000, // 10 seconds
         },
-      })
+      });
     });
   });
 });

--- a/jupyter-extension/src/plugins/mount/mount.tsx
+++ b/jupyter-extension/src/plugins/mount/mount.tsx
@@ -177,6 +177,9 @@ export class MountPlugin implements IMountPlugin {
         <UseSignal signal={this._saveInputSpecSignal}>
           {(_, repoViewInputSpec) => (
             <Datum
+              executeCommand={(command, options) => {
+                this._app.commands.execute(command, options);
+              }}
               open={this.openDatum}
               pollRefresh={this._poller.refresh}
               currentDatumInfo={this._currentDatumInfo}


### PR DESCRIPTION
When the user clicks "Load Datum" a new toast info notification appears explaining the datum order is not guaranteed. This toast notification can be manually dismissed or it disappears automatically after 10 seconds.

<img width="355" alt="Screenshot 2024-03-26 at 11 18 33 AM" src="https://github.com/pachyderm/pachyderm/assets/401518/cc7870fb-e82f-4242-845a-d85e3493f2db">
