### PR TITLE
iron bank release support - backport

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -612,6 +612,10 @@ jobs:
             else
               make docker-build VERSION=${v} VERSION_ADDITIONAL=${v:index}
             fi
+      - persist_to_workspace:
+          root: ../
+          paths:
+            - dist-pach/docker/pachd_linux_*
       - run:
           name: Push docker
           command: |-
@@ -1180,10 +1184,10 @@ jobs:
             if [[ $CIRCLE_TAG == *"-"* ]];
             then
                 echo "git tag has - assuming prerelease."
-                gh release create --draft ${CIRCLE_TAG} --title ${CIRCLE_TAG:1} ./cr-release-packages/local_template/*.yaml ./dist-pach/pachctl/pachctl_${CIRCLE_TAG:1}* --generate-notes --prerelease
+                gh release create --draft ${CIRCLE_TAG} --title ${CIRCLE_TAG:1} ./cr-release-packages/local_template/*.yaml ./dist-pach/pachctl/pachctl_${CIRCLE_TAG:1}* ./dist-pach/docker/pachyderm_*_linux_amd64.tar.gz ./dist-pach/docker/pachyderm_*linux_arm64.tar.gz  --generate-notes --prerelease
             else
                 echo "regular release."
-                gh release create --draft ${CIRCLE_TAG} --title ${CIRCLE_TAG:1} ./cr-release-packages/local_template/*.yaml ./dist-pach/pachctl/pachctl_${CIRCLE_TAG:1}* --generate-notes
+                gh release create --draft ${CIRCLE_TAG} --title ${CIRCLE_TAG:1} ./cr-release-packages/local_template/*.yaml ./dist-pach/pachctl/pachctl_${CIRCLE_TAG:1}* ./dist-pach/docker/pachyderm_*_linux_arm64.tar.gz ./dist-pach/docker/pachyderm_*linux_arm64.tar.gz --generate-notes
             fi
   console-release-draft:
     docker:
@@ -1868,6 +1872,7 @@ workflows:
           filters: *only-release-tags
           requires:
             - build-pachctl-bin
+            - build-docker-images
             - helm-build
       - jupyter-extension-test:
           matrix:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -615,7 +615,7 @@ jobs:
       - persist_to_workspace:
           root: ../
           paths:
-            - dist-pach/docker/pachd_linux_*
+            - dist-pach/docker/*
       - run:
           name: Push docker
           command: |-

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release-pachctl:
 	@goreleaser release -p 1 $(GORELSNAP) $(GORELDEBUG) --release-notes=$(CHLOGFILE) --clean -f goreleaser/pachctl.yml
 
 docker-build:
-	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker.yml
+	DOCKER_BUILDKIT=1 goreleaser release -p 1 $(GORELDEBUG) --skip-validate --skip-publish --clean -f goreleaser/docker.yml
 
 docker-build-amd:
 	DOCKER_BUILDKIT=1 goreleaser release -p 1 --snapshot $(GORELDEBUG) --skip-publish --clean -f goreleaser/docker-amd.yml

--- a/goreleaser/docker.yml
+++ b/goreleaser/docker.yml
@@ -67,6 +67,21 @@ archives:
     - format: binary
       builds:
           - pachctl
+    - id: pach-archives
+      builds:
+          - pachd
+          - worker
+          - worker_init
+      format_overrides:
+          - goos: linux
+            format: tar.gz
+      wrap_in_directory: true
+      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+      files:
+          - pachd*/pachd
+          - worker_init*/worker_init
+          - worker*/worker
+          - dex-assets/*
 
 checksum:
     disable: true


### PR DESCRIPTION
backport, to allow additional bins artifacts on gh release that ironbank builds will need 