### PR TITLE
Disable ms test for now

### DIFF
--- a/src/server/pfs/server/storage_bucket_test.go
+++ b/src/server/pfs/server/storage_bucket_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestMicrosoft(t *testing.T) {
+	t.Skip("azure account seems broken: PFS-255")
 	integrationtests.LoadMicrosoftParameters(t)
 	require.NoError(t, os.Setenv("AZURE_STORAGE_ACCOUNT", os.Getenv("MICROSOFT_CLIENT_ID")))
 	require.NoError(t, os.Setenv("AZURE_STORAGE_KEY", os.Getenv("MICROSOFT_CLIENT_SECRET")))


### PR DESCRIPTION
PFS-255 tracks reenabling this test, if we want to.

There is also a Slack thread: https://hpe-aiatscale.slack.com/archives/C055C0EN7CJ/p1719429651318399