### PR TITLE
Move jsonnet linting to Bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -4,12 +4,9 @@ examples/deferred-processing
 examples/err_cmd
 examples/gatk
 examples/globalID
-examples/group
 examples/img
-examples/joins
 examples/kubeflow
 examples/ml
-examples/opencv
 examples/redshift
 examples/run
 examples/shuffle

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -718,20 +718,6 @@ jobs:
       - checkout
       - run: sudo npm install -g prettier
       - run: prettier -c etc/helm/pachyderm/values.yaml .circleci/config.yml .circleci/main.yml
-  jsonnet-lint:
-    resource_class: small
-    docker:
-      - image: cimg/go:<< pipeline.parameters.go-version >>
-    steps:
-      - checkout
-      - run:
-          name: Install go-jsonnet
-          command: |
-            go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
-      - run:
-          name: lint all jsonnet files
-          command: |
-            find . -maxdepth 10 -name \*.jsonnet | xargs jsonnet-lint
   test-envoy:
     docker:
       - image: envoyproxy/envoy:v1.29.3
@@ -1748,7 +1734,6 @@ workflows:
       - check-prettier
       - bazel-style-tests
       - bazel-govulncheck
-      - jsonnet-lint
       - static-go-checks
       - test-envoy
   helm-tests:

--- a/console/cypress/fixtures/BUILD.bazel
+++ b/console/cypress/fixtures/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "edges_jsonnet_test",
     size = "small",
     src = "edges.jsonnet",

--- a/console/cypress/fixtures/BUILD.bazel
+++ b/console/cypress/fixtures/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "edges_jsonnet_test",
+    size = "small",
+    src = "edges.jsonnet",
+)

--- a/console/frontend/BUILD.bazel
+++ b/console/frontend/BUILD.bazel
@@ -37,9 +37,9 @@ jest_test(
         "node_modules_frontend",
         "tsconfig.json",
         "//console:jest_config_base",
+        "//console/frontend/src/views/Project/components/PipelineTemplate/templates",
         "//src/internal/jsonschema:jsonschema_js",
         "//src/typescript:typescript_protos",
-        "//console/frontend/src/views/Project/components/PipelineTemplate/templates",
     ],
     env = {
         "NODE_ENV": "test",

--- a/console/frontend/BUILD.bazel
+++ b/console/frontend/BUILD.bazel
@@ -39,6 +39,7 @@ jest_test(
         "//console:jest_config_base",
         "//src/internal/jsonschema:jsonschema_js",
         "//src/typescript:typescript_protos",
+        "//console/frontend/src/views/Project/components/PipelineTemplate/templates",
     ],
     env = {
         "NODE_ENV": "test",
@@ -51,5 +52,6 @@ jest_test(
         "./src",
     ],
     node_modules = "node_modules_frontend",
+    shard_count = 50,
     visibility = ["//visibility:public"],
 )

--- a/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
+++ b/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
 jsonnet_lint_test(
@@ -10,4 +11,10 @@ jsonnet_lint_test(
     name = "snowflake_jsonnet_test",
     size = "small",
     src = "snowflake.jsonnet",
+)
+
+js_library(
+    name = "templates",
+    srcs = ["snowflake.jsonnet", "huggingFaceDownloader.jsonnet", "index.ts"],
+    visibility = ["//console/frontend:__pkg__"],
 )

--- a/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
+++ b/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
@@ -15,6 +15,10 @@ jsonnet_lint_test(
 
 js_library(
     name = "templates",
-    srcs = ["snowflake.jsonnet", "huggingFaceDownloader.jsonnet", "index.ts"],
+    srcs = [
+        "huggingFaceDownloader.jsonnet",
+        "index.ts",
+        "snowflake.jsonnet",
+    ],
     visibility = ["//console/frontend:__pkg__"],
 )

--- a/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
+++ b/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "huggingFaceDownloader_jsonnet_test",
+    size = "small",
+    src = "huggingFaceDownloader.jsonnet",
+)
+
+jsonnet_test(
+    name = "snowflake_jsonnet_test",
+    size = "small",
+    src = "snowflake.jsonnet",
+)

--- a/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
+++ b/console/frontend/src/views/Project/components/PipelineTemplate/templates/BUILD.bazel
@@ -1,12 +1,12 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "huggingFaceDownloader_jsonnet_test",
     size = "small",
     src = "huggingFaceDownloader.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "snowflake_jsonnet_test",
     size = "small",
     src = "snowflake.jsonnet",

--- a/console/test-dags/cluster-setup/src/pipelines/BUILD.bazel
+++ b/console/test-dags/cluster-setup/src/pipelines/BUILD.bazel
@@ -1,24 +1,24 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "echo_name_jsonnet_test",
     size = "small",
     src = "echo-name.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "generate_large_file_jsonnet_test",
     size = "small",
     src = "generate-large-file.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "generate_small_files_jsonnet_test",
     size = "small",
     src = "generate-small-files.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "log_and_copy_files_jsonnet_test",
     size = "small",
     src = "log-and-copy-files.jsonnet",

--- a/console/test-dags/cluster-setup/src/pipelines/BUILD.bazel
+++ b/console/test-dags/cluster-setup/src/pipelines/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "echo_name_jsonnet_test",
+    size = "small",
+    src = "echo-name.jsonnet",
+)
+
+jsonnet_test(
+    name = "generate_large_file_jsonnet_test",
+    size = "small",
+    src = "generate-large-file.jsonnet",
+)
+
+jsonnet_test(
+    name = "generate_small_files_jsonnet_test",
+    size = "small",
+    src = "generate-small-files.jsonnet",
+)
+
+jsonnet_test(
+    name = "log_and_copy_files_jsonnet_test",
+    size = "small",
+    src = "log-and-copy-files.jsonnet",
+)

--- a/console/test-dags/pipelines/jsonnet/BUILD.bazel
+++ b/console/test-dags/pipelines/jsonnet/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "edges_jsonnet_test",
+    size = "small",
+    src = "edges.jsonnet",
+)
+
+jsonnet_test(
+    name = "error_args_jsonnet_test",
+    size = "small",
+    src = "error-args.jsonnet",
+)
+
+jsonnet_test(
+    name = "snowflake_jsonnet_test",
+    size = "small",
+    src = "snowflake.jsonnet",
+)

--- a/console/test-dags/pipelines/jsonnet/BUILD.bazel
+++ b/console/test-dags/pipelines/jsonnet/BUILD.bazel
@@ -1,18 +1,18 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "edges_jsonnet_test",
     size = "small",
     src = "edges.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "error_args_jsonnet_test",
     size = "small",
     src = "error-args.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "snowflake_jsonnet_test",
     size = "small",
     src = "snowflake.jsonnet",

--- a/etc/generate-envoy-config/BUILD.bazel
+++ b/etc/generate-envoy-config/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
 files = [
     "envoy",
@@ -31,7 +31,7 @@ tar(
     visibility = ["//etc/helm/pachyderm:__pkg__"],
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "envoy_jsonnet_test",
     size = "small",
     src = "envoy.jsonnet",
@@ -41,7 +41,7 @@ jsonnet_test(
     ],
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "envoy_tls_jsonnet_test",
     size = "small",
     src = "envoy-tls.jsonnet",

--- a/etc/generate-envoy-config/BUILD.bazel
+++ b/etc/generate-envoy-config/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
 
 files = [
     "envoy",
@@ -28,4 +29,24 @@ tar(
         "etc/helm/pachyderm/envoy-tls.json uid=0 gid=0 time=0 mode=0644 type=file content=$(location envoy-tls.json)",
     ],
     visibility = ["//etc/helm/pachyderm:__pkg__"],
+)
+
+jsonnet_test(
+    name = "envoy_jsonnet_test",
+    size = "small",
+    src = "envoy.jsonnet",
+    deps = [
+        "envoy.libsonnet",
+        "pachyderm-services.libsonnet",
+    ],
+)
+
+jsonnet_test(
+    name = "envoy_tls_jsonnet_test",
+    size = "small",
+    src = "envoy-tls.jsonnet",
+    deps = [
+        "envoy.libsonnet",
+        "pachyderm-services.libsonnet",
+    ],
 )

--- a/examples/group/pipelines/lab/BUILD.bazel
+++ b/examples/group/pipelines/lab/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "lab_group_by_hospital_jsonnet_test",
+    size = "small",
+    src = "lab_group_by_hospital.jsonnet",
+)
+
+jsonnet_test(
+    name = "lab_group_by_patient_jsonnet_test",
+    size = "small",
+    src = "lab_group_by_patient.jsonnet",
+)

--- a/examples/group/pipelines/lab/BUILD.bazel
+++ b/examples/group/pipelines/lab/BUILD.bazel
@@ -1,12 +1,12 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "lab_group_by_hospital_jsonnet_test",
     size = "small",
     src = "lab_group_by_hospital.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "lab_group_by_patient_jsonnet_test",
     size = "small",
     src = "lab_group_by_patient.jsonnet",

--- a/examples/group/pipelines/retail/BUILD.bazel
+++ b/examples/group/pipelines/retail/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "retail_group_jsonnet_test",
     size = "small",
     src = "retail_group.jsonnet",

--- a/examples/group/pipelines/retail/BUILD.bazel
+++ b/examples/group/pipelines/retail/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "retail_group_jsonnet_test",
+    size = "small",
+    src = "retail_group.jsonnet",
+)

--- a/examples/joins/pipelines/outer/BUILD.bazel
+++ b/examples/joins/pipelines/outer/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "outer_join_jsonnet_test",
     size = "small",
     src = "outer_join.jsonnet",

--- a/examples/joins/pipelines/outer/BUILD.bazel
+++ b/examples/joins/pipelines/outer/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "outer_join_jsonnet_test",
+    size = "small",
+    src = "outer_join.jsonnet",
+)

--- a/examples/opencv/goclient-example/BUILD.bazel
+++ b/examples/opencv/goclient-example/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "goclient-example_lib",
+    srcs = ["opencv-example.go"],
+    importpath = "github.com/pachyderm/pachyderm/v2/examples/opencv/goclient-example",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/client",
+        "//src/pfs",
+        "//src/pps",
+    ],
+)
+
+go_binary(
+    name = "goclient-example",
+    embed = [":goclient-example_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/opencv/jsonnet/BUILD.bazel
+++ b/examples/opencv/jsonnet/BUILD.bazel
@@ -1,12 +1,12 @@
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "edges_jsonnet_test",
     size = "small",
     src = "edges.jsonnet",
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "montage_jsonnet_test",
     size = "small",
     src = "montage.jsonnet",

--- a/examples/opencv/jsonnet/BUILD.bazel
+++ b/examples/opencv/jsonnet/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+
+jsonnet_test(
+    name = "edges_jsonnet_test",
+    size = "small",
+    src = "edges.jsonnet",
+)
+
+jsonnet_test(
+    name = "montage_jsonnet_test",
+    size = "small",
+    src = "montage.jsonnet",
+)

--- a/private/rules/jsonnet-lint/BUILD.bazel
+++ b/private/rules/jsonnet-lint/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "jsonnet-lint",
+    srcs = ["jsonnet-lint.bzl"],
+    visibility = ["//:__subpackages__"],
+)

--- a/private/rules/jsonnet-lint/jsonnet-lint.bzl
+++ b/private/rules/jsonnet-lint/jsonnet-lint.bzl
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 exec {JSONNET_LINT} {SRC}
 """
 
-def _jsonnet_test_impl(ctx):
+def _jsonnet_lint_test_impl(ctx):
     linter = ctx.actions.declare_file("%s_lint.sh" % (ctx.label.name))
     ctx.actions.write(
         output = linter,
@@ -26,8 +26,8 @@ def _jsonnet_test_impl(ctx):
         runfiles = runfiles,
     )
 
-jsonnet_test = rule(
-    implementation = _jsonnet_test_impl,
+jsonnet_lint_test = rule(
+    implementation = _jsonnet_lint_test_impl,
     attrs = {
         "src": attr.label(
             allow_single_file = True,

--- a/private/rules/jsonnet-lint/jsonnet-lint.bzl
+++ b/private/rules/jsonnet-lint/jsonnet-lint.bzl
@@ -1,0 +1,48 @@
+"""Module jsonnet-lint provides a jsonnet_test rule for testing that jsonnet files are syntactically valid."""
+
+_LINTER_TMPL = """#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+exec {JSONNET_LINT} {SRC}
+"""
+
+def _jsonnet_test_impl(ctx):
+    linter = ctx.actions.declare_file("%s_lint.sh" % (ctx.label.name))
+    ctx.actions.write(
+        output = linter,
+        content = _LINTER_TMPL.format(
+            JSONNET_LINT = ctx.attr._runfiles[0][DefaultInfo].files_to_run.executable.short_path,
+            SRC = ctx.attr.src.files.to_list()[0].short_path,
+        ),
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles(ctx.files.deps + ctx.files.src + [linter])
+    for r in ctx.attr._runfiles:
+        runfiles = runfiles.merge(r.default_runfiles)
+    return DefaultInfo(
+        executable = linter,
+        runfiles = runfiles,
+    )
+
+jsonnet_test = rule(
+    implementation = _jsonnet_test_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            doc = "A jsonnet program to check for validity.",
+            mandatory = True,
+        ),
+        "deps": attr.label_list(
+            allow_files = True,
+            doc = "Any jsonnet libraries needed by the jsonnet program to be validated.",
+        ),
+        "_runfiles": attr.label_list(default = ["@jsonnet_go//cmd/jsonnet-lint:jsonnet-lint"]),
+    },
+    toolchains = [
+        "@bazel_tools//tools/sh:toolchain_type",
+    ],
+    executable = True,
+    test = True,
+)

--- a/src/testing/cmds/go-test-results/cleanup-cron/BUILD.bazel
+++ b/src/testing/cmds/go-test-results/cleanup-cron/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
 go_library(
     name = "cleanup-cron_lib",
@@ -22,7 +22,7 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "pipeline_jsonnet_test",
     size = "small",
     src = "pipeline.jsonnet",

--- a/src/testing/cmds/go-test-results/cleanup-cron/BUILD.bazel
+++ b/src/testing/cmds/go-test-results/cleanup-cron/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
 
 go_library(
     name = "cleanup-cron_lib",
@@ -19,4 +20,10 @@ go_binary(
     name = "cleanup-cron",
     embed = [":cleanup-cron_lib"],
     visibility = ["//visibility:public"],
+)
+
+jsonnet_test(
+    name = "pipeline_jsonnet_test",
+    size = "small",
+    src = "pipeline.jsonnet",
 )

--- a/src/testing/cmds/go-test-results/egress/BUILD.bazel
+++ b/src/testing/cmds/go-test-results/egress/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
-load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_lint_test")
 
 go_library(
     name = "egress_lib",
@@ -27,7 +27,7 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-jsonnet_test(
+jsonnet_lint_test(
     name = "pipeline_jsonnet_test",
     size = "small",
     src = "pipeline.jsonnet",

--- a/src/testing/cmds/go-test-results/egress/BUILD.bazel
+++ b/src/testing/cmds/go-test-results/egress/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("//private/rules/jsonnet-lint:jsonnet-lint.bzl", "jsonnet_test")
 
 go_library(
     name = "egress_lib",
@@ -24,4 +25,10 @@ go_binary(
     name = "egress",
     embed = [":egress_lib"],
     visibility = ["//visibility:public"],
+)
+
+jsonnet_test(
+    name = "pipeline_jsonnet_test",
+    size = "small",
+    src = "pipeline.jsonnet",
 )


### PR DESCRIPTION
The existing jsonnet-lint rule requires cimg/go, which isn't available for go 1.23, which blocks upgrading to go 1.23.  So I've removed the need for this CI job and added the linting to Bazel instead.  Each file is linted in a test (that can be cached) now.