### PR TITLE
Remove nested transactions

### DIFF
--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -719,25 +719,26 @@ func (d *driver) getCompactedDiffFileSet(ctx context.Context, commit *pfs.Commit
 // The ProjectInfo provided to the closure is repurposed on each invocation, so it's the client's responsibility to clone the ProjectInfo if desired
 func (d *driver) listProject(ctx context.Context, cb func(*pfs.ProjectInfo) error) error {
 	authIsActive := true
-	return errors.Wrap(dbutil.WithTx(ctx, d.env.DB, func(ctx context.Context, tx *pachsql.Tx) error {
-		return d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
-			return d.listProjectInTransaction(ctx, txnCtx, func(proj *pfs.ProjectInfo) error {
-				if authIsActive {
-					resp, err := d.env.Auth.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{Resource: proj.GetProject().AuthResource()})
-					if err != nil {
-						if errors.Is(err, auth.ErrNotActivated) {
-							// Avoid unnecessary subsequent Auth API calls.
-							authIsActive = false
-							return cb(proj)
-						}
-						return errors.Wrapf(err, "getting permissions for project %s", proj.Project)
+	if err := d.txnEnv.WithWriteContext(ctx, func(txnCtx *txncontext.TransactionContext) error {
+		return d.listProjectInTransaction(ctx, txnCtx, func(proj *pfs.ProjectInfo) error {
+			if authIsActive {
+				resp, err := d.env.Auth.GetPermissionsInTransaction(txnCtx, &auth.GetPermissionsRequest{Resource: proj.GetProject().AuthResource()})
+				if err != nil {
+					if errors.Is(err, auth.ErrNotActivated) {
+						// Avoid unnecessary subsequent Auth API calls.
+						authIsActive = false
+						return cb(proj)
 					}
-					proj.AuthInfo = &pfs.AuthInfo{Permissions: resp.Permissions, Roles: resp.Roles}
+					return errors.Wrapf(err, "getting permissions for project %s", proj.Project)
 				}
-				return cb(proj)
-			})
+				proj.AuthInfo = &pfs.AuthInfo{Permissions: resp.Permissions, Roles: resp.Roles}
+			}
+			return cb(proj)
 		})
-	}), "list projects")
+	}); err != nil {
+		return errors.Wrap(err, "list projects")
+	}
+	return nil
 }
 
 // The ProjectInfo provided to the closure is repurposed on each invocation, so it's the client's responsibility to clone the ProjectInfo if desired


### PR DESCRIPTION
This removes a couple cases where WithReadContext is run inside WithTx, which ends up consuming 2 connections from the database connection pool in a way that can deadlock if there is only 1 connection available in the pool.

This is sort of a backport of #9942, but without infrastructure/refactorings to detect nested transactions.  This should be sufficient to eliminate any existing problems, as long as we don't add more code directly to this branch.

Part of CORE-2246.