### PR TITLE
[CORE-2300] Backport update notional dex in spout example to 2.10

### DIFF
--- a/examples/spouts/go-rabbitmq-spout/source/go.mod
+++ b/examples/spouts/go-rabbitmq-spout/source/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dexidp/dex v2.13.0+incompatible // indirect
+	github.com/dexidp/dex v2.36.0+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect


### PR DESCRIPTION
TODO: determine if the example even needs a separate go.mod …

Backport of #10090.