### PR TITLE
[Jupyter] (Backport) Bugfix: notebook path relative to server_root_dir (#10073)

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/handlers.py
+++ b/jupyter-extension/jupyterlab_pachyderm/handlers.py
@@ -72,10 +72,14 @@ class BaseHandler(APIHandler):
 
     @client.setter
     def client(self, new_client: Client) -> None:
+        # server_root_dir is the root path from which all data and notebook files
+        #   are relative. This may be different from the CWD.
+        root_dir = Path(self.settings.get("server_root_dir", os.getcwd())).resolve()
+
         self.settings["pachyderm_client"] = new_client
         self.settings["pfs_contents_manager"] = PFSManager(client=new_client)
         self.settings["datum_contents_manager"] = DatumManager(client=new_client)
-        self.settings["pachyderm_pps_client"] = PPSClient(client=new_client)
+        self.settings["pachyderm_pps_client"] = PPSClient(client=new_client, root_dir=root_dir)
 
     @property
     def config_file(self) -> Path:
@@ -624,9 +628,12 @@ def setup_handlers(
                 "Could not find config file -- no pachyderm client instantiated"
             )
 
+    # server_root_dir is the root path from which all data and notebook files
+    #   are relative. This may be different from the CWD.
+    root_dir = Path(web_app.settings.get("server_root_dir", os.getcwd())).resolve()
     if client:
         web_app.settings["pachyderm_client"] = client
-        web_app.settings["pachyderm_pps_client"] = PPSClient(client=client)
+        web_app.settings["pachyderm_pps_client"] = PPSClient(client=client, root_dir=root_dir)
         web_app.settings["pfs_contents_manager"] = PFSManager(client=client)
         web_app.settings["datum_contents_manager"] = DatumManager(client=client)
 

--- a/jupyter-extension/jupyterlab_pachyderm/pps_client.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pps_client.py
@@ -226,12 +226,16 @@ def upload_environment(
 class PPSClient:
     """Client interface for the PPS extension backend."""
 
-    def __init__(self, client: Client):
+    def __init__(self, client: Client, root_dir: Path):
+        """
+        client: The pachyderm client.
+        root_dir: The root path from which all data and notebook files are relative.
+        """
         self.nbconvert = PythonExporter()
         self.client = client
+        self.root_dir = root_dir
 
-    @staticmethod
-    async def generate(path):
+    async def generate(self, path):
         """Generates the pipeline spec from the Notebook file specified.
 
         Args:
@@ -239,7 +243,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path}")
 
-        path = Path(path.lstrip("/"))
+        path = self.root_dir.joinpath(path.lstrip("/")).resolve()
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 
@@ -259,7 +263,7 @@ class PPSClient:
         """
         get_logger().debug(f"path: {path} | body: {body}")
 
-        path = Path(path.lstrip("/"))
+        path = self.root_dir.joinpath(path.lstrip("/")).resolve()
         if not path.exists():
             raise HTTPError(status_code=400, reason=f"notebook does not exist: {path}")
 


### PR DESCRIPTION
Jupyterlab users can configure the server_root_dir to be different than the CWD of the backend process