### PR TITLE
Update helm chart for det 0.35.0

### DIFF
--- a/etc/helm/examples/int-test-values-with-det.yaml
+++ b/etc/helm/examples/int-test-values-with-det.yaml
@@ -62,7 +62,6 @@ determined:
   enabled: true
   enterpriseEdition: true
   useNodePortForMaster: true
-  detVersion: 0.31.0
   masterPort: 8282
   masterCpuRequest: 250m
   masterMemRequest: 512M # turn requests way down for automated smoke tests

--- a/etc/helm/examples/local-dev-values-with-det.yaml
+++ b/etc/helm/examples/local-dev-values-with-det.yaml
@@ -77,7 +77,6 @@ determined:
   enterpriseEdition: true
   useNodePortForMaster: false
   useNodePortForDB: false
-  detVersion: 0.31.0 # set to latest in tests
   masterPort: 8282
   masterCpuRequest: 250m
   masterMemRequest: 256M

--- a/etc/helm/pachyderm/templates/determined/genai/genai-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/genai/genai-deployment.yaml
@@ -54,6 +54,10 @@ spec:
             value: genai-backend-service-{{ .Release.Name }}.{{ .Release.Namespace }}
           - name: GENAI_HOST_PORT
             value: {{ .Values.determined.genai.port | quote }}
+          {{- if .Values.determined.genai.imagePullSecretName}}
+          - name: GENAI_IMAGE_PULL_SECRET_NAME
+            value: {{ .Values.determined.genai.imagePullSecretName }}
+          {{- end}}
         volumeMounts:
           - name: genai-pvc-storage
             mountPath: /run/determined/workdir/shared_fs
@@ -77,9 +81,9 @@ spec:
             memory: {{ .Values.determined.genai.memLimit  | quote }}
             {{- end}}
           {{- end}}
-      {{- if .Values.determined.imagePullSecretName}}
+      {{- if .Values.determined.genai.imagePullSecretName}}
       imagePullSecrets:
-        - name: {{ .Values.determined.imagePullSecretName }}
+        - name: {{ .Values.determined.genai.imagePullSecretName }}
       {{- end}}
       volumes:
         - name: genai-pvc-storage

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -117,8 +117,11 @@ stringData:
       {{- if .Values.determined.oidc.groupsAttributeName }}
       groups_attribute_name: {{ .Values.determined.oidc.groupsAttributeName }}
       {{- end }}
-       {{- if .Values.determined.oidc.displayNameAttributeName }}
+      {{- if .Values.determined.oidc.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.determined.oidc.displayNameAttributeName }}
+      {{- end }}
+      {{- if .Values.determined.oidc.alwaysRedirect }}
+      always_redirect: {{ .Values.determined.oidc.alwaysRedirect }}
       {{- end }}
     {{- end }}
 
@@ -155,7 +158,9 @@ stringData:
 
     resource_manager:
       type: "kubernetes"
-      namespace: {{ .Release.Namespace }}
+      {{- if .Values.defaultNamespace }}
+      default_namespace: {{ .Values.defaultNamespace }}
+      {{- end }}
       {{- if .Values.determined.enabled }}
       max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.determined.maxSlotsPerPod }}
       {{- end }}

--- a/etc/helm/pachyderm/templates/determined/master-config.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-config.yaml
@@ -158,11 +158,14 @@ stringData:
 
     resource_manager:
       type: "kubernetes"
-      {{- if .Values.defaultNamespace }}
-      default_namespace: {{ .Values.defaultNamespace }}
+      {{- if $defaultNamespace := coalesce .Values.determined.resourceManager.defaultNamespace .Release.Namespace }}
+      default_namespace: {{ quote $defaultNamespace }}
+      {{- end }}
+      {{- if .Values.determined.resourceManager.clusterName }}
+      cluster_name: {{ .Values.determined.resourceManager.clusterName }}
       {{- end }}
       {{- if .Values.determined.enabled }}
-      max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.determined.maxSlotsPerPod }}
+      max_slots_per_pod: {{ required "A valid Values.determined.maxSlotsPerPod entry is required!" .Values.determined.maxSlotsPerPod }}
       {{- end }}
       master_service_name: determined-master-service-{{ .Release.Name }}
       {{- if .Values.determined.defaultScheduler}}

--- a/etc/helm/pachyderm/templates/determined/master-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: determined-master-{{ .Release.Name }}
     release: {{ .Release.Name }}
+    release-namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -37,9 +38,13 @@ spec:
         {{- end -}}
         image: {{ .Values.determined.imageRegistry }}/{{ $image }}:{{ $tag }}
         imagePullPolicy: "Always"
+        env:
+          - name: DET_RELEASE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         {{- if .Values.determined.enterpriseEdition }}
         {{- if and .Values.determined.oidc .Values.determined.oidc.enabled }}
-        env:
           - name: DET_OIDC_CLIENT_SECRET
             valueFrom:
               secretKeyRef:

--- a/etc/helm/pachyderm/templates/determined/master-deployment.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: determined-master-{{ .Release.Name }}
+        release-namespace: {{ .Release.Namespace }}
         determined-system: master
       annotations:
         # This is added so that the master deployment restarts when an upgrade occurs that

--- a/etc/helm/pachyderm/templates/determined/master-permissions.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-permissions.yaml
@@ -19,13 +19,13 @@ metadata:
      release: {{ .Release.Name }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/status", "pods/log", "configmaps"]
+    resources: ["pods", "pods/status", "pods/log", "configmaps", "namespaces", "resourcequotas"]
     verbs: ["create", "get", "list", "delete"]
   - apiGroups: [""]
     resources: ["services", "resourcequotas"]
     verbs: ["get", "list"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "resourcequotas"]
     verbs: ["watch", "patch"]
   - apiGroups: [""]
     resources: ["events"]

--- a/etc/helm/pachyderm/templates/determined/master-service.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-service.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    {{- if .Values.determined.service.annotations }}
+    {{- toYaml .Values.determined.service.annotations | nindent 4 }}
+    {{- end }}
   name: determined-master-service-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/etc/helm/pachyderm/templates/determined/master-service.yaml
+++ b/etc/helm/pachyderm/templates/determined/master-service.yaml
@@ -2,10 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    {{- if .Values.determined.service.annotations }}
-    {{- toYaml .Values.determined.service.annotations | nindent 4 }}
-    {{- end }}
   name: determined-master-service-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/etc/helm/pachyderm/values.schema.json
+++ b/etc/helm/pachyderm/values.schema.json
@@ -275,6 +275,9 @@
                 "oidc": {
                     "type": "object",
                     "properties": {
+                        "alwaysRedirect": {
+                            "type": "boolean"
+                        },
                         "authenticationClaim": {
                             "type": "string"
                         },
@@ -290,10 +293,13 @@
                         "clientSecretName": {
                             "type": "string"
                         },
+                        "displayNameAttributeName": {
+                            "type": "string"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
-                        "groupsClaimName": {
+                        "groupsAttributeName": {
                             "type": "string"
                         },
                         "idpRecipientUrl": {
@@ -307,6 +313,17 @@
                         },
                         "scimAuthenticationAttribute": {
                             "type": "string"
+                        }
+                    }
+                },
+                "resourceManager": {
+                    "type": "object",
+                    "properties": {
+                        "clusterName": {
+                            "type": "null"
+                        },
+                        "defaultNamespace": {
+                            "type": "null"
                         }
                     }
                 },
@@ -326,6 +343,9 @@
                     "properties": {
                         "forcePullImage": {
                             "type": "boolean"
+                        },
+                        "startupHook": {
+                            "type": "string"
                         }
                     }
                 },

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -434,7 +434,7 @@ determined:
   #       determined_master_ip: 10.11.12.13
   #       determined_master_port: 8080
   #     resource_pools:
-  #       - pool_name: additional_pool 
+  #       - pool_name: additional_pool
   resourceManager:
     # Specifies the namespace in a given Kubernetes compute cluster where all workload pods will be sent by default.
     defaultNamespace:

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -427,16 +427,18 @@ determined:
   #   - resource_manager:
   #       type: kubernetes
   #       max_slots_per_pod: 1
-  #       name: determined-multirm-1
+  #       cluster_name: additional-cluster
   #       default_namespace: default
   #       kubeconfig_secret_name: additionalrm
   #       kubeconfig_secret_value: config
   #       determined_master_ip: 10.11.12.13
   #       determined_master_port: 8080
   #     resource_pools:
-  #       - pool_name: additional_pool
-  # The default namespace to be referenced by each resource manager.
-  # defaultNamespace:
+  #       - pool_name: additional_pool 
+  resourceManager:
+    # Specifies the namespace in a given Kubernetes compute cluster where all workload pods will be sent by default.
+    defaultNamespace:
+    clusterName:
 
 console:
   # enabled controls whether the console manifests are created or not.

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -191,6 +191,7 @@ determined:
     autoProvisionUsers: false
     groupsAttributeName: ""
     displayNameAttributeName: ""
+    alwaysRedirect: false
 
   # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
   # only available if enterpriseEdition is true. It allows administrators to easily and securely
@@ -331,7 +332,7 @@ determined:
     # Configure an inline script that will be executed as part of the task setup process that will install
     # the Pachyderm notebook extension in det launched notebooks.
     startupHook: |
-      if [ "$PACHD_ADDRESS" != "" ] && [ "$SKIP_PACHYDERM_INSTALL" != "true" ] && [ "$DET_TASK_TYPE" = "NOTEBOOK" ]; then
+      if [[ -n "$PACHD_ADDRESS" && "$SKIP_PACHYDERM_INSTALL" != "true" && "$DET_TASK_TYPE" == "NOTEBOOK" ]]; then
           proxy_dns=$(echo $PACHD_ADDRESS | sed 's/grpc:\/\/pachd/pachyderm-proxy/' | sed 's/:30650//') 
           version=$(curl -skLX POST -H "Content-Type: application/json" $proxy_dns/api/versionpb_v2.API/GetVersion | sed -n 's/.*"major": *\([0-9]*\), *"minor": *\([0-9]*\), *"micro": *\([0-9]*\), *"additional": *"\([^"]*\)".*/\1.\2.\3\4/p')
           jupyterlab_version=$(echo $version | sed 's/-alpha\.\([0-9]*\)/a\1/;s/-rc\.\([0-9]*\)/rc\1/')
@@ -427,13 +428,15 @@ determined:
   #       type: kubernetes
   #       max_slots_per_pod: 1
   #       name: determined-multirm-1
-  #       namespace: default
+  #       default_namespace: default
   #       kubeconfig_secret_name: additionalrm
   #       kubeconfig_secret_value: config
   #       determined_master_ip: 10.11.12.13
   #       determined_master_port: 8080
   #     resource_pools:
   #       - pool_name: additional_pool
+  # The default namespace to be referenced by each resource manager.
+  # defaultNamespace:
 
 console:
   # enabled controls whether the console manifests are created or not.

--- a/etc/helm/pachyderm/values.yaml
+++ b/etc/helm/pachyderm/values.yaml
@@ -63,7 +63,7 @@ global:
 
 determined:
   enabled: false
-  detVersion: "0.34.0"
+  detVersion: "0.35.0"
   # The image registry to be used to pull the Master image.
   # Determined OSS edition uses the determinedai repository in DockerHub.
   imageRegistry: determinedai


### PR DESCRIPTION
Updates the helm chart to be compatible with 0.35.0 of Determined. Also fixes the startupHook so that it is processed correctly, and doesn't run during experiments.