### PR TITLE
[Backport 2.10] Add pachctl to PATH in det notebooks (#10101)

### DIFF
--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -352,6 +352,7 @@ determined:
                   exit 1
                   ;;
           esac
+          export PATH=/run/determined:$PATH
       fi
 
   ## Configure whether we collect anonymous information about the usage of Determined.


### PR DESCRIPTION
ensure pachctl is in PATH so that it can be used from any directory