### PR TITLE
A few tweaks for `pachctl logs2`

### DIFF
--- a/src/internal/cmdutil/pflag.go
+++ b/src/internal/cmdutil/pflag.go
@@ -19,6 +19,9 @@ func (value *TimeFlag) String() string {
 // Set implements the pflag.Value interface.  It sets the value of the flag to
 // its parsed argument, if it is acceptable RFC 3339 (with optional nanoseconds) format.
 func (value *TimeFlag) Set(s string) error {
+	if s == "" {
+		*value = TimeFlag(time.Time{})
+	}
 	ts, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
 		return errors.Wrapf(err, "invalid RFC3339 date: %s", s)

--- a/src/internal/cmdutil/pflag.go
+++ b/src/internal/cmdutil/pflag.go
@@ -22,12 +22,24 @@ func (value *TimeFlag) Set(s string) error {
 	if s == "" {
 		*value = TimeFlag(time.Time{})
 	}
-	ts, err := time.Parse(time.RFC3339Nano, s)
-	if err != nil {
-		return errors.Wrapf(err, "invalid RFC3339 date: %s", s)
+
+	var errs error
+	// Try parsing as a timestamp.
+	if ts, err := time.Parse(time.RFC3339Nano, s); err != nil {
+		errors.JoinInto(&errs, errors.Wrapf(err, "invalid RFC3339 date: %s", s))
+	} else {
+		*value = TimeFlag(ts)
+		return nil
 	}
-	*value = TimeFlag(ts)
-	return nil
+
+	// Try parsing as a duration.
+	if d, err := time.ParseDuration(s); err != nil {
+		errors.JoinInto(&errs, errors.Wrapf(err, "invalid duration: %s", s))
+	} else {
+		*value = TimeFlag(time.Now().Add(-d))
+		return nil
+	}
+	return errs
 }
 
 // Type implements the pflag.Value interface.  It simply returns a string

--- a/src/server/logs/BUILD.bazel
+++ b/src/server/logs/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//src/pfs",
         "//src/pps",
         "//src/server/auth",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/structpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_uber_go_zap//:zap",

--- a/src/server/logs/cmds/BUILD.bazel
+++ b/src/server/logs/cmds/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/src/server/logs/cmds/cmds.go
+++ b/src/server/logs/cmds/cmds.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pachyderm/pachyderm/v2/src/auth"
@@ -300,6 +301,17 @@ func Cmds(pachCtx *config.Context, pachctlCfg *pachctl.Config) []*cobra.Command 
 
 				switch resp.ResponseType.(type) {
 				case *logs.GetLogsResponse_Log:
+					l := resp.GetLog()
+					if o := l.Object; o != nil {
+						b, err := (protojson.MarshalOptions{
+							Multiline: false,
+						}).Marshal(o)
+						if err == nil {
+							fmt.Println(string(b))
+							continue
+						}
+						// If error, just print the verbatim log entry instead.
+					}
 					fmt.Println(string(resp.GetLog().GetVerbatim().GetLine()))
 				case *logs.GetLogsResponse_PagingHint:
 					hint := resp.GetPagingHint()

--- a/src/server/logs/internal_test.go
+++ b/src/server/logs/internal_test.go
@@ -108,6 +108,13 @@ func Test_adapter_publish(t *testing.T) {
 			"blank": {
 				entry: loki.Entry{},
 				want: &logs.LogMessage{
+					Object: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"ts":       structpb.NewStringValue("0001-01-01T00:00:00Z"),
+							"message":  structpb.NewStringValue(""),
+							"severity": structpb.NewStringValue("info"),
+						},
+					},
 					Verbatim: &logs.VerbatimLogMessage{
 						Timestamp: timestamppb.New(time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)),
 					},
@@ -115,12 +122,25 @@ func Test_adapter_publish(t *testing.T) {
 			},
 			"pgbouncer": {
 				entry: loki.Entry{
-					Line: `2024-04-16 21:33:01.362 UTC [1] LOG S-0x557bad51cc70: pachyderm/pachyderm@10.96.52.159:5432 closing because: server idle timeout (age=1350s)`,
+					Line:      `2024-04-16 21:33:01.362 UTC [1] LOG S-0x557bad51cc70: pachyderm/pachyderm@10.96.52.159:5432 closing because: server idle timeout (age=1350s)`,
+					Timestamp: time.Date(2024, 4, 16, 21, 33, 1, 362000000, time.UTC),
 				},
 				want: &logs.LogMessage{
+					Object: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"ts":       structpb.NewStringValue("2024-04-16T21:33:01.362Z"),
+							"message":  structpb.NewStringValue("2024-04-16 21:33:01.362 UTC [1] LOG S-0x557bad51cc70: pachyderm/pachyderm@10.96.52.159:5432 closing because: server idle timeout (age=1350s)"),
+							"severity": structpb.NewStringValue("info"),
+						},
+					},
+					NativeTimestamp: timestamppb.New(time.Date(2024, 4, 16, 21, 33, 1, 362000000, time.UTC)),
 					Verbatim: &logs.VerbatimLogMessage{
 						Line:      []byte(`2024-04-16 21:33:01.362 UTC [1] LOG S-0x557bad51cc70: pachyderm/pachyderm@10.96.52.159:5432 closing because: server idle timeout (age=1350s)`),
-						Timestamp: timestamppb.New(time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)),
+						Timestamp: timestamppb.New(time.Date(2024, 4, 16, 21, 33, 1, 362000000, time.UTC)),
+					},
+					PpsLogMessage: &pps.LogMessage{
+						Ts:      timestamppb.New(time.Date(2024, 4, 16, 21, 33, 1, 362000000, time.UTC)),
+						Message: "2024-04-16 21:33:01.362 UTC [1] LOG S-0x557bad51cc70: pachyderm/pachyderm@10.96.52.159:5432 closing because: server idle timeout (age=1350s)",
 					},
 				},
 			},

--- a/src/server/logs/internal_test.go
+++ b/src/server/logs/internal_test.go
@@ -110,7 +110,7 @@ func Test_adapter_publish(t *testing.T) {
 				want: &logs.LogMessage{
 					Object: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"ts":       structpb.NewStringValue("0001-01-01T00:00:00Z"),
+							"time":     structpb.NewStringValue("0001-01-01T00:00:00Z"),
 							"message":  structpb.NewStringValue(""),
 							"severity": structpb.NewStringValue("info"),
 						},
@@ -128,7 +128,7 @@ func Test_adapter_publish(t *testing.T) {
 				want: &logs.LogMessage{
 					Object: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"ts":       structpb.NewStringValue("2024-04-16T21:33:01.362Z"),
+							"time":     structpb.NewStringValue("2024-04-16T21:33:01.362Z"),
 							"message":  structpb.NewStringValue("2024-04-16 21:33:01.362 UTC [1] LOG S-0x557bad51cc70: pachyderm/pachyderm@10.96.52.159:5432 closing because: server idle timeout (age=1350s)"),
 							"severity": structpb.NewStringValue("info"),
 						},

--- a/src/server/logs/logs.go
+++ b/src/server/logs/logs.go
@@ -580,26 +580,28 @@ func (a *adapter) publish(ctx context.Context, labels loki.LabelSet, entry *loki
 			msg.Object = &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"message":  structpb.NewStringValue(entry.Line),
-					"ts":       structpb.NewStringValue(entry.Timestamp.Format(time.RFC3339Nano)),
+					"time":     structpb.NewStringValue(entry.Timestamp.Format(time.RFC3339Nano)),
 					"severity": structpb.NewStringValue("error"),
 					"#error":   structpb.NewStringValue(err.Error()),
 				},
 			}
 			obj = map[string]any{
-				"message": entry.Line,
-				"ts":      entry.Timestamp,
+				"message":  entry.Line,
+				"time":     entry.Timestamp,
+				"severity": "error",
 			}
 		}
 	} else {
 		// Synthesize an object when the raw line doesn't parse as JSON.
 		msg.Object = &structpb.Struct{Fields: map[string]*structpb.Value{
 			"message":  structpb.NewStringValue(entry.Line),
-			"ts":       structpb.NewStringValue(entry.Timestamp.Format(time.RFC3339Nano)),
+			"time":     structpb.NewStringValue(entry.Timestamp.Format(time.RFC3339Nano)),
 			"severity": structpb.NewStringValue("info"),
 		}}
 		obj = map[string]any{
-			"message": entry.Line,
-			"ts":      entry.Timestamp,
+			"message":  entry.Line,
+			"time":     entry.Timestamp,
+			"severity": "info",
 		}
 	}
 

--- a/src/server/logs/logs.go
+++ b/src/server/logs/logs.go
@@ -668,7 +668,6 @@ func extract[T any](obj map[string]any, dst *T, key string) {
 	if raw, ok := obj[key]; ok {
 		if v, ok := raw.(T); ok {
 			*dst = v
-			return
 		}
 	}
 }


### PR DESCRIPTION
This adjusts a couple of quality-of-life issues:

1. Time flags that are unset are not sent to the server.  This changes the default query from "logs starting a month ago to now" to "logs from the beginning of time", which is something that TimeRangeIterator knows how to handle efficiently.  This means that no matter how old your pipeline is, you'll always see logs with `pachctl logs2 --pipeline=edges --user` or something like that.
2. Time flags can be durations instead of absolute times.  To get pachd logs from the last minute, `pachctl logs2 --from=1m`.
3. All logs are printed as their object now, so that Loki metadata makes it into the printed output.  An object is now always synthesized when the loki line doesn't parse as JSON.  This lets you always pipe the output into jlog or similar for further filtering / querying.
4. `logs2` always prints a warning about an invalid log level; consider "unset" to be valid and don't warn on the default configuration ;)