### PR TITLE
[INT-1226] Follow up: Only show datum order warning if input spec is more complicated than pfs:

### DIFF
--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -95,7 +95,7 @@ const Datum: React.FC<DatumProps> = ({
             className="pachyderm-button-link"
             onClick={() => {
               // Only show the datum order warning if the input spec is more complicated than a simple mount
-              if (!inputSpec.startsWith("pfs:")) {
+              if (!inputSpec.startsWith('pfs:')) {
                 executeCommand('apputils:notify', {
                   message: 'Datum order not guaranteed when loading datums.',
                   type: 'info',

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -94,13 +94,17 @@ const Datum: React.FC<DatumProps> = ({
             data-testid="Datum__loadDatums"
             className="pachyderm-button-link"
             onClick={() => {
-              executeCommand('apputils:notify', {
-                message: 'Datum order not guaranteed when loading datums.',
-                type: 'info',
-                options: {
-                  autoClose: 10000, // 10 seconds
-                },
-              });
+              // Only show the datum order warning if the input spec is more complicated than a simple mount
+              if (!inputSpec.startsWith("pfs:")) {
+                executeCommand('apputils:notify', {
+                  message: 'Datum order not guaranteed when loading datums.',
+                  type: 'info',
+                  options: {
+                    autoClose: 10000, // 10 seconds
+                  },
+                });
+              }
+
               callMountDatums();
             }}
             style={{padding: '0.5rem'}}

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -228,7 +228,35 @@ describe('datum screen', () => {
       );
     });
 
-    it('executes command for toast notification on load.', async () => {
+    it('executes command for datum order warning if not pfs mount.', async () => {
+      const executeCommand = jest.fn();
+      const {findByTestId} = render(
+        <Datum
+          executeCommand={executeCommand}
+          open={jest.fn()}
+          pollRefresh={jest.fn()}
+          repoViewInputSpec={{}}
+        />,
+      );
+
+      const input = await findByTestId('Datum__inputSpecInput');
+      const submit = await findByTestId('Datum__loadDatums');
+      userEvent.type(
+        input,
+        YAML.stringify({cross: [{pfs: 'repo'}, {pfs: 'repo'}]}),
+      );
+      submit.click();
+
+      expect(executeCommand).toHaveBeenCalledWith('apputils:notify', {
+        message: 'Datum order not guaranteed when loading datums.',
+        type: 'info',
+        options: {
+          autoClose: 10000, // 10 seconds
+        },
+      });
+    });
+
+    it('does not execute command for datum order warning if pfs mount.', async () => {
       const executeCommand = jest.fn();
       const {findByTestId} = render(
         <Datum
@@ -244,13 +272,7 @@ describe('datum screen', () => {
       userEvent.type(input, YAML.stringify({pfs: 'repo'}));
       submit.click();
 
-      expect(executeCommand).toHaveBeenCalledWith('apputils:notify', {
-        message: 'Datum order not guaranteed when loading datums.',
-        type: 'info',
-        options: {
-          autoClose: 10000, // 10 seconds
-        },
-      });
+      expect(executeCommand).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Just a quick update to the previous pr. The datum order issue only applies to more complicated mounts like cross and unions. This PR checks if the input spec does not start with `pfs:` and shows the warning toast notification only in that case.