### PR TITLE
Add branch creator / creation time / update time

### DIFF
--- a/src/internal/clusterstate/v2.11.0/clusterstate.go
+++ b/src/internal/clusterstate/v2.11.0/clusterstate.go
@@ -11,5 +11,6 @@ func Migrate(state migrations.State) migrations.State {
 		Apply("Add auth principals table", addAuthPrincipals, migrations.Squash).
 		Apply("Add project created_by", addProjectCreatedBy, migrations.Squash).
 		Apply("Create PJS schema", createPJSSchema, migrations.Squash).
-		Apply("Add commit created_by", addCommitCreatedBy, migrations.Squash)
+		Apply("Add commit created_by", addCommitCreatedBy, migrations.Squash).
+		Apply("Add branch created_by", addBranchCreatedBy, migrations.Squash)
 }

--- a/src/internal/clusterstate/v2.11.0/metadata.go
+++ b/src/internal/clusterstate/v2.11.0/metadata.go
@@ -24,3 +24,12 @@ func addCommitCreatedBy(ctx context.Context, env migrations.Env) error {
 	}
 	return nil
 }
+
+func addBranchCreatedBy(ctx context.Context, env migrations.Env) error {
+	ctx = pctx.Child(ctx, "addBranchCreatedBy")
+	tx := env.Tx
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE pfs.branches ADD COLUMN created_by TEXT REFERENCES auth.principals(subject)`); err != nil {
+		return errors.Wrap(err, "add created_by column to pfs.branches")
+	}
+	return nil
+}

--- a/src/internal/pfsdb/branches_test.go
+++ b/src/internal/pfsdb/branches_test.go
@@ -25,6 +25,8 @@ import (
 
 func compareBranchOpts() []cmp.Option {
 	return []cmp.Option{
+		protocmp.FilterField(new(pfs.BranchInfo), "created_at", cmp.Ignore()),
+		protocmp.FilterField(new(pfs.BranchInfo), "updated_at", cmp.Ignore()),
 		cmpopts.SortSlices(func(a, b *pfs.Branch) bool { return a.Key() < b.Key() }), // Note that this is before compareBranch because we need to sort first.
 		cmpopts.SortMaps(func(a, b pfsdb.BranchID) bool { return a < b }),
 		cmpopts.EquateEmpty(),

--- a/src/internal/pfsdb/branches_test.go
+++ b/src/internal/pfsdb/branches_test.go
@@ -121,7 +121,8 @@ func TestBranchUpsert(t *testing.T) {
 					Repo: repoInfo.Repo,
 					Name: "master",
 				},
-				Head: commit1.CommitInfo.Commit,
+				Head:      commit1.CommitInfo.Commit,
+				CreatedBy: "the_tests",
 			}
 			id, err := pfsdb.UpsertBranch(ctx, tx, branchInfo)
 			require.NoError(t, err)
@@ -147,9 +148,18 @@ func TestBranchUpsert(t *testing.T) {
 			id3, err := pfsdb.UpsertBranch(ctx, tx, branchInfo)
 			require.NoError(t, err)
 			require.Equal(t, id, id3, "UpsertBranch should keep id stable")
-			gotBranchInfo3, err := pfsdb.GetBranchInfo(ctx, tx, id2)
+			gotBranchInfo3, err := pfsdb.GetBranchInfo(ctx, tx, id3)
 			require.NoError(t, err)
 			require.NoDiff(t, branchInfo, gotBranchInfo3, compareBranchOpts())
+
+			// Attempt to change creator.
+			branchInfo.CreatedBy = ""
+			id4, err := pfsdb.UpsertBranch(ctx, tx, branchInfo)
+			require.NoError(t, err)
+			require.Equal(t, id, id4, "UpsertBranch should keep id stable")
+			gotBranchInfo4, err := pfsdb.GetBranchInfo(ctx, tx, id4)
+			require.NoError(t, err)
+			require.NoDiff(t, gotBranchInfo3, gotBranchInfo4, compareBranchOpts())
 		})
 	})
 }

--- a/src/internal/pfsdb/model.go
+++ b/src/internal/pfsdb/model.go
@@ -157,11 +157,12 @@ func (commit *CommitRow) Pb() *pfs.Commit {
 
 // BranchRow is a row in the pfs.branches table.
 type BranchRow struct {
-	ID       BranchID              `db:"id"`
-	Head     CommitRow             `db:"head"`
-	Repo     RepoRow               `db:"repo"`
-	Name     string                `db:"name"`
-	Metadata pgjsontypes.StringMap `db:"metadata"`
+	ID        BranchID              `db:"id"`
+	Head      CommitRow             `db:"head"`
+	Repo      RepoRow               `db:"repo"`
+	Name      string                `db:"name"`
+	Metadata  pgjsontypes.StringMap `db:"metadata"`
+	CreatedBy sql.NullString        `db:"created_by"`
 	CreatedAtUpdatedAt
 }
 

--- a/src/server/pfs/server/driver.go
+++ b/src/server/pfs/server/driver.go
@@ -881,7 +881,9 @@ func (d *driver) startCommit(
 		}
 		updateCommitBranchField = true // the branch field on the commit will have to be updated after the branch is created.
 	}
-	branchInfo := &pfs.BranchInfo{}
+	branchInfo := &pfs.BranchInfo{
+		CreatedBy: txnCtx.Username(),
+	}
 	if b != nil && b.BranchInfo != nil {
 		branchInfo = b.BranchInfo
 	}
@@ -1708,7 +1710,7 @@ func (d *driver) fillNewBranches(ctx context.Context, txnCtx *txncontext.Transac
 			updateHead = head
 			newRepoCommits[p.Repo.Key()] = head
 		}
-		branchInfo := &pfs.BranchInfo{Branch: p, Head: head.CommitInfo.Commit}
+		branchInfo := &pfs.BranchInfo{Branch: p, Head: head.CommitInfo.Commit, CreatedBy: txnCtx.Username()}
 		if _, err := pfsdb.UpsertBranch(ctx, txnCtx.SqlTx, branchInfo); err != nil {
 			return errors.Wrap(err, "upsert branch")
 		}
@@ -1854,7 +1856,9 @@ func (d *driver) createBranch(ctx context.Context, txnCtx *txncontext.Transactio
 	if err != nil && !pfsdb.IsNotFoundError(err) {
 		return errors.Wrap(err, "create branch")
 	}
-	branchInfo := &pfs.BranchInfo{}
+	branchInfo := &pfs.BranchInfo{
+		CreatedBy: txnCtx.Username(),
+	}
 	if branch != nil {
 		branchInfo = branch.BranchInfo
 	}


### PR DESCRIPTION
This tracks the original creator of branches.  I audited all the points where we UpsertBranch and passed the creator through where it's possible to create a new branch.  (The impossible case is branch deletion.)

`pachctl` has been adjusted to print the creator when pretty-printing branches (list / inspect).  There was also a bug where printing the branch head during `inspect` failed after the branch removal refactor, I fixed that as well.

```
$ pachctl inspect branch images@master
Name: images@master
Head Commit: images@7efc7c68e8444dff8ecdf6175d86ecee
Created by: pach:root
Created at: 2024-07-19T00:20:39Z
```
```
$ pachctl list branch images
BRANCH HEAD                             TRIGGER CREATOR   CREATED
master 7efc7c68e8444dff8ecdf6175d86ecee -       pach:root 2024-07-18T20:20:39-04:00
```