### PR TITLE
debug: lock server.Send; lock progress increment (#10177)

### DIFF
--- a/src/server/debug/server/BUILD.bazel
+++ b/src/server/debug/server/BUILD.bazel
@@ -59,6 +59,7 @@ go_library(
         "@org_golang_google_protobuf//types/known/wrapperspb",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
 )


### PR DESCRIPTION
This avoids two data races in the debug dumper. One is calling `Send()` concurrently, the other is incrementing the progress concurrently.

You can see the race conditions without this PR if you run `bazel run --@rules_go//go/config:race //src/testing/testpachd` and then take a debug dump.

Part of CORE-2278.