### PR TITLE
CONSOLE: Remove typename in tests to fix the build

### DIFF
--- a/console/frontend/src/lib/DAG/convertPipelinesAndReposToVertices.ts
+++ b/console/frontend/src/lib/DAG/convertPipelinesAndReposToVertices.ts
@@ -28,7 +28,6 @@ import {
 } from './DAGhelpers';
 
 export type Vertex = {
-  __typename?: 'Vertex';
   access: boolean;
   createdAt?: number;
   id: string;

--- a/console/frontend/src/mocks/branches.ts
+++ b/console/frontend/src/mocks/branches.ts
@@ -9,14 +9,11 @@ const BRANCH_MASTER: BranchInfo = {
     repo: {
       name: 'images',
       type: undefined,
-      __typename: 'Repo',
     },
-    __typename: 'Branch',
   },
   head: {
     id: 'c43fffd650a24b40b7d9f1bf90fcfdbe',
   },
-  __typename: 'BranchInfo',
 };
 
 const BRANCH_NEW: BranchInfo = {
@@ -25,14 +22,11 @@ const BRANCH_NEW: BranchInfo = {
     repo: {
       name: 'images',
       type: undefined,
-      __typename: 'Repo',
     },
-    __typename: 'Branch',
   },
   head: {
     id: '4a83c74809664f899261baccdb47cd90',
   },
-  __typename: 'BranchInfo',
 };
 
 const BRANCH_SAMPLE: BranchInfo = {
@@ -41,14 +35,11 @@ const BRANCH_SAMPLE: BranchInfo = {
     repo: {
       name: 'images',
       type: undefined,
-      __typename: 'Repo',
     },
-    __typename: 'Branch',
   },
   head: {
     id: '4eb1aa567dab483f93a109db4641ee75',
   },
-  __typename: 'BranchInfo',
 };
 
 export const BRANCH_RENDER: BranchInfo = {
@@ -57,14 +48,11 @@ export const BRANCH_RENDER: BranchInfo = {
     repo: {
       name: 'images',
       type: undefined,
-      __typename: 'Repo',
     },
-    __typename: 'Branch',
   },
   head: {
     id: '252d1850a5fa484ca7320ce1091cf483',
   },
-  __typename: 'BranchInfo',
 };
 
 const BRANCH_RENDERTWO: BranchInfo = {
@@ -73,14 +61,11 @@ const BRANCH_RENDERTWO: BranchInfo = {
     repo: {
       name: 'images',
       type: undefined,
-      __typename: 'Repo',
     },
-    __typename: 'Branch',
   },
   head: {
     id: '252d1850a5fa484ca7320ce1091cf483',
   },
-  __typename: 'BranchInfo',
 };
 
 const BRANCH_TEST: BranchInfo = {
@@ -89,11 +74,8 @@ const BRANCH_TEST: BranchInfo = {
     repo: {
       name: 'images',
       type: undefined,
-      __typename: 'Repo',
     },
-    __typename: 'Branch',
   },
-  __typename: 'BranchInfo',
 };
 
 export const mockGetBranchesMasterOnly = () =>

--- a/console/frontend/src/mocks/commits.ts
+++ b/console/frontend/src/mocks/commits.ts
@@ -20,7 +20,6 @@ import generateId from '@dash-frontend/lib/generateId';
 
 export const buildCommit = (commit: CommitInfo) => {
   const defaultCommit: CommitInfo = {
-    __typename: 'CommitInfo',
     origin: {kind: OriginKind.USER},
     metadata: {metadataCommitKey: 'metadataCommitValue'},
   };
@@ -290,7 +289,6 @@ export const mockStartCommit = (id: string) =>
             project: {
               name: 'default',
             },
-            __typename: 'Repo',
           },
           id,
           branch: {
@@ -303,7 +301,6 @@ export const mockStartCommit = (id: string) =>
             },
             name: 'master',
           },
-          __typename: 'Commit',
         }),
       );
     },

--- a/console/frontend/src/mocks/datums.ts
+++ b/console/frontend/src/mocks/datums.ts
@@ -32,7 +32,6 @@ export const buildDatum = (datum: Partial<DatumInfo>): DatumInfo => {
       uploadBytes: '',
     },
     state: DatumState.SUCCESS,
-    __typename: 'DatumInfo',
   };
 
   return merge(defaultDatum, datum);

--- a/console/frontend/src/mocks/files.ts
+++ b/console/frontend/src/mocks/files.ts
@@ -11,9 +11,7 @@ import {
 } from '@dash-frontend/api/pfs';
 import {RequestError} from '@dash-frontend/api/utils/error';
 export const buildFile = (file: FileInfo) => {
-  const defaultFile: FileInfo = {
-    __typename: 'FileInfo',
-  };
+  const defaultFile: FileInfo = {};
 
   return merge(defaultFile, file);
 };

--- a/console/frontend/src/mocks/jobs.ts
+++ b/console/frontend/src/mocks/jobs.ts
@@ -39,7 +39,6 @@ export const buildJob = (job: Partial<JobInfo> = {}): JobInfo => {
     finished: undefined,
     reason: undefined,
     outputCommit: undefined,
-    __typename: 'JobInfo',
   };
 
   return merge(defaultJob, job);

--- a/console/frontend/src/mocks/logs.ts
+++ b/console/frontend/src/mocks/logs.ts
@@ -9,7 +9,6 @@ export const buildLog = (log: Partial<LogMessage>): LogMessage => {
     message: '',
     user: false,
     ts: undefined,
-    __typename: 'LogMessage',
   };
   return merge(defaultLog, log);
 };

--- a/console/frontend/src/mocks/pipelines.ts
+++ b/console/frontend/src/mocks/pipelines.ts
@@ -111,7 +111,6 @@ export const buildPipeline = (pipeline: PipelineInfo = {}): PipelineInfo => {
     type: PipelineInfoPipelineType.PIPELINE_TYPE_TRANSFORM,
     lastJobState: PipelineInfoJobState.JOB_CREATED,
     reason: undefined,
-    __typename: 'PipelineInfo',
   };
 
   return merge(defaultPipeline, pipeline);

--- a/console/frontend/src/mocks/projects.ts
+++ b/console/frontend/src/mocks/projects.ts
@@ -14,19 +14,16 @@ type ProjectsMap = {
 export const ALL_PROJECTS: ProjectsMap = {
   projects: [
     {
-      __typename: 'ProjectInfo',
       project: {name: 'ProjectA'},
       description: 'A description for project a',
       createdAt: '2020-09-13T12:26:10.000Z',
     },
     {
-      __typename: 'ProjectInfo',
       project: {name: 'ProjectB'},
       description: 'A description for project b',
       createdAt: '2017-07-14T02:40:20.000Z',
     },
     {
-      __typename: 'ProjectInfo',
       project: {name: 'ProjectC'},
       description: 'A description for project c',
       createdAt: '2014-05-13T16:53:40.000Z',

--- a/console/frontend/src/mocks/repos.ts
+++ b/console/frontend/src/mocks/repos.ts
@@ -16,7 +16,6 @@ export const buildRepo = (repo: Partial<RepoInfo> = {}): RepoInfo => {
     branches: [
       {
         name: 'master',
-        __typename: 'Branch',
       },
     ],
     created: '2023-07-24T17:58:24.000Z',
@@ -31,9 +30,7 @@ export const buildRepo = (repo: Partial<RepoInfo> = {}): RepoInfo => {
     sizeBytesUpperBound: '14783',
     authInfo: {
       roles: ['clusterAdmin'],
-      __typename: 'AuthInfo',
     },
-    __typename: 'RepoInfo',
   };
 
   return merge(defaultRepo, repo);
@@ -50,7 +47,6 @@ const REPO_INFO_EDGES: RepoInfo = buildRepo({
   branches: [
     {
       name: 'master',
-      __typename: 'Branch',
     },
   ],
   created: '2023-07-24T17:58:25Z',
@@ -63,7 +59,6 @@ const REPO_INFO_IMAGES: RepoInfo = buildRepo({
   branches: [
     {
       name: 'master',
-      __typename: 'Branch',
     },
   ],
   created: '2023-07-24T17:58:24Z',
@@ -80,7 +75,6 @@ export const REPO_INFO_EMPTY: RepoInfo = buildRepo({
   sizeBytesUpperBound: '0',
   authInfo: {
     roles: ['clusterAdmin', 'repoOwner'],
-    __typename: 'AuthInfo',
   },
 });
 

--- a/console/frontend/src/views/FileBrowser/components/FilePreview/__tests__/FilePreview.test.tsx
+++ b/console/frontend/src/views/FileBrowser/components/FilePreview/__tests__/FilePreview.test.tsx
@@ -608,7 +608,7 @@ describe('File Preview', () => {
           async (req, res, ctx) => {
             const body = await req.text();
             const expected =
-              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"},"__typename":"Repo"},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"},"__typename":"Commit"}}\n' +
+              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"}}}\n' +
               '{"deleteFile":{"path":"/image.png"}}';
             if (body === expected) {
               return res(ctx.json({}));
@@ -649,7 +649,7 @@ describe('File Preview', () => {
           async (req, res, ctx) => {
             const body = await req.text();
             const expected =
-              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"},"__typename":"Repo"},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"},"__typename":"Commit"}}\n' +
+              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"}}}\n' +
               '{"deleteFile":{"path":"/image.png"}}';
             if (body === expected) {
               return res(ctx.json({}));

--- a/console/frontend/src/views/FileBrowser/components/ListViewTable/__tests__/ListViewTable.test.tsx
+++ b/console/frontend/src/views/FileBrowser/components/ListViewTable/__tests__/ListViewTable.test.tsx
@@ -185,7 +185,7 @@ describe('List View Table', () => {
           async (req, res, ctx) => {
             const body = await req.text();
             const expected =
-              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"},"__typename":"Repo"},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"},"__typename":"Commit"}}\n' +
+              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"}}}\n' +
               '{"deleteFile":{"path":"/fruit.png"}}';
             if (body === expected) {
               return res(ctx.json({}));
@@ -216,7 +216,7 @@ describe('List View Table', () => {
           async (req, res, ctx) => {
             const body = await req.text();
             const expected =
-              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"},"__typename":"Repo"},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"},"__typename":"Commit"}}\n' +
+              '{"setCommit":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"id":"720d471659dc4682a53576fdb637a482","branch":{"repo":{"name":"images","type":"user","project":{"name":"default"}},"name":"master"}}}\n' +
               '{"deleteFile":{"path":"/fruit.png"}}\n' +
               '{"deleteFile":{"path":"/cats/"}}\n' +
               '{"deleteFile":{"path":"/liberty.png"}}';

--- a/console/frontend/src/views/Project/components/RepoList/__tests__/RepoList.test.tsx
+++ b/console/frontend/src/views/Project/components/RepoList/__tests__/RepoList.test.tsx
@@ -49,7 +49,6 @@ const mockMontageLastCommit = () =>
                 },
                 branch: {
                   name: 'master',
-                  __typename: 'Branch',
                 },
               },
               description: 'commit not finished',
@@ -80,7 +79,6 @@ const mockEdgesLastCommit = () =>
                 },
                 branch: {
                   name: 'master',
-                  __typename: 'Branch',
                 },
               },
               started: '2023-07-24T17:58:25Z',
@@ -110,7 +108,6 @@ const mockImagesLastCommit = () =>
                 },
                 branch: {
                   name: 'master',
-                  __typename: 'Branch',
                 },
               },
               started: '2023-07-24T17:58:25Z',


### PR DESCRIPTION
Build was failing in CI. We needed to remove the `__typename` field that was still present on our mocks.