### PR TITLE
[PFS-260] Work in Progress Pin Function

### DIFF
--- a/src/internal/storage/fileset/BUILD.bazel
+++ b/src/internal/storage/fileset/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
     shard_count = 8,
     tags = ["cpu:4"],
     deps = [
+        "//src/internal/dbutil",
         "//src/internal/dockertestenv",
         "//src/internal/errors",
         "//src/internal/miscutil",

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -465,3 +465,17 @@ func (d *deleter) DeleteTx(tx *pachsql.Tx, oid string) error {
 	}
 	return d.store.DeleteTx(tx, *id)
 }
+
+type PinnedFileset ID
+
+// Pin clones a fileset, keeping it alive forever.
+/* 	TODO(Fahad): Replace cloning with a Pin that is a big int.
+	A pin will point to a fileset ID, where the ID is a stable hash of the root index.
+   	Fileset trees must be convergent in order to achieve this. */
+func (s *Storage) Pin(tx *pachsql.Tx, fs ID) (PinnedFileset, error) {
+	id, err := s.CloneTx(tx, fs, track.NoTTL)
+	if err != nil {
+		return PinnedFileset{}, errors.Wrap(err, "pin")
+	}
+	return PinnedFileset(*id), nil
+}


### PR DESCRIPTION
The real pin function will create an entry in the storage.fileset_pins table pointing back to a storage.fileset. In the meantime, we decided that a clone with an unlimited TTL would suffice for now.