### PR TITLE
Fix panic in pipelines_test

### DIFF
--- a/src/internal/ppsdb/BUILD.bazel
+++ b/src/internal/ppsdb/BUILD.bazel
@@ -33,11 +33,27 @@ go_library(
 go_test(
     name = "ppsdb_test",
     size = "small",
-    srcs = ["ppsdb_test.go"],
+    srcs = [
+        "pipelines_test.go",
+        "ppsdb_test.go",
+    ],
     embed = [":ppsdb"],
     deps = [
+        "//src/internal/clusterstate",
+        "//src/internal/dockertestenv",
+        "//src/internal/migrations",
+        "//src/internal/pachsql",
+        "//src/internal/pctx",
+        "//src/internal/pfsdb",
+        "//src/internal/protoutil",
+        "//src/internal/require",
+        "//src/internal/testetcd",
+        "//src/internal/uuid",
         "//src/pfs",
         "//src/pps",
+        "@com_github_google_go_cmp//cmp",
+        "@org_golang_google_protobuf//testing/protocmp",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 

--- a/src/internal/ppsdb/pipelines_test.go
+++ b/src/internal/ppsdb/pipelines_test.go
@@ -121,6 +121,7 @@ func TestUpsertPipeline(t *testing.T) {
 			},
 			Id: uuid.NewWithoutDashes(),
 		},
+		Details: &pps.PipelineInfo_Details{},
 	}
 	withTx(t, ctx, db, func(ctx context.Context, tx *pachsql.Tx) {
 		err := pfsdb.UpsertProject(ctx, tx, &pfs.ProjectInfo{Project: expectedInfo.Pipeline.Project})


### PR DESCRIPTION
This panics and CI didn't notice because it wasn't being run.  I have no idea why `gazelle -mode=diff` doesn't work on CI, but that's how this made it in.