### PR TITLE
[Backport] Fixes for pipeline extension request handling (#10031)

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -483,6 +483,11 @@ class PPSCreateHandler(BaseHandler):
             response = await self.pps_client.create(path, body)
             get_logger().debug(f"CreatePipeline: {response}")
             await self.finish(response)
+        except ValueError as e:
+            get_logger().error(f"bad pipeline spec: {e}")
+            raise tornado.web.HTTPError(
+                status_code=400, reason=f"Bad pipeline spec: {e}"
+            )
         except Exception as e:
             if isinstance(e, tornado.web.HTTPError):
                 # Common case: only way to print the "reason" field of HTTPError

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -68,7 +68,7 @@ class PpsConfig:
             raise ValueError("field image not set")
 
         requirements = config.get("requirements")
-        if requirements is not None:
+        if requirements:
             requirements = notebook_path.parent.joinpath(requirements).resolve()
 
         external_files = []
@@ -81,6 +81,8 @@ class PpsConfig:
         if input_spec_str is None:
             raise ValueError("field input_spec not set")
         input_spec_dict = yaml.safe_load(input_spec_str)
+        if input_spec_dict is None:
+            raise ValueError("invalid input spec")
         input_spec = pps.Input().from_dict(input_spec_dict)
 
         port = config.get("port")
@@ -281,7 +283,7 @@ class PPSClient:
 
         if config.requirements and not os.path.exists(config.requirements):
             raise HTTPError(status_code=400, reason="requirements file does not exist")
-        
+
         for external_file in config.external_files:
             if not os.path.exists(external_file):
                 raise HTTPError(status_code=400, reason=f'external file {os.path.basename(external_file)} could not be found in the directory of the Jupyter notebook')


### PR DESCRIPTION
Fixes the way that we handle bad input specs and empty requirements files. Before, an empty requirements file would cause the pipeline creation to fail because it was defaulting to the home directory of the container, since the requirements file was an empty string and not `None`. Now, it correctly defaults to no requirements file. Bad input specs before would throw 500 responses, which is incorrect given it is due to user error.

[INT-1261](https://pachyderm.atlassian.net/browse/INT-1266)

[INT-1261]:
https://pachyderm.atlassian.net/browse/INT-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---------

[INT-1261]: https://pachyderm.atlassian.net/browse/INT-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-1261]: https://pachyderm.atlassian.net/browse/INT-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ