### PR TITLE
MLDM-60: Stopgap Hashing in PJS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@ load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test", "build
 load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@rules_go//go:def.bzl", "go_library", "nogo")
 load("//src/internal/analyzers/staticcheck:def.bzl", "all_staticcheck_analyzers")  # buildifier: disable=bzl-visibility
+
 licenses(["notice"])
 
 exports_files([

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,6 @@ load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test", "build
 load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@rules_go//go:def.bzl", "go_library", "nogo")
 load("//src/internal/analyzers/staticcheck:def.bzl", "all_staticcheck_analyzers")  # buildifier: disable=bzl-visibility
-
 licenses(["notice"])
 
 exports_files([

--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -333,3 +333,10 @@ func GetAuthTokenOutgoing(ctx context.Context) (string, error) {
 	}
 	return md[ContextTokenKey][0], nil
 }
+
+func WithToken(ctx context.Context, authToken string) context.Context {
+	if authToken != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, ContextTokenKey, authToken)
+	}
+	return ctx
+}

--- a/src/internal/pachd/full.go
+++ b/src/internal/pachd/full.go
@@ -322,17 +322,22 @@ func NewFull(env Env, config pachconfig.PachdFullConfiguration, opt *FullOption)
 				GetPPSServer: func() ppsiface.APIServer { return pd.ppsSrv.(pps_server.APIServer) },
 			}
 		}),
-		initPJSAPIServer(&pd.pjsSrv, func() pjs_server.Env {
-			return pjs_server.Env{
-				DB:               env.DB,
-				GetPermissionser: pd.authSrv.(pjs_server.GetPermissionser),
-			}
-		}),
 		initStorageServer(&pd.storageSrv, func() storage_server.Env {
 			return storage_server.Env{
 				DB:     env.DB,
 				Bucket: env.Bucket,
 				Config: config.StorageConfiguration,
+			}
+		}),
+		initPJSAPIServer(&pd.pjsSrv, func() pjs_server.Env {
+			return pjs_server.Env{
+				DB:               env.DB,
+				GetPermissionser: pd.authSrv.(pjs_server.GetPermissionser),
+				GetStorageClient: func(ctx context.Context) storage.FilesetClient {
+					pachClient := pd.mustGetPachClient(ctx)
+					return pachClient.FilesetClient
+				},
+				GetAuthToken: auth.GetAuthToken,
 			}
 		}),
 		initPPSAPIServer(&pd.ppsSrv, func() pps_server.Env {

--- a/src/internal/pjs/BUILD.bazel
+++ b/src/internal/pjs/BUILD.bazel
@@ -21,12 +21,12 @@ go_library(
         "//src/internal/pjsdb",
         "//src/internal/storage/fileset",
         "//src/internal/tarutil",
+        "//src/internal/testutil",
         "//src/pjs",
         "//src/storage",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
-        "@org_uber_go_zap//:zap",
     ],
 )
 
@@ -35,7 +35,6 @@ go_test(
     srcs = [
         "hash_test.go",
         "server_internal_test.go",
-        "hash_test.go",
         "server_test.go",
     ],
     embed = [":pjs"],
@@ -51,7 +50,6 @@ go_test(
         "//src/internal/pctx",
         "//src/internal/require",
         "//src/internal/storage",
-        "//src/internal/storage/fileset",
         "//src/internal/testetcd",
         "//src/internal/testpachd/realenv",
         "//src/internal/testutil",

--- a/src/internal/pjs/BUILD.bazel
+++ b/src/internal/pjs/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = [
         "hash_test.go",
         "server_internal_test.go",
+        "hash_test.go",
         "server_test.go",
     ],
     embed = [":pjs"],

--- a/src/internal/pjs/server.go
+++ b/src/internal/pjs/server.go
@@ -2,20 +2,34 @@ package pjs
 
 import (
 	"context"
-
 	"github.com/pachyderm/pachyderm/v2/src/auth"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
-
 	pjsserver "github.com/pachyderm/pachyderm/v2/src/pjs"
+	"github.com/pachyderm/pachyderm/v2/src/storage"
+	"time"
+
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
+// Env defines the PJS API server's dependencies. optional fields ought to go somewhere else.
 type Env struct {
-	DB               *pachsql.DB
+	// DB is the postgres database client.
+	DB *pachsql.DB
+	// GetPermissionser is a subset of Pachyderm Auth server's gRPC service.
 	GetPermissionser GetPermissionser
+	// GetAuthToken doesn't go through an RPC, otherwise it would make more sense to combine it
+	// with the GetPermissionser interface. Using a closure here makes it easier to mock in tests.
+	GetAuthToken func(context.Context) (string, error)
+	// GetStorageClient follows a common pattern within the Pachyderm code base for getting a client to another server
+	// that implements a gRPC service. Using a client is better than having a pointer to the server directly, which
+	// could lead to tight coupling of services that ought to be independent.
+	GetStorageClient func(ctx context.Context) storage.FilesetClient
 }
 
 func NewAPIServer(env Env) pjsserver.APIServer {
-	return newAPIServer(env)
+	return &apiServer{
+		env:          env,
+		pollInterval: 5 * time.Second,
+	}
 }
 
 // GetPermissionser is an interface that currently exposes the Pachyderm Auth server's GetPermissions RPC.

--- a/src/internal/pjs/server_internal_test.go
+++ b/src/internal/pjs/server_internal_test.go
@@ -3,7 +3,6 @@ package pjs
 import (
 	"context"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -100,7 +99,7 @@ func TestRunJob(t *testing.T) {
 		Input:   []string{inputFileset},
 	}
 
-	out, err := runJob(t, ctx, c, in, func(resp *pjs.ProcessQueueResponse) error {
+	out, err := runJob(t, ctx, c, fc, in, func(resp *pjs.ProcessQueueResponse) error {
 		// for now we do nothing here, simply return the input filesets
 		resp.Input = in.Input
 		return nil
@@ -159,7 +158,7 @@ func TestCancelJob(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		_, err = runJobFrom(t, ctx, c, createResp.Id.Id, program, func(resp *pjs.ProcessQueueResponse) error {
+		_, err = runJobFrom(t, ctx, c, fc, createResp.Id.Id, program, func(resp *pjs.ProcessQueueResponse) error {
 			cancel()
 			// simulate processing time and ensure cancelJob is finished
 			time.Sleep(5 * time.Second)
@@ -186,7 +185,7 @@ func TestCancelJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		eg.Go(func() error {
-			_, err := runJobFrom(t, egCtx, c, createRespA.Id.Id, programA, func(resp *pjs.ProcessQueueResponse) error {
+			_, err := runJobFrom(t, egCtx, c, fc, createRespA.Id.Id, programA, func(resp *pjs.ProcessQueueResponse) error {
 				jobAContext = resp.Context
 				close(jobAProcessing)
 				time.Sleep(5 * time.Second)
@@ -205,7 +204,7 @@ func TestCancelJob(t *testing.T) {
 		require.NoError(t, err)
 		var jobBContext string
 		eg.Go(func() error {
-			_, err := runJobFrom(t, egCtx, c, createRespB.Id.Id, programB, func(resp *pjs.ProcessQueueResponse) error {
+			_, err := runJobFrom(t, egCtx, c, fc, createRespB.Id.Id, programB, func(resp *pjs.ProcessQueueResponse) error {
 				jobBContext = resp.Context
 				close(jobBProcessing)
 				time.Sleep(5 * time.Second)
@@ -223,7 +222,7 @@ func TestCancelJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		eg.Go(func() error {
-			_, err := runJobFrom(t, egCtx, c, createRespC.Id.Id, programC, func(resp *pjs.ProcessQueueResponse) error {
+			_, err := runJobFrom(t, egCtx, c, fc, createRespC.Id.Id, programC, func(resp *pjs.ProcessQueueResponse) error {
 				close(jobCProcessing)
 				time.Sleep(5 * time.Second)
 				return nil
@@ -293,18 +292,17 @@ func TestWalkJob(t *testing.T) {
 }
 
 // runJob does work through PJS.
-func runJob(t *testing.T, ctx context.Context, c pjs.APIClient, in *pjs.CreateJobRequest,
+func runJob(t *testing.T, ctx context.Context, c pjs.APIClient, fc storage.FilesetClient, in *pjs.CreateJobRequest,
 	fn func(resp *pjs.ProcessQueueResponse) error) (*pjs.JobInfo_Success, error) {
 	jres, err := c.CreateJob(ctx, in)
 	require.NoError(t, err)
-	return runJobFrom(t, ctx, c, jres.Id.Id, in.Program, fn)
+	return runJobFrom(t, ctx, c, fc, jres.Id.Id, in.Program, fn)
 }
 
-func runJobFrom(t *testing.T, ctx context.Context, c pjs.APIClient, from int64, programStr string,
+func runJobFrom(t *testing.T, ctx context.Context, c pjs.APIClient, fc storage.FilesetClient, from int64, programStr string,
 	fn func(resp *pjs.ProcessQueueResponse) error) (*pjs.JobInfo_Success, error) {
-	program, err := fileset.ParseID(programStr)
+	programHash, err := HashFileset(ctx, fc, programStr)
 	require.NoError(t, err)
-	programHash := []byte(program.HexString())
 	ctx, cf := context.WithCancel(ctx)
 	defer cf()
 	eg, ctx := errgroup.WithContext(ctx)
@@ -430,7 +428,8 @@ func setupTest(t testing.TB, opts ...ClientOptions) (pjs.APIClient, storage.File
 	db := dockertestenv.NewTestDB(t)
 	migrationEnv := migrations.Env{EtcdClient: testetcd.NewEnv(ctx, t).EtcdClient}
 	require.NoError(t, migrations.ApplyMigrations(ctx, db, migrationEnv, clusterstate.DesiredClusterState), "should be able to set up tables")
-	return NewTestClient(t, db, opts...), storagesrv.NewTestFilesetClient(t, db)
+	client := storagesrv.NewTestFilesetClient(t, db)
+	return NewTestClient(t, db, client, opts...), client
 }
 
 func createFileSet(t *testing.T, fc storage.FilesetClient, files map[string][]byte) string {
@@ -470,7 +469,7 @@ func fullBinaryJobTree(t *testing.T, ctx context.Context, maxDepth int, c pjs.AP
 	createResp, err := c.CreateJob(ctx, req)
 	require.NoError(t, err)
 	var processResp *pjs.ProcessQueueResponse
-	_, err = runJobFrom(t, ctx, c, createResp.Id.Id, program, func(resp *pjs.ProcessQueueResponse) error {
+	_, err = runJobFrom(t, ctx, c, fc, createResp.Id.Id, program, func(resp *pjs.ProcessQueueResponse) error {
 		processResp = resp
 		return nil
 	})
@@ -493,7 +492,7 @@ func fullBinaryJobTree(t *testing.T, ctx context.Context, maxDepth int, c pjs.AP
 				cResp, err := c.CreateJob(ctx, req)
 				require.NoError(t, err)
 				var pResp *pjs.ProcessQueueResponse
-				_, err = runJobFrom(t, ctx, c, cResp.Id.Id, prog, func(resp *pjs.ProcessQueueResponse) error {
+				_, err = runJobFrom(t, ctx, c, fc, cResp.Id.Id, prog, func(resp *pjs.ProcessQueueResponse) error {
 					pResp = resp
 					return nil
 				})
@@ -589,7 +588,7 @@ func TestAuth(t *testing.T) {
 
 		var jobContext string
 		// run process queue to get a job context token.
-		_, err = runJobFrom(t, ctx, c, jobResp.Id.Id, testFileset, func(resp *pjs.ProcessQueueResponse) error {
+		_, err = runJobFrom(t, ctx, c, fc, jobResp.Id.Id, testFileset, func(resp *pjs.ProcessQueueResponse) error {
 			jobContext = resp.Context
 			return nil
 		})

--- a/src/internal/pjs/util.go
+++ b/src/internal/pjs/util.go
@@ -2,6 +2,9 @@ package pjs
 
 import (
 	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
+	tu "github.com/pachyderm/pachyderm/v2/src/internal/testutil"
+	"github.com/pachyderm/pachyderm/v2/src/storage"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -9,16 +12,17 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/auth"
 	"github.com/pachyderm/pachyderm/v2/src/pjs"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/grpcutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 )
 
 type ClientOptions func(env *Env)
 
-func NewTestClient(t testing.TB, db *pachsql.DB, opts ...ClientOptions) pjs.APIClient {
+func NewTestClient(t testing.TB, db *pachsql.DB, client storage.FilesetClient, opts ...ClientOptions) pjs.APIClient {
 	env := Env{
 		DB:               db,
 		GetPermissionser: &testPermitter{mode: permitterAllow},
+		GetStorageClient: func(ctx context.Context) storage.FilesetClient { return client },
+		GetAuthToken:     func(ctx context.Context) (string, error) { return tu.RootToken, nil },
 	}
 	for _, opt := range opts {
 		opt(&env)

--- a/src/internal/pjsdb/BUILD.bazel
+++ b/src/internal/pjsdb/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//src/internal/dockertestenv",
         "//src/internal/errors",
         "//src/internal/migrations",
+        "//src/internal/pachhash",
         "//src/internal/pachsql",
         "//src/internal/pctx",
         "//src/internal/require",

--- a/src/internal/pjsdb/job_crud.go
+++ b/src/internal/pjsdb/job_crud.go
@@ -50,6 +50,9 @@ type CreateJobRequest struct {
 	Parent  JobID
 	Inputs  []fileset.PinnedFileset
 	Program fileset.PinnedFileset
+	// The user is responsible for supplying the hash.
+	// The hash ought to be computed with HashFileset() in the internal PJS package (src/internal/pjs.go)
+	ProgramHash []byte
 }
 
 // IsSanitized is a utility function that wraps sanitize() for the purposes of testing.
@@ -67,7 +70,7 @@ func (req CreateJobRequest) sanitize(ctx context.Context, tx *pachsql.Tx) (creat
 	}
 	sanitizedReq := createJobRequest{
 		Program:     []byte(fileset.ID(req.Program).HexString()), // there aren't real pins as of yet.
-		ProgramHash: []byte(fileset.ID(req.Program).HexString()), // eventually the ID will be a hash.
+		ProgramHash: req.ProgramHash,                             // eventually the ID will be a hash.
 	}
 	// validate parent.
 	sanitizedReq.Parent = sql.NullInt64{Valid: false}

--- a/src/internal/pjsdb/job_crud_test.go
+++ b/src/internal/pjsdb/job_crud_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 func createRootJob(t *testing.T, d dependencies) pjsdb.JobID {
+	fs, hash := mockAndHashFileset(t, d, "/", "")
 	req := pjsdb.CreateJobRequest{
-		Parent:  0,
-		Inputs:  nil,
-		Program: mockFileset(t, d, "/", ""),
+		Parent:      0,
+		Inputs:      nil,
+		Program:     fs,
+		ProgramHash: hash,
 	}
 	id, err := pjsdb.CreateJob(d.ctx, d.tx, req)
 	require.NoError(t, err)
@@ -261,9 +263,9 @@ func TestListJobTxByFilter(t *testing.T) {
 		withDependencies(t, func(d dependencies) {
 			expected := make([]pjsdb.Job, 0)
 			var err error
-			targetFs := mockFileset(t, d, "/program", "#!/bin/bash; echo 'hello';")
+			targetFs, targetHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo 'hello';")
 			for i := 0; i < 5; i++ {
-				included, err := pjsdb.GetJob(d.ctx, d.tx, createJobWithFilesets(t, d, 0, targetFs))
+				included, err := pjsdb.GetJob(d.ctx, d.tx, createJobWithFilesets(t, d, 0, targetFs, targetHash))
 				require.NoError(t, err)
 				_, err = createJob(t, d, 0)
 				require.NoError(t, err)

--- a/src/internal/storage/util.go
+++ b/src/internal/storage/util.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func NewTestFilesetServer(t testing.TB, db *pachsql.DB) storage.FilesetServer {
+func NewTestFilesetServer(t testing.TB, db *pachsql.DB) *Server {
 	ctx := pctx.TestContext(t)
 	b, buckURL := dockertestenv.NewTestBucket(ctx, t)
 	t.Log("bucket", buckURL)


### PR DESCRIPTION
Task Service integration can't begin until we have consistent hashing for program filesets in PJS. This incorporates @robert-uhl 's changes into pjsdb and pjs, allowing job publishers and subscribers to have a consistent ID for queues. 