### PR TITLE
Update JupyterLab classifier

### DIFF
--- a/jupyter-extension/setup.cfg
+++ b/jupyter-extension/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
   Programming Language :: Python :: 3.10
   Framework :: Jupyter
   Framework :: Jupyter :: JupyterLab
-  Framework :: Jupyter :: JupyterLab :: 3
+  Framework :: Jupyter :: JupyterLab :: 4
   Framework :: Jupyter :: JupyterLab :: Extensions
   Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt
 


### PR DESCRIPTION
## Summary
- switch the trove classifier to Framework :: Jupyter :: JupyterLab :: 4 so PyPI shows the correct supported version
