### PR TITLE
Pass a context to ReadWrite postgres transactions

### DIFF
--- a/src/internal/authdb/authdb.go
+++ b/src/internal/authdb/authdb.go
@@ -1,6 +1,7 @@
 package authdb
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
@@ -86,17 +87,17 @@ func CollectionsV0() []col.PostgresCollection {
 }
 
 // InternalAuthUserPermissions adds the Internal Auth User as a cluster admin
-func InternalAuthUserPermissions(tx *pachsql.Tx) error {
+func InternalAuthUserPermissions(ctx context.Context, tx *pachsql.Tx) error {
 	roleBindings := RoleBindingCollection(nil, nil)
 	var binding auth.RoleBinding
-	if err := roleBindings.ReadWrite(tx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
+	if err := roleBindings.ReadWrite(ctx, tx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil
 		}
 		return errors.Wrapf(err, "getting the cluster role binding")
 	}
 	binding.Entries[InternalUser] = &auth.Roles{Roles: map[string]bool{auth.ClusterAdminRole: true}}
-	return errors.EnsureStack(roleBindings.ReadWrite(tx).Put(auth.ClusterRoleBindingKey, &binding))
+	return errors.EnsureStack(roleBindings.ReadWrite(ctx, tx).Put(auth.ClusterRoleBindingKey, &binding))
 }
 
 // ResourceKey generates the key for a resource in the role bindings collection.

--- a/src/internal/clusterstate/v2.3.0.go
+++ b/src/internal/clusterstate/v2.3.0.go
@@ -9,7 +9,7 @@ import (
 
 var state_2_3_0 migrations.State = state_2_1_0.
 	Apply("Add internal auth user as a cluster admin", func(ctx context.Context, env migrations.Env) error {
-		return authdb.InternalAuthUserPermissions(env.Tx)
+		return authdb.InternalAuthUserPermissions(ctx, env.Tx)
 	})
 	// DO NOT MODIFY THIS STATE
 	// IT HAS ALREADY SHIPPED IN A RELEASE

--- a/src/internal/clusterstate/v2.5.0/auth.go
+++ b/src/internal/clusterstate/v2.5.0/auth.go
@@ -41,7 +41,7 @@ func migrateAuth(ctx context.Context, tx *pachsql.Tx) error {
 	}
 
 	// If auth is already activated, then run the migrations below because they wouldn't have gotten the new role bindings via activation.
-	roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(tx)
+	roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(ctx, tx)
 	if !authIsActive(roleBindingsCol) {
 		return nil
 	}

--- a/src/internal/clusterstate/v2.5.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.5.0/clusterstate.go
@@ -23,7 +23,7 @@ func Migrate(state migrations.State) migrations.State {
 					Name: "default", // hardcoded so that pfs.DefaultProjectName may change in the future
 				},
 			}
-			if err := projects(nil, nil).ReadWrite(env.Tx).Create("default", defaultProject); err != nil {
+			if err := projects(nil, nil).ReadWrite(ctx, env.Tx).Create("default", defaultProject); err != nil {
 				return errors.Wrap(err, "could not create default project")
 			}
 			return nil

--- a/src/internal/clusterstate/v2.5.0/collection_test.go
+++ b/src/internal/clusterstate/v2.5.0/collection_test.go
@@ -54,7 +54,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could create test collection:", err)
 	}
 	if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
-		return testCol.ReadWrite(tx).Put("foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
+		return testCol.ReadWrite(ctx, tx).Put("foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
 	}); err != nil {
 		t.Fatal("could not write test item:", err)
 	}

--- a/src/internal/clusterstate/v2.6.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.6.0/clusterstate.go
@@ -18,7 +18,7 @@ func authIsActive(c collection.PostgresReadWriteCollection) bool {
 func Migrate(state migrations.State) migrations.State {
 	return state.
 		Apply("Grant all users ProjectWriter role for the default project", func(ctx context.Context, env migrations.Env) error {
-			roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(env.Tx)
+			roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(ctx, env.Tx)
 			if !authIsActive(roleBindingsCol) {
 				return nil
 			}

--- a/src/internal/clusterstate/v2.8.0/collection_test.go
+++ b/src/internal/clusterstate/v2.8.0/collection_test.go
@@ -54,7 +54,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could create test collection:", err)
 	}
 	if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
-		return testCol.ReadWrite(tx).Put("foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
+		return testCol.ReadWrite(ctx, tx).Put("foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
 	}); err != nil {
 		t.Fatal("could not write test item:", err)
 	}

--- a/src/internal/clusterstate/v2.8.0/defaults.go
+++ b/src/internal/clusterstate/v2.8.0/defaults.go
@@ -37,7 +37,7 @@ func synthesizeClusterDefaults(ctx context.Context, env migrations.Env) error {
 		return errors.Wrap(err, "could not marshal cluster defaults to JSON")
 	}
 	wrapper := &ppsdb.ClusterDefaultsWrapper{Json: string(js)}
-	if err := ppsdb.CollectionsV2_7_0()[0].ReadWrite(env.Tx).Create("", wrapper); err != nil {
+	if err := ppsdb.CollectionsV2_7_0()[0].ReadWrite(ctx, env.Tx).Create("", wrapper); err != nil {
 		return errors.Wrap(err, "could not create cluster defaults")
 	}
 

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -78,7 +78,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col
 
 		writeCallback := func(ctx context.Context, f func(col.ReadWriteCollection) error) error {
 			return dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
-				return f(testCol.ReadWrite(tx))
+				return f(testCol.ReadWrite(ctx, tx))
 			})
 		}
 

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -21,7 +21,7 @@ type PostgresCollection interface {
 	// invalidated at the end of the transaction.  Basically, it's
 	// software transactional memory.  See this blog post for details:
 	// https://coreos.com/blog/transactional-memory-with-etcd3.html
-	ReadWrite(tx *pachsql.Tx) PostgresReadWriteCollection
+	ReadWrite(ctx context.Context, tx *pachsql.Tx) PostgresReadWriteCollection
 
 	// For read-only operations, use the ReadOnly for better performance
 	ReadOnly(ctx context.Context) PostgresReadOnlyCollection

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -175,7 +175,7 @@ func SetPipelineState(ctx context.Context, db *pachsql.DB, pipelinesCollection c
 	err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, sqlTx *pachsql.Tx) error {
 		resultMessage = ""
 		warn = false
-		pipelines := pipelinesCollection.ReadWrite(sqlTx)
+		pipelines := pipelinesCollection.ReadWrite(ctx, sqlTx)
 		pipelineInfo := &pps.PipelineInfo{}
 		if err := pipelines.Get(specCommit, pipelineInfo); err != nil {
 			return errors.EnsureStack(err)

--- a/src/internal/testpachd/mock_pachd.go
+++ b/src/internal/testpachd/mock_pachd.go
@@ -94,21 +94,21 @@ type RotateRootTokenFunc func(context.Context, *auth.RotateRootTokenRequest) (*a
 type checkClusterIsAuthorizedFunc func(context.Context, ...auth.Permission) error
 type checkProjectIsAuthorizedFunc func(context.Context, *pfs.Project, ...auth.Permission) error
 type checkRepoIsAuthorizedFunc func(context.Context, *pfs.Repo, ...auth.Permission) error
-type checkClusterIsAuthorizedInTransactionFunc func(*txncontext.TransactionContext, ...auth.Permission) error
-type checkProjectIsAuthorizedInTransactionFunc func(*txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
-type checkRepoIsAuthorizedInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
-type authorizeInTransactionFunc func(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
-type modifyRoleBindingInTransactionFunc func(*txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
-type getRoleBindingInTransactionFunc func(*txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
-type addPipelineReaderToRepoInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-type addPipelineWriterToRepoInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) error
-type addPipelineWriterToSourceRepoInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-type removePipelineReaderFromRepoInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-type createRoleBindingInTransactionFunc func(*txncontext.TransactionContext, string, []string, *auth.Resource) error
-type deleteRoleBindingInTransactionFunc func(*txncontext.TransactionContext, *auth.Resource) error
-type getPipelineAuthTokenInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) (string, error)
-type revokeAuthTokenInTransactionFunc func(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
-type getPermissionsInTransactionFunc func(*txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
+type checkClusterIsAuthorizedInTransactionFunc func(context.Context, *txncontext.TransactionContext, ...auth.Permission) error
+type checkProjectIsAuthorizedInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
+type checkRepoIsAuthorizedInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
+type authorizeInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
+type modifyRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
+type getRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
+type addPipelineReaderToRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+type addPipelineWriterToRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.Pipeline) error
+type addPipelineWriterToSourceRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+type removePipelineReaderFromRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+type createRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, string, []string, *auth.Resource) error
+type deleteRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.Resource) error
+type getPipelineAuthTokenInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (string, error)
+type revokeAuthTokenInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
+type getPermissionsInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 
 type mockActivateAuth struct{ handler activateAuthFunc }
 type mockDeactivateAuth struct{ handler deactivateAuthFunc }
@@ -503,107 +503,107 @@ func (api *authServerAPI) CheckRepoIsAuthorized(ctx context.Context, repo *pfs.R
 	return errors.Errorf("unhandled pachd mock auth.CheckRepoIsAuthorized")
 }
 
-func (api *authServerAPI) CheckClusterIsAuthorizedInTransaction(transactionContext *txncontext.TransactionContext, permission ...auth.Permission) error {
+func (api *authServerAPI) CheckClusterIsAuthorizedInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, permission ...auth.Permission) error {
 	if api.mock.CheckClusterIsAuthorizedInTransaction.handler != nil {
-		return api.mock.CheckClusterIsAuthorizedInTransaction.handler(transactionContext, permission...)
+		return api.mock.CheckClusterIsAuthorizedInTransaction.handler(ctx, transactionContext, permission...)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CheckClusterIsAuthorizedInTransaction")
 }
 
-func (api *authServerAPI) CheckRepoIsAuthorizedInTransaction(transactionContext *txncontext.TransactionContext, repo *pfs.Repo, permission ...auth.Permission) error {
+func (api *authServerAPI) CheckRepoIsAuthorizedInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, repo *pfs.Repo, permission ...auth.Permission) error {
 	if api.mock.CheckRepoIsAuthorizedInTransaction.handler != nil {
-		return api.mock.CheckRepoIsAuthorizedInTransaction.handler(transactionContext, repo, permission...)
+		return api.mock.CheckRepoIsAuthorizedInTransaction.handler(ctx, transactionContext, repo, permission...)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CheckRepoIsAuthorizedInTransaction")
 }
 
-func (api *authServerAPI) CheckProjectIsAuthorizedInTransaction(transactionContext *txncontext.TransactionContext, project *pfs.Project, permission ...auth.Permission) error {
+func (api *authServerAPI) CheckProjectIsAuthorizedInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, project *pfs.Project, permission ...auth.Permission) error {
 	if api.mock.CheckProjectIsAuthorizedInTransaction.handler != nil {
-		return api.mock.CheckProjectIsAuthorizedInTransaction.handler(transactionContext, project, permission...)
+		return api.mock.CheckProjectIsAuthorizedInTransaction.handler(ctx, transactionContext, project, permission...)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CheckProjectIsAuthorizedInTransaction")
 }
 
-func (api *authServerAPI) AuthorizeInTransaction(transactionContext *txncontext.TransactionContext, request *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error) {
+func (api *authServerAPI) AuthorizeInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error) {
 	if api.mock.AuthorizeInTransaction.handler != nil {
-		return api.mock.AuthorizeInTransaction.handler(transactionContext, request)
+		return api.mock.AuthorizeInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.AuthorizeInTransaction")
 }
 
-func (api *authServerAPI) ModifyRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, request *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
+func (api *authServerAPI) ModifyRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
 	if api.mock.ModifyRoleBindingInTransaction.handler != nil {
-		return api.mock.ModifyRoleBindingInTransaction.handler(transactionContext, request)
+		return api.mock.ModifyRoleBindingInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.ModifyRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) GetRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, request *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error) {
+func (api *authServerAPI) GetRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error) {
 	if api.mock.GetRoleBindingInTransaction.handler != nil {
-		return api.mock.GetRoleBindingInTransaction.handler(transactionContext, request)
+		return api.mock.GetRoleBindingInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.GetRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) AddPipelineReaderToRepoInTransaction(transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
+func (api *authServerAPI) AddPipelineReaderToRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
 	if api.mock.AddPipelineReaderToRepoInTransaction.handler != nil {
-		return api.mock.AddPipelineReaderToRepoInTransaction.handler(transactionContext, r, p)
+		return api.mock.AddPipelineReaderToRepoInTransaction.handler(ctx, transactionContext, r, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.AddPipelineReaderToRepoInTransaction")
 }
 
-func (api *authServerAPI) AddPipelineWriterToRepoInTransaction(transactionContext *txncontext.TransactionContext, p *pps.Pipeline) error {
+func (api *authServerAPI) AddPipelineWriterToRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, p *pps.Pipeline) error {
 	if api.mock.AddPipelineWriterToRepoInTransaction.handler != nil {
-		return api.mock.AddPipelineWriterToRepoInTransaction.handler(transactionContext, p)
+		return api.mock.AddPipelineWriterToRepoInTransaction.handler(ctx, transactionContext, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.AddPipelineWriterToRepoInTransaction")
 }
 
-func (api *authServerAPI) AddPipelineWriterToSourceRepoInTransaction(transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
+func (api *authServerAPI) AddPipelineWriterToSourceRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
 	if api.mock.AddPipelineWriterToSourceRepoInTransaction.handler != nil {
-		return api.mock.AddPipelineWriterToSourceRepoInTransaction.handler(transactionContext, r, p)
+		return api.mock.AddPipelineWriterToSourceRepoInTransaction.handler(ctx, transactionContext, r, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.AddPipelineWriterToSourceRepoInTransaction")
 }
 
-func (api *authServerAPI) RemovePipelineReaderFromRepoInTransaction(transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
+func (api *authServerAPI) RemovePipelineReaderFromRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
 	if api.mock.RemovePipelineReaderFromRepoInTransaction.handler != nil {
-		return api.mock.RemovePipelineReaderFromRepoInTransaction.handler(transactionContext, r, p)
+		return api.mock.RemovePipelineReaderFromRepoInTransaction.handler(ctx, transactionContext, r, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.RemovePipelineReaderFromRepoInTransaction")
 }
 
-func (api *authServerAPI) CreateRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, s string, strings []string, resource *auth.Resource) error {
+func (api *authServerAPI) CreateRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, s string, strings []string, resource *auth.Resource) error {
 	if api.mock.CreateRoleBindingInTransaction.handler != nil {
-		return api.mock.CreateRoleBindingInTransaction.handler(transactionContext, s, strings, resource)
+		return api.mock.CreateRoleBindingInTransaction.handler(ctx, transactionContext, s, strings, resource)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CreateRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) DeleteRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, resource *auth.Resource) error {
+func (api *authServerAPI) DeleteRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, resource *auth.Resource) error {
 	if api.mock.DeleteRoleBindingInTransaction.handler != nil {
-		return api.mock.DeleteRoleBindingInTransaction.handler(transactionContext, resource)
+		return api.mock.DeleteRoleBindingInTransaction.handler(ctx, transactionContext, resource)
 	}
 	return errors.Errorf("unhandled pachd mock auth.DeleteRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) GetPipelineAuthTokenInTransaction(transactionContext *txncontext.TransactionContext, p *pps.Pipeline) (string, error) {
+func (api *authServerAPI) GetPipelineAuthTokenInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, p *pps.Pipeline) (string, error) {
 	if api.mock.GetPipelineAuthTokenInTransaction.handler != nil {
-		return api.mock.GetPipelineAuthTokenInTransaction.handler(transactionContext, p)
+		return api.mock.GetPipelineAuthTokenInTransaction.handler(ctx, transactionContext, p)
 	}
 	return "", errors.Errorf("unhandled pachd mock auth.GetPipelineAuthTokenInTransaction")
 }
 
-func (api *authServerAPI) RevokeAuthTokenInTransaction(transactionContext *txncontext.TransactionContext, request *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error) {
+func (api *authServerAPI) RevokeAuthTokenInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error) {
 	if api.mock.RevokeAuthTokenInTransaction.handler != nil {
-		return api.mock.RevokeAuthTokenInTransaction.handler(transactionContext, request)
+		return api.mock.RevokeAuthTokenInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.RevokeAuthTokenInTransaction")
 }
 
-func (api *authServerAPI) GetPermissionsInTransaction(transactionContext *txncontext.TransactionContext, request *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
+func (api *authServerAPI) GetPermissionsInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
 	if api.mock.GetPermissionsInTransaction.handler != nil {
-		return api.mock.GetPermissionsInTransaction.handler(transactionContext, request)
+		return api.mock.GetPermissionsInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.GetPermissionsInTransaction")
 }

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -90,8 +90,8 @@ type PPSBackend interface {
 }
 
 type AuthBackend interface {
-	ModifyRoleBindingInTransaction(*txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
-	DeleteRoleBindingInTransaction(*txncontext.TransactionContext, *auth.Resource) error
+	ModifyRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
+	DeleteRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.Resource) error
 	WhoAmI(context.Context, *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 }
 
@@ -218,7 +218,7 @@ func (t *directTransaction) UpdateJobState(original *pps.UpdateJobStateRequest) 
 
 func (t *directTransaction) ModifyRoleBinding(original *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
 	req := proto.Clone(original).(*auth.ModifyRoleBindingRequest)
-	res, err := t.txnEnv.getAuth().ModifyRoleBindingInTransaction(t.txnCtx, req)
+	res, err := t.txnEnv.getAuth().ModifyRoleBindingInTransaction(t.ctx, t.txnCtx, req)
 	return res, errors.EnsureStack(err)
 }
 
@@ -229,7 +229,7 @@ func (t *directTransaction) CreatePipeline(original *pps.CreatePipelineTransacti
 
 func (t *directTransaction) DeleteRoleBinding(original *auth.Resource) error {
 	req := proto.Clone(original).(*auth.Resource)
-	return errors.EnsureStack(t.txnEnv.getAuth().DeleteRoleBindingInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.getAuth().DeleteRoleBindingInTransaction(t.ctx, t.txnCtx, req))
 }
 
 type appendTransaction struct {

--- a/src/server/auth/iface.go
+++ b/src/server/auth/iface.go
@@ -18,28 +18,28 @@ type APIServer interface {
 	CheckClusterIsAuthorized(ctx context.Context, p ...auth.Permission) error
 	CheckProjectIsAuthorized(context.Context, *pfs.Project, ...auth.Permission) error
 	CheckRepoIsAuthorized(context.Context, *pfs.Repo, ...auth.Permission) error
-	CheckClusterIsAuthorizedInTransaction(*txncontext.TransactionContext, ...auth.Permission) error
-	CheckProjectIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
-	CheckRepoIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
+	CheckClusterIsAuthorizedInTransaction(context.Context, *txncontext.TransactionContext, ...auth.Permission) error
+	CheckProjectIsAuthorizedInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
+	CheckRepoIsAuthorizedInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
 
-	AuthorizeInTransaction(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
-	ModifyRoleBindingInTransaction(*txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
-	GetRoleBindingInTransaction(*txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
+	AuthorizeInTransaction(context.Context, *txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
+	ModifyRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
+	GetRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
 
 	// Methods to add and remove pipelines from input and output repos. These do their own auth checks
 	// for specific permissions required to use a repo as a pipeline input/output.
-	AddPipelineReaderToRepoInTransaction(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-	AddPipelineWriterToRepoInTransaction(*txncontext.TransactionContext, *pps.Pipeline) error
-	AddPipelineWriterToSourceRepoInTransaction(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-	RemovePipelineReaderFromRepoInTransaction(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+	AddPipelineReaderToRepoInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+	AddPipelineWriterToRepoInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) error
+	AddPipelineWriterToSourceRepoInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+	RemovePipelineReaderFromRepoInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
 
 	// Create and Delete are internal-only APIs used by other services when creating/destroying resources.
-	CreateRoleBindingInTransaction(*txncontext.TransactionContext, string, []string, *auth.Resource) error
-	DeleteRoleBindingInTransaction(*txncontext.TransactionContext, *auth.Resource) error
+	CreateRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, string, []string, *auth.Resource) error
+	DeleteRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.Resource) error
 
 	// GetPipelineAuthTokenInTransaction is an internal API used by PPS to generate tokens for pipelines
-	GetPipelineAuthTokenInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (string, error)
-	RevokeAuthTokenInTransaction(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
+	GetPipelineAuthTokenInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (string, error)
+	RevokeAuthTokenInTransaction(context.Context, *txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
 
-	GetPermissionsInTransaction(*txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
+	GetPermissionsInTransaction(context.Context, *txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 }

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -381,15 +381,15 @@ func (a *apiServer) isActive(ctx context.Context) error {
 	return err
 }
 
-func (a *apiServer) isActiveInTransaction(txnCtx *txncontext.TransactionContext) error {
-	_, err := a.getClusterRoleBindingInTransaction(txnCtx)
+func (a *apiServer) isActiveInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
+	_, err := a.getClusterRoleBindingInTransaction(ctx, txnCtx)
 	return err
 }
 
 // getClusterRoleBinding attempts to get the current cluster role bindings,
 // and returns an error if auth is not activated. This can require hitting
 // postgres if watches are not enabled (in the worker sidecar).
-func (a *apiServer) getClusterRoleBindingInTransaction(txnCtx *txncontext.TransactionContext) (*auth.RoleBinding, error) {
+func (a *apiServer) getClusterRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext) (*auth.RoleBinding, error) {
 	if a.watchesEnabled && !txnCtx.AuthBeingActivated.Load() {
 		bindings, ok := a.clusterRoleBindingCache.Load().(*auth.RoleBinding)
 		if !ok {
@@ -403,7 +403,7 @@ func (a *apiServer) getClusterRoleBindingInTransaction(txnCtx *txncontext.Transa
 	}
 
 	var binding auth.RoleBinding
-	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
+	if err := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, auth.ErrNotActivated
 		}
@@ -515,7 +515,7 @@ func (a *apiServer) activateInTransaction(ctx context.Context, txCtx *txncontext
 	// Activating an already activated auth service should fail, because
 	// otherwise anyone can just activate the service again and set
 	// themselves as an admin.
-	if err := a.isActiveInTransaction(txCtx); err == nil {
+	if err := a.isActiveInTransaction(ctx, txCtx); err == nil {
 		return nil, auth.ErrAlreadyActivated
 	}
 
@@ -528,7 +528,7 @@ func (a *apiServer) activateInTransaction(ctx context.Context, txCtx *txncontext
 
 	// Store a new Pachyderm token (as the caller is authenticating) and
 	// initialize the root user as a cluster admin
-	roleBindings := a.roleBindings.ReadWrite(txCtx.SqlTx)
+	roleBindings := a.roleBindings.ReadWrite(ctx, txCtx.SqlTx)
 	if err := roleBindings.Put(auth.ClusterRoleBindingKey, &auth.RoleBinding{
 		Entries: map[string]*auth.Roles{
 			auth.RootUser:               {Roles: map[string]bool{auth.ClusterAdminRole: true}},
@@ -583,19 +583,19 @@ func (a *apiServer) rotateRootTokenInTransaction(txCtx *txncontext.TransactionCo
 // Deactivate implements the protobuf auth.Deactivate RPC
 func (a *apiServer) Deactivate(ctx context.Context, req *auth.DeactivateRequest) (resp *auth.DeactivateResponse, retErr error) {
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		if err := a.roleBindings.ReadWrite(sqlTx).DeleteAll(); err != nil {
+		if err := a.roleBindings.ReadWrite(ctx, sqlTx).DeleteAll(); err != nil {
 			return errors.EnsureStack(err)
 		}
 		if err := a.deleteAllAuthTokens(ctx, sqlTx); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := a.members.ReadWrite(sqlTx).DeleteAll(); err != nil {
+		if err := a.members.ReadWrite(ctx, sqlTx).DeleteAll(); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := a.groups.ReadWrite(sqlTx).DeleteAll(); err != nil {
+		if err := a.groups.ReadWrite(ctx, sqlTx).DeleteAll(); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := a.authConfig.ReadWrite(sqlTx).DeleteAll(); err != nil {
+		if err := a.authConfig.ReadWrite(ctx, sqlTx).DeleteAll(); err != nil {
 			return errors.EnsureStack(err)
 		}
 		return nil
@@ -692,13 +692,13 @@ func (a *apiServer) Authenticate(ctx context.Context, req *auth.AuthenticateRequ
 	}, nil
 }
 
-func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, principal string, resource *auth.Resource, permissions map[auth.Permission]bool) (*authorizeRequest, error) {
+func (a *apiServer) evaluateRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, principal string, resource *auth.Resource, permissions map[auth.Permission]bool) (*authorizeRequest, error) {
 	request := newAuthorizeRequest(principal, permissions, a.getGroupsInTransaction)
 
 	// Special-case making spec repos world-readable, because the alternative breaks reading pipelines.
 	// TOOD: 2.0 - should we make this a user-configurable cluster binding instead of hard-coding it?
 	if resource.Type == auth.ResourceType_SPEC_REPO {
-		if err := request.evaluateRoleBinding(txnCtx, &auth.RoleBinding{
+		if err := request.evaluateRoleBinding(ctx, txnCtx, &auth.RoleBinding{
 			Entries: map[string]*auth.Roles{
 				auth.AllClusterUsersSubject: {
 					Roles: map[string]bool{
@@ -719,12 +719,12 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 	}
 
 	// Check the permissions at the cluster level
-	binding, err := a.getClusterRoleBindingInTransaction(txnCtx)
+	binding, err := a.getClusterRoleBindingInTransaction(ctx, txnCtx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := request.evaluateRoleBinding(txnCtx, binding); err != nil {
+	if err := request.evaluateRoleBinding(ctx, txnCtx, binding); err != nil {
 		return nil, err
 	}
 
@@ -744,13 +744,13 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 		}
 		projectResource := &auth.Resource{Type: auth.ResourceType_PROJECT, Name: repo.Project.Name}
 		projectKey := authdb.ResourceKey(projectResource)
-		if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(projectKey, &roleBinding); err != nil {
+		if err := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx).Get(projectKey, &roleBinding); err != nil {
 			if col.IsErrNotFound(err) {
 				return nil, &auth.ErrNoRoleBinding{Resource: projectResource}
 			}
 			return nil, errors.Wrapf(err, "error getting role bindings for %s", projectKey)
 		}
-		if err := request.evaluateRoleBinding(txnCtx, &roleBinding); err != nil {
+		if err := request.evaluateRoleBinding(ctx, txnCtx, &roleBinding); err != nil {
 			return nil, err
 		}
 		if request.isSatisfied() {
@@ -759,7 +759,7 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 	}
 
 	// Get the role bindings for the resource to check
-	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(authdb.ResourceKey(resource), &roleBinding); err != nil {
+	if err := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx).Get(authdb.ResourceKey(resource), &roleBinding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, &auth.ErrNoRoleBinding{
 				Resource: resource,
@@ -767,7 +767,7 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 		}
 		return nil, errors.Wrapf(err, "error getting role bindings for %s \"%s\"", resource.Type, resource.Name)
 	}
-	if err := request.evaluateRoleBinding(txnCtx, &roleBinding); err != nil {
+	if err := request.evaluateRoleBinding(ctx, txnCtx, &roleBinding); err != nil {
 		return nil, err
 	}
 	return request, nil
@@ -775,6 +775,7 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 
 // AuthorizeInTransaction is identical to Authorize except that it can run in a `pachsql.Tx`.
 func (a *apiServer) AuthorizeInTransaction(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	req *auth.AuthorizeRequest,
 ) (resp *auth.AuthorizeResponse, retErr error) {
@@ -788,7 +789,7 @@ func (a *apiServer) AuthorizeInTransaction(
 		permissions[p] = true
 	}
 
-	request, err := a.evaluateRoleBindingInTransaction(txnCtx, me.Username, req.Resource, permissions)
+	request, err := a.evaluateRoleBindingInTransaction(ctx, txnCtx, me.Username, req.Resource, permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -809,7 +810,7 @@ func (a *apiServer) Authorize(
 	var response *auth.AuthorizeResponse
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		var err error
-		response, err = a.AuthorizeInTransaction(txnCtx, req)
+		response, err = a.AuthorizeInTransaction(ctx, txnCtx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -825,7 +826,7 @@ func (a *apiServer) GetPermissionsForPrincipal(ctx context.Context, req *auth.Ge
 	var request *authorizeRequest
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		var err error
-		request, err = a.evaluateRoleBindingInTransaction(txnCtx, req.Principal, req.Resource, permissions)
+		request, err = a.evaluateRoleBindingInTransaction(ctx, txnCtx, req.Principal, req.Resource, permissions)
 		return err
 	}); err != nil {
 		return nil, errors.Wrap(err, "cannot evaluate role binding")
@@ -850,22 +851,22 @@ func (a *apiServer) GetPermissions(ctx context.Context, req *auth.GetPermissions
 	return resp, nil
 }
 
-func (a *apiServer) GetPermissionsInTransaction(txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
+func (a *apiServer) GetPermissionsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
 	callerInfo, err := txnCtx.WhoAmI()
 	if err != nil {
 		return nil, err
 	}
 
-	return a.getPermissionsForPrincipalInTransaction(txnCtx, &auth.GetPermissionsForPrincipalRequest{Principal: callerInfo.Username, Resource: req.Resource})
+	return a.getPermissionsForPrincipalInTransaction(ctx, txnCtx, &auth.GetPermissionsForPrincipalRequest{Principal: callerInfo.Username, Resource: req.Resource})
 }
 
-func (a *apiServer) getPermissionsForPrincipalInTransaction(txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsForPrincipalRequest) (*auth.GetPermissionsResponse, error) {
+func (a *apiServer) getPermissionsForPrincipalInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsForPrincipalRequest) (*auth.GetPermissionsResponse, error) {
 	permissions := make(map[auth.Permission]bool)
 	for p := range auth.Permission_name {
 		permissions[auth.Permission(p)] = true
 	}
 
-	request, err := a.evaluateRoleBindingInTransaction(txnCtx, req.Principal, req.Resource, permissions)
+	request, err := a.evaluateRoleBindingInTransaction(ctx, txnCtx, req.Principal, req.Resource, permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -896,8 +897,8 @@ func (a *apiServer) WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (resp *
 // DeleteRoleBindingInTransaction is used to remove role bindings for resources when they're deleted in other services.
 // It doesn't do any auth checks itself - the calling method should ensure the user is allowed to delete this resource.
 // This is not an RPC, this is only called in-process.
-func (a *apiServer) DeleteRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, resource *auth.Resource) error {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+func (a *apiServer) DeleteRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, resource *auth.Resource) error {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return err
 	}
 
@@ -906,7 +907,7 @@ func (a *apiServer) DeleteRoleBindingInTransaction(txnCtx *txncontext.Transactio
 	}
 
 	key := authdb.ResourceKey(resource)
-	roleBindings := a.roleBindings.ReadWrite(txnCtx.SqlTx)
+	roleBindings := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx)
 	if err := roleBindings.Delete(key); err != nil {
 		return errors.EnsureStack(err)
 	}
@@ -937,7 +938,7 @@ func rolesFromRoleSlice(rs []string) (*auth.Roles, error) {
 // CreateRoleBindingInTransaction is an internal-only API to create a role binding for a new resource.
 // It doesn't do any authorization checks itself - the calling method should ensure the user is allowed
 // to create the resource. This is not an RPC.
-func (a *apiServer) CreateRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error {
+func (a *apiServer) CreateRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error {
 	bindings := &auth.RoleBinding{
 		Entries: make(map[string]*auth.Roles),
 	}
@@ -958,7 +959,7 @@ func (a *apiServer) CreateRoleBindingInTransaction(txnCtx *txncontext.Transactio
 
 	// Call Create, this will raise an error if the role binding already exists.
 	key := authdb.ResourceKey(resource)
-	roleBindings := a.roleBindings.ReadWrite(txnCtx.SqlTx)
+	roleBindings := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx)
 	if err := roleBindings.Create(key, bindings); err != nil {
 		return errors.EnsureStack(err)
 	}
@@ -970,17 +971,17 @@ func (a *apiServer) CreateRoleBindingInTransaction(txnCtx *txncontext.Transactio
 // This is distinct from ModifyRoleBinding because AddPipelineReader is a less expansive permission
 // that is included in the repoReader role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) AddPipelineReaderToRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
+func (a *apiServer) AddPipelineReaderToRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
 	r := &pfs.Repo{
 		Project: sourceRepo.Project,
 		Name:    sourceRepo.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_READER); err != nil {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_READER); err != nil {
 		return err
 	}
 
-	return a.setUserRoleBindingInTransaction(txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoReaderRole})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoReaderRole})
 }
 
 // AddPipelineWriterToSourceRepoInTransaction gives a pipeline access to write data to the specified source repo.
@@ -988,42 +989,42 @@ func (a *apiServer) AddPipelineReaderToRepoInTransaction(txnCtx *txncontext.Tran
 // This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) AddPipelineWriterToSourceRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
+func (a *apiServer) AddPipelineWriterToSourceRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
 	// Check that the user is allowed to add a pipeline to write to the output repo.
 	r := &pfs.Repo{
 		Project: sourceRepo.Project,
 		Name:    sourceRepo.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
 		return err
 	}
-	return a.setUserRoleBindingInTransaction(txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
 }
 
 // AddPipelineWriterToRepoInTransaction gives a pipeline access to write to it's own output repo.
 // This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) AddPipelineWriterToRepoInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) error {
+func (a *apiServer) AddPipelineWriterToRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) error {
 	// Check that the user is allowed to add a pipeline to write to the output repo.
 	r := &pfs.Repo{
 		Project: pipeline.Project,
 		Name:    pipeline.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
 		return err
 	}
 
-	return a.setUserRoleBindingInTransaction(txnCtx, r.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, r.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
 }
 
 // RemovePipelineReaderFromRepo revokes a pipeline's access to read data from the specified source repo.
 // This is distinct from ModifyRoleBinding because RemovePipelineReader is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) RemovePipelineReaderFromRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
+func (a *apiServer) RemovePipelineReaderFromRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
 	// Check that the user is allowed to remove input repos from the pipeline repo - this check is on the pipeline itself
 	// and not sourceRepo because otherwise users could break piplines they don't have access to by revoking them from the
 	// input repo.
@@ -1032,20 +1033,21 @@ func (a *apiServer) RemovePipelineReaderFromRepoInTransaction(txnCtx *txncontext
 		Name:    pipeline.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_REMOVE_PIPELINE_READER); err != nil && !auth.IsErrNoRoleBinding(err) {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_REMOVE_PIPELINE_READER); err != nil && !auth.IsErrNoRoleBinding(err) {
 		return err
 	}
 
-	return a.setUserRoleBindingInTransaction(txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{})
 }
 
 // ModifyRoleBindingInTransaction is identical to ModifyRoleBinding except that it can run inside
 // an existing postgres transaction.  This is not an RPC.
 func (a *apiServer) ModifyRoleBindingInTransaction(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	req *auth.ModifyRoleBindingRequest,
 ) (*auth.ModifyRoleBindingResponse, error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return nil, err
 	}
 
@@ -1070,25 +1072,25 @@ func (a *apiServer) ModifyRoleBindingInTransaction(
 	default:
 		return nil, errors.Errorf("unknown resource type %v", req.Resource.Type)
 	}
-	if err := a.checkResourceIsAuthorizedInTransaction(txnCtx, req.Resource, permission); err != nil {
+	if err := a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, req.Resource, permission); err != nil {
 		return nil, err
 	}
 
-	if err := a.setUserRoleBindingInTransaction(txnCtx, req.Resource, req.Principal, req.Roles); err != nil {
+	if err := a.setUserRoleBindingInTransaction(ctx, txnCtx, req.Resource, req.Principal, req.Roles); err != nil {
 		return nil, err
 	}
 
 	return &auth.ModifyRoleBindingResponse{}, nil
 }
 
-func (a *apiServer) setUserRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, resource *auth.Resource, principal string, roleSlice []string) error {
+func (a *apiServer) setUserRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, resource *auth.Resource, principal string, roleSlice []string) error {
 	roles, err := rolesFromRoleSlice(roleSlice)
 	if err != nil {
 		return err
 	}
 
 	key := authdb.ResourceKey(resource)
-	roleBindings := a.roleBindings.ReadWrite(txnCtx.SqlTx)
+	roleBindings := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx)
 	var bindings auth.RoleBinding
 	if err := roleBindings.Get(key, &bindings); err != nil {
 		if col.IsErrNotFound(err) {
@@ -1148,15 +1150,16 @@ func (a *apiServer) ModifyRoleBinding(ctx context.Context, req *auth.ModifyRoleB
 // GetRoleBindingInTransaction is identical to GetRoleBinding except that it can run inside
 // an existing postgres transaction.  This is not an RPC.
 func (a *apiServer) GetRoleBindingInTransaction(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	req *auth.GetRoleBindingRequest,
 ) (*auth.GetRoleBindingResponse, error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return nil, err
 	}
 
 	var roleBindings auth.RoleBinding
-	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(authdb.ResourceKey(req.Resource), &roleBindings); err != nil && !col.IsErrNotFound(err) {
+	if err := a.roleBindings.ReadWrite(ctx, txnCtx.SqlTx).Get(authdb.ResourceKey(req.Resource), &roleBindings); err != nil && !col.IsErrNotFound(err) {
 		return nil, errors.EnsureStack(err)
 	}
 
@@ -1173,7 +1176,7 @@ func (a *apiServer) GetRoleBinding(ctx context.Context, req *auth.GetRoleBinding
 	var response *auth.GetRoleBindingResponse
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		var err error
-		response, err = a.GetRoleBindingInTransaction(txnCtx, req)
+		response, err = a.GetRoleBindingInTransaction(ctx, txnCtx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -1209,8 +1212,8 @@ func (a *apiServer) GetRobotToken(ctx context.Context, req *auth.GetRobotTokenRe
 
 // GetPipelineAuthTokenInTransaction is an internal API used to create a pipeline token for a given pipeline.
 // Not an RPC.
-func (a *apiServer) GetPipelineAuthTokenInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (string, error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+func (a *apiServer) GetPipelineAuthTokenInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (string, error) {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return "", err
 	}
 
@@ -1237,7 +1240,7 @@ func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequ
 // RevokeAuthToken implements the protobuf auth.RevokeAuthToken RPC
 func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
 	if err := a.env.TxnEnv.WithWriteContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
-		resp, retErr = a.RevokeAuthTokenInTransaction(txnCtx, req)
+		resp, retErr = a.RevokeAuthTokenInTransaction(ctx, txnCtx, req)
 		return retErr
 	}); err != nil {
 		return nil, err
@@ -1245,8 +1248,8 @@ func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTok
 	return resp, retErr
 }
 
-func (a *apiServer) RevokeAuthTokenInTransaction(txnCtx *txncontext.TransactionContext, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+func (a *apiServer) RevokeAuthTokenInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return nil, err
 	}
 
@@ -1263,7 +1266,7 @@ func (a *apiServer) RevokeAuthTokenInTransaction(txnCtx *txncontext.TransactionC
 // relevant authorization.
 func (a *apiServer) setGroupsForUserInternal(ctx context.Context, subject string, groups []string) error {
 	return dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		members := a.members.ReadWrite(sqlTx)
+		members := a.members.ReadWrite(ctx, sqlTx)
 
 		// Get groups to remove/add user from/to
 		var removeGroups auth.Groups
@@ -1285,7 +1288,7 @@ func (a *apiServer) setGroupsForUserInternal(ctx context.Context, subject string
 		}
 
 		// Remove user from previous groups
-		groups := a.groups.ReadWrite(sqlTx)
+		groups := a.groups.ReadWrite(ctx, sqlTx)
 		var membersProto auth.Users
 		for group := range removeGroups.Groups {
 			if err := groups.Upsert(group, &membersProto, func() error {
@@ -1333,7 +1336,7 @@ func (a *apiServer) ModifyMembers(ctx context.Context, req *auth.ModifyMembersRe
 	}
 
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		members := a.members.ReadWrite(sqlTx)
+		members := a.members.ReadWrite(ctx, sqlTx)
 		var groupsProto auth.Groups
 		for _, username := range req.Add {
 			if err := members.Upsert(username, &groupsProto, func() error {
@@ -1352,7 +1355,7 @@ func (a *apiServer) ModifyMembers(ctx context.Context, req *auth.ModifyMembersRe
 			}
 		}
 
-		groups := a.groups.ReadWrite(sqlTx)
+		groups := a.groups.ReadWrite(ctx, sqlTx)
 		var membersProto auth.Users
 		if err := groups.Upsert(req.Group, &membersProto, func() error {
 			membersProto.Usernames = addToSet(membersProto.Usernames, req.Add...)
@@ -1407,8 +1410,8 @@ func (a *apiServer) getGroups(ctx context.Context, subject string) ([]string, er
 
 // getGroups is a helper function used primarily by the GRPC API GetGroups, but
 // also by Authorize() and isAdmin().
-func (a *apiServer) getGroupsInTransaction(txnCtx *txncontext.TransactionContext, subject string) ([]string, error) {
-	members := a.members.ReadWrite(txnCtx.SqlTx)
+func (a *apiServer) getGroupsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, subject string) ([]string, error) {
+	members := a.members.ReadWrite(ctx, txnCtx.SqlTx)
 	var groupsProto auth.Groups
 	if err := members.Get(subject, &groupsProto); err != nil {
 		if col.IsErrNotFound(err) {
@@ -1448,7 +1451,7 @@ func (a *apiServer) GetUsers(ctx context.Context, req *auth.GetUsersRequest) (re
 	if req.Group != "" {
 		var membersProto auth.Users
 		if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-			groups := a.groups.ReadWrite(sqlTx)
+			groups := a.groups.ReadWrite(ctx, sqlTx)
 			if err := groups.Get(req.Group, &membersProto); err != nil {
 				return errors.EnsureStack(err)
 			}
@@ -1602,7 +1605,7 @@ func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigura
 
 	// set the new config
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		return errors.EnsureStack(a.authConfig.ReadWrite(sqlTx).Put(configKey, configToStore))
+		return errors.EnsureStack(a.authConfig.ReadWrite(ctx, sqlTx).Put(configKey, configToStore))
 	}); err != nil {
 		return nil, err
 	}

--- a/src/server/auth/server/authorize_req.go
+++ b/src/server/auth/server/authorize_req.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"sort"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -8,7 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 )
 
-type groupLookupFn func(txnCtx *txncontext.TransactionContext, subject string) ([]string, error)
+type groupLookupFn func(ctx context.Context, txnCtx *txncontext.TransactionContext, subject string) ([]string, error)
 
 // authorizeRequest is a helper struct used to evaluate an incoming Authorize request.
 // It's initialized with the subject and set of permissions required for an Operation,
@@ -73,7 +74,7 @@ func (r *authorizeRequest) missing() []auth.Permission {
 // - role bindings that refer to them by name
 // - role bindings that refer to allClusterUsers
 // - role bindings that refer to any group the subject belongs to
-func (r *authorizeRequest) evaluateRoleBinding(txnCtx *txncontext.TransactionContext, binding *auth.RoleBinding) error {
+func (r *authorizeRequest) evaluateRoleBinding(ctx context.Context, txnCtx *txncontext.TransactionContext, binding *auth.RoleBinding) error {
 	if err := r.evaluateRoleBindingForSubject(r.subject, binding); err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (r *authorizeRequest) evaluateRoleBinding(txnCtx *txncontext.TransactionCon
 	// bindings to cover the set of permissions.
 	if r.groups == nil {
 		var err error
-		r.groups, err = r.groupsForSubject(txnCtx, r.subject)
+		r.groups, err = r.groupsForSubject(ctx, txnCtx, r.subject)
 		if err != nil {
 			return err
 		}

--- a/src/server/auth/server/util.go
+++ b/src/server/auth/server/util.go
@@ -11,26 +11,26 @@ import (
 
 // CheckClusterIsAuthorizedInTransaction returns an error if the current user doesn't have
 // the permissions in `p` on the cluster
-func (a *apiServer) CheckClusterIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, p ...auth.Permission) error {
-	return a.checkResourceIsAuthorizedInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_CLUSTER}, p...)
+func (a *apiServer) CheckClusterIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, p ...auth.Permission) error {
+	return a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, &auth.Resource{Type: auth.ResourceType_CLUSTER}, p...)
 }
 
 // CheckProjectIsAuthorizedInTransaction returns an error if the current user doesn't have the permissions in `p` on the project.
 // Projects inherit access controls from its parent cluster. Therefore, behind the scene, we check the cluster first, followed by this project.
-func (a *apiServer) CheckProjectIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error {
-	return a.checkResourceIsAuthorizedInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: project.Name}, p...)
+func (a *apiServer) CheckProjectIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error {
+	return a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: project.Name}, p...)
 }
 
 // CheckRepoIsAuthorizedInTransaction is identical to CheckRepoIsAuthorized except that
 // it performs reads consistent with the latest state of the STM transaction.
 // Repos inherit access controls from its parent project, which in turn inherits from the cluster.
 // Therefore, behind the scene, we check the cluster first, then this repo's project, and finally this repo.
-func (a *apiServer) CheckRepoIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error {
-	return a.checkResourceIsAuthorizedInTransaction(txnCtx, repo.AuthResource(), p...)
+func (a *apiServer) CheckRepoIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error {
+	return a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, repo.AuthResource(), p...)
 }
 
 // CheckResourceIsAuthorizedInTransaction returns an error if the subject/user doesn't have permission in `p` on the `resource`
-func (a *apiServer) checkResourceIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, resource *auth.Resource, p ...auth.Permission) error {
+func (a *apiServer) checkResourceIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, resource *auth.Resource, p ...auth.Permission) error {
 	me, err := txnCtx.WhoAmI()
 	if err != nil {
 		if errors.Is(err, auth.ErrNotActivated) {
@@ -40,7 +40,7 @@ func (a *apiServer) checkResourceIsAuthorizedInTransaction(txnCtx *txncontext.Tr
 	}
 
 	req := &auth.AuthorizeRequest{Resource: resource, Permissions: p}
-	resp, err := a.AuthorizeInTransaction(txnCtx, req)
+	resp, err := a.AuthorizeInTransaction(ctx, txnCtx, req)
 	if err != nil {
 		return err
 	}

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -256,7 +256,7 @@ func (a *apiServer) Activate(ctx context.Context, req *ec.ActivateRequest) (resp
 
 	// If the test heartbeat succeeded, write the state and config to etcd
 	if err := a.env.TxnEnv.WithWriteContext(ctx, func(ctx context.Context, txCtx *txncontext.TransactionContext) error {
-		if err := a.configCol.ReadWrite(txCtx.SqlTx).Put(configKey, &ec.EnterpriseConfig{
+		if err := a.configCol.ReadWrite(ctx, txCtx.SqlTx).Put(configKey, &ec.EnterpriseConfig{
 			LicenseServer: req.LicenseServer,
 			Id:            req.Id,
 			Secret:        req.Secret,
@@ -377,7 +377,7 @@ func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (
 	}
 
 	if err := a.env.TxnEnv.WithWriteContext(ctx, func(ctx context.Context, txCtx *txncontext.TransactionContext) error {
-		err := a.configCol.ReadWrite(txCtx.SqlTx).Delete(configKey)
+		err := a.configCol.ReadWrite(ctx, txCtx.SqlTx).Delete(configKey)
 		if err != nil && !col.IsErrNotFound(err) {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -71,7 +71,7 @@ func EnterpriseConfigPostgresMigration(ctx context.Context, tx *pachsql.Tx, etcd
 		return err
 	}
 	if config != nil {
-		return errors.EnsureStack(EnterpriseConfigCollection(nil, nil).ReadWrite(tx).Put(configKey, config))
+		return errors.EnsureStack(EnterpriseConfigCollection(nil, nil).ReadWrite(ctx, tx).Put(configKey, config))
 	}
 	return nil
 }

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -123,7 +123,7 @@ func (a *apiServer) activate(ctx context.Context, req *lc.ActivateRequest) (resp
 	}
 
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		return errors.EnsureStack(a.license.ReadWrite(sqlTx).Put(licenseRecordKey, newRecord))
+		return errors.EnsureStack(a.license.ReadWrite(ctx, sqlTx).Put(licenseRecordKey, newRecord))
 	}); err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, req *lc.DeleteAllRequest) (re
 	}
 
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		err := a.license.ReadWrite(sqlTx).Delete(licenseRecordKey)
+		err := a.license.ReadWrite(ctx, sqlTx).Delete(licenseRecordKey)
 		if err != nil && !col.IsErrNotFound(err) {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -81,7 +81,7 @@ func (a *apiServer) ActivateAuthInTransaction(ctx context.Context, txnCtx *txnco
 			principal = auth.AllClusterUsersSubject
 			roleSlice = []string{auth.ProjectWriterRole}
 		}
-		err := a.env.Auth.CreateRoleBindingInTransaction(txnCtx, principal, roleSlice,
+		err := a.env.Auth.CreateRoleBindingInTransaction(ctx, txnCtx, principal, roleSlice,
 			&auth.Resource{Type: auth.ResourceType_PROJECT, Name: proj.ProjectInfo.Project.Name})
 		if err != nil && !col.IsErrExists(err) {
 			return errors.Wrap(err, "activate auth in transaction")
@@ -92,7 +92,7 @@ func (a *apiServer) ActivateAuthInTransaction(ctx context.Context, txnCtx *txnco
 	}
 	// Create role bindings for repos created before auth activation
 	if err := pfsdb.ForEachRepo(ctx, txnCtx.SqlTx, nil, nil, func(repoInfoWithID pfsdb.RepoInfoWithID) error {
-		err := a.env.Auth.CreateRoleBindingInTransaction(txnCtx, "", nil, repoInfoWithID.RepoInfo.Repo.AuthResource())
+		err := a.env.Auth.CreateRoleBindingInTransaction(ctx, txnCtx, "", nil, repoInfoWithID.RepoInfo.Repo.AuthResource())
 		if err != nil && !col.IsErrExists(err) {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -145,7 +145,7 @@ func (d *driver) createRepo(ctx context.Context, txnCtx *txncontext.TransactionC
 	}
 
 	// Check whether the user has the permission to create a repo in this project.
-	if err := d.env.Auth.CheckProjectIsAuthorizedInTransaction(txnCtx, repo.Project, auth.Permission_PROJECT_CREATE_REPO); err != nil {
+	if err := d.env.Auth.CheckProjectIsAuthorizedInTransaction(ctx, txnCtx, repo.Project, auth.Permission_PROJECT_CREATE_REPO); err != nil {
 		return errors.Wrap(err, "failed to create repo")
 	}
 
@@ -180,7 +180,7 @@ func (d *driver) createRepo(ctx context.Context, txnCtx *txncontext.TransactionC
 			// and the ACL already exists with a different owner, this will fail.
 			// For now, we expect system repos to share auth info with their corresponding
 			// user repo, so the role binding should exist
-			if err := d.env.Auth.CreateRoleBindingInTransaction(txnCtx, whoAmI.Username, []string{auth.RepoOwnerRole}, repo.AuthResource()); err != nil && (!col.IsErrExists(err) || repo.Type == pfs.UserRepoType) {
+			if err := d.env.Auth.CreateRoleBindingInTransaction(ctx, txnCtx, whoAmI.Username, []string{auth.RepoOwnerRole}, repo.AuthResource()); err != nil && (!col.IsErrExists(err) || repo.Type == pfs.UserRepoType) {
 				return errors.Wrapf(grpcutil.ScrubGRPC(err), "could not create role binding for new repo %q", repo)
 			}
 		}
@@ -207,7 +207,7 @@ func (d *driver) createRepo(ctx context.Context, txnCtx *txncontext.TransactionC
 	// idempotent way to ensure that R exists. By permitting these calls when
 	// they don't actually change anything, even if the caller doesn't have
 	// WRITER access, we make the pattern more generally useful.
-	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, repo, auth.Permission_REPO_WRITE); err != nil {
+	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, repo, auth.Permission_REPO_WRITE); err != nil {
 		return errors.Wrapf(err, "could not update description of %q", repo)
 	}
 	existingRepoInfo.Description = description
@@ -228,7 +228,7 @@ func (d *driver) inspectRepo(ctx context.Context, txnCtx *txncontext.Transaction
 		return nil, errors.EnsureStack(err)
 	}
 	if includeAuth {
-		resp, err := d.env.Auth.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{
+		resp, err := d.env.Auth.GetPermissionsInTransaction(ctx, txnCtx, &auth.GetPermissionsRequest{
 			Resource: repo.AuthResource(),
 		})
 		if err != nil {
@@ -242,8 +242,8 @@ func (d *driver) inspectRepo(ctx context.Context, txnCtx *txncontext.Transaction
 	return repoInfo, nil
 }
 
-func (d *driver) getPermissionsInTransaction(txnCtx *txncontext.TransactionContext, repo *pfs.Repo) ([]auth.Permission, []string, error) {
-	resp, err := d.env.Auth.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{Resource: repo.AuthResource()})
+func (d *driver) getPermissionsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo) ([]auth.Permission, []string, error) {
+	resp, err := d.env.Auth.GetPermissionsInTransaction(ctx, txnCtx, &auth.GetPermissionsRequest{Resource: repo.AuthResource()})
 	if err != nil {
 		return nil, nil, errors.EnsureStack(err)
 	}
@@ -252,6 +252,7 @@ func (d *driver) getPermissionsInTransaction(txnCtx *txncontext.TransactionConte
 }
 
 func (d *driver) hasProjectAccess(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	repoInfo *pfs.RepoInfo,
 	checkProjectAccess func(string) error) (bool, error) {
@@ -260,7 +261,7 @@ func (d *driver) hasProjectAccess(
 			return false, err
 		}
 		// Allow access if user has the right permissions at the individual Repo-level.
-		if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, repoInfo.Repo, auth.Permission_REPO_READ); err != nil {
+		if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, repoInfo.Repo, auth.Permission_REPO_READ); err != nil {
 			if !errors.As(err, &auth.ErrNotAuthorized{}) {
 				return false, errors.Wrapf(err, "could not check user is authorized to list repo, problem with repo %s", repoInfo.Repo)
 			}
@@ -289,19 +290,19 @@ func (d *driver) listRepoInTransaction(ctx context.Context, txnCtx *txncontext.T
 	}
 	// Cache the project level access because it applies to every repo within the same project.
 	checkProjectAccess := miscutil.CacheFunc(func(project string) error {
-		return d.env.Auth.CheckProjectIsAuthorizedInTransaction(txnCtx, &pfs.Project{Name: project}, auth.Permission_PROJECT_LIST_REPO)
+		return d.env.Auth.CheckProjectIsAuthorizedInTransaction(ctx, txnCtx, &pfs.Project{Name: project}, auth.Permission_PROJECT_LIST_REPO)
 	}, 100)
 	var repos []*pfs.RepoInfo
 	if err := pfsdb.ForEachRepo(ctx, txnCtx.SqlTx, filter, page, func(repoWithID pfsdb.RepoInfoWithID) error {
 		if authActive {
-			hasAccess, err := d.hasProjectAccess(txnCtx, repoWithID.RepoInfo, checkProjectAccess)
+			hasAccess, err := d.hasProjectAccess(ctx, txnCtx, repoWithID.RepoInfo, checkProjectAccess)
 			if err != nil {
 				return errors.Wrap(err, "checking project access")
 			}
 			if !hasAccess {
 				return nil
 			}
-			permissions, roles, err := d.getPermissionsInTransaction(txnCtx, repoWithID.RepoInfo.Repo)
+			permissions, roles, err := d.getPermissionsInTransaction(ctx, txnCtx, repoWithID.RepoInfo.Repo)
 			if err != nil {
 				return errors.Wrapf(err, "error getting access level for %q", repoWithID.RepoInfo.Repo)
 			}
@@ -478,7 +479,7 @@ func (d *driver) deleteRepoInfo(ctx context.Context, txnCtx *txncontext.Transact
 	}
 	// since system repos share a role binding, only delete it if this is the user repo, in which case the other repos will be deleted anyway
 	if ri.Repo.Type == pfs.UserRepoType {
-		if err := d.env.Auth.DeleteRoleBindingInTransaction(txnCtx, ri.Repo.AuthResource()); err != nil && !auth.IsErrNotActivated(err) {
+		if err := d.env.Auth.DeleteRoleBindingInTransaction(ctx, txnCtx, ri.Repo.AuthResource()); err != nil && !auth.IsErrNotActivated(err) {
 			return grpcutil.ScrubGRPC(err)
 		}
 	}
@@ -509,7 +510,7 @@ func (d *driver) relatedRepos(ctx context.Context, txnCtx *txncontext.Transactio
 func (d *driver) canDeleteRepo(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo) (bool, error) {
 	userRepo := proto.Clone(repo).(*pfs.Repo)
 	userRepo.Type = pfs.UserRepoType
-	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, userRepo, auth.Permission_REPO_DELETE); err != nil {
+	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, userRepo, auth.Permission_REPO_DELETE); err != nil {
 		if auth.IsErrNotAuthorized(err) {
 			return false, nil
 		}
@@ -550,6 +551,7 @@ func (d *driver) createProjectInTransaction(ctx context.Context, txnCtx *txncont
 	// If auth is active, make caller the owner of this new project.
 	if whoAmI, err := txnCtx.WhoAmI(); err == nil {
 		if err := d.env.Auth.CreateRoleBindingInTransaction(
+			ctx,
 			txnCtx,
 			whoAmI.Username,
 			[]string{auth.ProjectOwnerRole},
@@ -729,7 +731,7 @@ func (d *driver) listProject(ctx context.Context, cb func(*pfs.ProjectInfo) erro
 	return errors.Wrap(d.txnEnv.WithWriteContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		return d.listProjectInTransaction(ctx, txnCtx, func(proj *pfs.ProjectInfo) error {
 			if authIsActive {
-				resp, err := d.env.Auth.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{Resource: proj.GetProject().AuthResource()})
+				resp, err := d.env.Auth.GetPermissionsInTransaction(ctx, txnCtx, &auth.GetPermissionsRequest{Resource: proj.GetProject().AuthResource()})
 				if err != nil {
 					if errors.Is(err, auth.ErrNotActivated) {
 						// Avoid unnecessary subsequent Auth API calls.
@@ -757,7 +759,7 @@ func (d *driver) deleteProject(ctx context.Context, txnCtx *txncontext.Transacti
 	if err := project.ValidateName(); err != nil {
 		return errors.Wrap(err, "invalid project name")
 	}
-	if err := d.env.Auth.CheckProjectIsAuthorizedInTransaction(txnCtx, project, auth.Permission_PROJECT_DELETE, auth.Permission_PROJECT_MODIFY_BINDINGS); err != nil {
+	if err := d.env.Auth.CheckProjectIsAuthorizedInTransaction(ctx, txnCtx, project, auth.Permission_PROJECT_DELETE, auth.Permission_PROJECT_MODIFY_BINDINGS); err != nil {
 		return errors.Wrapf(err, "user is not authorized to delete project %q", project)
 	}
 	var errs error
@@ -774,7 +776,7 @@ func (d *driver) deleteProject(ctx context.Context, txnCtx *txncontext.Transacti
 	if err := pfsdb.DeleteProject(ctx, txnCtx.SqlTx, pfsdb.ProjectKey(project)); err != nil {
 		return errors.Wrapf(err, "delete project %q", project)
 	}
-	if err := d.env.Auth.DeleteRoleBindingInTransaction(txnCtx, project.AuthResource()); err != nil {
+	if err := d.env.Auth.DeleteRoleBindingInTransaction(ctx, txnCtx, project.AuthResource()); err != nil {
 		if !errors.Is(err, auth.ErrNotActivated) {
 			return errors.Wrapf(err, "delete role binding for project %q", project)
 		}
@@ -853,7 +855,7 @@ func (d *driver) startCommit(
 		return nil, errors.Errorf("branch must be specified")
 	}
 	// Check that caller is authorized
-	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Permission_REPO_WRITE); err != nil {
+	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, branch.Repo, auth.Permission_REPO_WRITE); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	// New commit and commitInfo
@@ -1782,7 +1784,7 @@ func (d *driver) createBranch(ctx context.Context, txnCtx *txncontext.Transactio
 		return errors.New("a branch cannot have both provenance and a trigger")
 	}
 	var err error
-	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Permission_REPO_CREATE_BRANCH); err != nil {
+	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, branch.Repo, auth.Permission_REPO_CREATE_BRANCH); err != nil {
 		return errors.EnsureStack(err)
 	}
 	// Validate request
@@ -1963,7 +1965,7 @@ func (d *driver) listBranchInTransaction(ctx context.Context, txnCtx *txncontext
 		return errors.New("repo cannot be nil")
 	}
 
-	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, repo, auth.Permission_REPO_LIST_BRANCH); err != nil {
+	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, repo, auth.Permission_REPO_LIST_BRANCH); err != nil {
 		return errors.EnsureStack(err)
 	}
 	// Make sure that the repo exists
@@ -1989,7 +1991,7 @@ func (d *driver) listBranchInTransaction(ctx context.Context, txnCtx *txncontext
 }
 
 func (d *driver) deleteBranch(ctx context.Context, txnCtx *txncontext.TransactionContext, branch *pfs.Branch, force bool) error {
-	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(txnCtx, branch.Repo, auth.Permission_REPO_DELETE_BRANCH); err != nil {
+	if err := d.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, branch.Repo, auth.Permission_REPO_DELETE_BRANCH); err != nil {
 		return errors.EnsureStack(err)
 	}
 	branchInfoWithID, err := pfsdb.GetBranchInfoWithID(ctx, txnCtx.SqlTx, branch)

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -36,11 +36,11 @@ type PFSAuth interface {
 	WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 	GetPermissions(ctx context.Context, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 
-	CheckProjectIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error
-	CheckRepoIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error
-	CreateRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error
-	DeleteRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, resource *auth.Resource) error
-	GetPermissionsInTransaction(txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
+	CheckProjectIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error
+	CheckRepoIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error
+	CreateRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error
+	DeleteRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, resource *auth.Resource) error
+	GetPermissionsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 }
 
 // Env is the dependencies needed to run the PFS API server

--- a/src/server/pfs/server/val_server.go
+++ b/src/server/pfs/server/val_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
@@ -46,7 +47,7 @@ func (a *validatedAPIServer) FinishCommitInTransaction(ctx context.Context, txnC
 	if err := checkCommit(userCommit); err != nil {
 		return errors.Wrap(err, "check new file commit")
 	}
-	if err := a.auth.CheckRepoIsAuthorizedInTransaction(txnCtx, userCommit.Repo, auth.Permission_REPO_WRITE); err != nil {
+	if err := a.auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, userCommit.Repo, auth.Permission_REPO_WRITE); err != nil {
 		return errors.EnsureStack(err)
 	}
 	return a.apiServer.FinishCommitInTransaction(ctx, txnCtx, request)

--- a/src/server/pps/server/transaction_defer.go
+++ b/src/server/pps/server/transaction_defer.go
@@ -81,7 +81,7 @@ func (t *JobStopper) StopJob(commit *pfs.Commit) {
 func (t *JobStopper) Run(ctx context.Context) error {
 	for _, commitset := range t.commitsets {
 		jobInfo := &pps.JobInfo{}
-		if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commitset.Id, jobInfo, col.DefaultOptions(), func(string) error {
+		if err := t.a.jobs.ReadWrite(ctx, t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commitset.Id, jobInfo, col.DefaultOptions(), func(string) error {
 			return t.a.stopJob(ctx, t.txnCtx, jobInfo.Job, "output commit removed")
 		}); err != nil {
 			return errors.EnsureStack(err)
@@ -96,7 +96,7 @@ func (t *JobStopper) Run(ctx context.Context) error {
 		job := cache[pfsdb.CommitKey(commit)]
 		if job == nil {
 			jobInfo := &pps.JobInfo{}
-			if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commit.Id, jobInfo, col.DefaultOptions(), func(string) error {
+			if err := t.a.jobs.ReadWrite(ctx, t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commit.Id, jobInfo, col.DefaultOptions(), func(string) error {
 				if _, ok := cache[pfsdb.CommitKey(jobInfo.OutputCommit)]; ok {
 					cache[pfsdb.CommitKey(jobInfo.OutputCommit)] = proto.Clone(jobInfo.Job).(*pps.Job)
 				}
@@ -135,8 +135,8 @@ func (jf *JobFinisher) FinishJob(commitInfo *pfs.CommitInfo) {
 
 func (jf *JobFinisher) Run(ctx context.Context) error {
 	if len(jf.commitInfos) > 0 {
-		pipelines := jf.a.pipelines.ReadWrite(jf.txnCtx.SqlTx)
-		jobs := jf.a.jobs.ReadWrite(jf.txnCtx.SqlTx)
+		pipelines := jf.a.pipelines.ReadWrite(ctx, jf.txnCtx.SqlTx)
+		jobs := jf.a.jobs.ReadWrite(ctx, jf.txnCtx.SqlTx)
 		for _, commitInfo := range jf.commitInfos {
 			if commitInfo.Commit.Repo.Type != pfs.UserRepoType {
 				continue

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -506,10 +506,10 @@ func (d *driver) RunUserErrorHandlingCode(
 func (d *driver) UpdateJobState(job *pps.Job, state pps.JobState, reason string) error {
 	return d.NewSQLTx(func(ctx context.Context, sqlTx *pachsql.Tx) error {
 		jobInfo := &pps.JobInfo{}
-		if err := d.Jobs().ReadWrite(sqlTx).Get(ppsdb.JobKey(job), jobInfo); err != nil {
+		if err := d.Jobs().ReadWrite(d.ctx, sqlTx).Get(ppsdb.JobKey(job), jobInfo); err != nil {
 			return errors.EnsureStack(err)
 		}
-		return errors.EnsureStack(ppsutil.UpdateJobState(d.Pipelines().ReadWrite(sqlTx), d.Jobs().ReadWrite(sqlTx), jobInfo, state, reason))
+		return errors.EnsureStack(ppsutil.UpdateJobState(d.Pipelines().ReadWrite(d.ctx, sqlTx), d.Jobs().ReadWrite(d.ctx, sqlTx), jobInfo, state, reason))
 	})
 }
 
@@ -525,7 +525,7 @@ func (d *driver) GetJobInfo(job *pps.Job) (*pps.JobInfo, error) {
 // that should be deleted rather than marked failed.  Jobs may be deleted if
 // their output commit is deleted.
 func (d *driver) DeleteJob(sqlTx *pachsql.Tx, jobInfo *pps.JobInfo) error {
-	return errors.EnsureStack(d.Jobs().ReadWrite(sqlTx).Delete(ppsdb.JobKey(jobInfo.Job)))
+	return errors.EnsureStack(d.Jobs().ReadWrite(d.ctx, sqlTx).Delete(ppsdb.JobKey(jobInfo.Job)))
 }
 
 func (d *driver) unlinkData(inputs []*common.Input) error {

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -220,7 +220,7 @@ func (reg *registry) superviseJob(pj *pendingJob) error {
 				if err := pj.driver.NewSQLTx(func(ctx context.Context, sqlTx *pachsql.Tx) error {
 					// Delete the job if no other worker has deleted it yet
 					jobInfo := &pps.JobInfo{}
-					if err := pj.driver.Jobs().ReadWrite(sqlTx).Get(ppsdb.JobKey(pj.ji.Job), jobInfo); err != nil {
+					if err := pj.driver.Jobs().ReadWrite(ctx, sqlTx).Get(ppsdb.JobKey(pj.ji.Job), jobInfo); err != nil {
 						return errors.EnsureStack(err)
 					}
 					return errors.EnsureStack(pj.driver.DeleteJob(sqlTx, jobInfo))

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -107,7 +107,7 @@ func setupPachAndWorker(ctx context.Context, t *testing.T, dbConfig pachconfig.C
 	testEnv.PachClient = testEnv.driver.PachClient()
 	// Put the pipeline info into the collection (which is read by the master)
 	err = testEnv.driver.NewSQLTx(func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		rw := testEnv.driver.Pipelines().ReadWrite(sqlTx)
+		rw := testEnv.driver.Pipelines().ReadWrite(ctx, sqlTx)
 		err := rw.Put(specCommit, pipelineInfo) // pipeline/info needs to contain spec
 		return errors.EnsureStack(err)
 	})


### PR DESCRIPTION
This will allow aborted RPCs to free up database connections when they are stuck somewhere inside collections.  CORE-2236 was noticed after Console started making a lot more Authorize calls, and the auth server is most affected by this change.

The history here is that originally we decided that functions should only get EITHER a context or a transaction context.  That way, anything transactional wouldn't be able to do I/O.  What happened was that people inside those functions found ways to do I/O, like just using context.Background().  And, we were making all database calls (like `Exec`) without a context.  

Having a context allows those calls to be canceled when the context is canceled, and it allows query logs to be associated with the RPC that issued them.  Doing I/O is still inadvisable, but it's not being enforced right now.  The plan is to mark transactions with a context value, and then look for that value in RPCs or the HTTP client, and forbid them there. 