### PR TITLE
debug: lock server.Send; lock progress increment

### DIFF
--- a/src/server/debug/server/BUILD.bazel
+++ b/src/server/debug/server/BUILD.bazel
@@ -59,6 +59,7 @@ go_library(
         "@org_golang_google_protobuf//types/known/wrapperspb",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -322,8 +322,8 @@ func (s *lockedServer) Send(c *debug.DumpChunk) error {
 	return s.Debug_DumpV2Server.Send(c)
 }
 
-func (s *debugServer) DumpV2(request *debug.DumpV2Request, _server debug.Debug_DumpV2Server) error {
-	server := &lockedServer{Debug_DumpV2Server: _server}
+func (s *debugServer) DumpV2(request *debug.DumpV2Request, originalServer debug.Debug_DumpV2Server) error {
+	server := &lockedServer{Debug_DumpV2Server: originalServer}
 	if request == nil {
 		return errors.New("nil debug.DumpV2Request")
 	}

--- a/src/server/debug/server/server.go
+++ b/src/server/debug/server/server.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/wcharczuk/go-chart"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
@@ -310,7 +311,19 @@ func (s *debugServer) fillApps(ctx context.Context, reqApps []*debug.App) error 
 	return nil
 }
 
-func (s *debugServer) DumpV2(request *debug.DumpV2Request, server debug.Debug_DumpV2Server) error {
+type lockedServer struct {
+	sync.Mutex
+	debug.Debug_DumpV2Server
+}
+
+func (s *lockedServer) Send(c *debug.DumpChunk) error {
+	s.Lock()
+	defer s.Unlock()
+	return s.Debug_DumpV2Server.Send(c)
+}
+
+func (s *debugServer) DumpV2(request *debug.DumpV2Request, _server debug.Debug_DumpV2Server) error {
+	server := &lockedServer{Debug_DumpV2Server: _server}
 	if request == nil {
 		return errors.New("nil debug.DumpV2Request")
 	}
@@ -633,15 +646,15 @@ func recordProgress(server debug.Debug_DumpV2Server, task string, total int) inc
 	if server == nil {
 		return func(ctx context.Context) {}
 	}
-	inc := 0
+	var inc atomic.Int64
 	return func(ctx context.Context) {
-		inc++
+		inc.Add(1)
 		if err := server.Send(
 			&debug.DumpChunk{
 				Chunk: &debug.DumpChunk_Progress{
 					Progress: &debug.DumpProgress{
 						Task:     task,
-						Progress: int64(inc),
+						Progress: inc.Load(),
 						Total:    int64(total),
 					},
 				},


### PR DESCRIPTION
This avoids two data races in the debug dumper.  One is calling `Send()` concurrently, the other is incrementing the progress concurrently.

You can see the race conditions without this PR if you run `bazel run --@rules_go//go/config:race //src/testing/testpachd` and then take a debug dump.

Part of CORE-2278.