### PR TITLE
Add the ability to Tail loki logs

### DIFF
--- a/src/internal/lokiutil/client/BUILD.bazel
+++ b/src/internal/lokiutil/client/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client",
     visibility = ["//src:__subpackages__"],
     deps = [
+        "//src/internal/backoff",
         "//src/internal/errors",
         "//src/internal/log",
         "//src/internal/promutil",

--- a/src/internal/lokiutil/client/BUILD.bazel
+++ b/src/internal/lokiutil/client/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+# gazelle:go_test file
 
 go_library(
     name = "client",
@@ -11,8 +13,32 @@ go_library(
     visibility = ["//src:__subpackages__"],
     deps = [
         "//src/internal/errors",
+        "//src/internal/log",
         "//src/internal/promutil",
         "@com_github_json_iterator_go//:go",
         "@com_github_modern_go_reflect2//:reflect2",
+        "@org_golang_x_net//websocket",
+        "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "client_test",
+    size = "small",
+    srcs = ["client_test.go"],
+    deps = [
+        ":client",
+        "//src/internal/errors",
+        "//src/internal/lokiutil/testloki",
+        "//src/internal/pctx",
+        "//src/internal/require",
+    ],
+)
+
+go_test(
+    name = "protocol_test",
+    size = "small",
+    srcs = ["protocol_test.go"],
+    embed = [":client"],
+    deps = ["//src/internal/require"],
 )

--- a/src/internal/lokiutil/client/client_test.go
+++ b/src/internal/lokiutil/client/client_test.go
@@ -1,0 +1,120 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/client"
+	"github.com/pachyderm/pachyderm/v2/src/internal/lokiutil/testloki"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+)
+
+func TestTail(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	loki, err := testloki.New(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("set up loki: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := loki.Close(); err != nil {
+			t.Fatalf("clean up loki: %v", err)
+		}
+	})
+	var line int
+	want := []*client.TailChunk{
+		{
+			Fields: map[string]string{"app": "a", "suite": "pachyderm"},
+			Lines:  []string{"starting 1"},
+		},
+		{
+			Fields: map[string]string{"app": "b", "suite": "pachyderm"},
+			Lines:  []string{"starting 2"},
+		},
+		{
+			Fields: map[string]string{"app": "a", "suite": "pachyderm"},
+			Lines:  []string{"line 3"},
+		},
+		{
+			Fields: map[string]string{"app": "b", "suite": "pachyderm"},
+			Lines:  []string{"line 4"},
+		},
+		{
+			Fields: map[string]string{"app": "a", "suite": "pachyderm"},
+			Lines:  []string{"line 5"},
+		},
+		{
+			Fields: map[string]string{"app": "b", "suite": "pachyderm"},
+			Lines:  []string{"line 6"},
+		},
+		{
+			Fields: map[string]string{"app": "a", "suite": "pachyderm"},
+			Lines:  []string{"line 7"},
+		},
+		{
+			Fields: map[string]string{"app": "b", "suite": "pachyderm"},
+			Lines:  []string{"line 8"},
+		},
+		{
+			Fields: map[string]string{"app": "a", "suite": "pachyderm"},
+			Lines:  []string{"line 9"},
+		},
+		{
+			Fields: map[string]string{"app": "b", "suite": "pachyderm"},
+			Lines:  []string{"line 10"},
+		},
+	}
+	send := func(app, msg string) {
+		ts := time.Now()
+		if err := loki.AddLog(ctx, &testloki.Log{
+			Time:    ts,
+			Message: msg,
+			Labels:  map[string]string{"app": app, "suite": "pachyderm"},
+		}); err != nil {
+			t.Fatalf("add log: %v", err)
+		}
+		// Loki will be mad if logs are too far in the past, so we have to use time.Now() or
+		// similar.  This adds the time we sent into the expected return value (with the
+		// time.Unix() thing to strip off the monotonic part of the timestamp).
+		want[line].Time = time.Unix(0, ts.UnixNano())
+		line++
+	}
+	send("a", "starting 1")
+	send("b", "starting 2")
+
+	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	t.Cleanup(cancel)
+
+	errDone := errors.New("done")
+	var got []*client.TailChunk
+	var gotOne bool
+	cb := func(chunk *client.TailChunk) error {
+		got = append(got, chunk)
+		if line >= 10 {
+			t.Log("recevied enough lines; ending tail")
+			return errDone
+		}
+		app := "a"
+		if line%2 == 1 {
+			app = "b"
+		}
+		if gotOne {
+			send(app, fmt.Sprintf("line %v", line+1))
+		} else {
+			// This keeps the lines reading logically; line 1 arrives, we do nothing,
+			// line 2 arrives, we send line 3, etc.
+			gotOne = true
+		}
+		return nil
+	}
+	client.TailPerReadDeadline = 100 * time.Millisecond
+	if err := loki.Client.Tail(tctx, time.Now().Add(-24*time.Hour), `{suite="pachyderm"}`, cb); err != nil {
+		if !errors.Is(err, errDone) {
+			t.Fatalf("tail ended in error: %v", err)
+		}
+	}
+	require.NoDiff(t, want, got, nil, "received lines should match expected lines")
+}

--- a/src/internal/lokiutil/client/protocol_test.go
+++ b/src/internal/lokiutil/client/protocol_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/require"
+)
+
+func TestUnmarshalTailResponse(t *testing.T) {
+	// This was read directly from Loki, but the timestamps were changed to something simpler.
+	input := `{"streams":[{"stream":{"app":"a","suite":"pachyderm"},"values":[["1000000000000000000","starting"]]},{"stream":{"app":"a","suite":"pachyderm"},"values":[["1200000000000000000","starting 2"]]},{"stream":{"app":"b","suite":"pachyderm"},"values":[["1300000000000000000","starting"]]}]}`
+	var got tailResponse
+	if err := json.Unmarshal([]byte(input), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := tailResponse{
+		Streams: []tailStream{
+			{
+				Stream: map[string]string{"app": "a", "suite": "pachyderm"},
+				Values: []tailValue{
+					{
+						Time:     time.Date(2001, 9, 9, 1, 46, 40, 0, time.UTC),
+						Messages: []string{"starting"},
+					},
+				},
+			},
+			{
+				Stream: map[string]string{"app": "a", "suite": "pachyderm"},
+				Values: []tailValue{
+					{
+						Time:     time.Date(2008, 1, 10, 21, 20, 0, 0, time.UTC),
+						Messages: []string{"starting 2"},
+					},
+				},
+			},
+			{
+				Stream: map[string]string{"app": "b", "suite": "pachyderm"},
+				Values: []tailValue{
+					{
+						Time:     time.Date(2011, 3, 13, 7, 6, 40, 0, time.UTC),
+						Messages: []string{"starting"},
+					},
+				},
+			},
+		},
+	}
+	require.NoDiff(t, want, got, nil, "json should decode")
+}


### PR DESCRIPTION
This adds `Tail` to our client library.  Tail is designed to run forever (cancel it with the context), and will survive Loki restarts and such.

Websocket reads are blocking by default with the golang.org/x/net/websocket library; we work around this by setting explicit deadlines and handling the case where nothing arrives in that time interval. 