### PR TITLE
[Jupyter] Move dockerfile source out of home directory

### DIFF
--- a/jupyter-extension/Dockerfile
+++ b/jupyter-extension/Dockerfile
@@ -10,6 +10,8 @@ USER root
 # The following line requires a compiled pachctl binary.
 COPY ./dist-pach/pachctl/pachctl_linux_amd64_v1/pachctl /usr/local/bin/pachctl
 
+WORKDIR /app
+
 COPY /scripts/config.sh .
 RUN chmod +x config.sh
 RUN mkdir /pfs
@@ -18,8 +20,9 @@ RUN chmod 777 /pfs
 
 USER $NB_UID
 COPY dist dist
-WORKDIR /home/jovyan
 RUN pip install --upgrade pip
 RUN pip install `find /app/dist/ -name \*.whl` nbgitpuller==1.2.1
 RUN pip install determined==0.31.0
 RUN /opt/conda/bin/jupyter lab extension disable nbclassic
+
+WORKDIR /home/jovyan


### PR DESCRIPTION
When doing clean up I inadvertently put some internal stuff into the user's home directory. Move these back to the /app directory where they were before.