### PR TITLE
Add ./python-sdk to extra paths for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
       ],
       "url": "https://raw.githubusercontent.com/pachyderm/pachyderm/master/src/internal/jsonschema/pps_v2/CreatePipelineRequest.schema.json"
     }
+  ],
+  "python.analysis.extraPaths": [
+    "./python-sdk"
   ]
 }


### PR DESCRIPTION
Adding `./python-sdk` to `"python.analysis.extraPaths": []` fixes problems with VSCode not being able to resolve types for our python-sdk when being used in the JupyterLab extension 