### PR TITLE
Disable fail tests on console due to display issues.

### DIFF
--- a/jupyter-extension/jest.config.js
+++ b/jupyter-extension/jest.config.js
@@ -11,7 +11,8 @@ const esModules = [
 baseConfig.transformIgnorePatterns = [`/node_modules/(?!${esModules}).+`];
 baseConfig.preset = 'ts-jest/presets/js-with-babel';
 baseConfig.testEnvironment = 'jsdom';
-baseConfig.setupFilesAfterEnv.push('<rootDir>/scripts/jest.setup.js');
+// TODO: Reenable this once we figure out why it is causing issues with stack traces being inaccurate and general display bugs.
+// baseConfig.setupFilesAfterEnv.push('<rootDir>/scripts/jest.setup.js');
 
 // On the current version of Jest we are using it will warn us about real timers being cleared when using `advanceTimersByTime`
 // regardless of if we setup fake timers or not. In future versions of jest timers are rewritten again and should not have this issue.

--- a/jupyter-extension/scripts/jest.setup.js
+++ b/jupyter-extension/scripts/jest.setup.js
@@ -1,8 +1,12 @@
+// NOTE: This is temporarily unused see `jest.config.js` for where it is commented out.
+
 import failOnConsole from 'jest-fail-on-console'
 
 const ignoredErrors = [
-  // I am not exactly sure what causes this error to occur. This typically occurs when findByTestId is not properly awaited which is not happening.
-  // The tests seem fine and pass. I think we should revisit this error once we can update all the testing libraries, but for now it can be silenced.
+  // This error is caused because we are running two different versions of react in our application. JupyterLab depends on a higher
+  // version of react than our extension does. React supports this behavior by design, but this is something we should eventually address by
+  // updating our version of React. Two different versions of React can cause some unexpected problems given the difference between the two is a major version and
+  // the ability to run two different versions of react is meant primarily for entirely separate areas of an application not tightly coupled like JupyterLab and our extension.
   (msg) => msg.includes('Warning: An update to Datum inside a test was not wrapped in act(...)')
 ]
 const ignoredWarnings = [


### PR DESCRIPTION
@kevyang and I were noticing that this failOnConsole functionality seems to be causing a lot of display issues with the test output and even some missing stack traces. Since we can enforce this manually by just checking the output of tests I think it is better for developer velocity to disable this for now. 

While I am working on the 4.0.0 tests I'll see if I can fix this, but it is really a nice to have more than a requirement for our development environment.

I also found out the exact reason for the `Warning: An update to Datum inside a test was not wrapped in act(...)` errors. We probably should tackle getting our react versions in sync, but in theory it should not cause any issues besides page load. I am a little worried though since two separate versions of React is meant more for entirely separate parts of an application not tightly coupled dependencies.