### PR TITLE
capitalize "Delete" in pachctl help

### DIFF
--- a/src/internal/snapshot/cmds/cmds.go
+++ b/src/internal/snapshot/cmds/cmds.go
@@ -90,7 +90,7 @@ func Cmds(pachctlCfg *pachctl.Config) []*cobra.Command {
 
 	var idStr string
 	deleteSnapshot := &cobra.Command{
-		Short: "delete a snapshot",
+		Short: "Delete a snapshot",
 		Long:  "This command deletes a snapshot",
 		Run: cmdutil.RunBoundedArgs(0, 1, func(cmd *cobra.Command, args []string) (retErr error) {
 			ctx := cmd.Context()


### PR DESCRIPTION
Makes the following uniform:
```
Available Commands:
  all         Delete everything.
  branch      Delete a branch
  commit      Delete the sub-commits of a commit.
  commitV2    Delete a commit.
  defaults    Delete defaults.
  file        Delete a file.
  job         Delete a job.
  pipeline    Delete a pipeline.
  project     Delete a project.
  repo        Delete a repo.
  secret      Delete a secret from the cluster.
  snapshot    delete a snapshot
  transaction Cancel and delete an existing transaction.
```