### PR TITLE
[MLDM-52] Delete Job RPC Without Cancelling on Behalf of User

### DIFF
--- a/src/internal/pjsdb/job_crud.go
+++ b/src/internal/pjsdb/job_crud.go
@@ -296,7 +296,7 @@ func DeleteJob(ctx context.Context, tx *pachsql.Tx, id JobID) ([]JobID, error) {
 	}
 	ids := make([]JobID, 0)
 	if err = sqlx.SelectContext(ctx, tx, &ids, recursiveTraverseChildren+`
-	DELETE FROM pjs.jobs WHERE id IN (SELECT id FROM children) AND done IS NOT NULL
+	DELETE FROM pjs.jobs WHERE id IN (SELECT id FROM children) AND (done IS NOT NULL OR processing IS NULL)
 	RETURNING id;`, job.ID, maxDepth); err != nil {
 		return nil, errors.Wrap(err, "cancel job")
 	}

--- a/src/internal/pjsdb/job_crud_test.go
+++ b/src/internal/pjsdb/job_crud_test.go
@@ -186,6 +186,15 @@ func TestWalkJob(t *testing.T) {
 }
 
 func TestDeleteJob(t *testing.T) {
+	t.Run("valid/delete/single/queued", func(t *testing.T) {
+		withDependencies(t, func(d dependencies) {
+			id, err := createJob(t, d, createRootJob(t, d))
+			require.NoError(t, err)
+			deletedIds, err := pjsdb.DeleteJob(d.ctx, d.tx, id)
+			require.NoError(t, err)
+			require.Equal(t, deletedIds[0], id)
+		})
+	})
 	t.Run("valid/delete/single", func(t *testing.T) {
 		withDependencies(t, func(d dependencies) {
 			id, err := createJob(t, d, createRootJob(t, d))
@@ -240,6 +249,8 @@ func TestDeleteJob(t *testing.T) {
 	t.Run("invalid/delete/single", func(t *testing.T) {
 		withDependencies(t, func(d dependencies) {
 			id, err := createJob(t, d, createRootJob(t, d))
+			require.NoError(t, err)
+			_, err = d.tx.ExecContext(d.ctx, `UPDATE pjs.jobs SET processing = CURRENT_TIMESTAMP where id = $1`, id)
 			require.NoError(t, err)
 			deletedIds, err := pjsdb.DeleteJob(d.ctx, d.tx, id)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description
This PR adds the Delete Job RPC without cancelling on behalf of the user. Because there is some disagreement on the exact semantics of the RPC, we'll defer cancelling or waiting on behalf of the user until there is consensus. 

Once there is consensus, we'll add flags to the RPC's request and then support those flags in the API server.