### PR TITLE
workspace_status: work on mac os, upgrade hard-coded master version

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -11,10 +11,16 @@ echo "GIT_BRANCH $git_branch"
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
 echo "GIT_TREE_STATUS $git_tree_status"
 
-exact=$(git describe --exact-match 2>/dev/null | sed -e s/^v// | cut -d - -f 1 || echo 2.11.0)
+exact=$(git describe --exact-match 2>/dev/null | sed -e s/^v// | cut -d - -f 1 || echo 2.12.0)
 echo "STABLE_APP_VERSION $exact"
 
-additional_version=$(git describe --exact-match 2>/dev/null | cut -d - -f 2- || echo "pre.$(git describe --long --dirty=".$(git diff HEAD | sha256sum | cut -c 1-10)" | rev | cut -d - -f 1 | rev)")
+SHA256SUM="sha256sum"
+if command -v sha256sum &> /dev/null; then
+    # Mac OS ships shasum instead of sha256sum.
+    SHA256SUM="shasum -a 256"
+fi
+
+additional_version=$(git describe --exact-match 2>/dev/null | cut -d - -f 2- || echo "pre.$(git describe --long --dirty=".$(git diff HEAD | $SHA256SUM | cut -c 1-10)" | rev | cut -d - -f 1 | rev)")
 echo "STABLE_ADDITIONAL_VERSION -$additional_version"
 
 ci_runner_image_version="$(date +%Y%m%d)-${commit_sha}"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -15,7 +15,7 @@ exact=$(git describe --exact-match 2>/dev/null | sed -e s/^v// | cut -d - -f 1 |
 echo "STABLE_APP_VERSION $exact"
 
 SHA256SUM="sha256sum"
-if command -v sha256sum &> /dev/null; then
+if command -v shasum &> /dev/null; then
     # Mac OS ships shasum instead of sha256sum.
     SHA256SUM="shasum -a 256"
 fi


### PR DESCRIPTION
2.11 is out, so prerelease artifacts from this branch should be 2.12.0.

I also fixed a bug where mac os builds don't have the sha256sum of the diffs (making it hard for pachdev to tell if your image was updated and running).  Nobody cared, but I fixed that.