### PR TITLE
Add a function to restore a snapshot

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -216,6 +216,7 @@ use_repo(
     "com_github_hashicorp_golang_lru_v2",
     "com_github_iancoleman_orderedmap",
     "com_github_iancoleman_strcase",
+    "com_github_icholy_replace",
     "com_github_instrumenta_kubeval",
     "com_github_itchyny_gojq",
     "com_github_jackc_pgconn",

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,10 @@ require github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 
 require github.com/nishanths/exhaustive v0.12.0
 
-require github.com/golangci/gofmt v0.0.0-20240816233607-d8596aa466a9
+require (
+	github.com/golangci/gofmt v0.0.0-20240816233607-d8596aa466a9
+	github.com/icholy/replace v0.6.0
+)
 
 require (
 	github.com/containerd/containerd v1.6.26 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1207,6 +1207,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
+github.com/icholy/replace v0.6.0 h1:EBiD2pGqZIOJAbEaf/5GVRaD/Pmbb4n+K3LrBdXd4dw=
+github.com/icholy/replace v0.6.0/go.mod h1:zzi8pxElj2t/5wHHHYmH45D+KxytX/t4w3ClY5nlK+g=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/private/apt/BUILD.bazel
+++ b/private/apt/BUILD.bazel
@@ -12,6 +12,19 @@ genrule(
 )
 
 genrule(
+    name = "psql_genrule",
+    srcs = select({
+        "//:is_x86_64_linux": ["@postgres//postgresql-client-17/amd64:data"],
+        "//:is_aarch64_linux": ["@postgres//postgresql-client-17/arm64:data"],
+    }),
+    outs = ["psql"],
+    cmd = "$(BSDTAR_BIN) --extract --strip-components 6 --file $< usr/lib/postgresql/17/bin/psql; mv psql $@",
+    executable = True,
+    toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
+    visibility = ["//tools/postgres/psql:__pkg__"],
+)
+
+genrule(
     name = "libpq_genrule",
     srcs = select({
         "//:is_x86_64_linux": ["@postgres//libpq5/amd64:data"],

--- a/src/internal/recovery/BUILD.bazel
+++ b/src/internal/recovery/BUILD.bazel
@@ -85,7 +85,6 @@ go_test(
         "//src/internal/storage/fileset",
         "//src/internal/storage/kv",
         "//src/internal/storage/track",
-        "//src/version",
         "@com_github_google_go_cmp//cmp",
         "@com_github_klauspost_compress//zstd",
         "@com_github_satori_go_uuid//:go_uuid",

--- a/src/internal/recovery/BUILD.bazel
+++ b/src/internal/recovery/BUILD.bazel
@@ -9,6 +9,7 @@ LINUX_LIBRARIES = [
 
 LINUX_VARS = {
     "pgdump": "$(rlocationpath //tools/postgres/pg_dump)",
+    "psql": "$(rlocationpath //tools/postgres/psql)",
     "libpq": "$(rlocationpath //private/apt:libpq.so.5)",
     "libldap": "$(rlocationpath //private/apt:libldap-2.5.so.0)",
     "liblber": "$(rlocationpath //private/apt:liblber-2.5.so.0)",
@@ -22,6 +23,7 @@ MAC_LIBRARIES = [
 
 MAC_VARS = {
     "pgdump": "$(rlocationpath //tools/postgres/pg_dump)",
+    "psql": "$(rlocationpath //tools/postgres/psql)",
     "libpq": "$(rlocationpath @com_enterprisedb_get_postgresql_macos//:lib/libpq.5.dylib)",
 }
 
@@ -30,6 +32,7 @@ go_library(
     srcs = ["recovery.go"],
     data = [
         "//tools/postgres/pg_dump",
+        "//tools/postgres/psql",
     ] + select({
         "//:is_x86_64_linux": LINUX_LIBRARIES,
         "//:is_aarch64_linux": LINUX_LIBRARIES,
@@ -46,15 +49,22 @@ go_library(
     }),
     deps = [
         "//src/internal/bazel",
+        "//src/internal/clusterstate",
         "//src/internal/dbutil",
         "//src/internal/errors",
         "//src/internal/log",
+        "//src/internal/migrations",
         "//src/internal/pachsql",
         "//src/internal/pctx",
         "//src/internal/storage/fileset",
         "//src/version",
+        "@com_github_icholy_replace//:replace",
         "@com_github_jmoiron_sqlx//:sqlx",
         "@com_github_klauspost_compress//zstd",
+        "@com_github_satori_go_uuid//:go_uuid",
+        "@io_etcd_go_etcd_client_v3//:client",
+        "@org_golang_x_mod//semver",
+        "@org_golang_x_text//transform",
         "@org_uber_go_zap//:zap",
         "@rules_go//go/runfiles:go_default_library",
     ],

--- a/src/internal/recovery/recovery_test.go
+++ b/src/internal/recovery/recovery_test.go
@@ -20,62 +20,34 @@ import (
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/fileset"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/kv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
-	"github.com/pachyderm/pachyderm/v2/src/version"
 	uuid "github.com/satori/go.uuid"
 )
 
-func TestCreateSnaphot(t *testing.T) {
-	ctx := pctx.TestContext(t)
-	db := dockertestenv.NewMigratedTestDB(t, clusterstate.DesiredClusterState)
-	tracker := track.NewPostgresTracker(db)
-	s := fileset.NewStorage(fileset.NewPostgresStore(db), tracker, chunk.NewStorage(kv.NewMemStore(), nil, db, tracker))
-
-	snapID, err := CreateSnapshot(ctx, db, s)
+func validateDumpFileset(ctx context.Context, t *testing.T, s *fileset.Storage, fsHandle *fileset.Handle) {
+	t.Helper()
+	fs, err := s.Open(ctx, []*fileset.Handle{fsHandle})
 	if err != nil {
-		t.Fatalf("CreateSnapshot: %v", err)
+		t.Fatalf("open fileset (%v): %v", fsHandle.HexString(), err)
 	}
-
-	var got, want struct {
-		ChunksetID          int64     `db:"chunkset_id"`
-		PachydermVersion    string    `db:"pachyderm_version"`
-		SQLDumpFilesetToken uuid.UUID `db:"sql_dump_fileset_id"`
-	}
-	want.ChunksetID = 1
-	want.PachydermVersion = version.Version.String()
-	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
-		if err := tx.GetContext(ctx, &got, `select chunkset_id, pachyderm_version, sql_dump_fileset_id from recovery.snapshots where id=$1`, snapID); err != nil {
-			return errors.Wrap(err, "read snapshot")
-		}
-		return nil
-	}); err != nil {
-		t.Fatalf("WithTx: %v", err)
-	}
-	fsToken := fileset.Token(got.SQLDumpFilesetToken[:])
-	got.SQLDumpFilesetToken = uuid.UUID{}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("snapshot row (-want +got):\n%s", diff)
-	}
-
-	fs, err := s.Open(ctx, []*fileset.Handle{fileset.NewHandle(fsToken)})
-	if err != nil {
-		t.Fatalf("open fileset (%v): %v", got.SQLDumpFilesetToken.String(), err)
-	}
-	var buf bytes.Buffer
+	var lines []string
 	if err := fs.Iterate(ctx, func(f fileset.File) error {
 		if got, want := f.Index().Path, "dump.sql.zst"; got != want {
-			return errors.Errorf("invalid file in filest:\n  got: %v\n want: %v", got, want)
+			return errors.Errorf("invalid file in fileset:\n  got: %v\n want: %v", got, want)
 		}
 		r, w := io.Pipe()
 		zr, err := zstd.NewReader(r)
-		doneCh := make(chan error)
-		go func() {
-			_, err := io.Copy(&buf, zr)
-			doneCh <- err
-			close(doneCh)
-		}()
 		if err != nil {
 			return errors.Wrap(err, "new zstd reader")
 		}
+		doneCh := make(chan error)
+		go func() {
+			s := bufio.NewScanner(zr)
+			for s.Scan() {
+				lines = append(lines, s.Text())
+			}
+			doneCh <- s.Err()
+			close(doneCh)
+		}()
 		if err := f.Content(ctx, w); err != nil {
 			w.CloseWithError(err) //nolint:errcheck
 			return errors.Wrap(err, "read content")
@@ -88,13 +60,12 @@ func TestCreateSnaphot(t *testing.T) {
 	}); err != nil {
 		t.Errorf("iterate over fileset: %v", err)
 	}
+	if len(lines) < 10 {
+		t.Fatalf("too few lines in buf:\n%v", strings.Join(lines, "\n"))
+	}
 	var looksLikeDump bool
-	scan := bufio.NewScanner(&buf)
 	for i := 0; i < 10; i++ {
-		if !scan.Scan() {
-			t.Fatal("too few lines in buf")
-		}
-		line := scan.Text()
+		line := lines[i]
 		t.Logf("database dump line: %v", line)
 		if strings.Contains(line, "-- PostgreSQL database dump") {
 			looksLikeDump = true
@@ -102,5 +73,115 @@ func TestCreateSnaphot(t *testing.T) {
 	}
 	if !looksLikeDump {
 		t.Errorf("the file we got out of PFS does not look like a database dump; see debug logs above")
+	}
+}
+
+func TestCreateAndRestoreSnaphot(t *testing.T) {
+	ctx := pctx.TestContext(t)
+	db := dockertestenv.NewMigratedTestDB(t, clusterstate.DesiredClusterState)
+	tracker := track.NewPostgresTracker(db)
+	storage := fileset.NewStorage(fileset.NewPostgresStore(db), tracker, chunk.NewStorage(kv.NewMemStore(), nil, db, tracker))
+	w := storage.NewWriter(ctx)
+	if err := w.Add("test", "", strings.NewReader("this is a test")); err != nil {
+		t.Fatalf("add test file: %v", err)
+	}
+	testDataFsHandle, err := w.Close()
+	if err != nil {
+		t.Fatalf("close testdata fileset: %v", err)
+	}
+
+	s := &Snapshotter{DB: db, Storage: storage}
+
+	snapID, err := s.CreateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	var got, want snapshot
+	want.ID = snapID
+	want.ChunksetID = 1
+	want.PachydermVersion = "v0.0.0"
+	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
+		var err error
+		got, err = getSnapshotRow(ctx, tx, snapID)
+		if err != nil {
+			return errors.Wrap(err, "getSnapshotRow")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WithTx: %v", err)
+	}
+	fsToken := fileset.Token(got.SQLDumpFileSetToken[:])
+	t.Logf("fileset handle: %v", fsToken.HexString())
+	got.SQLDumpFileSetToken = uuid.UUID{}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("snapshot row (-want +got):\n%s", diff)
+	}
+	validateDumpFileset(ctx, t, storage, fileset.NewHandle(fsToken))
+
+	if err := s.RestoreSnapshot(ctx, snapID, RestoreSnapshotOptions{}); err != nil {
+		t.Errorf("snapshot not restorable: %v", err)
+	}
+	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
+		var err error
+		got, err = getSnapshotRow(ctx, tx, snapID)
+		if err != nil {
+			return errors.Wrap(err, "getSnapshotRow (after restore)")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WithTx: %v", err)
+	}
+	validateDumpFileset(ctx, t, storage, fileset.NewHandle(fsToken))
+
+	fs, err := storage.Open(ctx, []*fileset.Handle{testDataFsHandle})
+	if err != nil {
+		t.Fatalf("open testdata fileset: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := fs.Iterate(ctx, func(f fileset.File) error {
+		if err := f.Content(ctx, &buf); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read testdata filest: %v", err)
+	}
+	if got, want := buf.String(), "this is a test"; got != want {
+		t.Errorf("test data in snapshotted fileset:\n  got: %v\n want: %v", got, want)
+	}
+}
+
+func TestVersionCompatibility(t *testing.T) {
+	testData := []struct {
+		snapshot, running string
+		ok                bool
+	}{
+		{"", "", true},
+		{"foo", "bar", true},
+		{"bar", "foo", true},
+		{"", "v1.2.3", true},
+		{"v1.2.3", "", true},
+		{"v2.12.1", "v2.12.0", false},
+		{"v2.12.0", "v2.12.1", true},
+		{"v2.13.0", "v2.12.0", false},
+		{"v2.12.0", "v2.13.0", true},
+		{"v2.12.0-pre.gb26915d9b7", "v2.12.0-pre.gb26915d9b7", true},
+		{"v2.12.0-pre.gffffffffff", "v2.12.0-pre.g0000000000", true},
+		{"v2.12.0-pre.g0000000000", "v2.12.0-pre.gaaaaaaaaaa", true},
+		{"v2.12.0-pre.gb26915d9b7", "v2.12.0", true},
+		{"v2.12.0-pre.gb26915d9b7", "v2.12.1", true},
+		{"v2.12.0-pre.gb26915d9b7", "v2.13.0", true},
+		{"v2.12.0", "v2.12.0-pre.gb26915d9b7", false},
+		{"v2.12.1", "v2.12.0-pre.gb26915d9b7", false},
+		{"v2.13.0", "v2.12.0-pre.gb26915d9b7", false},
+		{"v2.12.0-pre.abc123", "v2.13.0-pre.123abc", true},
+	}
+
+	for _, test := range testData {
+		err := checkVersionCompatibility(test.snapshot, test.running)
+		if got, want := err == nil, test.ok; got != want {
+			t.Errorf("restore %v onto %v:\n  got: %v (%v)\n want: %v", test.snapshot, test.running, got, err, want)
+		}
 	}
 }

--- a/src/internal/recovery/recovery_test.go
+++ b/src/internal/recovery/recovery_test.go
@@ -129,6 +129,7 @@ func TestCreateAndRestoreSnaphot(t *testing.T) {
 	if err := s.RestoreSnapshot(ctx, snapID, RestoreSnapshotOptions{}); err != nil {
 		t.Errorf("snapshot not restorable: %v", err)
 	}
+	got.SQLDumpFileSetToken = uuid.UUID{}
 	if err := dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
 		var err error
 		got, err = getSnapshotRow(ctx, tx, snapID)
@@ -140,7 +141,7 @@ func TestCreateAndRestoreSnaphot(t *testing.T) {
 		t.Fatalf("WithTx: %v", err)
 	}
 	// Validate the database backup fileset created during restoration.
-	validateDumpFileset(ctx, t, storage, fileset.NewHandle(fsToken))
+	validateDumpFileset(ctx, t, storage, fileset.NewHandle(fileset.Token(got.SQLDumpFileSetToken)))
 
 	// Drop the chunkset that's keeping the backed up chunks alive (if the restore failed), just
 	// to make sure that it's the original references that are keeping the backed up filesets

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -543,7 +543,7 @@ func (s *Storage) CreateChunkSet(ctx context.Context, tx *sqlx.Tx) (ChunkSetID, 
 }
 
 func (s *Storage) DropChunkSet(ctx context.Context, tx *sqlx.Tx, id ChunkSetID) error {
-	result, err := tx.Exec("DELETE FROM storage.chunksets WHERE id = $1", id)
+	result, err := tx.ExecContext(ctx, "DELETE FROM storage.chunksets WHERE id = $1", id)
 	if err != nil {
 		return errors.Wrap(err, "delete chunkset in db")
 	}

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -583,15 +583,13 @@ func (s *Storage) DumpTracker(ctx context.Context, tx *pachsql.Tx, w io.Writer) 
 	return nil
 }
 
-// DumpTrackerTableNames returns a list of tables that DumpTracker is responsible for dumping.  If
-// dumping the entire database, data in these tables should be skipped, as DumpTracker() handles
-// dumping them.
-func (s *Storage) DumpTrackerTableNames() []string {
+// DumpTrackerTablePattern returns a postgres pattern that matches the tables DumpTracker will dump.
+func (s *Storage) DumpTrackerTablePattern() string {
 	t, ok := s.tracker.(track.Dumper)
 	if !ok {
-		return nil
+		return ""
 	}
-	return t.DumpTrackerTableNames()
+	return t.DumpTrackerTablePattern()
 }
 
 // Storage implements track.Dumper.

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -515,6 +515,9 @@ func (s *Storage) Pin(tx *pachsql.Tx, handle *Handle) (PinnedFileset, error) {
 
 type ChunkSetID uint64
 
+// CreateChunkSet creates a new chunkset.  If you change how this code works, make sure to update
+// the database dump / snapshotting code.  It relies on the exact details of this function to create
+// a restorable database.
 func (s *Storage) CreateChunkSet(ctx context.Context, tx *sqlx.Tx) (ChunkSetID, error) {
 	ctx = pctx.Child(ctx, "createChunkset")
 	// Insert ChunkSet into ChunkSet table.

--- a/src/internal/storage/track/BUILD.bazel
+++ b/src/internal/storage/track/BUILD.bazel
@@ -27,9 +27,11 @@ go_test(
     srcs = ["postgres_tracker_test.go"],
     deps = [
         ":track",
+        "//src/internal/clusterstate",
         "//src/internal/dbutil",
         "//src/internal/dockertestenv",
         "//src/internal/pachsql",
+        "//src/internal/pctx",
         "//src/internal/require",
     ],
 )

--- a/src/internal/storage/track/postgres_tracker.go
+++ b/src/internal/storage/track/postgres_tracker.go
@@ -296,9 +296,9 @@ func (t *postgresTracker) DumpTracker(ctx context.Context, tx *pachsql.Tx, w io.
 	return nil
 }
 
-// DumpTrackerTableNames implements Dumper.
-func (t *postgresTracker) DumpTrackerTableNames() []string {
-	return []string{"storage.tracker_objects", "storage.tracker_refs"}
+// DumpTrackerTablePattern implements Dumper.
+func (t *postgresTracker) DumpTrackerTablePattern() string {
+	return "storage.tracker_objects|tracker_refs"
 }
 
 func dumpTrackerObjects(ctx context.Context, tx *pachsql.Tx, w io.Writer) (retErr error) {

--- a/src/internal/storage/track/postgres_tracker.go
+++ b/src/internal/storage/track/postgres_tracker.go
@@ -3,6 +3,8 @@ package track
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"io"
 	"sort"
 	"time"
 
@@ -278,6 +280,78 @@ func removeDuplicates(xs []string) []string {
 		}
 	}
 	return xs[:len(xs)-countDeleted]
+}
+
+// postgresTime is a time format that `psql` can read.
+const postgresTime = "2006-01-02 15:04:05.999999"
+
+// DumpTracker implements Dumper.
+func (t *postgresTracker) DumpTracker(ctx context.Context, tx *pachsql.Tx, w io.Writer) error {
+	if err := dumpTrackerObjects(ctx, tx, w); err != nil {
+		return errors.Wrap(err, "dump tracker objects")
+	}
+	if err := dumpTrackerRefs(ctx, tx, w); err != nil {
+		return errors.Wrap(err, "dump tracker refs")
+	}
+	return nil
+}
+
+// DumpTrackerTableNames implements Dumper.
+func (t *postgresTracker) DumpTrackerTableNames() []string {
+	return []string{"storage.tracker_objects", "storage.tracker_refs"}
+}
+
+func dumpTrackerObjects(ctx context.Context, tx *pachsql.Tx, w io.Writer) (retErr error) {
+	fmt.Fprintf(w, "\n\nCOPY storage.tracker_objects (int_id, str_id, created_at, expires_at) FROM stdin;\n")
+	rows, err := tx.QueryxContext(ctx, `select int_id, str_id, created_at, expires_at from storage.tracker_objects order by int_id asc`)
+	if err != nil {
+		return errors.Wrap(err, "select")
+	}
+	defer errors.Close(&retErr, rows, "close rows")
+	var intID int64
+	var strID sql.NullString
+	var createdAt time.Time
+	var expiresAt sql.NullTime
+	for rows.Next() {
+		if err := rows.Scan(&intID, &strID, &createdAt, &expiresAt); err != nil {
+			return errors.Wrap(err, "scan")
+		}
+		if !strID.Valid {
+			strID.String = `\N`
+		}
+		created := createdAt.Format(postgresTime)
+		expires := expiresAt.Time.Format(postgresTime)
+		if !expiresAt.Valid {
+			expires = `\N`
+		}
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", intID, strID.String, created, expires)
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(err, "check final error")
+	}
+	fmt.Fprintf(w, `\.`+"\n")
+	return nil
+}
+
+func dumpTrackerRefs(ctx context.Context, tx *pachsql.Tx, w io.Writer) (retErr error) {
+	fmt.Fprintf(w, "\n\nCOPY storage.tracker_refs (from_id, to_id) FROM stdin;\n")
+	rows, err := tx.QueryxContext(ctx, `select from_id, to_id from storage.tracker_refs order by (from_id, to_id) asc`)
+	if err != nil {
+		return errors.Wrap(err, "select")
+	}
+	defer errors.Close(&retErr, rows, "close rows")
+	var fromID, toID int64
+	for rows.Next() {
+		if err := rows.Scan(&fromID, &toID); err != nil {
+			return errors.Wrap(err, "scan")
+		}
+		fmt.Fprintf(w, "%v\t%v\n", fromID, toID)
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(err, "check final error")
+	}
+	fmt.Fprintf(w, `\.`+"\n")
+	return nil
 }
 
 // SetupPostgresTrackerV0 sets up the table for the postgres tracker

--- a/src/internal/storage/track/postgres_tracker_test.go
+++ b/src/internal/storage/track/postgres_tracker_test.go
@@ -4,12 +4,17 @@
 package track_test
 
 import (
+	"bytes"
 	"context"
+	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/pachyderm/pachyderm/v2/src/internal/clusterstate"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dbutil"
 	"github.com/pachyderm/pachyderm/v2/src/internal/dockertestenv"
 	"github.com/pachyderm/pachyderm/v2/src/internal/pachsql"
+	"github.com/pachyderm/pachyderm/v2/src/internal/pctx"
 	"github.com/pachyderm/pachyderm/v2/src/internal/require"
 	"github.com/pachyderm/pachyderm/v2/src/internal/storage/track"
 )
@@ -26,4 +31,37 @@ func TestPostgresTracker(t *testing.T) {
 		require.NoError(t, err)
 		return track.NewPostgresTracker(db)
 	})
+}
+
+func TestTrackerDump(t *testing.T) {
+	db := dockertestenv.NewMigratedTestDB(t, clusterstate.DesiredClusterState)
+	tr := track.NewPostgresTracker(db)
+	dt, ok := tr.(track.Dumper)
+	if !ok {
+		t.Fatalf("should be able convert %#v to a track.Dumper", tr)
+	}
+	ctx := pctx.TestContext(t)
+	require.NoError(t, track.Create(ctx, tr, "foo/1", nil, 0), "should create foo/1")
+	require.NoError(t, track.Create(ctx, tr, "foo/2", []string{"foo/1"}, 0), "should create foo/2")
+	var buf bytes.Buffer
+	require.NoError(t, dbutil.WithTx(ctx, db, func(cbCtx context.Context, tx *pachsql.Tx) error {
+		return dt.DumpTracker(cbCtx, tx, &buf)
+	}))
+	want := strings.Join([]string{
+		"",
+		"",
+		"COPY storage.tracker_objects (int_id, str_id, created_at, expires_at) FROM stdin;",
+		"1\tfoo/1\tXXX-XXX-XXX XXX:XXX:XXX.XXX\t\\N",
+		"2\tfoo/2\tXXX-XXX-XXX XXX:XXX:XXX.XXX\t\\N",
+		`\.`,
+		"",
+		"",
+		"COPY storage.tracker_refs (from_id, to_id) FROM stdin;",
+		"2\t1",
+		`\.`,
+		"",
+	}, "\n")
+	got := buf.String()
+	got = regexp.MustCompile(`[0-9]{2,}`).ReplaceAllString(got, "XXX")
+	require.NoDiff(t, want, got, nil, "should produce expected dump")
 }

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -6,6 +6,7 @@ package track
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"testing"
 	"time"
@@ -228,3 +229,20 @@ func NewTestTracker(t testing.TB, db *pachsql.DB) Tracker {
 	db.MustExec(schema)
 	return NewPostgresTracker(db)
 }
+
+// Dumper is a tracker that can dump its state as a SQL dump.  This exists because creating a
+// snapshot of the cluster involves creating tracker entries and dumping the database in the same
+// transaction, but the writes on the tracker side are not visible to the dumping side.  Thus, this
+// runs on the dumping side and ensures that we read our (yet-to-be-committed) writes for the dump.
+//
+// See SET TRANSACTION SNAPSHOT docs: https://www.postgresql.org/docs/17/sql-set-transaction.html
+type Dumper interface {
+	// DumpTracker dumps the state of the tracker as a psql-format SQL script.  The best writer
+	// to use is a bufio.Writer, since the dump may make many small writes.
+	DumpTracker(context.Context, *pachsql.Tx, io.Writer) error
+	// DumpTrackerTableNames returns the names of tables that DumpTracker creates.
+	DumpTrackerTableNames() []string
+}
+
+// The postgres tracker is dumpable.
+var _ Dumper = (*postgresTracker)(nil)

--- a/src/internal/storage/track/tracker.go
+++ b/src/internal/storage/track/tracker.go
@@ -235,13 +235,15 @@ func NewTestTracker(t testing.TB, db *pachsql.DB) Tracker {
 // transaction, but the writes on the tracker side are not visible to the dumping side.  Thus, this
 // runs on the dumping side and ensures that we read our (yet-to-be-committed) writes for the dump.
 //
-// See SET TRANSACTION SNAPSHOT docs: https://www.postgresql.org/docs/17/sql-set-transaction.html
+// See SET TRANSACTION SNAPSHOT docs: https://www.postgresql.org/docs/current/sql-set-transaction.html
 type Dumper interface {
 	// DumpTracker dumps the state of the tracker as a psql-format SQL script.  The best writer
 	// to use is a bufio.Writer, since the dump may make many small writes.
 	DumpTracker(context.Context, *pachsql.Tx, io.Writer) error
-	// DumpTrackerTableNames returns the names of tables that DumpTracker creates.
-	DumpTrackerTableNames() []string
+	// DumpTrackerTablePattern returns a postgres Pattern that matches the tables DumpTracker
+	// will dump.  Postgres patterns:
+	// https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-PATTERNS
+	DumpTrackerTablePattern() string
 }
 
 // The postgres tracker is dumpable.

--- a/tools/postgres/psql/BUILD.bazel
+++ b/tools/postgres/psql/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "psql",
+    src = select({
+        "//:is_x86_64_linux": "//private/apt:psql",
+        "//:is_aarch64_linux": "//private/apt:psql",
+        "//:is_x86_64_macos": "@com_enterprisedb_get_postgresql_macos//:bin/psql",
+        "//:is_aarch64_macos": "@com_enterprisedb_get_postgresql_macos//:bin/psql",
+    }),
+    out = "psql",
+    visibility = ["//:__subpackages__"],
+)


### PR DESCRIPTION
This adds the ability to restore the database state to that contained in a snapshot.  After restoring, the snapshot is still restorable, because we re-upload the database dump and adjust the snapshot to show the new ID.  This makes it look like snapshots contain themselves, which is a nice feature ;)

To restore cleanly, we can't rely on queries running against a default schema (public), it seems, so I updated the migrations code to be explicit about the schema the queries are in.

`psql` is used to restore the dump, because that's what the `pg_dump` documentation says to do.  I thought about parsing the SQL and sending one statement at a time, but it seems like something that is likely to go wrong in weird ways.  As a result of this, `psql` is available in //tools/postgres/psql now, which should be convenient.

We use pg_dump v17 to dump any version of postgres.  For various reasons, these dumps can only be restored onto postgres 17.  The snapshotting code has been adjusted to remove the v17-specific functionality so that we can take snapshots of v13 and restore onto v13.

Finally, I adjusted the snapshotting code to atomically create the pachyderm snapshot and the postgres snapshot.  This involves sharing the transaction between Go and pg_dump which is possible (see pg_export_snapshot).  We have to manually dump everything created in that transaction, though, which we now do.  (The start READING the same MVCC snapshot, but can't see each other's writes because postgres doesn't have READ UNCOMMITTED isolation.  Thus, we make a list of everything we wrote and add it to the end of the dump file ourselves.)  This fixes MLDM-143.
