### PR TITLE
Re-enable the printf linter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -146,7 +146,7 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/nilfunc",
         # "@org_golang_x_tools//go/analysis/passes/nilness:nilness",
         # "@org_golang_x_tools//go/analysis/passes/pkgfact:pkgfact",
-        # "@org_golang_x_tools//go/analysis/passes/printf", # TODO: reenable
+        "@org_golang_x_tools//go/analysis/passes/printf",
         # "@org_golang_x_tools//go/analysis/passes/reflectvaluecompare:reflectvaluecompare",
         # "@org_golang_x_tools//go/analysis/passes/shadow:shadow",
         "@org_golang_x_tools//go/analysis/passes/shift",

--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -1,9 +1,9 @@
 // Package require implements test assertions.
 package require
 
+//nolint:printf
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"regexp"
 	"runtime/debug"
@@ -87,7 +87,7 @@ func NoDiff(tb testing.TB, expected any, actual any, opts []cmp.Option, msgAndAr
 func Equal(tb testing.TB, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	tb.Helper()
 	if err := EqualOrErr(expected, actual); err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 }
 
@@ -241,11 +241,11 @@ func ImagesEqual(tb testing.TB, expecteds interface{}, actuals interface{}, f fu
 
 	// Check if 'actuals' is empty; if so, just pass nil (no need to transform)
 	if actuals != nil && !as.IsNil() && as.Kind() != reflect.Slice {
-		fatal(tb, msgAndArgs, fmt.Sprintf("\"actuals\" must be a slice, but was %s", as.Type().String()))
+		fatal(tb, msgAndArgs, "\"actuals\" must be a slice, but was %s", as.Type().String())
 	} else if actuals == nil || as.IsNil() || as.Len() == 0 {
 		// Just pass 'nil' for 'actuals'
 		if err := ElementsEqualOrErr(expecteds, nil); err != nil {
-			fatal(tb, msgAndArgs, err.Error())
+			fatal(tb, msgAndArgs, "%v", err.Error())
 		}
 		return
 	}
@@ -253,9 +253,9 @@ func ImagesEqual(tb testing.TB, expecteds interface{}, actuals interface{}, f fu
 	// Check if 'expecteds' is empty: if so, return an error (since 'actuals' is
 	// not empty)
 	if expecteds != nil && !es.IsNil() && es.Kind() != reflect.Slice {
-		fatal(tb, msgAndArgs, fmt.Sprintf("\"expecteds\" must be a slice, but was %s", as.Type().String()))
+		fatal(tb, msgAndArgs, "\"expecteds\" must be a slice, but was %s", as.Type().String())
 	} else if expecteds == nil || es.IsNil() || es.Len() == 0 {
-		fatal(tb, msgAndArgs, fmt.Sprintf("expected 0 distinct elements, but got %d\n elements (before function is applied): %v", as.Len(), actuals))
+		fatal(tb, msgAndArgs, "expected 0 distinct elements, but got %d\n elements (before function is applied): %v", as.Len(), actuals)
 	}
 
 	// Make sure expecteds and actuals are slices of the same type, modulo
@@ -298,7 +298,7 @@ func ImagesEqual(tb testing.TB, expecteds interface{}, actuals interface{}, f fu
 		newActuals = append(newActuals, f(as.Index(i).Interface()))
 	}
 	if err := ElementsEqualOrErr(newExpecteds, newActuals); err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 }
 
@@ -318,11 +318,11 @@ func ElementsEqualUnderFn(tb testing.TB, expecteds interface{}, actuals interfac
 
 	// Check if 'actuals' is empty; if so, just pass nil (no need to transform)
 	if actuals != nil && !as.IsNil() && as.Kind() != reflect.Slice {
-		fatal(tb, msgAndArgs, fmt.Sprintf("\"actuals\" must be a slice, but was %s", as.Type().String()))
+		fatal(tb, msgAndArgs, "\"actuals\" must be a slice, but was %s", as.Type().String())
 	} else if actuals == nil || as.IsNil() || as.Len() == 0 {
 		// Just pass 'nil' for 'actuals'
 		if err := ElementsEqualOrErr(expecteds, nil); err != nil {
-			fatal(tb, msgAndArgs, err.Error())
+			fatal(tb, msgAndArgs, "%v", err.Error())
 		}
 		return
 	}
@@ -330,9 +330,9 @@ func ElementsEqualUnderFn(tb testing.TB, expecteds interface{}, actuals interfac
 	// Check if 'expecteds' is empty: if so, return an error (since 'actuals' is
 	// not empty)
 	if expecteds != nil && !es.IsNil() && es.Kind() != reflect.Slice {
-		fatal(tb, msgAndArgs, fmt.Sprintf("\"expecteds\" must be a slice, but was %s", as.Type().String()))
+		fatal(tb, msgAndArgs, "\"expecteds\" must be a slice, but was %s", as.Type().String())
 	} else if expecteds == nil || es.IsNil() || es.Len() == 0 {
-		fatal(tb, msgAndArgs, fmt.Sprintf("expected 0 distinct elements, but got %d\n elements (before function is applied): %v", as.Len(), actuals))
+		fatal(tb, msgAndArgs, "expected 0 distinct elements, but got %d\n elements (before function is applied): %v", as.Len(), actuals)
 	}
 
 	// Neither 'expecteds' nor 'actuals' is empty--apply 'f' to 'actuals'
@@ -341,7 +341,7 @@ func ElementsEqualUnderFn(tb testing.TB, expecteds interface{}, actuals interfac
 		newActuals.Index(i).Set(reflect.ValueOf(f(as.Index(i).Interface())))
 	}
 	if err := ElementsEqualOrErr(expecteds, newActuals.Interface()); err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 }
 
@@ -359,7 +359,7 @@ func ElementsEqualUnderFn(tb testing.TB, expecteds interface{}, actuals interfac
 func ElementsEqual(tb testing.TB, expecteds interface{}, actuals interface{}, msgAndArgs ...interface{}) {
 	tb.Helper()
 	if err := ElementsEqualOrErr(expecteds, actuals); err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 }
 
@@ -396,7 +396,7 @@ func EqualOneOf(tb testing.TB, expecteds interface{}, actual interface{}, msgAnd
 	tb.Helper()
 	equal, err := oneOfEquals("expecteds", expecteds, actual)
 	if err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 	if !equal {
 		fatal(
@@ -413,7 +413,7 @@ func OneOfEquals(tb testing.TB, expected interface{}, actuals interface{}, msgAn
 	tb.Helper()
 	equal, err := oneOfEquals("actuals", actuals, expected)
 	if err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 	if !equal {
 		fatal(tb, msgAndArgs,
@@ -428,7 +428,7 @@ func NoneEquals(tb testing.TB, expected interface{}, actuals interface{}, msgAnd
 	tb.Helper()
 	equal, err := oneOfEquals("actuals", actuals, expected)
 	if err != nil {
-		fatal(tb, msgAndArgs, err.Error())
+		fatal(tb, msgAndArgs, "%v", err.Error())
 	}
 	if equal {
 		fatal(tb, msgAndArgs,
@@ -588,7 +588,7 @@ func Len(tb testing.TB, x interface{}, l int, msgAndArgs ...interface{}) {
 func logMessage(tb testing.TB, msgAndArgs []interface{}) {
 	tb.Helper()
 	if len(msgAndArgs) == 1 {
-		tb.Logf(msgAndArgs[0].(string))
+		tb.Log(msgAndArgs[0].(string))
 	}
 	if len(msgAndArgs) > 1 {
 		tb.Logf(msgAndArgs[0].(string), msgAndArgs[1:]...)

--- a/src/internal/require/require.go
+++ b/src/internal/require/require.go
@@ -1,7 +1,6 @@
 // Package require implements test assertions.
 package require
 
-//nolint:printf
 import (
 	"context"
 	"reflect"

--- a/src/server/pps/pretty/pretty.go
+++ b/src/server/pps/pretty/pretty.go
@@ -238,7 +238,7 @@ func PrintWorkerStatus(w io.Writer, workerStatus *ppsclient.WorkerStatus, fullTi
 	if workerStatus.DatumStatus != nil {
 		datumStatus := workerStatus.DatumStatus
 		for _, datum := range datumStatus.Data {
-			fmt.Fprintf(w, datum.Path)
+			fmt.Fprint(w, datum.Path)
 		}
 		fmt.Fprintf(w, "\t")
 		if fullTimestamps {


### PR DESCRIPTION
I have noticed this rule triggering in the test sharder, causing all integration tests to fail, which is very annoying.  It shouldn't have been turned off in the first place, but I didn't understand the multitude of mistakes it was detecting and decided "later".  I understand the mistakes now (someone was very cut-n-paste happy while writing the require library), and have fixed them.  So now you don't have to worry about the integration tests failing because of a lint error.

MLDM-172