### PR TITLE
FRON-1554: use only needed directories in console image

### DIFF
--- a/Dockerfile.console
+++ b/Dockerfile.console
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY console/ ./console/
 COPY src/typescript/ ./src/typescript/
-COPY src/internal/ ./src/internal/
+COPY src/internal/jsonschema/ ./src/internal/jsonschema/
 
 RUN cd console \
     && make docker-ci \

--- a/Dockerfile.console
+++ b/Dockerfile.console
@@ -7,7 +7,9 @@ RUN apt-get update && apt-get install -y \
     build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ADD . .
+COPY console/ ./console/
+COPY src/typescript/ ./src/typescript/
+COPY src/internal/ ./src/internal/
 
 RUN cd console \
     && make docker-ci \


### PR DESCRIPTION
Looks like we go from a 2GB image to 1.31 if we only include folders console actually needs in the docker image.