### PR TITLE
bump version of requests in label-studio tests

### DIFF
--- a/label-studio/requirements.txt
+++ b/label-studio/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=7.4.0
-requests~=2.31.0
+requests~=2.32.0
 pachyderm-sdk~=2.7.0
 label-studio-sdk~=0.0.29


### PR DESCRIPTION
addresses dependabot alert #308 