### PR TITLE
[Jupyter] Don't show "invalid address" when cluster is valid

### DIFF
--- a/jupyter-extension/jupyterlab_pachyderm/tests/data/TestNotebook.ipynb
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/data/TestNotebook.ipynb
@@ -4,10 +4,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    }
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -17,34 +14,34 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
   },
   "pachyderm_pps": {
+   "version": "v1.0.0",
    "config": {
     "image": "python:3.10",
     "input_spec": "pfs:\n  repo: images\n  glob: \"/*\"",
     "pipeline": {
-     "name": "my_pipeline"
+     "name":"my_pipeline"
     },
     "requirements": "./requirements.txt"
-   },
-   "version": "v1.0.0"
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/jupyter-extension/jupyterlab_pachyderm/tests/data/TestNotebook.ipynb
+++ b/jupyter-extension/jupyterlab_pachyderm/tests/data/TestNotebook.ipynb
@@ -4,7 +4,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -14,34 +17,34 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
   },
   "pachyderm_pps": {
-   "version": "v1.0.0",
    "config": {
     "image": "python:3.10",
     "input_spec": "pfs:\n  repo: images\n  glob: \"/*\"",
     "pipeline": {
-     "name":"my_pipeline"
+     "name": "my_pipeline"
     },
     "requirements": "./requirements.txt"
-   }
+   },
+   "version": "v1.0.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
@@ -6,6 +6,8 @@ import {mockedRequestAPI} from 'utils/testUtils';
 import userEvent from '@testing-library/user-event';
 import {AuthConfig, HealthCheck} from 'plugins/mount/types';
 import Config from '../Config';
+import {ReadonlyJSONObject} from "@lumino/coreutils";
+import {ServerConnection} from "@jupyterlab/services";
 jest.mock('../../../../../handler');
 
 describe('config screen', () => {
@@ -281,9 +283,16 @@ describe('config screen', () => {
       };
 
       mockRequestAPI.requestAPI.mockImplementation(
-        mockedRequestAPI({
-          status: 'HEALTHY_INVALID_CLUSTER',
-        }),
+        (
+          _endPoint?: string,
+          method?: string,
+          body?: ReadonlyJSONObject | null,
+          namespace?: string,
+        ) => {
+          throw new ServerConnection.ResponseError(
+            new Response(null, {status: 400}),
+          );
+        },
       );
 
       const {getByTestId, findByText} = render(
@@ -300,6 +309,7 @@ describe('config screen', () => {
 
       userEvent.type(input, 'grpc://test.com:31400');
       submit.click();
+      // await new Promise((r) => setTimeout(r, 2000));
       await findByText('Invalid address.');
       expect(mockRequestAPI.requestAPI).toHaveBeenCalledTimes(1);
 

--- a/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
+++ b/jupyter-extension/src/plugins/mount/components/Config/__tests__/Config.test.tsx
@@ -6,8 +6,8 @@ import {mockedRequestAPI} from 'utils/testUtils';
 import userEvent from '@testing-library/user-event';
 import {AuthConfig, HealthCheck} from 'plugins/mount/types';
 import Config from '../Config';
-import {ReadonlyJSONObject} from "@lumino/coreutils";
-import {ServerConnection} from "@jupyterlab/services";
+import {ReadonlyJSONObject} from '@lumino/coreutils';
+import {ServerConnection} from '@jupyterlab/services';
 jest.mock('../../../../../handler');
 
 describe('config screen', () => {
@@ -309,7 +309,6 @@ describe('config screen', () => {
 
       userEvent.type(input, 'grpc://test.com:31400');
       submit.click();
-      // await new Promise((r) => setTimeout(r, 2000));
       await findByText('Invalid address.');
       expect(mockRequestAPI.requestAPI).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
This fixes a bug where, when a user starts up the the extension with no config information and sets the cluster address for the first time, the "invalid address" error message shows briefly before the extension redirects, even when the address is valid. This was occurring because after calling `PUT /config` with the new cluster address, the error handling used the stale cluster state instead of the response from the server. This change uses the response from the server to determine if an error message should be displayed to the user. 