### PR TITLE
Djanicek/infeng 734/tests to datadog

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -559,7 +559,7 @@ jobs:
           name: Create JunitXML for DataDog
           command: |
             go install gotest.tools/gotestsum@latest
-            gotestsum --junitxml junit_test_results.xml --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
+            gotestsum --junitfile junit_test_results.xml --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
           when: always
       - run:
           name: Dump debugging info in case of failure

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -564,7 +564,7 @@ jobs:
           name: Create JunitXML for DataDog
           command: |
             go install gotest.tools/gotestsum@latest
-            gotestsum --junitfile "${TEST_RESULTS}/junit_test_results.xml" --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
+            gotestsum --junitfile "${TEST_RESULTS}/junit-test-results.xml" --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
           when: always
       - run:
           name: Dump debugging info in case of failure
@@ -577,6 +577,7 @@ jobs:
       - upload-junit-datadog:
           service: deploy-tests
           env: ci-minikube
+          path: /tmp/test-results/junit-test-results.xml
           amd: true
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2218,7 +2218,7 @@ commands:
       path:
         type: string
         default: "/tmp/test-results"
-      amd: 
+      amd:
         type: boolean
         default: false
     steps:
@@ -2226,7 +2226,7 @@ commands:
           name: Upload Tests to DataDog
           when: always
           command: |
-            if [ amd ]; then
+            if [ << parameters.amd >> ]; then
               curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
               ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
             else

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -565,6 +565,9 @@ jobs:
           name: Format code coverage
           when: always
           command: etc/testing/circle/format-coverage.sh
+      - upload-junit-datadog:
+        service: deploy-tests
+        env: ci-minikube
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -2203,6 +2206,24 @@ commands:
       - run:
           name: Wait for pachd
           command: until pachctl inspect cluster; do sleep 5; done
+  upload-junit-datadog:
+    parameters:
+      service:
+        type: string
+        default: ""
+      env:
+        type: string
+        default: "ci-local"
+      path:
+        type: string
+        default: "/tmp/test-results"
+    steps:
+      - run:
+          name: Upload Tests to DataDog
+          when: always
+          command: |
+              curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
+              ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
   collect-test-results:
     steps:
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1582,7 +1582,7 @@ jobs:
       - upload-junit-datadog:
           service: bazel-tests
           env: ci-bazel
-          path: /tmp/bazel-testlogs/**
+          path: /tmp/bazel-testlogs/* /tmp/bazel-testlogs/src/**/**/**/* /tmp/bazel-testlogs/src/**/**/**/**/*
       - store_test_results:
           path: /tmp/bazel-testlogs/
       - codecov/upload:
@@ -1627,12 +1627,13 @@ jobs:
           --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} \
           //:privileged_tests
       - run: |
-          ls -lf
-          ls -lf /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs
+          ls -lf bazel-testlogs
+          echo '---'
+          ls -lf /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/src
       - upload-junit-datadog:
           service: bazel-privileged-tests
           env: ci-bazel
-          path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/
+          path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/**
       - store_test_results:
           path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/
       - codecov/upload:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1582,7 +1582,7 @@ jobs:
       - upload-junit-datadog:
           service: bazel-tests
           env: ci-bazel
-          path: /tmp/bazel-testlogs/*
+          path: /tmp/bazel-testlogs/**
       - store_test_results:
           path: /tmp/bazel-testlogs/
       - codecov/upload:
@@ -1628,7 +1628,7 @@ jobs:
           //:privileged_tests
       - run: |
           ls -lf
-          ls -lf /home/circleci/out
+          ls -lf /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs
       - upload-junit-datadog:
           service: bazel-privileged-tests
           env: ci-bazel

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1579,6 +1579,10 @@ jobs:
       - run:
           command: cp -a bazel-testlogs/ /tmp/bazel-testlogs # store_test_results can't handle bazel-testlogs being a symlink
           when: always
+      - upload-junit-datadog:
+          service: bazel-tests
+          env: ci-bazel
+          path: /tmp/bazel-testlogs
       - store_test_results:
           path: /tmp/bazel-testlogs/
       - codecov/upload:
@@ -1622,6 +1626,10 @@ jobs:
           --config=remotecache \
           --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} \
           //:privileged_tests
+      - upload-junit-datadog:
+          service: bazel-privileged-tests
+          env: ci-bazel
+          path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/
       - store_test_results:
           path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/
       - codecov/upload:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -557,16 +557,6 @@ jobs:
           command: etc/testing/circle/upload_stats.sh
           when: always
       - run:
-          name: Format test results for upload
-          command: go tool test2json -t < "/tmp/go-test-results.txt" > "${TEST_RESULTS}/go-test-results.jsonl" || true
-          when: always
-      - run:
-          name: Create JunitXML for DataDog
-          command: |
-            go install gotest.tools/gotestsum@latest
-            gotestsum --junitfile "${TEST_RESULTS}/junit-test-results.xml" --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
-          when: always
-      - run:
           name: Dump debugging info in case of failure
           when: on_fail
           command: etc/testing/circle/kube_debug.sh

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -550,6 +550,7 @@ jobs:
           name: Wait for docker images to be built
           command: etc/testing/circle/wait_for_docker_images.sh
       - run: etc/testing/circle/wait-minikube.sh
+      - run: go install gotest.tools/gotestsum@latest
       - run:
           name: Run Tests
           command: etc/testing/circle/deploy_test.sh | ts '%Y-%m-%dT%H:%M:%S'

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -268,7 +268,6 @@ jobs:
           service: integration-tests
           env: ci-minikube
           path: /tmp/test-results/circle
-          amd: true
       - store_test_results:
           path: "/tmp/test-results/circle"
       - store_artifacts:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -555,9 +555,11 @@ jobs:
           name: Format test results for upload
           command: go tool test2json -t < "/tmp/go-test-results.txt" > "${TEST_RESULTS}/go-test-results.jsonl" || true
           when: always
-      - run: 
+      - run:
           name: Create JunitXML for DataDog
-          command: gotestsum --junitxml junit_test_results.xml --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
+          command: |
+            go install gotest.tools/gotestsum@latest
+            gotestsum --junitxml junit_test_results.xml --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
           when: always
       - run:
           name: Dump debugging info in case of failure

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1582,7 +1582,7 @@ jobs:
       - upload-junit-datadog:
           service: bazel-tests
           env: ci-bazel
-          path: /tmp/bazel-testlogs/* /tmp/bazel-testlogs/src/**/**/**/* /tmp/bazel-testlogs/src/**/**/**/**/*
+          path: /tmp/bazel-testlogs/*.xml /tmp/bazel-testlogs/src/**/**/**/*.xml /tmp/bazel-testlogs/src/**/**/**/**/*.xml
       - store_test_results:
           path: /tmp/bazel-testlogs/
       - codecov/upload:
@@ -1626,14 +1626,6 @@ jobs:
           --config=remotecache \
           --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} \
           //:privileged_tests
-      - run: |
-          ls -lf bazel-testlogs
-          echo '---'
-          ls -lf /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/src
-      - upload-junit-datadog:
-          service: bazel-privileged-tests
-          env: ci-bazel
-          path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/**
       - store_test_results:
           path: /home/circleci/out/execroot/_main/bazel-out/k8-fastbuild/testlogs/
       - codecov/upload:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1582,7 +1582,7 @@ jobs:
       - upload-junit-datadog:
           service: bazel-tests
           env: ci-bazel
-          path: /tmp/bazel-testlogs
+          path: /tmp/bazel-testlogs/*
       - store_test_results:
           path: /tmp/bazel-testlogs/
       - codecov/upload:
@@ -1626,6 +1626,9 @@ jobs:
           --config=remotecache \
           --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} \
           //:privileged_tests
+      - run: |
+          ls -lf
+          ls -lf /home/circleci/out
       - upload-junit-datadog:
           service: bazel-privileged-tests
           env: ci-bazel

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1582,7 +1582,7 @@ jobs:
       - upload-junit-datadog:
           service: bazel-tests
           env: ci-bazel
-          path: /tmp/bazel-testlogs/*.xml /tmp/bazel-testlogs/src/**/**/**/*.xml /tmp/bazel-testlogs/src/**/**/**/**/*.xml
+          path: /tmp/bazel-testlogs/**/*.xml /tmp/bazel-testlogs/src/**/**/**/*.xml /tmp/bazel-testlogs/src/**/**/**/**/*.xml
       - store_test_results:
           path: /tmp/bazel-testlogs/
       - codecov/upload:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -568,6 +568,7 @@ jobs:
       - upload-junit-datadog:
           service: deploy-tests
           env: ci-minikube
+          amd: true
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -2217,12 +2218,19 @@ commands:
       path:
         type: string
         default: "/tmp/test-results"
+      amd: 
+        type: boolean
+        default: false
     steps:
       - run:
           name: Upload Tests to DataDog
           when: always
           command: |
-            curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
+            if [ amd ]; then
+              curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
+            else
+              npm install -g @datadog/datadog-ci 
+            fi
             ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
   collect-test-results:
     steps:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -559,7 +559,7 @@ jobs:
           name: Create JunitXML for DataDog
           command: |
             go install gotest.tools/gotestsum@latest
-            gotestsum --junitfile junit_test_results.xml --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
+            gotestsum --junitfile "${TEST_RESULTS}/junit_test_results.xml" --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
           when: always
       - run:
           name: Dump debugging info in case of failure

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -566,8 +566,8 @@ jobs:
           when: always
           command: etc/testing/circle/format-coverage.sh
       - upload-junit-datadog:
-        service: deploy-tests
-        env: ci-minikube
+          service: deploy-tests
+          env: ci-minikube
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -2222,8 +2222,8 @@ commands:
           name: Upload Tests to DataDog
           when: always
           command: |
-              curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
-              ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
+            curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
+            ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
   collect-test-results:
     steps:
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -555,12 +555,14 @@ jobs:
           name: Format test results for upload
           command: go tool test2json -t < "/tmp/go-test-results.txt" > "${TEST_RESULTS}/go-test-results.jsonl" || true
           when: always
+      - run: 
+          name: Create JunitXML for DataDog
+          command: gotestsum --junitxml junit_test_results.xml --raw-command cat "${TEST_RESULTS}/go-test-results.jsonl"
+          when: always
       - run:
           name: Dump debugging info in case of failure
           when: on_fail
           command: etc/testing/circle/kube_debug.sh
-      - store_artifacts:
-          path: /tmp/test-results
       - run:
           name: Format code coverage
           when: always

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2228,10 +2228,11 @@ commands:
           command: |
             if [ amd ]; then
               curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
+              ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
             else
               npm install -g @datadog/datadog-ci 
+              datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
             fi
-            ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
   collect-test-results:
     steps:
       - run:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2227,11 +2227,11 @@ commands:
           when: always
           command: |
             if [ << parameters.amd >> ]; then
-              curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
-              ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
-            else
               npm install -g @datadog/datadog-ci 
               datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
+            else
+              curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "./datadog-ci" && chmod +x ./datadog-ci
+              ./datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
             fi
   collect-test-results:
     steps:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -264,6 +264,11 @@ jobs:
           name: Dump debugging info in case of failure
           when: on_fail
           command: etc/testing/circle/kube_debug.sh
+      - upload-junit-datadog:
+          service: integration-tests
+          env: ci-minikube
+          path: /tmp/test-results/circle
+          amd: true
       - store_test_results:
           path: "/tmp/test-results/circle"
       - store_artifacts:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -2235,7 +2235,7 @@ commands:
           name: Upload Tests to DataDog
           when: always
           command: |
-            if [ << parameters.amd >> ]; then
+            if [ "<< parameters.amd >>" = "true" ]; then
               npm install -g @datadog/datadog-ci 
               datadog-ci junit upload --service "pachyderm/<< parameters.service >>" --env "<< parameters.env >>" << parameters.path >>
             else

--- a/etc/testing/circle/deploy_test.sh
+++ b/etc/testing/circle/deploy_test.sh
@@ -33,8 +33,8 @@ then
     if [ "${#test_names}" -gt 0 ]
     then
         test_names="${test_names::-1}" # trim last |
-        go test -v=test2json -run "$test_names" -failfast -parallel=3 -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
+        gotestsum --raw-command --junitfile "/tmp/test-results/junit-test-results.xml" --jsonfile "/tmp/test-results/go-test-results.jsonl" --debug -- go test -json -run "$test_names" -failfast -parallel=3 -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
     fi
 else
-    go test -v=test2json -failfast -parallel=3 -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
+    gotestsum --raw-command --junitfile "/tmp/test-results/junit-test-results.xml" --jsonfile "/tmp/test-results/go-test-results.jsonl" --debug -- go test -json -failfast -parallel=3 -timeout 3600s ./src/testing/deploy -tags=k8s -cover -test.gocoverdir="$TEST_RESULTS" -covermode=atomic -coverpkg=./... | stdbuf -i0 tee -a /tmp/go-test-results.txt
 fi


### PR DESCRIPTION
We have DataDog now in a non-trial capacity. With a little instrumentation, we can effectively replace all the grafana stuff I did before with DataDogs version which happens to be basically the same thing, but with all the data from all the ai-at-scale repos. 

This PR hooks up the integration, deploy and bazel tests. to datadog so now we can get individual test statistics which should help with over time results and flaky test detection. Here's the test from this branch! Let me know if you need access. [Search](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40git.branch%3A%22djanicek%2Finfeng-734%2Ftests-to-datadog%22&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1718048675313&end=1718653475313&paused=false) 

This change should let us deprecate the test results that I was collecting in grafana. This collects all that data plus some more.