### PR TITLE
[Python SDK] Helper methods for Picker objects

### DIFF
--- a/python-sdk/pachyderm_sdk/api/pfs/_additions.py
+++ b/python-sdk/pachyderm_sdk/api/pfs/_additions.py
@@ -9,10 +9,33 @@ Note: These are internally patched and this file should
 """
 import re
 
-from . import Branch, Commit, File, Project, Repo
+from . import (
+    Branch,
+    BranchPicker,
+    BranchPickerBranchName,
+    Commit,
+    CommitPicker,
+    CommitPickerAncestorOf,
+    CommitPickerBranchRoot,
+    CommitPickerCommitByGlobalId,
+    File,
+    Project,
+    ProjectPicker,
+    Repo,
+    RepoPicker,
+    RepoPickerRepoName,
+)
 
 branch_re = re.compile(r"^[a-zA-Z\d_-]+$")
 uuid_re = re.compile(r"^[\da-f]{12}4[\da-f]{19}$")
+
+
+def _Project_as_picker(self: "Project") -> ProjectPicker:
+    """Converts a Project to a ProjectPicker."""
+    return ProjectPicker(name=self.name)
+
+
+Project.as_picker = _Project_as_picker
 
 
 def _Repo_from_uri(uri: str) -> Repo:
@@ -49,9 +72,54 @@ def _Repo___post_init__(self: "Repo") -> None:
     super(self.__class__, self).__post_init__()
 
 
+def _Repo_as_picker(self: "Repo") -> RepoPicker:
+    """Converts a Repo to a RepoPicker"""
+    project = None if self.project is None else self.project.as_picker()
+    return RepoPicker(
+        name=RepoPickerRepoName(name=self.name, type=self.type, project=project)
+    )
+
+
 Repo.from_uri = _Repo_from_uri
 Repo.as_uri = Repo.__str__ = _Repo_as_uri
 Repo.__post_init__ = _Repo___post_init__
+Repo.as_picker = _Repo_as_picker
+
+
+def _RepoPicker_from_uri(uri: str) -> RepoPicker:
+    """
+    Parses the following format:
+        [project/]repo
+
+    If no project is specified it defaults to "default".
+    """
+    return Repo.from_uri(uri).as_picker()
+
+
+def _RepoPicker_as_uri(self: RepoPicker) -> str:
+    """
+    Returns the URI for the RepoPicker object in the following format:
+        project/repo
+
+    If no project is specified it defaults to "default"
+    """
+    project = "default"
+    if self.name.project and self.name.project.name:
+        project = self.name.project.name
+    return f"{project}/{self.name.name}"
+
+
+def _RepoPickerRepoName___post_init__(self: "RepoPickerRepoName") -> None:
+    if not self.project or not self.project.name:
+        self.project = ProjectPicker(name="default")
+    if not self.type:
+        self.type = "user"
+    super(self.__class__, self).__post_init__()
+
+
+RepoPicker.from_uri = _RepoPicker_from_uri
+RepoPicker.as_uri = RepoPicker.__str__ = _RepoPicker_as_uri
+RepoPickerRepoName.__post_init__ = _RepoPickerRepoName___post_init__
 
 
 def _Branch_from_uri(uri: str) -> Branch:
@@ -84,8 +152,43 @@ def _Branch_as_uri(self: "Branch") -> str:
     return f"{self.repo.as_uri()}@{self.name}"
 
 
+def _Branch_as_picker(self: "Branch") -> BranchPicker:
+    """Converts a Branch to a BranchPicker."""
+    repo = self.repo.as_picker()
+    return BranchPicker(
+        name=BranchPickerBranchName(name=self.name, repo=repo)
+    )
+
+
 Branch.from_uri = _Branch_from_uri
 Branch.as_uri = Branch.__str__ = _Branch_as_uri
+Branch.as_picker = _Branch_as_picker
+
+
+def _BranchPicker_from_uri(uri: str) -> BranchPicker:
+    """
+    Parses the following format:
+        [project/]repo@branch
+
+    If no project is specified it defaults to "default".
+
+    Raises:
+        ValueError: If no branch is specified.
+    """
+    return Branch.from_uri(uri).as_picker()
+
+
+def _BranchPicker_as_uri(self: BranchPicker) -> str:
+    """Returns the URI for the BranchPicker object in the following format:
+      project/repo@branch
+
+    If no project is specified it defaults to "default"
+    """
+    return f"{self.name.repo.as_uri()}@{self.name.name}"
+
+
+BranchPicker.from_uri = _BranchPicker_from_uri
+BranchPicker.as_uri = BranchPicker.__str__ = _BranchPicker_as_uri
 
 
 def _Commit_from_uri(uri: str) -> Commit:
@@ -141,8 +244,102 @@ def _Commit_as_uri(self: "Commit") -> str:
         return f"{project_repo}@{self.id}"
 
 
+def _Commit_as_picker(self: "Commit") -> CommitPicker:
+    """Converts a Commit to a CommitPicker."""
+    # Note: Due to the fact the ancestor/branch offset notation was
+    #   encoded within the Commit.id field, a more direct conversion
+    #   from Commit -> CommitPicker would already require a lot of
+    #   str parsing. Therefore, the choice was made to implement all
+    #   of this within the CommitPicker.from_uri method.
+    return CommitPicker.from_uri(self.as_uri())
+
+
 Commit.from_uri = _Commit_from_uri
 Commit.as_uri = Commit.__str__ = _Commit_as_uri
+Commit.as_picker = _Commit_as_picker
+
+
+def _CommitPicker_from_uri(uri: str) -> CommitPicker:
+    """
+    Parses the following format:
+        [project/]repo@branch-or-commit
+    where @branch-or-commit can take the form:
+        @branch
+        @branch=commit
+        @commit
+    Additionally @branch-or-commit can be augmented in the following ways:
+        @branch.2
+        @commit^3
+
+    All unspecified components will default to None, except for an unspecified
+      project which defaults to "default".
+    """
+
+    def parse_offset(value: str) -> int:
+        try:
+            return int(value)
+        except ValueError:
+            raise ValueError(
+                "Could not parse commit uri. "
+                "Branch name is invalid - expected a integer offset. "
+                f"uri: {uri}"
+            )
+
+    if "@" not in uri:
+        raise ValueError(
+            "Could not parse branch/commit. URI must have the form: "
+            "[project/]<repo>@(branch|branch=commit|commit)"
+        )
+    project_repo, branch_or_commit = uri.split("@", 1)
+    repo = RepoPicker.from_uri(project_repo)
+    if "=" in branch_or_commit:
+        _, commit = branch_or_commit.split("=", 1)
+        return CommitPicker(id=CommitPickerCommitByGlobalId(repo=repo, id=commit))
+    elif uuid_re.match(branch_or_commit) or not branch_re.match(branch_or_commit):
+        if "." in branch_or_commit:
+            branch_name, offset_str = branch_or_commit.split(".")
+            return CommitPicker(
+                branch_root=CommitPickerBranchRoot(
+                    branch=BranchPicker(
+                        name=BranchPickerBranchName(name=branch_name, repo=repo)
+                    ),
+                    offset=parse_offset(offset_str),
+                )
+            )
+        if "^" in branch_or_commit:
+            start_uri, offset_str = uri.split("^")
+            return CommitPicker(
+                ancestor=CommitPickerAncestorOf(
+                    offset=parse_offset(offset_str),
+                    start=_CommitPicker_from_uri(start_uri),
+                )
+            )
+        return CommitPicker(id=CommitPickerCommitByGlobalId(repo=repo, id=branch_or_commit))
+    else:
+        return CommitPicker(
+            branch_head=BranchPicker(
+                name=BranchPickerBranchName(name=branch_or_commit, repo=repo)
+            ),
+        )
+
+
+def _CommitPicker_as_uri(self: CommitPicker) -> str:
+    """Returns the URI for the CommitPicker object.
+    If no project is specified it defaults to "default"
+    """
+    if self.branch_head:
+        return self.branch_head.as_uri()
+    if self.id:
+        return f"{self.id.repo}@{self.id.id}"
+    if self.ancestor:
+        return f"{self.ancestor.start}^{self.ancestor.offset}"
+    if self.branch_root:
+        return f"{self.branch_root.branch}.{self.branch_root.offset}"
+    raise ValueError(f"invalid CommitPicker: {repr(self)}")
+
+
+CommitPicker.from_uri = _CommitPicker_from_uri
+CommitPicker.as_uri = CommitPicker.__str__ = _CommitPicker_as_uri
 
 
 def _File_from_uri(uri: str) -> File:

--- a/python-sdk/pachyderm_sdk/api/pfs/_additions.py
+++ b/python-sdk/pachyderm_sdk/api/pfs/_additions.py
@@ -155,9 +155,7 @@ def _Branch_as_uri(self: "Branch") -> str:
 def _Branch_as_picker(self: "Branch") -> BranchPicker:
     """Converts a Branch to a BranchPicker."""
     repo = self.repo.as_picker()
-    return BranchPicker(
-        name=BranchPickerBranchName(name=self.name, repo=repo)
-    )
+    return BranchPicker(name=BranchPickerBranchName(name=self.name, repo=repo))
 
 
 Branch.from_uri = _Branch_from_uri

--- a/python-sdk/tests/test_pfs_additions.py
+++ b/python-sdk/tests/test_pfs_additions.py
@@ -1,6 +1,16 @@
+import betterproto
 import pytest
 
-from pachyderm_sdk.api.pfs import Branch, Commit, File, Project, Repo
+from pachyderm_sdk.api.pfs import (
+    Branch,
+    BranchPicker,
+    Commit,
+    CommitPicker,
+    File,
+    Project,
+    Repo,
+    RepoPicker,
+)
 
 
 # fmt: off
@@ -15,8 +25,11 @@ from pachyderm_sdk.api.pfs import Branch, Commit, File, Project, Repo
 # fmt: on
 def test_repo(message: Repo, uri: str):
     """Test the Repo.from_uri and Repo.as_uri methods."""
+    picker = message.as_picker()
     assert message.as_uri() == str(message) == uri
+    assert picker.as_uri() == str(picker) == uri
     assert Repo.from_uri(uri).as_uri() == uri
+    assert RepoPicker.from_uri(uri).as_uri() == uri
 
 
 # fmt: off
@@ -30,8 +43,11 @@ def test_repo(message: Repo, uri: str):
 )
 # fmt: on
 def test_branch(message: Branch, uri: str):
+    picker = message.as_picker()
     assert message.as_uri() == str(message) == uri
+    assert picker.as_uri() == str(picker) == uri
     assert Branch.from_uri(uri).as_uri() == uri
+    assert BranchPicker.from_uri(uri).as_uri() == uri
 
 
 @pytest.mark.parametrize(
@@ -44,30 +60,53 @@ def test_branch_error(bad_uri: str):
 
 # fmt: off
 @pytest.mark.parametrize(
-    "message, uri",
-    [
-        (Commit(branch=Branch(name="master", repo=Repo(name="images", project=None))),
-         "default/images@master"),
-        (Commit(
-            id="abcdef1234564abcdef123456789abcd",
-            branch=Branch(repo=Repo(name="data", project=Project()))
-        ), "default/data@abcdef1234564abcdef123456789abcd"),
-        (Commit(
-            id="123456789abc4def1234567890abcdef",
-            branch=Branch(name="explore", repo=Repo(name="results", project=Project(name="prod")))
-        ), "prod/results@explore=123456789abc4def1234567890abcdef")
-    ]
+    "message, uri, picker_field",
+    [(Commit(branch=Branch(name="master", repo=Repo(name="images", project=None))),
+      "default/images@master",
+      "branch_head"
+      ),
+     (Commit(id="abcdef1234564abcdef123456789abcd", branch=Branch(repo=Repo(name="data", project=Project()))),
+      "default/data@abcdef1234564abcdef123456789abcd",
+      "id"
+      ),
+     (Commit(id="dev.6", branch=Branch(name=None, repo=Repo(name="images", project=None))),
+      "default/images@dev.6",
+      "branch_root"
+      ),
+     (Commit(id="123456789abc4def1234567890abcdef^2", branch=Branch(name=None, repo=Repo(name="results", project=Project(name="prod")))),
+      "prod/results@123456789abc4def1234567890abcdef^2",
+      "ancestor"
+      ),
+     ]
 )
 # fmt: on
-def test_commit(message: Commit, uri: str):
+def test_commit(message: Commit, uri: str, picker_field: str):
+    picker = message.as_picker()
     assert message.as_uri() == str(message) == uri
+    assert picker.as_uri() == str(picker) == uri
+    assert betterproto.which_one_of(picker, "picker")[0] == picker_field
     assert Commit.from_uri(uri).as_uri() == uri
+    assert CommitPicker.from_uri(uri).as_uri() == uri
 
 
 def test_commit_error():
     bad_uri = "project/repo"
     with pytest.raises(ValueError):
         Commit.from_uri(bad_uri)
+
+
+def test_commit_picker_error():
+    with pytest.raises(ValueError):
+        CommitPicker.from_uri("project/repo")
+    with pytest.raises(ValueError):
+        CommitPicker.from_uri("project/repo@branch.abcd")
+    with pytest.raises(ValueError):
+        CommitPicker.from_uri("project/repo@branch^abcd")
+
+
+def test_commit_picker_uri_error():
+    with pytest.raises(ValueError):
+        CommitPicker().as_uri()
 
 
 # fmt: off


### PR DESCRIPTION
Implements the following methods:
* Project.as_picker()
* Repo.as_picker()
* RepoPicker.as_uri()
* RepoPicker.from_uri()
* Branch.as_picker()
* BranchPicker.as_uri()
* BranchPicker.from_uri()
* Commit.as_picker()
* CommitPicker.as_uri()
* CommitPicker.from_uri()