### PR TITLE
avoid logging span start with duplicate fields

### DIFF
--- a/src/internal/log/span.go
+++ b/src/internal/log/span.go
@@ -130,8 +130,7 @@ func SpanContextL(rctx context.Context, event string, level Level, fields ...Fie
 func spanContextL(rctx context.Context, event string, level Level, startSkip, endSkip int, fields ...Field) (context.Context, EndSpanFunc) {
 	l := extractLogger(rctx).Named(event).With(fields...)
 	if e := l.WithOptions(zap.AddCallerSkip(startSkip)).Check(level.coreLevel(), event+": "+string(spanStarting)); e != nil {
-		fields = append(fields, ContextInfo(rctx))
-		e.Write(fields...)
+		e.Write(ContextInfo(rctx))
 	}
 	ctx := withLogger(rctx, l)
 	return ctx, makeSpanEndFunc(ctx, l.WithOptions(zap.AddCallerSkip(endSkip)), event, level, time.Now())

--- a/src/internal/log/span_test.go
+++ b/src/internal/log/span_test.go
@@ -359,7 +359,7 @@ func TestDeadlineSpan(t *testing.T) {
 	ctx, c := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer c()
 	ctx = TestParallel(ctx, t)
-	sctx, done := SpanContext(ctx, "Test")
+	sctx, done := SpanContext(ctx, "Test", zap.String("string", "string"))
 	Info(sctx, "before")
 	<-ctx.Done()
 	Info(sctx, "after")


### PR DESCRIPTION
Prior to this change, the span start logged all fields twice.  The fields make their way into the CheckedEntry that we Write because they were added on the line above.  We can't detect this, because our test capturing logger uses the Go JSON parser which doesn't have a way to detect duplicate fields, so we simply never noticed :(

TestDeadlineSpan is one of those tests that you have to manually review the output of, but I made it so that this mistake is visible and fixed it.

The original bug didn't make into 2.10.x, so there is no hurry on the review.