### PR TITLE
Revert base image update for jupyter extension

### DIFF
--- a/jupyter-extension/Dockerfile
+++ b/jupyter-extension/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook:lab-4.0.7
+FROM jupyter/scipy-notebook:lab-3.3.3
 
 ENV PFS_MOUNT_DIR=/pfs
 


### PR DESCRIPTION
Reverts the base image used to 3.3.3. Unfortunately, jupyter server does not provide a clean way to check if the extension is compatible with the jupyter version. Adding a message asking the user to check in all cases seems overly intrusive. Perhaps we can just make it clear in the docs what the currently supported version is.