### PR TITLE
[Jupyter] `ListDatum` -> `CreateDatum` used in Test View

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
@@ -427,11 +427,11 @@ class DatumManager(FileContentsManager):
     class DatumState(typing.TypedDict):
         id: str
         idx: int
-        num_datums: int
+        num_datums_received: int
         all_datums_received: bool
 
     class CurrentDatum(typing.TypedDict):
-        num_datums: int
+        num_datums_received: int
         input: str
         idx: int
         all_datums_received: bool
@@ -564,13 +564,13 @@ class DatumManager(FileContentsManager):
         return self.DatumState(
             id=self._datum_list[self._datum_index].datum.id,
             idx=self._datum_index,
-            num_datums=len(self._datum_list),
+            num_datums_received=len(self._datum_list),
             all_datums_received=self._all_datums_received,
         )
 
     def current_datum(self) -> dict:
         return self.CurrentDatum(
-            num_datums=len(self._datum_list),
+            num_datums_received=len(self._datum_list),
             input=self._input.to_json() if self._input else None,
             idx=self._datum_index,
             all_datums_received=self._all_datums_received,

--- a/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
@@ -514,6 +514,7 @@ class DatumManager(FileContentsManager):
             self._datum_batch_generator = self._client.pps.generate_datums(
                 input_spec=input, batch_size=DatumManager.DATUM_BATCH_SIZE
             )
+            self._datum_list = list()
             self._get_datum_batch()
             self._datum_index = 0
             self._mount_time = datetime.datetime.now()

--- a/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
@@ -486,8 +486,7 @@ class DatumManager(FileContentsManager):
                     raise ValueError(f"Input contains non-existent branch {branch}")
                 raise err
 
-            commit = pfs.Commit(id=commit_id)
-            commit_uri = commit.as_uri()
+            commit_uri = f"{repo.as_uri()}@{commit_id}"
             if commit_uri in self._repo_names:
                 raise ValueError(
                     "Loading multiple instances of the same commit is currently not supported in the extension"
@@ -634,7 +633,8 @@ class DatumManager(FileContentsManager):
             raise e
 
     def _get_relative_path(self, fileinfo: pfs.FileInfo) -> Path:
-        commit_uri = fileinfo.file.commit.as_uri()
+        commit = fileinfo.file.commit
+        commit_uri = f"{commit.repo.as_uri()}@{commit.id}"
         name = self._repo_names[commit_uri]
         return Path(name, fileinfo.file.path.strip("/"))
 

--- a/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/test_integrations.py
@@ -119,7 +119,7 @@ async def test_view_datum_pagination(pachyderm_resources, http_client: AsyncClie
     assert r.status_code == 200, r.text
     r = r.json()
     assert r["idx"] == 0
-    assert r["num_datums"] == 1
+    assert r["num_datums_received"] == 1
     assert r["all_datums_received"] == 1
 
     # Assert default parameters return all
@@ -228,7 +228,7 @@ async def test_mount_datums(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.put("/datums/_mount", json=input_spec)
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 0
-    assert r.json()["num_datums"] == 4
+    assert r.json()["num_datums_received"] == 4
     assert r.json()["all_datums_received"] is True
     datum0_id = r.json()["id"]
 
@@ -251,7 +251,7 @@ async def test_mount_datums(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.put("/datums/_next")
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 1
-    assert r.json()["num_datums"] == 4
+    assert r.json()["num_datums_received"] == 4
     assert r.json()["id"] != datum0_id
     assert r.json()["all_datums_received"] is True
 
@@ -270,7 +270,7 @@ async def test_mount_datums(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.put("/datums/_prev")
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 0
-    assert r.json()["num_datums"] == 4
+    assert r.json()["num_datums_received"] == 4
     assert r.json()["id"] == datum0_id
     assert r.json()["all_datums_received"] is True
 
@@ -289,7 +289,7 @@ async def test_mount_datums(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.get("/datums")
     assert r.status_code == 200, r.text
     assert json.loads(r.json()["input"]) == input_spec["input"]
-    assert r.json()["num_datums"] == 4
+    assert r.json()["num_datums_received"] == 4
     assert r.json()["idx"] == 0
     assert r.json()["all_datums_received"] is True
 
@@ -308,7 +308,7 @@ async def test_mount_datums(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.put("/datums/_mount", json=input_spec)
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 0
-    assert r.json()["num_datums"] == 1
+    assert r.json()["num_datums_received"] == 1
     assert r.json()["all_datums_received"] is True
     datum0_id = r.json()["id"]
 
@@ -346,7 +346,7 @@ async def test_mount_datums_multiple_batches(http_client: AsyncClient):
     r = await http_client.put("/datums/_mount", json=input_spec)
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 0
-    assert r.json()["num_datums"] == batch_size
+    assert r.json()["num_datums_received"] == batch_size
     assert r.json()["all_datums_received"] is False
 
     # Cycle to the last datum in the current batch
@@ -354,7 +354,7 @@ async def test_mount_datums_multiple_batches(http_client: AsyncClient):
         r = await http_client.put("/datums/_next")
         assert r.status_code == 200, r.text
         assert r.json()["idx"] == i
-        assert r.json()["num_datums"] == batch_size
+        assert r.json()["num_datums_received"] == batch_size
         assert r.json()["all_datums_received"] is False
 
     # Grab the next (final) batch of datums
@@ -362,7 +362,7 @@ async def test_mount_datums_multiple_batches(http_client: AsyncClient):
         r = await http_client.put("/datums/_next")
         assert r.status_code == 200, r.text
         assert r.json()["idx"] == i
-        assert r.json()["num_datums"] == total_datums
+        assert r.json()["num_datums_received"] == total_datums
         assert r.json()["all_datums_received"] is True
 
     # Verify no more datums and cycler wraps to beginning
@@ -404,7 +404,7 @@ async def test_download_datum(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.put("/datums/_mount", json=input_spec)
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 0
-    assert r.json()["num_datums"] == 4
+    assert r.json()["num_datums_received"] == 4
     assert r.json()["all_datums_received"] is True
 
     r = await http_client.put("/datums/_download")
@@ -419,7 +419,7 @@ async def test_download_datum(pachyderm_resources, http_client: AsyncClient):
     r = await http_client.put("/datums/_next")
     assert r.status_code == 200, r.text
     assert r.json()["idx"] == 1
-    assert r.json()["num_datums"] == 4
+    assert r.json()["num_datums_received"] == 4
     assert r.json()["all_datums_received"] is True
 
     r = await http_client.put("/datums/_download")

--- a/jupyter-extension/requirements.txt
+++ b/jupyter-extension/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml>=6.0,<7.0
 jupyter_server>=2.7.0,<2.12
-pachyderm_sdk>=2.9.0,<2.10.0
+pachyderm_sdk>=2.10.1,<2.11.0
 
 
 # security patches

--- a/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/Datum.tsx
@@ -144,14 +144,14 @@ const Datum: React.FC<DatumProps> = ({
               {'(' +
                 (currDatum.idx + 1) +
                 '/' +
-                currDatum.num_datums +
+                currDatum.num_datums_received +
                 (currDatum.all_datums_received ? '' : '+') +
                 ')'}
               <button
                 className="pachyderm-button-link"
                 data-testid="Datum__cyclerRight"
                 disabled={
-                  currDatum.idx >= currDatum.num_datums - 1 &&
+                  currDatum.idx >= currDatum.num_datums_received - 1 &&
                   currDatum.all_datums_received
                 }
                 onClick={callNextDatum}

--- a/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/__tests__/Datum.test.tsx
@@ -31,7 +31,7 @@ describe('datum screen', () => {
         mockedRequestAPI({
           id: 'asdfaew34ri92jafiolwe',
           idx: 0,
-          num_datums: 6,
+          num_datums_received: 6,
           all_datums_received: true,
         }),
       );
@@ -78,7 +78,7 @@ describe('datum screen', () => {
         mockedRequestAPI({
           id: 'asdfaew34ri92jafiolwe',
           idx: 0,
-          num_datums: 6,
+          num_datums_received: 6,
           all_datums_received: false,
         }),
       );
@@ -103,7 +103,7 @@ describe('datum screen', () => {
         mockedRequestAPI({
           id: 'ilwe9nme9902ja039jf20snv',
           idx: 1,
-          num_datums: 6,
+          num_datums_received: 6,
           all_datums_received: false,
         }),
       );

--- a/jupyter-extension/src/plugins/mount/components/Datum/hooks/useDatum.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Datum/hooks/useDatum.tsx
@@ -40,7 +40,7 @@ export const useDatum = (
   const [currDatum, setCurrDatum] = useState<MountDatumResponse>({
     id: '',
     idx: -1,
-    num_datums: 0,
+    num_datums_received: 0,
     all_datums_received: false,
   });
   const [inputSpec, setInputSpec] = useState('');
@@ -58,7 +58,7 @@ export const useDatum = (
       setCurrDatum({
         id: '',
         idx: currentDatumInfo.idx,
-        num_datums: currentDatumInfo.num_datums,
+        num_datums_received: currentDatumInfo.num_datums_received,
         all_datums_received: currentDatumInfo.all_datums_received,
       });
       setInputSpec(inputSpecObjToText(currentDatumInfo.input));
@@ -170,7 +170,7 @@ export const useDatum = (
         setCurrDatum({
           id: currDatum.id,
           idx: currDatum.idx,
-          num_datums: currDatum.num_datums,
+          num_datums_received: currDatum.num_datums_received,
           all_datums_received: true,
         });
         setErrorMessage('Reached final datum');

--- a/jupyter-extension/src/plugins/mount/types.ts
+++ b/jupyter-extension/src/plugins/mount/types.ts
@@ -34,7 +34,7 @@ export type CrossInputSpec = {
 };
 
 export type CurrentDatumResponse = {
-  num_datums: number;
+  num_datums_received: number;
   input: {[key: string]: any};
   idx: number;
   all_datums_received: boolean;
@@ -47,7 +47,7 @@ export type DownloadPath = {
 export type MountDatumResponse = {
   id: string;
   idx: number;
-  num_datums: number;
+  num_datums_received: number;
   all_datums_received: boolean;
 };
 


### PR DESCRIPTION
Switch the Test View logic for getting datums from a `ListDatum` call to a `CreateDatum` call to improve performance when many datums exist.

No changes are needed to the FE. The FE logic already includes proper handling for when the total number of datums is unknown. As long as the `all_datums_received` field in the server response is correct, the datum counter (i.e. 1/50, 1/100+) displays proper information.

Jira: [INT-1253]

[INT-1253]: https://pachyderm.atlassian.net/browse/INT-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ