### PR TITLE
[Jupyter] Bugfix: notebook path relative to server_root_dir

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -4,6 +4,11 @@ from distutils.util import strtobool
 
 from pachyderm_sdk.constants import CONFIG_PATH_LOCAL
 
+# JUPYTER_SERVER_ROOT is the root path from which all data and notebook files
+#   are relative to. This may be different from the CWD which, if different,
+#   is specified under JUPYTER_RUNTIME_DIR.
+JUPYTER_SERVER_ROOT = Path(os.environ["JUPYTER_SERVER_ROOT"])
+
 PACH_CONFIG = Path(
     os.path.expanduser(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
 ).resolve()

--- a/jupyter-extension/jupyterlab_pachyderm/env.py
+++ b/jupyter-extension/jupyterlab_pachyderm/env.py
@@ -4,11 +4,6 @@ from distutils.util import strtobool
 
 from pachyderm_sdk.constants import CONFIG_PATH_LOCAL
 
-# JUPYTER_SERVER_ROOT is the root path from which all data and notebook files
-#   are relative to. This may be different from the CWD which, if different,
-#   is specified under JUPYTER_RUNTIME_DIR.
-JUPYTER_SERVER_ROOT = Path(os.environ["JUPYTER_SERVER_ROOT"])
-
 PACH_CONFIG = Path(
     os.path.expanduser(os.environ.get("PACH_CONFIG", CONFIG_PATH_LOCAL))
 ).resolve()

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -624,9 +624,12 @@ def setup_handlers(
                 "Could not find config file -- no pachyderm client instantiated"
             )
 
+    # server_root_dir is the root path from which all data and notebook files
+    #   are relative. This may be different from the CWD.
+    root_dir = Path(web_app.settings.get("server_root_dir", os.getcwd())).resolve()
     if client:
         web_app.settings["pachyderm_client"] = client
-        web_app.settings["pachyderm_pps_client"] = PPSClient(client=client)
+        web_app.settings["pachyderm_pps_client"] = PPSClient(client=client, root_dir=root_dir)
         web_app.settings["pfs_contents_manager"] = PFSManager(client=client)
         web_app.settings["datum_contents_manager"] = DatumManager(client=client)
 

--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -72,10 +72,14 @@ class BaseHandler(APIHandler):
 
     @client.setter
     def client(self, new_client: Client) -> None:
+        # server_root_dir is the root path from which all data and notebook files
+        #   are relative. This may be different from the CWD.
+        root_dir = Path(self.settings.get("server_root_dir", os.getcwd())).resolve()
+
         self.settings["pachyderm_client"] = new_client
         self.settings["pfs_contents_manager"] = PFSManager(client=new_client)
         self.settings["datum_contents_manager"] = DatumManager(client=new_client)
-        self.settings["pachyderm_pps_client"] = PPSClient(client=new_client)
+        self.settings["pachyderm_pps_client"] = PPSClient(client=new_client, root_dir=root_dir)
 
     @property
     def config_file(self) -> Path:

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -13,6 +13,7 @@ from pachyderm_sdk.api import pfs, pps
 from nbconvert import PythonExporter
 from tornado.web import HTTPError
 
+from .env import JUPYTER_SERVER_ROOT
 from .log import get_logger
 
 METADATA_KEY = "pachyderm_pps"
@@ -239,7 +240,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path}")
 
-        path = Path(path.lstrip("/"))
+        path = Path(path.lstrip("/")).relative_to(JUPYTER_SERVER_ROOT)
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -243,7 +243,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path}")
 
-        path = Path(path.lstrip("/")).absolute().relative_to(self.root_dir)
+        path = self.root_dir.joinpath(path.lstrip("/")).resolve()
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 
@@ -263,7 +263,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path} | body: {body}")
 
-        path = Path(path.lstrip("/")).absolute().relative_to(self.root_dir)
+        path = self.root_dir.joinpath(path.lstrip("/")).resolve()
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -243,7 +243,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path}")
 
-        path = Path(path.lstrip("/")).relative_to(self.root_dir)
+        path = Path(path.lstrip("/")).absolute().relative_to(self.root_dir)
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 
@@ -263,7 +263,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path} | body: {body}")
 
-        path = Path(path.lstrip("/")).relative_to(self.root_dir)
+        path = Path(path.lstrip("/")).absolute().relative_to(self.root_dir)
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 


### PR DESCRIPTION
Jupyterlab users can configure the server_root_dir to be different than the CWD of the backend process