### PR TITLE
add meters.NewWriter to count bytes

### DIFF
--- a/src/internal/meters/BUILD.bazel
+++ b/src/internal/meters/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     deps = [
         "//src/internal/log",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_zeebo_blake3//:blake3",
         "@org_uber_go_zap//:zap",
     ],
 )


### PR DESCRIPTION
This adds an io.Writer that monitors the number of bytes that have been successfully written to an io.Writer.