### PR TITLE
[PFS-222] Remove PachW Fallback Options

### DIFF
--- a/etc/helm/pachyderm/templates/pachd/deployment.yaml
+++ b/etc/helm/pachyderm/templates/pachd/deployment.yaml
@@ -59,8 +59,6 @@ spec:
         - name: STORAGE_URL
           value: {{ required "storage URL required" .Values.pachd.storage.storageURL | quote }}
         {{- end }}
-        - name: PACHW_IN_SIDECARS
-          value: {{ .Values.pachw.inSidecars | quote }}
         - name: PACHW_MIN_REPLICAS
           value: {{ .Values.pachw.minReplicas | default 0 | quote }}
         - name: PACHW_MAX_REPLICAS

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -1478,9 +1478,6 @@
         "pachw": {
             "type": "object",
             "properties": {
-                "inSidecars": {
-                    "type": "boolean"
-                },
                 "inheritFromPachd": {
                     "type": "boolean"
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -747,10 +747,6 @@ pachw:
   # When set to false, a nil value will be used by default instead. Some configuration variables will always use their
   # corresponding pachd value, regardless of whether 'inheritFromPachd' is true, such as 'serviceAccountName'
   inheritFromPachd: true
-  # When set to true, inSidecars also processes storage related tasks in pipeline storage sidecars like version 2.4 or less.
-  # when enabled, pachw instances can still run in their own dedicated kubernetes deployment if maxReplicas is greater than 0.
-  # For more control of where pachw instances run, 'inSidecars' should be disabled.
-  inSidecars: false
   # maxReplicas should be tuned based on the number of pipelines on a user-per-user basis.
   maxReplicas: 1
   # minReplicas: 0

--- a/src/internal/pachconfig/config.go
+++ b/src/internal/pachconfig/config.go
@@ -39,7 +39,6 @@ type GlobalConfiguration struct {
 	LokiPort               string `env:"LOKI_SERVICE_PORT"`
 	OidcPort               uint16 `env:"OIDC_PORT,default=1657"`
 	IsPachw                bool   `env:"IS_PACHW,default=false"`
-	PachwInSidecars        bool   `env:"PACHW_IN_SIDECARS,default=true"`
 	PachwMinReplicas       int    `env:"PACHW_MIN_REPLICAS"`
 	PachwMaxReplicas       int    `env:"PACHW_MAX_REPLICAS,default=1"`
 	PachdServiceHost       string `env:"PACHD_SERVICE_HOST"`

--- a/src/internal/pachd/env.go
+++ b/src/internal/pachd/env.go
@@ -200,7 +200,6 @@ func PPSEnv(senv serviceenv.ServiceEnv, txnEnv *txnenv.TransactionEnv, reporter 
 		Reporter:          reporter,
 		BackgroundContext: pctx.Child(senv.Context(), "PPS"),
 		Config:            *senv.Config(),
-		PachwInSidecar:    senv.Config().PachwInSidecars,
 	}
 }
 

--- a/src/server/pps/server/monitor.go
+++ b/src/server/pps/server/monitor.go
@@ -242,19 +242,6 @@ func (pc *pipelineController) monitorPipeline(ctx context.Context, pipelineInfo 
 
 func (pc *pipelineController) blockStandby(pachClient *client.APIClient, commit *pfs.Commit) error {
 	ctx := pachClient.Ctx()
-	if pc.env.PachwInSidecar {
-		if _, err := pachClient.PfsAPIClient.InspectCommit(ctx, &pfs.InspectCommitRequest{
-			Commit: commit,
-			Wait:   pfs.CommitState_FINISHED,
-		}); err != nil {
-			return err
-		}
-		_, err := pachClient.PfsAPIClient.InspectCommit(ctx, &pfs.InspectCommitRequest{
-			Commit: ppsutil.MetaCommit(commit),
-			Wait:   pfs.CommitState_FINISHED,
-		})
-		return err
-	}
 	if _, err := pachClient.PfsAPIClient.InspectCommit(ctx, &pfs.InspectCommitRequest{
 		Commit: commit,
 		Wait:   pfs.CommitState_FINISHING,

--- a/src/server/pps/server/server.go
+++ b/src/server/pps/server/server.go
@@ -43,7 +43,6 @@ type Env struct {
 	Reporter          *metrics.Reporter
 	BackgroundContext context.Context
 	Config            pachconfig.Configuration
-	PachwInSidecar    bool
 }
 
 type APIServer = *apiServer

--- a/src/server/pps/server/worker_rc.go
+++ b/src/server/pps/server/worker_rc.go
@@ -213,10 +213,6 @@ func (kd *kubeDriver) workerPodSpec(ctx context.Context, options *workerOptions,
 			},
 		},
 		{
-			Name:  "PACHW_IN_SIDECARS",
-			Value: strconv.FormatBool(kd.config.PachwInSidecars),
-		},
-		{
 			Name:  "GC_PERCENT",
 			Value: strconv.FormatInt(int64(kd.config.GCPercent), 10),
 		},


### PR DESCRIPTION
PachW's been in the product for quite a while now and I think its safe to remove the `inSidecars` fallback configuration options.