### PR TITLE
[NT-1264] Explore view does not update after changing branches

### DIFF
--- a/jupyter-extension/src/utils/components/DropdownCombobox/DropdownCombobox.tsx
+++ b/jupyter-extension/src/utils/components/DropdownCombobox/DropdownCombobox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useCombobox} from 'downshift';
 import {matchSorter} from 'match-sorter';
 
@@ -31,6 +31,7 @@ export const DropdownCombobox: React.FC<DropdownComboboxProps> = ({
     getItemProps,
     selectedItem,
     selectItem,
+    inputValue,
   } = useCombobox({
     items: inputItems,
     initialIsOpen: initialSelectedItem ? false : true,
@@ -48,6 +49,10 @@ export const DropdownCombobox: React.FC<DropdownComboboxProps> = ({
       onSelectedItemChange(selectedItem || null, selectItem);
     },
   });
+
+  useEffect(() => {
+    setInputItems(inputValue ? matchSorter(items, inputValue) : items);
+  }, [items]);
 
   return (
     <div className="pachyderm-DropdownCombobox">


### PR DESCRIPTION
Just was missing the useEffect call in the dropdown to update the internal items state on change of the items prop. Without this it only updates the internal items state once upon mount and never again hence this bug.