### PR TITLE
[PFS-242] Fix issues that prevent gocdk from being disabled.

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - "$(MODE)"
         env:
         - name: GOCDK_ENABLED
-          value: {{ .Values.pachd.storage.gocdkEnabled | default true | quote }}
+          value: {{ .Values.pachd.storage.gocdkEnabled | quote }}
         {{- if and (ne .Values.deployTarget "LOCAL") .Values.pachd.storage.gocdkEnabled  }}
         - name: STORAGE_URL
           value: {{ required "storage URL required" .Values.pachd.storage.storageURL | quote }}

--- a/etc/helm/pachyderm/templates/pachw/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachw/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - name: IS_PACHW
           value: "true"
         - name: GOCDK_ENABLED
-          value: {{ .Values.pachd.storage.gocdkEnabled | default true | quote }}
+          value: {{ .Values.pachd.storage.gocdkEnabled | quote }}
         {{- if and (ne .Values.deployTarget "LOCAL") .Values.pachd.storage.gocdkEnabled  }}
         - name: STORAGE_URL
           value: {{ required "storage URL required" .Values.pachd.storage.storageURL | quote }}


### PR DESCRIPTION
It turns out that the `default` function in Helm doesn't work as expected for `boolean` types (which you would expect it to work for at the bare minimum), but this is because of a technicality in Helm's design: https://github.com/helm/helm/issues/3308

Also, we had to add code to handle legacy storage configuration in the new StorageEnv code for the storage service.