### PR TITLE
fix call zap.Error with a nil value error

### DIFF
--- a/src/internal/pachd/testpachd.go
+++ b/src/internal/pachd/testpachd.go
@@ -111,7 +111,8 @@ func WithS3Server(t *testing.T, addr *string) TestPachdOption {
 				if err != nil {
 					return errors.Wrapf(err, "wait for s3: attempt %d", i)
 				}
-				if _, err := http.DefaultClient.Do(req); err == nil {
+				_, err = http.DefaultClient.Do(req)
+				if err == nil {
 					break
 				}
 				log.Debug(ctx, "s3 server not ready yet", zap.Error(err))


### PR DESCRIPTION
the origin code
```
if _, err := http.DefaultClient.Do(req); err == nil {
        break
}
```
is create a new var, not cover the origin err, so the Debug log will print nil