### PR TITLE
pin pip version for jupyter extension docker build

### DIFF
--- a/jupyter-extension/Dockerfile
+++ b/jupyter-extension/Dockerfile
@@ -11,7 +11,7 @@ USER root
 COPY ./dist-pach/pachctl/pachctl_linux_amd64_v1/pachctl /usr/local/bin/pachctl
 
 USER $NB_UID
-RUN pip install --upgrade pip
+RUN pip install pip==24.0
 
 USER root
 WORKDIR /app


### PR DESCRIPTION
the latest release of pip was pulling in different versions of dependencies which broke our build. this change pins the pip install version to the version before that, which was working.