### PR TITLE
fix broken alpha release

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -615,7 +615,7 @@ jobs:
       - persist_to_workspace:
           root: ../
           paths:
-            - dist-pach/docker/pachd_linux_*
+            - dist-pach/docker/*
       - run:
           name: Push docker
           command: |-

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release-pachctl:
 	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --clean -f goreleaser/pachctl.yml
 
 docker-build:
-	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker.yml
+	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker.yml
 
 docker-build-amd:
 	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker-amd.yml

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release-pachctl:
 	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --clean -f goreleaser/pachctl.yml
 
 docker-build:
-	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker.yml
+	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELDEBUG) --skip-validate --skip-publish --clean -f goreleaser/docker.yml
 
 docker-build-amd:
 	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker-amd.yml


### PR DESCRIPTION
`goreleaser` was naming the archive `pachyderm_*` not `pachd_*` like I wrongly assumed, also removed `--snapshot` as that would add a funky `snapshot` string to the archive name that we don't want. we have the `--skip-publish` and `--skip-validate` so we don't need that `--snapshot `flag will have same effect without there being a `snapshot` string on the archive. 