### PR TITLE
Cascade when deleting snapshots

### DIFF
--- a/src/internal/snapshot/api_server.go
+++ b/src/internal/snapshot/api_server.go
@@ -91,7 +91,7 @@ func (a *APIServer) DeleteSnapshot(ctx context.Context, req *snapshotpb.DeleteSn
 		Storage: a.Store,
 	}
 	if err := s.DropSnapshot(ctx, SnapshotID(req.GetId())); err != nil {
-		return nil, status.Errorf(codes.Unknown, "drop snapshot: %v", err)
+		return nil, errors.Wrap(err, "drop snapshot")
 	}
 	return ret, nil
 }

--- a/src/internal/snapshot/api_server.go
+++ b/src/internal/snapshot/api_server.go
@@ -86,14 +86,12 @@ func (a *APIServer) ListSnapshot(req *snapshotpb.ListSnapshotRequest, srv snapsh
 
 func (a *APIServer) DeleteSnapshot(ctx context.Context, req *snapshotpb.DeleteSnapshotRequest) (*snapshotpb.DeleteSnapshotResponse, error) {
 	var ret *snapshotpb.DeleteSnapshotResponse
-	if err := dbutil.WithTx(ctx, a.DB, func(ctx context.Context, sqlTx *pachsql.Tx) error {
-		err := snapshotdb.DeleteSnapshot(ctx, sqlTx, req.Id)
-		if err != nil {
-			return errors.Wrap(err, "delete snapshot in db")
-		}
-		return nil
-	}); err != nil {
-		return nil, errors.Wrap(err, "with Tx")
+	s := &Snapshotter{
+		DB:      a.DB,
+		Storage: a.Store,
+	}
+	if err := s.DropSnapshot(ctx, SnapshotID(req.GetId())); err != nil {
+		return nil, status.Errorf(codes.Unknown, "drop snapshot: %v", err)
 	}
 	return ret, nil
 }

--- a/src/internal/storage/fileset/storage.go
+++ b/src/internal/storage/fileset/storage.go
@@ -536,7 +536,7 @@ func (s *Storage) DropChunkSet(ctx context.Context, tx *sqlx.Tx, id ChunkSetID) 
 	// Check the number of affected rows
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return errors.Wrap(err, "rows effected")
+		return errors.Wrap(err, "rows affected")
 	}
 	if rowsAffected == 0 {
 		return errors.Errorf("no chunkset found with the given id: %d", id)


### PR DESCRIPTION
Otherwise we orphan fileset pins and chunksets, which would silently keep all data alive forever.

MLDM-170