### PR TITLE
[MLDM-91] benchmark dequeueAndProcess

### DIFF
--- a/src/internal/pjs/server_internal_test.go
+++ b/src/internal/pjs/server_internal_test.go
@@ -2,15 +2,16 @@ package pjs
 
 import (
 	"context"
+	"io"
+	"math"
+	"testing"
+	"time"
+
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"io"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"math"
-	"testing"
-	"time"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
@@ -655,7 +656,7 @@ func setupTest(t testing.TB, opts ...ClientOptions) (pjs.APIClient, storage.File
 	return NewTestClient(t, db, client, opts...), client
 }
 
-func createFileSet(t *testing.T, fc storage.FilesetClient, files map[string][]byte) string {
+func createFileSet(t testing.TB, fc storage.FilesetClient, files map[string][]byte) string {
 	ctx := pctx.TestContext(t)
 	ctx, cf := context.WithCancel(ctx)
 	defer cf()

--- a/src/internal/pjsdb/BUILD.bazel
+++ b/src/internal/pjsdb/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     deps = [
         ":pjsdb",
         "//src/internal/clusterstate",
+        "//src/internal/dbutil",
         "//src/internal/dockertestenv",
         "//src/internal/errors",
         "//src/internal/migrations",
@@ -55,5 +56,6 @@ go_test(
         "//src/internal/storage/kv",
         "//src/internal/storage/track",
         "//src/internal/testetcd",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/src/internal/pjsdb/BUILD.bazel
+++ b/src/internal/pjsdb/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     deps = [
         ":pjsdb",
         "//src/internal/clusterstate",
-        "//src/internal/dbutil",
         "//src/internal/dockertestenv",
         "//src/internal/errors",
         "//src/internal/migrations",
@@ -56,6 +55,5 @@ go_test(
         "//src/internal/storage/kv",
         "//src/internal/storage/track",
         "//src/internal/testetcd",
-        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/src/internal/pjsdb/pjsdb_test.go
+++ b/src/internal/pjsdb/pjsdb_test.go
@@ -30,7 +30,7 @@ type dependencies struct {
 	s   *fileset.Storage
 }
 
-func DB(t *testing.T) (context.Context, *pachsql.DB) {
+func DB(t testing.TB) (context.Context, *pachsql.DB) {
 	t.Helper()
 	ctx := pctx.Child(pctx.TestContext(t), t.Name())
 	db := dockertestenv.NewTestDB(t)
@@ -39,14 +39,14 @@ func DB(t *testing.T) (context.Context, *pachsql.DB) {
 	return ctx, db
 }
 
-func FilesetStorage(t *testing.T, db *pachsql.DB) *fileset.Storage {
+func FilesetStorage(t testing.TB, db *pachsql.DB) *fileset.Storage {
 	t.Helper()
 	store := kv.NewFSStore(filepath.Join(t.TempDir(), "obj-store"), 512, chunk.DefaultMaxChunkSize)
 	tr := track.NewPostgresTracker(db)
 	return fileset.NewStorage(fileset.NewPostgresStore(db), tr, chunk.NewStorage(store, nil, db, tr))
 }
 
-func withTx(t *testing.T, ctx context.Context, db *pachsql.DB, s *fileset.Storage, f func(d dependencies)) {
+func withTx(t testing.TB, ctx context.Context, db *pachsql.DB, s *fileset.Storage, f func(d dependencies)) {
 	t.Helper()
 	tx, err := db.BeginTxx(ctx, nil)
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func withDependencies(t *testing.T, f func(d dependencies)) {
 	})
 }
 
-func mockFileset(t *testing.T, d dependencies, path, value string) fileset.PinnedFileset {
+func mockFileset(t testing.TB, d dependencies, path, value string) fileset.PinnedFileset {
 	var id *fileset.ID
 	uw, err := d.s.NewUnorderedWriter(d.ctx)
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func mockFileset(t *testing.T, d dependencies, path, value string) fileset.Pinne
 	return pin
 }
 
-func mockAndHashFileset(t *testing.T, d dependencies, path, value string) (fileset.PinnedFileset, []byte) {
+func mockAndHashFileset(t testing.TB, d dependencies, path, value string) (fileset.PinnedFileset, []byte) {
 	fs := mockFileset(t, d, path, value)
 	hasher := pachhash.New()
 	_, err := hasher.Write([]byte(path))
@@ -108,7 +108,7 @@ func makeReq(t *testing.T, d dependencies, parent pjsdb.JobID, mutate func(req *
 	return *createRequest
 }
 
-func createJobWithFilesets(t *testing.T, d dependencies, parent pjsdb.JobID, program fileset.PinnedFileset,
+func createJobWithFilesets(t testing.TB, d dependencies, parent pjsdb.JobID, program fileset.PinnedFileset,
 	targetHash []byte, inputs ...fileset.PinnedFileset) pjsdb.JobID {
 	createRequest := pjsdb.CreateJobRequest{
 		Program:     program,

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -91,6 +91,7 @@ func BenchmarkDequeuePerformance(t *testing.B) {
 	//numItems := t.N
 	//numWorkers := 10
 	//_, db := DB(t)
+	_, _ = DB(t)
 	//db.SetMaxOpenConns(numWorkers)
 	//s := FilesetStorage(t, db)
 	//_ = FilesetStorage(t, db)

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -89,10 +89,10 @@ func TestDequeue(t *testing.T) {
 func BenchmarkDequeuePerformance(t *testing.B) {
 	t.StopTimer()
 	//numItems := t.N
-	//numWorkers := 10
-	//_, db := DB(t)
-	_, _ = DB(t)
-	//db.SetMaxOpenConns(numWorkers)
+	numWorkers := 10
+	_, db := DB(t)
+	//_, _ = DB(t)
+	db.SetMaxOpenConns(numWorkers)
 	//s := FilesetStorage(t, db)
 	//_ = FilesetStorage(t, db)
 

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -86,40 +86,40 @@ func TestDequeue(t *testing.T) {
 	})
 }
 
-//func BenchmarkDequeuePerformance(t *testing.B) {
-//	t.StopTimer()
-//	numItems := t.N
-//	numWorkers := 10
-//	ctx, db := DB(t)
-//	db.SetMaxOpenConns(numWorkers)
-//	s := FilesetStorage(t, db)
-//	var queueId []byte
-//	withTx(t, ctx, db, s, func(d dependencies) {
-//		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
-//		for i := 0; i < numItems; i++ {
-//			createJobWithFilesets(t, d, 0, prog, progHash)
-//		}
-//		queueId = progHash
-//	})
-//
-//	t.StartTimer()
-//	var eg errgroup.Group
-//
-//	for i := 0; i < numWorkers; i++ {
-//		eg.Go(func() error {
-//			for j := 0; j < numItems/numWorkers; j++ {
-//				err := dbutil.WithTx(ctx, db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-//					_, err := pjsdb.DequeueAndProcess(ctx, sqlTx, queueId)
-//					return err
-//				})
-//				if err != nil {
-//					return err
-//				}
-//			}
-//			return nil
-//		})
-//	}
-//	require.NoError(t, eg.Wait())
-//
-//	t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
-//}
+func BenchmarkDequeuePerformance(t *testing.B) {
+	t.StopTimer()
+	numItems := t.N
+	numWorkers := 10
+	ctx, db := DB(t)
+	db.SetMaxOpenConns(numWorkers)
+	s := FilesetStorage(t, db)
+	//var queueId []byte
+	withTx(t, ctx, db, s, func(d dependencies) {
+		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
+		for i := 0; i < numItems; i++ {
+			createJobWithFilesets(t, d, 0, prog, progHash)
+		}
+		//	queueId = progHash
+	})
+
+	t.StartTimer()
+	//var eg errgroup.Group
+
+	//for i := 0; i < numWorkers; i++ {
+	//	eg.Go(func() error {
+	//		for j := 0; j < numItems/numWorkers; j++ {
+	//			err := dbutil.WithTx(ctx, db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
+	//				_, err := pjsdb.DequeueAndProcess(ctx, sqlTx, queueId)
+	//				return err
+	//			})
+	//			if err != nil {
+	//				return err
+	//			}
+	//		}
+	//		return nil
+	//	})
+	//}
+	//require.NoError(t, eg.Wait())
+	//
+	//t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
+}

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -2,7 +2,6 @@ package pjsdb_test
 
 import (
 	"context"
-	"fmt"
 	"golang.org/x/sync/errgroup"
 	"testing"
 
@@ -99,8 +98,6 @@ func BenchmarkDequeuePerformance(t *testing.B) {
 	db.SetMaxOpenConns(numWorkers)
 	s := FilesetStorage(t, db)
 	var queueId [32]byte
-	// 1. create 1000 jobs. same queue
-	// 2. dequeue 1000/N jobs across N go routines
 	withTx(t, ctx, db, s, func(d dependencies) {
 		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
 		for i := 0; i < numItems; i++ {
@@ -128,5 +125,5 @@ func BenchmarkDequeuePerformance(t *testing.B) {
 	}
 	require.NoError(t, eg.Wait())
 
-	fmt.Printf("took %s with t.N = %d\n", t.Elapsed(), t.N)
+	t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
 }

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -1,13 +1,9 @@
 package pjsdb_test
 
 import (
-	"context"
-	"golang.org/x/sync/errgroup"
 	"testing"
 
-	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
-	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pjsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
@@ -90,40 +86,40 @@ func TestDequeue(t *testing.T) {
 	})
 }
 
-func BenchmarkDequeuePerformance(t *testing.B) {
-	t.StopTimer()
-	numItems := t.N
-	numWorkers := 10
-	ctx, db := DB(t)
-	db.SetMaxOpenConns(numWorkers)
-	s := FilesetStorage(t, db)
-	var queueId []byte
-	withTx(t, ctx, db, s, func(d dependencies) {
-		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
-		for i := 0; i < numItems; i++ {
-			createJobWithFilesets(t, d, 0, prog, progHash)
-		}
-		queueId = progHash
-	})
-
-	t.StartTimer()
-	var eg errgroup.Group
-
-	for i := 0; i < numWorkers; i++ {
-		eg.Go(func() error {
-			for j := 0; j < numItems/numWorkers; j++ {
-				err := dbutil.WithTx(ctx, db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-					_, err := pjsdb.DequeueAndProcess(ctx, sqlTx, queueId)
-					return err
-				})
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-	}
-	require.NoError(t, eg.Wait())
-
-	t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
-}
+//func BenchmarkDequeuePerformance(t *testing.B) {
+//	t.StopTimer()
+//	numItems := t.N
+//	numWorkers := 10
+//	ctx, db := DB(t)
+//	db.SetMaxOpenConns(numWorkers)
+//	s := FilesetStorage(t, db)
+//	var queueId []byte
+//	withTx(t, ctx, db, s, func(d dependencies) {
+//		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
+//		for i := 0; i < numItems; i++ {
+//			createJobWithFilesets(t, d, 0, prog, progHash)
+//		}
+//		queueId = progHash
+//	})
+//
+//	t.StartTimer()
+//	var eg errgroup.Group
+//
+//	for i := 0; i < numWorkers; i++ {
+//		eg.Go(func() error {
+//			for j := 0; j < numItems/numWorkers; j++ {
+//				err := dbutil.WithTx(ctx, db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
+//					_, err := pjsdb.DequeueAndProcess(ctx, sqlTx, queueId)
+//					return err
+//				})
+//				if err != nil {
+//					return err
+//				}
+//			}
+//			return nil
+//		})
+//	}
+//	require.NoError(t, eg.Wait())
+//
+//	t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
+//}

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -88,19 +88,21 @@ func TestDequeue(t *testing.T) {
 
 func BenchmarkDequeuePerformance(t *testing.B) {
 	t.StopTimer()
-	numItems := t.N
+	//numItems := t.N
 	numWorkers := 10
-	ctx, db := DB(t)
+	_, db := DB(t)
 	db.SetMaxOpenConns(numWorkers)
-	s := FilesetStorage(t, db)
+	//s := FilesetStorage(t, db)
+	_ = FilesetStorage(t, db)
+
 	//var queueId []byte
-	withTx(t, ctx, db, s, func(d dependencies) {
-		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
-		for i := 0; i < numItems; i++ {
-			createJobWithFilesets(t, d, 0, prog, progHash)
-		}
-		//	queueId = progHash
-	})
+	//withTx(t, ctx, db, s, func(d dependencies) {
+	//	prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
+	//	for i := 0; i < numItems; i++ {
+	//		createJobWithFilesets(t, d, 0, prog, progHash)
+	//	}
+	//	//	queueId = progHash
+	//})
 
 	t.StartTimer()
 	//var eg errgroup.Group

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -103,7 +103,7 @@ func BenchmarkDequeuePerformance(t *testing.B) {
 		for i := 0; i < numItems; i++ {
 			createJobWithFilesets(t, d, 0, prog, progHash)
 		}
-		queueId = [32]byte(progHash)
+		copy(queueId[:], progHash[:32])
 	})
 
 	t.StartTimer()

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -89,11 +89,11 @@ func TestDequeue(t *testing.T) {
 func BenchmarkDequeuePerformance(t *testing.B) {
 	t.StopTimer()
 	//numItems := t.N
-	numWorkers := 10
-	_, db := DB(t)
-	db.SetMaxOpenConns(numWorkers)
+	//numWorkers := 10
+	//_, db := DB(t)
+	//db.SetMaxOpenConns(numWorkers)
 	//s := FilesetStorage(t, db)
-	_ = FilesetStorage(t, db)
+	//_ = FilesetStorage(t, db)
 
 	//var queueId []byte
 	//withTx(t, ctx, db, s, func(d dependencies) {

--- a/src/internal/pjsdb/queue_crud_test.go
+++ b/src/internal/pjsdb/queue_crud_test.go
@@ -1,9 +1,13 @@
 package pjsdb_test
 
 import (
+	"context"
+	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
+	"golang.org/x/sync/errgroup"
 	"testing"
 
 	"github.com/pachyderm/pachyderm/v2/src/internal/errors"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pjsdb"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
@@ -88,41 +92,39 @@ func TestDequeue(t *testing.T) {
 
 func BenchmarkDequeuePerformance(t *testing.B) {
 	t.StopTimer()
-	//numItems := t.N
+	numItems := t.N
 	numWorkers := 10
-	_, db := DB(t)
-	//_, _ = DB(t)
-	db.SetMaxOpenConns(numWorkers)
-	//s := FilesetStorage(t, db)
-	//_ = FilesetStorage(t, db)
+	ctx, db := DB(t)
+	db.DB.SetMaxOpenConns(numWorkers)
+	s := FilesetStorage(t, db)
 
-	//var queueId []byte
-	//withTx(t, ctx, db, s, func(d dependencies) {
-	//	prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
-	//	for i := 0; i < numItems; i++ {
-	//		createJobWithFilesets(t, d, 0, prog, progHash)
-	//	}
-	//	//	queueId = progHash
-	//})
+	var queueId []byte
+	withTx(t, ctx, db, s, func(d dependencies) {
+		prog, progHash := mockAndHashFileset(t, d, "/program", "#!/bin/bash; echo;")
+		for i := 0; i < numItems; i++ {
+			createJobWithFilesets(t, d, 0, prog, progHash)
+		}
+		queueId = progHash
+	})
 
 	t.StartTimer()
-	//var eg errgroup.Group
+	var eg errgroup.Group
 
-	//for i := 0; i < numWorkers; i++ {
-	//	eg.Go(func() error {
-	//		for j := 0; j < numItems/numWorkers; j++ {
-	//			err := dbutil.WithTx(ctx, db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-	//				_, err := pjsdb.DequeueAndProcess(ctx, sqlTx, queueId)
-	//				return err
-	//			})
-	//			if err != nil {
-	//				return err
-	//			}
-	//		}
-	//		return nil
-	//	})
-	//}
-	//require.NoError(t, eg.Wait())
-	//
-	//t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
+	for i := 0; i < numWorkers; i++ {
+		eg.Go(func() error {
+			for j := 0; j < numItems/numWorkers; j++ {
+				err := dbutil.WithTx(ctx, db, func(ctx context.Context, sqlTx *pachsql.Tx) error {
+					_, err := pjsdb.DequeueAndProcess(ctx, sqlTx, queueId)
+					return err
+				})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
+
+	t.Logf("took %s with t.N = %d\n", t.Elapsed(), t.N)
 }


### PR DESCRIPTION
Investigate dequeue performance

cd into the pjsdb directory. Run 
`go test -bench=. --run=BenchmarkDequeuePerformance -benchtime=60s` to run the benchmark.