### PR TITLE
[PFS-248] Normalize Commit Diffs

### DIFF
--- a/src/internal/clusterstate/v2.11.0/BUILD.bazel
+++ b/src/internal/clusterstate/v2.11.0/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "v2_11_0",
     srcs = [
         "clusterstate.go",
+        "commit_diffs.go",
         "commit_totals.go",
     ],
     importpath = "github.com/pachyderm/pachyderm/v2/src/internal/clusterstate/v2.11.0",

--- a/src/internal/clusterstate/v2.11.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.11.0/clusterstate.go
@@ -6,5 +6,6 @@ import (
 
 func Migrate(state migrations.State) migrations.State {
 	return state.
-		Apply("Normalize commit totals", normalizeCommitTotals, migrations.Squash)
+		Apply("Normalize commit totals", normalizeCommitTotals, migrations.Squash).
+		Apply("Normalize commit diffs", normalizeCommitDiffs, migrations.Squash)
 }

--- a/src/internal/clusterstate/v2.11.0/commit_diffs.go
+++ b/src/internal/clusterstate/v2.11.0/commit_diffs.go
@@ -1,0 +1,33 @@
+package v2_10_0
+
+import (
+	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/log"
+	"github.com/pachyderm/pachyderm/v2/src/internal/migrations"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+)
+
+func normalizeCommitDiffs(ctx context.Context, env migrations.Env) error {
+	ctx = pctx.Child(ctx, "normalizeCommitDiffs")
+	tx := env.Tx
+	_, err := tx.ExecContext(ctx,
+		`ALTER TABLE pfs.commit_diffs ADD COLUMN commit_int_id BIGINT REFERENCES pfs.commits(int_id) ON DELETE CASCADE`)
+	if err != nil {
+		return errors.Wrap(err, "add commit_int_id column to pfs.commit_diffs")
+	}
+	log.Info(ctx, "normalizing pfs.commit_diffs")
+	_, err = tx.ExecContext(ctx, "UPDATE pfs.commit_diffs d SET commit_int_id = int_id FROM pfs.commits c WHERE d.commit_id = c.commit_id")
+	if err != nil {
+		return errors.Wrap(err, "migrate diffs")
+	}
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE pfs.commit_diffs DROP CONSTRAINT commit_diffs_pkey;
+		ALTER TABLE pfs.commit_diffs ADD PRIMARY KEY (commit_int_id, num);
+		ALTER TABLE pfs.commit_diffs DROP COLUMN commit_id; 
+		`)
+	if err != nil {
+		return errors.Wrap(err, "change the primary key column of pfs.commit_diffs")
+	}
+	return nil
+}

--- a/src/internal/clusterstate/v2.7.0_test.go
+++ b/src/internal/clusterstate/v2.7.0_test.go
@@ -161,9 +161,13 @@ func setupTestData(t *testing.T, ctx context.Context, db *sqlx.DB) {
 		_, err = tx.ExecContext(ctx, `INSERT INTO pfs.commits(commit_id, commit_set_id) VALUES($1, $2)`, commitInfo.Commit.Key(), commitInfo.Commit.Id)
 		require.NoError(t, err)
 
+		// add multiple diff file sets randomly.
 		diffFileset := newFilesetId()
-		_, err = tx.ExecContext(ctx, `INSERT INTO pfs.commit_diffs (commit_id, fileset_id) VALUES ($1, $2)`, commitInfo.Commit.Key(), diffFileset)
-		require.NoError(t, err)
+		d3 := random.Random(0, 3)
+		for i := 0; i < d3; i++ {
+			_, err = tx.ExecContext(ctx, `INSERT INTO pfs.commit_diffs (commit_id, num, fileset_id) VALUES ($1, $2, $3)`, commitInfo.Commit.Key(), i, diffFileset)
+			require.NoError(t, err)
+		}
 
 		d4 := random.Random(1, 4)
 		if d4 != 4 {


### PR DESCRIPTION
This PR is similar to the Normalize Commit Totals change. A separate diff table was kept due to the possibility of multiple diffs existing for an open commit (from parallel pipeline workers). 