### PR TITLE
[PFS-260] Work-In-Progress Pin()

### DIFF
--- a/src/internal/storage/fileset/BUILD.bazel
+++ b/src/internal/storage/fileset/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
         "//src/internal/storage/fileset/index",
         "//src/internal/storage/track",
         "@com_github_docker_go_units//:go-units",
+        "@com_github_google_go_cmp//cmp",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_x_sync//errgroup",

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -465,3 +465,44 @@ func (d *deleter) DeleteTx(tx *pachsql.Tx, oid string) error {
 	}
 	return d.store.DeleteTx(tx, *id)
 }
+
+// ResolveHandle determines which ValidFileset a Handle points to.
+// TODO(Fahad): once handles are actually external, we'll need to determine this via a lookup table.
+func (s *Storage) ResolveHandle(ctx context.Context, handle Handle) (ValidFileset, error) {
+	id, err := ParseID(string(handle))
+	if err != nil {
+		return nil, errors.Wrap(err, "resolve handle")
+	}
+	fs, err := s.Open(ctx, []ID{*id})
+	if err != nil {
+		return nil, errors.Wrap(err, "resolve handle")
+	}
+	return internalFileset{
+		id:      *id,
+		fileset: fs,
+	}, nil
+}
+
+// Pin resolves and clones a ValidFileset, keeping it alive forever.
+/* 	TODO(Fahad): Replace cloning with new fileset ID system where IDs are stable hashes of the root.
+   	Fileset trees must be convergent in order to achieve this. */
+func (s *Storage) Pin(ctx context.Context, fs ValidFileset) (PinnedFileset, error) {
+	var id *ID
+	var err error
+	if err = dbutil.WithTx(ctx, s.store.DB(), func(ctx context.Context, tx *pachsql.Tx) error {
+		id, err = s.CloneTx(tx, fs.ID(), track.NoTTL)
+		return err
+	}); err != nil {
+		return PinnedFileset{}, errors.Wrap(err, "pin")
+	}
+	newFs, err := s.Open(ctx, []ID{*id})
+	if err != nil {
+		return PinnedFileset{}, errors.Wrap(err, "pin")
+	}
+	return PinnedFileset{
+		internalFileset{
+			id:      *id,
+			fileset: newFs,
+		},
+	}, nil
+}


### PR DESCRIPTION
This PR includes interfaces that will be consumed by PJS DB to force a user to validate their filesets before passing them to PJS DB functions. It also defines a Pin() function that will be used later by PJS. Currently the Pin() function clones filesets with a TTL of 0, but in the future we want to update the way Pin() works. That change is blocked on a design for a new fileset system where IDs are hashes of the root index and fileset trees are convergent.