### PR TITLE
[PFS-171] Update onUpsert Interface, Refactor StartCommit

### DIFF
--- a/src/server/pfs/server/master.go
+++ b/src/server/pfs/server/master.go
@@ -289,8 +289,9 @@ func (m *Master) runCronTrigger(ctx context.Context, branch *pfs.Branch) error {
 
 func (m *Master) watchCommitsByRepo(ctx context.Context, repo pfsdb.Repo) error {
 	return pfsdb.WatchCommitsInRepo(ctx, m.env.DB, m.env.Listener, repo.ID,
-		func(id pfsdb.CommitID, ci *pfs.CommitInfo) error {
-			return m.postProcessCommit(ctx, repo, &pfsdb.Commit{ID: id, CommitInfo: ci})
+		func(commit pfsdb.Commit) error {
+			c := commit
+			return m.postProcessCommit(ctx, repo, &c)
 		},
 		func(_ pfsdb.CommitID) error {
 			// Don't finish commits that are deleted.

--- a/src/server/pfs/server/server_branch.go
+++ b/src/server/pfs/server/server_branch.go
@@ -67,7 +67,7 @@ func (a *apiServer) propagateBranches(ctx context.Context, txnCtx *txncontext.Tr
 	})
 	// add new commits, set their ancestry + provenance pointers, and advance branch heads
 	for _, bi := range propagatedBranches {
-		// TODO(acohen4): can we just make calls to addCommit() here?
+		// TODO(acohen4): can we just make calls to createCommit() here?
 		// Do not propagate an open commit onto spout output branches (which should
 		// only have a single provenance on a spec commit)
 		if len(bi.Provenance) == 1 && bi.Provenance[0].Repo.Type == pfs.SpecRepoType {
@@ -145,27 +145,35 @@ func (a *apiServer) fillNewBranches(ctx context.Context, txnCtx *txncontext.Tran
 			// Skip because the branch already exists.
 			continue
 		}
-		var updateHead *pfsdb.Commit
+		var newHead *pfsdb.Commit
 		head, ok := newRepoCommits[p.Repo.Key()]
 		if !ok {
 			head, err = a.makeEmptyCommit(ctx, txnCtx, p, nil, nil)
 			if err != nil {
 				return errors.Wrap(err, "create empty commit")
 			}
-			updateHead = head
+			newHead = head
 			newRepoCommits[p.Repo.Key()] = head
 		}
 		branchInfo := &pfs.BranchInfo{Branch: p, Head: head.CommitInfo.Commit, CreatedBy: txnCtx.Username()}
-		branchID, err := pfsdb.UpsertBranch(ctx, txnCtx.SqlTx, branchInfo)
-		if err != nil {
-			return errors.Wrap(err, "upsert branch")
+		if err := atomicUpsertBranchAndCommitBranch(ctx, txnCtx.SqlTx, branchInfo, newHead.ID); err != nil {
+			return errors.Wrap(err, "fill new branches")
 		}
-		// Now that the branch exists, add the branch_id to the head commit.
-		if updateHead != nil {
-			if err := pfsdb.UpdateCommitBranch(ctx, txnCtx.SqlTx, updateHead.ID, branchID); err != nil {
-				return errors.Wrap(err, "update commit")
-			}
-		}
+	}
+	return nil
+}
+
+// atomicUpsertBranchAndCommitBranch upserts a branch but also updates the head commit's 'Branch' field if needed.
+// the reason why this exists is because, in our data model, a branch must have a head commit, but a commit is also dependent
+// on the branch name.
+// the 'Branch' field is targeted for deprecation, so this function should make it easy to find all the callers.
+func atomicUpsertBranchAndCommitBranch(ctx context.Context, tx *pachsql.Tx, branchInfo *pfs.BranchInfo, headID pfsdb.CommitID) error {
+	branchID, err := pfsdb.UpsertBranch(ctx, tx, branchInfo)
+	if err != nil {
+		return errors.Wrap(err, "update head")
+	}
+	if headID != 0 {
+		return errors.Wrap(pfsdb.UpdateCommitBranch(ctx, tx, headID, branchID), "atomic upsert branch and commit branch")
 	}
 	return nil
 }
@@ -245,7 +253,7 @@ func (a *apiServer) createBranch(ctx context.Context, txnCtx *txncontext.Transac
 		branchInfo.Head = commitHandle
 		propagate = true
 	}
-	var updateHead *pfsdb.Commit
+	newHead := pfsdb.CommitID(0)
 	// if we don't have a branch head, or the provenance has changed, add a new commit to the branch to capture the changed structure
 	// the one edge case here, is that it's undesirable to add a commit in the case where provenance is completely removed...
 	//
@@ -256,21 +264,14 @@ func (a *apiServer) createBranch(ctx context.Context, txnCtx *txncontext.Transac
 			return err
 		}
 		branchInfo.Head = c.CommitInfo.Commit
-		updateHead = c
+		newHead = c.ID
 		propagate = true
 	}
 	if trigger != nil && trigger.Branch != "" {
 		branchInfo.Trigger = trigger
 	}
-	branchID, err := pfsdb.UpsertBranch(ctx, txnCtx.SqlTx, branchInfo)
-	if err != nil {
+	if err := atomicUpsertBranchAndCommitBranch(ctx, txnCtx.SqlTx, branchInfo, newHead); err != nil {
 		return errors.Wrap(err, "create branch")
-	}
-	// need to update head commit's branch_id after the branch is created.
-	if updateHead != nil {
-		if err := pfsdb.UpdateCommitBranch(ctx, txnCtx.SqlTx, updateHead.ID, branchID); err != nil {
-			return errors.Wrap(err, "create branch")
-		}
 	}
 	// propagate the head commit to 'branch'. This may also modify 'branch', by
 	// creating a new HEAD commit if 'branch's provenance was changed and its

--- a/src/server/pfs/server/server_commit.go
+++ b/src/server/pfs/server/server_commit.go
@@ -78,7 +78,7 @@ func (a *apiServer) makeEmptyCommit(ctx context.Context, txnCtx *txncontext.Tran
 		commitInfo.Finished = txnCtx.Timestamp
 		commitInfo.Details = &pfs.CommitInfo_Details{}
 	}
-	commitId, err := a.addCommit(ctx, txnCtx, commitInfo, parent, directProvenance, false /* needsFinishedParent */)
+	commitId, err := a.createCommit(ctx, txnCtx, commitInfo, parent, directProvenance, false /* needsFinishedParent */)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (a *apiServer) makeEmptyCommit(ctx context.Context, txnCtx *txncontext.Tran
 // NOTE: Requiring source commits to have finishing / finished parents ensures that the commits are not compacted
 // in a pathological order (finishing later commits before earlier commits will result with us compacting
 // the earlier commits multiple times).
-func (a *apiServer) addCommit(ctx context.Context, txnCtx *txncontext.TransactionContext, newCommitInfo *pfs.CommitInfo, parent *pfs.Commit, directProvenance []*pfs.Branch, needsFinishedParent bool) (pfsdb.CommitID, error) {
+func (a *apiServer) createCommit(ctx context.Context, txnCtx *txncontext.TransactionContext, newCommitInfo *pfs.CommitInfo, parent *pfs.Commit, directProvenance []*pfs.Branch, needsFinishedParent bool) (pfsdb.CommitID, error) {
 	if err := a.linkParent(ctx, txnCtx, newCommitInfo, parent, needsFinishedParent); err != nil {
 		return 0, err
 	}
@@ -144,68 +144,14 @@ func (a *apiServer) startCommit(
 	branch *pfs.Branch,
 	description string,
 ) (*pfsdb.Commit, error) {
-	// Validate arguments:
-	if branch == nil || branch.Name == "" {
-		return nil, errors.Errorf("branch must be specified")
+	if err := a.validateStartCommitArgs(ctx, txnCtx, branch); err != nil {
+		return nil, err
 	}
-	// Check that caller is authorized
-	if err := a.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, branch.Repo, auth.Permission_REPO_WRITE); err != nil {
-		return nil, errors.EnsureStack(err)
-	}
-	// New commit and commitInfo
 	newCommitInfo := newUserCommitInfo(txnCtx, branch)
 	newCommitInfo.Description = description
-	if err := ancestry.ValidateName(branch.Name); err != nil {
-		return nil, err
-	}
-	// Check if repo exists
-	_, err := pfsdb.GetRepoByName(ctx, txnCtx.SqlTx, branch.Repo.Project.Name, branch.Repo.Name, branch.Repo.Type)
+	commitID, branchInfo, err := a.atomicCreateCommit(ctx, txnCtx, newCommitInfo, parent, branch)
 	if err != nil {
-		if pfsdb.IsErrRepoNotFound(err) {
-			return nil, pfsserver.ErrRepoNotFound{Repo: branch.Repo}
-		}
-		return nil, errors.EnsureStack(err)
-	}
-	updateCommitBranchField := false
-	// update 'branch' (which must always be set) and set parent.ID (if 'parent'
-	// was not set)
-	b, err := pfsdb.GetBranch(ctx, txnCtx.SqlTx, branch)
-	if err != nil {
-		if !pfsdb.IsNotFoundError(err) {
-			return nil, errors.Wrap(err, "start commit")
-		}
-		updateCommitBranchField = true // the branch field on the commit will have to be updated after the branch is created.
-	}
-	branchInfo := &pfs.BranchInfo{
-		CreatedBy: txnCtx.Username(),
-	}
-	if b != nil && b.BranchInfo != nil {
-		branchInfo = b.BranchInfo
-	}
-	if branchInfo.Branch == nil {
-		// New branch
-		branchInfo.Branch = branch
-	}
-	// If the parent is unspecified, use the current head of the branch
-	if parent == nil {
-		parent = branchInfo.Head
-	}
-	commitID, err := a.addCommit(ctx, txnCtx, newCommitInfo, parent, branchInfo.DirectProvenance, true)
-	if err != nil {
-		return nil, err
-	}
-	// Point 'branch' at the new commit
-	branchInfo.Head = newCommitInfo.Commit
-	branchID, err := pfsdb.UpsertBranch(ctx, txnCtx.SqlTx, branchInfo)
-	if err != nil {
-		return nil, errors.Wrap(err, "start commit")
-	}
-	// update branch field after a new branch is created.
-	if updateCommitBranchField {
-		newCommitInfo.Commit.Branch = branchInfo.Branch
-		if err := pfsdb.UpdateCommitBranch(ctx, txnCtx.SqlTx, commitID, branchID); err != nil {
-			return nil, errors.Wrap(err, "start commit: update branch field after new branch is created")
-		}
+		return nil, errors.Wrap(err, "create commit")
 	}
 	// check if this is happening in a spout pipeline, and alias the spec commit
 	_, ok1 := os.LookupEnv(client.PPSPipelineNameEnv)
@@ -214,12 +160,82 @@ func (a *apiServer) startCommit(
 		// Otherwise, we don't allow user code to start commits on output branches
 		return nil, pfsserver.ErrCommitOnOutputBranch{Branch: branch}
 	}
-	// Defer propagation of the commit until the end of the transaction so we can
+	// Defer propagation of the commit until the end of the transaction, so we can
 	// batch downstream commits together if there are multiple changes.
 	if err := txnCtx.PropagateBranch(branch); err != nil {
 		return nil, err
 	}
 	return &pfsdb.Commit{ID: commitID, CommitInfo: newCommitInfo}, nil
+}
+
+func (a *apiServer) validateStartCommitArgs(ctx context.Context, txnCtx *txncontext.TransactionContext, branchHandle *pfs.Branch) error {
+	// Validate arguments:
+	if branchHandle == nil || branchHandle.Name == "" {
+		return errors.Errorf("branch must be specified")
+	}
+	// Check that caller is authorized
+	if err := a.env.Auth.CheckRepoIsAuthorizedInTransaction(ctx, txnCtx, branchHandle.Repo, auth.Permission_REPO_WRITE); err != nil {
+		return errors.EnsureStack(err)
+	}
+	// Check if repo exists
+	_, err := pfsdb.GetRepoByName(ctx, txnCtx.SqlTx, branchHandle.Repo.Project.Name, branchHandle.Repo.Name, branchHandle.Repo.Type)
+	if err != nil {
+		if pfsdb.IsErrRepoNotFound(err) {
+			return pfsserver.ErrRepoNotFound{Repo: branchHandle.Repo}
+		}
+		return errors.EnsureStack(err)
+	}
+	if err := ancestry.ValidateName(branchHandle.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
+// atomicCreateCommit creates a commit and also creates a branch if needed.
+// it handles updating the commit's 'branch' field after the branch is resolved.
+func (a *apiServer) atomicCreateCommit(
+	ctx context.Context,
+	txnCtx *txncontext.TransactionContext,
+	newCommitInfo *pfs.CommitInfo,
+	parent *pfs.Commit,
+	branchHandle *pfs.Branch,
+) (pfsdb.CommitID, *pfs.BranchInfo, error) {
+	branchInfo, err := getOrDefaultBranchInfo(ctx, txnCtx, branchHandle)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "create commit")
+	}
+	// If the parent is unspecified, use the current head of the branch.
+	if parent == nil {
+		parent = branchInfo.Head
+	}
+	commitID, err := a.createCommit(ctx, txnCtx, newCommitInfo, parent, branchInfo.DirectProvenance, true)
+	if err != nil {
+		return 0, nil, err
+	}
+	branchInfo.Head = newCommitInfo.Commit
+	if err := atomicUpsertBranchAndCommitBranch(ctx, txnCtx.SqlTx, branchInfo, commitID); err != nil {
+		return 0, nil, errors.Wrap(err, "create commit")
+	}
+	return commitID, branchInfo, nil
+}
+
+// getOrDefaultBranchInfo attempts to get the branchInfo from the database referenced by branchHandle.
+// the purpose of this function is to improve readability for apiServer.createCommit().
+func getOrDefaultBranchInfo(ctx context.Context, txnCtx *txncontext.TransactionContext, branchHandle *pfs.Branch) (branchInfo *pfs.BranchInfo, err error) {
+	b, err := pfsdb.GetBranch(ctx, txnCtx.SqlTx, branchHandle)
+	if err != nil {
+		if !pfsdb.IsNotFoundError(err) {
+			return nil, errors.Wrap(err, "get or default branchHandle info")
+		}
+		branchInfo = &pfs.BranchInfo{
+			CreatedBy: txnCtx.Username(),
+			Branch:    branchHandle,
+		}
+	}
+	if b != nil && b.BranchInfo != nil { // The branch exists already in postgres.
+		branchInfo = b.BranchInfo
+	}
+	return branchInfo, nil
 }
 
 // Set child.ParentCommit (if 'parent' has been determined).
@@ -388,7 +404,6 @@ func (a *apiServer) inspectCommit(ctx context.Context, commitHandle *pfs.Commit,
 		}
 	}
 	return commit, nil
-
 }
 
 // inspectCommitInfo takes a Commit and returns the corresponding CommitInfo.
@@ -410,17 +425,17 @@ func (a *apiServer) inspectProcessingCommits(ctx context.Context, commit *pfsdb.
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	if err := pfsdb.WatchCommit(ctx, a.env.DB, a.env.Listener, commit.ID,
-		func(id pfsdb.CommitID, ci *pfs.CommitInfo) error {
+		func(c pfsdb.Commit) error {
 			switch wait {
 			case pfs.CommitState_FINISHING:
-				if ci.Finishing != nil {
-					commit.CommitInfo = ci
+				if c.Finishing != nil {
+					commit.CommitInfo = c.CommitInfo
 					cancel(expectedErr)
 					return nil
 				}
 			case pfs.CommitState_FINISHED:
-				if ci.Finished != nil {
-					commit.CommitInfo = ci
+				if c.Finished != nil {
+					commit.CommitInfo = c.CommitInfo
 					cancel(expectedErr)
 					return nil
 				}
@@ -823,19 +838,19 @@ func (a *apiServer) subscribeCommit(
 		return err
 	}
 	return pfsdb.WatchCommitsInRepo(ctx, a.env.DB, a.env.Listener, repoID,
-		func(id pfsdb.CommitID, commitInfo *pfs.CommitInfo) error { // onUpsert
+		func(c pfsdb.Commit) error { // onUpsert
 			// if branch is provided, make sure the commit was created on that branch
-			if branch != "" && commitInfo.Commit.Branch.Name != branch {
+			if branch != "" && c.Commit.Branch.Name != branch {
 				return nil
 			}
 			// If the origin of the commit doesn't match what we're interested in, skip it
-			if !passesCommitOriginFilter(commitInfo, all, originKind) {
+			if !passesCommitOriginFilter(c.CommitInfo, all, originKind) {
 				return nil
 			}
 			// We don't want to include the `from` commit itself
-			if !(seen[commitInfo.Commit.Id] || (from != nil && from.Id == commitInfo.Commit.Id)) {
+			if !(seen[c.Commit.Id] || (from != nil && from.Id == c.Commit.Id)) {
 				// Wait for the commit to enter the right state
-				commitInfo, err := a.inspectCommitInfo(ctx, proto.Clone(commitInfo.Commit).(*pfs.Commit), state)
+				commitInfo, err := a.inspectCommitInfo(ctx, proto.Clone(c.Commit).(*pfs.Commit), state)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
1. onUpsert now passes through the pfsdb.Commit
2. There's some weird branch and commit logic that we have to do as a result of our data model that I figured I'd extract into a single function to make deprecation later easier to do.

The next PR will be an update that actually creates an internal commit model that we can use. This will be handiest in functions like inspect commit which have to re-resolve the commit handles for provenance and such.