### PR TITLE
[MLDM-34] list queue and list job RPC

### DIFF
--- a/src/internal/pjs/api_server.go
+++ b/src/internal/pjs/api_server.go
@@ -329,13 +329,9 @@ func (a *apiServer) InspectQueue(ctx context.Context, req *pjs.InspectQueueReque
 		if err != nil {
 			return errors.Wrap(err, "get queue")
 		}
-		uniquePrograms := make(map[string]struct{})
-		for _, program := range q.Programs {
-			uniquePrograms[program.HexString()] = struct{}{}
-		}
 		var programs []string
-		for k := range uniquePrograms {
-			programs = append(programs, k)
+		for _, program := range q.Programs {
+			programs = append(programs, program.HexString())
 		}
 		queueInfoDetails = &pjs.QueueInfoDetails{
 			QueueInfo: &pjs.QueueInfo{
@@ -353,6 +349,78 @@ func (a *apiServer) InspectQueue(ctx context.Context, req *pjs.InspectQueueReque
 	return &pjs.InspectQueueResponse{
 		Details: queueInfoDetails,
 	}, nil
+}
+
+func (a *apiServer) ListJob(req *pjs.ListJobRequest, srv pjs.API_ListJobServer) (err error) {
+	ctx, done := log.SpanContext(srv.Context(), "list job")
+	defer done(log.Errorp(&err))
+
+	// handle job context and request validation.
+	id, err := a.resolveJob(ctx, req.Context, req.GetJob().GetId())
+	if err != nil {
+		return err
+	}
+
+	// list jobs and stream back results.
+	var jobs []pjsdb.Job
+	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
+		// list job returns direct children
+		jobs, err = pjsdb.ListJobTxByFilter(ctx, sqlTx,
+			pjsdb.IterateJobsRequest{Filter: pjsdb.IterateJobsFilter{Parent: id}})
+		return errors.Wrap(err, "list job in pjsdb")
+	}, dbutil.WithReadOnly()); err != nil {
+		return errors.Wrap(err, "with tx")
+	}
+	for i, job := range jobs {
+		jobInfo, err := toJobInfo(job)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("to job info, iteration=%d/%d", i, len(jobs)))
+		}
+		resp := &pjs.ListJobResponse{
+			Id:   jobInfo.Job,
+			Info: jobInfo,
+			Details: &pjs.JobInfoDetails{
+				JobInfo: jobInfo,
+			},
+		}
+		if err := srv.Send(resp); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("send, iteration=%d/%d", i, len(jobs)))
+		}
+	}
+	return nil
+}
+
+func (a *apiServer) ListQueue(req *pjs.ListQueueRequest, srv pjs.API_ListQueueServer) (err error) {
+	ctx, done := log.SpanContext(srv.Context(), "list queue")
+	defer done(log.Errorp(&err))
+
+	var queues []pjsdb.Queue
+	if err := dbutil.WithTx(ctx, a.env.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
+		queues, err = pjsdb.ListQueues(ctx, a.env.DB, pjsdb.IterateQueuesRequest{})
+		return errors.Wrap(err, "list queue in pjsdb")
+	}, dbutil.WithReadOnly()); err != nil {
+		return errors.Wrap(err, "with tx")
+	}
+	for i, queue := range queues {
+		queueInfo, err := pjsdb.ToQueueInfo(queue)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("to queue info, iteration=%d/%d", i, len(queues)))
+		}
+		resp := &pjs.ListQueueResponse{
+			Id: &pjs.Queue{
+				Id: []byte(queue.ID),
+			},
+			Info: queueInfo,
+			Details: &pjs.QueueInfoDetails{
+				QueueInfo: queueInfo,
+				Size:      int64(queue.Size),
+			},
+		}
+		if err := srv.Send(resp); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("send, iteration=%d/%d", i, len(queues)))
+		}
+	}
+	return nil
 }
 
 // resolveJobCtx returns an error annotated with a GRPC status and therefore probably shouldn't be wrapped.

--- a/src/internal/pjs/server_internal_test.go
+++ b/src/internal/pjs/server_internal_test.go
@@ -572,49 +572,152 @@ func TestInspectQueue(t *testing.T) {
 		require.NoError(t, err)
 		hash3, err := HashFileset(ctx, fc, programFileset3)
 		require.NoError(t, err)
+		expected := make(map[string][]string)
+		inspect := func(hash []byte, i int) {
+			inspectQueueResp1, err := c.InspectQueue(ctx, &pjs.InspectQueueRequest{
+				Queue: &pjs.Queue{
+					Id: hash,
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, int64(i), inspectQueueResp1.Details.Size)
+			require.Equal(t, expected[string(hash)], inspectQueueResp1.Details.QueueInfo.Program)
+			require.Equal(t, hash, inspectQueueResp1.Details.QueueInfo.Queue.Id)
+		}
 		for i := 1; i <= 10; i++ {
+			expected[string(hash1)] = append(expected[string(hash1)], programFileset1)
 			_, err := c.CreateJob(ctx, &pjs.CreateJobRequest{
 				Program: programFileset1,
 				Input:   []string{programFileset1},
 			})
 			require.NoError(t, err)
-			inspectQueueResp1, err := c.InspectQueue(ctx, &pjs.InspectQueueRequest{
-				Queue: &pjs.Queue{
-					Id: hash1,
-				},
-			})
-			require.NoError(t, err)
-			require.Equal(t, int64(i), inspectQueueResp1.Details.Size)
-			require.Equal(t, []string{programFileset1}, inspectQueueResp1.Details.QueueInfo.Program)
-			require.Equal(t, hash1, inspectQueueResp1.Details.QueueInfo.Queue.Id)
+			inspect(hash1, i)
+
+			expected[string(hash2)] = append(expected[string(hash2)], programFileset2)
 			_, err = c.CreateJob(ctx, &pjs.CreateJobRequest{
 				Program: programFileset2,
 				Input:   []string{programFileset2},
 			})
 			require.NoError(t, err)
-			inspectQueueResp2, err := c.InspectQueue(ctx, &pjs.InspectQueueRequest{
-				Queue: &pjs.Queue{
-					Id: hash2,
-				},
-			})
-			require.NoError(t, err)
-			require.Equal(t, int64(i), inspectQueueResp2.Details.Size)
-			require.Equal(t, hash2, inspectQueueResp2.Details.QueueInfo.Queue.Id)
+			inspect(hash2, i)
+
+			expected[string(hash3)] = append(expected[string(hash3)], programFileset3)
 			_, err = c.CreateJob(ctx, &pjs.CreateJobRequest{
 				Program: programFileset3,
 				Input:   []string{programFileset3},
 			})
 			require.NoError(t, err)
-			inspectQueueResp3, err := c.InspectQueue(ctx, &pjs.InspectQueueRequest{
-				Queue: &pjs.Queue{
-					Id: hash3,
-				},
-			})
-			require.NoError(t, err)
-			require.Equal(t, int64(i), inspectQueueResp3.Details.Size)
-			require.Equal(t, hash3, inspectQueueResp3.Details.QueueInfo.Queue.Id)
+			inspect(hash3, i)
 		}
 	})
+}
+
+func TestListJob(t *testing.T) {
+	c, fc := setupTest(t)
+	ctx := pctx.TestContext(t)
+	depth := 3
+	fullBinaryJobTree(t, ctx, depth, c, fc)
+
+	for jid := 1; jid <= 3; jid++ {
+		expected := []int64{int64(jid * 2), int64(jid*2 + 1)}
+		listC, err := c.ListJob(ctx, &pjs.ListJobRequest{
+			Job: &pjs.Job{
+				Id: int64(jid),
+			},
+		})
+		require.NoError(t, err)
+		var actual []int64
+		for {
+			resp, err := listC.Recv()
+			if err != nil {
+				if errors.As(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
+			}
+			parentJob := resp.Details.JobInfo.ParentJob
+			if parentJob != nil && parentJob.Id != 0 {
+				actual = append(actual, resp.Id.Id)
+			}
+			require.NoError(t, err)
+		}
+		require.NoDiff(t, expected, actual, nil)
+	}
+}
+
+func TestListQueue(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	c, fc := setupTest(t)
+	inputFileset := createFileSet(t, fc, map[string][]byte{
+		"a.txt": []byte(`dummy input`),
+	})
+	programFileset1 := createFileSet(t, fc, map[string][]byte{
+		"file": []byte(`program1`),
+	})
+	req1 := &pjs.CreateJobRequest{
+		Program: programFileset1,
+		Input:   []string{inputFileset},
+	}
+	programFileset2 := createFileSet(t, fc, map[string][]byte{
+		"file": []byte(`program2`),
+	})
+	req2 := &pjs.CreateJobRequest{
+		Program: programFileset2,
+		Input:   []string{inputFileset},
+	}
+	programFileset3 := createFileSet(t, fc, map[string][]byte{
+		"file": []byte(`program3`),
+	})
+	hash1, err := HashFileset(ctx, fc, programFileset1)
+	require.NoError(t, err)
+	hash2, err := HashFileset(ctx, fc, programFileset2)
+	require.NoError(t, err)
+	hash3, err := HashFileset(ctx, fc, programFileset3)
+	require.NoError(t, err)
+	expected := make(map[string][]string)
+	// ListQueue should return QueueIDs an lengths based on all jobs in all states.
+	// Length should come from counting only jobs in QUEUED state.
+	for i := 1; i <= 10; i++ {
+		// queue1 and queue2 has no queued jobs.
+		_, err := runJob(t, ctx, c, fc, req1, func(resp *pjs.ProcessQueueResponse) error {
+			return nil
+		})
+		require.NoError(t, err)
+		_, err = runJob(t, ctx, c, fc, req2, func(resp *pjs.ProcessQueueResponse) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		_, err = c.CreateJob(ctx, &pjs.CreateJobRequest{
+			Program: programFileset3,
+			Input:   []string{inputFileset},
+		})
+		require.NoError(t, err)
+		expected[string(hash3)] = append(expected[string(hash3)], programFileset3)
+	}
+	listC, err := c.ListQueue(ctx, &pjs.ListQueueRequest{})
+	require.NoError(t, err)
+
+	for {
+		resp, err := listC.Recv()
+		if err != nil {
+			if errors.As(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+		require.NoError(t, err)
+		if idHashEqual(resp.Id.Id, hash1) || idHashEqual(resp.Id.Id, hash2) {
+			require.Equal(t, int64(0), resp.Details.Size)
+		} else {
+			require.Equal(t, int64(10), resp.Details.Size)
+		}
+		require.Equal(t, expected[string(resp.Id.Id)], resp.Info.Program)
+	}
+}
+
+func idHashEqual(a []byte, b []byte) bool {
+	return string(a) == string(b)
 }
 
 func setupTest(t testing.TB, opts ...ClientOptions) (pjs.APIClient, storage.FilesetClient) {

--- a/src/internal/pjsdb/job_iterator.go
+++ b/src/internal/pjsdb/job_iterator.go
@@ -24,6 +24,7 @@ type IterateJobsFilter struct {
 	Operation filterOperation
 
 	// fields to filter on
+	NullParent  bool
 	Parent      JobID
 	HasInput    []byte
 	Program     []byte
@@ -46,7 +47,7 @@ func (f IterateJobsFilter) IsEmpty() bool {
 func (f IterateJobsFilter) apply() (where string, values []any) {
 	var conditions []string
 	// from pjs.jobs
-	if f.Parent != 0 {
+	if f.Parent != 0 && !f.NullParent {
 		conditions = append(conditions, "j.parent = ?")
 		values = append(values, f.Parent)
 	}
@@ -70,6 +71,9 @@ func (f IterateJobsFilter) apply() (where string, values []any) {
 	if f.HasOutput != nil {
 		conditions = append(conditions, "jf_output.fileset IN (?)")
 		values = append(values, f.HasOutput)
+	}
+	if f.NullParent {
+		conditions = append(conditions, "j.parent IS NULL")
 	}
 	if len(conditions) == 0 {
 		return "", nil

--- a/src/internal/pjsdb/pjsdb.go
+++ b/src/internal/pjsdb/pjsdb.go
@@ -5,6 +5,7 @@ package pjsdb
 import (
 	"database/sql"
 	"encoding/hex"
+	"github.com/pachyderm/pachyderm/v2/src/pjs"
 	"strconv"
 	"strings"
 	"time"
@@ -183,4 +184,17 @@ func parseFileset(filesets string) ([]fileset.ID, error) {
 		ids = append(ids, *id)
 	}
 	return ids, nil
+}
+
+func ToQueueInfo(queue Queue) (*pjs.QueueInfo, error) {
+	var programs []string
+	for _, p := range queue.Programs {
+		programs = append(programs, p.HexString())
+	}
+	return &pjs.QueueInfo{
+		Queue: &pjs.Queue{
+			Id: queue.ID,
+		},
+		Program: programs,
+	}, nil
 }

--- a/src/internal/pjsdb/queue_crud.go
+++ b/src/internal/pjsdb/queue_crud.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
-	"github.com/pachyderm/pachyderm/v2/src/pjs"
 )
 
 // ListQueues returns a list of Queue objects.
@@ -83,17 +82,4 @@ func GetQueue(ctx context.Context, tx *pachsql.Tx, queueId []byte) (Queue, error
 		return Queue{}, errors.Wrap(err, "queue record to Queue")
 	}
 	return queue, nil
-}
-
-func ToQueueInfo(queue Queue) (*pjs.QueueInfo, error) {
-	var programs []string
-	for _, p := range queue.Programs {
-		programs = append(programs, p.HexString())
-	}
-	return &pjs.QueueInfo{
-		Queue: &pjs.Queue{
-			Id: queue.ID,
-		},
-		Program: programs,
-	}, nil
 }

--- a/src/internal/pjsdb/queue_crud.go
+++ b/src/internal/pjsdb/queue_crud.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
+	"github.com/pachyderm/pachyderm/v2/src/pjs"
 )
 
 // ListQueues returns a list of Queue objects.
@@ -82,4 +83,17 @@ func GetQueue(ctx context.Context, tx *pachsql.Tx, queueId []byte) (Queue, error
 		return Queue{}, errors.Wrap(err, "queue record to Queue")
 	}
 	return queue, nil
+}
+
+func ToQueueInfo(queue Queue) (*pjs.QueueInfo, error) {
+	var programs []string
+	for _, p := range queue.Programs {
+		programs = append(programs, p.HexString())
+	}
+	return &pjs.QueueInfo{
+		Queue: &pjs.Queue{
+			Id: queue.ID,
+		},
+		Program: programs,
+	}, nil
 }

--- a/src/internal/pjsdb/queue_iterator.go
+++ b/src/internal/pjsdb/queue_iterator.go
@@ -20,7 +20,7 @@ const (
 				count(j.id) AS "size"
 			  FROM 
 				queues 
-			  JOIN 
+			  LEFT JOIN 
 				pjs.jobs j 
 				ON j.program_hash = queues.program_hash
               WHERE


### PR DESCRIPTION
ListQueue and ListJob RPC are implemented in this PR. "ListQueue should return QueueIDs an lengths based on all jobs in all states.  Length should come from counting only jobs in QUEUED state."


This PR also fixes a wrong implementation in inspectQueue.