### PR TITLE
Unpin pachyderm-sdk version for LabelStudio tests

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -1452,6 +1452,7 @@ jobs:
           name: Run tests
           command: |
             pip3 install -r requirements.txt
+            pip3 install ../python-sdk
             PACHD_ADDRESS=$(minikube ip):30080 python3 -m pytest
   bazel-style-tests:
     resource_class: xlarge

--- a/label-studio/Makefile
+++ b/label-studio/Makefile
@@ -13,9 +13,10 @@ run-test-program:
 	label-studio -b --username user@domain --password pass --user-token abcdef &
 
 install-test-deps:
-	python -m venv env
-	. env/bin/activate
+	python -m venv venv
+	. venv/bin/activate
 	pip install -r requirements.txt
+	pip install ../python-sdk
 
 run-tests:
 	# Add PACHD_ADDRESS env variable to below line

--- a/label-studio/requirements.txt
+++ b/label-studio/requirements.txt
@@ -1,4 +1,3 @@
 pytest~=7.4.0
 requests~=2.32.0
-pachyderm-sdk~=2.7.0
 label-studio-sdk~=0.0.29


### PR DESCRIPTION
We should be testing against the latest builds of the pachyderm-sdk package.