### PR TITLE
increase ttl in compaction test

### DIFF
--- a/src/internal/storage/fileset/compaction_test.go
+++ b/src/internal/storage/fileset/compaction_test.go
@@ -135,7 +135,7 @@ func TestCompactLevelBasedFuzz(t *testing.T) {
 func TestCompactLevelBasedRenewal(t *testing.T) {
 	ctx := pctx.TestContext(t)
 	s := newTestStorage(ctx, t)
-	ttl := 100 * time.Millisecond
+	ttl := 300 * time.Millisecond
 	gc := s.NewGC(ttl)
 	cancelCtx, cancel := pctx.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
I spent quite a lot of time reading the code here, and found that the problem is that database queries that are run by the renewer end up timing out.  The renewer gives the renewal code ttl/3 to run the database queries, and when the CPU is busy, we end up using more than 33ms ("commit" is the most frequently timing out operation; makes sense).  That is what makes this test flaky, so I increased the ttl to 300ms, giving 100ms for the database queries to run.

To test this, I ran 64 copies of the test in parallel, while also running something to burn CPU in the background (which simulates other tests running).  The CPU burning code is just:

```go
package main

import (
        "crypto/sha256"
        "runtime"
)

func main() {
        for i := 0; i < runtime.GOMAXPROCS(-1); i++ {
                go func() {
                        var data [sha256.Size]byte
                        for {
                                data = sha256.Sum256(data[:])
                        }
                }()
        }
        select {}
}
```

The thing that was most helpful in identifying the timeouts was modifying the logging library to print `time.Until(ctx.Deadline())` on contexts with deadlines and enabling SQL query logs... this makes it easy to see queries that have negative values, which are the ones that timed out.  (To be fair, the error message is "timeout: context deadline exceeded", but it is hard to figure out what's timing out because of the lack of error wrapping in any of the compaction code.)

I will probably have a follow up PR to enable sql query logging in tests with an optional environment variable, and do some performance testing on the "print the deadline as part of every log operation" to see if we want to always do that.