### PR TITLE
[2.10.x] Unignore the pulumi code and add a test for it

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,2 @@
 examples/
-etc/testing/circle/workloads/pulumi/
 .envrc

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -294,11 +294,6 @@ Then use buildozer to adjust those targets:
 This will not print anything if everything is already fixed, so you can run this freely and know
 whether or not it affected anything.
 
-### pulumi
-
-Pulumi eventually depends on github.com/cloudflare/circl, which will require this workaround:
-https://github.com/bazelbuild/bazel-gazelle/issues/1421#issuecomment-1424075874
-
 ### Profiling
 
 Sometimes you want a whole-system profile of some tests running or something. Build the Go binaries

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")  # Needed for arm64 jq and rules_oci/#425.
+bazel_dep(name = "circl", version = "1.3.7")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "gazelle", version = "0.36.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "54debb95c2316325509cc042393fa99b28689ec91fdf360099c185440b662159",
+  "moduleFileHash": "69e884bfe022db0ff0945f3bfa22c1a24166842ad23d9bff0870fcfdd20132f8",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -30,7 +30,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 16,
+            "line": 17,
             "column": 23
           },
           "imports": {
@@ -46,7 +46,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 17,
+                "line": 18,
                 "column": 12
               }
             },
@@ -59,7 +59,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 18,
+                "line": 19,
                 "column": 16
               }
             }
@@ -73,7 +73,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 24,
+            "line": 25,
             "column": 24
           },
           "imports": {
@@ -212,7 +212,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 25,
+                "line": 26,
                 "column": 18
               }
             },
@@ -227,7 +227,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 26,
+                "line": 27,
                 "column": 25
               }
             },
@@ -242,7 +242,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 32,
+                "line": 33,
                 "column": 25
               }
             },
@@ -257,7 +257,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 38,
+                "line": 39,
                 "column": 25
               }
             },
@@ -277,7 +277,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 44,
+                "line": 45,
                 "column": 25
               }
             },
@@ -292,7 +292,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 55,
+                "line": 56,
                 "column": 25
               }
             },
@@ -308,7 +308,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 61,
+                "line": 62,
                 "column": 24
               }
             },
@@ -321,7 +321,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 68,
+                "line": 69,
                 "column": 25
               }
             },
@@ -336,7 +336,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 72,
+                "line": 73,
                 "column": 25
               }
             },
@@ -351,7 +351,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 78,
+                "line": 79,
                 "column": 25
               }
             },
@@ -366,7 +366,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 84,
+                "line": 85,
                 "column": 25
               }
             },
@@ -381,7 +381,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 90,
+                "line": 91,
                 "column": 25
               }
             },
@@ -396,7 +396,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 96,
+                "line": 97,
                 "column": 25
               }
             },
@@ -411,7 +411,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 102,
+                "line": 103,
                 "column": 25
               }
             },
@@ -426,7 +426,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 108,
+                "line": 109,
                 "column": 25
               }
             },
@@ -439,7 +439,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 117,
+                "line": 118,
                 "column": 25
               }
             },
@@ -455,7 +455,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 121,
+                "line": 122,
                 "column": 24
               }
             },
@@ -469,7 +469,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 134,
+                "line": 135,
                 "column": 15
               }
             },
@@ -483,7 +483,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 146,
+                "line": 147,
                 "column": 15
               }
             },
@@ -497,7 +497,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 151,
+                "line": 152,
                 "column": 15
               }
             },
@@ -511,7 +511,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 156,
+                "line": 157,
                 "column": 15
               }
             }
@@ -525,7 +525,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 289,
+            "line": 290,
             "column": 32
           },
           "imports": {
@@ -608,7 +608,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 363,
+            "line": 364,
             "column": 20
           },
           "imports": {
@@ -633,7 +633,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 366,
+                "line": 367,
                 "column": 9
               }
             },
@@ -651,7 +651,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 377,
+                "line": 378,
                 "column": 9
               }
             },
@@ -665,7 +665,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 388,
+                "line": 389,
                 "column": 9
               }
             },
@@ -679,7 +679,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 393,
+                "line": 394,
                 "column": 9
               }
             }
@@ -693,7 +693,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 401,
+            "line": 402,
             "column": 23
           },
           "imports": {},
@@ -707,7 +707,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 402,
+                "line": 403,
                 "column": 17
               }
             }
@@ -721,7 +721,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 407,
+            "line": 408,
             "column": 20
           },
           "imports": {
@@ -740,7 +740,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 408,
+                "line": 409,
                 "column": 10
               }
             },
@@ -756,7 +756,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 413,
+                "line": 414,
                 "column": 10
               }
             }
@@ -767,6 +767,7 @@
       ],
       "deps": {
         "aspect_bazel_lib": "aspect_bazel_lib@2.5.3",
+        "circl": "circl@1.3.7",
         "container_structure_test": "container_structure_test@1.16.0",
         "gazelle": "gazelle@0.36.0",
         "jsonnet_go": "jsonnet_go@0.20.0",
@@ -923,6 +924,71 @@
           "remote_patches": {
             "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/patches/go_dev_dep.patch": "sha256-KgABwDzOT+DugUHn9tHLOz05osnk2FLsS10d5zqG/M0=",
             "https://bcr.bazel.build/modules/aspect_bazel_lib/2.5.3/patches/module_dot_bazel_version.patch": "sha256-lJcPl3qi//Az5K9CO6WnDIL8gtJVzpOWhyailCiKeVY="
+          },
+          "remote_patch_strip": 1
+        }
+      }
+    },
+    "circl@1.3.7": {
+      "name": "circl",
+      "version": "1.3.7",
+      "key": "circl@1.3.7",
+      "repoName": "circl",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@gazelle//:extensions.bzl",
+          "extensionName": "go_deps",
+          "usingModule": "circl@1.3.7",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/circl/1.3.7/MODULE.bazel",
+            "line": 9,
+            "column": 24
+          },
+          "imports": {
+            "com_github_bwesterb_go_ristretto": "com_github_bwesterb_go_ristretto",
+            "org_golang_x_crypto": "org_golang_x_crypto",
+            "org_golang_x_sys": "org_golang_x_sys"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "from_file",
+              "attributeValues": {
+                "go_mod": "//:go.mod"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/circl/1.3.7/MODULE.bazel",
+                "line": 10,
+                "column": 18
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "io_bazel_rules_go": "rules_go@0.47.0",
+        "gazelle": "gazelle@0.36.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "urls": [
+            "https://proxy.golang.org/github.com/cloudflare/circl/@v/v1.3.7.zip"
+          ],
+          "integrity": "sha256-RJcJPLdUTTDp1ddBpeYsFPuJicQnHKCpoKA6c1cLO4M=",
+          "strip_prefix": "github.com/cloudflare/circl@v1.3.7",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/circl/1.3.7/patches/add_module_file.patch": "sha256-oJqWBroozXyWQ2XpjeE9Bc1ovwCE+eFjuuHZp6tke68=",
+            "https://bcr.bazel.build/modules/circl/1.3.7/patches/generate_build_files.patch": "sha256-eeaK8yZzN37I4sMke+y0VZkGs6umdC1NGFNM6oPuMpc=",
+            "https://bcr.bazel.build/modules/circl/1.3.7/patches/modify_build_files.patch": "sha256-tQe2SIRz5t9HN9n5KrWCakNujPWQUcR3AR4uakOBIy8="
           },
           "remote_patch_strip": 1
         }

--- a/etc/testing/circle/workloads/pulumi/aws/BUILD.bazel
+++ b/etc/testing/circle/workloads/pulumi/aws/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "aws_lib",
+    srcs = [
+        "app.go",
+        "cluster.go",
+        "database.go",
+        "main.go",
+        "storage.go",
+    ],
+    importpath = "github.com/pachyderm/pachyderm/v2/etc/testing/circle/workloads/pulumi/aws",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_pkg_errors//:errors",
+        "@com_github_pulumi_pulumi_aws_sdk_v5//go/aws/eks",
+        "@com_github_pulumi_pulumi_aws_sdk_v5//go/aws/iam",
+        "@com_github_pulumi_pulumi_aws_sdk_v5//go/aws/rds",
+        "@com_github_pulumi_pulumi_aws_sdk_v5//go/aws/s3",
+        "@com_github_pulumi_pulumi_awsx_sdk//go/awsx/ec2",
+        "@com_github_pulumi_pulumi_eks_sdk//go/eks",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v3//go/kubernetes",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v3//go/kubernetes/core/v1:core",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v3//go/kubernetes/helm/v3:helm",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v3//go/kubernetes/meta/v1:meta",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v3//go/kubernetes/storage/v1:storage",
+        "@com_github_pulumi_pulumi_postgresql_sdk_v3//go/postgresql",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi/config",
+    ],
+)
+
+go_binary(
+    name = "aws",
+    embed = [":aws_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "aws_test",
+    srcs = ["main_test.go"],
+    data = glob(["*.md"]) + [
+        "//etc/helm/pachyderm",
+        "//tools/helm",
+    ],
+    embed = [":aws_lib"],
+    deps = [
+        "@com_github_gruntwork_io_terratest//modules/helm",
+        "@com_github_gruntwork_io_terratest//modules/logger",
+        "@com_github_pkg_errors//:errors",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v3//go/kubernetes",
+        "@com_github_pulumi_pulumi_sdk_v3//go/common/resource",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/runfiles:go_default_library",
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/etc/testing/circle/workloads/pulumi/aws/app.go
+++ b/etc/testing/circle/workloads/pulumi/aws/app.go
@@ -19,51 +19,51 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
-func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *iam.Role, rdsInstance *rds.Instance, bucket *s3.Bucket) error {
+func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *iam.Role, rdsInstance *rds.Instance, bucket *s3.Bucket) (pulumi.Map, error) {
 	cfg := config.New(ctx, "")
 	enterpriseKey := os.Getenv("ENT_ACT_CODE")
 	if enterpriseKey == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var ENT_ACT_CODE"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var ENT_ACT_CODE"))
 	}
 	awsSAkey := os.Getenv("AWS_ACCESS_KEY_ID")
 	awsSAsecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	metricCreds := os.Getenv("BIGQUERY_AUTH_JSON")
 	if metricCreds == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var BIGQUERY_AUTH_JSON"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var BIGQUERY_AUTH_JSON"))
 	}
 	jsonKey := []byte(metricCreds)
 	encoded := base64.StdEncoding.EncodeToString(jsonKey)
 	wpCloudFlareLoadTestAWSKeyID := os.Getenv("CF_WP_LOADTEST_AWSKEYID")
 	if wpCloudFlareLoadTestAWSKeyID == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var cloudflare loadtest aws access key id."))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var cloudflare loadtest aws access key id."))
 	}
 	wpCloudFlareLoadTestEndpoint := os.Getenv("CF_WP_LOADTEST_ENDPOINT_URL")
 	if wpCloudFlareLoadTestEndpoint == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var cloudflare loadtest endpoint."))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var cloudflare loadtest endpoint."))
 	}
 	wpCloudFlareLoadTestSecretAccessKey := os.Getenv("CF_WP_LOADTEST_AWSACCESSKEY")
 	if wpCloudFlareLoadTestSecretAccessKey == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var cloudflare loadtest aws access key."))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var cloudflare loadtest aws access key."))
 	}
 	issuerURI := os.Getenv("ISSUER_URI")
 	if issuerURI == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var ISSUER_URI"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var ISSUER_URI"))
 	}
 	clientID := os.Getenv("CLIENT_ID")
 	if clientID == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var CLIENT_ID"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var CLIENT_ID"))
 	}
 	clientSecret := os.Getenv("CLIENT_SECRET")
 	if clientSecret == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var CLIENT_SECRET"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var CLIENT_SECRET"))
 	}
 	tlsCrt := os.Getenv("TLS_CRT")
 	if tlsCrt == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var TLS_CRT"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var TLS_CRT"))
 	}
 	tlsKey := os.Getenv("TLS_KEY")
 	if tlsKey == "" {
-		return errors.WithStack(fmt.Errorf("need to supply env var TLS_KEY"))
+		return nil, errors.WithStack(fmt.Errorf("need to supply env var TLS_KEY"))
 	}
 	pachdImageTag, err := cfg.Try("pachdVersion")
 	if err != nil {
@@ -101,7 +101,7 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 		pulumi.Provider(k8sProvider))
 
 	if err != nil {
-		return errors.WithStack(fmt.Errorf("error occurred while attempting to create test-ns: %w", err))
+		return nil, errors.WithStack(fmt.Errorf("error occurred while attempting to create test-ns: %w", err))
 	}
 	_, err = secret.NewSecret(ctx, "metrics-secret", &secret.SecretArgs{
 		Metadata: &metav1.ObjectMetaArgs{
@@ -114,7 +114,7 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 		Type: pulumi.String("Opaque"),
 	}, pulumi.Provider(k8sProvider))
 	if err != nil {
-		return errors.WithStack(fmt.Errorf("error creating metric secret: %w", err))
+		return nil, errors.WithStack(fmt.Errorf("error creating metric secret: %w", err))
 	}
 	_, err = secret.NewSecret(ctx, " transfer-config", &secret.SecretArgs{
 		Metadata: &metav1.ObjectMetaArgs{
@@ -129,7 +129,7 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 		Type: pulumi.String("Opaque"),
 	}, pulumi.Provider(k8sProvider))
 	if err != nil {
-		return errors.WithStack(fmt.Errorf("error creating metric secret: %w", err))
+		return nil, errors.WithStack(fmt.Errorf("error creating metric secret: %w", err))
 	}
 	_, err = secret.NewSecret(ctx, "workspace-wildcard", &secret.SecretArgs{
 		Metadata: &metav1.ObjectMetaArgs{
@@ -143,7 +143,7 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 		Type: pulumi.String("kubernetes.io/tls"),
 	}, pulumi.Provider(k8sProvider))
 	if err != nil {
-		return errors.WithStack(fmt.Errorf("error creating tls secret: %w", err))
+		return nil, errors.WithStack(fmt.Errorf("error creating tls secret: %w", err))
 	}
 	redirectURI := fmt.Sprintf("https://%s.workspace.pachyderm.com/dex/callback", strings.ToLower(ctx.Stack()))
 	host := fmt.Sprintf("%s.workspace.pachyderm.com", strings.ToLower(ctx.Stack()))
@@ -190,13 +190,12 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 				"tag": pulumi.String(pachdImageTag),
 			},
 			"storage": pulumi.Map{
-				"backend": pulumi.String("AMAZON"),
+				"backend":      pulumi.String("AMAZON"),
+				"gocdkEnabled": pulumi.Bool(true),
+				"storageURL":   pulumi.Sprintf("s3://%s?region=us-west-2", bucket.Bucket),
 				"amazon": pulumi.Map{
-					"gocdkEnabled": pulumi.Bool(true),
-					"storageURL":   pulumi.Sprintf("s3://%s", bucket.Bucket),
-					"region":       pulumi.String("us-west-2"),
-					"id":           pulumi.String(awsSAkey),
-					"secret":       pulumi.String(awsSAsecret),
+					"id":     pulumi.String(awsSAkey),
+					"secret": pulumi.String(awsSAsecret),
 				},
 			},
 			"externalService": pulumi.Map{
@@ -258,8 +257,8 @@ func DeployApp(ctx *pulumi.Context, k8sProvider *kubernetes.Provider, saRole *ia
 	}
 
 	if err != nil {
-		return errors.WithStack(fmt.Errorf("failed to successfully helm install: %w", err))
+		return nil, errors.WithStack(fmt.Errorf("failed to successfully helm install: %w", err))
 	}
 
-	return nil
+	return values, nil
 }

--- a/etc/testing/circle/workloads/pulumi/aws/main.go
+++ b/etc/testing/circle/workloads/pulumi/aws/main.go
@@ -26,7 +26,7 @@ func DeployResources() pulumi.RunFunc {
 		if err != nil {
 			return err
 		}
-		err = DeployApp(ctx, k8sProvider, saRole, rdsInstance, bucket)
+		_, err = DeployApp(ctx, k8sProvider, saRole, rdsInstance, bucket)
 		if err != nil {
 			return err
 		}

--- a/etc/testing/circle/workloads/pulumi/aws/main_test.go
+++ b/etc/testing/circle/workloads/pulumi/aws/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/require"
+)
+
+type mocks struct{}
+
+func (mocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	outputs := args.Inputs.Mappable()
+	switch args.TypeToken {
+	case "aws:rds/instance:Instance":
+		outputs["address"] = "postgres"
+	}
+	return args.Name + "_id", resource.NewPropertyMapFromMap(outputs), nil
+}
+
+func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+func TestDeployApp(t *testing.T) {
+	chart, err := runfiles.Rlocation("_main/etc/helm/pachyderm")
+	if err != nil {
+		t.Logf("error resolving chart: %v, using etc/helm/pachyderm as the chart location", err)
+		chart = "etc/helm/pachyderm"
+	}
+	if helmPath, ok := bazel.FindBinary("//tools/helm", "_helm"); ok {
+		tmpdir := t.TempDir()
+		if err := os.Symlink(helmPath, filepath.Join(tmpdir, "helm")); err != nil {
+			t.Fatalf("symlink helm into $PATH: %v", err)
+		}
+		os.Setenv("PATH", fmt.Sprintf("%s:%s", tmpdir, os.Getenv("PATH")))
+	}
+
+	for _, stack := range []string{"dev1", "LOAD1", "LOAD2", "LOAD3", "LOAD4", "qa1", "qa2", "qa3", "qa4"} {
+		t.Run(stack, func(t *testing.T) {
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				os.Setenv("BIGQUERY_AUTH_JSON", "{}")
+				os.Setenv("CF_WP_LOADTEST_AWSKEYID", "x")
+				os.Setenv("CF_WP_LOADTEST_AWSACCESSKEY", "x")
+				os.Setenv("CF_WP_LOADTEST_ENDPOINT_URL", "s3://example.com")
+				os.Setenv("ISSUER_URI", "https://example.com")
+				os.Setenv("CLIENT_ID", "x")
+				os.Setenv("CLIENT_SECRET", "x")
+				os.Setenv("TLS_CRT", "x")
+				os.Setenv("TLS_KEY", "x")
+
+				rdsInstance, err := DeployRDS(ctx)
+				if err != nil {
+					return errors.Wrap(err, "XXX")
+				}
+
+				bucket, err := DeployBucket(ctx)
+				if err != nil {
+					return errors.Wrap(err, "DeployBucket")
+				}
+
+				renderProvider, err := kubernetes.NewProvider(ctx, "k8s-yaml-renderer", &kubernetes.ProviderArgs{
+					RenderYamlToDirectory: pulumi.String(t.TempDir()),
+				})
+				if err != nil {
+					return errors.Wrap(err, "NewProvider")
+				}
+
+				valuesOutput, err := DeployApp(ctx, renderProvider, nil, rdsInstance, bucket)
+				if err != nil {
+					return errors.Wrap(err, "DeployApp")
+				}
+
+				valuesCh := make(chan map[string]any)
+				valuesOutput.ToMapOutput().ApplyT(func(x map[string]any) error {
+					valuesCh <- x
+					close(valuesCh)
+					return nil
+				})
+				values := <-valuesCh
+				js, err := json.Marshal(values)
+				if err != nil {
+					return errors.Wrap(err, "marshal helm values")
+				}
+				valuesFile := filepath.Join(t.TempDir(), "values.json")
+				if err := os.WriteFile(valuesFile, js, 0o644); err != nil {
+					return errors.Wrap(err, "write helm values")
+				}
+
+				helm.RenderTemplate(t, &helm.Options{
+					ValuesFiles: []string{valuesFile},
+					Logger:      logger.Discard,
+				}, chart, "pachyderm", nil)
+
+				return nil
+			}, func(ri *pulumi.RunInfo) {
+				pulumi.WithMocks("project", stack, mocks{})(ri)
+				ri.Config = map[string]string{
+					"project:rdsPGDBPassword": "x",
+				}
+			})
+			require.NoError(t, err, "DeployApp should run")
+		})
+	}
+}


### PR DESCRIPTION
There was an issue with a dependency of Pulumi that prevented us from building with Bazel. That is fixed, or at least worked around cleanly: https://github.com/bazelbuild/rules_go/issues/3799#issuecomment-1880035642

With the workarounds, this now builds OK, so I've unignored it and added a BUILD file.

There was also an issue where it generates invalid helm values. I fixed that bug and added a test.

Backports #10017 