### PR TITLE
[Jupyter] Add repo back to identify commit

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
+++ b/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py
@@ -460,7 +460,7 @@ class DatumManager(FileContentsManager):
                     raise ValueError(f"Input contains non-existent branch {branch}")
                 raise err
 
-            commit = pfs.Commit(id=commit_id)
+            commit = pfs.Commit(repo=repo, id=commit_id)
             commit_uri = commit.as_uri()
             if commit_uri in self._repo_names:
                 raise ValueError(


### PR DESCRIPTION
I think we'll want to add back the `repo` field since that data is returned in a commit, unlike branch. It's needed to properly index on the commit in the code [here](https://github.com/pachyderm/pachyderm/blob/master/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py#L464) and [here](https://github.com/pachyderm/pachyderm/blob/master/jupyter-extension/jupyterlab_pachyderm/pfs_manager.py#L592). Otherwise, the key looks like `default/@4c1a1f3628cd440b862c37d57e1163cf`. The reason tests didn't fail earlier was because the logic for `Commit.as_uri()` wasn't updated after the nil branch change. After #10104 is merged, released in the next python sdk version, and the python sdk mininum version for the jupyterlab dependency is bumped, the tests should fail. This is because in the current code, repo is included in one but not both of the keys linked above. This PR should fix the bug.

Edit: Addressed in #10047 