### PR TITLE
avoid deployTarget=LOCAL

### DIFF
--- a/src/internal/kindenv/pachyderm-values.json
+++ b/src/internal/kindenv/pachyderm-values.json
@@ -1,5 +1,5 @@
 {
-  "deployTarget": "LOCAL",
+  "deployTarget": "CUSTOM",
   "global": {
     "postgresql": { "postgresqlPassword": "user", "postgresqlPostgresPassword": "root" },
     "image": { "registry": "" }


### PR DESCRIPTION
The helm chart now deletes storage configuration if deployTarget=LOCAL.  So, use CUSTOM.