### PR TITLE
add BAZEL_TRACK_SOURCE_DIRECTORIES option to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,8 +51,8 @@ test:race --@rules_go//go/config:race
 # Set a tag for tests which can only run in a Bazel environment.
 common --define gotags=bazel
 
-# local modifications should take priority
-try-import %workspace%/.bazelrc.local
-
 # Recommended when using rules_js.
 startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
+
+# local modifications should take priority
+try-import %workspace%/.bazelrc.local

--- a/.bazelrc
+++ b/.bazelrc
@@ -53,3 +53,6 @@ common --define gotags=bazel
 
 # local modifications should take priority
 try-import %workspace%/.bazelrc.local
+
+# Recommended when using rules_js.
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1


### PR DESCRIPTION
Enables option recommended by rules_js maintainers.