### PR TITLE
Instrument Storage Layer

### DIFF
--- a/src/internal/storage/chunk/BUILD.bazel
+++ b/src/internal/storage/chunk/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//src/internal/errors",
         "//src/internal/errutil",
         "//src/internal/log",
+        "//src/internal/meters",
         "//src/internal/miscutil",
         "//src/internal/pacherr",
         "//src/internal/pachhash",

--- a/src/internal/storage/chunk/BUILD.bazel
+++ b/src/internal/storage/chunk/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//src/internal/storage/track",
         "//src/internal/stream",
         "//src/internal/taskchain",
+        "//src/pfs",
         "//src/protoextensions",
         "@com_github_chmduquesne_rollinghash//buzhash64",
         "@com_github_docker_go_units//:go-units",

--- a/src/internal/storage/chunk/batcher.go
+++ b/src/internal/storage/chunk/batcher.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"fmt"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 
 	"golang.org/x/sync/semaphore"
@@ -42,7 +43,7 @@ type entry struct {
 
 // TODO: Add config for number of entries.
 func (s *Storage) NewBatcher(ctx context.Context, name string, threshold int, opts ...BatcherOption) *Batcher {
-	ctx = pctx.Child(ctx, "batcher")
+	ctx = pctx.Child(ctx, fmt.Sprintf("batcher(%s)", name))
 	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL), s.pool)
 	b := &Batcher{
 		client:    client,

--- a/src/internal/storage/chunk/batcher.go
+++ b/src/internal/storage/chunk/batcher.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 
 	"golang.org/x/sync/semaphore"
 
@@ -41,6 +42,7 @@ type entry struct {
 
 // TODO: Add config for number of entries.
 func (s *Storage) NewBatcher(ctx context.Context, name string, threshold int, opts ...BatcherOption) *Batcher {
+	ctx = pctx.Child(ctx, "batcher")
 	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL), s.pool)
 	b := &Batcher{
 		client:    client,

--- a/src/internal/storage/chunk/client.go
+++ b/src/internal/storage/chunk/client.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	fmt "fmt"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"strconv"
 	"time"
 
@@ -53,6 +54,7 @@ func NewClient(store kv.Store, db *pachsql.DB, tr track.Tracker, renewer *Renewe
 // Create creates a new chunk from metadata and chunkData.
 // It returns the ID for the chunk
 func (c *trackedClient) Create(ctx context.Context, md Metadata, chunkData []byte) (_ ID, retErr error) {
+	ctx = pctx.Child(ctx, "trackedClient")
 	if c.renewer == nil {
 		panic("client must have a renewer to create chunks")
 	}

--- a/src/internal/storage/chunk/reader.go
+++ b/src/internal/storage/chunk/reader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"io"
 	"time"
 
@@ -105,7 +106,8 @@ type DataReader struct {
 
 func newDataReader(ctx context.Context, s *Storage, client Client, dataRef *DataRef, offset int64) *DataReader {
 	return &DataReader{
-		ctx: pctx.Child(ctx, fmt.Sprintf("dataReader('%s')", Base64Hash(dataRef)),
+		ctx: pctx.Child(ctx, fmt.Sprintf("dataReader('chunk_id':'%s','data_ref_hash':'%s')", pfs.EncodeHash(dataRef.Ref.Id),
+			pfs.EncodeHash(dataRef.Hash)),
 			pctx.WithCounter("tx_bytes", 0)),
 		client:   client,
 		memCache: s.memCache,

--- a/src/internal/storage/chunk/renewer.go
+++ b/src/internal/storage/chunk/renewer.go
@@ -19,8 +19,11 @@ func NewRenewer(ctx context.Context, tr track.Tracker, name string, ttl time.Dur
 	ctx = pctx.Child(ctx, "trackerRenewer", pctx.WithCounter("renewals", 0))
 	renewFunc := func(ctx context.Context, x string, ttl time.Duration) error {
 		_, err := tr.SetTTL(ctx, x, ttl)
+		if err != nil {
+			return errors.EnsureStack(err)
+		}
 		meters.Inc(ctx, "renewals", 1)
-		return errors.EnsureStack(err)
+		return nil
 	}
 	composeFunc := renew.NewTmpComposer(tr, name)
 	return &Renewer{

--- a/src/internal/storage/chunk/renewer.go
+++ b/src/internal/storage/chunk/renewer.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -14,6 +15,7 @@ type Renewer struct {
 }
 
 func NewRenewer(ctx context.Context, tr track.Tracker, name string, ttl time.Duration) *Renewer {
+	pctx.Child(ctx, "trackerRenewer")
 	renewFunc := func(ctx context.Context, x string, ttl time.Duration) error {
 		_, err := tr.SetTTL(ctx, x, ttl)
 		return errors.EnsureStack(err)

--- a/src/internal/storage/chunk/storage.go
+++ b/src/internal/storage/chunk/storage.go
@@ -63,13 +63,14 @@ func NewStorage(store kv.Store, db *pachsql.DB, tracker track.Tracker, opts ...S
 
 // NewReader creates a new Reader.
 func (s *Storage) NewReader(ctx context.Context, dataRefs []*DataRef, opts ...ReaderOption) *Reader {
-	pctx.Child(ctx, "chunkReader")
+	ctx = pctx.Child(ctx, "chunkReader")
 	client := NewClient(s.store, s.db, s.tracker, nil, s.pool)
 	defaultOpts := []ReaderOption{WithPrefetchLimit(s.prefetchLimit)}
 	return newReader(ctx, s, client, dataRefs, append(defaultOpts, opts...)...)
 }
 
 func (s *Storage) NewDataReader(ctx context.Context, dataRef *DataRef) *DataReader {
+	ctx = pctx.Child(ctx, "chunkLazyDataReader")
 	client := NewClient(s.store, s.db, s.tracker, nil, s.pool)
 	return newDataReader(ctx, s, client, dataRef, 0)
 }

--- a/src/internal/storage/chunk/storage.go
+++ b/src/internal/storage/chunk/storage.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -62,6 +63,7 @@ func NewStorage(store kv.Store, db *pachsql.DB, tracker track.Tracker, opts ...S
 
 // NewReader creates a new Reader.
 func (s *Storage) NewReader(ctx context.Context, dataRefs []*DataRef, opts ...ReaderOption) *Reader {
+	pctx.Child(ctx, "chunkReader")
 	client := NewClient(s.store, s.db, s.tracker, nil, s.pool)
 	defaultOpts := []ReaderOption{WithPrefetchLimit(s.prefetchLimit)}
 	return newReader(ctx, s, client, dataRefs, append(defaultOpts, opts...)...)

--- a/src/internal/storage/chunk/storage.go
+++ b/src/internal/storage/chunk/storage.go
@@ -70,7 +70,7 @@ func (s *Storage) NewReader(ctx context.Context, dataRefs []*DataRef, opts ...Re
 }
 
 func (s *Storage) NewDataReader(ctx context.Context, dataRef *DataRef) *DataReader {
-	ctx = pctx.Child(ctx, "chunkLazyDataReader")
+	ctx = pctx.Child(ctx, "chunkDataReader")
 	client := NewClient(s.store, s.db, s.tracker, nil, s.pool)
 	return newDataReader(ctx, s, client, dataRef, 0)
 }

--- a/src/internal/storage/chunk/uploader.go
+++ b/src/internal/storage/chunk/uploader.go
@@ -36,7 +36,11 @@ type Uploader struct {
 }
 
 func (s *Storage) NewUploader(ctx context.Context, name string, noUpload bool, cb UploadFunc) *Uploader {
+<<<<<<< HEAD
 	ctx = pctx.Child(ctx, "uploader")
+=======
+	pctx.Child(ctx, "uploader")
+>>>>>>> 11c68b70ba ([PFS-221] Add child contexts throughout storage layer.)
 	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL), s.pool)
 	return &Uploader{
 		ctx:       ctx,

--- a/src/internal/storage/chunk/uploader.go
+++ b/src/internal/storage/chunk/uploader.go
@@ -35,6 +35,7 @@ type Uploader struct {
 }
 
 func (s *Storage) NewUploader(ctx context.Context, name string, noUpload bool, cb UploadFunc) *Uploader {
+	pctx.Child(ctx, "uploader")
 	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL), s.pool)
 	return &Uploader{
 		ctx:       ctx,

--- a/src/internal/storage/chunk/uploader.go
+++ b/src/internal/storage/chunk/uploader.go
@@ -36,11 +36,7 @@ type Uploader struct {
 }
 
 func (s *Storage) NewUploader(ctx context.Context, name string, noUpload bool, cb UploadFunc) *Uploader {
-<<<<<<< HEAD
 	ctx = pctx.Child(ctx, "uploader")
-=======
-	pctx.Child(ctx, "uploader")
->>>>>>> 11c68b70ba ([PFS-221] Add child contexts throughout storage layer.)
 	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL), s.pool)
 	return &Uploader{
 		ctx:       ctx,

--- a/src/internal/storage/chunk/uploader.go
+++ b/src/internal/storage/chunk/uploader.go
@@ -182,8 +182,7 @@ func (u *Uploader) CopyByReference(meta interface{}, dataRefs []*DataRef) error 
 }
 
 func upload(ctx context.Context, client Client, chunkBytes []byte, pointsTo []ID, noUpload bool) (*DataRef, error) {
-	ctx = pctx.Child(ctx, "upload", pctx.WithCounter("bytes", 0))
-	meters.Inc(ctx, "tx_bytes", len(chunkBytes))
+	ctx = pctx.Child(ctx, "upload", pctx.WithCounter("tx_bytes", 0))
 	md := Metadata{
 		Size:     len(chunkBytes),
 		PointsTo: pointsTo,
@@ -202,6 +201,7 @@ func upload(ctx context.Context, client Client, chunkBytes []byte, pointsTo []ID
 		return nil, err
 	}
 	contentHash := Hash(chunkBytes)
+	meters.Inc(ctx, "tx_bytes", len(chunkBytes))
 	return &DataRef{
 		Hash:      contentHash,
 		Ref:       ref,

--- a/src/internal/storage/chunk/uploader.go
+++ b/src/internal/storage/chunk/uploader.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/meters"
 	"io"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -35,7 +36,7 @@ type Uploader struct {
 }
 
 func (s *Storage) NewUploader(ctx context.Context, name string, noUpload bool, cb UploadFunc) *Uploader {
-	pctx.Child(ctx, "uploader")
+	ctx = pctx.Child(ctx, "uploader")
 	client := NewClient(s.store, s.db, s.tracker, NewRenewer(ctx, s.tracker, name, defaultChunkTTL), s.pool)
 	return &Uploader{
 		ctx:       ctx,
@@ -180,6 +181,8 @@ func (u *Uploader) CopyByReference(meta interface{}, dataRefs []*DataRef) error 
 }
 
 func upload(ctx context.Context, client Client, chunkBytes []byte, pointsTo []ID, noUpload bool) (*DataRef, error) {
+	ctx = pctx.Child(ctx, "upload", pctx.WithCounter("bytes", 0))
+	meters.Inc(ctx, "bytes", len(chunkBytes))
 	md := Metadata{
 		Size:     len(chunkBytes),
 		PointsTo: pointsTo,

--- a/src/internal/storage/chunk/util.go
+++ b/src/internal/storage/chunk/util.go
@@ -2,7 +2,6 @@ package chunk
 
 import (
 	"context"
-	"encoding/base64"
 	"path/filepath"
 	"testing"
 
@@ -42,8 +41,4 @@ func NewDataRef(chunkRef *DataRef, chunkBytes []byte, offset, size int64) *DataR
 	dataRef.OffsetBytes = offset
 	dataRef.SizeBytes = size
 	return dataRef
-}
-
-func Base64Hash(dataRef *DataRef) string {
-	return base64.StdEncoding.EncodeToString(dataRef.Hash)
 }

--- a/src/internal/storage/chunk/util.go
+++ b/src/internal/storage/chunk/util.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"encoding/base64"
 	"path/filepath"
 	"testing"
 
@@ -41,4 +42,8 @@ func NewDataRef(chunkRef *DataRef, chunkBytes []byte, offset, size int64) *DataR
 	dataRef.OffsetBytes = offset
 	dataRef.SizeBytes = size
 	return dataRef
+}
+
+func Base64Hash(dataRef *DataRef) string {
+	return base64.StdEncoding.EncodeToString(dataRef.Hash)
 }

--- a/src/internal/storage/fileset/BUILD.bazel
+++ b/src/internal/storage/fileset/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//src/internal/tarutil",
         "//src/internal/taskchain",
         "//src/internal/uuid",
+        "//src/pfs",
         "@com_github_docker_go_units//:go-units",
         "@com_github_hashicorp_golang_lru_v2//:golang-lru",
         "@com_github_jmoiron_sqlx//:sqlx",

--- a/src/internal/storage/fileset/dir_inserter.go
+++ b/src/internal/storage/fileset/dir_inserter.go
@@ -2,6 +2,7 @@ package fileset
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"io"
 	"path"
 	"strings"
@@ -26,6 +27,7 @@ func NewDirInserter(x FileSet, lower string) FileSet {
 
 // Iterate calls cb once for every file in lexicographical order by path
 func (s *dirInserter) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "dirInserter")
 	lastPath := ""
 	var emit func(p string, f File) error
 	emit = func(p string, f File) error {

--- a/src/internal/storage/fileset/index/BUILD.bazel
+++ b/src/internal/storage/fileset/index/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//src/internal/errors",
         "//src/internal/errutil",
+        "//src/internal/meters",
         "//src/internal/miscutil",
         "//src/internal/pbutil",
         "//src/internal/pctx",

--- a/src/internal/storage/fileset/index/writer.go
+++ b/src/internal/storage/fileset/index/writer.go
@@ -39,6 +39,7 @@ type Writer struct {
 
 // NewWriter create a new Writer.
 func NewWriter(ctx context.Context, chunks *chunk.Storage, tmpID string) *Writer {
+	pctx.Child(ctx, "indexWriter")
 	ctx, cancel := pctx.WithCancel(ctx)
 	return &Writer{
 		ctx:    ctx,

--- a/src/internal/storage/fileset/merge.go
+++ b/src/internal/storage/fileset/merge.go
@@ -126,7 +126,7 @@ func (mfr *MergeFileReader) Hash(ctx context.Context) ([]byte, error) {
 	var hashes [][]byte
 	size := index.SizeBytes(mfr.idx)
 	if size >= DefaultBatchThreshold {
-		uploader := mfr.chunks.NewUploader(pctx.Child(ctx, "chunkUploaderResolver"), "chunk-uploader-resolver", true, func(_ interface{}, dataRefs []*chunk.DataRef) error {
+		uploader := mfr.chunks.NewUploader(ctx, "chunk-uploader-resolver", true, func(_ interface{}, dataRefs []*chunk.DataRef) error {
 			for _, dataRef := range dataRefs {
 				hashes = append(hashes, dataRef.Hash)
 			}

--- a/src/internal/storage/fileset/merge.go
+++ b/src/internal/storage/fileset/merge.go
@@ -28,7 +28,7 @@ func newMergeReader(chunks *chunk.Storage, fileSets []FileSet) *MergeReader {
 
 // Iterate iterates over the files in the merge reader.
 func (mr *MergeReader) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
-	ctx = pctx.Child(ctx, "mergedReader")
+	ctx = pctx.Child(ctx, "mergeReader")
 	var ss []stream.Stream
 	for i, fs := range mr.fileSets {
 		// Ignore the base file set's deletive set since it does not affect the state.

--- a/src/internal/storage/fileset/merge.go
+++ b/src/internal/storage/fileset/merge.go
@@ -3,6 +3,7 @@ package fileset
 import (
 	"bytes"
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"io"
 	"strings"
 
@@ -27,6 +28,7 @@ func newMergeReader(chunks *chunk.Storage, fileSets []FileSet) *MergeReader {
 
 // Iterate iterates over the files in the merge reader.
 func (mr *MergeReader) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "mergedReader")
 	var ss []stream.Stream
 	for i, fs := range mr.fileSets {
 		// Ignore the base file set's deletive set since it does not affect the state.
@@ -70,6 +72,7 @@ func (mr *MergeReader) Iterate(ctx context.Context, cb func(File) error, opts ..
 }
 
 func (mr *MergeReader) IterateDeletes(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "mergedReader")
 	var ss []stream.Stream
 	for _, fs := range mr.fileSets {
 		ss = append(ss, &fileStream{
@@ -86,6 +89,7 @@ func (mr *MergeReader) IterateDeletes(ctx context.Context, cb func(File) error, 
 // TODO: Look at the sizes?
 // TODO: Come up with better heuristics for sharding.
 func (mr *MergeReader) Shards(ctx context.Context, opts ...index.Option) ([]*index.PathRange, error) {
+	ctx = pctx.Child(ctx, "mergedReader")
 	shards, err := mr.fileSets[0].Shards(ctx, opts...)
 	return shards, errors.EnsureStack(err)
 }
@@ -122,7 +126,7 @@ func (mfr *MergeFileReader) Hash(ctx context.Context) ([]byte, error) {
 	var hashes [][]byte
 	size := index.SizeBytes(mfr.idx)
 	if size >= DefaultBatchThreshold {
-		uploader := mfr.chunks.NewUploader(ctx, "chunk-uploader-resolver", true, func(_ interface{}, dataRefs []*chunk.DataRef) error {
+		uploader := mfr.chunks.NewUploader(pctx.Child(ctx, "chunkUploaderResolver"), "chunk-uploader-resolver", true, func(_ interface{}, dataRefs []*chunk.DataRef) error {
 			for _, dataRef := range dataRefs {
 				hashes = append(hashes, dataRef.Hash)
 			}

--- a/src/internal/storage/fileset/prefetcher.go
+++ b/src/internal/storage/fileset/prefetcher.go
@@ -40,6 +40,7 @@ func NewPrefetcher(storage *Storage, fileSet FileSet, upper string) FileSet {
 func (p *prefetcher) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
 	ctx = pctx.Child(ctx, "prefetcher")
 	ctx, cancel := pctx.WithCancel(ctx)
+	ctx = pctx.Child(ctx, "prefetcher")
 	defer cancel()
 	taskChain := taskchain.New(ctx, semaphore.NewWeighted(int64(p.storage.prefetchLimit)))
 	fetchChunk := func(ref *chunk.DataRef, files []File) error {

--- a/src/internal/storage/fileset/prefetcher.go
+++ b/src/internal/storage/fileset/prefetcher.go
@@ -39,6 +39,7 @@ func NewPrefetcher(storage *Storage, fileSet FileSet, upper string) FileSet {
 
 func (p *prefetcher) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
 	ctx, cancel := pctx.WithCancel(ctx)
+	ctx = pctx.Child(ctx, "prefetcher")
 	defer cancel()
 	taskChain := taskchain.New(ctx, semaphore.NewWeighted(int64(p.storage.prefetchLimit)))
 	fetchChunk := func(ref *chunk.DataRef, files []File) error {

--- a/src/internal/storage/fileset/prefetcher.go
+++ b/src/internal/storage/fileset/prefetcher.go
@@ -40,7 +40,6 @@ func NewPrefetcher(storage *Storage, fileSet FileSet, upper string) FileSet {
 func (p *prefetcher) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
 	ctx = pctx.Child(ctx, "prefetcher")
 	ctx, cancel := pctx.WithCancel(ctx)
-	ctx = pctx.Child(ctx, "prefetcher")
 	defer cancel()
 	taskChain := taskchain.New(ctx, semaphore.NewWeighted(int64(p.storage.prefetchLimit)))
 	fetchChunk := func(ref *chunk.DataRef, files []File) error {

--- a/src/internal/storage/fileset/reader.go
+++ b/src/internal/storage/fileset/reader.go
@@ -3,7 +3,6 @@ package fileset
 import (
 	"context"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
-	"go.uber.org/zap"
 	"io"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -57,7 +56,7 @@ func (r *Reader) withPrimitive(ctx context.Context, cb func(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	ctx = pctx.Child(ctx, "", pctx.WithFields(zap.Object("startIdx", prim.Additive)))
+	ctx = pctx.Child(ctx, "", pctx.WithFields(LogIndex(prim.Additive, "startIdx")))
 	return cb(ctx, prim)
 }
 

--- a/src/internal/storage/fileset/reader.go
+++ b/src/internal/storage/fileset/reader.go
@@ -2,6 +2,7 @@ package fileset
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"io"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
@@ -27,6 +28,7 @@ func newReader(store MetadataStore, chunks *chunk.Storage, idxCache *index.Cache
 }
 
 func (r *Reader) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "reader")
 	prim, err := r.getPrimitive(ctx)
 	if err != nil {
 		return err
@@ -50,6 +52,7 @@ func (r *Reader) getPrimitive(ctx context.Context) (*Primitive, error) {
 }
 
 func (r *Reader) IterateDeletes(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "reader")
 	prim, err := r.getPrimitive(ctx)
 	if err != nil {
 		return err
@@ -61,6 +64,7 @@ func (r *Reader) IterateDeletes(ctx context.Context, cb func(File) error, opts .
 }
 
 func (r *Reader) Shards(ctx context.Context, opts ...index.Option) ([]*index.PathRange, error) {
+	ctx = pctx.Child(ctx, "reader")
 	prim, err := r.getPrimitive(ctx)
 	if err != nil {
 		return nil, err

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -2,6 +2,7 @@ package fileset
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"math"
 	"strings"
 	"time"
@@ -107,6 +108,7 @@ func (s *Storage) NewWriter(ctx context.Context, opts ...WriterOption) *Writer {
 }
 
 func (s *Storage) newWriter(ctx context.Context, opts ...WriterOption) *Writer {
+	ctx = pctx.Child(ctx, "fileSetWriter")
 	return newWriter(ctx, s, opts...)
 }
 
@@ -249,8 +251,8 @@ func (s *Storage) getPrimitives(ctx context.Context, ids []ID) ([]*Primitive, er
 // Concat always returns the ID of a primitive fileset.
 func (s *Storage) Concat(ctx context.Context, ids []ID, ttl time.Duration) (*ID, error) {
 	var size int64
-	additive := index.NewWriter(ctx, s.chunks, "additive-index-writer")
-	deletive := index.NewWriter(ctx, s.chunks, "deletive-index-writer")
+	additive := index.NewWriter(pctx.Child(ctx, "additiveIndexWriter"), s.chunks, "additive-index-writer")
+	deletive := index.NewWriter(pctx.Child(ctx, "deletiveIndexWriter"), s.chunks, "deletive-index-writer")
 	for _, id := range ids {
 		md, err := s.store.Get(ctx, id)
 		if err != nil {

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -251,8 +251,8 @@ func (s *Storage) getPrimitives(ctx context.Context, ids []ID) ([]*Primitive, er
 // Concat always returns the ID of a primitive fileset.
 func (s *Storage) Concat(ctx context.Context, ids []ID, ttl time.Duration) (*ID, error) {
 	var size int64
-	additive := index.NewWriter(pctx.Child(ctx, "additiveIndexWriter"), s.chunks, "additive-index-writer")
-	deletive := index.NewWriter(pctx.Child(ctx, "deletiveIndexWriter"), s.chunks, "deletive-index-writer")
+	additive := index.NewWriter(pctx.Child(ctx, "additive"), s.chunks, "additive-index-writer")
+	deletive := index.NewWriter(pctx.Child(ctx, "deletive"), s.chunks, "deletive-index-writer")
 	for _, id := range ids {
 		md, err := s.store.Get(ctx, id)
 		if err != nil {

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -251,8 +251,8 @@ func (s *Storage) getPrimitives(ctx context.Context, ids []ID) ([]*Primitive, er
 // Concat always returns the ID of a primitive fileset.
 func (s *Storage) Concat(ctx context.Context, ids []ID, ttl time.Duration) (*ID, error) {
 	var size int64
-	additive := index.NewWriter(pctx.Child(ctx, "additive"), s.chunks, "additive-index-writer")
-	deletive := index.NewWriter(pctx.Child(ctx, "deletive"), s.chunks, "deletive-index-writer")
+	additive := index.NewWriter(ctx, s.chunks, "additive-index-writer")
+	deletive := index.NewWriter(ctx, s.chunks, "deletive-index-writer")
 	for _, id := range ids {
 		md, err := s.store.Get(ctx, id)
 		if err != nil {

--- a/src/internal/storage/fileset/transforms.go
+++ b/src/internal/storage/fileset/transforms.go
@@ -2,6 +2,7 @@ package fileset
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"io"
 	"strings"
 
@@ -31,6 +32,7 @@ func NewIndexFilter(fs FileSet, predicate func(idx *index.Index) bool, full ...b
 }
 
 func (idxf *indexFilter) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "indexFilter")
 	var dir string
 	err := idxf.fs.Iterate(ctx, func(f File) error {
 		idx := f.Index()
@@ -72,6 +74,7 @@ func NewIndexMapper(x FileSet, fn func(*index.Index) *index.Index) FileSet {
 }
 
 func (im *indexMapper) Iterate(ctx context.Context, cb func(File) error, opts ...index.Option) error {
+	ctx = pctx.Child(ctx, "indexMapper")
 	err := im.x.Iterate(ctx, func(fr File) error {
 		y := im.fn(fr.Index())
 		return cb(&indexMap{

--- a/src/internal/storage/fileset/util.go
+++ b/src/internal/storage/fileset/util.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"context"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"go.uber.org/zap"
 	"io"
 	"path"
 	"strings"
@@ -167,4 +168,21 @@ func SizeFromIndex(idx *index.Index) (size int64) {
 		size += dr.SizeBytes
 	}
 	return size
+}
+
+// LogIndex returns a zap field with prefix keyPrefix for use by logging contexts passed into fileset related functions.
+func LogIndex(idx *index.Index, keyPrefix string) zap.Field {
+	if keyPrefix != "" {
+		keyPrefix += "."
+	}
+	if idx == nil {
+		return zap.String(keyPrefix+"idx", "nil")
+	}
+	fieldName := "idx.file.path"
+	topIdx := idx.Path
+	if idx.Range != nil {
+		fieldName = "idx.range.hash"
+		topIdx = chunk.Base64Hash(idx.Range.ChunkRef)
+	}
+	return zap.String(keyPrefix+fieldName, topIdx)
 }

--- a/src/internal/storage/fileset/util.go
+++ b/src/internal/storage/fileset/util.go
@@ -3,6 +3,7 @@ package fileset
 import (
 	"archive/tar"
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"io"
 	"path"
 	"strings"
@@ -99,6 +100,7 @@ type Iterator struct {
 type iterFunc = func(ctx context.Context, cb func(File) error, opts ...index.Option) error
 
 func NewIterator(ctx context.Context, iter iterFunc, opts ...index.Option) *Iterator {
+	ctx = pctx.Child(ctx, "imperativeIterator")
 	fileChan := make(chan File)
 	errChan := make(chan error, 1)
 	go func() {

--- a/src/internal/storage/fileset/util.go
+++ b/src/internal/storage/fileset/util.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"context"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"go.uber.org/zap"
 	"io"
 	"path"
@@ -182,7 +183,7 @@ func LogIndex(idx *index.Index, keyPrefix string) zap.Field {
 	topIdx := idx.Path
 	if idx.Range != nil {
 		fieldName = "idx.range.hash"
-		topIdx = chunk.Base64Hash(idx.Range.ChunkRef)
+		topIdx = pfs.EncodeHash(idx.Range.ChunkRef.Hash)
 	}
 	return zap.String(keyPrefix+fieldName, topIdx)
 }

--- a/src/internal/storage/fileset/writer.go
+++ b/src/internal/storage/fileset/writer.go
@@ -3,6 +3,7 @@ package fileset
 import (
 	"bytes"
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"io"
 	"sync/atomic"
 	"time"
@@ -39,8 +40,8 @@ func newWriter(ctx context.Context, storage *Storage, opts ...WriterOption) *Wri
 	for _, opt := range opts {
 		opt(w)
 	}
-	w.additive = index.NewWriter(ctx, storage.chunks, "additive-index-writer")
-	w.uploader = storage.chunks.NewUploader(ctx, "chunk-uploader", false, func(meta interface{}, dataRefs []*chunk.DataRef) error {
+	w.additive = index.NewWriter(pctx.Child(ctx, "additiveIndexWriter"), storage.chunks, "additive-index-writer")
+	w.uploader = storage.chunks.NewUploader(pctx.Child(ctx, "chunkUploader"), "chunk-uploader", false, func(meta interface{}, dataRefs []*chunk.DataRef) error {
 		idx := meta.(*index.Index)
 		idx.File.DataRefs = dataRefs
 		idx.NumFiles = 1
@@ -49,8 +50,8 @@ func newWriter(ctx context.Context, storage *Storage, opts ...WriterOption) *Wri
 		atomic.AddInt64(&w.sizeBytes, size)
 		return w.additive.WriteIndex(idx)
 	})
-	w.additiveBatched = index.NewWriter(ctx, storage.chunks, "additive-batched-index-writer")
-	w.batcher = storage.chunks.NewBatcher(ctx, "chunk-batcher", w.batchThreshold, chunk.WithEntryCallback(func(meta interface{}, dataRef *chunk.DataRef) error {
+	w.additiveBatched = index.NewWriter(pctx.Child(ctx, "additiveBatchedIndexWriter"), storage.chunks, "additive-batched-index-writer")
+	w.batcher = storage.chunks.NewBatcher(pctx.Child(ctx, "chunkBatcher"), "chunk-batcher", w.batchThreshold, chunk.WithEntryCallback(func(meta interface{}, dataRef *chunk.DataRef) error {
 		idx := meta.(*index.Index)
 		if dataRef != nil {
 			idx.File.DataRefs = []*chunk.DataRef{dataRef}
@@ -61,7 +62,7 @@ func newWriter(ctx context.Context, storage *Storage, opts ...WriterOption) *Wri
 		atomic.AddInt64(&w.sizeBytes, size)
 		return w.additiveBatched.WriteIndex(idx)
 	}))
-	w.deletive = index.NewWriter(ctx, storage.chunks, "deletive-index-writer")
+	w.deletive = index.NewWriter(pctx.Child(ctx, "deletiveIndexWriter"), storage.chunks, "deletive-index-writer")
 	return w
 }
 

--- a/src/internal/storage/fileset/writer.go
+++ b/src/internal/storage/fileset/writer.go
@@ -40,8 +40,8 @@ func newWriter(ctx context.Context, storage *Storage, opts ...WriterOption) *Wri
 	for _, opt := range opts {
 		opt(w)
 	}
-	w.additive = index.NewWriter(pctx.Child(ctx, "additiveIndexWriter"), storage.chunks, "additive-index-writer")
-	w.uploader = storage.chunks.NewUploader(pctx.Child(ctx, "chunkUploader"), "chunk-uploader", false, func(meta interface{}, dataRefs []*chunk.DataRef) error {
+	w.additive = index.NewWriter(pctx.Child(ctx, "additive"), storage.chunks, "additive-index-writer")
+	w.uploader = storage.chunks.NewUploader(pctx.Child(ctx, "chunk"), "chunk-uploader", false, func(meta interface{}, dataRefs []*chunk.DataRef) error {
 		idx := meta.(*index.Index)
 		idx.File.DataRefs = dataRefs
 		idx.NumFiles = 1
@@ -50,8 +50,8 @@ func newWriter(ctx context.Context, storage *Storage, opts ...WriterOption) *Wri
 		atomic.AddInt64(&w.sizeBytes, size)
 		return w.additive.WriteIndex(idx)
 	})
-	w.additiveBatched = index.NewWriter(pctx.Child(ctx, "additiveBatchedIndexWriter"), storage.chunks, "additive-batched-index-writer")
-	w.batcher = storage.chunks.NewBatcher(pctx.Child(ctx, "chunkBatcher"), "chunk-batcher", w.batchThreshold, chunk.WithEntryCallback(func(meta interface{}, dataRef *chunk.DataRef) error {
+	w.additiveBatched = index.NewWriter(pctx.Child(ctx, "additiveBatched"), storage.chunks, "additive-batched-index-writer")
+	w.batcher = storage.chunks.NewBatcher(pctx.Child(ctx, "chunk"), "chunk-batcher", w.batchThreshold, chunk.WithEntryCallback(func(meta interface{}, dataRef *chunk.DataRef) error {
 		idx := meta.(*index.Index)
 		if dataRef != nil {
 			idx.File.DataRefs = []*chunk.DataRef{dataRef}
@@ -62,7 +62,7 @@ func newWriter(ctx context.Context, storage *Storage, opts ...WriterOption) *Wri
 		atomic.AddInt64(&w.sizeBytes, size)
 		return w.additiveBatched.WriteIndex(idx)
 	}))
-	w.deletive = index.NewWriter(pctx.Child(ctx, "deletiveIndexWriter"), storage.chunks, "deletive-index-writer")
+	w.deletive = index.NewWriter(pctx.Child(ctx, "deletive"), storage.chunks, "deletive-index-writer")
 	return w
 }
 

--- a/src/internal/storage/kv/BUILD.bazel
+++ b/src/internal/storage/kv/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//src/internal/errors",
         "//src/internal/log",
+        "//src/internal/meters",
         "//src/internal/miscutil",
         "//src/internal/obj",
         "//src/internal/pacherr",

--- a/src/internal/storage/kv/lru_cache.go
+++ b/src/internal/storage/kv/lru_cache.go
@@ -36,7 +36,7 @@ func NewLRUCache(slow, fast Store, size int) *LRUCache {
 }
 
 func (c *LRUCache) Get(ctx context.Context, key []byte, buf []byte) (int, error) {
-	pctx.Child(ctx, "lruCache", pctx.WithCounter("hits", 0), pctx.WithCounter("misses", 0))
+	ctx = pctx.Child(ctx, "lruCache", pctx.WithCounter("hits", 0), pctx.WithCounter("misses", 0))
 	// note that we don't need a lock here because stores are thread-safe and Put/Deletes are atomic.
 	n, err := c.fast.Get(ctx, key, buf)
 	if err == nil {

--- a/src/internal/task/util.go
+++ b/src/internal/task/util.go
@@ -19,7 +19,7 @@ import (
 
 // DoOrdered processes tasks in parallel, but returns outputs in order via the provided callback cb.
 func DoOrdered(ctx context.Context, doer Doer, inputs chan *anypb.Any, parallelism int, cb CollectFunc) error {
-	pctx.Child(ctx, "doOrdered")
+	ctx = pctx.Child(ctx, "doOrdered")
 	taskChain := taskchain.New(ctx, semaphore.NewWeighted(int64(parallelism)))
 	for {
 		select {

--- a/src/internal/task/util.go
+++ b/src/internal/task/util.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -18,6 +19,7 @@ import (
 
 // DoOrdered processes tasks in parallel, but returns outputs in order via the provided callback cb.
 func DoOrdered(ctx context.Context, doer Doer, inputs chan *anypb.Any, parallelism int, cb CollectFunc) error {
+	pctx.Child(ctx, "doOrdered")
 	taskChain := taskchain.New(ctx, semaphore.NewWeighted(int64(parallelism)))
 	for {
 		select {

--- a/src/internal/taskchain/BUILD.bazel
+++ b/src/internal/taskchain/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//src:__subpackages__"],
     deps = [
         "//src/internal/errors",
+        "//src/internal/pctx",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//semaphore",
     ],

--- a/src/internal/taskchain/task_chain.go
+++ b/src/internal/taskchain/task_chain.go
@@ -2,6 +2,7 @@ package taskchain
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -22,6 +23,7 @@ type TaskChain struct {
 
 // New creates a new task chain.
 func New(ctx context.Context, sem *semaphore.Weighted) *TaskChain {
+	ctx = pctx.Child(ctx, "taskChain")
 	eg, errCtx := errgroup.WithContext(ctx)
 	prevChan := make(chan struct{})
 	close(prevChan)

--- a/src/server/pfs/server/source.go
+++ b/src/server/pfs/server/source.go
@@ -79,7 +79,7 @@ func NewSource(commitInfo *pfs.CommitInfo, fs fileset.FileSet, opts ...SourceOpt
 func (s *source) Iterate(ctx context.Context, cb func(*pfs.FileInfo, fileset.File) error) error {
 	ctx, cf := pctx.WithCancel(ctx)
 	defer cf()
-	iter := fileset.NewIterator(ctx, s.fileSet.Iterate, s.dirIndexOpts...)
+	iter := fileset.NewIterator(pctx.Child(ctx, "directoryIterator"), s.fileSet.Iterate, s.dirIndexOpts...)
 	cache := make(map[string]*pfs.FileInfo)
 	err := s.fileSet.Iterate(ctx, func(f fileset.File) error {
 		idx := f.Index()


### PR DESCRIPTION
This is a first pass at instrumenting the storage layer. There's a few high level changes you'll generally see throughout this PR:
1. Child contexts have been passed throughout. Particular areas of focus are distributed systems like the task service and low level constructs like file set, index, and chunk readers & writers.
2. Metrics have been added. The metrics vary based on what is relevant, but generally we're reporting bytes read/written as well as indicators like cache misses vs cache hits, indices skipped vs indices read, and so forth.

I'm sure I've missed areas that we want to instrument, but that's fine. We can add those in a follow up PR.
Metrics are visible when running at a 'debug' level.

Here are some snippets of metrics:
```json
{
  "severity": "debug",
  "time": "2024-04-18T19:30:24.935036734Z",
  "logger": "grpc.pfs_v2.API/ModifyFile.fileSetWriter.indexWriter(deletive-index-writer)",
  "caller": "index/writer.go:85",
  "message": "meter: bytes",
  "service": "pfs_v2.API",
  "method": "ModifyFile",
  "command": [
    "pachctl put file images@master -f liberty.jpg"
  ],
  "peer": "127.0.0.1:48528",
  "type": "int",
  "delta": 35,
  "meter": "bytes"
}
{
  "severity": "debug",
  "time": "2024-04-18T19:30:24.935196695Z",
  "logger": "grpc.pfs_v2.API/ModifyFile.fileSetWriter.batcher(chunk-batcher).taskChain.upload",
  "caller": "chunk/uploader.go:186",
  "message": "meter: tx_bytes",
  "service": "pfs_v2.API",
  "method": "ModifyFile",
  "command": [
    "pachctl put file images@master -f liberty.jpg"
  ],
  "peer": "127.0.0.1:48528",
  "type": "int",
  "delta": 133858,
  "meter": "tx_bytes"
}
{
  "severity": "debug",
  "time": "2024-04-18T19:30:24.954077375Z",
  "logger": "grpc.pfs_v2.API/ModifyFile.fileSetWriter.indexWriter(additive-batched-index-writer)",
  "caller": "index/writer.go:85",
  "message": "meter: bytes",
  "service": "pfs_v2.API",
  "method": "ModifyFile",
  "command": [
    "pachctl put file images@master -f liberty.jpg"
  ],
  "peer": "127.0.0.1:48528",
  "type": "int",
  "delta": 155,
  "meter": "bytes"
}

```