### PR TITLE
Let psql handle C-c 

### DIFF
--- a/src/testing/psql/main.go
+++ b/src/testing/psql/main.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
@@ -145,6 +146,10 @@ func RunPsql(ctx context.Context, host string, port int, password string) error 
 	environ := os.Environ()
 	environ = append(environ, "PGPASSWORD="+password)
 	cmd.Env = environ
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:    true,
+		Foreground: true,
+	}
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, "run psql")
 	}


### PR DESCRIPTION
Pressing Control-C while psql is running cancels the context that runs psql, which kills psql with signal 9.  This is annoying as Control-C is used by psql for other things.  This PR changes the behavior to ignore the cancellation behavior on the go side, so that psql receives the signal and can cancel ongoing queries, etc.