### PR TITLE
[2.10.x] Avoid logging the database password

### DIFF
--- a/src/internal/dbutil/db.go
+++ b/src/internal/dbutil/db.go
@@ -126,7 +126,7 @@ func NewDB(opts ...Option) (*pachsql.DB, error) {
 		panic("must specify user")
 	}
 	dsn := getDSN(dbc)
-	log.Info(pctx.TODO(), "connecting to postgres", zap.String("dsn", dsn))
+	log.Info(pctx.TODO(), "connecting to postgres", log.RedactedString("dsn", dsn, dbc.password))
 	db, err := sqlx.Open("pgx", dsn)
 	if err != nil {
 		return nil, errors.EnsureStack(err)

--- a/src/internal/log/field.go
+++ b/src/internal/log/field.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -128,4 +129,15 @@ func OutgoingMetadata(ctx context.Context) Field {
 		return zap.Skip()
 	}
 	return Metadata("metadata", md)
+}
+
+// RedactedString returns a field that logs val, redacting all occurrences of redact in val with
+// "[<length> masked bytes]".
+func RedactedString(name, val, redact string) Field {
+	if redact == "" {
+		// This is intended to do nothing, but ReplaceAll will replace each byte instead.
+		return zap.String(name, val)
+	}
+	return zap.String(name, strings.ReplaceAll(val, redact,
+		fmt.Sprintf("[%d masked bytes]", len(redact))))
 }


### PR DESCRIPTION
This adds a log field that will redact strings as they are logged, and uses it to redact the password in the DSN.

Backports #10094