### PR TITLE
Ignore shellcheck for console dir

### DIFF
--- a/etc/testing/lint.sh
+++ b/etc/testing/lint.sh
@@ -23,7 +23,7 @@ GOMEMLIMIT=10000000000 golangci-lint run --max-same-issues=1000 --
 
 # shellcheck disable=SC2046
 find . \
-  \( -path ./etc/plugin "${skip_paths[@]}" \) -prune -o -name "*.sh" -print0 \
+  \( -path ./etc/plugin "${skip_paths[@]}" \) -prune -o -name "*.sh" ! -path "*/console/*" -print0 \
 | xargs -0 -P 16 shellcheck -e SC1091 -e SC2010 -e SC2181 -e SC2004 -e SC2219
 
 go install github.com/neilpa/yajsv@latest


### PR DESCRIPTION
`static-go-checks` shouldn't care about the console directory.