### PR TITLE
enable sql statement linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,9 @@ linters:
         - exhaustive
         - goprintffuncname
         - depguard
+        - sqlclosecheck
+        - rowserrcheck
+        - execinquery
         # - bodyclose CORE-1317
         # - gocritic CORE-1318
         # - gosec CORE-1319


### PR DESCRIPTION
```
src/internal/clusterstate/v2.8.0/pfsdb_28x/branches.go:288:12: Use ExecContext instead of QueryRowContext to execute `INSERT` query (execinquery)
        if err := tx.QueryRowContext(ctx,
                  ^
src/internal/clusterstate/v2.8.0/pfsdb_28x/repos.go:180:12: Use ExecContext instead of QueryRowContext to execute `INSERT` query (execinquery)
        if err := tx.QueryRowContext(ctx,
                  ^
src/internal/pfsdb/branches.go:290:12: Use ExecContext instead of QueryRowContext to execute `INSERT` query (execinquery)
        if err := tx.QueryRowContext(ctx,
                  ^
src/testing/cmds/go-test-results/cleanup-cron/main.go:37:17: Use Exec instead of Query to execute `DELETE` query (execinquery)
        result, err := db.Query(`
                       ^
src/internal/clusterstate/v2.7.0/coredb.go:89:39: Rows/Stmt/NamedStmt was not closed (sqlclosecheck)
        insertStmt, err := tx.PreparexContext(ctx, "INSERT INTO core.projects(name, description, created_at, updated_at) VALUES($1, $2, $3, $4)")
                                             ^
src/internal/clusterstate/v2.8.0/pfsdb_28x/commit_provenance.go:46:24: Rows/Stmt/NamedStmt was not closed (sqlclosecheck)
        rows, err := tx.Queryx(q, id)
                              ^
src/internal/clusterstate/v2.8.0/pfsdb_28x/commit_provenance.go:108:24: Rows/Stmt/NamedStmt was not closed (sqlclosecheck)
        rows, err := tx.Queryx(q, id)
```