### PR TITLE
Make collections methods take a context

### DIFF
--- a/etc/helm/test/BUILD.bazel
+++ b/etc/helm/test/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@io_k8s_api//apps/v1:apps",
         "@io_k8s_api//core/v1:core",
-        "@io_k8s_api//networking/v1:networking",
         "@io_k8s_api//networking/v1beta1",
         "@io_k8s_api//rbac/v1:rbac",
         "@io_k8s_apimachinery//pkg/util/intstr",

--- a/src/internal/authdb/authdb.go
+++ b/src/internal/authdb/authdb.go
@@ -1,6 +1,7 @@
 package authdb
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
@@ -86,10 +87,10 @@ func CollectionsV0() []col.PostgresCollection {
 }
 
 // InternalAuthUserPermissions adds the Internal Auth User as a cluster admin
-func InternalAuthUserPermissions(tx *pachsql.Tx) error {
+func InternalAuthUserPermissions(ctx context.Context, tx *pachsql.Tx) error {
 	roleBindings := RoleBindingCollection(nil, nil)
 	var binding auth.RoleBinding
-	if err := roleBindings.ReadWrite(tx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
+	if err := roleBindings.ReadWrite(tx).Get(ctx, auth.ClusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil
 		}

--- a/src/internal/authdb/authdb.go
+++ b/src/internal/authdb/authdb.go
@@ -97,7 +97,7 @@ func InternalAuthUserPermissions(ctx context.Context, tx *pachsql.Tx) error {
 		return errors.Wrapf(err, "getting the cluster role binding")
 	}
 	binding.Entries[InternalUser] = &auth.Roles{Roles: map[string]bool{auth.ClusterAdminRole: true}}
-	return errors.EnsureStack(roleBindings.ReadWrite(tx).Put(auth.ClusterRoleBindingKey, &binding))
+	return errors.EnsureStack(roleBindings.ReadWrite(tx).Put(ctx, auth.ClusterRoleBindingKey, &binding))
 }
 
 // ResourceKey generates the key for a resource in the role bindings collection.

--- a/src/internal/clusterstate/v2.3.0.go
+++ b/src/internal/clusterstate/v2.3.0.go
@@ -9,7 +9,7 @@ import (
 
 var state_2_3_0 migrations.State = state_2_1_0.
 	Apply("Add internal auth user as a cluster admin", func(ctx context.Context, env migrations.Env) error {
-		return authdb.InternalAuthUserPermissions(env.Tx)
+		return authdb.InternalAuthUserPermissions(ctx, env.Tx)
 	})
 	// DO NOT MODIFY THIS STATE
 	// IT HAS ALREADY SHIPPED IN A RELEASE

--- a/src/internal/clusterstate/v2.5.0/auth.go
+++ b/src/internal/clusterstate/v2.5.0/auth.go
@@ -48,7 +48,7 @@ func migrateAuth(ctx context.Context, tx *pachsql.Tx) error {
 
 	// Grant all users the ProjectCreator role at the cluster level
 	clusterRbs := &auth.RoleBinding{Entries: make(map[string]*auth.Roles)}
-	if err := roleBindingsCol.Upsert(clusterRoleBindingKey, clusterRbs, func() error {
+	if err := roleBindingsCol.Upsert(ctx, clusterRoleBindingKey, clusterRbs, func() error {
 		if _, ok := clusterRbs.Entries[allUsersPrincipalKey]; !ok {
 			clusterRbs.Entries[allUsersPrincipalKey] = &auth.Roles{Roles: make(map[string]bool)}
 		}
@@ -61,7 +61,7 @@ func migrateAuth(ctx context.Context, tx *pachsql.Tx) error {
 	// TODO CORE-1048, grant all users the ProjectWriter role for default project
 	log.Info(ctx, "Creating initial empty role binding for default project")
 	defaultProjectRbs := &auth.RoleBinding{Entries: make(map[string]*auth.Roles)}
-	if err := roleBindingsCol.Upsert(projectRoleBindingKeyPrefix+defaultProjectName, defaultProjectRbs, func() error {
+	if err := roleBindingsCol.Upsert(ctx, projectRoleBindingKeyPrefix+defaultProjectName, defaultProjectRbs, func() error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "could not update default project's role bindings")

--- a/src/internal/clusterstate/v2.5.0/auth.go
+++ b/src/internal/clusterstate/v2.5.0/auth.go
@@ -25,8 +25,8 @@ const (
 	projectCreatorRole = "projectCreator"
 )
 
-func authIsActive(c collection.PostgresReadWriteCollection) bool {
-	return !errors.Is(c.Get(clusterRoleBindingKey, &auth.RoleBinding{}), collection.ErrNotFound{})
+func authIsActive(ctx context.Context, c collection.PostgresReadWriteCollection) bool {
+	return !errors.Is(c.Get(ctx, clusterRoleBindingKey, &auth.RoleBinding{}), collection.ErrNotFound{})
 }
 
 // migrateAuth migrates auth to be fully project-aware with a default project.
@@ -42,7 +42,7 @@ func migrateAuth(ctx context.Context, tx *pachsql.Tx) error {
 
 	// If auth is already activated, then run the migrations below because they wouldn't have gotten the new role bindings via activation.
 	roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(tx)
-	if !authIsActive(roleBindingsCol) {
+	if !authIsActive(ctx, roleBindingsCol) {
 		return nil
 	}
 

--- a/src/internal/clusterstate/v2.5.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.5.0/clusterstate.go
@@ -23,7 +23,7 @@ func Migrate(state migrations.State) migrations.State {
 					Name: "default", // hardcoded so that pfs.DefaultProjectName may change in the future
 				},
 			}
-			if err := projects(nil, nil).ReadWrite(env.Tx).Create("default", defaultProject); err != nil {
+			if err := projects(nil, nil).ReadWrite(env.Tx).Create(ctx, "default", defaultProject); err != nil {
 				return errors.Wrap(err, "could not create default project")
 			}
 			return nil

--- a/src/internal/clusterstate/v2.5.0/collection_test.go
+++ b/src/internal/clusterstate/v2.5.0/collection_test.go
@@ -69,7 +69,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could not migrate test item:", err)
 	}
 	var item col.TestItem
-	if err := testCol.ReadOnly(ctx).Get("foo", &item); err != nil {
+	if err := testCol.ReadOnly(ctx).Get(ctx, "foo", &item); err != nil {
 		t.Error("could not read migrated item:", err)
 	}
 	if item.Id != "foo" {
@@ -78,7 +78,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 	if item.Value != "bar quux" {
 		t.Errorf("%q ≠ %q", item.Value, "bar quux")
 	}
-	if err := testCol.ReadOnly(ctx).Get("foo1", &item); err != nil {
+	if err := testCol.ReadOnly(ctx).Get(ctx, "foo1", &item); err != nil {
 		if !col.IsErrNotFound(err) {
 			t.Error("could not try to get migrated item:", err)
 		}

--- a/src/internal/clusterstate/v2.5.0/collection_test.go
+++ b/src/internal/clusterstate/v2.5.0/collection_test.go
@@ -54,7 +54,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could create test collection:", err)
 	}
 	if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
-		return testCol.ReadWrite(tx).Put("foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
+		return testCol.ReadWrite(tx).Put(ctx, "foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
 	}); err != nil {
 		t.Fatal("could not write test item:", err)
 	}

--- a/src/internal/clusterstate/v2.5.0/collection_test.go
+++ b/src/internal/clusterstate/v2.5.0/collection_test.go
@@ -69,7 +69,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could not migrate test item:", err)
 	}
 	var item col.TestItem
-	if err := testCol.ReadOnly(ctx).Get(ctx, "foo", &item); err != nil {
+	if err := testCol.ReadOnly().Get(ctx, "foo", &item); err != nil {
 		t.Error("could not read migrated item:", err)
 	}
 	if item.Id != "foo" {
@@ -78,7 +78,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 	if item.Value != "bar quux" {
 		t.Errorf("%q ≠ %q", item.Value, "bar quux")
 	}
-	if err := testCol.ReadOnly(ctx).Get(ctx, "foo1", &item); err != nil {
+	if err := testCol.ReadOnly().Get(ctx, "foo1", &item); err != nil {
 		if !col.IsErrNotFound(err) {
 			t.Error("could not try to get migrated item:", err)
 		}

--- a/src/internal/clusterstate/v2.6.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.6.0/clusterstate.go
@@ -11,15 +11,15 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
 )
 
-func authIsActive(c collection.PostgresReadWriteCollection) bool {
-	return !errors.Is(c.Get("CLUSTER:", &auth.RoleBinding{}), collection.ErrNotFound{})
+func authIsActive(ctx context.Context, c collection.PostgresReadWriteCollection) bool {
+	return !errors.Is(c.Get(ctx, "CLUSTER:", &auth.RoleBinding{}), collection.ErrNotFound{})
 }
 
 func Migrate(state migrations.State) migrations.State {
 	return state.
 		Apply("Grant all users ProjectWriter role for the default project", func(ctx context.Context, env migrations.Env) error {
 			roleBindingsCol := authdb.RoleBindingCollection(nil, nil).ReadWrite(env.Tx)
-			if !authIsActive(roleBindingsCol) {
+			if !authIsActive(ctx, roleBindingsCol) {
 				return nil
 			}
 			rb := &auth.RoleBinding{}

--- a/src/internal/clusterstate/v2.6.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.6.0/clusterstate.go
@@ -23,7 +23,7 @@ func Migrate(state migrations.State) migrations.State {
 				return nil
 			}
 			rb := &auth.RoleBinding{}
-			if err := roleBindingsCol.Upsert("PROJECT:default", rb, func() error {
+			if err := roleBindingsCol.Upsert(ctx, "PROJECT:default", rb, func() error {
 				if rb.Entries == nil {
 					rb.Entries = make(map[string]*auth.Roles)
 				}

--- a/src/internal/clusterstate/v2.8.0/collection_test.go
+++ b/src/internal/clusterstate/v2.8.0/collection_test.go
@@ -69,7 +69,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could not migrate test item:", err)
 	}
 	var item col.TestItem
-	if err := testCol.ReadOnly(ctx).Get("foo", &item); err != nil {
+	if err := testCol.ReadOnly(ctx).Get(ctx, "foo", &item); err != nil {
 		t.Error("could not read migrated item:", err)
 	}
 	if item.Id != "foo" {
@@ -78,7 +78,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 	if item.Value != "bar quux" {
 		t.Errorf("%q ≠ %q", item.Value, "bar quux")
 	}
-	if err := testCol.ReadOnly(ctx).Get("foo1", &item); err != nil {
+	if err := testCol.ReadOnly(ctx).Get(ctx, "foo1", &item); err != nil {
 		if !col.IsErrNotFound(err) {
 			t.Error("could not try to get migrated item:", err)
 		}

--- a/src/internal/clusterstate/v2.8.0/collection_test.go
+++ b/src/internal/clusterstate/v2.8.0/collection_test.go
@@ -54,7 +54,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could create test collection:", err)
 	}
 	if err := dbutil.WithTx(ctx, db, func(ctx context.Context, tx *pachsql.Tx) error {
-		return testCol.ReadWrite(tx).Put("foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
+		return testCol.ReadWrite(tx).Put(ctx, "foo1", &col.TestItem{Id: "foo", Value: "bar", Data: "baz"})
 	}); err != nil {
 		t.Fatal("could not write test item:", err)
 	}

--- a/src/internal/clusterstate/v2.8.0/collection_test.go
+++ b/src/internal/clusterstate/v2.8.0/collection_test.go
@@ -69,7 +69,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 		t.Fatal("could not migrate test item:", err)
 	}
 	var item col.TestItem
-	if err := testCol.ReadOnly(ctx).Get(ctx, "foo", &item); err != nil {
+	if err := testCol.ReadOnly().Get(ctx, "foo", &item); err != nil {
 		t.Error("could not read migrated item:", err)
 	}
 	if item.Id != "foo" {
@@ -78,7 +78,7 @@ func TestMigratePostgreSQLCollection(t *testing.T) {
 	if item.Value != "bar quux" {
 		t.Errorf("%q ≠ %q", item.Value, "bar quux")
 	}
-	if err := testCol.ReadOnly(ctx).Get(ctx, "foo1", &item); err != nil {
+	if err := testCol.ReadOnly().Get(ctx, "foo1", &item); err != nil {
 		if !col.IsErrNotFound(err) {
 			t.Error("could not try to get migrated item:", err)
 		}

--- a/src/internal/clusterstate/v2.8.0/defaults.go
+++ b/src/internal/clusterstate/v2.8.0/defaults.go
@@ -37,7 +37,7 @@ func synthesizeClusterDefaults(ctx context.Context, env migrations.Env) error {
 		return errors.Wrap(err, "could not marshal cluster defaults to JSON")
 	}
 	wrapper := &ppsdb.ClusterDefaultsWrapper{Json: string(js)}
-	if err := ppsdb.CollectionsV2_7_0()[0].ReadWrite(env.Tx).Create("", wrapper); err != nil {
+	if err := ppsdb.CollectionsV2_7_0()[0].ReadWrite(env.Tx).Create(ctx, "", wrapper); err != nil {
 		return errors.Wrap(err, "could not create cluster defaults")
 	}
 

--- a/src/internal/collection/collection_test.go
+++ b/src/internal/collection/collection_test.go
@@ -395,7 +395,7 @@ func collectionTests(
 					for _, k := range modKeys {
 						err := writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 							testProto := &col.TestItem{}
-							if err := rw.Update(k, testProto, func() error {
+							if err := rw.Update(ctx, k, testProto, func() error {
 								testProto.Value = changedValue
 								return nil
 							}); err != nil {
@@ -675,7 +675,7 @@ func collectionTests(
 				readOnly, writer := initCollection(ctx, t, newCollection)
 				err := writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 					testProto := &col.TestItem{}
-					return errors.EnsureStack(rw.Update(updateID, testProto, func() error {
+					return errors.EnsureStack(rw.Update(ctx, updateID, testProto, func() error {
 						return &TestError{}
 					}))
 				})
@@ -690,7 +690,7 @@ func collectionTests(
 				readOnly, writer := initCollection(ctx, t, newCollection)
 				err := writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 					testProto := &col.TestItem{}
-					return errors.EnsureStack(rw.Update(notExistsID, testProto, func() error {
+					return errors.EnsureStack(rw.Update(ctx, notExistsID, testProto, func() error {
 						return nil
 					}))
 				})
@@ -707,13 +707,13 @@ func collectionTests(
 					t.Parallel()
 					err := testRollback(t, func(ctx context.Context, rw col.ReadWriteCollection) error {
 						testProto := &col.TestItem{}
-						if err := rw.Update(makeID(2), testProto, func() error {
+						if err := rw.Update(ctx, makeID(2), testProto, func() error {
 							testProto.Value = changedValue
 							return nil
 						}); err != nil {
 							return errors.EnsureStack(err)
 						}
-						return errors.EnsureStack(rw.Update(makeID(2), testProto, func() error {
+						return errors.EnsureStack(rw.Update(ctx, makeID(2), testProto, func() error {
 							return &TestError{}
 						}))
 					})
@@ -725,13 +725,13 @@ func collectionTests(
 					notExistsID := makeID(10)
 					err := testRollback(t, func(ctx context.Context, rw col.ReadWriteCollection) error {
 						testProto := &col.TestItem{}
-						if err := rw.Update(makeID(3), testProto, func() error {
+						if err := rw.Update(ctx, makeID(3), testProto, func() error {
 							testProto.Value = changedValue
 							return nil
 						}); err != nil {
 							return errors.EnsureStack(err)
 						}
-						return errors.EnsureStack(rw.Update(notExistsID, testProto, func() error {
+						return errors.EnsureStack(rw.Update(ctx, notExistsID, testProto, func() error {
 							testProto.Value = changedValue
 							return nil
 						}))
@@ -744,7 +744,7 @@ func collectionTests(
 					t.Parallel()
 					err := testRollback(t, func(ctx context.Context, rw col.ReadWriteCollection) error {
 						testProto := &col.TestItem{}
-						if err := rw.Update(makeID(6), testProto, func() error {
+						if err := rw.Update(ctx, makeID(6), testProto, func() error {
 							testProto.Value = changedValue
 							return nil
 						}); err != nil {

--- a/src/internal/collection/collection_test.go
+++ b/src/internal/collection/collection_test.go
@@ -187,7 +187,7 @@ func collectionTests(
 			subsuite.Run("ErrNotFound", func(t *testing.T) {
 				t.Parallel()
 				testProto := &col.TestItem{}
-				err := defaultRead.Get("baz", testProto)
+				err := defaultRead.Get(ctx, "baz", testProto)
 				require.True(t, errors.Is(err, col.ErrNotFound{}), "Incorrect error: %v", err)
 				require.True(t, col.IsErrNotFound(err), "Incorrect error: %v", err)
 			})
@@ -195,7 +195,7 @@ func collectionTests(
 			subsuite.Run("Success", func(t *testing.T) {
 				t.Parallel()
 				testProto := &col.TestItem{}
-				require.NoError(t, defaultRead.Get("5", testProto))
+				require.NoError(t, defaultRead.Get(ctx, "5", testProto))
 				require.Equal(t, "5", testProto.Id)
 			})
 		})
@@ -206,7 +206,7 @@ func collectionTests(
 			subsuite.Run("Empty", func(t *testing.T) {
 				t.Parallel()
 				testProto := &col.TestItem{}
-				err := emptyRead.GetByIndex(TestSecondaryIndex, "foo", testProto, col.DefaultOptions(), func(key string) error {
+				err := emptyRead.GetByIndex(ctx, TestSecondaryIndex, "foo", testProto, col.DefaultOptions(), func(key string) error {
 					return errors.New("GetByIndex callback should not have been called for an empty collection")
 				})
 				require.NoError(t, err)
@@ -216,7 +216,7 @@ func collectionTests(
 				t.Parallel()
 				testProto := &col.TestItem{}
 				keys := []string{}
-				err := defaultRead.GetByIndex(TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
+				err := defaultRead.GetByIndex(ctx, TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
 					require.Equal(t, testProto.Id, key)
 					require.Equal(t, testProto.Value, originalValue)
 					keys = append(keys, key)
@@ -232,7 +232,7 @@ func collectionTests(
 			subsuite.Run("NoResults", func(t *testing.T) {
 				t.Parallel()
 				testProto := &col.TestItem{}
-				err := defaultRead.GetByIndex(TestSecondaryIndex, changedValue, testProto, col.DefaultOptions(), func(string) error {
+				err := defaultRead.GetByIndex(ctx, TestSecondaryIndex, changedValue, testProto, col.DefaultOptions(), func(string) error {
 					return errors.New("GetByIndex callback should not have been called for an index value with no rows")
 				})
 				require.NoError(t, err)
@@ -241,7 +241,7 @@ func collectionTests(
 			subsuite.Run("InvalidIndex", func(t *testing.T) {
 				t.Parallel()
 				t.Skip("etcd collections do not validate their indexes")
-				err := defaultRead.GetByIndex(&col.Index{}, "", &col.TestItem{}, col.DefaultOptions(), func(key string) error {
+				err := defaultRead.GetByIndex(ctx, &col.Index{}, "", &col.TestItem{}, col.DefaultOptions(), func(key string) error {
 					return errors.New("GetByIndex callback should not have been called when using an invalid index")
 				})
 				require.YesError(t, err)
@@ -276,7 +276,7 @@ func collectionTests(
 				for idxVal, ids := range expected {
 					testProto := &col.TestItem{}
 					keys := []string{}
-					err := partitionedRead.GetByIndex(TestSecondaryIndex, idxVal, testProto, col.DefaultOptions(), func(key string) error {
+					err := partitionedRead.GetByIndex(ctx, TestSecondaryIndex, idxVal, testProto, col.DefaultOptions(), func(key string) error {
 						require.Equal(t, testProto.Id, key)
 						require.Equal(t, testProto.Value, idxVal)
 						keys = append(keys, key)
@@ -443,11 +443,11 @@ func collectionTests(
 			subsuite.Parallel()
 			subsuite.Run("Success", func(t *testing.T) {
 				t.Parallel()
-				count, err := defaultRead.Count()
+				count, err := defaultRead.Count(ctx)
 				require.NoError(t, err)
 				require.Equal(t, int64(10), count)
 
-				count, err = emptyRead.Count()
+				count, err = emptyRead.Count(ctx)
 				require.NoError(t, err)
 				require.Equal(t, int64(0), count)
 			})
@@ -513,7 +513,7 @@ func collectionTests(
 				require.NoError(t, err)
 				checkDefaultCollection(t, readOnly, RowDiff{Deleted: idRange(0, defaultCollectionSize)})
 
-				count, err := readOnly.Count()
+				count, err := readOnly.Count(ctx)
 				require.NoError(t, err)
 				require.Equal(t, int64(0), count)
 			})
@@ -939,7 +939,7 @@ func collectionTests(
 				})
 				require.NoError(t, err)
 				checkDefaultCollection(t, readOnly, RowDiff{Deleted: idRange(0, 10)})
-				count, err := readOnly.Count()
+				count, err := readOnly.Count(ctx)
 				require.NoError(t, err)
 				require.Equal(t, int64(0), count)
 			})

--- a/src/internal/collection/collection_test.go
+++ b/src/internal/collection/collection_test.go
@@ -474,7 +474,7 @@ func collectionTests(
 
 				err := writer(ctx, func(rw col.ReadWriteCollection) error {
 					testProto := &col.TestItem{}
-					if err := rw.Get(makeID(8), testProto); err != nil {
+					if err := rw.Get(ctx, makeID(8), testProto); err != nil {
 						return errors.EnsureStack(err)
 					}
 					if testProto.Value != originalValue {
@@ -492,19 +492,19 @@ func collectionTests(
 
 				err := writer(ctx, func(rw col.ReadWriteCollection) error {
 					testProto := &col.TestItem{}
-					if err := rw.Get(makeID(1), testProto); err != nil {
+					if err := rw.Get(ctx, makeID(1), testProto); err != nil {
 						return errors.EnsureStack(err)
 					}
 
 					oobID := makeID(10)
-					if err := rw.Get(oobID, testProto); !col.IsErrNotFound(err) {
+					if err := rw.Get(ctx, oobID, testProto); !col.IsErrNotFound(err) {
 						return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", oobID)
 					}
 
 					require.NoError(t, rw.DeleteAll())
 
 					for _, id := range idRange(0, defaultCollectionSize) {
-						if err := rw.Get(id, testProto); !col.IsErrNotFound(err) {
+						if err := rw.Get(ctx, id, testProto); !col.IsErrNotFound(err) {
 							return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", id)
 						}
 					}
@@ -660,7 +660,7 @@ func collectionTests(
 					}); err != nil {
 						return errors.EnsureStack(err)
 					}
-					if err := rw.Get(updateID, testProto); err != nil {
+					if err := rw.Get(ctx, updateID, testProto); err != nil {
 						return errors.EnsureStack(err)
 					}
 					return checkItem(t, testProto, updateID, changedValue)

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -84,10 +84,9 @@ func (c *etcdCollection) ReadWrite(stm STM) EtcdReadWriteCollection {
 	}
 }
 
-func (c *etcdCollection) ReadOnly(ctx context.Context) EtcdReadOnlyCollection {
+func (c *etcdCollection) ReadOnly() EtcdReadOnlyCollection {
 	return &etcdReadOnlyCollection{
 		etcdCollection: c,
-		ctx:            ctx,
 	}
 }
 
@@ -421,7 +420,6 @@ func (c *etcdReadWriteCollection) DeleteAllPrefix(ctx context.Context, prefix st
 
 type etcdReadOnlyCollection struct {
 	*etcdCollection
-	ctx context.Context
 }
 
 // get is an internal wrapper around etcdClient.Get that wraps the call in a

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -100,7 +100,7 @@ func (c *etcdCollection) Claim(ctx context.Context, key string, val proto.Messag
 				return errors.EnsureStack(err)
 			}
 			claimed = true
-			return errors.EnsureStack(readWriteC.PutTTL(key, val, DefaultTTL))
+			return errors.EnsureStack(readWriteC.PutTTL(ctx, key, val, DefaultTTL))
 		}
 		claimed = false
 		return nil
@@ -242,7 +242,7 @@ func (c *etcdReadWriteCollection) Put(ctx context.Context, maybeKey interface{},
 	if !ok {
 		return errors.New("key must be a string")
 	}
-	return c.PutTTL(key, val, 0)
+	return c.PutTTL(ctx, key, val, 0)
 }
 
 func (c *etcdReadWriteCollection) TTL(key string) (int64, error) {
@@ -253,7 +253,7 @@ func (c *etcdReadWriteCollection) TTL(key string) (int64, error) {
 	return ttl, errors.EnsureStack(err)
 }
 
-func (c *etcdReadWriteCollection) PutTTL(key string, val proto.Message, ttl int64) error {
+func (c *etcdReadWriteCollection) PutTTL(ctx context.Context, key string, val proto.Message, ttl int64) error {
 	return c.put(key, val, func(key string, val string, ptr uintptr) error {
 		return errors.EnsureStack(c.stm.Put(key, val, ttl, ptr))
 	})
@@ -326,7 +326,7 @@ func (c *etcdReadWriteCollection) putIgnoreLease(key string, val proto.Message) 
 // Update reads the current value associated with 'key', calls 'f' to update
 // the value, and writes the new value back to the collection. 'key' must be
 // present in the collection, or a 'Not Found' error is returned
-func (c *etcdReadWriteCollection) Update(maybeKey interface{}, val proto.Message, f func() error) error {
+func (c *etcdReadWriteCollection) Update(ctx context.Context, maybeKey interface{}, val proto.Message, f func() error) error {
 	key, ok := maybeKey.(string)
 	if !ok {
 		return errors.New("key must be a string")

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -237,7 +237,7 @@ func (c *etcdReadWriteCollection) getIndexPath(val proto.Message, index *Index, 
 	return c.indexPath(index, index.Extract(val), key)
 }
 
-func (c *etcdReadWriteCollection) Put(maybeKey interface{}, val proto.Message) error {
+func (c *etcdReadWriteCollection) Put(ctx context.Context, maybeKey interface{}, val proto.Message) error {
 	key, ok := maybeKey.(string)
 	if !ok {
 		return errors.New("key must be a string")
@@ -361,7 +361,7 @@ func (c *etcdReadWriteCollection) Upsert(maybeKey interface{}, val proto.Message
 	if err := f(); err != nil {
 		return err
 	}
-	return c.Put(key, val)
+	return c.Put(pctx.TODO(), key, val)
 }
 
 func (c *etcdReadWriteCollection) Create(maybeKey interface{}, val proto.Message) error {
@@ -380,7 +380,7 @@ func (c *etcdReadWriteCollection) Create(maybeKey interface{}, val proto.Message
 	if err == nil {
 		return ErrExists{Type: c.prefix, Key: key}
 	}
-	return c.Put(key, val)
+	return c.Put(pctx.TODO(), key, val)
 }
 
 func (c *etcdReadWriteCollection) Delete(maybeKey interface{}) error {

--- a/src/internal/collection/etcd_collection.go
+++ b/src/internal/collection/etcd_collection.go
@@ -211,7 +211,7 @@ func (c *etcdReadWriteCollection) Get(ctx context.Context, maybeKey interface{},
 	if err := watch.CheckType(c.template, val); err != nil {
 		return err
 	}
-	valStr, err := c.stm.Get(c.path(key))
+	valStr, err := c.stm.Get(ctx, c.path(key))
 	if err != nil {
 		if IsErrNotFound(err) {
 			return ErrNotFound{Type: c.prefix, Key: key}
@@ -245,7 +245,7 @@ func (c *etcdReadWriteCollection) Put(ctx context.Context, maybeKey interface{},
 }
 
 func (c *etcdReadWriteCollection) TTL(ctx context.Context, key string) (int64, error) {
-	ttl, err := c.stm.TTL(c.path(key))
+	ttl, err := c.stm.TTL(ctx, c.path(key))
 	if IsErrNotFound(err) {
 		return ttl, ErrNotFound{Type: c.prefix, Key: key}
 	}
@@ -254,7 +254,7 @@ func (c *etcdReadWriteCollection) TTL(ctx context.Context, key string) (int64, e
 
 func (c *etcdReadWriteCollection) PutTTL(ctx context.Context, key string, val proto.Message, ttl int64) error {
 	return c.put(ctx, key, val, func(key string, val string, ptr uintptr) error {
-		return errors.EnsureStack(c.stm.Put(key, val, ttl, ptr))
+		return errors.EnsureStack(c.stm.Put(ctx, key, val, ttl, ptr))
 	})
 }
 
@@ -372,7 +372,7 @@ func (c *etcdReadWriteCollection) Create(ctx context.Context, maybeKey interface
 		return err
 	}
 	fullKey := c.path(key)
-	_, err := c.stm.Get(fullKey)
+	_, err := c.stm.Get(ctx, fullKey)
 	if err != nil && !IsErrNotFound(err) {
 		return errors.EnsureStack(err)
 	}
@@ -388,7 +388,7 @@ func (c *etcdReadWriteCollection) Delete(ctx context.Context, maybeKey interface
 		return errors.New("key must be a string")
 	}
 	fullKey := c.path(key)
-	if _, err := c.stm.Get(fullKey); err != nil {
+	if _, err := c.stm.Get(ctx, fullKey); err != nil {
 		return errors.EnsureStack(err)
 	}
 	if c.indexes != nil && c.template != nil {

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -107,7 +107,7 @@ func TestDeletePrefix(t *testing.T) {
 		Job: client.NewJob(pfs.DefaultProjectName, "p", "Job4"),
 	}
 
-	_, err := col.NewSTM(context.Background(), env.EtcdClient, func(stm col.STM) error {
+	_, err := col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
 		rw := jobInfos.ReadWrite(stm)
 		if err := rw.Put(ppsdb.JobKey(j1.Job), j1); err != nil {
 			return errors.EnsureStack(err)
@@ -125,60 +125,60 @@ func TestDeletePrefix(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = col.NewSTM(context.Background(), env.EtcdClient, func(stm col.STM) error {
+	_, err = col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
 		job := &pps.JobInfo{}
 		rw := jobInfos.ReadWrite(stm)
 
 		if err := rw.DeleteAllPrefix("default/p@prefix/suffix"); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := rw.Get(ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
+		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j1.Job.Id)
 		}
-		if err := rw.Get(ppsdb.JobKey(j2.Job), job); !col.IsErrNotFound(err) {
+		if err := rw.Get(ctx, ppsdb.JobKey(j2.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j2.Job.Id)
 		}
-		if err := rw.Get(ppsdb.JobKey(j3.Job), job); err != nil {
+		if err := rw.Get(ctx, ppsdb.JobKey(j3.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := rw.Get(ppsdb.JobKey(j4.Job), job); err != nil {
+		if err := rw.Get(ctx, ppsdb.JobKey(j4.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
 
 		if err := rw.DeleteAllPrefix("default/p@prefix"); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := rw.Get(ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
+		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j1.Job.Id)
 		}
-		if err := rw.Get(ppsdb.JobKey(j2.Job), job); !col.IsErrNotFound(err) {
+		if err := rw.Get(ctx, ppsdb.JobKey(j2.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j2.Job.Id)
 		}
-		if err := rw.Get(ppsdb.JobKey(j3.Job), job); !col.IsErrNotFound(err) {
+		if err := rw.Get(ctx, ppsdb.JobKey(j3.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j3.Job.Id)
 		}
-		if err := rw.Get(ppsdb.JobKey(j4.Job), job); err != nil {
+		if err := rw.Get(ctx, ppsdb.JobKey(j4.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
 
 		if err := rw.Put(ppsdb.JobKey(j1.Job), j1); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := rw.Get(ppsdb.JobKey(j1.Job), job); err != nil {
+		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
 
 		if err := rw.DeleteAllPrefix("default/p@prefix/suffix"); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := rw.Get(ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
+		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
 			return errors.Wrapf(err, "Expected ErrNotFound for key '%s', but got", j1.Job.Id)
 		}
 
 		if err := rw.Put(ppsdb.JobKey(j2.Job), j2); err != nil {
 			return errors.EnsureStack(err)
 		}
-		if err := rw.Get(ppsdb.JobKey(j2.Job), job); err != nil {
+		if err := rw.Get(ctx, ppsdb.JobKey(j2.Job), job); err != nil {
 			return errors.EnsureStack(err)
 		}
 
@@ -187,7 +187,7 @@ func TestDeletePrefix(t *testing.T) {
 	require.NoError(t, err)
 
 	job := &pps.JobInfo{}
-	ro := jobInfos.ReadOnly(context.Background())
+	ro := jobInfos.ReadOnly(ctx)
 	require.True(t, col.IsErrNotFound(ro.Get(ppsdb.JobKey(j1.Job), job)))
 	require.NoError(t, ro.Get(ppsdb.JobKey(j2.Job), job))
 	require.Equal(t, j2, job)

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -48,7 +48,7 @@ func TestEtcdCollections(suite *testing.T) {
 		}
 		testCol := col.NewEtcdCollection(etcdEnv.EtcdClient, prefix, index, &col.TestItem{}, nil, nil)
 
-		readCallback := func(ctx context.Context) col.ReadOnlyCollection {
+		readCallback := func() col.ReadOnlyCollection {
 			return testCol.ReadOnly()
 		}
 

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -313,7 +313,7 @@ func TestTTL(t *testing.T) {
 	clxn := col.NewEtcdCollection(env.EtcdClient, uuidPrefix, nil, &wrapperspb.BoolValue{}, nil, nil)
 	const TTL = 5
 	_, err := col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
-		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL("key", epsilon, TTL))
+		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL(ctx, "key", epsilon, TTL))
 	})
 	require.NoError(t, err)
 
@@ -336,7 +336,7 @@ func TestTTLExpire(t *testing.T) {
 	clxn := col.NewEtcdCollection(env.EtcdClient, uuidPrefix, nil, &wrapperspb.BoolValue{}, nil, nil)
 	const TTL = 5
 	_, err := col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
-		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL("key", epsilon, TTL))
+		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL(ctx, "key", epsilon, TTL))
 	})
 	require.NoError(t, err)
 
@@ -357,7 +357,7 @@ func TestTTLExtend(t *testing.T) {
 	clxn := col.NewEtcdCollection(env.EtcdClient, uuidPrefix, nil, &wrapperspb.BoolValue{}, nil, nil)
 	const TTL = 5
 	_, err := col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
-		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL("key", epsilon, TTL))
+		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL(ctx, "key", epsilon, TTL))
 	})
 	require.NoError(t, err)
 
@@ -373,7 +373,7 @@ func TestTTLExtend(t *testing.T) {
 	// Put value with new, longer TLL and check that it was set
 	const LongerTTL = 15
 	_, err = col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
-		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL("key", epsilon, LongerTTL))
+		return errors.EnsureStack(clxn.ReadWrite(stm).PutTTL(ctx, "key", epsilon, LongerTTL))
 	})
 	require.NoError(t, err)
 

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -49,7 +49,7 @@ func TestEtcdCollections(suite *testing.T) {
 		testCol := col.NewEtcdCollection(etcdEnv.EtcdClient, prefix, index, &col.TestItem{}, nil, nil)
 
 		readCallback := func(ctx context.Context) col.ReadOnlyCollection {
-			return testCol.ReadOnly(ctx)
+			return testCol.ReadOnly()
 		}
 
 		writeCallback := func(ctx context.Context, f func(context.Context, col.ReadWriteCollection) error) error {
@@ -82,7 +82,7 @@ func TestDryRun(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = jobInfos.ReadOnly(context.Background()).Get(ctx, "j1", job)
+	err = jobInfos.ReadOnly().Get(ctx, "j1", job)
 	require.True(t, col.IsErrNotFound(err))
 }
 
@@ -187,7 +187,7 @@ func TestDeletePrefix(t *testing.T) {
 	require.NoError(t, err)
 
 	job := &pps.JobInfo{}
-	ro := jobInfos.ReadOnly(ctx)
+	ro := jobInfos.ReadOnly()
 	require.True(t, col.IsErrNotFound(ro.Get(ctx, ppsdb.JobKey(j1.Job), job)))
 	require.NoError(t, ro.Get(ctx, ppsdb.JobKey(j2.Job), job))
 	require.Equal(t, j2, job)
@@ -228,7 +228,7 @@ func TestIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ro := jobInfos.ReadOnly(context.Background())
+	ro := jobInfos.ReadOnly()
 
 	job := &pps.JobInfo{}
 	i := 1
@@ -342,7 +342,7 @@ func TestTTLExpire(t *testing.T) {
 
 	time.Sleep((TTL + 1) * time.Second)
 	value := &wrapperspb.BoolValue{}
-	err = clxn.ReadOnly(ctx).Get(ctx, "key", value)
+	err = clxn.ReadOnly().Get(ctx, "key", value)
 	require.NotNil(t, err)
 	require.True(t, errutil.IsNotFoundError(err))
 }
@@ -401,7 +401,7 @@ func TestIteration(t *testing.T) {
 			})
 			require.NoError(t, err)
 		}
-		ro := c.ReadOnly(ctx)
+		ro := c.ReadOnly()
 		testProto := &col.TestItem{}
 		i := numVals - 1
 		require.NoError(t, ro.List(ctx, testProto, col.DefaultOptions(), func(string) error {
@@ -428,7 +428,7 @@ func TestIteration(t *testing.T) {
 			require.NoError(t, err)
 		}
 		vals := make(map[string]bool)
-		ro := c.ReadOnly(ctx)
+		ro := c.ReadOnly()
 		testProto := &col.TestItem{}
 		require.NoError(t, ro.List(ctx, testProto, col.DefaultOptions(), func(string) error {
 			require.False(t, vals[testProto.Id], "saw value %s twice", testProto.Id)
@@ -449,7 +449,7 @@ func TestIteration(t *testing.T) {
 			})
 			require.NoError(t, err)
 		}
-		ro := c.ReadOnly(context.Background())
+		ro := c.ReadOnly()
 		val := &col.TestItem{}
 		vals := make(map[string]bool)
 		valsOrder := []string{}

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -82,7 +82,7 @@ func TestDryRun(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = jobInfos.ReadOnly(context.Background()).Get("j1", job)
+	err = jobInfos.ReadOnly(context.Background()).Get(ctx, "j1", job)
 	require.True(t, col.IsErrNotFound(err))
 }
 
@@ -129,7 +129,7 @@ func TestDeletePrefix(t *testing.T) {
 		job := &pps.JobInfo{}
 		rw := jobInfos.ReadWrite(stm)
 
-		if err := rw.DeleteAllPrefix("default/p@prefix/suffix"); err != nil {
+		if err := rw.DeleteAllPrefix(ctx, "default/p@prefix/suffix"); err != nil {
 			return errors.EnsureStack(err)
 		}
 		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
@@ -145,7 +145,7 @@ func TestDeletePrefix(t *testing.T) {
 			return errors.EnsureStack(err)
 		}
 
-		if err := rw.DeleteAllPrefix("default/p@prefix"); err != nil {
+		if err := rw.DeleteAllPrefix(ctx, "default/p@prefix"); err != nil {
 			return errors.EnsureStack(err)
 		}
 		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
@@ -168,7 +168,7 @@ func TestDeletePrefix(t *testing.T) {
 			return errors.EnsureStack(err)
 		}
 
-		if err := rw.DeleteAllPrefix("default/p@prefix/suffix"); err != nil {
+		if err := rw.DeleteAllPrefix(ctx, "default/p@prefix/suffix"); err != nil {
 			return errors.EnsureStack(err)
 		}
 		if err := rw.Get(ctx, ppsdb.JobKey(j1.Job), job); !col.IsErrNotFound(err) {
@@ -188,11 +188,11 @@ func TestDeletePrefix(t *testing.T) {
 
 	job := &pps.JobInfo{}
 	ro := jobInfos.ReadOnly(ctx)
-	require.True(t, col.IsErrNotFound(ro.Get(ppsdb.JobKey(j1.Job), job)))
-	require.NoError(t, ro.Get(ppsdb.JobKey(j2.Job), job))
+	require.True(t, col.IsErrNotFound(ro.Get(ctx, ppsdb.JobKey(j1.Job), job)))
+	require.NoError(t, ro.Get(ctx, ppsdb.JobKey(j2.Job), job))
 	require.Equal(t, j2, job)
-	require.True(t, col.IsErrNotFound(ro.Get(ppsdb.JobKey(j3.Job), job)))
-	require.NoError(t, ro.Get(ppsdb.JobKey(j4.Job), job))
+	require.True(t, col.IsErrNotFound(ro.Get(ctx, ppsdb.JobKey(j3.Job), job)))
+	require.NoError(t, ro.Get(ctx, ppsdb.JobKey(j4.Job), job))
 	require.Equal(t, j4, job)
 }
 
@@ -232,7 +232,7 @@ func TestIndex(t *testing.T) {
 
 	job := &pps.JobInfo{}
 	i := 1
-	require.NoError(t, ro.GetByIndex(pipelineIndex, j1.Job.Pipeline.Name, job, col.DefaultOptions(), func(string) error {
+	require.NoError(t, ro.GetByIndex(ctx, pipelineIndex, j1.Job.Pipeline.Name, job, col.DefaultOptions(), func(string) error {
 		switch i {
 		case 1:
 			require.Equal(t, j1, job)
@@ -246,7 +246,7 @@ func TestIndex(t *testing.T) {
 	}))
 
 	i = 1
-	require.NoError(t, ro.GetByIndex(pipelineIndex, j3.Job.Pipeline.Name, job, col.DefaultOptions(), func(string) error {
+	require.NoError(t, ro.GetByIndex(ctx, pipelineIndex, j3.Job.Pipeline.Name, job, col.DefaultOptions(), func(string) error {
 		switch i {
 		case 1:
 			require.Equal(t, j3, job)
@@ -320,7 +320,7 @@ func TestTTL(t *testing.T) {
 	var actualTTL int64
 	_, err = col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
 		var err error
-		actualTTL, err = clxn.ReadWrite(stm).TTL("key")
+		actualTTL, err = clxn.ReadWrite(stm).TTL(ctx, "key")
 		return errors.EnsureStack(err)
 	})
 	require.NoError(t, err)
@@ -342,7 +342,7 @@ func TestTTLExpire(t *testing.T) {
 
 	time.Sleep((TTL + 1) * time.Second)
 	value := &wrapperspb.BoolValue{}
-	err = clxn.ReadOnly(ctx).Get("key", value)
+	err = clxn.ReadOnly(ctx).Get(ctx, "key", value)
 	require.NotNil(t, err)
 	require.True(t, errutil.IsNotFoundError(err))
 }
@@ -364,7 +364,7 @@ func TestTTLExtend(t *testing.T) {
 	var actualTTL int64
 	_, err = col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
 		var err error
-		actualTTL, err = clxn.ReadWrite(stm).TTL("key")
+		actualTTL, err = clxn.ReadWrite(stm).TTL(ctx, "key")
 		return errors.EnsureStack(err)
 	})
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestTTLExtend(t *testing.T) {
 
 	_, err = col.NewSTM(ctx, env.EtcdClient, func(stm col.STM) error {
 		var err error
-		actualTTL, err = clxn.ReadWrite(stm).TTL("key")
+		actualTTL, err = clxn.ReadWrite(stm).TTL(ctx, "key")
 		return errors.EnsureStack(err)
 	})
 	require.NoError(t, err)

--- a/src/internal/collection/etcd_collection_test.go
+++ b/src/internal/collection/etcd_collection_test.go
@@ -401,10 +401,10 @@ func TestIteration(t *testing.T) {
 			})
 			require.NoError(t, err)
 		}
-		ro := c.ReadOnly(context.Background())
+		ro := c.ReadOnly(ctx)
 		testProto := &col.TestItem{}
 		i := numVals - 1
-		require.NoError(t, ro.List(testProto, col.DefaultOptions(), func(string) error {
+		require.NoError(t, ro.List(ctx, testProto, col.DefaultOptions(), func(string) error {
 			require.Equal(t, fmt.Sprintf("%d", i), testProto.Id)
 			i--
 			return nil
@@ -430,7 +430,7 @@ func TestIteration(t *testing.T) {
 		vals := make(map[string]bool)
 		ro := c.ReadOnly(ctx)
 		testProto := &col.TestItem{}
-		require.NoError(t, ro.List(testProto, col.DefaultOptions(), func(string) error {
+		require.NoError(t, ro.List(ctx, testProto, col.DefaultOptions(), func(string) error {
 			require.False(t, vals[testProto.Id], "saw value %s twice", testProto.Id)
 			vals[testProto.Id] = true
 			return nil
@@ -453,7 +453,7 @@ func TestIteration(t *testing.T) {
 		val := &col.TestItem{}
 		vals := make(map[string]bool)
 		valsOrder := []string{}
-		require.NoError(t, ro.List(val, col.DefaultOptions(), func(string) error {
+		require.NoError(t, ro.List(ctx, val, col.DefaultOptions(), func(string) error {
 			require.False(t, vals[val.Id], "saw value %s twice", val.Id)
 			vals[val.Id] = true
 			valsOrder = append(valsOrder, val.Id)
@@ -465,7 +465,7 @@ func TestIteration(t *testing.T) {
 		require.Equal(t, numVals, len(vals), "didn't receive every value")
 		vals = make(map[string]bool)
 		valsOrder = []string{}
-		require.NoError(t, ro.List(val, &col.Options{Target: col.SortByCreateRevision, Order: col.SortAscend}, func(string) error {
+		require.NoError(t, ro.List(ctx, val, &col.Options{Target: col.SortByCreateRevision, Order: col.SortAscend}, func(string) error {
 			require.False(t, vals[val.Id], "saw value %s twice", val.Id)
 			vals[val.Id] = true
 			valsOrder = append(valsOrder, val.Id)

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -678,11 +678,11 @@ type postgresReadWriteCollection struct {
 	tx *pachsql.Tx
 }
 
-func (c *postgresReadWriteCollection) Get(key interface{}, val proto.Message) error {
+func (c *postgresReadWriteCollection) Get(ctx context.Context, key interface{}, val proto.Message) error {
 	var result *model
 	var err error
 	err = c.withKey(key, func(rawKey string) error {
-		result, err = c.get(context.Background(), rawKey, c.tx)
+		result, err = c.get(ctx, rawKey, c.tx)
 		return err
 	})
 	if err != nil {
@@ -717,7 +717,7 @@ func (c *postgresReadWriteCollection) getWriteParams(key string, val proto.Messa
 }
 
 func (c *postgresReadWriteCollection) Update(key interface{}, val proto.Message, f func() error) error {
-	if err := c.Get(key, val); err != nil {
+	if err := c.Get(pctx.TODO(), key, val); err != nil {
 		return err
 	}
 	if err := f(); err != nil {
@@ -797,7 +797,7 @@ func (c *postgresReadWriteCollection) insert(key string, val proto.Message, upse
 }
 
 func (c *postgresReadWriteCollection) Upsert(key interface{}, val proto.Message, f func() error) error {
-	if err := c.Get(key, val); err != nil && !IsErrNotFound(err) {
+	if err := c.Get(pctx.TODO(), key, val); err != nil && !IsErrNotFound(err) {
 		return err
 	}
 	if err := f(); err != nil {

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -209,11 +209,11 @@ func (c *postgresCollection) get(ctx context.Context, key string, q sqlx.Queryer
 	return result, nil
 }
 
-func (c *postgresReadOnlyCollection) Get(key interface{}, val proto.Message) error {
+func (c *postgresReadOnlyCollection) Get(ctx context.Context, key interface{}, val proto.Message) error {
 	var result *model
 	var err error
 	err = c.withKey(key, func(rawKey string) error {
-		result, err = c.get(c.ctx, rawKey, c.db)
+		result, err = c.get(ctx, rawKey, c.db)
 		return err
 	})
 	if err != nil {
@@ -261,8 +261,8 @@ func (c *postgresCollection) getByIndex(ctx context.Context, q sqlx.ExtContext, 
 
 // NOTE: Internally, GetByIndex scans the collection over multiple transactions,
 // making this method susceptible to inconsistent reads
-func (c *postgresReadOnlyCollection) GetByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error {
-	return c.getByIndex(c.ctx, c.db, index, indexVal, val, opts, f)
+func (c *postgresReadOnlyCollection) GetByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error {
+	return c.getByIndex(ctx, c.db, index, indexVal, val, opts, f)
 }
 
 // NOTE: Internally, GetByIndex scans the collection using multiple queries,
@@ -288,8 +288,8 @@ func (c *postgresCollection) getUniqueByIndex(ctx context.Context, q sqlx.ExtCon
 	return nil
 }
 
-func (c *postgresReadOnlyCollection) GetUniqueByIndex(index *Index, indexVal string, val proto.Message) error {
-	return c.getUniqueByIndex(c.ctx, c.db, index, indexVal, val)
+func (c *postgresReadOnlyCollection) GetUniqueByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message) error {
+	return c.getUniqueByIndex(ctx, c.db, index, indexVal, val)
 }
 
 func (c *postgresReadWriteCollection) GetUniqueByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message) error {
@@ -505,9 +505,9 @@ func (c *postgresReadWriteCollection) List(ctx context.Context, val proto.Messag
 	})
 }
 
-func (c *postgresReadOnlyCollection) Count() (int64, error) {
+func (c *postgresReadOnlyCollection) Count(ctx context.Context) (int64, error) {
 	query := fmt.Sprintf("select count(*) from collections.%s", c.table)
-	row := c.db.QueryRowContext(c.ctx, query)
+	row := c.db.QueryRowContext(ctx, query)
 
 	var result int64
 	err := row.Scan(&result)

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -136,8 +136,8 @@ func (c *postgresCollection) indexWatchChannel(field string, value string) strin
 	return c.tableWatchChannel() + "_" + fmt.Sprintf("%x", md5.Sum([]byte(data)))
 }
 
-func (c *postgresCollection) ReadOnly(ctx context.Context) PostgresReadOnlyCollection {
-	return &postgresReadOnlyCollection{c, ctx}
+func (c *postgresCollection) ReadOnly() PostgresReadOnlyCollection {
+	return &postgresReadOnlyCollection{c}
 }
 
 func (c *postgresCollection) ReadWrite(tx *pachsql.Tx) PostgresReadWriteCollection {
@@ -185,7 +185,6 @@ func (c *postgresCollection) mapSQLError(err error, key string) error {
 
 type postgresReadOnlyCollection struct {
 	*postgresCollection
-	ctx context.Context
 }
 
 func (c *postgresCollection) get(ctx context.Context, key string, q sqlx.QueryerContext) (*model, error) {

--- a/src/internal/collection/postgres_collection.go
+++ b/src/internal/collection/postgres_collection.go
@@ -716,8 +716,8 @@ func (c *postgresReadWriteCollection) getWriteParams(key string, val proto.Messa
 	return params, nil
 }
 
-func (c *postgresReadWriteCollection) Update(key interface{}, val proto.Message, f func() error) error {
-	if err := c.Get(pctx.TODO(), key, val); err != nil {
+func (c *postgresReadWriteCollection) Update(ctx context.Context, key interface{}, val proto.Message, f func() error) error {
+	if err := c.Get(ctx, key, val); err != nil {
 		return err
 	}
 	if err := f(); err != nil {
@@ -737,7 +737,7 @@ func (c *postgresReadWriteCollection) Update(key interface{}, val proto.Message,
 
 		query := fmt.Sprintf("update collections.%s set %s where key = :key", c.table, strings.Join(updateFields, ", "))
 
-		_, err = c.tx.NamedExec(query, params)
+		_, err = c.tx.NamedExecContext(ctx, query, params)
 		return c.mapSQLError(err, rawKey)
 	})
 }

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -72,7 +72,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col
 			return col.SetupPostgresCollections(ctx, sqlTx, testCol)
 		}))
 
-		readCallback := func(ctx context.Context) col.ReadOnlyCollection {
+		readCallback := func() col.ReadOnlyCollection {
 			return testCol.ReadOnly()
 		}
 
@@ -109,7 +109,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 				return errors.EnsureStack(err)
 			})
 			require.NoError(t, err)
-			count, err := emptyRead(ctx).Count(ctx)
+			count, err := emptyRead().Count(ctx)
 			require.NoError(t, err)
 			require.Equal(t, int64(0), count)
 		})

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -109,7 +109,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 				return errors.EnsureStack(err)
 			})
 			require.NoError(t, err)
-			count, err := emptyRead(ctx).Count()
+			count, err := emptyRead(ctx).Count(ctx)
 			require.NoError(t, err)
 			require.Equal(t, int64(0), count)
 		})

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -103,7 +103,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			t.Parallel()
 			err := emptyWriter(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 				pgrw := rw.(col.PostgresReadWriteCollection)
-				err := pgrw.GetByIndex(TestSecondaryIndex, "foo", &col.TestItem{}, col.DefaultOptions(), func(string) error {
+				err := pgrw.GetByIndex(ctx, TestSecondaryIndex, "foo", &col.TestItem{}, col.DefaultOptions(), func(string) error {
 					return errors.New("GetByIndex callback should not have been called for an empty collection")
 				})
 				return errors.EnsureStack(err)
@@ -120,7 +120,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			err := defaultWriter(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 				testProto := &col.TestItem{}
 				pgrw := rw.(col.PostgresReadWriteCollection)
-				err := pgrw.GetByIndex(TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
+				err := pgrw.GetByIndex(ctx, TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
 					require.Equal(t, testProto.Id, key)
 					require.Equal(t, testProto.Value, originalValue)
 					keys = append(keys, key)
@@ -141,7 +141,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			err := defaultWriter(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 				testProto := &col.TestItem{}
 				pgrw := rw.(col.PostgresReadWriteCollection)
-				err := pgrw.GetByIndex(TestSecondaryIndex, changedValue, testProto, col.DefaultOptions(), func(string) error {
+				err := pgrw.GetByIndex(ctx, TestSecondaryIndex, changedValue, testProto, col.DefaultOptions(), func(string) error {
 					return errors.New("GetByIndex callback should not have been called for an index value with no rows")
 				})
 				return errors.EnsureStack(err)
@@ -154,7 +154,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			t.Parallel()
 			err := defaultWriter(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 				pgrw := rw.(col.PostgresReadWriteCollection)
-				err := pgrw.GetByIndex(&col.Index{}, "", &col.TestItem{}, col.DefaultOptions(), func(key string) error {
+				err := pgrw.GetByIndex(ctx, &col.Index{}, "", &col.TestItem{}, col.DefaultOptions(), func(key string) error {
 					return errors.New("GetByIndex callback should not have been called when using an invalid index")
 				})
 				return errors.EnsureStack(err)
@@ -172,7 +172,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			err := defaultWriter(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 				testProto := &col.TestItem{}
 				pgrw := rw.(col.PostgresReadWriteCollection)
-				err := pgrw.GetByIndex(TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
+				err := pgrw.GetByIndex(ctx, TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
 					outerKeys = append(outerKeys, testProto.Id)
 					if err := pgrw.Get(ctx, innerID, testProto); err != nil {
 						return errors.EnsureStack(err)

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -73,7 +73,7 @@ func newCollectionFunc(setup func(context.Context, *testing.T) (*pachsql.DB, col
 		}))
 
 		readCallback := func(ctx context.Context) col.ReadOnlyCollection {
-			return testCol.ReadOnly(ctx)
+			return testCol.ReadOnly()
 		}
 
 		writeCallback := func(ctx context.Context, f func(context.Context, col.ReadWriteCollection) error) error {

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -174,7 +174,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 				pgrw := rw.(col.PostgresReadWriteCollection)
 				err := pgrw.GetByIndex(TestSecondaryIndex, originalValue, testProto, col.DefaultOptions(), func(key string) error {
 					outerKeys = append(outerKeys, testProto.Id)
-					if err := pgrw.Get(innerID, testProto); err != nil {
+					if err := pgrw.Get(ctx, innerID, testProto); err != nil {
 						return errors.EnsureStack(err)
 					}
 					innerKeys = append(innerKeys, testProto.Id)

--- a/src/internal/collection/postgres_collection_test.go
+++ b/src/internal/collection/postgres_collection_test.go
@@ -133,7 +133,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			})
 			require.NoError(t, err)
 			require.ElementsEqual(t, keys, idRange(0, defaultCollectionSize))
-			checkDefaultCollection(t, defaultRead, RowDiff{})
+			checkDefaultCollection(t, ctx, defaultRead, RowDiff{})
 		})
 
 		subsuite.Run("NoResults", func(t *testing.T) {
@@ -147,7 +147,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 				return errors.EnsureStack(err)
 			})
 			require.NoError(t, err)
-			checkDefaultCollection(t, defaultRead, RowDiff{})
+			checkDefaultCollection(t, ctx, defaultRead, RowDiff{})
 		})
 
 		subsuite.Run("InvalidIndex", func(t *testing.T) {
@@ -161,7 +161,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			})
 			require.YesError(t, err)
 			require.Matches(t, "Unknown collection index", err.Error())
-			checkDefaultCollection(t, defaultRead, RowDiff{})
+			checkDefaultCollection(t, ctx, defaultRead, RowDiff{})
 		})
 
 		subsuite.Run("Nested", func(t *testing.T) {
@@ -194,7 +194,7 @@ func PostgresCollectionBasicTests(suite *testing.T, newCollection func(context.C
 			}
 
 			require.ElementsEqual(t, expectedInnerKeys, innerKeys)
-			checkDefaultCollection(t, defaultRead, RowDiff{})
+			checkDefaultCollection(t, ctx, defaultRead, RowDiff{})
 		})
 	})
 

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -126,12 +126,12 @@ type ReadOnlyCollection interface {
 	GetByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
 	List(ctx context.Context, val proto.Message, opts *Options, f func(string) error) error
 	Count(ctx context.Context) (int64, error)
-	Watch(opts ...watch.Option) (watch.Watcher, error)
-	WatchF(f func(*watch.Event) error, opts ...watch.Option) error
-	WatchOne(key interface{}, opts ...watch.Option) (watch.Watcher, error)
-	WatchOneF(key interface{}, f func(*watch.Event) error, opts ...watch.Option) error
-	WatchByIndex(index *Index, val string, opts ...watch.Option) (watch.Watcher, error)
-	WatchByIndexF(index *Index, val string, f func(*watch.Event) error, opts ...watch.Option) error
+	Watch(ctx context.Context, opts ...watch.Option) (watch.Watcher, error)
+	WatchF(ctx context.Context, f func(*watch.Event) error, opts ...watch.Option) error
+	WatchOne(ctx context.Context, key interface{}, opts ...watch.Option) (watch.Watcher, error)
+	WatchOneF(ctx context.Context, key interface{}, f func(*watch.Event) error, opts ...watch.Option) error
+	WatchByIndex(ctx context.Context, index *Index, val string, opts ...watch.Option) (watch.Watcher, error)
+	WatchByIndexF(ctx context.Context, index *Index, val string, f func(*watch.Event) error, opts ...watch.Option) error
 }
 
 type PostgresReadOnlyCollection interface {

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -75,7 +75,7 @@ type Index struct {
 // operations.
 type ReadWriteCollection interface {
 	Get(ctx context.Context, key interface{}, val proto.Message) error
-	Put(key interface{}, val proto.Message) error
+	Put(ctx context.Context, key interface{}, val proto.Message) error
 	// Update reads the current value associated with 'key', calls 'f' to update
 	// the value, and writes the new value back to the collection. 'key' must be
 	// present in the collection, or a 'Not Found' error is returned

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -109,7 +109,7 @@ type EtcdReadWriteCollection interface {
 
 	// TTL returns the amount of time that 'key' will continue to exist in the
 	// collection, or '0' if 'key' will remain in the collection indefinitely
-	TTL(key string) (int64, error)
+	TTL(ctx context.Context, key string) (int64, error)
 	// PutTTL is the same as Put except that the object is removed after
 	// TTL seconds.
 	// WARNING: using PutTTL with a collection that has secondary indices
@@ -117,15 +117,15 @@ type EtcdReadWriteCollection interface {
 	// but not exactly the same time as the documents.
 	PutTTL(ctx context.Context, key string, val proto.Message, ttl int64) error
 
-	DeleteAllPrefix(prefix string) error
+	DeleteAllPrefix(ctx context.Context, prefix string) error
 }
 
 // ReadOnlyCollection is a collection interface that only supports read ops.
 type ReadOnlyCollection interface {
-	Get(key interface{}, val proto.Message) error
-	GetByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
+	Get(ctx context.Context, key interface{}, val proto.Message) error
+	GetByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
 	List(val proto.Message, opts *Options, f func(string) error) error
-	Count() (int64, error)
+	Count(ctx context.Context) (int64, error)
 	Watch(opts ...watch.Option) (watch.Watcher, error)
 	WatchF(f func(*watch.Event) error, opts ...watch.Option) error
 	WatchOne(key interface{}, opts ...watch.Option) (watch.Watcher, error)
@@ -140,7 +140,7 @@ type PostgresReadOnlyCollection interface {
 	// GetUniqueByIndex is identical to GetByIndex except it is an error if
 	// exactly one row is not found.
 	// TODO: decide if we should merge this with GetByIndex and use an `Options`.
-	GetUniqueByIndex(index *Index, indexVal string, val proto.Message) error
+	GetUniqueByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message) error
 }
 
 type EtcdReadOnlyCollection interface {
@@ -149,10 +149,5 @@ type EtcdReadOnlyCollection interface {
 	// TTL returns the number of seconds that 'key' will continue to exist in the
 	// collection, or '0' if 'key' will remain in the collection indefinitely
 	// TODO: TTL might be unused
-	TTL(key string) (int64, error)
-	// CountRev returns the number of items in the collection at a specific
-	// revision, it's only in EtcdReadOnlyCollection because only etcd has
-	// revs.
-	// TODO: CountRev might be unused
-	CountRev(int64) (int64, int64, error)
+	TTL(ctx context.Context, key string) (int64, error)
 }

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -79,7 +79,7 @@ type ReadWriteCollection interface {
 	// Update reads the current value associated with 'key', calls 'f' to update
 	// the value, and writes the new value back to the collection. 'key' must be
 	// present in the collection, or a 'Not Found' error is returned
-	Update(key interface{}, val proto.Message, f func() error) error
+	Update(ctx context.Context, key interface{}, val proto.Message, f func() error) error
 	// Upsert is like Update but 'key' is not required to be present
 	Upsert(key interface{}, val proto.Message, f func() error) error
 	Create(key interface{}, val proto.Message) error
@@ -115,7 +115,7 @@ type EtcdReadWriteCollection interface {
 	// WARNING: using PutTTL with a collection that has secondary indices
 	// can result in inconsistency, as the indices are removed at roughly
 	// but not exactly the same time as the documents.
-	PutTTL(key string, val proto.Message, ttl int64) error
+	PutTTL(ctx context.Context, key string, val proto.Message, ttl int64) error
 
 	DeleteAllPrefix(prefix string) error
 }

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -81,27 +81,27 @@ type ReadWriteCollection interface {
 	// present in the collection, or a 'Not Found' error is returned
 	Update(ctx context.Context, key interface{}, val proto.Message, f func() error) error
 	// Upsert is like Update but 'key' is not required to be present
-	Upsert(key interface{}, val proto.Message, f func() error) error
-	Create(key interface{}, val proto.Message) error
-	Delete(key interface{}) error
-	DeleteAll() error
+	Upsert(ctx context.Context, key interface{}, val proto.Message, f func() error) error
+	Create(ctx context.Context, key interface{}, val proto.Message) error
+	Delete(ctx context.Context, key interface{}) error
+	DeleteAll(ctx context.Context) error
 }
 
 type PostgresReadWriteCollection interface {
 	ReadWriteCollection
 
-	DeleteByIndex(index *Index, indexVal string) error
+	DeleteByIndex(ctx context.Context, index *Index, indexVal string) error
 	// GetByIndex can have a large impact on database contention if used to retrieve
 	// a large number of rows. Consider using a read-only collection if possible
-	GetByIndex(index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
+	GetByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
 
 	// GetUniqueByIndex is identical to GetByIndex except it is an error if
 	// exactly one row is not found.
 	// TODO: decide if we should merge this with GetByIndex and use an `Options`.
-	GetUniqueByIndex(index *Index, indexVal string, val proto.Message) error
+	GetUniqueByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message) error
 	// NOTE: List scans the collection over multiple queries,
 	// making this method susceptible to inconsistent reads
-	List(val proto.Message, opts *Options, f func(string) error) error
+	List(ctx context.Context, val proto.Message, opts *Options, f func(string) error) error
 }
 
 type EtcdReadWriteCollection interface {

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -74,7 +74,7 @@ type Index struct {
 // ReadWriteCollection is a collection interface that supports read,write and delete
 // operations.
 type ReadWriteCollection interface {
-	Get(key interface{}, val proto.Message) error
+	Get(ctx context.Context, key interface{}, val proto.Message) error
 	Put(key interface{}, val proto.Message) error
 	// Update reads the current value associated with 'key', calls 'f' to update
 	// the value, and writes the new value back to the collection. 'key' must be

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -24,7 +24,7 @@ type PostgresCollection interface {
 	ReadWrite(tx *pachsql.Tx) PostgresReadWriteCollection
 
 	// For read-only operations, use the ReadOnly for better performance
-	ReadOnly(ctx context.Context) PostgresReadOnlyCollection
+	ReadOnly() PostgresReadOnlyCollection
 }
 
 type EtcdCollection interface {
@@ -37,7 +37,7 @@ type EtcdCollection interface {
 	ReadWrite(stm STM) EtcdReadWriteCollection
 
 	// For read-only operations, use the ReadOnly for better performance
-	ReadOnly(ctx context.Context) EtcdReadOnlyCollection
+	ReadOnly() EtcdReadOnlyCollection
 
 	// Claim attempts to claim a key and run the passed in callback with
 	// the context for the claim.

--- a/src/internal/collection/types.go
+++ b/src/internal/collection/types.go
@@ -124,7 +124,7 @@ type EtcdReadWriteCollection interface {
 type ReadOnlyCollection interface {
 	Get(ctx context.Context, key interface{}, val proto.Message) error
 	GetByIndex(ctx context.Context, index *Index, indexVal string, val proto.Message, opts *Options, f func(string) error) error
-	List(val proto.Message, opts *Options, f func(string) error) error
+	List(ctx context.Context, val proto.Message, opts *Options, f func(string) error) error
 	Count(ctx context.Context) (int64, error)
 	Watch(opts ...watch.Option) (watch.Watcher, error)
 	WatchF(f func(*watch.Event) error, opts ...watch.Option) error

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -76,15 +76,15 @@ func (tester *ChannelWatchTester) nextEvent(timeout time.Duration) *watch.Event 
 
 func (tester *ChannelWatchTester) Write(ctx context.Context, item *col.TestItem) {
 	tester.t.Helper()
-	err := tester.writer(ctx, func(rw col.ReadWriteCollection) error {
-		return putItem(item)(rw)
+	err := tester.writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
+		return putItem(item)(ctx, rw)
 	})
 	require.NoError(tester.t, err)
 }
 
 func (tester *ChannelWatchTester) Delete(ctx context.Context, id string) {
 	tester.t.Helper()
-	err := tester.writer(ctx, func(rw col.ReadWriteCollection) error {
+	err := tester.writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 		return errors.EnsureStack(rw.Delete(id))
 	})
 	require.NoError(tester.t, err)
@@ -92,7 +92,7 @@ func (tester *ChannelWatchTester) Delete(ctx context.Context, id string) {
 
 func (tester *ChannelWatchTester) DeleteAll(ctx context.Context) {
 	tester.t.Helper()
-	err := tester.writer(ctx, func(rw col.ReadWriteCollection) error {
+	err := tester.writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
 		return errors.EnsureStack(rw.DeleteAll())
 	})
 	require.NoError(tester.t, err)

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -345,7 +345,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
 			ctx := canceledContext()
-			watchRead := reader(ctx)
+			watchRead := reader()
 			require.NoError(t, writer(rctx, putItem(makeProto(makeID(3)))))
 			testInterruptionPreemptive(t, func() (watch.Watcher, error) {
 				res, err := watchRead.Watch(ctx)
@@ -354,7 +354,7 @@ func watchTests(
 		})
 
 		watchAllTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback) watch.Watcher {
-			watcher, err := reader(ctx).Watch(ctx)
+			watcher, err := reader().Watch(ctx)
 			require.NoError(t, err)
 			t.Cleanup(watcher.Close)
 			return watcher
@@ -367,12 +367,11 @@ func watchTests(
 		suite.Run("InterruptionPreemptive", func(t *testing.T) {
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
-			ctx := canceledContext()
-			watchRead := reader(ctx)
+			watchRead := reader()
 			require.NoError(t, writer(rctx, putItem(makeProto(makeID(1)))))
 
 			events := []*watch.Event{}
-			err := watchRead.WatchF(ctx, func(ev *watch.Event) error {
+			err := watchRead.WatchF(canceledContext(), func(ev *watch.Event) error {
 				return errors.New("should have been canceled before receiving event")
 			})
 			require.YesError(t, err)
@@ -384,7 +383,7 @@ func watchTests(
 		suite.Run("ErrBreak", func(t *testing.T) {
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
-			watchRead := reader(rctx)
+			watchRead := reader()
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
 			require.NoError(t, writer(rctx, putItem(rowA)))
@@ -401,7 +400,7 @@ func watchTests(
 
 		watchAllTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback) watch.Watcher {
 			return NewWatchShim(ctx, t, func(ctx context.Context, cb func(*watch.Event) error) error {
-				return errors.EnsureStack(reader(ctx).WatchF(ctx, cb))
+				return errors.EnsureStack(reader().WatchF(ctx, cb))
 			})
 		})
 	})
@@ -524,18 +523,17 @@ func watchTests(
 		suite.Run("InterruptionPreemptive", func(t *testing.T) {
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
-			ctx := canceledContext()
-			watchRead := reader(ctx)
+			watchRead := reader()
 			row := makeProto(makeID(1))
 			require.NoError(t, writer(rctx, putItem(row)))
 			testInterruptionPreemptive(t, func() (watch.Watcher, error) {
-				res, err := watchRead.WatchOne(ctx, row.Id)
+				res, err := watchRead.WatchOne(canceledContext(), row.Id)
 				return res, errors.EnsureStack(err)
 			})
 		})
 
 		watchOneTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, key string) watch.Watcher {
-			watcher, err := reader(ctx).WatchOne(ctx, key)
+			watcher, err := reader().WatchOne(ctx, key)
 			require.NoError(t, err)
 			t.Cleanup(watcher.Close)
 			return watcher
@@ -549,7 +547,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
 			ctx := canceledContext()
-			watchRead := reader(ctx)
+			watchRead := reader()
 			row := makeProto(makeID(1))
 			require.NoError(t, writer(rctx, putItem(row)))
 
@@ -565,7 +563,7 @@ func watchTests(
 		suite.Run("ErrBreak", func(t *testing.T) {
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
-			watchRead := reader(rctx)
+			watchRead := reader()
 			rowA := makeProto(makeID(1))
 			rowB := makeProto(makeID(2))
 			require.NoError(t, writer(rctx, putItem(rowA)))
@@ -582,7 +580,7 @@ func watchTests(
 
 		watchOneTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, key string) watch.Watcher {
 			return NewWatchShim(ctx, t, func(ctx context.Context, cb func(ev *watch.Event) error) error {
-				return errors.EnsureStack(reader(ctx).WatchOneF(ctx, key, cb))
+				return errors.EnsureStack(reader().WatchOneF(ctx, key, cb))
 			})
 		})
 	})
@@ -716,7 +714,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
 			ctx := canceledContext()
-			watchRead := reader(ctx)
+			watchRead := reader()
 			row := makeProto(makeID(1), originalValue)
 			require.NoError(t, writer(rctx, putItem(row)))
 			testInterruptionPreemptive(t, func() (watch.Watcher, error) {
@@ -726,7 +724,7 @@ func watchTests(
 		})
 
 		watchByIndexTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, value string) watch.Watcher {
-			watcher, err := reader(ctx).WatchByIndex(ctx, TestSecondaryIndex, value)
+			watcher, err := reader().WatchByIndex(ctx, TestSecondaryIndex, value)
 			require.NoError(t, err)
 			t.Cleanup(watcher.Close)
 			return watcher
@@ -740,7 +738,7 @@ func watchTests(
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
 			ctx := canceledContext()
-			watchRead := reader(ctx)
+			watchRead := reader()
 			row := makeProto(makeID(1), originalValue)
 			require.NoError(t, writer(rctx, putItem(row)))
 
@@ -756,7 +754,7 @@ func watchTests(
 		suite.Run("ErrBreak", func(t *testing.T) {
 			t.Parallel()
 			reader, writer := newCollection(rctx, t)
-			watchRead := reader(rctx)
+			watchRead := reader()
 			rowA := makeProto(makeID(1), originalValue)
 			rowB := makeProto(makeID(2), originalValue)
 			require.NoError(t, writer(rctx, putItem(rowA)))
@@ -772,7 +770,7 @@ func watchTests(
 		})
 
 		watchByIndexTests(suite, func(ctx context.Context, t *testing.T, reader ReadCallback, value string) watch.Watcher {
-			watcher, err := reader(ctx).WatchByIndex(ctx, TestSecondaryIndex, value)
+			watcher, err := reader().WatchByIndex(ctx, TestSecondaryIndex, value)
 			require.NoError(t, err)
 			t.Cleanup(watcher.Close)
 			return watcher

--- a/src/internal/collection/watch_test.go
+++ b/src/internal/collection/watch_test.go
@@ -85,7 +85,7 @@ func (tester *ChannelWatchTester) Write(ctx context.Context, item *col.TestItem)
 func (tester *ChannelWatchTester) Delete(ctx context.Context, id string) {
 	tester.t.Helper()
 	err := tester.writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
-		return errors.EnsureStack(rw.Delete(id))
+		return errors.EnsureStack(rw.Delete(ctx, id))
 	})
 	require.NoError(tester.t, err)
 }
@@ -93,7 +93,7 @@ func (tester *ChannelWatchTester) Delete(ctx context.Context, id string) {
 func (tester *ChannelWatchTester) DeleteAll(ctx context.Context) {
 	tester.t.Helper()
 	err := tester.writer(ctx, func(ctx context.Context, rw col.ReadWriteCollection) error {
-		return errors.EnsureStack(rw.DeleteAll())
+		return errors.EnsureStack(rw.DeleteAll(ctx))
 	})
 	require.NoError(tester.t, err)
 }

--- a/src/internal/consistenthashing/etcd.go
+++ b/src/internal/consistenthashing/etcd.go
@@ -140,7 +140,7 @@ func (ring *Ring) createNode(ctx context.Context, col collection.EtcdCollection,
 // on delete happens by default since each member attempts to retrieve all locks. When a member is deleted,
 // the pending calls to Lock by each member will go through on the nodes that associates to given lock.
 func (ring *Ring) watch(ctx context.Context, col collection.EtcdCollection) error {
-	if err := col.ReadOnly(ctx).WatchF(func(event *watch.Event) error {
+	if err := col.ReadOnly(ctx).WatchF(ctx, func(event *watch.Event) error {
 		ring.stateLock.Lock()
 		defer ring.stateLock.Unlock()
 		nodeKey := string(event.Key)

--- a/src/internal/consistenthashing/etcd.go
+++ b/src/internal/consistenthashing/etcd.go
@@ -140,7 +140,7 @@ func (ring *Ring) createNode(ctx context.Context, col collection.EtcdCollection,
 // on delete happens by default since each member attempts to retrieve all locks. When a member is deleted,
 // the pending calls to Lock by each member will go through on the nodes that associates to given lock.
 func (ring *Ring) watch(ctx context.Context, col collection.EtcdCollection) error {
-	if err := col.ReadOnly(ctx).WatchF(ctx, func(event *watch.Event) error {
+	if err := col.ReadOnly().WatchF(ctx, func(event *watch.Event) error {
 		ring.stateLock.Lock()
 		defer ring.stateLock.Unlock()
 		nodeKey := string(event.Key)

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -522,7 +522,7 @@ func ListPipelineInfo(ctx context.Context,
 		}
 		return nil
 	}
-	return errors.EnsureStack(pipelines.ReadOnly(ctx).List(p, opts, checkPipelineVersion))
+	return errors.EnsureStack(pipelines.ReadOnly(ctx).List(ctx, p, opts, checkPipelineVersion))
 }
 
 func FilterLogLines(request *pps.GetLogsRequest, r io.Reader, plainText bool, send func(*pps.LogMessage) error) error {

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -177,7 +177,7 @@ func SetPipelineState(ctx context.Context, db *pachsql.DB, pipelinesCollection c
 		warn = false
 		pipelines := pipelinesCollection.ReadWrite(sqlTx)
 		pipelineInfo := &pps.PipelineInfo{}
-		if err := pipelines.Get(specCommit, pipelineInfo); err != nil {
+		if err := pipelines.Get(ctx, specCommit, pipelineInfo); err != nil {
 			return errors.EnsureStack(err)
 		}
 		tracing.TagAnySpan(cbCtx, "old-state", pipelineInfo.State)

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -435,7 +435,7 @@ func GetWorkerPipelineInfo(pachClient *client.APIClient, db *pachsql.DB, l col.P
 	// the pipeline in the image of a different verison.
 	specCommit := client.NewSystemRepo(pipeline.Project.GetName(), pipeline.Name, pfs.SpecRepoType).
 		NewCommit("master", specCommitID)
-	if err := pipelines.ReadOnly(ctx).Get(specCommit, pipelineInfo); err != nil {
+	if err := pipelines.ReadOnly(ctx).Get(ctx, specCommit, pipelineInfo); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	pachClient.SetAuthToken(pipelineInfo.AuthToken)
@@ -508,6 +508,7 @@ func ListPipelineInfo(ctx context.Context,
 	opts := col.DefaultOptions()
 	if filter != nil {
 		if err := pipelines.ReadOnly(ctx).GetByIndex(
+			ctx,
 			ppsdb.PipelinesNameIndex,
 			ppsdb.PipelinesNameKey(filter),
 			p,

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -229,7 +229,7 @@ func SetPipelineState(ctx context.Context, db *pachsql.DB, pipelinesCollection c
 		}
 		pipelineInfo.State = to
 		pipelineInfo.Reason = reason
-		return errors.EnsureStack(pipelines.Put(specCommit, pipelineInfo))
+		return errors.EnsureStack(pipelines.Put(ctx, specCommit, pipelineInfo))
 	})
 	if resultMessage != "" {
 		if warn {
@@ -296,7 +296,7 @@ func PipelineReqFromInfo(pipelineInfo *pps.PipelineInfo) *pps.CreatePipelineRequ
 }
 
 // UpdateJobState performs the operations involved with a job state transition.
-func UpdateJobState(pipelines col.PostgresReadWriteCollection, jobs col.ReadWriteCollection, jobInfo *pps.JobInfo, state pps.JobState, reason string) error {
+func UpdateJobState(ctx context.Context, pipelines col.PostgresReadWriteCollection, jobs col.ReadWriteCollection, jobInfo *pps.JobInfo, state pps.JobState, reason string) error {
 	// Check if this is a new job
 	if jobInfo.State != pps.JobState_JOB_STATE_UNKNOWN {
 		if pps.IsTerminal(jobInfo.State) {
@@ -316,7 +316,7 @@ func UpdateJobState(pipelines col.PostgresReadWriteCollection, jobs col.ReadWrit
 	}
 	jobInfo.State = state
 	jobInfo.Reason = reason
-	return errors.Wrapf(jobs.Put(ppsdb.JobKey(jobInfo.Job), jobInfo), "put job %v", ppsdb.JobKey(jobInfo.Job))
+	return errors.Wrapf(jobs.Put(ctx, ppsdb.JobKey(jobInfo.Job), jobInfo), "put job %v", ppsdb.JobKey(jobInfo.Job))
 }
 
 func FinishJob(pachClient *client.APIClient, jobInfo *pps.JobInfo, state pps.JobState, reason string) (retErr error) {

--- a/src/internal/ppsutil/util.go
+++ b/src/internal/ppsutil/util.go
@@ -435,7 +435,7 @@ func GetWorkerPipelineInfo(pachClient *client.APIClient, db *pachsql.DB, l col.P
 	// the pipeline in the image of a different verison.
 	specCommit := client.NewSystemRepo(pipeline.Project.GetName(), pipeline.Name, pfs.SpecRepoType).
 		NewCommit("master", specCommitID)
-	if err := pipelines.ReadOnly(ctx).Get(ctx, specCommit, pipelineInfo); err != nil {
+	if err := pipelines.ReadOnly().Get(ctx, specCommit, pipelineInfo); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	pachClient.SetAuthToken(pipelineInfo.AuthToken)
@@ -507,7 +507,7 @@ func ListPipelineInfo(ctx context.Context,
 	}
 	opts := col.DefaultOptions()
 	if filter != nil {
-		if err := pipelines.ReadOnly(ctx).GetByIndex(
+		if err := pipelines.ReadOnly().GetByIndex(
 			ctx,
 			ppsdb.PipelinesNameIndex,
 			ppsdb.PipelinesNameKey(filter),
@@ -522,7 +522,7 @@ func ListPipelineInfo(ctx context.Context,
 		}
 		return nil
 	}
-	return errors.EnsureStack(pipelines.ReadOnly(ctx).List(ctx, p, opts, checkPipelineVersion))
+	return errors.EnsureStack(pipelines.ReadOnly().List(ctx, p, opts, checkPipelineVersion))
 }
 
 func FilterLogLines(request *pps.GetLogsRequest, r io.Reader, plainText bool, send func(*pps.LogMessage) error) error {

--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -389,7 +389,7 @@ func (es *etcdSource) createTaskFunc(ctx context.Context, taskKey string, cb Pro
 				}
 				task := &Task{}
 				_, err := col.NewSTM(ctx, es.etcdClient, func(stm col.STM) error {
-					err := es.taskCol.ReadWrite(stm).Update(taskKey, task, func() error {
+					err := es.taskCol.ReadWrite(stm).Update(ctx, taskKey, task, func() error {
 						if task.State != State_RUNNING {
 							return nil
 						}

--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -62,7 +62,7 @@ func (es *etcdService) List(ctx context.Context, namespace, group string, cb fun
 	etcdCols := newNamespaceEtcd(es.etcdClient, es.etcdPrefix, prefix)
 	var taskData Task
 	var claim Claim
-	return errors.EnsureStack(etcdCols.taskCol.ReadOnly(ctx).List(&taskData, col.DefaultOptions(), func(key string) error {
+	return errors.EnsureStack(etcdCols.taskCol.ReadOnly(ctx).List(ctx, &taskData, col.DefaultOptions(), func(key string) error {
 		var claimed bool
 		if taskData.State == State_RUNNING && etcdCols.claimCol.ReadOnly(ctx).Get(ctx, key, &claim) == nil {
 			claimed = true

--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -249,7 +249,7 @@ func (ed *etcdDoer) withGroup(ctx context.Context, cb func(ctx context.Context, 
 		key := path.Join(ed.group, uuid.NewWithoutDashes())
 		defer func() {
 			if _, err := col.NewSTM(ctx, ed.etcdClient, func(stm col.STM) error {
-				return errors.EnsureStack(ed.groupCol.ReadWrite(stm).Delete(key))
+				return errors.EnsureStack(ed.groupCol.ReadWrite(stm).Delete(ctx, key))
 			}); err != nil {
 				log.Info(ctx, "errored deleting group key", zap.String("key", key), zap.Error(err))
 			}

--- a/src/internal/task/etcd_service.go
+++ b/src/internal/task/etcd_service.go
@@ -366,7 +366,7 @@ func (es *etcdSource) createTaskFunc(ctx context.Context, taskKey string, cb Pro
 		if err := func() error {
 			task := &Task{}
 			if _, err := col.NewSTM(ctx, es.etcdClient, func(stm col.STM) error {
-				return errors.EnsureStack(es.taskCol.ReadWrite(stm).Get(taskKey, task))
+				return errors.EnsureStack(es.taskCol.ReadWrite(stm).Get(ctx, taskKey, task))
 			}); err != nil {
 				return err
 			}

--- a/src/internal/testpachd/mock_pachd.go
+++ b/src/internal/testpachd/mock_pachd.go
@@ -94,21 +94,21 @@ type RotateRootTokenFunc func(context.Context, *auth.RotateRootTokenRequest) (*a
 type checkClusterIsAuthorizedFunc func(context.Context, ...auth.Permission) error
 type checkProjectIsAuthorizedFunc func(context.Context, *pfs.Project, ...auth.Permission) error
 type checkRepoIsAuthorizedFunc func(context.Context, *pfs.Repo, ...auth.Permission) error
-type checkClusterIsAuthorizedInTransactionFunc func(*txncontext.TransactionContext, ...auth.Permission) error
-type checkProjectIsAuthorizedInTransactionFunc func(*txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
-type checkRepoIsAuthorizedInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
-type authorizeInTransactionFunc func(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
-type modifyRoleBindingInTransactionFunc func(*txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
-type getRoleBindingInTransactionFunc func(*txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
-type addPipelineReaderToRepoInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-type addPipelineWriterToRepoInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) error
-type addPipelineWriterToSourceRepoInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-type removePipelineReaderFromRepoInTransactionFunc func(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-type createRoleBindingInTransactionFunc func(*txncontext.TransactionContext, string, []string, *auth.Resource) error
-type deleteRoleBindingInTransactionFunc func(*txncontext.TransactionContext, *auth.Resource) error
-type getPipelineAuthTokenInTransactionFunc func(*txncontext.TransactionContext, *pps.Pipeline) (string, error)
-type revokeAuthTokenInTransactionFunc func(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
-type getPermissionsInTransactionFunc func(*txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
+type checkClusterIsAuthorizedInTransactionFunc func(context.Context, *txncontext.TransactionContext, ...auth.Permission) error
+type checkProjectIsAuthorizedInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
+type checkRepoIsAuthorizedInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
+type authorizeInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
+type modifyRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
+type getRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
+type addPipelineReaderToRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+type addPipelineWriterToRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.Pipeline) error
+type addPipelineWriterToSourceRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+type removePipelineReaderFromRepoInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+type createRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, string, []string, *auth.Resource) error
+type deleteRoleBindingInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.Resource) error
+type getPipelineAuthTokenInTransactionFunc func(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (string, error)
+type revokeAuthTokenInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
+type getPermissionsInTransactionFunc func(context.Context, *txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 
 type mockActivateAuth struct{ handler activateAuthFunc }
 type mockDeactivateAuth struct{ handler deactivateAuthFunc }
@@ -503,107 +503,107 @@ func (api *authServerAPI) CheckRepoIsAuthorized(ctx context.Context, repo *pfs.R
 	return errors.Errorf("unhandled pachd mock auth.CheckRepoIsAuthorized")
 }
 
-func (api *authServerAPI) CheckClusterIsAuthorizedInTransaction(transactionContext *txncontext.TransactionContext, permission ...auth.Permission) error {
+func (api *authServerAPI) CheckClusterIsAuthorizedInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, permission ...auth.Permission) error {
 	if api.mock.CheckClusterIsAuthorizedInTransaction.handler != nil {
-		return api.mock.CheckClusterIsAuthorizedInTransaction.handler(transactionContext, permission...)
+		return api.mock.CheckClusterIsAuthorizedInTransaction.handler(ctx, transactionContext, permission...)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CheckClusterIsAuthorizedInTransaction")
 }
 
-func (api *authServerAPI) CheckRepoIsAuthorizedInTransaction(transactionContext *txncontext.TransactionContext, repo *pfs.Repo, permission ...auth.Permission) error {
+func (api *authServerAPI) CheckRepoIsAuthorizedInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, repo *pfs.Repo, permission ...auth.Permission) error {
 	if api.mock.CheckRepoIsAuthorizedInTransaction.handler != nil {
-		return api.mock.CheckRepoIsAuthorizedInTransaction.handler(transactionContext, repo, permission...)
+		return api.mock.CheckRepoIsAuthorizedInTransaction.handler(ctx, transactionContext, repo, permission...)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CheckRepoIsAuthorizedInTransaction")
 }
 
-func (api *authServerAPI) CheckProjectIsAuthorizedInTransaction(transactionContext *txncontext.TransactionContext, project *pfs.Project, permission ...auth.Permission) error {
+func (api *authServerAPI) CheckProjectIsAuthorizedInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, project *pfs.Project, permission ...auth.Permission) error {
 	if api.mock.CheckProjectIsAuthorizedInTransaction.handler != nil {
-		return api.mock.CheckProjectIsAuthorizedInTransaction.handler(transactionContext, project, permission...)
+		return api.mock.CheckProjectIsAuthorizedInTransaction.handler(ctx, transactionContext, project, permission...)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CheckProjectIsAuthorizedInTransaction")
 }
 
-func (api *authServerAPI) AuthorizeInTransaction(transactionContext *txncontext.TransactionContext, request *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error) {
+func (api *authServerAPI) AuthorizeInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error) {
 	if api.mock.AuthorizeInTransaction.handler != nil {
-		return api.mock.AuthorizeInTransaction.handler(transactionContext, request)
+		return api.mock.AuthorizeInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.AuthorizeInTransaction")
 }
 
-func (api *authServerAPI) ModifyRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, request *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
+func (api *authServerAPI) ModifyRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
 	if api.mock.ModifyRoleBindingInTransaction.handler != nil {
-		return api.mock.ModifyRoleBindingInTransaction.handler(transactionContext, request)
+		return api.mock.ModifyRoleBindingInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.ModifyRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) GetRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, request *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error) {
+func (api *authServerAPI) GetRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error) {
 	if api.mock.GetRoleBindingInTransaction.handler != nil {
-		return api.mock.GetRoleBindingInTransaction.handler(transactionContext, request)
+		return api.mock.GetRoleBindingInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.GetRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) AddPipelineReaderToRepoInTransaction(transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
+func (api *authServerAPI) AddPipelineReaderToRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
 	if api.mock.AddPipelineReaderToRepoInTransaction.handler != nil {
-		return api.mock.AddPipelineReaderToRepoInTransaction.handler(transactionContext, r, p)
+		return api.mock.AddPipelineReaderToRepoInTransaction.handler(ctx, transactionContext, r, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.AddPipelineReaderToRepoInTransaction")
 }
 
-func (api *authServerAPI) AddPipelineWriterToRepoInTransaction(transactionContext *txncontext.TransactionContext, p *pps.Pipeline) error {
+func (api *authServerAPI) AddPipelineWriterToRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, p *pps.Pipeline) error {
 	if api.mock.AddPipelineWriterToRepoInTransaction.handler != nil {
-		return api.mock.AddPipelineWriterToRepoInTransaction.handler(transactionContext, p)
+		return api.mock.AddPipelineWriterToRepoInTransaction.handler(ctx, transactionContext, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.AddPipelineWriterToRepoInTransaction")
 }
 
-func (api *authServerAPI) AddPipelineWriterToSourceRepoInTransaction(transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
+func (api *authServerAPI) AddPipelineWriterToSourceRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
 	if api.mock.AddPipelineWriterToSourceRepoInTransaction.handler != nil {
-		return api.mock.AddPipelineWriterToSourceRepoInTransaction.handler(transactionContext, r, p)
+		return api.mock.AddPipelineWriterToSourceRepoInTransaction.handler(ctx, transactionContext, r, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.AddPipelineWriterToSourceRepoInTransaction")
 }
 
-func (api *authServerAPI) RemovePipelineReaderFromRepoInTransaction(transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
+func (api *authServerAPI) RemovePipelineReaderFromRepoInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, r *pfs.Repo, p *pps.Pipeline) error {
 	if api.mock.RemovePipelineReaderFromRepoInTransaction.handler != nil {
-		return api.mock.RemovePipelineReaderFromRepoInTransaction.handler(transactionContext, r, p)
+		return api.mock.RemovePipelineReaderFromRepoInTransaction.handler(ctx, transactionContext, r, p)
 	}
 	return errors.Errorf("unhandled pachd mock auth.RemovePipelineReaderFromRepoInTransaction")
 }
 
-func (api *authServerAPI) CreateRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, s string, strings []string, resource *auth.Resource) error {
+func (api *authServerAPI) CreateRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, s string, strings []string, resource *auth.Resource) error {
 	if api.mock.CreateRoleBindingInTransaction.handler != nil {
-		return api.mock.CreateRoleBindingInTransaction.handler(transactionContext, s, strings, resource)
+		return api.mock.CreateRoleBindingInTransaction.handler(ctx, transactionContext, s, strings, resource)
 	}
 	return errors.Errorf("unhandled pachd mock auth.CreateRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) DeleteRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, resource *auth.Resource) error {
+func (api *authServerAPI) DeleteRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, resource *auth.Resource) error {
 	if api.mock.DeleteRoleBindingInTransaction.handler != nil {
-		return api.mock.DeleteRoleBindingInTransaction.handler(transactionContext, resource)
+		return api.mock.DeleteRoleBindingInTransaction.handler(ctx, transactionContext, resource)
 	}
 	return errors.Errorf("unhandled pachd mock auth.DeleteRoleBindingInTransaction")
 }
 
-func (api *authServerAPI) GetPipelineAuthTokenInTransaction(transactionContext *txncontext.TransactionContext, p *pps.Pipeline) (string, error) {
+func (api *authServerAPI) GetPipelineAuthTokenInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, p *pps.Pipeline) (string, error) {
 	if api.mock.GetPipelineAuthTokenInTransaction.handler != nil {
-		return api.mock.GetPipelineAuthTokenInTransaction.handler(transactionContext, p)
+		return api.mock.GetPipelineAuthTokenInTransaction.handler(ctx, transactionContext, p)
 	}
 	return "", errors.Errorf("unhandled pachd mock auth.GetPipelineAuthTokenInTransaction")
 }
 
-func (api *authServerAPI) RevokeAuthTokenInTransaction(transactionContext *txncontext.TransactionContext, request *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error) {
+func (api *authServerAPI) RevokeAuthTokenInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error) {
 	if api.mock.RevokeAuthTokenInTransaction.handler != nil {
-		return api.mock.RevokeAuthTokenInTransaction.handler(transactionContext, request)
+		return api.mock.RevokeAuthTokenInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.RevokeAuthTokenInTransaction")
 }
 
-func (api *authServerAPI) GetPermissionsInTransaction(transactionContext *txncontext.TransactionContext, request *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
+func (api *authServerAPI) GetPermissionsInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, request *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
 	if api.mock.GetPermissionsInTransaction.handler != nil {
-		return api.mock.GetPermissionsInTransaction.handler(transactionContext, request)
+		return api.mock.GetPermissionsInTransaction.handler(ctx, transactionContext, request)
 	}
 	return nil, errors.Errorf("unhandled pachd mock auth.GetPermissionsInTransaction")
 }

--- a/src/internal/tracing/extended/extended_trace.go
+++ b/src/internal/tracing/extended/extended_trace.go
@@ -123,7 +123,7 @@ func AddSpanToAnyPipelineTrace(ctx context.Context, c *etcd.Client,
 
 	traceProto := &TraceProto{}
 	tracesCol := TracesCol(c).ReadOnly(ctx)
-	if err := tracesCol.Get(pipeline, traceProto); err != nil {
+	if err := tracesCol.Get(ctx, pipeline, traceProto); err != nil {
 		if !col.IsErrNotFound(err) {
 			log.Error(ctx, "error getting trace for pipeline", zap.String("pipeline", pipeline.GetName()), zap.Error(err))
 		}

--- a/src/internal/tracing/extended/extended_trace.go
+++ b/src/internal/tracing/extended/extended_trace.go
@@ -102,7 +102,7 @@ func PersistAny(ctx context.Context, c *etcd.Client, pipeline *pps.Pipeline) {
 	}
 	if _, err := col.NewSTM(ctx, c, func(stm col.STM) error {
 		tracesCol := TracesCol(c).ReadWrite(stm)
-		return errors.EnsureStack(tracesCol.PutTTL(pipeline.String(), traceProto, int64(duration.Seconds())))
+		return errors.EnsureStack(tracesCol.PutTTL(ctx, pipeline.String(), traceProto, int64(duration.Seconds())))
 	}); err != nil {
 		log.Error(ctx, "could not persist extended trace for pipeline to etcd", zap.String("pipeline", pipeline.GetName()), zap.Error(err))
 	}

--- a/src/internal/tracing/extended/extended_trace.go
+++ b/src/internal/tracing/extended/extended_trace.go
@@ -122,7 +122,7 @@ func AddSpanToAnyPipelineTrace(ctx context.Context, c *etcd.Client,
 	}
 
 	traceProto := &TraceProto{}
-	tracesCol := TracesCol(c).ReadOnly(ctx)
+	tracesCol := TracesCol(c).ReadOnly()
 	if err := tracesCol.Get(ctx, pipeline, traceProto); err != nil {
 		if !col.IsErrNotFound(err) {
 			log.Error(ctx, "error getting trace for pipeline", zap.String("pipeline", pipeline.GetName()), zap.Error(err))

--- a/src/internal/transactionenv/env.go
+++ b/src/internal/transactionenv/env.go
@@ -90,8 +90,8 @@ type PPSBackend interface {
 }
 
 type AuthBackend interface {
-	ModifyRoleBindingInTransaction(*txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
-	DeleteRoleBindingInTransaction(*txncontext.TransactionContext, *auth.Resource) error
+	ModifyRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
+	DeleteRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.Resource) error
 	WhoAmI(context.Context, *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 }
 
@@ -218,7 +218,7 @@ func (t *directTransaction) UpdateJobState(original *pps.UpdateJobStateRequest) 
 
 func (t *directTransaction) ModifyRoleBinding(original *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error) {
 	req := proto.Clone(original).(*auth.ModifyRoleBindingRequest)
-	res, err := t.txnEnv.getAuth().ModifyRoleBindingInTransaction(t.txnCtx, req)
+	res, err := t.txnEnv.getAuth().ModifyRoleBindingInTransaction(t.ctx, t.txnCtx, req)
 	return res, errors.EnsureStack(err)
 }
 
@@ -229,7 +229,7 @@ func (t *directTransaction) CreatePipeline(original *pps.CreatePipelineTransacti
 
 func (t *directTransaction) DeleteRoleBinding(original *auth.Resource) error {
 	req := proto.Clone(original).(*auth.Resource)
-	return errors.EnsureStack(t.txnEnv.getAuth().DeleteRoleBindingInTransaction(t.txnCtx, req))
+	return errors.EnsureStack(t.txnEnv.getAuth().DeleteRoleBindingInTransaction(t.ctx, t.txnCtx, req))
 }
 
 type appendTransaction struct {

--- a/src/server/auth/iface.go
+++ b/src/server/auth/iface.go
@@ -18,28 +18,28 @@ type APIServer interface {
 	CheckClusterIsAuthorized(ctx context.Context, p ...auth.Permission) error
 	CheckProjectIsAuthorized(context.Context, *pfs.Project, ...auth.Permission) error
 	CheckRepoIsAuthorized(context.Context, *pfs.Repo, ...auth.Permission) error
-	CheckClusterIsAuthorizedInTransaction(*txncontext.TransactionContext, ...auth.Permission) error
-	CheckProjectIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
-	CheckRepoIsAuthorizedInTransaction(*txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
+	CheckClusterIsAuthorizedInTransaction(context.Context, *txncontext.TransactionContext, ...auth.Permission) error
+	CheckProjectIsAuthorizedInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Project, ...auth.Permission) error
+	CheckRepoIsAuthorizedInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, ...auth.Permission) error
 
-	AuthorizeInTransaction(*txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
-	ModifyRoleBindingInTransaction(*txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
-	GetRoleBindingInTransaction(*txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
+	AuthorizeInTransaction(context.Context, *txncontext.TransactionContext, *auth.AuthorizeRequest) (*auth.AuthorizeResponse, error)
+	ModifyRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.ModifyRoleBindingRequest) (*auth.ModifyRoleBindingResponse, error)
+	GetRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.GetRoleBindingRequest) (*auth.GetRoleBindingResponse, error)
 
 	// Methods to add and remove pipelines from input and output repos. These do their own auth checks
 	// for specific permissions required to use a repo as a pipeline input/output.
-	AddPipelineReaderToRepoInTransaction(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-	AddPipelineWriterToRepoInTransaction(*txncontext.TransactionContext, *pps.Pipeline) error
-	AddPipelineWriterToSourceRepoInTransaction(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
-	RemovePipelineReaderFromRepoInTransaction(*txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+	AddPipelineReaderToRepoInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+	AddPipelineWriterToRepoInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) error
+	AddPipelineWriterToSourceRepoInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
+	RemovePipelineReaderFromRepoInTransaction(context.Context, *txncontext.TransactionContext, *pfs.Repo, *pps.Pipeline) error
 
 	// Create and Delete are internal-only APIs used by other services when creating/destroying resources.
-	CreateRoleBindingInTransaction(*txncontext.TransactionContext, string, []string, *auth.Resource) error
-	DeleteRoleBindingInTransaction(*txncontext.TransactionContext, *auth.Resource) error
+	CreateRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, string, []string, *auth.Resource) error
+	DeleteRoleBindingInTransaction(context.Context, *txncontext.TransactionContext, *auth.Resource) error
 
 	// GetPipelineAuthTokenInTransaction is an internal API used by PPS to generate tokens for pipelines
-	GetPipelineAuthTokenInTransaction(*txncontext.TransactionContext, *pps.Pipeline) (string, error)
-	RevokeAuthTokenInTransaction(*txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
+	GetPipelineAuthTokenInTransaction(context.Context, *txncontext.TransactionContext, *pps.Pipeline) (string, error)
+	RevokeAuthTokenInTransaction(context.Context, *txncontext.TransactionContext, *auth.RevokeAuthTokenRequest) (*auth.RevokeAuthTokenResponse, error)
 
-	GetPermissionsInTransaction(*txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
+	GetPermissionsInTransaction(context.Context, *txncontext.TransactionContext, *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 }

--- a/src/server/auth/server/BUILD.bazel
+++ b/src/server/auth/server/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//src/internal/watch",
         "//src/pfs",
         "//src/pps",
+        "//src/server/auth",
         "//src/server/enterprise",
         "//src/server/pfs",
         "//src/server/pps",

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -121,14 +121,14 @@ func NewAuthServer(env Env, public, requireNoncriticalServers, watchesEnabled bo
 	}
 
 	if watchesEnabled {
-		s.configCache = keycache.NewCache(env.BackgroundContext, s.authConfig.ReadOnly(env.BackgroundContext), configKey, &DefaultOIDCConfig)
-		s.clusterRoleBindingCache = keycache.NewCache(env.BackgroundContext, s.roleBindings.ReadOnly(env.BackgroundContext), auth.ClusterRoleBindingKey, &auth.RoleBinding{})
+		s.configCache = keycache.NewCache(s.authConfig.ReadOnly(env.BackgroundContext), configKey, &DefaultOIDCConfig)
+		s.clusterRoleBindingCache = keycache.NewCache(s.roleBindings.ReadOnly(env.BackgroundContext), auth.ClusterRoleBindingKey, &auth.RoleBinding{})
 
 		// Watch for new auth config options
-		go s.configCache.Watch()
+		go s.configCache.Watch(env.BackgroundContext)
 
 		// Watch for changes to the cluster role binding
-		go s.clusterRoleBindingCache.Watch()
+		go s.clusterRoleBindingCache.Watch(env.BackgroundContext)
 	}
 
 	if err := s.deleteExpiredTokensRoutine(env.BackgroundContext); err != nil {

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -1469,7 +1469,7 @@ func (a *apiServer) GetUsers(ctx context.Context, req *auth.GetUsersRequest) (re
 	membersCol := a.members.ReadOnly(ctx)
 	groups := &auth.Groups{}
 	var users []string
-	if err := membersCol.List(groups, col.DefaultOptions(), func(user string) error {
+	if err := membersCol.List(ctx, groups, col.DefaultOptions(), func(user string) error {
 		users = append(users, user)
 		return nil
 	}); err != nil {

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -532,7 +532,7 @@ func (a *apiServer) activateInTransaction(ctx context.Context, txCtx *txncontext
 	// Store a new Pachyderm token (as the caller is authenticating) and
 	// initialize the root user as a cluster admin
 	roleBindings := a.roleBindings.ReadWrite(txCtx.SqlTx)
-	if err := roleBindings.Put(auth.ClusterRoleBindingKey, &auth.RoleBinding{
+	if err := roleBindings.Put(ctx, auth.ClusterRoleBindingKey, &auth.RoleBinding{
 		Entries: map[string]*auth.Roles{
 			auth.RootUser:               {Roles: map[string]bool{auth.ClusterAdminRole: true}},
 			authdb.InternalUser:         {Roles: map[string]bool{auth.ClusterAdminRole: true}},
@@ -1113,7 +1113,7 @@ func (a *apiServer) setUserRoleBindingInTransaction(ctx context.Context, txnCtx 
 	} else {
 		bindings.Entries[principal] = roles
 	}
-	return errors.EnsureStack(roleBindings.Put(key, &bindings))
+	return errors.EnsureStack(roleBindings.Put(ctx, key, &bindings))
 }
 
 // ModifyRoleBinding implements the protobuf auth.ModifyRoleBinding RPC
@@ -1284,7 +1284,7 @@ func (a *apiServer) setGroupsForUserInternal(ctx context.Context, subject string
 		}
 
 		// Set groups for user
-		if err := members.Put(subject, &auth.Groups{
+		if err := members.Put(ctx, subject, &auth.Groups{
 			Groups: addToSet(nil, groups...),
 		}); err != nil {
 			return errors.EnsureStack(err)
@@ -1608,7 +1608,7 @@ func (a *apiServer) SetConfiguration(ctx context.Context, req *auth.SetConfigura
 
 	// set the new config
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		return errors.EnsureStack(a.authConfig.ReadWrite(sqlTx).Put(configKey, configToStore))
+		return errors.EnsureStack(a.authConfig.ReadWrite(sqlTx).Put(ctx, configKey, configToStore))
 	}); err != nil {
 		return nil, err
 	}

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -370,7 +370,7 @@ func (a *apiServer) getClusterRoleBinding(ctx context.Context) (*auth.RoleBindin
 	}
 
 	var binding auth.RoleBinding
-	if err := a.roleBindings.ReadOnly(ctx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
+	if err := a.roleBindings.ReadOnly(ctx).Get(ctx, auth.ClusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, auth.ErrNotActivated
 		}
@@ -1402,7 +1402,7 @@ func removeFromSet(set map[string]bool, elems ...string) map[string]bool {
 func (a *apiServer) getGroups(ctx context.Context, subject string) ([]string, error) {
 	members := a.members.ReadOnly(ctx)
 	var groupsProto auth.Groups
-	if err := members.Get(subject, &groupsProto); err != nil {
+	if err := members.Get(ctx, subject, &groupsProto); err != nil {
 		if col.IsErrNotFound(err) {
 			return []string{}, nil
 		}

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -121,8 +121,8 @@ func NewAuthServer(env Env, public, requireNoncriticalServers, watchesEnabled bo
 	}
 
 	if watchesEnabled {
-		s.configCache = keycache.NewCache(s.authConfig.ReadOnly(env.BackgroundContext), configKey, &DefaultOIDCConfig)
-		s.clusterRoleBindingCache = keycache.NewCache(s.roleBindings.ReadOnly(env.BackgroundContext), auth.ClusterRoleBindingKey, &auth.RoleBinding{})
+		s.configCache = keycache.NewCache(s.authConfig.ReadOnly(), configKey, &DefaultOIDCConfig)
+		s.clusterRoleBindingCache = keycache.NewCache(s.roleBindings.ReadOnly(), auth.ClusterRoleBindingKey, &auth.RoleBinding{})
 
 		// Watch for new auth config options
 		go s.configCache.Watch(env.BackgroundContext)
@@ -370,7 +370,7 @@ func (a *apiServer) getClusterRoleBinding(ctx context.Context) (*auth.RoleBindin
 	}
 
 	var binding auth.RoleBinding
-	if err := a.roleBindings.ReadOnly(ctx).Get(ctx, auth.ClusterRoleBindingKey, &binding); err != nil {
+	if err := a.roleBindings.ReadOnly().Get(ctx, auth.ClusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, auth.ErrNotActivated
 		}
@@ -1400,7 +1400,7 @@ func removeFromSet(set map[string]bool, elems ...string) map[string]bool {
 // getGroups is a helper function used primarily by the GRPC API GetGroups, but
 // also by Authorize() and isAdmin().
 func (a *apiServer) getGroups(ctx context.Context, subject string) ([]string, error) {
-	members := a.members.ReadOnly(ctx)
+	members := a.members.ReadOnly()
 	var groupsProto auth.Groups
 	if err := members.Get(ctx, subject, &groupsProto); err != nil {
 		if col.IsErrNotFound(err) {
@@ -1466,7 +1466,7 @@ func (a *apiServer) GetUsers(ctx context.Context, req *auth.GetUsersRequest) (re
 		return &auth.GetUsersResponse{Usernames: setToList(membersProto.Usernames)}, nil
 	}
 
-	membersCol := a.members.ReadOnly(ctx)
+	membersCol := a.members.ReadOnly()
 	groups := &auth.Groups{}
 	var users []string
 	if err := membersCol.List(ctx, groups, col.DefaultOptions(), func(user string) error {

--- a/src/server/auth/server/api_server.go
+++ b/src/server/auth/server/api_server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/uuid"
 	"github.com/pachyderm/pachyderm/v2/src/pfs"
 	"github.com/pachyderm/pachyderm/v2/src/pps"
+	authiface "github.com/pachyderm/pachyderm/v2/src/server/auth"
 )
 
 const (
@@ -55,6 +56,8 @@ const (
 var DefaultOIDCConfig = auth.OIDCConfig{}
 
 type APIServer = *apiServer
+
+var _ authiface.APIServer = (APIServer)(nil)
 
 // apiServer implements the public interface of the Pachyderm auth system,
 // including all RPCs defined in the protobuf spec.
@@ -381,15 +384,15 @@ func (a *apiServer) isActive(ctx context.Context) error {
 	return err
 }
 
-func (a *apiServer) isActiveInTransaction(txnCtx *txncontext.TransactionContext) error {
-	_, err := a.getClusterRoleBindingInTransaction(txnCtx)
+func (a *apiServer) isActiveInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
+	_, err := a.getClusterRoleBindingInTransaction(ctx, txnCtx)
 	return err
 }
 
 // getClusterRoleBinding attempts to get the current cluster role bindings,
 // and returns an error if auth is not activated. This can require hitting
 // postgres if watches are not enabled (in the worker sidecar).
-func (a *apiServer) getClusterRoleBindingInTransaction(txnCtx *txncontext.TransactionContext) (*auth.RoleBinding, error) {
+func (a *apiServer) getClusterRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext) (*auth.RoleBinding, error) {
 	if a.watchesEnabled && !txnCtx.AuthBeingActivated.Load() {
 		bindings, ok := a.clusterRoleBindingCache.Load().(*auth.RoleBinding)
 		if !ok {
@@ -403,7 +406,7 @@ func (a *apiServer) getClusterRoleBindingInTransaction(txnCtx *txncontext.Transa
 	}
 
 	var binding auth.RoleBinding
-	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(auth.ClusterRoleBindingKey, &binding); err != nil {
+	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(ctx, auth.ClusterRoleBindingKey, &binding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, auth.ErrNotActivated
 		}
@@ -515,7 +518,7 @@ func (a *apiServer) activateInTransaction(ctx context.Context, txCtx *txncontext
 	// Activating an already activated auth service should fail, because
 	// otherwise anyone can just activate the service again and set
 	// themselves as an admin.
-	if err := a.isActiveInTransaction(txCtx); err == nil {
+	if err := a.isActiveInTransaction(ctx, txCtx); err == nil {
 		return nil, auth.ErrAlreadyActivated
 	}
 
@@ -692,13 +695,13 @@ func (a *apiServer) Authenticate(ctx context.Context, req *auth.AuthenticateRequ
 	}, nil
 }
 
-func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, principal string, resource *auth.Resource, permissions map[auth.Permission]bool) (*authorizeRequest, error) {
+func (a *apiServer) evaluateRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, principal string, resource *auth.Resource, permissions map[auth.Permission]bool) (*authorizeRequest, error) {
 	request := newAuthorizeRequest(principal, permissions, a.getGroupsInTransaction)
 
 	// Special-case making spec repos world-readable, because the alternative breaks reading pipelines.
 	// TOOD: 2.0 - should we make this a user-configurable cluster binding instead of hard-coding it?
 	if resource.Type == auth.ResourceType_SPEC_REPO {
-		if err := request.evaluateRoleBinding(txnCtx, &auth.RoleBinding{
+		if err := request.evaluateRoleBinding(ctx, txnCtx, &auth.RoleBinding{
 			Entries: map[string]*auth.Roles{
 				auth.AllClusterUsersSubject: {
 					Roles: map[string]bool{
@@ -719,12 +722,12 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 	}
 
 	// Check the permissions at the cluster level
-	binding, err := a.getClusterRoleBindingInTransaction(txnCtx)
+	binding, err := a.getClusterRoleBindingInTransaction(ctx, txnCtx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := request.evaluateRoleBinding(txnCtx, binding); err != nil {
+	if err := request.evaluateRoleBinding(ctx, txnCtx, binding); err != nil {
 		return nil, err
 	}
 
@@ -744,13 +747,13 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 		}
 		projectResource := &auth.Resource{Type: auth.ResourceType_PROJECT, Name: repo.Project.Name}
 		projectKey := authdb.ResourceKey(projectResource)
-		if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(projectKey, &roleBinding); err != nil {
+		if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(ctx, projectKey, &roleBinding); err != nil {
 			if col.IsErrNotFound(err) {
 				return nil, &auth.ErrNoRoleBinding{Resource: projectResource}
 			}
 			return nil, errors.Wrapf(err, "error getting role bindings for %s", projectKey)
 		}
-		if err := request.evaluateRoleBinding(txnCtx, &roleBinding); err != nil {
+		if err := request.evaluateRoleBinding(ctx, txnCtx, &roleBinding); err != nil {
 			return nil, err
 		}
 		if request.isSatisfied() {
@@ -759,7 +762,7 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 	}
 
 	// Get the role bindings for the resource to check
-	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(authdb.ResourceKey(resource), &roleBinding); err != nil {
+	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(ctx, authdb.ResourceKey(resource), &roleBinding); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, &auth.ErrNoRoleBinding{
 				Resource: resource,
@@ -767,7 +770,7 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 		}
 		return nil, errors.Wrapf(err, "error getting role bindings for %s \"%s\"", resource.Type, resource.Name)
 	}
-	if err := request.evaluateRoleBinding(txnCtx, &roleBinding); err != nil {
+	if err := request.evaluateRoleBinding(ctx, txnCtx, &roleBinding); err != nil {
 		return nil, err
 	}
 	return request, nil
@@ -775,6 +778,7 @@ func (a *apiServer) evaluateRoleBindingInTransaction(txnCtx *txncontext.Transact
 
 // AuthorizeInTransaction is identical to Authorize except that it can run in a `pachsql.Tx`.
 func (a *apiServer) AuthorizeInTransaction(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	req *auth.AuthorizeRequest,
 ) (resp *auth.AuthorizeResponse, retErr error) {
@@ -788,7 +792,7 @@ func (a *apiServer) AuthorizeInTransaction(
 		permissions[p] = true
 	}
 
-	request, err := a.evaluateRoleBindingInTransaction(txnCtx, me.Username, req.Resource, permissions)
+	request, err := a.evaluateRoleBindingInTransaction(ctx, txnCtx, me.Username, req.Resource, permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -809,7 +813,7 @@ func (a *apiServer) Authorize(
 	var response *auth.AuthorizeResponse
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		var err error
-		response, err = a.AuthorizeInTransaction(txnCtx, req)
+		response, err = a.AuthorizeInTransaction(ctx, txnCtx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -825,7 +829,7 @@ func (a *apiServer) GetPermissionsForPrincipal(ctx context.Context, req *auth.Ge
 	var request *authorizeRequest
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		var err error
-		request, err = a.evaluateRoleBindingInTransaction(txnCtx, req.Principal, req.Resource, permissions)
+		request, err = a.evaluateRoleBindingInTransaction(ctx, txnCtx, req.Principal, req.Resource, permissions)
 		return err
 	}); err != nil {
 		return nil, errors.Wrap(err, "cannot evaluate role binding")
@@ -850,22 +854,22 @@ func (a *apiServer) GetPermissions(ctx context.Context, req *auth.GetPermissions
 	return resp, nil
 }
 
-func (a *apiServer) GetPermissionsInTransaction(txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
+func (a *apiServer) GetPermissionsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error) {
 	callerInfo, err := txnCtx.WhoAmI()
 	if err != nil {
 		return nil, err
 	}
 
-	return a.getPermissionsForPrincipalInTransaction(txnCtx, &auth.GetPermissionsForPrincipalRequest{Principal: callerInfo.Username, Resource: req.Resource})
+	return a.getPermissionsForPrincipalInTransaction(ctx, txnCtx, &auth.GetPermissionsForPrincipalRequest{Principal: callerInfo.Username, Resource: req.Resource})
 }
 
-func (a *apiServer) getPermissionsForPrincipalInTransaction(txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsForPrincipalRequest) (*auth.GetPermissionsResponse, error) {
+func (a *apiServer) getPermissionsForPrincipalInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsForPrincipalRequest) (*auth.GetPermissionsResponse, error) {
 	permissions := make(map[auth.Permission]bool)
 	for p := range auth.Permission_name {
 		permissions[auth.Permission(p)] = true
 	}
 
-	request, err := a.evaluateRoleBindingInTransaction(txnCtx, req.Principal, req.Resource, permissions)
+	request, err := a.evaluateRoleBindingInTransaction(ctx, txnCtx, req.Principal, req.Resource, permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -896,8 +900,8 @@ func (a *apiServer) WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (resp *
 // DeleteRoleBindingInTransaction is used to remove role bindings for resources when they're deleted in other services.
 // It doesn't do any auth checks itself - the calling method should ensure the user is allowed to delete this resource.
 // This is not an RPC, this is only called in-process.
-func (a *apiServer) DeleteRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, resource *auth.Resource) error {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+func (a *apiServer) DeleteRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, resource *auth.Resource) error {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return err
 	}
 
@@ -937,7 +941,7 @@ func rolesFromRoleSlice(rs []string) (*auth.Roles, error) {
 // CreateRoleBindingInTransaction is an internal-only API to create a role binding for a new resource.
 // It doesn't do any authorization checks itself - the calling method should ensure the user is allowed
 // to create the resource. This is not an RPC.
-func (a *apiServer) CreateRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error {
+func (a *apiServer) CreateRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error {
 	bindings := &auth.RoleBinding{
 		Entries: make(map[string]*auth.Roles),
 	}
@@ -970,17 +974,17 @@ func (a *apiServer) CreateRoleBindingInTransaction(txnCtx *txncontext.Transactio
 // This is distinct from ModifyRoleBinding because AddPipelineReader is a less expansive permission
 // that is included in the repoReader role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) AddPipelineReaderToRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
+func (a *apiServer) AddPipelineReaderToRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
 	r := &pfs.Repo{
 		Project: sourceRepo.Project,
 		Name:    sourceRepo.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_READER); err != nil {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_READER); err != nil {
 		return err
 	}
 
-	return a.setUserRoleBindingInTransaction(txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoReaderRole})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoReaderRole})
 }
 
 // AddPipelineWriterToSourceRepoInTransaction gives a pipeline access to write data to the specified source repo.
@@ -988,42 +992,42 @@ func (a *apiServer) AddPipelineReaderToRepoInTransaction(txnCtx *txncontext.Tran
 // This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) AddPipelineWriterToSourceRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
+func (a *apiServer) AddPipelineWriterToSourceRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
 	// Check that the user is allowed to add a pipeline to write to the output repo.
 	r := &pfs.Repo{
 		Project: sourceRepo.Project,
 		Name:    sourceRepo.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
 		return err
 	}
-	return a.setUserRoleBindingInTransaction(txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
 }
 
 // AddPipelineWriterToRepoInTransaction gives a pipeline access to write to it's own output repo.
 // This is distinct from ModifyRoleBinding because AddPipelineWriter is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) AddPipelineWriterToRepoInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) error {
+func (a *apiServer) AddPipelineWriterToRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) error {
 	// Check that the user is allowed to add a pipeline to write to the output repo.
 	r := &pfs.Repo{
 		Project: pipeline.Project,
 		Name:    pipeline.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_ADD_PIPELINE_WRITER); err != nil {
 		return err
 	}
 
-	return a.setUserRoleBindingInTransaction(txnCtx, r.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, r.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{auth.RepoWriterRole})
 }
 
 // RemovePipelineReaderFromRepo revokes a pipeline's access to read data from the specified source repo.
 // This is distinct from ModifyRoleBinding because RemovePipelineReader is a less expansive permission
 // that is included in the repoWriter role, versus being able to modify all role bindings which is
 // part of repoOwner. This method is for internal use and is not exposed as an RPC.
-func (a *apiServer) RemovePipelineReaderFromRepoInTransaction(txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
+func (a *apiServer) RemovePipelineReaderFromRepoInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, sourceRepo *pfs.Repo, pipeline *pps.Pipeline) error {
 	// Check that the user is allowed to remove input repos from the pipeline repo - this check is on the pipeline itself
 	// and not sourceRepo because otherwise users could break piplines they don't have access to by revoking them from the
 	// input repo.
@@ -1032,20 +1036,21 @@ func (a *apiServer) RemovePipelineReaderFromRepoInTransaction(txnCtx *txncontext
 		Name:    pipeline.Name,
 		Type:    pfs.UserRepoType,
 	}
-	if err := a.CheckRepoIsAuthorizedInTransaction(txnCtx, r, auth.Permission_REPO_REMOVE_PIPELINE_READER); err != nil && !auth.IsErrNoRoleBinding(err) {
+	if err := a.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, r, auth.Permission_REPO_REMOVE_PIPELINE_READER); err != nil && !auth.IsErrNoRoleBinding(err) {
 		return err
 	}
 
-	return a.setUserRoleBindingInTransaction(txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{})
+	return a.setUserRoleBindingInTransaction(ctx, txnCtx, sourceRepo.AuthResource(), auth.PipelinePrefix+pipeline.String(), []string{})
 }
 
 // ModifyRoleBindingInTransaction is identical to ModifyRoleBinding except that it can run inside
 // an existing postgres transaction.  This is not an RPC.
 func (a *apiServer) ModifyRoleBindingInTransaction(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	req *auth.ModifyRoleBindingRequest,
 ) (*auth.ModifyRoleBindingResponse, error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return nil, err
 	}
 
@@ -1070,18 +1075,18 @@ func (a *apiServer) ModifyRoleBindingInTransaction(
 	default:
 		return nil, errors.Errorf("unknown resource type %v", req.Resource.Type)
 	}
-	if err := a.checkResourceIsAuthorizedInTransaction(txnCtx, req.Resource, permission); err != nil {
+	if err := a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, req.Resource, permission); err != nil {
 		return nil, err
 	}
 
-	if err := a.setUserRoleBindingInTransaction(txnCtx, req.Resource, req.Principal, req.Roles); err != nil {
+	if err := a.setUserRoleBindingInTransaction(ctx, txnCtx, req.Resource, req.Principal, req.Roles); err != nil {
 		return nil, err
 	}
 
 	return &auth.ModifyRoleBindingResponse{}, nil
 }
 
-func (a *apiServer) setUserRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, resource *auth.Resource, principal string, roleSlice []string) error {
+func (a *apiServer) setUserRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, resource *auth.Resource, principal string, roleSlice []string) error {
 	roles, err := rolesFromRoleSlice(roleSlice)
 	if err != nil {
 		return err
@@ -1090,7 +1095,7 @@ func (a *apiServer) setUserRoleBindingInTransaction(txnCtx *txncontext.Transacti
 	key := authdb.ResourceKey(resource)
 	roleBindings := a.roleBindings.ReadWrite(txnCtx.SqlTx)
 	var bindings auth.RoleBinding
-	if err := roleBindings.Get(key, &bindings); err != nil {
+	if err := roleBindings.Get(ctx, key, &bindings); err != nil {
 		if col.IsErrNotFound(err) {
 			return &auth.ErrNoRoleBinding{
 				Resource: resource,
@@ -1148,15 +1153,16 @@ func (a *apiServer) ModifyRoleBinding(ctx context.Context, req *auth.ModifyRoleB
 // GetRoleBindingInTransaction is identical to GetRoleBinding except that it can run inside
 // an existing postgres transaction.  This is not an RPC.
 func (a *apiServer) GetRoleBindingInTransaction(
+	ctx context.Context,
 	txnCtx *txncontext.TransactionContext,
 	req *auth.GetRoleBindingRequest,
 ) (*auth.GetRoleBindingResponse, error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return nil, err
 	}
 
 	var roleBindings auth.RoleBinding
-	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(authdb.ResourceKey(req.Resource), &roleBindings); err != nil && !col.IsErrNotFound(err) {
+	if err := a.roleBindings.ReadWrite(txnCtx.SqlTx).Get(ctx, authdb.ResourceKey(req.Resource), &roleBindings); err != nil && !col.IsErrNotFound(err) {
 		return nil, errors.EnsureStack(err)
 	}
 
@@ -1173,7 +1179,7 @@ func (a *apiServer) GetRoleBinding(ctx context.Context, req *auth.GetRoleBinding
 	var response *auth.GetRoleBindingResponse
 	if err := a.env.TxnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		var err error
-		response, err = a.GetRoleBindingInTransaction(txnCtx, req)
+		response, err = a.GetRoleBindingInTransaction(ctx, txnCtx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -1209,8 +1215,8 @@ func (a *apiServer) GetRobotToken(ctx context.Context, req *auth.GetRobotTokenRe
 
 // GetPipelineAuthTokenInTransaction is an internal API used to create a pipeline token for a given pipeline.
 // Not an RPC.
-func (a *apiServer) GetPipelineAuthTokenInTransaction(txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (string, error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+func (a *apiServer) GetPipelineAuthTokenInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, pipeline *pps.Pipeline) (string, error) {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return "", err
 	}
 
@@ -1237,7 +1243,7 @@ func (a *apiServer) GetOIDCLogin(ctx context.Context, req *auth.GetOIDCLoginRequ
 // RevokeAuthToken implements the protobuf auth.RevokeAuthToken RPC
 func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
 	if err := a.env.TxnEnv.WithWriteContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
-		resp, retErr = a.RevokeAuthTokenInTransaction(txnCtx, req)
+		resp, retErr = a.RevokeAuthTokenInTransaction(ctx, txnCtx, req)
 		return retErr
 	}); err != nil {
 		return nil, err
@@ -1245,8 +1251,8 @@ func (a *apiServer) RevokeAuthToken(ctx context.Context, req *auth.RevokeAuthTok
 	return resp, retErr
 }
 
-func (a *apiServer) RevokeAuthTokenInTransaction(txnCtx *txncontext.TransactionContext, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
-	if err := a.isActiveInTransaction(txnCtx); err != nil {
+func (a *apiServer) RevokeAuthTokenInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.RevokeAuthTokenRequest) (resp *auth.RevokeAuthTokenResponse, retErr error) {
+	if err := a.isActiveInTransaction(ctx, txnCtx); err != nil {
 		return nil, err
 	}
 
@@ -1268,7 +1274,7 @@ func (a *apiServer) setGroupsForUserInternal(ctx context.Context, subject string
 		// Get groups to remove/add user from/to
 		var removeGroups auth.Groups
 		addGroups := addToSet(nil, groups...)
-		if err := members.Get(subject, &removeGroups); err == nil {
+		if err := members.Get(ctx, subject, &removeGroups); err == nil {
 			for _, group := range groups {
 				if removeGroups.Groups[group] {
 					removeGroups.Groups = removeFromSet(removeGroups.Groups, group)
@@ -1407,10 +1413,10 @@ func (a *apiServer) getGroups(ctx context.Context, subject string) ([]string, er
 
 // getGroups is a helper function used primarily by the GRPC API GetGroups, but
 // also by Authorize() and isAdmin().
-func (a *apiServer) getGroupsInTransaction(txnCtx *txncontext.TransactionContext, subject string) ([]string, error) {
+func (a *apiServer) getGroupsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, subject string) ([]string, error) {
 	members := a.members.ReadWrite(txnCtx.SqlTx)
 	var groupsProto auth.Groups
-	if err := members.Get(subject, &groupsProto); err != nil {
+	if err := members.Get(ctx, subject, &groupsProto); err != nil {
 		if col.IsErrNotFound(err) {
 			return []string{}, nil
 		}
@@ -1449,7 +1455,7 @@ func (a *apiServer) GetUsers(ctx context.Context, req *auth.GetUsersRequest) (re
 		var membersProto auth.Users
 		if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
 			groups := a.groups.ReadWrite(sqlTx)
-			if err := groups.Get(req.Group, &membersProto); err != nil {
+			if err := groups.Get(ctx, req.Group, &membersProto); err != nil {
 				return errors.EnsureStack(err)
 			}
 			return nil

--- a/src/server/auth/server/authorize_req.go
+++ b/src/server/auth/server/authorize_req.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"sort"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/transactionenv/txncontext"
@@ -8,7 +9,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 )
 
-type groupLookupFn func(txnCtx *txncontext.TransactionContext, subject string) ([]string, error)
+type groupLookupFn func(ctx context.Context, txnCtx *txncontext.TransactionContext, subject string) ([]string, error)
 
 // authorizeRequest is a helper struct used to evaluate an incoming Authorize request.
 // It's initialized with the subject and set of permissions required for an Operation,
@@ -73,7 +74,7 @@ func (r *authorizeRequest) missing() []auth.Permission {
 // - role bindings that refer to them by name
 // - role bindings that refer to allClusterUsers
 // - role bindings that refer to any group the subject belongs to
-func (r *authorizeRequest) evaluateRoleBinding(txnCtx *txncontext.TransactionContext, binding *auth.RoleBinding) error {
+func (r *authorizeRequest) evaluateRoleBinding(ctx context.Context, txnCtx *txncontext.TransactionContext, binding *auth.RoleBinding) error {
 	if err := r.evaluateRoleBindingForSubject(r.subject, binding); err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (r *authorizeRequest) evaluateRoleBinding(txnCtx *txncontext.TransactionCon
 	// bindings to cover the set of permissions.
 	if r.groups == nil {
 		var err error
-		r.groups, err = r.groupsForSubject(txnCtx, r.subject)
+		r.groups, err = r.groupsForSubject(ctx, txnCtx, r.subject)
 		if err != nil {
 			return err
 		}

--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -190,7 +190,7 @@ func (a *apiServer) OIDCStateToEmail(ctx context.Context, state string) (email s
 	}()
 	// reestablish watch in a loop, in case there's a watch error
 	if err := backoff.RetryNotify(func() error {
-		watcher, err := a.oidcStates.ReadOnly(ctx).WatchOne(ctx, state)
+		watcher, err := a.oidcStates.ReadOnly().WatchOne(ctx, state)
 		if err != nil {
 			log.Error(ctx, "error watching OIDC state token during authorization",
 				zap.String("state", state), zap.Error(err))

--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -152,7 +152,7 @@ func (a *apiServer) GetOIDCLoginURL(ctx context.Context) (string, string, error)
 	nonce := random.String(30)
 
 	if _, err := col.NewSTM(ctx, a.env.EtcdClient, func(stm col.STM) error {
-		return errors.EnsureStack(a.oidcStates.ReadWrite(stm).PutTTL(state, &auth.SessionInfo{
+		return errors.EnsureStack(a.oidcStates.ReadWrite(stm).PutTTL(ctx, state, &auth.SessionInfo{
 			Nonce: nonce, // read & verified by /authorization-code/callback
 		}, threeMinutes))
 	}); err != nil {
@@ -287,7 +287,7 @@ func (a *apiServer) handleOIDCExchange(w http.ResponseWriter, req *http.Request)
 	nonce, email, conversionErr := a.handleOIDCExchangeInternal(ctx, code, state)
 	_, txErr := col.NewSTM(ctx, a.env.EtcdClient, func(stm col.STM) error {
 		var si auth.SessionInfo
-		err := a.oidcStates.ReadWrite(stm).Update(state, &si, func() error {
+		err := a.oidcStates.ReadWrite(stm).Update(ctx, state, &si, func() error {
 			// nonce can only be checked inside postgres txn, but if nonces don't match
 			// that's a non-retryable authentication error, so set conversionErr as
 			// if handleOIDCExchangeInternal had errored and proceed

--- a/src/server/auth/server/oidc.go
+++ b/src/server/auth/server/oidc.go
@@ -190,7 +190,7 @@ func (a *apiServer) OIDCStateToEmail(ctx context.Context, state string) (email s
 	}()
 	// reestablish watch in a loop, in case there's a watch error
 	if err := backoff.RetryNotify(func() error {
-		watcher, err := a.oidcStates.ReadOnly(ctx).WatchOne(state)
+		watcher, err := a.oidcStates.ReadOnly(ctx).WatchOne(ctx, state)
 		if err != nil {
 			log.Error(ctx, "error watching OIDC state token during authorization",
 				zap.String("state", state), zap.Error(err))

--- a/src/server/auth/server/util.go
+++ b/src/server/auth/server/util.go
@@ -11,26 +11,26 @@ import (
 
 // CheckClusterIsAuthorizedInTransaction returns an error if the current user doesn't have
 // the permissions in `p` on the cluster
-func (a *apiServer) CheckClusterIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, p ...auth.Permission) error {
-	return a.checkResourceIsAuthorizedInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_CLUSTER}, p...)
+func (a *apiServer) CheckClusterIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, p ...auth.Permission) error {
+	return a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, &auth.Resource{Type: auth.ResourceType_CLUSTER}, p...)
 }
 
 // CheckProjectIsAuthorizedInTransaction returns an error if the current user doesn't have the permissions in `p` on the project.
 // Projects inherit access controls from its parent cluster. Therefore, behind the scene, we check the cluster first, followed by this project.
-func (a *apiServer) CheckProjectIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error {
-	return a.checkResourceIsAuthorizedInTransaction(txnCtx, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: project.Name}, p...)
+func (a *apiServer) CheckProjectIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error {
+	return a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, &auth.Resource{Type: auth.ResourceType_PROJECT, Name: project.Name}, p...)
 }
 
 // CheckRepoIsAuthorizedInTransaction is identical to CheckRepoIsAuthorized except that
 // it performs reads consistent with the latest state of the STM transaction.
 // Repos inherit access controls from its parent project, which in turn inherits from the cluster.
 // Therefore, behind the scene, we check the cluster first, then this repo's project, and finally this repo.
-func (a *apiServer) CheckRepoIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error {
-	return a.checkResourceIsAuthorizedInTransaction(txnCtx, repo.AuthResource(), p...)
+func (a *apiServer) CheckRepoIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error {
+	return a.checkResourceIsAuthorizedInTransaction(ctx, txnCtx, repo.AuthResource(), p...)
 }
 
 // CheckResourceIsAuthorizedInTransaction returns an error if the subject/user doesn't have permission in `p` on the `resource`
-func (a *apiServer) checkResourceIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, resource *auth.Resource, p ...auth.Permission) error {
+func (a *apiServer) checkResourceIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, resource *auth.Resource, p ...auth.Permission) error {
 	me, err := txnCtx.WhoAmI()
 	if err != nil {
 		if errors.Is(err, auth.ErrNotActivated) {
@@ -40,7 +40,7 @@ func (a *apiServer) checkResourceIsAuthorizedInTransaction(txnCtx *txncontext.Tr
 	}
 
 	req := &auth.AuthorizeRequest{Resource: resource, Permissions: p}
-	resp, err := a.AuthorizeInTransaction(txnCtx, req)
+	resp, err := a.AuthorizeInTransaction(ctx, txnCtx, req)
 	if err != nil {
 		return err
 	}

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -74,11 +74,11 @@ func NewEnterpriseServer(env *Env, config Config) (*apiServer, error) {
 	s := &apiServer{
 		env:                  env,
 		config:               config,
-		enterpriseTokenCache: keycache.NewCache(env.BackgroundContext, enterpriseTokenCol.ReadOnly(env.BackgroundContext), enterpriseTokenKey, defaultEnterpriseRecord),
+		enterpriseTokenCache: keycache.NewCache(enterpriseTokenCol.ReadOnly(env.BackgroundContext), enterpriseTokenKey, defaultEnterpriseRecord),
 		enterpriseTokenCol:   enterpriseTokenCol,
 		configCol:            EnterpriseConfigCollection(env.DB, env.Listener),
 	}
-	go s.enterpriseTokenCache.Watch()
+	go s.enterpriseTokenCache.Watch(env.BackgroundContext)
 
 	if config.Heartbeat {
 		go s.heartbeatRoutine(env.BackgroundContext)

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -367,7 +367,7 @@ func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (
 		return nil, errors.New("cannot deactivate paused cluster; unpause first")
 	}
 	if _, err := col.NewSTM(ctx, a.env.EtcdClient, func(stm col.STM) error {
-		err := a.enterpriseTokenCol.ReadWrite(stm).Delete(enterpriseTokenKey)
+		err := a.enterpriseTokenCol.ReadWrite(stm).Delete(ctx, enterpriseTokenKey)
 		if err != nil && !col.IsErrNotFound(err) {
 			return errors.EnsureStack(err)
 		}
@@ -377,7 +377,7 @@ func (a *apiServer) Deactivate(ctx context.Context, req *ec.DeactivateRequest) (
 	}
 
 	if err := a.env.TxnEnv.WithWriteContext(ctx, func(ctx context.Context, txCtx *txncontext.TransactionContext) error {
-		err := a.configCol.ReadWrite(txCtx.SqlTx).Delete(configKey)
+		err := a.configCol.ReadWrite(txCtx.SqlTx).Delete(ctx, configKey)
 		if err != nil && !col.IsErrNotFound(err) {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -74,7 +74,7 @@ func NewEnterpriseServer(env *Env, config Config) (*apiServer, error) {
 	s := &apiServer{
 		env:                  env,
 		config:               config,
-		enterpriseTokenCache: keycache.NewCache(enterpriseTokenCol.ReadOnly(env.BackgroundContext), enterpriseTokenKey, defaultEnterpriseRecord),
+		enterpriseTokenCache: keycache.NewCache(enterpriseTokenCol.ReadOnly(), enterpriseTokenKey, defaultEnterpriseRecord),
 		enterpriseTokenCol:   enterpriseTokenCol,
 		configCol:            EnterpriseConfigCollection(env.DB, env.Listener),
 	}
@@ -158,7 +158,7 @@ func (a *apiServer) heartbeatRoutine(ctx context.Context) {
 func (a *apiServer) heartbeatIfConfigured(ctx context.Context) error {
 	// If we can't get the license server address, skip heartbeating
 	var config ec.EnterpriseConfig
-	if err := a.configCol.ReadOnly(ctx).Get(ctx, configKey, &config); err != nil {
+	if err := a.configCol.ReadOnly().Get(ctx, configKey, &config); err != nil {
 		if col.IsErrNotFound(err) {
 			return lc.ErrNotActivated
 		}

--- a/src/server/enterprise/server/api_server.go
+++ b/src/server/enterprise/server/api_server.go
@@ -158,7 +158,7 @@ func (a *apiServer) heartbeatRoutine(ctx context.Context) {
 func (a *apiServer) heartbeatIfConfigured(ctx context.Context) error {
 	// If we can't get the license server address, skip heartbeating
 	var config ec.EnterpriseConfig
-	if err := a.configCol.ReadOnly(ctx).Get(configKey, &config); err != nil {
+	if err := a.configCol.ReadOnly(ctx).Get(ctx, configKey, &config); err != nil {
 		if col.IsErrNotFound(err) {
 			return lc.ErrNotActivated
 		}

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -261,7 +261,7 @@ func TestEnterpriseConfigMigration(t *testing.T) {
 
 	etcdConfigCol := col.NewEtcdCollection(etcd, "", nil, &enterprise.EnterpriseConfig{}, nil, nil)
 	_, err := col.NewSTM(ctx, etcd, func(stm col.STM) error {
-		return errors.EnsureStack(etcdConfigCol.ReadWrite(stm).Put("config", config))
+		return errors.EnsureStack(etcdConfigCol.ReadWrite(stm).Put(ctx, "config", config))
 	})
 	require.NoError(t, err)
 

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -290,12 +290,12 @@ func TestEnterpriseConfigMigration(t *testing.T) {
 
 	pgCol := server.EnterpriseConfigCollection(db, nil)
 	result := &enterprise.EnterpriseConfig{}
-	require.NoError(t, pgCol.ReadOnly(ctx).Get(ctx, "config", result))
+	require.NoError(t, pgCol.ReadOnly().Get(ctx, "config", result))
 	require.Equal(t, config.Id, result.Id)
 	require.Equal(t, config.LicenseServer, result.LicenseServer)
 	require.Equal(t, config.Secret, result.Secret)
 
-	err = etcdConfigCol.ReadOnly(ctx).Get(ctx, "config", &enterprise.EnterpriseConfig{})
+	err = etcdConfigCol.ReadOnly().Get(ctx, "config", &enterprise.EnterpriseConfig{})
 	require.YesError(t, err)
 	require.True(t, col.IsErrNotFound(err))
 }

--- a/src/server/enterprise/server/enterprise_test.go
+++ b/src/server/enterprise/server/enterprise_test.go
@@ -290,12 +290,12 @@ func TestEnterpriseConfigMigration(t *testing.T) {
 
 	pgCol := server.EnterpriseConfigCollection(db, nil)
 	result := &enterprise.EnterpriseConfig{}
-	require.NoError(t, pgCol.ReadOnly(ctx).Get("config", result))
+	require.NoError(t, pgCol.ReadOnly(ctx).Get(ctx, "config", result))
 	require.Equal(t, config.Id, result.Id)
 	require.Equal(t, config.LicenseServer, result.LicenseServer)
 	require.Equal(t, config.Secret, result.Secret)
 
-	err = etcdConfigCol.ReadOnly(ctx).Get("config", &enterprise.EnterpriseConfig{})
+	err = etcdConfigCol.ReadOnly(ctx).Get(ctx, "config", &enterprise.EnterpriseConfig{})
 	require.YesError(t, err)
 	require.True(t, col.IsErrNotFound(err))
 }

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -79,7 +79,7 @@ func EnterpriseConfigPostgresMigration(ctx context.Context, tx *pachsql.Tx, etcd
 func checkForEtcdRecord(ctx context.Context, etcd *clientv3.Client) (*ec.EnterpriseConfig, error) {
 	etcdConfigCol := col.NewEtcdCollection(etcd, "", nil, &ec.EnterpriseConfig{}, nil, nil)
 	var config ec.EnterpriseConfig
-	if err := etcdConfigCol.ReadOnly(ctx).Get(configKey, &config); err != nil {
+	if err := etcdConfigCol.ReadOnly(ctx).Get(ctx, configKey, &config); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, nil
 		}

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -71,7 +71,7 @@ func EnterpriseConfigPostgresMigration(ctx context.Context, tx *pachsql.Tx, etcd
 		return err
 	}
 	if config != nil {
-		return errors.EnsureStack(EnterpriseConfigCollection(nil, nil).ReadWrite(tx).Put(configKey, config))
+		return errors.EnsureStack(EnterpriseConfigCollection(nil, nil).ReadWrite(tx).Put(ctx, configKey, config))
 	}
 	return nil
 }

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -91,7 +91,7 @@ func checkForEtcdRecord(ctx context.Context, etcd *clientv3.Client) (*ec.Enterpr
 func DeleteEnterpriseConfigFromEtcd(ctx context.Context, etcd *clientv3.Client) error {
 	if _, err := col.NewSTM(ctx, etcd, func(stm col.STM) error {
 		etcdConfigCol := col.NewEtcdCollection(etcd, "", nil, &ec.EnterpriseConfig{}, nil, nil)
-		return errors.EnsureStack(etcdConfigCol.ReadWrite(stm).Delete(configKey))
+		return errors.EnsureStack(etcdConfigCol.ReadWrite(stm).Delete(ctx, configKey))
 	}); err != nil {
 		if !col.IsErrNotFound(err) {
 			return err

--- a/src/server/enterprise/server/env.go
+++ b/src/server/enterprise/server/env.go
@@ -79,7 +79,7 @@ func EnterpriseConfigPostgresMigration(ctx context.Context, tx *pachsql.Tx, etcd
 func checkForEtcdRecord(ctx context.Context, etcd *clientv3.Client) (*ec.EnterpriseConfig, error) {
 	etcdConfigCol := col.NewEtcdCollection(etcd, "", nil, &ec.EnterpriseConfig{}, nil, nil)
 	var config ec.EnterpriseConfig
-	if err := etcdConfigCol.ReadOnly(ctx).Get(ctx, configKey, &config); err != nil {
+	if err := etcdConfigCol.ReadOnly().Get(ctx, configKey, &config); err != nil {
 		if col.IsErrNotFound(err) {
 			return nil, nil
 		}

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -253,7 +253,7 @@ func (a *apiServer) DeleteAll(ctx context.Context, req *lc.DeleteAllRequest) (re
 	}
 
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		err := a.license.ReadWrite(sqlTx).Delete(licenseRecordKey)
+		err := a.license.ReadWrite(sqlTx).Delete(ctx, licenseRecordKey)
 		if err != nil && !col.IsErrNotFound(err) {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -123,7 +123,7 @@ func (a *apiServer) activate(ctx context.Context, req *lc.ActivateRequest) (resp
 	}
 
 	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		return errors.EnsureStack(a.license.ReadWrite(sqlTx).Put(licenseRecordKey, newRecord))
+		return errors.EnsureStack(a.license.ReadWrite(sqlTx).Put(ctx, licenseRecordKey, newRecord))
 	}); err != nil {
 		return nil, err
 	}

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -142,7 +142,7 @@ func (a *apiServer) GetActivationCode(ctx context.Context, req *lc.GetActivation
 
 func (a *apiServer) getLicenseRecord(ctx context.Context) (*lc.GetActivationCodeResponse, error) {
 	var record ec.LicenseRecord
-	if err := a.license.ReadOnly(ctx).Get(ctx, licenseRecordKey, &record); err != nil {
+	if err := a.license.ReadOnly().Get(ctx, licenseRecordKey, &record); err != nil {
 		if col.IsErrNotFound(err) {
 			return &lc.GetActivationCodeResponse{State: ec.State_NONE}, nil
 		}
@@ -236,7 +236,7 @@ func (a *apiServer) Heartbeat(ctx context.Context, req *lc.HeartbeatRequest) (re
 	}
 
 	var record ec.LicenseRecord
-	if err := a.license.ReadOnly(ctx).Get(ctx, licenseRecordKey, &record); err != nil {
+	if err := a.license.ReadOnly().Get(ctx, licenseRecordKey, &record); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -142,7 +142,7 @@ func (a *apiServer) GetActivationCode(ctx context.Context, req *lc.GetActivation
 
 func (a *apiServer) getLicenseRecord(ctx context.Context) (*lc.GetActivationCodeResponse, error) {
 	var record ec.LicenseRecord
-	if err := a.license.ReadOnly(ctx).Get(licenseRecordKey, &record); err != nil {
+	if err := a.license.ReadOnly(ctx).Get(ctx, licenseRecordKey, &record); err != nil {
 		if col.IsErrNotFound(err) {
 			return &lc.GetActivationCodeResponse{State: ec.State_NONE}, nil
 		}
@@ -236,7 +236,7 @@ func (a *apiServer) Heartbeat(ctx context.Context, req *lc.HeartbeatRequest) (re
 	}
 
 	var record ec.LicenseRecord
-	if err := a.license.ReadOnly(ctx).Get(licenseRecordKey, &record); err != nil {
+	if err := a.license.ReadOnly(ctx).Get(ctx, licenseRecordKey, &record); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 

--- a/src/server/logs/BUILD.bazel
+++ b/src/server/logs/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "internal_test.go",
         "logs_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":logs"],
     deps = [
         "//src/internal/errors",

--- a/src/server/pfs/server/api_server.go
+++ b/src/server/pfs/server/api_server.go
@@ -81,7 +81,7 @@ func (a *apiServer) ActivateAuthInTransaction(ctx context.Context, txnCtx *txnco
 			principal = auth.AllClusterUsersSubject
 			roleSlice = []string{auth.ProjectWriterRole}
 		}
-		err := a.env.Auth.CreateRoleBindingInTransaction(txnCtx, principal, roleSlice,
+		err := a.env.Auth.CreateRoleBindingInTransaction(ctx, txnCtx, principal, roleSlice,
 			&auth.Resource{Type: auth.ResourceType_PROJECT, Name: proj.ProjectInfo.Project.Name})
 		if err != nil && !col.IsErrExists(err) {
 			return errors.Wrap(err, "activate auth in transaction")
@@ -92,7 +92,7 @@ func (a *apiServer) ActivateAuthInTransaction(ctx context.Context, txnCtx *txnco
 	}
 	// Create role bindings for repos created before auth activation
 	if err := pfsdb.ForEachRepo(ctx, txnCtx.SqlTx, nil, nil, func(repoInfoWithID pfsdb.RepoInfoWithID) error {
-		err := a.env.Auth.CreateRoleBindingInTransaction(txnCtx, "", nil, repoInfoWithID.RepoInfo.Repo.AuthResource())
+		err := a.env.Auth.CreateRoleBindingInTransaction(ctx, txnCtx, "", nil, repoInfoWithID.RepoInfo.Repo.AuthResource())
 		if err != nil && !col.IsErrExists(err) {
 			return errors.EnsureStack(err)
 		}

--- a/src/server/pfs/server/server.go
+++ b/src/server/pfs/server/server.go
@@ -36,11 +36,11 @@ type PFSAuth interface {
 	WhoAmI(ctx context.Context, req *auth.WhoAmIRequest) (*auth.WhoAmIResponse, error)
 	GetPermissions(ctx context.Context, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 
-	CheckProjectIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error
-	CheckRepoIsAuthorizedInTransaction(txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error
-	CreateRoleBindingInTransaction(txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error
-	DeleteRoleBindingInTransaction(transactionContext *txncontext.TransactionContext, resource *auth.Resource) error
-	GetPermissionsInTransaction(txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
+	CheckProjectIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, project *pfs.Project, p ...auth.Permission) error
+	CheckRepoIsAuthorizedInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, repo *pfs.Repo, p ...auth.Permission) error
+	CreateRoleBindingInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, principal string, roleSlice []string, resource *auth.Resource) error
+	DeleteRoleBindingInTransaction(ctx context.Context, transactionContext *txncontext.TransactionContext, resource *auth.Resource) error
+	GetPermissionsInTransaction(ctx context.Context, txnCtx *txncontext.TransactionContext, req *auth.GetPermissionsRequest) (*auth.GetPermissionsResponse, error)
 }
 
 // Env is the dependencies needed to run the PFS API server

--- a/src/server/pfs/server/val_server.go
+++ b/src/server/pfs/server/val_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pfsdb"
 
@@ -45,7 +46,7 @@ func (a *validatedAPIServer) FinishCommitInTransaction(ctx context.Context, txnC
 	if err := checkCommit(userCommit); err != nil {
 		return errors.Wrap(err, "check new file commit")
 	}
-	if err := a.auth.CheckRepoIsAuthorizedInTransaction(txnCtx, userCommit.Repo, auth.Permission_REPO_WRITE); err != nil {
+	if err := a.auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, userCommit.Repo, auth.Permission_REPO_WRITE); err != nil {
 		return errors.EnsureStack(err)
 	}
 	return a.apiServer.FinishCommitInTransaction(ctx, txnCtx, request)

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -471,7 +471,7 @@ func (a *apiServer) InspectJob(ctx context.Context, request *pps.InspectJobReque
 		return nil, errors.EnsureStack(err)
 	}
 	if request.Wait {
-		watcher, err := jobs.WatchOne(ppsdb.JobKey(request.Job))
+		watcher, err := jobs.WatchOne(ctx, ppsdb.JobKey(request.Job))
 		if err != nil {
 			return nil, errors.EnsureStack(err)
 		}
@@ -890,7 +890,7 @@ func (a *apiServer) SubscribeJob(request *pps.SubscribeJobRequest, stream pps.AP
 	// keep track of the jobs that have been sent
 	seen := map[string]struct{}{}
 
-	err := a.jobs.ReadOnly(ctx).WatchByIndexF(ppsdb.JobsTerminalIndex, ppsdb.JobsTerminalKey(request.Pipeline, false), func(ev *watch.Event) error {
+	err := a.jobs.ReadOnly(ctx).WatchByIndexF(ctx, ppsdb.JobsTerminalIndex, ppsdb.JobsTerminalKey(request.Pipeline, false), func(ev *watch.Event) error {
 		var key string
 		jobInfo := &pps.JobInfo{}
 		if err := ev.Unmarshal(&key, jobInfo); err != nil {

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -616,7 +616,7 @@ func (a *apiServer) ListJobSet(request *pps.ListJobSetRequest, serv pps.API_List
 	if request.Reverse {
 		opts.Order = col.SortAscend
 	}
-	if err := a.jobs.ReadOnly(serv.Context()).List(jobInfo, opts, func(string) error {
+	if err := a.jobs.ReadOnly(serv.Context()).List(serv.Context(), jobInfo, opts, func(string) error {
 		if number == 0 {
 			return errutil.ErrBreak
 		}
@@ -862,7 +862,7 @@ func (a *apiServer) ListJob(request *pps.ListJobRequest, resp pps.API_ListJobSer
 	if pipeline != nil {
 		err = jobs.GetByIndex(ctx, ppsdb.JobsPipelineIndex, ppsdb.JobsPipelineKey(pipeline), jobInfo, opts, _f)
 	} else {
-		err = jobs.List(jobInfo, opts, _f)
+		err = jobs.List(ctx, jobInfo, opts, _f)
 	}
 	if err != nil && err != errutil.ErrBreak {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -1914,7 +1914,7 @@ func (a *apiServer) validateEnterpriseChecks(ctx context.Context, req *pps.Creat
 	}
 	var info pps.PipelineInfo
 	seen := make(map[string]struct{})
-	if err := a.pipelines.ReadOnly(ctx).List(&info, col.DefaultOptions(), func(_ string) error {
+	if err := a.pipelines.ReadOnly(ctx).List(ctx, &info, col.DefaultOptions(), func(_ string) error {
 		seen[info.Pipeline.Name] = struct{}{}
 		return nil
 	}); err != nil {
@@ -3242,7 +3242,7 @@ func (a *apiServer) DeletePipelines(ctx context.Context, request *pps.DeletePipe
 	dr.Pipeline = &pps.Pipeline{}
 	pipelineInfo := &pps.PipelineInfo{}
 	deleted := make(map[string]struct{})
-	if err := a.pipelines.ReadOnly(ctx).List(pipelineInfo, col.DefaultOptions(), func(string) error {
+	if err := a.pipelines.ReadOnly(ctx).List(ctx, pipelineInfo, col.DefaultOptions(), func(string) error {
 		if _, ok := deleted[pipelineInfo.Pipeline.String()]; ok {
 			// while the delete pipeline call will delete historical versions,
 			// they could still show up in the list.  Ignore them.

--- a/src/server/pps/server/api_server.go
+++ b/src/server/pps/server/api_server.go
@@ -2840,7 +2840,7 @@ func (a *apiServer) updatePipeline(
 		return errors.Wrap(err, "find pipeline spec commit")
 	}
 
-	return errors.Wrapf(a.pipelines.ReadWrite(txnCtx.SqlTx).Update(key, info, cb), "update pipeline %v", key)
+	return errors.Wrapf(a.pipelines.ReadWrite(txnCtx.SqlTx).Update(ctx, key, info, cb), "update pipeline %v", key)
 }
 
 // InspectPipeline implements the protobuf pps.InspectPipeline RPC

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -124,6 +124,7 @@ func (sd *stateDriver) ListPipelineInfo(ctx context.Context, f func(*pps.Pipelin
 func (sd *stateDriver) GetPipelineInfo(ctx context.Context, pipeline *pps.Pipeline, version int) (*pps.PipelineInfo, error) {
 	var pipelineInfo pps.PipelineInfo
 	if err := sd.pipelines.ReadOnly(ctx).GetUniqueByIndex(
+		ctx,
 		ppsdb.PipelinesVersionIndex,
 		ppsdb.VersionKey(pipeline, uint64(version)),
 		&pipelineInfo); err != nil {
@@ -158,7 +159,7 @@ func (sd *stateDriver) loadLatestPipelineInfo(ctx context.Context, pipeline *pps
 	if err != nil {
 		return errors.Wrapf(err, "could not find spec commit for pipeline %q", pipeline)
 	}
-	if err := sd.pipelines.ReadOnly(ctx).Get(specCommit, message); err != nil {
+	if err := sd.pipelines.ReadOnly(ctx).Get(ctx, specCommit, message); err != nil {
 		return errors.Wrapf(err, "could not retrieve pipeline info for %q", pipeline)
 	}
 	return nil

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -110,7 +110,7 @@ func (sd *stateDriver) TransitionState(ctx context.Context, specCommit *pfs.Comm
 }
 
 func (sd *stateDriver) Watch(ctx context.Context) (<-chan *watch.Event, func(), error) {
-	pipelineWatcher, err := sd.pipelines.ReadOnly(ctx).Watch()
+	pipelineWatcher, err := sd.pipelines.ReadOnly(ctx).Watch(ctx)
 	if err != nil {
 		return nil, nil, errors.EnsureStack(err)
 	}

--- a/src/server/pps/server/pipeline_state_driver.go
+++ b/src/server/pps/server/pipeline_state_driver.go
@@ -110,7 +110,7 @@ func (sd *stateDriver) TransitionState(ctx context.Context, specCommit *pfs.Comm
 }
 
 func (sd *stateDriver) Watch(ctx context.Context) (<-chan *watch.Event, func(), error) {
-	pipelineWatcher, err := sd.pipelines.ReadOnly(ctx).Watch(ctx)
+	pipelineWatcher, err := sd.pipelines.ReadOnly().Watch(ctx)
 	if err != nil {
 		return nil, nil, errors.EnsureStack(err)
 	}
@@ -123,7 +123,7 @@ func (sd *stateDriver) ListPipelineInfo(ctx context.Context, f func(*pps.Pipelin
 
 func (sd *stateDriver) GetPipelineInfo(ctx context.Context, pipeline *pps.Pipeline, version int) (*pps.PipelineInfo, error) {
 	var pipelineInfo pps.PipelineInfo
-	if err := sd.pipelines.ReadOnly(ctx).GetUniqueByIndex(
+	if err := sd.pipelines.ReadOnly().GetUniqueByIndex(
 		ctx,
 		ppsdb.PipelinesVersionIndex,
 		ppsdb.VersionKey(pipeline, uint64(version)),
@@ -159,7 +159,7 @@ func (sd *stateDriver) loadLatestPipelineInfo(ctx context.Context, pipeline *pps
 	if err != nil {
 		return errors.Wrapf(err, "could not find spec commit for pipeline %q", pipeline)
 	}
-	if err := sd.pipelines.ReadOnly(ctx).Get(ctx, specCommit, message); err != nil {
+	if err := sd.pipelines.ReadOnly().Get(ctx, specCommit, message); err != nil {
 		return errors.Wrapf(err, "could not retrieve pipeline info for %q", pipeline)
 	}
 	return nil

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -305,7 +305,7 @@ func (h *handleJobsCtx) start(ctx context.Context) {
 		var watcher watch.Watcher
 		backoff.Retry(func() error { //nolint:errcheck
 			var err error
-			watcher, err = h.s.apiServer.jobs.ReadOnly(ctx).WatchByIndex(
+			watcher, err = h.s.apiServer.jobs.ReadOnly().WatchByIndex(
 				ctx, ppsdb.JobsPipelineIndex, ppsdb.JobsPipelineKey(h.s.pipelineInfo.Pipeline))
 			if err != nil {
 				return errors.Wrapf(err, "error creating watch")

--- a/src/server/pps/server/s3g_sidecar.go
+++ b/src/server/pps/server/s3g_sidecar.go
@@ -117,10 +117,9 @@ type jobHandler interface {
 func (s *sidecarS3G) serveS3Instances(ctx context.Context) {
 	// Watch for new jobs & initialize s3g for each new job
 	(&handleJobsCtx{
-		ctx: ctx,
-		s:   s,
-		h:   &s3InstanceCreatingJobHandler{s},
-	}).start()
+		s: s,
+		h: &s3InstanceCreatingJobHandler{s},
+	}).start(ctx)
 }
 
 func (s *sidecarS3G) createK8sServices(ctx context.Context) {
@@ -143,10 +142,9 @@ func (s *sidecarS3G) createK8sServices(ctx context.Context) {
 
 		// Watch for new jobs & create kubernetes service for each new job
 		(&handleJobsCtx{
-			ctx: ctx,
-			s:   s,
-			h:   &k8sServiceCreatingJobHandler{s},
-		}).start()
+			s: s,
+			h: &k8sServiceCreatingJobHandler{s},
+		}).start(ctx)
 
 		// Retry the unlock inside the larger retry as other sidecars may not be
 		// able to obtain mastership until the key expires if unlock is unsuccessful
@@ -295,12 +293,11 @@ func (s *k8sServiceCreatingJobHandler) OnTerminate(ctx context.Context, job *pps
 }
 
 type handleJobsCtx struct {
-	ctx context.Context
-	s   *sidecarS3G
-	h   jobHandler
+	s *sidecarS3G
+	h jobHandler
 }
 
-func (h *handleJobsCtx) start() {
+func (h *handleJobsCtx) start(ctx context.Context) {
 	defer func() {
 		panic("sidecar s3 gateway: start() is exiting; this should never happen")
 	}()
@@ -308,8 +305,8 @@ func (h *handleJobsCtx) start() {
 		var watcher watch.Watcher
 		backoff.Retry(func() error { //nolint:errcheck
 			var err error
-			watcher, err = h.s.apiServer.jobs.ReadOnly(context.Background()).WatchByIndex(
-				ppsdb.JobsPipelineIndex, ppsdb.JobsPipelineKey(h.s.pipelineInfo.Pipeline))
+			watcher, err = h.s.apiServer.jobs.ReadOnly(ctx).WatchByIndex(
+				ctx, ppsdb.JobsPipelineIndex, ppsdb.JobsPipelineKey(h.s.pipelineInfo.Pipeline))
 			if err != nil {
 				return errors.Wrapf(err, "error creating watch")
 			}
@@ -318,17 +315,17 @@ func (h *handleJobsCtx) start() {
 
 		for e := range watcher.Watch() {
 			if e.Type == watch.EventError {
-				log.Error(h.ctx, "sidecar s3 gateway watch error", zap.Error(e.Err))
+				log.Error(ctx, "sidecar s3 gateway watch error", zap.Error(e.Err))
 				break // reestablish watch
 			}
 
 			var key string
 			jobInfo := &pps.JobInfo{}
 			if err := e.Unmarshal(&key, jobInfo); err != nil {
-				log.Error(h.ctx, "sidecar s3 gateway watch unmarshal error", zap.Error(err))
+				log.Error(ctx, "sidecar s3 gateway watch unmarshal error", zap.Error(err))
 			}
 
-			h.processJobEvent(context.Background(), e.Type, jobInfo.Job)
+			h.processJobEvent(ctx, e.Type, jobInfo.Job)
 		}
 		watcher.Close()
 	}
@@ -342,7 +339,7 @@ func (h *handleJobsCtx) processJobEvent(jobCtx context.Context, t watch.EventTyp
 	// 'e' is a Put event (new or updated job)
 	pachClient := h.s.pachClient.WithCtx(jobCtx)
 	// Inspect the job and make sure it's relevant, as this worker may be old
-	log.Info(h.ctx, "sidecar s3 gateway: inspecting job to begin serving inputs over s3 gateway", log.Proto("job", job))
+	log.Info(jobCtx, "sidecar s3 gateway: inspecting job to begin serving inputs over s3 gateway", log.Proto("job", job))
 
 	var jobInfo *pps.JobInfo
 	if err := backoff.RetryNotify(func() error {
@@ -353,25 +350,25 @@ func (h *handleJobsCtx) processJobEvent(jobCtx context.Context, t watch.EventTyp
 				// TODO(msteffen): I'm not sure what this means--maybe that the service
 				// was created and immediately deleted, and there's a pending deletion
 				// event? In any case, without a job that exists there's nothing to act on
-				log.Error(h.ctx, "sidecar s3 gateway: job not found", log.Proto("job", job), zap.Error(err))
+				log.Error(jobCtx, "sidecar s3 gateway: job not found", log.Proto("job", job), zap.Error(err))
 				return nil
 			}
 			return err
 		}
 		return nil
 	}, backoff.NewExponentialBackOff(), func(err error, d time.Duration) error {
-		log.Error(h.ctx, "error inspecting job; retrying", log.Proto("job", job), zap.Error(err), zap.Duration("retryAfter", d))
+		log.Error(jobCtx, "error inspecting job; retrying", log.Proto("job", job), zap.Error(err), zap.Duration("retryAfter", d))
 		return nil
 	}); err != nil {
-		log.Error(h.ctx, "permanent error inspecting job", log.Proto("job", job), zap.Error(err))
+		log.Error(jobCtx, "permanent error inspecting job", log.Proto("job", job), zap.Error(err))
 		return // leak the job; better than getting stuck?
 	}
 	if jobInfo.PipelineVersion < h.s.pipelineInfo.Version {
-		log.Info(h.ctx, "skipping job as it uses old pipeline version", log.Proto("job", job), zap.Uint64("jobVersion", jobInfo.PipelineVersion), zap.Uint64("ourVersion", h.s.pipelineInfo.Version))
+		log.Info(jobCtx, "skipping job as it uses old pipeline version", log.Proto("job", job), zap.Uint64("jobVersion", jobInfo.PipelineVersion), zap.Uint64("ourVersion", h.s.pipelineInfo.Version))
 		return
 	}
 	if jobInfo.PipelineVersion > h.s.pipelineInfo.Version {
-		log.Info(h.ctx, "skipping job as its pipeline version version is "+
+		log.Info(jobCtx, "skipping job as its pipeline version version is "+
 			"greater than this worker's pipeline version; this should "+
 			"automatically resolve when the worker is updated",
 			log.Proto("job", job), zap.Uint64("jobVersion", jobInfo.PipelineVersion), zap.Uint64("ourVersion", h.s.pipelineInfo.Version))

--- a/src/server/pps/server/transaction_defer.go
+++ b/src/server/pps/server/transaction_defer.go
@@ -143,7 +143,7 @@ func (jf *JobFinisher) Run(ctx context.Context) error {
 			}
 			jobKey := ppsdb.JobKey(client.NewJob(commitInfo.Commit.Repo.Project.GetName(), commitInfo.Commit.Repo.Name, commitInfo.Commit.Id))
 			jobInfo := &pps.JobInfo{}
-			if err := jobs.Get(jobKey, jobInfo); err != nil {
+			if err := jobs.Get(ctx, jobKey, jobInfo); err != nil {
 				// Commits in source repos will not have a job associated with them.
 				if col.IsErrNotFound(err) {
 					continue

--- a/src/server/pps/server/transaction_defer.go
+++ b/src/server/pps/server/transaction_defer.go
@@ -159,7 +159,7 @@ func (jf *JobFinisher) Run(ctx context.Context) error {
 				state = pps.JobState_JOB_FAILURE
 				reason = commitInfo.Error
 			}
-			if err := ppsutil.UpdateJobState(pipelines, jobs, jobInfo, state, reason); err != nil {
+			if err := ppsutil.UpdateJobState(ctx, pipelines, jobs, jobInfo, state, reason); err != nil {
 				return err
 			}
 		}

--- a/src/server/pps/server/transaction_defer.go
+++ b/src/server/pps/server/transaction_defer.go
@@ -81,7 +81,7 @@ func (t *JobStopper) StopJob(commit *pfs.Commit) {
 func (t *JobStopper) Run(ctx context.Context) error {
 	for _, commitset := range t.commitsets {
 		jobInfo := &pps.JobInfo{}
-		if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commitset.Id, jobInfo, col.DefaultOptions(), func(string) error {
+		if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ctx, ppsdb.JobsJobSetIndex, commitset.Id, jobInfo, col.DefaultOptions(), func(string) error {
 			return t.a.stopJob(ctx, t.txnCtx, jobInfo.Job, "output commit removed")
 		}); err != nil {
 			return errors.EnsureStack(err)
@@ -96,7 +96,7 @@ func (t *JobStopper) Run(ctx context.Context) error {
 		job := cache[pfsdb.CommitKey(commit)]
 		if job == nil {
 			jobInfo := &pps.JobInfo{}
-			if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ppsdb.JobsJobSetIndex, commit.Id, jobInfo, col.DefaultOptions(), func(string) error {
+			if err := t.a.jobs.ReadWrite(t.txnCtx.SqlTx).GetByIndex(ctx, ppsdb.JobsJobSetIndex, commit.Id, jobInfo, col.DefaultOptions(), func(string) error {
 				if _, ok := cache[pfsdb.CommitKey(jobInfo.OutputCommit)]; ok {
 					cache[pfsdb.CommitKey(jobInfo.OutputCommit)] = proto.Clone(jobInfo.Job).(*pps.Job)
 				}

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -105,7 +105,7 @@ func (d *driver) listTransaction(ctx context.Context) ([]*transaction.Transactio
 	var result []*transaction.TransactionInfo
 	transactionInfo := &transaction.TransactionInfo{}
 	transactions := d.transactions.ReadOnly(ctx)
-	if err := transactions.List(transactionInfo, col.DefaultOptions(), func(string) error {
+	if err := transactions.List(ctx, transactionInfo, col.DefaultOptions(), func(string) error {
 		result = append(result, proto.Clone(transactionInfo).(*transaction.TransactionInfo))
 		return nil
 	}); err != nil {

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -89,7 +89,7 @@ func (d *driver) startTransaction(ctx context.Context) (*transaction.Transaction
 
 func (d *driver) inspectTransaction(ctx context.Context, txn *transaction.Transaction) (*transaction.TransactionInfo, error) {
 	info := &transaction.TransactionInfo{}
-	if err := d.transactions.ReadOnly(ctx).Get(txn.Id, info); err != nil {
+	if err := d.transactions.ReadOnly(ctx).Get(ctx, txn.Id, info); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	return info, nil

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -89,7 +89,7 @@ func (d *driver) startTransaction(ctx context.Context) (*transaction.Transaction
 
 func (d *driver) inspectTransaction(ctx context.Context, txn *transaction.Transaction) (*transaction.TransactionInfo, error) {
 	info := &transaction.TransactionInfo{}
-	if err := d.transactions.ReadOnly(ctx).Get(ctx, txn.Id, info); err != nil {
+	if err := d.transactions.ReadOnly().Get(ctx, txn.Id, info); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	return info, nil
@@ -104,7 +104,7 @@ func (d *driver) deleteTransaction(ctx context.Context, txn *transaction.Transac
 func (d *driver) listTransaction(ctx context.Context) ([]*transaction.TransactionInfo, error) {
 	var result []*transaction.TransactionInfo
 	transactionInfo := &transaction.TransactionInfo{}
-	transactions := d.transactions.ReadOnly(ctx)
+	transactions := d.transactions.ReadOnly()
 	if err := transactions.List(ctx, transactionInfo, col.DefaultOptions(), func(string) error {
 		result = append(result, proto.Clone(transactionInfo).(*transaction.TransactionInfo))
 		return nil

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -97,7 +97,7 @@ func (d *driver) inspectTransaction(ctx context.Context, txn *transaction.Transa
 
 func (d *driver) deleteTransaction(ctx context.Context, txn *transaction.Transaction) error {
 	return d.txnEnv.WithWriteContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
-		return errors.EnsureStack(d.transactions.ReadWrite(txnCtx.SqlTx).Delete(txn.Id))
+		return errors.EnsureStack(d.transactions.ReadWrite(txnCtx.SqlTx).Delete(ctx, txn.Id))
 	})
 }
 
@@ -125,7 +125,7 @@ func (d *driver) deleteAll(ctx context.Context, sqlTx *pachsql.Tx, running *tran
 	transactions := d.transactions.ReadWrite(sqlTx)
 	for _, info := range txns {
 		if running == nil || info.Transaction.Id != running.Id {
-			err := transactions.Delete(info.Transaction.Id)
+			err := transactions.Delete(ctx, info.Transaction.Id)
 			if err != nil {
 				return errors.EnsureStack(err)
 			}
@@ -186,7 +186,7 @@ func (d *driver) finishTransaction(ctx context.Context, txn *transaction.Transac
 		if err != nil {
 			return info, err
 		}
-		if err := d.transactions.ReadWrite(txnCtx.SqlTx).Delete(txn.Id); err != nil {
+		if err := d.transactions.ReadWrite(txnCtx.SqlTx).Delete(ctx, txn.Id); err != nil {
 			return info, errors.EnsureStack(err)
 		}
 		// no need to update the transaction, since it's gone

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -237,7 +237,7 @@ func (d *driver) updateTransaction(
 	attempt := func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
 		storedInfo := new(transaction.TransactionInfo)
 		var err error
-		if err := d.transactions.ReadWrite(txnCtx.SqlTx).Get(txn.Id, storedInfo); err != nil {
+		if err := d.transactions.ReadWrite(txnCtx.SqlTx).Get(ctx, txn.Id, storedInfo); err != nil {
 			return errors.EnsureStack(err)
 		}
 		restarted := localInfo == nil || storedInfo.Version != localInfo.Version
@@ -258,7 +258,7 @@ func (d *driver) updateTransaction(
 	// prefetch transaction info and add data to refresher ahead of time
 	var prefetch transaction.TransactionInfo
 	if err := d.txnEnv.WithReadContext(ctx, func(ctx context.Context, txnCtx *txncontext.TransactionContext) error {
-		return errors.EnsureStack(d.transactions.ReadWrite(txnCtx.SqlTx).Get(txn.Id, &prefetch))
+		return errors.EnsureStack(d.transactions.ReadWrite(txnCtx.SqlTx).Get(ctx, txn.Id, &prefetch))
 	}); err != nil {
 		return nil, err
 	}

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -281,7 +281,7 @@ func (d *driver) updateTransaction(
 			var storedInfo transaction.TransactionInfo
 			if err = dbutil.WithTx(ctx, d.db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
 				// Update the existing transaction with the new requests/responses
-				err := d.transactions.ReadWrite(sqlTx).Update(txn.Id, &storedInfo, func() error {
+				err := d.transactions.ReadWrite(sqlTx).Update(ctx, txn.Id, &storedInfo, func() error {
 					if storedInfo.Version != localInfo.Version {
 						return &transactionModifiedError{}
 					}

--- a/src/server/transaction/server/driver.go
+++ b/src/server/transaction/server/driver.go
@@ -77,6 +77,7 @@ func (d *driver) startTransaction(ctx context.Context) (*transaction.Transaction
 
 	if err := dbutil.WithTx(ctx, d.db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
 		return errors.EnsureStack(d.transactions.ReadWrite(sqlTx).Put(
+			ctx,
 			info.Transaction.Id,
 			info,
 		))

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -506,7 +506,7 @@ func (d *driver) RunUserErrorHandlingCode(
 func (d *driver) UpdateJobState(job *pps.Job, state pps.JobState, reason string) error {
 	return d.NewSQLTx(func(ctx context.Context, sqlTx *pachsql.Tx) error {
 		jobInfo := &pps.JobInfo{}
-		if err := d.Jobs().ReadWrite(sqlTx).Get(ppsdb.JobKey(job), jobInfo); err != nil {
+		if err := d.Jobs().ReadWrite(sqlTx).Get(ctx, ppsdb.JobKey(job), jobInfo); err != nil {
 			return errors.EnsureStack(err)
 		}
 		return errors.EnsureStack(ppsutil.UpdateJobState(d.Pipelines().ReadWrite(sqlTx), d.Jobs().ReadWrite(sqlTx), jobInfo, state, reason))

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -509,7 +509,7 @@ func (d *driver) UpdateJobState(job *pps.Job, state pps.JobState, reason string)
 		if err := d.Jobs().ReadWrite(sqlTx).Get(ctx, ppsdb.JobKey(job), jobInfo); err != nil {
 			return errors.EnsureStack(err)
 		}
-		return errors.EnsureStack(ppsutil.UpdateJobState(d.Pipelines().ReadWrite(sqlTx), d.Jobs().ReadWrite(sqlTx), jobInfo, state, reason))
+		return errors.EnsureStack(ppsutil.UpdateJobState(ctx, d.Pipelines().ReadWrite(sqlTx), d.Jobs().ReadWrite(sqlTx), jobInfo, state, reason))
 	})
 }
 

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -101,7 +101,7 @@ type Driver interface {
 
 	// TODO: provide a more generic interface for modifying jobs, and
 	// some quality-of-life functions for common operations.
-	DeleteJob(*pachsql.Tx, *pps.JobInfo) error
+	DeleteJob(context.Context, *pachsql.Tx, *pps.JobInfo) error
 	UpdateJobState(*pps.Job, pps.JobState, string) error
 
 	GetJobInfo(job *pps.Job) (*pps.JobInfo, error)
@@ -524,8 +524,8 @@ func (d *driver) GetJobInfo(job *pps.Job) (*pps.JobInfo, error) {
 // DeleteJob is identical to updateJobState, except that jobInfo points to a job
 // that should be deleted rather than marked failed.  Jobs may be deleted if
 // their output commit is deleted.
-func (d *driver) DeleteJob(sqlTx *pachsql.Tx, jobInfo *pps.JobInfo) error {
-	return errors.EnsureStack(d.Jobs().ReadWrite(sqlTx).Delete(ppsdb.JobKey(jobInfo.Job)))
+func (d *driver) DeleteJob(ctx context.Context, sqlTx *pachsql.Tx, jobInfo *pps.JobInfo) error {
+	return errors.EnsureStack(d.Jobs().ReadWrite(sqlTx).Delete(ctx, ppsdb.JobKey(jobInfo.Job)))
 }
 
 func (d *driver) unlinkData(inputs []*common.Input) error {

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -312,7 +312,7 @@ func (d *driver) NewProcessingTaskDoer(groupID string, cache task.Cache) task.Do
 
 func (d *driver) ExpectedNumWorkers() (int64, error) {
 	latestPipelineInfo := &pps.PipelineInfo{}
-	if err := d.Pipelines().ReadOnly(d.ctx).Get(d.ctx, d.PipelineInfo().SpecCommit, latestPipelineInfo); err != nil {
+	if err := d.Pipelines().ReadOnly().Get(d.ctx, d.PipelineInfo().SpecCommit, latestPipelineInfo); err != nil {
 		return 0, errors.EnsureStack(err)
 	}
 	numWorkers := latestPipelineInfo.Parallelism
@@ -515,7 +515,7 @@ func (d *driver) UpdateJobState(job *pps.Job, state pps.JobState, reason string)
 
 func (d *driver) GetJobInfo(job *pps.Job) (*pps.JobInfo, error) {
 	jobInfo := &pps.JobInfo{}
-	if err := d.Jobs().ReadOnly(d.ctx).Get(d.ctx, ppsdb.JobKey(job), jobInfo); err != nil {
+	if err := d.Jobs().ReadOnly().Get(d.ctx, ppsdb.JobKey(job), jobInfo); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	return jobInfo, nil

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -312,7 +312,7 @@ func (d *driver) NewProcessingTaskDoer(groupID string, cache task.Cache) task.Do
 
 func (d *driver) ExpectedNumWorkers() (int64, error) {
 	latestPipelineInfo := &pps.PipelineInfo{}
-	if err := d.Pipelines().ReadOnly(d.ctx).Get(d.PipelineInfo().SpecCommit, latestPipelineInfo); err != nil {
+	if err := d.Pipelines().ReadOnly(d.ctx).Get(d.ctx, d.PipelineInfo().SpecCommit, latestPipelineInfo); err != nil {
 		return 0, errors.EnsureStack(err)
 	}
 	numWorkers := latestPipelineInfo.Parallelism
@@ -515,7 +515,7 @@ func (d *driver) UpdateJobState(job *pps.Job, state pps.JobState, reason string)
 
 func (d *driver) GetJobInfo(job *pps.Job) (*pps.JobInfo, error) {
 	jobInfo := &pps.JobInfo{}
-	if err := d.Jobs().ReadOnly(d.ctx).Get(ppsdb.JobKey(job), jobInfo); err != nil {
+	if err := d.Jobs().ReadOnly(d.ctx).Get(d.ctx, ppsdb.JobKey(job), jobInfo); err != nil {
 		return nil, errors.EnsureStack(err)
 	}
 	return jobInfo, nil

--- a/src/server/worker/pipeline/transform/common_test.go
+++ b/src/server/worker/pipeline/transform/common_test.go
@@ -109,8 +109,8 @@ func (td *testDriver) RunUserCode(ctx context.Context, logger logs.TaggedLogger,
 func (td *testDriver) RunUserErrorHandlingCode(ctx context.Context, logger logs.TaggedLogger, env []string) error {
 	return errors.EnsureStack(td.inner.RunUserErrorHandlingCode(ctx, logger, env))
 }
-func (td *testDriver) DeleteJob(sqlTx *pachsql.Tx, ji *pps.JobInfo) error {
-	return errors.EnsureStack(td.inner.DeleteJob(sqlTx, ji))
+func (td *testDriver) DeleteJob(ctx context.Context, sqlTx *pachsql.Tx, ji *pps.JobInfo) error {
+	return errors.EnsureStack(td.inner.DeleteJob(ctx, sqlTx, ji))
 }
 func (td *testDriver) UpdateJobState(job *pps.Job, state pps.JobState, reason string) error {
 	return errors.EnsureStack(td.inner.UpdateJobState(job, state, reason))

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -223,7 +223,7 @@ func (reg *registry) superviseJob(pj *pendingJob) error {
 					if err := pj.driver.Jobs().ReadWrite(sqlTx).Get(ctx, ppsdb.JobKey(pj.ji.Job), jobInfo); err != nil {
 						return errors.EnsureStack(err)
 					}
-					return errors.EnsureStack(pj.driver.DeleteJob(sqlTx, jobInfo))
+					return errors.EnsureStack(pj.driver.DeleteJob(ctx, sqlTx, jobInfo))
 				}); err != nil && !col.IsErrNotFound(err) {
 					return errors.EnsureStack(err)
 				}

--- a/src/server/worker/pipeline/transform/registry.go
+++ b/src/server/worker/pipeline/transform/registry.go
@@ -220,7 +220,7 @@ func (reg *registry) superviseJob(pj *pendingJob) error {
 				if err := pj.driver.NewSQLTx(func(ctx context.Context, sqlTx *pachsql.Tx) error {
 					// Delete the job if no other worker has deleted it yet
 					jobInfo := &pps.JobInfo{}
-					if err := pj.driver.Jobs().ReadWrite(sqlTx).Get(ppsdb.JobKey(pj.ji.Job), jobInfo); err != nil {
+					if err := pj.driver.Jobs().ReadWrite(sqlTx).Get(ctx, ppsdb.JobKey(pj.ji.Job), jobInfo); err != nil {
 						return errors.EnsureStack(err)
 					}
 					return errors.EnsureStack(pj.driver.DeleteJob(sqlTx, jobInfo))

--- a/src/server/worker/pipeline/transform/transform_test.go
+++ b/src/server/worker/pipeline/transform/transform_test.go
@@ -108,7 +108,7 @@ func setupPachAndWorker(ctx context.Context, t *testing.T, dbConfig pachconfig.C
 	// Put the pipeline info into the collection (which is read by the master)
 	err = testEnv.driver.NewSQLTx(func(ctx context.Context, sqlTx *pachsql.Tx) error {
 		rw := testEnv.driver.Pipelines().ReadWrite(sqlTx)
-		err := rw.Put(specCommit, pipelineInfo) // pipeline/info needs to contain spec
+		err := rw.Put(ctx, specCommit, pipelineInfo) // pipeline/info needs to contain spec
 		return errors.EnsureStack(err)
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This reworks the collections package to avoid embedded contexts.  This is especially important for ReadWrite transactions, which didn't use contexts at all.  This resulted in many operations, especially related to auth, blocking indefinitely when Postgres was broken.  That's now fixed.

This replaces PR #9947.

Part of CORE-2246