### PR TITLE
Revert change that removes environment variables from the worker; only filter out POSTGRES_PASSWORD instead

### DIFF
--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -632,9 +632,6 @@ func (d *driver) inheritedEnvVars() []string {
 		"DET_MASTER",
 		"DET_USER",
 		"DET_PASS",
-		"PACHD_PEER_SERVICE_HOST",
-		"PACHD_PEER_SERVICE_PORT",
-		"PPS_WORKER_GRPC_PORT",
 	}
 	for k := range d.pipelineInfo.Details.Transform.Env {
 		results = append(results, k)

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -559,17 +559,17 @@ func (d *driver) UserCodeEnv(
 		result = append(result, e)
 	}
 
-	for _, input := range inputs {
-		result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))
-		result = append(result, fmt.Sprintf("%s_COMMIT=%s", input.Name, input.FileInfo.File.Commit.Id))
-		if input.JoinOn != "" {
-			result = append(result, fmt.Sprintf("PACH_DATUM_%s_JOIN_ON=%s", input.Name, input.JoinOn))
-		}
-		if input.GroupBy != "" {
-			result = append(result, fmt.Sprintf("PACH_DATUM_%s_GROUP_BY=%s", input.Name, input.GroupBy))
-		}
-	}
 	if len(inputs) > 0 {
+		for _, input := range inputs {
+			result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))
+			result = append(result, fmt.Sprintf("%s_COMMIT=%s", input.Name, input.FileInfo.File.Commit.Id))
+			if input.JoinOn != "" {
+				result = append(result, fmt.Sprintf("PACH_DATUM_%s_JOIN_ON=%s", input.Name, input.JoinOn))
+			}
+			if input.GroupBy != "" {
+				result = append(result, fmt.Sprintf("PACH_DATUM_%s_GROUP_BY=%s", input.Name, input.GroupBy))
+			}
+		}
 		result = append(result, fmt.Sprintf("%s=%s", client.DatumIDEnv, common.DatumID(inputs)))
 	}
 

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -624,21 +624,16 @@ func (d *driver) UserCodeEnv(
 }
 
 func (d *driver) inheritedEnvVars() []string {
-	results := []string{
-		"PATH",
-		"HOME",
-		"PACH_NAMESPACE",
-		"DET_MASTER_CERT_FILE",
-		"DET_MASTER",
-		"DET_USER",
-		"DET_PASS",
-	}
+	var results []string
 	for k := range d.pipelineInfo.Details.Transform.Env {
 		results = append(results, k)
 	}
 	for _, s := range d.pipelineInfo.Details.Transform.Secrets {
 		results = append(results, s.EnvVar)
 	}
+	results = append(results, "PATH")
+	results = append(results, "HOME")
+	results = append(results, "PACH_NAMESPACE")
 	return results
 }
 

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -551,14 +551,8 @@ func (d *driver) UserCodeEnv(
 	pachToken string,
 	filesetId string,
 ) []string {
-	var result []string
-	for _, kv := range os.Environ() {
-		for _, k := range d.inheritedEnvVars() {
-			if strings.HasPrefix(kv, k+"=") {
-				result = append(result, kv)
-			}
-		}
-	}
+	result := os.Environ()
+
 	for _, input := range inputs {
 		result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))
 		result = append(result, fmt.Sprintf("%s_COMMIT=%s", input.Name, input.FileInfo.File.Commit.Id))
@@ -621,20 +615,6 @@ func (d *driver) UserCodeEnv(
 		result = append(result, fmt.Sprintf("%s=%s", client.FilesetIDEnv, filesetId))
 	}
 	return result
-}
-
-func (d *driver) inheritedEnvVars() []string {
-	var results []string
-	for k := range d.pipelineInfo.Details.Transform.Env {
-		results = append(results, k)
-	}
-	for _, s := range d.pipelineInfo.Details.Transform.Secrets {
-		results = append(results, s.EnvVar)
-	}
-	results = append(results, "PATH")
-	results = append(results, "HOME")
-	results = append(results, "PACH_NAMESPACE")
-	return results
 }
 
 func (d *driver) GetContainerImageID(ctx context.Context, containerName string) (string, error) {

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -559,19 +559,18 @@ func (d *driver) UserCodeEnv(
 			}
 		}
 	}
-	if len(inputs) > 0 {
-		for _, input := range inputs {
-			result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))
-			result = append(result, fmt.Sprintf("%s_COMMIT=%s", input.Name, input.FileInfo.File.Commit.Id))
-			if input.JoinOn != "" {
-				result = append(result, fmt.Sprintf("PACH_DATUM_%s_JOIN_ON=%s", input.Name, input.JoinOn))
-			}
-			if input.GroupBy != "" {
-				result = append(result, fmt.Sprintf("PACH_DATUM_%s_GROUP_BY=%s", input.Name, input.GroupBy))
-			}
+	for _, input := range inputs {
+		result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))
+		result = append(result, fmt.Sprintf("%s_COMMIT=%s", input.Name, input.FileInfo.File.Commit.Id))
+		if input.JoinOn != "" {
+			result = append(result, fmt.Sprintf("PACH_DATUM_%s_JOIN_ON=%s", input.Name, input.JoinOn))
 		}
-		result = append(result, fmt.Sprintf("%s=%s", client.DatumIDEnv, common.DatumID(inputs)))
+		if input.GroupBy != "" {
+			result = append(result, fmt.Sprintf("PACH_DATUM_%s_GROUP_BY=%s", input.Name, input.GroupBy))
+		}
 	}
+	result = append(result, fmt.Sprintf("%s=%s", client.DatumIDEnv, common.DatumID(inputs)))
+
 	if jobID != "" {
 		result = append(result, fmt.Sprintf("%s=%s", client.JobIDEnv, jobID))
 		pipeline := &pps.Pipeline{

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -551,7 +551,13 @@ func (d *driver) UserCodeEnv(
 	pachToken string,
 	filesetId string,
 ) []string {
-	result := os.Environ()
+	var result []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "POSTGRES_PASSWORD=") {
+			continue
+		}
+		result = append(result, e)
+	}
 
 	for _, input := range inputs {
 		result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -569,7 +569,9 @@ func (d *driver) UserCodeEnv(
 			result = append(result, fmt.Sprintf("PACH_DATUM_%s_GROUP_BY=%s", input.Name, input.GroupBy))
 		}
 	}
-	result = append(result, fmt.Sprintf("%s=%s", client.DatumIDEnv, common.DatumID(inputs)))
+	if len(inputs) > 0 {
+		result = append(result, fmt.Sprintf("%s=%s", client.DatumIDEnv, common.DatumID(inputs)))
+	}
 
 	if jobID != "" {
 		result = append(result, fmt.Sprintf("%s=%s", client.JobIDEnv, jobID))

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -558,7 +558,6 @@ func (d *driver) UserCodeEnv(
 		}
 		result = append(result, e)
 	}
-
 	if len(inputs) > 0 {
 		for _, input := range inputs {
 			result = append(result, fmt.Sprintf("%s=%s", input.Name, filepath.Join(d.InputDir(), input.Name, input.FileInfo.File.Path)))
@@ -572,7 +571,6 @@ func (d *driver) UserCodeEnv(
 		}
 		result = append(result, fmt.Sprintf("%s=%s", client.DatumIDEnv, common.DatumID(inputs)))
 	}
-
 	if jobID != "" {
 		result = append(result, fmt.Sprintf("%s=%s", client.JobIDEnv, jobID))
 		pipeline := &pps.Pipeline{

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -338,12 +338,17 @@ func handleDatumSetBatching(ctx context.Context, driver driver.Driver, logger lo
 			}
 		}
 		defer stop()
+		jobInfo, err := driver.GetJobInfo(task.Job)
+		if err != nil {
+			return errors.Wrap(err, "error getting job info from task job")
+		}
+		env := driver.UserCodeEnv(logger.JobID(), task.OutputCommit, nil, jobInfo.GetAuthToken(), "")
 		start := func() error {
 			var cancelCtx context.Context
 			cancelCtx, cancel = pctx.WithCancel(ctx)
 			errChan = make(chan error, 1)
 			go func() {
-				err := driver.RunUserCode(cancelCtx, logger, nil)
+				err := driver.RunUserCode(cancelCtx, logger, env)
 				if err == nil {
 					err = errors.New("user code exited prematurely")
 				}

--- a/src/server/worker/pipeline/transform/worker.go
+++ b/src/server/worker/pipeline/transform/worker.go
@@ -338,17 +338,12 @@ func handleDatumSetBatching(ctx context.Context, driver driver.Driver, logger lo
 			}
 		}
 		defer stop()
-		jobInfo, err := driver.GetJobInfo(task.Job)
-		if err != nil {
-			return errors.Wrap(err, "error getting job info from task job")
-		}
-		env := driver.UserCodeEnv(logger.JobID(), task.OutputCommit, nil, jobInfo.GetAuthToken(), "")
 		start := func() error {
 			var cancelCtx context.Context
 			cancelCtx, cancel = pctx.WithCancel(ctx)
 			errChan = make(chan error, 1)
 			go func() {
-				err := driver.RunUserCode(cancelCtx, logger, env)
+				err := driver.RunUserCode(cancelCtx, logger, nil)
 				if err == nil {
 					err = errors.New("user code exited prematurely")
 				}


### PR DESCRIPTION
This broke a lot of stuff and we need another approach.  Reverts  #10228 #10221 #10159.