### PR TITLE
Rename WithID Functions, Structs, and Variables

### DIFF
--- a/src/internal/pfsdb/branches.go
+++ b/src/internal/pfsdb/branches.go
@@ -216,7 +216,7 @@ func GetBranchInfo(ctx context.Context, tx *pachsql.Tx, id BranchID) (*pfs.Branc
 	return fetchBranchInfoByBranch(ctx, tx, branch)
 }
 
-// GetBranch returns a *pfs.BranchInfo by name
+// GetBranch returns a *pfsdb.Branch by name.
 func GetBranch(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*Branch, error) {
 	if b == nil {
 		return nil, errors.Errorf("branch cannot be nil")

--- a/src/internal/pfsdb/branches.go
+++ b/src/internal/pfsdb/branches.go
@@ -67,7 +67,7 @@ const (
 )
 
 // Ensures BranchIterator implements the Iterator interface.
-var _ stream.Iterator[BranchInfoWithID] = &BranchIterator{}
+var _ stream.Iterator[Branch] = &BranchIterator{}
 
 // BranchProvCycleError is returned when a cycle is detected at branch creation time.
 type BranchProvCycleError struct {
@@ -106,11 +106,13 @@ func BranchesInRepoChannel(repoID RepoID) string {
 }
 
 type BranchIterator struct {
-	paginator pageIterator[Branch]
+	paginator pageIterator[BranchRow]
 	ext       sqlx.ExtContext
 }
 
-type BranchInfoWithID struct {
+// Branch wraps a *pfs.BranchInfo with an ID and an optional Revision.
+// The Revision is set by a BranchIterator.
+type Branch struct {
 	ID       BranchID
 	Revision int64
 	*pfs.BranchInfo
@@ -156,26 +158,26 @@ func NewBranchIterator(ctx context.Context, ext sqlx.ExtContext, startPage, page
 	query += "\n" + OrderByQuery[branchColumn](orderByGeneric...)
 	query = ext.Rebind(query)
 	return &BranchIterator{
-		paginator: newPageIterator[Branch](ctx, query, values, startPage, pageSize, 0),
+		paginator: newPageIterator[BranchRow](ctx, query, values, startPage, pageSize, 0),
 		ext:       ext,
 	}, nil
 }
 
-func ForEachBranch(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, cb func(branchInfoWithID BranchInfoWithID) error, orderBys ...OrderByBranchColumn) error {
+func ForEachBranch(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, cb func(branch Branch) error, orderBys ...OrderByBranchColumn) error {
 	iter, err := NewBranchIterator(ctx, tx, 0, 100, filter, orderBys...)
 	if err != nil {
 		return errors.Wrap(err, "for each branch")
 	}
-	if err := stream.ForEach[BranchInfoWithID](ctx, iter, cb); err != nil {
+	if err := stream.ForEach[Branch](ctx, iter, cb); err != nil {
 		return errors.Wrap(err, "for each branch")
 	}
 	return nil
 }
 
-func ListBranches(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, orderBys ...OrderByBranchColumn) ([]BranchInfoWithID, error) {
-	var branches []BranchInfoWithID
-	err := ForEachBranch(ctx, tx, filter, func(branchInfoWithID BranchInfoWithID) error {
-		branches = append(branches, branchInfoWithID)
+func ListBranches(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, orderBys ...OrderByBranchColumn) ([]Branch, error) {
+	var branches []Branch
+	err := ForEachBranch(ctx, tx, filter, func(branch Branch) error {
+		branches = append(branches, branch)
 		return nil
 	}, orderBys...)
 	if err != nil {
@@ -184,7 +186,7 @@ func ListBranches(ctx context.Context, tx *pachsql.Tx, filter *pfs.Branch, order
 	return branches, nil
 }
 
-func (i *BranchIterator) Next(ctx context.Context, dst *BranchInfoWithID) error {
+func (i *BranchIterator) Next(ctx context.Context, dst *Branch) error {
 	if dst == nil {
 		return errors.Errorf("dst BranchInfo cannot be nil")
 	}
@@ -204,7 +206,7 @@ func (i *BranchIterator) Next(ctx context.Context, dst *BranchInfoWithID) error 
 
 // GetBranchInfo returns a *pfs.BranchInfo by id.
 func GetBranchInfo(ctx context.Context, tx *pachsql.Tx, id BranchID) (*pfs.BranchInfo, error) {
-	branch := &Branch{}
+	branch := &BranchRow{}
 	if err := tx.GetContext(ctx, branch, getBranchByIDQuery, id); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, &BranchNotFoundError{ID: id}
@@ -214,12 +216,12 @@ func GetBranchInfo(ctx context.Context, tx *pachsql.Tx, id BranchID) (*pfs.Branc
 	return fetchBranchInfoByBranch(ctx, tx, branch)
 }
 
-// GetBranchInfoWithID returns a *pfs.BranchInfo by name
-func GetBranchInfoWithID(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*BranchInfoWithID, error) {
+// GetBranch returns a *pfs.BranchInfo by name
+func GetBranch(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*Branch, error) {
 	if b == nil {
 		return nil, errors.Errorf("branch cannot be nil")
 	}
-	row := &Branch{}
+	row := &BranchRow{}
 	project := b.GetRepo().GetProject().GetName()
 	repo := b.GetRepo().GetName()
 	repoType := b.GetRepo().GetType()
@@ -240,7 +242,7 @@ func GetBranchInfoWithID(ctx context.Context, tx *pachsql.Tx, b *pfs.Branch) (*B
 	if err != nil {
 		return nil, err
 	}
-	return &BranchInfoWithID{ID: row.ID, BranchInfo: branchInfo}, nil
+	return &Branch{ID: row.ID, BranchInfo: branchInfo}, nil
 }
 
 // GetBranchID returns the id of a branch given a set strings that uniquely identify a branch.
@@ -314,7 +316,7 @@ func UpsertBranch(ctx context.Context, tx *pachsql.Tx, branchInfo *pfs.BranchInf
 	// We know a cycle exists if the to_branch is in the subvenance of the from_branch.
 	// Note that we get the full subvenance set as an efficiency optimization,
 	// where we avoid having to query the database for each branch in the provenance chain.
-	fullSubv, err := GetBranchSubvenance(ctx, tx, branchID)
+	fullSubv, err := GetFullBranchSubvenance(ctx, tx, branchID)
 	if err != nil {
 		return branchID, errors.Wrap(err, "could not compute branch subvenance")
 	}
@@ -358,7 +360,7 @@ func UpsertBranch(ctx context.Context, tx *pachsql.Tx, branchInfo *pfs.BranchInf
 }
 
 // DeleteBranch deletes a branch.
-func DeleteBranch(ctx context.Context, tx *pachsql.Tx, b *BranchInfoWithID, force bool) error {
+func DeleteBranch(ctx context.Context, tx *pachsql.Tx, b *Branch, force bool) error {
 	if !force {
 		subv, err := GetDirectBranchSubvenance(ctx, tx, b.ID)
 		if err != nil {
@@ -411,7 +413,7 @@ func DeleteBranch(ctx context.Context, tx *pachsql.Tx, b *BranchInfoWithID, forc
 
 // GetDirectBranchProvenance returns the direct provenance of a branch, i.e. all branches that it directly depends on.
 func GetDirectBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID) ([]*pfs.Branch, error) {
-	var branches []Branch
+	var branches []BranchRow
 	if err := sqlx.SelectContext(ctx, ext, &branches, `
 		SELECT
 			branch.id,
@@ -434,9 +436,9 @@ func GetDirectBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id Bran
 	return branchPbs, nil
 }
 
-// GetBranchProvenance returns the full provenance of a branch, i.e. all branches that it either directly or transitively depends on.
-func GetBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*pfs.Branch, error) {
-	branches, err := getBranchProvenance(ctx, ext, id, opts...)
+// GetFullBranchProvenance returns the full provenance of a branch, i.e. all branches that it either directly or transitively depends on.
+func GetFullBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*pfs.Branch, error) {
+	branches, err := getProvenantBranchRows(ctx, ext, id, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "get branch provenance")
 	}
@@ -447,32 +449,32 @@ func GetBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, 
 	return branchPbs, nil
 }
 
-// GetBranchInfoWithIDProvenance is like GetBranchProvenance but returns a slice of BranchInfoWithID instead.
-func GetBranchInfoWithIDProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*BranchInfoWithID, error) {
-	branches, err := getBranchProvenance(ctx, ext, id, opts...)
+// GetProvenantBranches is like GetFullBranchProvenance but returns a slice of Branch structs instead.
+func GetProvenantBranches(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*Branch, error) {
+	provenantBranches, err := getProvenantBranchRows(ctx, ext, id, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "get branch with id provenance")
 	}
-	var branchWithIDs []*BranchInfoWithID
-	for _, branch := range branches {
+	var branches []*Branch
+	for _, branch := range provenantBranches {
 		branchInfo, err := fetchBranchInfoByBranch(ctx, ext, branch)
 		if err != nil {
 			return nil, errors.Wrap(err, "get branch with ID provenance")
 		}
-		branchWithIDs = append(branchWithIDs, &BranchInfoWithID{
+		branches = append(branches, &Branch{
 			ID:         branch.ID,
 			BranchInfo: branchInfo,
 		})
 	}
-	return branchWithIDs, nil
+	return branches, nil
 }
 
-func getBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*Branch, error) {
+func getProvenantBranchRows(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*BranchRow, error) {
 	graphOpts := defaultGraphOptions()
 	for _, opt := range opts {
 		opt(graphOpts)
 	}
-	var branches []*Branch
+	var branches []*BranchRow
 	if err := sqlx.SelectContext(ctx, ext, &branches, `
 		WITH RECURSIVE prov(from_id, to_id) AS (
 		    SELECT from_id, to_id, 1 as depth
@@ -502,7 +504,7 @@ func getBranchProvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, 
 }
 
 func GetDirectBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID) ([]*pfs.Branch, error) {
-	var branches []Branch
+	var branches []BranchRow
 	if err := sqlx.SelectContext(ctx, ext, &branches, `
 		SELECT
 			branch.id,
@@ -525,9 +527,9 @@ func GetDirectBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id Bran
 	return branchPbs, nil
 }
 
-// GetBranchSubvenance returns the full subvenance of a branch, i.e. all branches that either directly or transitively depend on it.
-func GetBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*pfs.Branch, error) {
-	branches, err := getBranchSubvenance(ctx, ext, id, opts...)
+// GetFullBranchSubvenance returns the full subvenance of a branch, i.e. all branches that either directly or transitively depend on it.
+func GetFullBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*pfs.Branch, error) {
+	branches, err := getSubvenantBranchRows(ctx, ext, id, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "get branch subvenance")
 	}
@@ -538,32 +540,32 @@ func GetBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, 
 	return branchPbs, nil
 }
 
-// GetBranchInfoWithIDSubvenance is like GetBranchSubvenance but returns a slice of BranchInfoWithID instead.
-func GetBranchInfoWithIDSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*BranchInfoWithID, error) {
-	branches, err := getBranchSubvenance(ctx, ext, id, opts...)
+// GetSubvenantBranches is like GetFullBranchSubvenance but returns a slice of Branch structs instead.
+func GetSubvenantBranches(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*Branch, error) {
+	subvenantBranches, err := getSubvenantBranchRows(ctx, ext, id, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "get branch with ID subvenance")
 	}
-	var branchWithIDs []*BranchInfoWithID
-	for _, branch := range branches {
+	var branches []*Branch
+	for _, branch := range subvenantBranches {
 		branchInfo, err := fetchBranchInfoByBranch(ctx, ext, branch)
 		if err != nil {
 			return nil, errors.Wrap(err, "get branch with ID subvenance")
 		}
-		branchWithIDs = append(branchWithIDs, &BranchInfoWithID{
+		branches = append(branches, &Branch{
 			ID:         branch.ID,
 			BranchInfo: branchInfo,
 		})
 	}
-	return branchWithIDs, nil
+	return branches, nil
 }
 
-func getBranchSubvenance(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*Branch, error) {
+func getSubvenantBranchRows(ctx context.Context, ext sqlx.ExtContext, id BranchID, opts ...GraphOption) ([]*BranchRow, error) {
 	graphOpts := defaultGraphOptions()
 	for _, opt := range opts {
 		opt(graphOpts)
 	}
-	var branches []*Branch
+	var branches []*BranchRow
 	if err := sqlx.SelectContext(ctx, ext, &branches, `
 		WITH RECURSIVE subv(from_id, to_id) AS (
 		    SELECT from_id, to_id, 1 as depth
@@ -606,7 +608,7 @@ func CreateDirectBranchProvenance(ctx context.Context, ext sqlx.ExtContext, from
 
 // GetTriggeredBranches lists all the branches that are directly triggered by a branch
 func GetTriggeredBranches(ctx context.Context, ext sqlx.ExtContext, bid BranchID) ([]*pfs.Branch, error) {
-	var branches []Branch
+	var branches []BranchRow
 	q := `SELECT branch.id,
 			branch.name,
 			repo.name as "repo.name",
@@ -630,7 +632,7 @@ func GetTriggeredBranches(ctx context.Context, ext sqlx.ExtContext, bid BranchID
 
 // GetTriggeringBranches lists all the branches that would directly trigger a branch
 func GetTriggeringBranches(ctx context.Context, ext sqlx.ExtContext, bid BranchID) ([]*pfs.Branch, error) {
-	var branches []Branch
+	var branches []BranchRow
 	q := `SELECT branch.id,
 			branch.name,
 			repo.name as "repo.name",
@@ -714,7 +716,7 @@ func DeleteBranchTrigger(ctx context.Context, tx *pachsql.Tx, from BranchID) err
 	return nil
 }
 
-func fetchBranchInfoByBranch(ctx context.Context, ext sqlx.ExtContext, branch *Branch) (*pfs.BranchInfo, error) {
+func fetchBranchInfoByBranch(ctx context.Context, ext sqlx.ExtContext, branch *BranchRow) (*pfs.BranchInfo, error) {
 	if branch == nil {
 		return nil, errors.Errorf("branch cannot be nil")
 	}
@@ -724,11 +726,11 @@ func fetchBranchInfoByBranch(ctx context.Context, ext sqlx.ExtContext, branch *B
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get direct branch provenance")
 	}
-	branchInfo.Provenance, err = GetBranchProvenance(ctx, ext, branch.ID)
+	branchInfo.Provenance, err = GetFullBranchProvenance(ctx, ext, branch.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get full branch provenance")
 	}
-	branchInfo.Subvenance, err = GetBranchSubvenance(ctx, ext, branch.ID)
+	branchInfo.Subvenance, err = GetFullBranchSubvenance(ctx, ext, branch.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get full branch subvenance")
 	}
@@ -753,13 +755,13 @@ func WatchBranchesInRepo(ctx context.Context, db *pachsql.DB, listener collectio
 	// Optimized query for getting branches in a repo.
 	query := getBranchBaseQuery + fmt.Sprintf("\nWHERE %s = ?\nORDER BY %s ASC", BranchColumnRepoID, BranchColumnID)
 	query = db.Rebind(query)
-	snapshot := &BranchIterator{paginator: newPageIterator[Branch](ctx, query, []any{repoID}, 0, branchesPageSize, 0), ext: db}
+	snapshot := &BranchIterator{paginator: newPageIterator[BranchRow](ctx, query, []any{repoID}, 0, branchesPageSize, 0), ext: db}
 	return watchBranches(ctx, db, snapshot, watcher.Watch(), onUpsert, onDelete)
 }
 
-func watchBranches(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator[BranchInfoWithID], events <-chan *postgres.Event, onUpsert branchUpsertHandler, onDelete branchDeleteHandler) error {
+func watchBranches(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator[Branch], events <-chan *postgres.Event, onUpsert branchUpsertHandler, onDelete branchDeleteHandler) error {
 	// Handle snapshot.
-	if err := stream.ForEach[BranchInfoWithID](ctx, snapshot, func(b BranchInfoWithID) error {
+	if err := stream.ForEach[Branch](ctx, snapshot, func(b Branch) error {
 		return onUpsert(b.ID, b.BranchInfo)
 	}); err != nil {
 		return err
@@ -804,7 +806,7 @@ func watchBranches(ctx context.Context, db *pachsql.DB, snapshot stream.Iterator
 	}
 }
 
-func PickBranch(ctx context.Context, branchPicker *pfs.BranchPicker, tx *pachsql.Tx) (*BranchInfoWithID, error) {
+func PickBranch(ctx context.Context, branchPicker *pfs.BranchPicker, tx *pachsql.Tx) (*Branch, error) {
 	if branchPicker == nil || branchPicker.Picker == nil {
 		return nil, errors.New("branch picker cannot be nil")
 	}
@@ -815,14 +817,14 @@ func PickBranch(ctx context.Context, branchPicker *pfs.BranchPicker, tx *pachsql
 		if err != nil {
 			return nil, errors.Wrap(err, "picking branch")
 		}
-		branchInfoWithID, err := GetBranchInfoWithID(ctx, tx, &pfs.Branch{
+		branch, err := GetBranch(ctx, tx, &pfs.Branch{
 			Repo: repo.RepoInfo.Repo,
 			Name: picker.Name,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "picking branch")
 		}
-		return branchInfoWithID, nil
+		return branch, nil
 	default:
 		return nil, errors.Errorf("branch picker is of an unknown type: %T", branchPicker.Picker)
 	}

--- a/src/internal/pfsdb/common.go
+++ b/src/internal/pfsdb/common.go
@@ -22,7 +22,7 @@ const (
 
 type (
 	ModelType interface {
-		Repo | Commit | Branch | Project
+		RepoRow | CommitRow | BranchRow | ProjectRow
 		GetCreatedAtUpdatedAt() CreatedAtUpdatedAt
 	}
 	ColumnName interface {

--- a/src/server/pfs/server/commit_store.go
+++ b/src/server/pfs/server/commit_store.go
@@ -18,27 +18,27 @@ const commitTrackerPrefix = "commit/"
 
 type commitStore interface {
 	// AddFileSet appends a fileset to the diff.
-	AddFileSet(ctx context.Context, commit *pfsdb.CommitWithID, filesetID fileset.ID) error
+	AddFileSet(ctx context.Context, commit *pfsdb.Commit, filesetID fileset.ID) error
 	// AddFileSetTx is identical to AddFileSet except it runs in the provided transaction.
-	AddFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID, filesetID fileset.ID) error
+	AddFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit, filesetID fileset.ID) error
 	// SetTotalFileSet sets the total file set for the commit, overwriting whatever is there.
-	SetTotalFileSet(ctx context.Context, commit *pfsdb.CommitWithID, id fileset.ID) error
+	SetTotalFileSet(ctx context.Context, commit *pfsdb.Commit, id fileset.ID) error
 	// SetTotalFileSetTx is like SetTotalFileSet, but in a transaction
-	SetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID, id fileset.ID) error
+	SetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit, id fileset.ID) error
 	// SetDiffFileSet sets the diff file set for the commit, overwriting whatever is there.
-	SetDiffFileSet(ctx context.Context, commit *pfsdb.CommitWithID, id fileset.ID) error
+	SetDiffFileSet(ctx context.Context, commit *pfsdb.Commit, id fileset.ID) error
 	// SetDiffFileSetTx is like SetDiffFileSet, but in a transaction
-	SetDiffFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID, id fileset.ID) error
+	SetDiffFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit, id fileset.ID) error
 	// GetTotalFileSet returns the total file set for a commit.
-	GetTotalFileSet(ctx context.Context, commit *pfsdb.CommitWithID) (*fileset.ID, error)
+	GetTotalFileSet(ctx context.Context, commit *pfsdb.Commit) (*fileset.ID, error)
 	// GetTotalFileSetTx is like GetTotalFileSet, but in a transaction
-	GetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID) (*fileset.ID, error)
+	GetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit) (*fileset.ID, error)
 	// GetDiffFileSet returns the diff file set for a commit
-	GetDiffFileSet(ctx context.Context, commit *pfsdb.CommitWithID) (*fileset.ID, error)
+	GetDiffFileSet(ctx context.Context, commit *pfsdb.Commit) (*fileset.ID, error)
 	// DropFileSets clears the diff and total file sets for the commit.
-	DropFileSets(ctx context.Context, commit *pfsdb.CommitWithID) error
+	DropFileSets(ctx context.Context, commit *pfsdb.Commit) error
 	// DropFileSetsTx is identical to DropFileSets except it runs in the provided transaction.
-	DropFileSetsTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID) error
+	DropFileSetsTx(tx *pachsql.Tx, commit *pfsdb.Commit) error
 }
 
 var _ commitStore = &postgresCommitStore{}
@@ -59,13 +59,13 @@ func newPostgresCommitStore(db *pachsql.DB, tr track.Tracker, s *fileset.Storage
 	}
 }
 
-func (cs *postgresCommitStore) AddFileSet(ctx context.Context, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func (cs *postgresCommitStore) AddFileSet(ctx context.Context, commit *pfsdb.Commit, id fileset.ID) error {
 	return dbutil.WithTx(ctx, cs.db, func(ctx context.Context, tx *pachsql.Tx) error {
 		return cs.AddFileSetTx(tx, commit, id)
 	})
 }
 
-func (cs *postgresCommitStore) AddFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func (cs *postgresCommitStore) AddFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit, id fileset.ID) error {
 	id2, err := cs.s.CloneTx(tx, id, defaultTTL)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (cs *postgresCommitStore) AddFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit
 	return errors.Wrap(cs.tr.CreateTx(tx, oid, pointsTo, track.NoTTL), "add file set tx")
 }
 
-func (cs *postgresCommitStore) GetTotalFileSet(ctx context.Context, commit *pfsdb.CommitWithID) (*fileset.ID, error) {
+func (cs *postgresCommitStore) GetTotalFileSet(ctx context.Context, commit *pfsdb.Commit) (*fileset.ID, error) {
 	var id *fileset.ID
 	if err := dbutil.WithTx(ctx, cs.db, func(ctx context.Context, tx *pachsql.Tx) error {
 		var err error
@@ -99,7 +99,7 @@ func (cs *postgresCommitStore) GetTotalFileSet(ctx context.Context, commit *pfsd
 	return id, nil
 }
 
-func (cs *postgresCommitStore) GetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID) (*fileset.ID, error) {
+func (cs *postgresCommitStore) GetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit) (*fileset.ID, error) {
 	id, err := getTotal(tx, commit)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
@@ -110,7 +110,7 @@ func (cs *postgresCommitStore) GetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.C
 	return cs.s.CloneTx(tx, *id, defaultTTL)
 }
 
-func (cs *postgresCommitStore) GetDiffFileSet(ctx context.Context, commit *pfsdb.CommitWithID) (*fileset.ID, error) {
+func (cs *postgresCommitStore) GetDiffFileSet(ctx context.Context, commit *pfsdb.Commit) (*fileset.ID, error) {
 	var ids []fileset.ID
 	if err := dbutil.WithTx(ctx, cs.db, func(ctx context.Context, tx *pachsql.Tx) error {
 		var err error
@@ -125,46 +125,46 @@ func (cs *postgresCommitStore) GetDiffFileSet(ctx context.Context, commit *pfsdb
 	return cs.s.Compose(ctx, ids, defaultTTL)
 }
 
-func (cs *postgresCommitStore) SetTotalFileSet(ctx context.Context, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func (cs *postgresCommitStore) SetTotalFileSet(ctx context.Context, commit *pfsdb.Commit, id fileset.ID) error {
 	return dbutil.WithTx(ctx, cs.db, func(ctx context.Context, tx *pachsql.Tx) error {
 		return cs.SetTotalFileSetTx(tx, commit, id)
 	})
 }
 
-func (cs *postgresCommitStore) SetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func (cs *postgresCommitStore) SetTotalFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit, id fileset.ID) error {
 	if err := dropTotal(tx, cs.tr, commit); err != nil {
 		return err
 	}
 	return setTotal(tx, cs.tr, commit, id)
 }
 
-func (cs *postgresCommitStore) SetDiffFileSet(ctx context.Context, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func (cs *postgresCommitStore) SetDiffFileSet(ctx context.Context, commit *pfsdb.Commit, id fileset.ID) error {
 	return dbutil.WithTx(ctx, cs.db, func(ctx context.Context, tx *pachsql.Tx) error {
 		return cs.SetDiffFileSetTx(tx, commit, id)
 	})
 }
 
-func (cs *postgresCommitStore) SetDiffFileSetTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func (cs *postgresCommitStore) SetDiffFileSetTx(tx *pachsql.Tx, commit *pfsdb.Commit, id fileset.ID) error {
 	if err := cs.dropDiff(tx, commit); err != nil {
 		return err
 	}
 	return setDiff(tx, cs.tr, commit, id)
 }
 
-func (cs *postgresCommitStore) DropFileSets(ctx context.Context, commit *pfsdb.CommitWithID) error {
+func (cs *postgresCommitStore) DropFileSets(ctx context.Context, commit *pfsdb.Commit) error {
 	return dbutil.WithTx(ctx, cs.db, func(ctx context.Context, tx *pachsql.Tx) error {
 		return cs.DropFileSetsTx(tx, commit)
 	})
 }
 
-func (cs *postgresCommitStore) DropFileSetsTx(tx *pachsql.Tx, commit *pfsdb.CommitWithID) error {
+func (cs *postgresCommitStore) DropFileSetsTx(tx *pachsql.Tx, commit *pfsdb.Commit) error {
 	if err := dropTotal(tx, cs.tr, commit); err != nil {
 		return errors.Wrap(err, "drop file set tx")
 	}
 	return cs.dropDiff(tx, commit)
 }
 
-func (cs *postgresCommitStore) dropDiff(tx *pachsql.Tx, commit *pfsdb.CommitWithID) error {
+func (cs *postgresCommitStore) dropDiff(tx *pachsql.Tx, commit *pfsdb.Commit) error {
 	diffIDs, err := getDiff(tx, commit)
 	if err != nil {
 		return err
@@ -181,7 +181,7 @@ func (cs *postgresCommitStore) dropDiff(tx *pachsql.Tx, commit *pfsdb.CommitWith
 	return nil
 }
 
-func getDiff(tx *pachsql.Tx, commit *pfsdb.CommitWithID) ([]fileset.ID, error) {
+func getDiff(tx *pachsql.Tx, commit *pfsdb.Commit) ([]fileset.ID, error) {
 	var ids []fileset.ID
 	if err := tx.Select(&ids,
 		`SELECT fileset_id FROM pfs.commit_diffs
@@ -193,7 +193,7 @@ func getDiff(tx *pachsql.Tx, commit *pfsdb.CommitWithID) ([]fileset.ID, error) {
 	return ids, nil
 }
 
-func getTotal(tx *pachsql.Tx, commit *pfsdb.CommitWithID) (*fileset.ID, error) {
+func getTotal(tx *pachsql.Tx, commit *pfsdb.Commit) (*fileset.ID, error) {
 	var id fileset.ID
 	if err := tx.Get(&id, `SELECT total_fileset_id FROM pfs.commits WHERE int_id = $1 AND total_fileset_id IS NOT NULL`,
 		commit.ID); err != nil {
@@ -202,7 +202,7 @@ func getTotal(tx *pachsql.Tx, commit *pfsdb.CommitWithID) (*fileset.ID, error) {
 	return &id, nil
 }
 
-func dropTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.CommitWithID) error {
+func dropTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.Commit) error {
 	id, err := getTotal(tx, commit)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -218,7 +218,7 @@ func dropTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.CommitWithID) err
 	return errors.Wrap(err, "drop total")
 }
 
-func setTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func setTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.Commit, id fileset.ID) error {
 	oid := commitTotalTrackerID(commit, id)
 	pointsTo := []string{id.TrackerID()}
 	if err := tr.CreateTx(tx, oid, pointsTo, track.NoTTL); err != nil {
@@ -228,7 +228,7 @@ func setTotal(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.CommitWithID, id f
 	return errors.Wrap(err, "set total")
 }
 
-func setDiff(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.CommitWithID, id fileset.ID) error {
+func setDiff(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.Commit, id fileset.ID) error {
 	oid := commitDiffTrackerID(commit, id)
 	pointsTo := []string{id.TrackerID()}
 	if err := tr.CreateTx(tx, oid, pointsTo, track.NoTTL); err != nil {
@@ -243,10 +243,10 @@ func setDiff(tx *pachsql.Tx, tr track.Tracker, commit *pfsdb.CommitWithID, id fi
 	return errors.Wrap(err, "set diff")
 }
 
-func commitDiffTrackerID(commit *pfsdb.CommitWithID, fs fileset.ID) string {
+func commitDiffTrackerID(commit *pfsdb.Commit, fs fileset.ID) string {
 	return commitTrackerPrefix + fmt.Sprintf("%d", commit.ID) + "/diff/" + fs.HexString()
 }
 
-func commitTotalTrackerID(commit *pfsdb.CommitWithID, fs fileset.ID) string {
+func commitTotalTrackerID(commit *pfsdb.Commit, fs fileset.ID) string {
 	return commitTrackerPrefix + fmt.Sprintf("%d", commit.ID) + "/total/" + fs.HexString()
 }

--- a/src/server/pfs/server/testing/server_test.go
+++ b/src/server/pfs/server/testing/server_test.go
@@ -448,9 +448,9 @@ func TestUpdateProject_PreservesMetadata(t *testing.T) {
 	var got *pfs.ProjectInfo
 	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
 		var err error
-		got, err = pfsdb.GetProjectByName(cbCtx, tx, "update")
+		got, err = pfsdb.GetProjectInfoByName(cbCtx, tx, "update")
 		if err != nil {
-			return errors.Wrap(err, "GetProjectByName")
+			return errors.Wrap(err, "GetProjectInfoByName")
 		}
 		return nil
 	}); err != nil {
@@ -6269,7 +6269,7 @@ func TestPutFileAtomic(t *testing.T) {
 
 func TestTestTopologicalSortCommits(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
-		require.True(t, len(server.TopologicalSort([]*pfsdb.CommitWithID{})) == 0)
+		require.True(t, len(server.TopologicalSort([]*pfsdb.Commit{})) == 0)
 	})
 	t.Run("Fuzz", func(t *testing.T) {
 		// TODO: update gopls for generics
@@ -6289,7 +6289,7 @@ func TestTestTopologicalSortCommits(t *testing.T) {
 		}
 		// commit.String() -> number of total transitive provenant commits
 		totalProvenance := make(map[string]map[string]struct{})
-		var cis []*pfsdb.CommitWithID
+		var cis []*pfsdb.Commit
 		total := 500
 		for i := 0; i < total; i++ {
 			totalProv := make(map[string]struct{})
@@ -6303,7 +6303,7 @@ func TestTestTopologicalSortCommits(t *testing.T) {
 					directProv = append(directProv, makeCommit(k))
 				}
 			}
-			ci := &pfsdb.CommitWithID{
+			ci := &pfsdb.Commit{
 				CommitInfo: &pfs.CommitInfo{
 					Commit:           makeCommit(i),
 					DirectProvenance: directProv,

--- a/src/server/pfs/server/url.go
+++ b/src/server/pfs/server/url.go
@@ -178,7 +178,7 @@ func (d *driver) getFileURL(ctx context.Context, taskService task.Service, URL s
 	if basePathRange == nil {
 		basePathRange = &pfs.PathRange{}
 	}
-	commitWithID, err := d.getCommit(ctx, file.Commit)
+	commit, err := d.getCommit(ctx, file.Commit)
 	if err != nil {
 		return 0, errors.Wrap(err, "get file url")
 	}
@@ -193,7 +193,7 @@ func (d *driver) getFileURL(ctx context.Context, taskService task.Service, URL s
 	var bytesWritten int64
 	eg.Go(func() error {
 		return d.storage.Filesets.WithRenewer(ctx, defaultTTL, func(ctx context.Context, renewer *fileset.Renewer) error {
-			fsID, err := d.getFileSet(ctx, commitWithID)
+			fsID, err := d.getFileSet(ctx, commit)
 			if err != nil {
 				return err
 			}

--- a/src/server/pfs/server/val_server.go
+++ b/src/server/pfs/server/val_server.go
@@ -249,7 +249,7 @@ func (a *validatedAPIServer) WalkCommitProvenance(request *pfs.WalkCommitProvena
 		}
 		return a.apiServer.WalkCommitProvenanceTx(ctx, txnCtx,
 			&WalkCommitProvenanceRequest{
-				StartWithID:                 commits,
+				Start:                       commits,
 				WalkCommitProvenanceRequest: request,
 			}, srv)
 	}), "walk commit provenance")
@@ -265,7 +265,7 @@ func (a *validatedAPIServer) WalkCommitSubvenance(request *pfs.WalkCommitSubvena
 		}
 		return a.apiServer.WalkCommitSubvenanceTx(ctx, txnCtx,
 			&WalkCommitSubvenanceRequest{
-				StartWithID:                 commits,
+				Start:                       commits,
 				WalkCommitSubvenanceRequest: request,
 			}, srv)
 	}), "walk commit subvenance")
@@ -281,7 +281,7 @@ func (a *validatedAPIServer) WalkBranchProvenance(request *pfs.WalkBranchProvena
 		}
 		return a.apiServer.WalkBranchProvenanceTx(ctx, txnCtx,
 			&WalkBranchProvenanceRequest{
-				StartWithID:                 branches,
+				Start:                       branches,
 				WalkBranchProvenanceRequest: request,
 			}, srv)
 	}), "walk branch provenance")
@@ -297,14 +297,14 @@ func (a *validatedAPIServer) WalkBranchSubvenance(request *pfs.WalkBranchSubvena
 		}
 		return a.apiServer.WalkBranchSubvenanceTx(ctx, txnCtx,
 			&WalkBranchSubvenanceRequest{
-				StartWithID:                 branches,
+				Start:                       branches,
 				WalkBranchSubvenanceRequest: request,
 			}, srv)
 	}), "walk branch subvenance")
 }
 
-func (a *validatedAPIServer) pickCommits(ctx context.Context, tx *pachsql.Tx, pickers []*pfs.CommitPicker) ([]*pfsdb.CommitWithID, error) {
-	commits := make([]*pfsdb.CommitWithID, 0)
+func (a *validatedAPIServer) pickCommits(ctx context.Context, tx *pachsql.Tx, pickers []*pfs.CommitPicker) ([]*pfsdb.Commit, error) {
+	commits := make([]*pfsdb.Commit, 0)
 	for _, picker := range pickers {
 		commit, err := pfsdb.PickCommit(ctx, picker, tx)
 		if err != nil {
@@ -315,8 +315,8 @@ func (a *validatedAPIServer) pickCommits(ctx context.Context, tx *pachsql.Tx, pi
 	return commits, nil
 }
 
-func (a *validatedAPIServer) pickBranches(ctx context.Context, tx *pachsql.Tx, pickers []*pfs.BranchPicker) ([]*pfsdb.BranchInfoWithID, error) {
-	branches := make([]*pfsdb.BranchInfoWithID, 0)
+func (a *validatedAPIServer) pickBranches(ctx context.Context, tx *pachsql.Tx, pickers []*pfs.BranchPicker) ([]*pfsdb.Branch, error) {
+	branches := make([]*pfsdb.Branch, 0)
 	for _, picker := range pickers {
 		branch, err := pfsdb.PickBranch(ctx, picker, tx)
 		if err != nil {


### PR DESCRIPTION
There's a bunch of renaming in this PR:

1. The `WithID` suffix was dropped wherever possible except the migrations packages. 
2. pfsdb `Get()` functions that return `Info` structs will include Info in their name (e.x. `GetProjectInfo()`). 
3. Otherwise, they return pfsdb structs with IDs (e.x. `GetProject()` returns a `*pfsdb.Project`). 
4. To avoid a collision with existing structs in pfsdb/model.go, the previous structs were renamed with a `Row` suffix (e.x. `CommitRow`). 
5. Parameters that reference pfs client-facing structs are called 'handles'. So a parameter of type `*pfs.Commit` is `commitHandle`.

This is _purely_ variable renaming. There are no (intended) semantic changes here.