### PR TITLE
delete existing restore-snapshot job before subsequent restore

### DIFF
--- a/etc/helm/pachyderm/templates/restore-snapshot/job.yaml
+++ b/etc/helm/pachyderm/templates/restore-snapshot/job.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        "helm.sh/hook-delete-policy": before-hook-creation
         {{- if .Values.restoreSnapshot.annotations -}}
         {{ toYaml .Values.restoreSnapshot.annotations | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
add hook-delete-policy: before-hook-creation annotation to restore-snapshot job