### PR TITLE
Add Schema Change and Data Model Code for the PJS Server-Side Cache

### DIFF
--- a/src/internal/clusterstate/v2.12.0/pjs.go
+++ b/src/internal/clusterstate/v2.12.0/pjs.go
@@ -40,6 +40,17 @@ func createPJSSchema(ctx context.Context, env migrations.Env) error {
 			'input', 
 			'output'
 		);
+		-- PJS has a server side cache for jobs. Utilizing this cache allows PJS to skip subtrees when spawning job trees.
+		CREATE TABLE pjs.job_cache (
+			job_hash BYTEA NOT NULL,
+			job_id BIGINT REFERENCES pjs.jobs(id) ON DELETE CASCADE,
+			cache_read BOOLEAN NOT NULL DEFAULT FALSE,
+		    cache_write BOOLEAN NOT NULL DEFAULT FALSE,
+		    PRIMARY KEY(job_hash, job_id)
+		);
+		CREATE INDEX id_to_hash ON pjs.job_cache (
+			job_id, job_hash
+		);
 		-- A job's input and output may be more than one fileset.
 		-- An extra table makes looking up, inserting, and reordering those filesets more efficient.
 		CREATE TABLE pjs.job_filesets (

--- a/src/internal/pjsdb/job_iterator.go
+++ b/src/internal/pjsdb/job_iterator.go
@@ -18,7 +18,7 @@ import (
 // IterateJobsFilter is translated to a 'where' SQL clause for use by the job iterator.
 // keeping this as its own separate struct makes it easy to check to see if a
 // filter is defined. It also allows filters to be combined later if needed.
-// TODO(Fahad): combine filters by adding filter.And(other Filter) and filter.Or(other Filter)
+// TODO(Fahad): if needed, combine filters by adding filter.And(other Filter) and filter.Or(other Filter)
 type IterateJobsFilter struct {
 	// Operation determines how fields are joined into a predicate. The default is 'AND'
 	Operation filterOperation
@@ -124,7 +124,7 @@ func NewJobsIterator(extCtx sqlx.ExtContext, req IterateJobsRequest) *JobsIterat
 	query := selectJobRecordPrefix
 	where, values := req.Filter.apply()
 	query += where
-	query += "\nGROUP BY j.id "
+	query += "\nGROUP BY j.id, jc.job_hash, jc.cache_write, jc.cache_read "
 	query += req.orderBy()
 	query = extCtx.Rebind(query)
 	if req.PageSize == 0 {

--- a/src/internal/pjsdb/pjsdb.go
+++ b/src/internal/pjsdb/pjsdb.go
@@ -34,7 +34,15 @@ type Job struct {
 	Queued     time.Time
 	Processing time.Time
 	Done       time.Time
-	// additional fields or metadata that would be computed would go here.
+
+	JobCacheMetadata
+}
+
+// JobCacheMetadata is the corresponding cache metadata of a Job.
+type JobCacheMetadata struct {
+	JobHash      []byte
+	ReadEnabled  bool
+	WriteEnabled bool
 }
 
 // jobRow models a single row in the pjs.jobs table.
@@ -61,12 +69,20 @@ type jobFilesetsRow struct {
 	Fileset       []byte `db:"fileset"`
 }
 
+// jobCacheRow models a single row in the pjs.job_cache table.
+type jobCacheRow struct {
+	JobHash      []byte `db:"job_hash"`
+	ReadEnabled  bool   `db:"cache_read"`
+	WriteEnabled bool   `db:"cache_write"`
+}
+
 // jobRecord is derived from the pjs.jobs and pjs.job_filesets tables.
 // note that this is a 'record' and not a row, because it is the result of joining tables together.
 type jobRecord struct {
 	jobRow
 	Inputs  string `db:"inputs"`
 	Outputs string `db:"outputs"`
+	jobCacheRow
 }
 
 func (r jobRecord) toJob() (Job, error) {
@@ -79,6 +95,11 @@ func (r jobRecord) toJob() (Job, error) {
 		Queued:      r.Queued,
 		Processing:  r.Processing.Time,
 		Done:        r.Done.Time,
+		JobCacheMetadata: JobCacheMetadata{
+			JobHash:      r.JobHash,
+			ReadEnabled:  r.ReadEnabled,
+			WriteEnabled: r.WriteEnabled,
+		},
 	}
 	var err error
 	if job.Inputs, err = parseFileset(r.Inputs); err != nil {


### PR DESCRIPTION
## Description
This PR updates the database schema to include new tables and indices for the PJS server-side job cache. It also updates the data model code so caching information is returned.

Caching has to still be implemented though. Currently these fields will be nil until a future PR writes the caching behavior. 