### PR TITLE
Enable the nilness check

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -144,7 +144,7 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/loopclosure",
         "@org_golang_x_tools//go/analysis/passes/lostcancel",
         "@org_golang_x_tools//go/analysis/passes/nilfunc",
-        # "@org_golang_x_tools//go/analysis/passes/nilness:nilness",
+        "@org_golang_x_tools//go/analysis/passes/nilness",
         # "@org_golang_x_tools//go/analysis/passes/pkgfact:pkgfact",
         "@org_golang_x_tools//go/analysis/passes/printf",
         # "@org_golang_x_tools//go/analysis/passes/reflectvaluecompare:reflectvaluecompare",

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -654,7 +654,7 @@ func newOnUserMachine(ctx context.Context, cfg *config.Config, context *config.C
 		if status.Code(err) == codes.Unimplemented {
 			// This is an older version check designed to detect 1.x vs. 2.x mismatch.
 			pachdVersion, versErr := client.Version()
-			if err != nil {
+			if versErr != nil {
 				return nil, errors.Wrap(scrubbedErr, errors.Wrap(versErr, "could not determine pachd version").Error())
 			}
 			pachdMajVersion, convErr := strconv.Atoi(strings.Split(pachdVersion, ".")[0])

--- a/src/client/pfs.go
+++ b/src/client/pfs.go
@@ -450,9 +450,6 @@ func (c APIClient) FindCommits(req *pfs.FindCommitsRequest) (*FindCommitsRespons
 		return nil, grpcutil.ScrubGRPC(err)
 	}
 	resp := &FindCommitsResponse{}
-	if err != nil {
-		return nil, grpcutil.ScrubGRPC(err)
-	}
 	if err := grpcutil.ForEach[*pfs.FindCommitsResponse](client, func(x *pfs.FindCommitsResponse) error {
 		switch x.Result.(type) {
 		case *pfs.FindCommitsResponse_LastSearchedCommit:

--- a/src/internal/client/client.go
+++ b/src/internal/client/client.go
@@ -636,7 +636,7 @@ func newOnUserMachine(ctx context.Context, cfg *config.Config, context *config.C
 		if status.Code(err) == codes.Unimplemented {
 			// This is an older version check designed to detect 1.x vs. 2.x mismatch.
 			pachdVersion, versErr := client.Version()
-			if err != nil {
+			if versErr != nil {
 				return nil, errors.Join(scrubbedErr, errors.Wrap(versErr, "could not determine pachd version"))
 			}
 			pachdMajVersion, convErr := strconv.Atoi(strings.Split(pachdVersion, ".")[0])

--- a/src/internal/client/pfs.go
+++ b/src/internal/client/pfs.go
@@ -299,9 +299,6 @@ func (c APIClient) FindCommits(req *pfs.FindCommitsRequest) (*FindCommitsRespons
 		return nil, err
 	}
 	resp := &FindCommitsResponse{}
-	if err != nil {
-		return nil, err
-	}
 	if err := grpcutil.ForEach[*pfs.FindCommitsResponse](client, func(x *pfs.FindCommitsResponse) error {
 		switch x.Result.(type) {
 		case *pfs.FindCommitsResponse_LastSearchedCommit:

--- a/src/internal/clusterstate/v2.8.0/pfsdb_28x/commits.go
+++ b/src/internal/clusterstate/v2.8.0/pfsdb_28x/commits.go
@@ -200,13 +200,11 @@ func CreateCommit(ctx context.Context, tx *pachsql.Tx, commitInfo *pfs.CommitInf
 	if err == nil {
 		return 0, &CommitAlreadyExistsError{CommitID: commit.CommitInfo.Commit.Key()}
 	}
-	if err != nil {
-		if errors.As(err, new(*ProjectNotFoundError)) || errors.As(err, new(*RepoNotFoundError)) {
-			return 0, err
-		}
-		if !errors.As(err, new(*CommitNotFoundError)) {
-			return 0, err
-		}
+	if errors.As(err, new(*ProjectNotFoundError)) || errors.As(err, new(*RepoNotFoundError)) {
+		return 0, err
+	}
+	if !errors.As(err, new(*CommitNotFoundError)) {
+		return 0, err
 	}
 	opt := AncestryOpt{}
 	if len(opts) > 0 {

--- a/src/internal/lokiutil/testloki/testloki.go
+++ b/src/internal/lokiutil/testloki/testloki.go
@@ -52,9 +52,7 @@ func New(ctx context.Context, tmp string, opts ...Option) (*TestLoki, error) {
 			errors.JoinInto(&errs, errors.Wrapf(err, "startup attempt %d", i))
 			continue
 		}
-		if err == nil {
-			return l, nil
-		}
+		return l, nil
 	}
 	return nil, errors.Wrapf(errs, "loki failed to start after %d attempts", attempts)
 }

--- a/src/internal/pfsdb/commits.go
+++ b/src/internal/pfsdb/commits.go
@@ -219,13 +219,11 @@ func CreateCommit(ctx context.Context, tx *pachsql.Tx, commitInfo *pfs.CommitInf
 	if err == nil {
 		return 0, &CommitAlreadyExistsError{CommitID: commit.CommitInfo.Commit.Key()}
 	}
-	if err != nil {
-		if errors.As(err, new(*ProjectNotFoundError)) || errors.As(err, new(*RepoNotFoundError)) {
-			return 0, err
-		}
-		if !errors.As(err, new(*CommitNotFoundError)) {
-			return 0, err
-		}
+	if errors.As(err, new(*ProjectNotFoundError)) || errors.As(err, new(*RepoNotFoundError)) {
+		return 0, err
+	}
+	if !errors.As(err, new(*CommitNotFoundError)) {
+		return 0, err
 	}
 	opt := AncestryOpt{}
 	if len(opts) > 0 {

--- a/src/internal/serviceenv/service_env.go
+++ b/src/internal/serviceenv/service_env.go
@@ -6,12 +6,13 @@ package serviceenv
 import (
 	"context"
 	"fmt"
-	pjs_server "github.com/pachyderm/pachyderm/v2/src/pjs"
 	"math"
 	"net"
 	"net/http"
 	"os"
 	"time"
+
+	pjs_server "github.com/pachyderm/pachyderm/v2/src/pjs"
 
 	dex_storage "github.com/dexidp/dex/storage"
 	"github.com/dlmiddlecote/sqlstats"
@@ -369,9 +370,6 @@ func (env *NonblockingServiceEnv) initDirectDBClient(ctx context.Context) error 
 		return err
 	}
 	env.directDBClient = db
-	if err != nil {
-		return err
-	}
 	if err := prometheus.Register(sqlstats.NewStatsCollector("direct", env.directDBClient.DB)); err != nil {
 		log.Info(ctx, "problem registering stats collector for direct db client", zap.Error(err))
 	}

--- a/src/server/license/server/api_server.go
+++ b/src/server/license/server/api_server.go
@@ -112,7 +112,7 @@ func (a *apiServer) activate(ctx context.Context, req *lc.ActivateRequest) (resp
 	// Allow request to override expiration in the activation code, for testing
 	if req.Expires != nil {
 		customExpiration := req.Expires.AsTime()
-		if err == nil && expiration.After(customExpiration) {
+		if expiration.After(customExpiration) {
 			expiration = customExpiration
 		}
 	}

--- a/src/server/pfs/server/server_repo.go
+++ b/src/server/pfs/server/server_repo.go
@@ -217,9 +217,6 @@ func (a *apiServer) relatedRepos(ctx context.Context, txnCtx *txncontext.Transac
 	if err != nil {
 		return nil, errors.Wrap(err, "list repo by name")
 	}
-	if err != nil && !pfsdb.IsErrRepoNotFound(err) { // TODO(acohen4): !RepoNotFound may be unnecessary
-		return nil, errors.Wrapf(err, "error finding dependent repos for %q", repo.Name)
-	}
 	return related, nil
 }
 
@@ -234,7 +231,7 @@ func (a *apiServer) canDeleteRepo(ctx context.Context, txnCtx *txncontext.Transa
 	}
 	if _, err := a.env.GetPipelineInspector().InspectPipelineInTransaction(ctx, txnCtx, pps.RepoPipeline(repo)); err == nil {
 		return false, errors.Errorf("cannot delete a repo associated with a pipeline - delete the pipeline instead")
-	} else if err != nil && !errutil.IsNotFoundError(err) {
+	} else if !errutil.IsNotFoundError(err) {
 		return false, errors.Wrapf(err, "inspect pipeline %q", pps.RepoPipeline(repo).String())
 	}
 	return true, nil

--- a/src/testing/cmds/harness/test-runner/main.go
+++ b/src/testing/cmds/harness/test-runner/main.go
@@ -88,9 +88,6 @@ func run(ctx context.Context, tags string, fileName string, gotestsumArgs []stri
 	for pkg, tests := range testsForShard {
 		threadLocalPkg := pkg
 		threadLocalTests := tests
-		if err != nil {
-			return errors.EnsureStack(err)
-		}
 		eg.Go(func() error {
 			return errors.EnsureStack(runTest(threadLocalPkg, threadLocalTests, tags, gotestsumArgs, gotestArgs))
 		})


### PR DESCRIPTION
This is a good one, detecting checks for nil where something has already proven to be nil.  For example:

```go
x, err := ...
if err == nil { 
   return
}
if err != nil {
    ....
}
```
This will be flagged as a tautological condition; err can't ever be nil at the second statement.  The checker also finds the opposite case, like:
```go
x, err := ...
if err != nil {
    return
}
...
if err != nil {
    return
}
```

This found some long-standing bugs...