### PR TITLE
[PFS-171] Replace UpdateCommit()

### DIFF
--- a/src/internal/pfsdb/repos_test.go
+++ b/src/internal/pfsdb/repos_test.go
@@ -139,13 +139,13 @@ func createCommitAndBranches(ctx context.Context, tx *pachsql.Tx, t *testing.T, 
 		commitInfo := &pfs.CommitInfo{Commit: commit,
 			Origin:  &pfs.CommitOrigin{Kind: pfs.OriginKind_USER},
 			Started: timestamppb.Now()}
-		_, err := pfsdb.UpsertCommit(ctx, tx, commitInfo)
+		commitID, err := pfsdb.CreateCommit(ctx, tx, commitInfo)
 		require.NoError(t, err, "should be able to create commit")
 		branchInfo := &pfs.BranchInfo{Branch: branch, Head: commit}
-		_, err = pfsdb.UpsertBranch(ctx, tx, branchInfo)
+		branchID, err := pfsdb.UpsertBranch(ctx, tx, branchInfo)
 		require.NoError(t, err, "should be able to create branch")
 		commitInfo.Commit.Branch = branch
-		_, err = pfsdb.UpsertCommit(ctx, tx, commitInfo)
+		err = pfsdb.UpdateCommitBranch(ctx, tx, commitID, branchID)
 		require.NoError(t, err, "should be able to update commit")
 	}
 }

--- a/src/server/metadata/metadata.go
+++ b/src/server/metadata/metadata.go
@@ -81,10 +81,7 @@ func editInTx(ctx context.Context, tc *txncontext.TransactionContext, authServer
 		if err := editMetadata(edit, &c.CommitInfo.Metadata); err != nil {
 			return errors.Wrapf(err, "edit commit %q", c.GetCommit().Key())
 		}
-		if err := pfsdb.UpdateCommit(ctx, tc.SqlTx, c.ID, c.CommitInfo, pfsdb.AncestryOpt{
-			SkipChildren: true,
-			SkipParent:   true,
-		}); err != nil {
+		if err := pfsdb.UpdateCommitMetadata(ctx, tc.SqlTx, c.ID, c.CommitInfo.Metadata); err != nil {
 			return errors.Wrapf(err, "update commit %q", c.GetCommit().Key())
 		}
 	case *metadata.Edit_Branch:


### PR DESCRIPTION
The goal of PFS-171 is to update the pfsdb.Commit struct to resolve resources at the top of RPCs and then use them once throughout. In order to facilitate that, we've split UpdateCommit() into functions that are smaller in scope and update a subset of the fields in a commit. Most of these updates happen to the branch. These are slated to be removed eventually so having the in a separate function is handy. Next, there is a function to update the metadata and a function to set some fields once a commit has been finalized.