### PR TITLE
Update Console Deployment to use Proxy's TLS Cert [CORE-2321]

### DIFF
--- a/etc/helm/pachyderm/templates/console/deployment.yaml
+++ b/etc/helm/pachyderm/templates/console/deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - name: UPGRADE_NO_OP
           value: {{ randAlphaNum 32 }}
         {{- end }}
-        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        {{- if and .Values.proxy.tls.enabled .Values.global.customCaCerts }}
         - name: NODE_EXTRA_CA_CERTS
           value:  /pach-tls/certs/root.crt
         {{- end }}
@@ -128,7 +128,7 @@ spec:
           name: home
         - mountPath: /tmp/
           name: tmp
-        {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+        {{- if and .Values.proxy.tls.enabled .Values.global.customCaCerts }}
         - mountPath: /pach-tls/certs
           name: pachd-tls-cert
         {{- end }}
@@ -160,10 +160,10 @@ spec:
         name: tmp
       - emptyDir: {}
         name: home
-      {{- if and .Values.pachd.tls.enabled .Values.global.customCaCerts }}
+      {{- if and .Values.proxy.tls.enabled .Values.global.customCaCerts }}
       - name: pachd-tls-cert
         secret:
-          secretName: {{ required "If pachd.tls.enabled, you must set pachd.tls.secretName" .Values.pachd.tls.secretName | quote }}
+          secretName: {{ required "If proxy.tls.enabled, you must set proxy.tls.secretName" .Values.proxy.tls.secretName | quote }}
           items:
           - key: tls.crt
             path: root.crt


### PR DESCRIPTION
Updates Console Helm deployment to use the Proxy's TLS Cert instead of Pachd's if `global.customCaCerts: true`