### PR TITLE
starlark: avoid the need to read $PWD

### DIFF
--- a/src/internal/starlark/starlark.go
+++ b/src/internal/starlark/starlark.go
@@ -101,7 +101,7 @@ func Run(rctx context.Context, in string, opts Options, f RunFunc) (starlark.Str
 	dir := filepath.Dir(path)
 	abs, err := filepath.Abs(dir)
 	if err != nil {
-		return nil, errors.Wrapf(err, "find absolute location of starlark file %v", path)
+		abs = dir
 	}
 
 	thread := newThread(filepath.Base(path))


### PR DESCRIPTION
It seems the pachdev containers don't run pachd in a readable $PWD.  This is fine, we shouldn't be looking at the filesystem during RunProgram anyway.

The reason that we do filepath.Abs is so `load()` works relative to the location of the script file.  Since RunProgram isn't running programs from the filesystem, there isn't really anything that makes sense for `load` to use as the script location.