### PR TITLE
[2.11.x] Revert change that removes environment variables from the worker; only filter out POSTGRES_PASSWORD instead

### DIFF
--- a/src/server/pachyderm_test.go
+++ b/src/server/pachyderm_test.go
@@ -11946,3 +11946,69 @@ func TestPipelinesSummary(t *testing.T) {
 		}
 	}
 }
+
+func TestNoPostgresPassword(t *testing.T) {
+	c, _ := minikubetestenv.AcquireCluster(t)
+
+	repo := "input"
+	require.NoError(t, c.CreateRepo(pfs.DefaultProjectName, repo))
+	commit, err := c.StartCommit(pfs.DefaultProjectName, repo, "master")
+	require.NoError(t, err, "start input commit")
+	require.NoError(t, c.PutFile(commit, "file", strings.NewReader("foo\n"), client.WithAppendPutFile()), "put dummy file")
+	require.NoError(t, c.FinishCommit(pfs.DefaultProjectName, repo, "master", ""), "finish input commit")
+
+	pipeline := "printenv"
+	_, err = c.PpsAPIClient.CreatePipeline(
+		c.Ctx(),
+		&pps.CreatePipelineRequest{
+			Pipeline: client.NewPipeline(pfs.DefaultProjectName, pipeline),
+			Transform: &pps.Transform{
+				Image: tu.DefaultTransformImage,
+				Cmd:   []string{"bash"},
+				Stdin: []string{"printenv > /pfs/out/env"},
+				Env:   map[string]string{"FOO": "BAR"},
+			},
+			Input: client.NewPFSInput(pfs.DefaultProjectName, repo, "/*"),
+		},
+	)
+	require.NoError(t, err, "create pipeline")
+
+	commitInfo, err := c.InspectCommit(pfs.DefaultProjectName, pipeline, "master", "")
+	require.NoError(t, err, "inspect commit %v@master", pipeline)
+	commitInfos, err := c.WaitCommitSetAll(commitInfo.Commit.Id)
+	require.NoError(t, err, "wait commitset %v", commitInfo.Commit.Id)
+
+	var output *pfs.CommitInfo
+	for _, info := range commitInfos {
+		if proto.Equal(info.Commit.Repo, client.NewRepo(pfs.DefaultProjectName, pipeline)) {
+			output = info
+			break
+		}
+	}
+	require.NotNil(t, output, "output should have been found")
+
+	var buf bytes.Buffer
+	require.NoError(t, c.GetFile(output.Commit, "env", &buf), "fetch env from output commit")
+
+	var foo string
+	env := strings.Split(buf.String(), "\n")
+	for _, e := range env {
+		t.Logf("env: %q", e)
+		if len(e) == 0 {
+			continue
+		}
+
+		i := strings.IndexByte(e, '=')
+		if i < 1 {
+			t.Logf("missing = in %v", e)
+			continue
+		}
+		key := e[:i]
+		t.Logf("key: %v", key)
+		require.NotEqual(t, "POSTGRES_PASSWORD", key, "environ line %v should not start with POSTGRES_PASSWORD=")
+		if key == "FOO" {
+			foo = e
+		}
+	}
+	require.Equal(t, "FOO=BAR", foo, "FOO=BAR should be in there")
+}

--- a/src/server/worker/driver/driver.go
+++ b/src/server/worker/driver/driver.go
@@ -552,12 +552,11 @@ func (d *driver) UserCodeEnv(
 	filesetId string,
 ) []string {
 	var result []string
-	for _, kv := range os.Environ() {
-		for _, k := range d.inheritedEnvVars() {
-			if strings.HasPrefix(kv, k+"=") {
-				result = append(result, kv)
-			}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "POSTGRES_PASSWORD=") {
+			continue
 		}
+		result = append(result, e)
 	}
 	if len(inputs) > 0 {
 		for _, input := range inputs {
@@ -622,28 +621,6 @@ func (d *driver) UserCodeEnv(
 		result = append(result, fmt.Sprintf("%s=%s", client.FilesetIDEnv, filesetId))
 	}
 	return result
-}
-
-func (d *driver) inheritedEnvVars() []string {
-	results := []string{
-		"PATH",
-		"HOME",
-		"PACH_NAMESPACE",
-		"DET_MASTER_CERT_FILE",
-		"DET_MASTER",
-		"DET_USER",
-		"DET_PASS",
-		"PACHD_PEER_SERVICE_HOST",
-		"PACHD_PEER_SERVICE_PORT",
-		"PPS_WORKER_GRPC_PORT",
-	}
-	for k := range d.pipelineInfo.Details.Transform.Env {
-		results = append(results, k)
-	}
-	for _, s := range d.pipelineInfo.Details.Transform.Secrets {
-		results = append(results, s.EnvVar)
-	}
-	return results
 }
 
 func (d *driver) GetContainerImageID(ctx context.Context, containerName string) (string, error) {


### PR DESCRIPTION
Backport of #10278.

This removes code that filters environment variables, in favor of only filtering out the one we care about.  Too much is broken by allowlisting, so we're going to come up with another approach for 2.12 or 2.13.

Jira: [MLDM-50]

[MLDM-50]: https://hpe-aiatscale.atlassian.net/browse/MLDM-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ